### PR TITLE
fix: create /enterprise directory before copying enterprise backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,7 +20,7 @@ ARG ENTERPRISE=false
 RUN --mount=type=bind,source=.,target=/repo,readonly \
     --mount=type=cache,target=/home/gradle/.gradle \
     if [ "$ENTERPRISE" = "true" ] && [ -d /repo/enterprise/backend ]; then \
-      cp -r /repo/enterprise/backend /enterprise/backend && \
+      mkdir -p /enterprise && cp -r /repo/enterprise/backend /enterprise/backend && \
       gradle shadowJar -Penterprise -PenterprisePath=/enterprise/backend --no-daemon --build-cache; \
     else \
       gradle shadowJar --no-daemon --build-cache; \


### PR DESCRIPTION
## Description

Fixes enterprise deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker build configuration to ensure the enterprise directory is created before attempting to copy files, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->