### PR TITLE
feat: add additional log viewer time filters

### DIFF
--- a/dashboard/src/components/logs/LogSearchBar.tsx
+++ b/dashboard/src/components/logs/LogSearchBar.tsx
@@ -44,6 +44,8 @@ const TIME_PRESETS: TimeRangePreset[] = [
   {label: 'Last 24 hours', value: '24h', minutes: 1440},
   {label: 'Last 3 days', value: '3d', minutes: 4320},
   {label: 'Last 7 days', value: '7d', minutes: 10080},
+  {label: 'Last 14 days', value: '14d', minutes: 20160},
+  {label: 'Last 30 days', value: '30d', minutes: 43200},
 ]
 
 const LEVEL_OPTIONS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']

--- a/dashboard/src/components/logs/logViewUrlState.ts
+++ b/dashboard/src/components/logs/logViewUrlState.ts
@@ -45,7 +45,7 @@ export interface LogViewSearch {
 }
 
 const VALID_VIZ_MODES: LogVizMode[] = ['timeseries', 'table', 'toplist', 'pie']
-const VALID_TIME_PRESETS = ['5m', '15m', '30m', '1h', '4h', '12h', '24h', '3d', '7d', 'custom']
+const VALID_TIME_PRESETS = ['5m', '15m', '30m', '1h', '4h', '12h', '24h', '3d', '7d', '14d', '30d', 'custom']
 
 /**
  * Parse URL search params into normalized log view state.


### PR DESCRIPTION
## Description
So that we can filter by more than just 7 days. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new time filter presets to the logs search: "Last 14 days" and "Last 30 days" are now available as quick-select options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->