### PR TITLE
fix: on-call display inconsistencies

### DIFF
--- a/dashboard/src/routes/on-call.index.tsx
+++ b/dashboard/src/routes/on-call.index.tsx
@@ -431,7 +431,9 @@ function OnCallOverview() {
                       <div className="min-w-0">
                         <p className="font-medium text-sm truncate group-hover:text-foreground">{incident.title}</p>
                         <p className="text-xs text-muted-foreground">
-                          {new Date(incident.declaredAt).toLocaleString()}
+                          {incident.declaredAt && !isNaN(new Date(incident.declaredAt).getTime())
+                            ? new Date(incident.declaredAt).toLocaleString()
+                            : '—'}
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## Description

On-call page shows 20 active incidents but the incident tab was empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Active on-call incidents now use a single "Open" status and are filtered accordingly.
  * Navigation paths for incident details and "View all" were renamed to the declared-incidents route.
  * Incident timestamps now show declaration time with a fallback when unset.
  * Status labels and UI text updated to reflect the new Open/Resolved handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->