### PR TITLE
fix: log viewer infinite scroll not triggering and missing end indicator

### DIFF
--- a/dashboard/src/components/logs/LogExplorer.tsx
+++ b/dashboard/src/components/logs/LogExplorer.tsx
@@ -592,7 +592,7 @@ export function LogExplorer({
     return () => {
       observer.disconnect()
     }
-  }, [logPage?.hasMore, logPage?.nextCursor, isLoadingMore, isFetching, cursor])
+  }, [logPage?.hasMore, logPage?.nextCursor, isLoadingMore, isFetching, cursor, logs.length])
 
   // Show loading state only on initial load with no accumulated logs
   const isInitialLoadingState = isInitialLoading && accumulatedLogs.length === 0
@@ -863,7 +863,7 @@ export function LogExplorer({
                       <div className="text-center text-xs text-muted-foreground/50">
                         Scroll for more
                       </div>
-                    ) : logs.length > 150 ? (
+                    ) : logPage && !logPage.hasMore ? (
                       <div className="border-t pt-3 text-center text-xs text-muted-foreground/70">
                         End of results • {logs.length} logs loaded
                       </div>


### PR DESCRIPTION
The IntersectionObserver for infinite scroll was never set up on initial page load. The accumulation effect defers setAccumulatedLogs via startTransition, so the scroll sentinel isn't in the DOM when the observer effect first runs. Since logs.length wasn't in the dependency array, the effect never re-ran when the sentinel appeared.

Also changed the 'end of results' indicator to show whenever hasMore is false, instead of only when logs.length > 150, so users always see feedback when they've reached the end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the log explorer's "End of results" message to display based on pagination state rather than an arbitrary log count threshold, ensuring accurate feedback when browsing logs.
  * Improved observer cleanup behavior when the number of loaded logs changes, ensuring consistent performance during log navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->