### PR TITLE
fix(projects): new project button not working

### DIFF
--- a/dashboard/src/components/AppTopBar.tsx
+++ b/dashboard/src/components/AppTopBar.tsx
@@ -167,7 +167,7 @@ export function AppTopBar({sidebarWidth, isSidebarExpanded}: AppTopBarProps) {
         <Button
           size="sm"
           variant="outline"
-          onClick={() => navigate({to: '/projects'})}
+          onClick={() => window.dispatchEvent(new CustomEvent('open-create-project-dialog'))}
           className="gap-1.5"
         >
           <Plus className="h-4 w-4" />

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useState} from 'react'
+import {useEffect, useState} from 'react'
 import {Link, useNavigate, useRouterState} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
@@ -87,6 +87,12 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
 
   // Create project dialog state
   const [showCreateDialog, setShowCreateDialog] = useState(false)
+
+  useEffect(() => {
+    const handler = () => setShowCreateDialog(true)
+    window.addEventListener('open-create-project-dialog', handler)
+    return () => window.removeEventListener('open-create-project-dialog', handler)
+  }, [])
   const [newProjectName, setNewProjectName] = useState('')
   const [selectedPlatform, setSelectedPlatform] = useState<string | null>(null)
   const [selectedTargets, setSelectedTargets] = useState<string[]>([])


### PR DESCRIPTION
## Description

New project button isn't working. Clicking the button causes an immediate redirect instead of opening the dialog. 

Fixes #171 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal workflow for opening the Create Project dialog. The dialog remains accessible through the same user interface, with no changes to functionality or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->