### PR TITLE
fix(dashboard): url generation with the new release process

### DIFF
--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -138,6 +138,16 @@ fun Application.configureRouting() {
             )
         }
 
+        get("/v1/features") {
+            call.respond(
+                FeaturesResponse(
+                    enterprise = FeatureRegistry.isEnterpriseAvailable,
+                    modules = FeatureRegistry.registeredModules.map { it.name },
+                    selfHost = EnvConfig.SelfHost.enabled
+                )
+            )
+        }
+
         // Liveness probe: lightweight check that the JVM and HTTP server are responsive
         get("/health/live") {
             call.respond(mapOf("status" to "ok"))

--- a/dashboard/src/hooks/useEnterpriseFeatures.ts
+++ b/dashboard/src/hooks/useEnterpriseFeatures.ts
@@ -7,7 +7,7 @@ interface FeaturesResponse {
 }
 
 const API_BASE = import.meta.env.VITE_BACKEND_URL || import.meta.env.VITE_API_URL || ''
-const FEATURES_URL = API_BASE ? `${API_BASE.replace(/\/$/, '')}/features` : '/features'
+const FEATURES_URL = `${API_BASE.replace(/\/$/, '')}/v1/features`
 
 function normalizeModuleName(value: string): string {
   return value.toLowerCase().replace(/[\s_-]/g, '')


### PR DESCRIPTION
## Description
Proxy URLs through /v1/xxx instead of VITE_XXX, this is no longer available since we're using a shared Docker image. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `/v1/features` API endpoint providing enterprise availability, registered modules, and self-hosted configuration.

* **Updates**
  * Updated feature detection to use the new versioned API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->