### PR TITLE
fix(clickhouse): unify escapeSql implementations via ClickHouseSqlUtils

### DIFF
--- a/backend/src/integrationTest/kotlin/com/moneat/integration/LogQueryParserIntegrationTest.kt
+++ b/backend/src/integrationTest/kotlin/com/moneat/integration/LogQueryParserIntegrationTest.kt
@@ -17,6 +17,7 @@
 package com.moneat.integration
 
 import com.moneat.logs.services.LogQueryParser
+import com.moneat.utils.ClickHouseSqlUtils
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
@@ -54,8 +55,6 @@ class LogQueryParserIntegrationTest {
     private val parser = LogQueryParser()
 
     private fun chBaseUrl(): String = "http://${clickhouse.host}:${clickhouse.getMappedPort(8123)}"
-
-    private fun escapeSql(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
 
     // ==========================================
     // Setup & Teardown
@@ -210,7 +209,7 @@ class LogQueryParserIntegrationTest {
         val parsed = parser.parse(ddQuery)
         val whereCondition =
             if (parsed.rootNode != null) {
-                parser.toClickHouseSql(parsed.rootNode, ::escapeSql)
+                parser.toClickHouseSql(parsed.rootNode, ClickHouseSqlUtils::escapeSql)
             } else {
                 "1=1"
             }
@@ -791,7 +790,7 @@ class LogQueryParserIntegrationTest {
             // Uses the production alias pattern: toString(level) AS level_text
             // combined with a WHERE clause that references toString(level) via level:error
             val parsed = parser.parse("level:error")
-            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ::escapeSql)
+            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ClickHouseSqlUtils::escapeSql)
 
             val sql =
                 """
@@ -816,7 +815,7 @@ class LogQueryParserIntegrationTest {
     fun `SELECT toString(source) AS source_text does not conflict with WHERE clause on source`() =
         runBlocking {
             val parsed = parser.parse("source:sdk")
-            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ::escapeSql)
+            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ClickHouseSqlUtils::escapeSql)
 
             val sql =
                 """
@@ -865,7 +864,7 @@ class LogQueryParserIntegrationTest {
             // Reproduce the exact production query shape — uses level_text/source_text aliases
             // to avoid Enum8 column name collision
             val parsed = parser.parse("level:error AND timeout")
-            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ::escapeSql)
+            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ClickHouseSqlUtils::escapeSql)
 
             val sql =
                 """
@@ -898,7 +897,7 @@ class LogQueryParserIntegrationTest {
         runBlocking {
             // Free text "api-gateway" with production SELECT shape
             val parsed = parser.parse("api-gateway")
-            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ::escapeSql)
+            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ClickHouseSqlUtils::escapeSql)
 
             val sql =
                 """
@@ -967,7 +966,7 @@ class LogQueryParserIntegrationTest {
         runBlocking {
             // Verify wildcard field search works with the production SELECT shape
             val parsed = parser.parse("host:server*")
-            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ::escapeSql)
+            val whereCondition = parser.toClickHouseSql(parsed.rootNode!!, ClickHouseSqlUtils::escapeSql)
 
             val sql =
                 """

--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
@@ -19,6 +19,7 @@ package com.moneat.analytics.services
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.analytics.models.EnrichedAnalyticsEvent
+import com.moneat.utils.ClickHouseSqlUtils
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
@@ -151,6 +152,6 @@ class AnalyticsIngestionWorker(
         private const val BRPOP_TIMEOUT = 5L
         private const val ERROR_BACKOFF_MS = 1000L
 
-        fun escapeCH(s: String): String = s.replace("\\", "\\\\").replace("'", "\\'")
+        fun escapeCH(s: String): String = ClickHouseSqlUtils.escapeSql(s)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseMigrations.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseMigrations.kt
@@ -19,6 +19,7 @@ package com.moneat.config
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.server.application.Application
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonObject
@@ -297,10 +298,6 @@ object ClickHouseMigrations {
         val digest = MessageDigest.getInstance("MD5")
         val hash = digest.digest(content.toByteArray())
         return hash.joinToString("") { "%02x".format(it) }
-    }
-
-    private fun escapeSql(text: String): String {
-        return text.replace("\\", "\\\\").replace("'", "\\'")
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestionService.kt
@@ -19,6 +19,7 @@ package com.moneat.datadog.networkdevices
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdNdmPayload
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -337,9 +338,6 @@ object NdmIngestionService {
         }
         return result
     }
-
-    private fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmQueryRoutes.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.networkdevices
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
@@ -302,6 +303,3 @@ private fun JsonObject.s(key: String): String {
         el.toString()
     }
 }
-
-private fun escapeSql(value: String): String =
-    value.replace("\\", "\\\\").replace("'", "\\'")

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogEventQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogEventQueryRoutes.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.routes
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
@@ -260,10 +261,4 @@ private fun kotlinx.serialization.json.JsonObject.s(
     } else {
         el.toString()
     }
-}
-
-private fun escapeSql(value: String): String {
-    return value
-        .replace("\\", "\\\\")
-        .replace("'", "\\'")
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogInfraQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogInfraQueryRoutes.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.routes
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
@@ -341,10 +342,4 @@ private fun JsonObject.s(key: String): String {
     } else {
         el.toString()
     }
-}
-
-private fun escapeSql(value: String): String {
-    return value
-        .replace("\\", "\\\\")
-        .replace("'", "\\'")
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
@@ -21,6 +21,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdActivityDumpPayload
 import com.moneat.datadog.models.DdCompliancePayload
 import com.moneat.datadog.models.DdSecurityEventPayload
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -269,9 +270,6 @@ object SecurityIngestionService {
         }
         return result
     }
-
-    private fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityQueryRoutes.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.security
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
@@ -273,6 +274,3 @@ private fun JsonObject.s(key: String): String {
         el.toString()
     }
 }
-
-private fun escapeSql(value: String): String =
-    value.replace("\\", "\\\\").replace("'", "\\'")

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogEventService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogEventService.kt
@@ -20,6 +20,7 @@ import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DatadogEvent
 import com.moneat.datadog.models.DatadogServiceCheck
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
@@ -247,11 +248,5 @@ object DatadogEventService {
         encoded: String
     ): QueuedServiceCheckBatch {
         return json.decodeFromString(encoded)
-    }
-
-    private fun escapeSql(value: String): String {
-        return value
-            .replace("\\", "\\\\")
-            .replace("'", "\\'")
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogInfraService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogInfraService.kt
@@ -21,6 +21,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DatadogConnectionsPayload
 import com.moneat.datadog.models.DatadogContainerPayload
 import com.moneat.datadog.models.DatadogProcessPayload
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
@@ -349,11 +350,5 @@ object DatadogInfraService {
 
     fun decodeInfraBatch(encoded: String): QueuedInfraBatch {
         return json.decodeFromString(encoded)
-    }
-
-    private fun escapeSql(value: String): String {
-        return value
-            .replace("\\", "\\\\")
-            .replace("'", "\\'")
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
@@ -21,6 +21,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DatadogMetricSeriesV1
 import com.moneat.datadog.models.DatadogMetricV1
 import com.moneat.datadog.models.DatadogSketchPayload
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
@@ -271,11 +272,5 @@ object DatadogMetricService {
             "count" -> "count"
             else -> "gauge"
         }
-    }
-
-    private fun escapeSql(value: String): String {
-        return value
-            .replace("\\", "\\\\")
-            .replace("'", "\\'")
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DbmIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DbmIngestionService.kt
@@ -24,6 +24,7 @@ import com.moneat.datadog.models.DdDbmMetadataPayload
 import com.moneat.datadog.models.DdDbmMetricsPayload
 import com.moneat.datadog.models.DdDbmQueryPayload
 import com.moneat.shared.services.UsageTrackingService
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -417,9 +418,6 @@ object DbmIngestionService {
         }
         return result
     }
-
-    private fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DebuggerIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DebuggerIngestionService.kt
@@ -21,6 +21,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdDebuggerDiagnostic
 import com.moneat.datadog.models.DdDebuggerInput
 import com.moneat.shared.services.UsageTrackingService
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -240,9 +241,6 @@ object DebuggerIngestionService {
         }
         return result
     }
-
-    private fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/datadog/services/MiscIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/MiscIngestionService.kt
@@ -25,6 +25,7 @@ import com.moneat.datadog.models.DdPipelineStatsPayload
 import com.moneat.datadog.models.DdSbomPayload
 import com.moneat.datadog.models.DdSymbolDbPayload
 import com.moneat.datadog.models.DdSyntheticsPayload
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -477,9 +478,6 @@ object MiscIngestionService {
         }
         return result
     }
-
-    private fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/datadog/services/OrchestratorIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/OrchestratorIngestionService.kt
@@ -21,6 +21,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdManifestPayload
 import com.moneat.datadog.models.DdOrchestratorPayload
 import com.moneat.shared.services.UsageTrackingService
+import com.moneat.utils.ClickHouseSqlUtils
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -236,7 +237,7 @@ object OrchestratorIngestionService {
         json.decodeFromString(encoded)
 
     internal fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
+        ClickHouseSqlUtils.escapeSql(value)
 
     internal fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
@@ -22,6 +22,7 @@ import com.moneat.datadog.models.DdProfileListResponse
 import com.moneat.datadog.models.DdProfileResponse
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -475,9 +476,6 @@ object ProfileIngestionService {
             emptyMap()
         }
     }
-
-    private fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -31,6 +31,7 @@ import com.moneat.datadog.models.DdServiceMapEntry
 import com.moneat.datadog.models.DdServiceMapResponse
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -694,9 +695,6 @@ object TraceIngestionService {
         if (element == null || element !is JsonObject) return emptyMap()
         return element.mapValues { it.value.jsonPrimitive.double }
     }
-
-    private fun escapeSql(value: String): String =
-        value.replace("\\", "\\\\").replace("'", "\\'")
 
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -56,6 +56,7 @@ import com.moneat.shared.services.CacheService
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
@@ -2404,10 +2405,6 @@ class DashboardService {
         }
 
         return null
-    }
-
-    private fun escapeSql(value: String): String {
-        return ClickHouseSqlUtils.escapeSql(value)
     }
 
     private suspend fun getProjectRetentionDays(projectId: Long): Int {

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -31,7 +31,7 @@ import com.moneat.shared.models.ProjectKeys
 import com.moneat.shared.models.Projects
 import com.moneat.shared.services.CacheService
 import com.moneat.shared.services.UsageTrackingService
-import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CoroutineScope
@@ -1198,10 +1198,6 @@ class EventService(private val notificationService: NotificationService? = null)
             logger.error(e) { "Failed to store Sentry profile" }
             return false
         }
-    }
-
-    private fun escapeSql(str: String): String {
-        return ClickHouseSqlUtils.escapeSql(str)
     }
 
     private fun fingerprintToArray(fingerprint: List<String>): String {

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogIndexService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogIndexService.kt
@@ -24,6 +24,7 @@ import com.moneat.logs.models.UpdateLogIndexRequest
 import com.moneat.shared.models.LogIndexes
 import com.moneat.shared.services.CacheService
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
@@ -393,11 +394,5 @@ class LogIndexService {
 
     private fun invalidateCache(organizationId: Int) {
         CacheService.invalidate("logindex:active:$organizationId")
-    }
-
-    private fun escapeSql(text: String): String {
-        return text
-            .replace("\\", "\\\\")
-            .replace("'", "\\'")
     }
 }

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
@@ -37,6 +37,7 @@ import com.moneat.logs.models.QueuedLogEntry
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
@@ -1445,10 +1446,6 @@ class LogService {
                     "'${escapeSql(key)}', '${escapeSql(mapValue)}'"
                 }
         return "map($pairs)"
-    }
-
-    private fun escapeSql(value: String?): String {
-        return ClickHouseSqlUtils.escapeSql(value)
     }
 
     private fun buildSimpleSearchCondition(term: String): String {

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
@@ -40,7 +40,7 @@ import com.moneat.shared.models.Hosts
 import com.moneat.shared.models.OrganizationAlertTemplates
 import com.moneat.shared.services.CacheService
 import com.moneat.shared.services.RetentionPolicyService
-import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
@@ -1223,10 +1223,6 @@ class MonitorService {
                     )
                 }
         }
-    }
-
-    private fun escapeSql(value: String): String {
-        return ClickHouseSqlUtils.escapeSql(value)
     }
 
     private fun getTierConfig(organizationId: Int): PricingTierConfigResponse {

--- a/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsRoutes.kt
@@ -18,6 +18,7 @@ package com.moneat.synthetics.routes
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.shared.models.Memberships
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -69,12 +70,6 @@ private fun orgIdsToChCondition(orgIds: List<Int>): String {
 private fun parseLimit(limitParam: String?): Int {
     val limit = limitParam?.toIntOrNull() ?: DEFAULT_LIMIT
     return limit.coerceIn(1, MAX_LIMIT)
-}
-
-private fun escapeSql(value: String): String {
-    return value
-        .replace("\\", "\\\\")
-        .replace("'", "\\'")
 }
 
 private fun snakeToCamel(snake: String): String {

--- a/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsService.kt
+++ b/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsService.kt
@@ -24,6 +24,7 @@ import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Subscriptions
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -444,12 +445,6 @@ class SyntheticsService {
             )
         """.trimIndent()
         ClickHouseClient.execute(sql)
-    }
-
-    private fun escapeSql(value: String): String {
-        return value
-            .replace("\\", "\\\\")
-            .replace("'", "\\'")
     }
 
     private fun resolveGlobalVariables(

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeService.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeService.kt
@@ -28,7 +28,7 @@ import com.moneat.uptime.models.UptimeHeartbeatResponse
 import com.moneat.uptime.models.UptimeMonitorData
 import com.moneat.uptime.models.UptimeMonitorResponse
 import com.moneat.uptime.models.UptimeMonitors
-import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -720,9 +720,5 @@ class UptimeService(
         val bytes = ByteArray(32)
         random.nextBytes(bytes)
         return bytes.joinToString("") { "%02x".format(it) }
-    }
-
-    private fun escapeSql(text: String): String {
-        return ClickHouseSqlUtils.escapeSql(text)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.services
 
 import com.moneat.datadog.models.DdProfileEvent
 import com.moneat.datadog.models.DdProfileEndpoint
+import com.moneat.utils.ClickHouseSqlUtils
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import kotlin.test.assertEquals
@@ -193,19 +194,11 @@ class ProfileIngestionServiceTest {
 
     // ============ SQL ESCAPING TESTS ============
 
-    private val escapeSqlMethod: Method =
-        ProfileIngestionService::class.java
-            .getDeclaredMethod("escapeSql", String::class.java)
-            .also { it.isAccessible = true }
-
-    private fun escapeSql(value: String): String =
-        escapeSqlMethod.invoke(ProfileIngestionService, value) as String
-
     @Test
     fun `escapeSql escapes single quotes`() {
         assertEquals(
             "O\\'Reilly",
-            escapeSql("O'Reilly"),
+            ClickHouseSqlUtils.escapeSql("O'Reilly"),
             "Single quotes should be escaped"
         )
     }
@@ -214,26 +207,26 @@ class ProfileIngestionServiceTest {
     fun `escapeSql escapes backslashes`() {
         assertEquals(
             "C:\\\\Users",
-            escapeSql("C:\\Users"),
+            ClickHouseSqlUtils.escapeSql("C:\\Users"),
             "Backslashes should be escaped"
         )
     }
 
     @Test
     fun `escapeSql handles normal strings unchanged`() {
-        assertEquals("hello world", escapeSql("hello world"))
+        assertEquals("hello world", ClickHouseSqlUtils.escapeSql("hello world"))
     }
 
     @Test
     fun `escapeSql handles empty string`() {
-        assertEquals("", escapeSql(""))
+        assertEquals("", ClickHouseSqlUtils.escapeSql(""))
     }
 
     @Test
     fun `escapeSql handles combined special chars`() {
         assertEquals(
             "it\\'s a \\\\path",
-            escapeSql("it's a \\path")
+            ClickHouseSqlUtils.escapeSql("it's a \\path")
         )
     }
 


### PR DESCRIPTION
## Description

escapeSql was duplicated across the project, this unifies it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated SQL escaping logic across multiple services into a centralized utility function, eliminating code duplication and improving overall maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->