### PR TITLE
fix: allow underscores and hyphens in DSN public keys

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
@@ -290,21 +290,21 @@ fun extractPublicKey(
     val headerKey =
         authHeader?.let { header ->
             // Parse "Sentry sentry_key=xxx, sentry_version=7"
-            val keyRegex = "(?i)sentry_key=([a-z0-9]+)".toRegex()
+            val keyRegex = "(?i)sentry_key=([a-z0-9_-]+)".toRegex()
             keyRegex.find(header)?.groupValues?.get(1)
         }
     if (headerKey != null) return headerKey
 
     // Fallback for SDKs that pass auth in query params:
     // ?sentry_key=xxx&sentry_version=7&sentry_client=...
-    val keyRegex = "^[a-zA-Z0-9]+$".toRegex()
+    val keyRegex = "^[a-zA-Z0-9_-]+$".toRegex()
     return sentryKeyParam?.takeIf { keyRegex.matches(it) }
 }
 
 fun extractPublicKeyFromDsn(dsnLikeHeader: String?): String? {
     if (dsnLikeHeader.isNullOrBlank()) return null
     val cleaned = dsnLikeHeader.removePrefix("DSN ").trim()
-    val regex = "https?://([a-zA-Z0-9]+)@[^/]+/[0-9]+".toRegex(RegexOption.IGNORE_CASE)
+    val regex = "https?://([a-zA-Z0-9_-]+)@[^/]+/[0-9]+".toRegex(RegexOption.IGNORE_CASE)
     return regex.find(cleaned)?.groupValues?.getOrNull(1)
 }
 

--- a/backend/src/test/kotlin/com/moneat/routes/IngestRoutesAuthParsingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IngestRoutesAuthParsingTest.kt
@@ -56,6 +56,37 @@ class IngestRoutesAuthParsingTest {
     }
 
     @Test
+    fun `extractPublicKey reads key with underscores from auth header`() {
+        val key =
+            extractPublicKey(
+                authHeader = "Sentry sentry_key=URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj, sentry_version=7"
+            )
+
+        assertEquals("URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj", key)
+    }
+
+    @Test
+    fun `extractPublicKey reads key with hyphens from auth header`() {
+        val key =
+            extractPublicKey(
+                authHeader = "Sentry sentry_key=abc-def-123, sentry_version=7"
+            )
+
+        assertEquals("abc-def-123", key)
+    }
+
+    @Test
+    fun `extractPublicKey accepts query param with underscores`() {
+        val key =
+            extractPublicKey(
+                authHeader = null,
+                sentryKeyParam = "URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj"
+            )
+
+        assertEquals("URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj", key)
+    }
+
+    @Test
     fun `extractPublicKey rejects invalid query param characters`() {
         val key =
             extractPublicKey(
@@ -70,6 +101,12 @@ class IngestRoutesAuthParsingTest {
     fun `extractPublicKeyFromDsn parses DSN auth header`() {
         val key = extractPublicKeyFromDsn("DSN https://abc123def@o1.ingest.sentry.io/42")
         assertEquals("abc123def", key)
+    }
+
+    @Test
+    fun `extractPublicKeyFromDsn parses DSN with underscores in key`() {
+        val key = extractPublicKeyFromDsn("DSN https://abc_123_def@o1.ingest.sentry.io/42")
+        assertEquals("abc_123_def", key)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/routes/IngestRoutesAuthParsingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IngestRoutesAuthParsingTest.kt
@@ -23,14 +23,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class IngestRoutesAuthParsingTest {
+
+    // ──── extractPublicKey ────
+
+    // ──── Happy path ────
+
     @Test
     fun `extractPublicKey reads sentry key from auth header`() {
         val key =
             extractPublicKey(
-                authHeader = "Sentry sentry_key=b422c0677570443e8ab25450d20b0f0c, sentry_version=7"
+                authHeader = "Sentry sentry_key=abc123def456, sentry_version=7"
             )
 
-        assertEquals("b422c0677570443e8ab25450d20b0f0c", key)
+        assertEquals("abc123def456", key)
     }
 
     @Test
@@ -38,10 +43,10 @@ class IngestRoutesAuthParsingTest {
         val key =
             extractPublicKey(
                 authHeader = null,
-                sentryKeyParam = "b422c0677570443e8ab25450d20b0f0c"
+                sentryKeyParam = "abc123def456"
             )
 
-        assertEquals("b422c0677570443e8ab25450d20b0f0c", key)
+        assertEquals("abc123def456", key)
     }
 
     @Test
@@ -55,24 +60,26 @@ class IngestRoutesAuthParsingTest {
         assertEquals("headerkey123", key)
     }
 
+    // ──── Special characters ────
+
     @Test
     fun `extractPublicKey reads key with underscores from auth header`() {
         val key =
             extractPublicKey(
-                authHeader = "Sentry sentry_key=URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj, sentry_version=7"
+                authHeader = "Sentry sentry_key=test_key_with_underscores_123, sentry_version=7"
             )
 
-        assertEquals("URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj", key)
+        assertEquals("test_key_with_underscores_123", key)
     }
 
     @Test
     fun `extractPublicKey reads key with hyphens from auth header`() {
         val key =
             extractPublicKey(
-                authHeader = "Sentry sentry_key=abc-def-123, sentry_version=7"
+                authHeader = "Sentry sentry_key=test-key-with-hyphens-123, sentry_version=7"
             )
 
-        assertEquals("abc-def-123", key)
+        assertEquals("test-key-with-hyphens-123", key)
     }
 
     @Test
@@ -80,22 +87,28 @@ class IngestRoutesAuthParsingTest {
         val key =
             extractPublicKey(
                 authHeader = null,
-                sentryKeyParam = "URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj"
+                sentryKeyParam = "test_key_with_underscores_123"
             )
 
-        assertEquals("URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj", key)
+        assertEquals("test_key_with_underscores_123", key)
     }
+
+    // ──── Rejection ────
 
     @Test
     fun `extractPublicKey rejects invalid query param characters`() {
         val key =
             extractPublicKey(
                 authHeader = null,
-                sentryKeyParam = "bad-key-123"
+                sentryKeyParam = "bad.key.123"
             )
 
         assertNull(key)
     }
+
+    // ──── extractPublicKeyFromDsn ────
+
+    // ──── Happy path ────
 
     @Test
     fun `extractPublicKeyFromDsn parses DSN auth header`() {
@@ -103,11 +116,21 @@ class IngestRoutesAuthParsingTest {
         assertEquals("abc123def", key)
     }
 
+    // ──── Special characters ────
+
     @Test
     fun `extractPublicKeyFromDsn parses DSN with underscores in key`() {
-        val key = extractPublicKeyFromDsn("DSN https://abc_123_def@o1.ingest.sentry.io/42")
-        assertEquals("abc_123_def", key)
+        val key = extractPublicKeyFromDsn("DSN https://test_key_underscore@o1.ingest.sentry.io/42")
+        assertEquals("test_key_underscore", key)
     }
+
+    @Test
+    fun `extractPublicKeyFromDsn parses DSN with hyphens in key`() {
+        val key = extractPublicKeyFromDsn("DSN https://test-key-hyphens@o1.ingest.sentry.io/42")
+        assertEquals("test-key-hyphens", key)
+    }
+
+    // ──── Rejection ────
 
     @Test
     fun `extractPublicKeyFromDsn returns null for invalid DSN format`() {


### PR DESCRIPTION
## Summary

- The regex patterns in `extractPublicKey` and `extractPublicKeyFromDsn` only matched `[a-z0-9]`, causing project keys containing underscores or hyphens to silently fail authentication with a `401 "Invalid DSN"` response
- The key generation flow can produce keys with underscores (via base64 encoding), but the ingestion auth parser rejected them
- Updated all three regex patterns in `IngestRoutes.kt` to include `_` and `-` in the character class
- Added tests for keys containing underscores and hyphens

## Reproduction

1. Create a project — if the generated `public_key` contains `_` (e.g. `URkP8i_m9_fR0rI087QrK1NMYQP8BbHelMCKUDHj`), all SDK ingestion fails
2. SDK sends `X-Sentry-Auth: Sentry sentry_key=URkP8i_m9_..., sentry_version=7`
3. `extractPublicKey` regex `([a-z0-9]+)` stops matching at the first `_`, returning a truncated key
4. `verifyProjectKey` lookup fails → 401

## Test plan

- [ ] Existing `IngestRoutesAuthParsingTest` tests still pass
- [ ] New tests verify keys with underscores and hyphens are correctly extracted
- [ ] Manual test: send envelope with underscore-containing DSN key → 202 accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Public key parsing now accepts underscores and hyphens, improving compatibility for keys supplied via headers, query parameters, and DSNs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->