### PR TITLE
fix: suppress Datadog SDK console warnings on self-hosted deployments

### DIFF
--- a/dashboard/src/lib/__tests__/datadog.test.ts
+++ b/dashboard/src/lib/__tests__/datadog.test.ts
@@ -69,6 +69,45 @@ describe('initDatadog', () => {
     expect(rumCall.env).toBe('staging')
   })
 
+  it('skips init when applicationId is empty', async () => {
+    const {datadogRum} = await import('@datadog/browser-rum')
+    const {datadogLogs} = await import('@datadog/browser-logs')
+
+    initDatadog({
+      applicationId: '',
+      clientToken: 'tok-456',
+    })
+
+    expect(datadogRum.init).not.toHaveBeenCalled()
+    expect(datadogLogs.init).not.toHaveBeenCalled()
+  })
+
+  it('skips init when clientToken is empty', async () => {
+    const {datadogRum} = await import('@datadog/browser-rum')
+    const {datadogLogs} = await import('@datadog/browser-logs')
+
+    initDatadog({
+      applicationId: 'app-123',
+      clientToken: '',
+    })
+
+    expect(datadogRum.init).not.toHaveBeenCalled()
+    expect(datadogLogs.init).not.toHaveBeenCalled()
+  })
+
+  it('skips init when values are unreplaced placeholders', async () => {
+    const {datadogRum} = await import('@datadog/browser-rum')
+    const {datadogLogs} = await import('@datadog/browser-logs')
+
+    initDatadog({
+      applicationId: '__MONEAT_DD_APPLICATION_ID__',
+      clientToken: '__MONEAT_DD_CLIENT_TOKEN__',
+    })
+
+    expect(datadogRum.init).not.toHaveBeenCalled()
+    expect(datadogLogs.init).not.toHaveBeenCalled()
+  })
+
   it('uses explicit proxyUrl over backendUrl', async () => {
     const {datadogRum} = await import('@datadog/browser-rum')
 

--- a/dashboard/src/lib/__tests__/datadog.test.ts
+++ b/dashboard/src/lib/__tests__/datadog.test.ts
@@ -69,40 +69,15 @@ describe('initDatadog', () => {
     expect(rumCall.env).toBe('staging')
   })
 
-  it('skips init when applicationId is empty', async () => {
+  it.each([
+    {desc: 'applicationId is empty', applicationId: '', clientToken: 'tok-456'},
+    {desc: 'clientToken is empty', applicationId: 'app-123', clientToken: ''},
+    {desc: 'values are unreplaced placeholders', applicationId: '__MONEAT_DD_APPLICATION_ID__', clientToken: '__MONEAT_DD_CLIENT_TOKEN__'},
+  ])('skips init when $desc', async ({applicationId, clientToken}) => {
     const {datadogRum} = await import('@datadog/browser-rum')
     const {datadogLogs} = await import('@datadog/browser-logs')
 
-    initDatadog({
-      applicationId: '',
-      clientToken: 'tok-456',
-    })
-
-    expect(datadogRum.init).not.toHaveBeenCalled()
-    expect(datadogLogs.init).not.toHaveBeenCalled()
-  })
-
-  it('skips init when clientToken is empty', async () => {
-    const {datadogRum} = await import('@datadog/browser-rum')
-    const {datadogLogs} = await import('@datadog/browser-logs')
-
-    initDatadog({
-      applicationId: 'app-123',
-      clientToken: '',
-    })
-
-    expect(datadogRum.init).not.toHaveBeenCalled()
-    expect(datadogLogs.init).not.toHaveBeenCalled()
-  })
-
-  it('skips init when values are unreplaced placeholders', async () => {
-    const {datadogRum} = await import('@datadog/browser-rum')
-    const {datadogLogs} = await import('@datadog/browser-logs')
-
-    initDatadog({
-      applicationId: '__MONEAT_DD_APPLICATION_ID__',
-      clientToken: '__MONEAT_DD_CLIENT_TOKEN__',
-    })
+    initDatadog({applicationId, clientToken})
 
     expect(datadogRum.init).not.toHaveBeenCalled()
     expect(datadogLogs.init).not.toHaveBeenCalled()

--- a/dashboard/src/lib/datadog.ts
+++ b/dashboard/src/lib/datadog.ts
@@ -19,7 +19,17 @@ function joinUrl(base: string, path: string): string {
   return base.replace(/\/+$/, '') + '/' + path.replace(/^\/+/, '')
 }
 
+function isConfigured(value: string | undefined): value is string {
+  if (!value || !value.trim()) return false
+  if (value.startsWith('__') && value.endsWith('__')) return false
+  return true
+}
+
 export function initDatadog(options: DatadogInitOptions): void {
+  if (!isConfigured(options.applicationId) || !isConfigured(options.clientToken)) {
+    return
+  }
+
   const ddProxyUrl = resolveProxyUrl(options.proxyUrl, options.backendUrl)
   const service = options.service || 'moneat-dashboard'
   const env = options.env || 'production'


### PR DESCRIPTION
## Summary
- Add runtime `isConfigured()` guard in `initDatadog()` that rejects empty strings, whitespace, and unreplaced Docker placeholders (`__MONEAT_DD_*__`)
- Prevents `datadogRum.init` / `datadogLogs.init` from being called with invalid credentials, eliminating noisy console warnings for self-hosted users
- No changes to Dockerfile, entrypoint, or `main.tsx` — the build-time guard remains useful for local dev; the new runtime guard handles Docker builds

## Root cause
Vite inlines `import.meta.env.VITE_DD_*` at build time. In Docker builds, these are placeholder strings (always truthy), so the `if` guard in `main.tsx` is optimized away. At runtime, `sed` replaces placeholders with actual values (empty if unset), but `datadogRum.init({applicationId: "", clientToken: ""})` still runs and warns.

## Test plan
- [x] `npx vitest run src/lib/__tests__/datadog.test.ts` — 9/9 pass
- [ ] Verify on self-hosted deployment: no DD warnings in console when env vars are unset
- [ ] Verify on configured deployment: Datadog RUM + Logs initialize normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analytics service initialization validation to skip setup when configuration values are empty, whitespace-only, or contain placeholder strings, preventing initialization errors.

* **Tests**
  * Added test coverage for analytics initialization validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->