### PR TITLE
fix: crash-free user stats

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
@@ -791,7 +791,7 @@ class EmailService {
                           </td>
                           <td style="width:33%;">
                             <p style="margin:0;margin-bottom:0.25rem;font-size:0.75rem;font-weight:500;color:#737373;">Crash-Free</p>
-                            <p style="margin:0;font-size:1.125rem;font-weight:700;color:#16a34a;">${project.crashFree.escapeHtml()}%</p>
+                            <p style="margin:0;font-size:1.125rem;font-weight:700;color:#16a34a;">${project.crashFree.escapeHtml()}</p>
                           </td>
                         </tr>
                       </table>

--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -374,11 +374,12 @@ class NotificationService(
         val projectSummaries =
             projects.map { (projectId, projectName) ->
                 val stats = getStatsForPeriod(listOf(projectId), startDate, endDate)
+                val crashFreeRate = getCrashFreeRate(projectId, startDate, endDate)
                 EmailService.ProjectSummary(
                     name = projectName,
                     events = formatNumber(stats.totalEvents),
                     issues = formatNumber(stats.uniqueIssues),
-                    crashFree = "99.5" // TODO: Calculate actual crash-free rate
+                    crashFree = crashFreeRate?.let { "%.1f%%".format(it) } ?: "N/A"
                 )
             }
 
@@ -444,6 +445,38 @@ class NotificationService(
             uniqueIssues = data?.get("unique_issues")?.jsonPrimitive?.longOrNull ?: 0,
             uniqueUsers = data?.get("unique_users")?.jsonPrimitive?.longOrNull ?: 0
         )
+    }
+
+    private suspend fun getCrashFreeRate(
+        projectId: Long,
+        startDate: Instant,
+        endDate: Instant
+    ): Double? {
+        val startMs = startDate.toEpochMilli()
+        val endMs = endDate.toEpochMilli()
+
+        val query =
+            """
+            SELECT countIf(errors = 0) * 100.0 / count() as rate
+            FROM `$clickhouseDb`.sessions
+            WHERE project_id = $projectId
+              AND started >= fromUnixTimestamp64Milli($startMs)
+              AND started < fromUnixTimestamp64Milli($endMs)
+            FORMAT JSON
+            """.trimIndent()
+
+        return try {
+            val response = ClickHouseClient.execute(query)
+            val responseBody = response.bodyAsText()
+            if (!response.status.isSuccess()) return null
+            val jsonResponse = Json.parseToJsonElement(responseBody).jsonObject
+            val data = jsonResponse["data"]?.jsonArray?.firstOrNull()?.jsonObject
+            val rate = data?.get("rate")?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()
+            if (rate == null || rate.isNaN() || rate.isInfinite()) null else rate
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to get crash-free rate for project $projectId" }
+            null
+        }
     }
 
     private suspend fun getTopIssues(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "rrd",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description

Fix crash-free users stats.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Weekly email summaries now compute and display accurate crash-free rates for each project based on recent performance data, replacing placeholder values.
  * Shows "N/A" when crash-free rate data is unavailable or fails to retrieve.
  * Updated crash-free metric display formatting in weekly email summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->