### PR TITLE
fix: compute real crash-free rate in weekly summary emails

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -25,6 +25,7 @@ import com.moneat.shared.models.Users
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.server.config.ApplicationConfig
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -473,6 +474,8 @@ class NotificationService(
             val data = jsonResponse["data"]?.jsonArray?.firstOrNull()?.jsonObject
             val rate = data?.get("rate")?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()
             if (rate == null || rate.isNaN() || rate.isInfinite()) null else rate
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.warn(e) { "Failed to get crash-free rate for project $projectId" }
             null

--- a/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
@@ -43,11 +43,12 @@ class NotificationFormattingTest {
         private const val MONITOR_DOWN = "Monitor Down"
         private const val MONITOR_RECOVERED = "Monitor Recovered"
         private const val SETTINGS_NOTIFICATIONS_URL = "https://app.moneat.io/settings/notifications"
+        private const val CRASH_FREE_NOT_AVAILABLE = "N/A"
     }
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    // ── Slack data class serialization ──────────────────────────────────
+    // ──── Slack data class serialization ────
 
     @Test
     fun `SlackBlock with header type serializes correctly`() {
@@ -102,7 +103,7 @@ class NotificationFormattingTest {
         assertEquals(1, elements?.size)
         assertEquals("button", elements?.get(0)?.jsonObject?.get("type")?.jsonPrimitive?.content)
         assertEquals(
-            "https://app.moneat.io/issues/1",
+            ISSUES_1_URL,
             elements?.get(0)?.jsonObject?.get("url")?.jsonPrimitive?.content
         )
     }
@@ -285,7 +286,7 @@ class NotificationFormattingTest {
         assertEquals("button", obj["accessory"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
     }
 
-    // ── Discord data class serialization ────────────────────────────────
+    // ──── Discord data class serialization ────
 
     @Test
     fun `DiscordEmbed serializes with all fields`() {
@@ -429,7 +430,7 @@ class NotificationFormattingTest {
         assertEquals(2, channel.type)
     }
 
-    // ── Discord color mapping for alert types ───────────────────────────
+    // ──── Discord color mapping for alert types ────
 
     @Test
     fun `Discord error color matches expected hex value`() {
@@ -449,7 +450,7 @@ class NotificationFormattingTest {
         assertEquals(0x2EB67D, embed.color)
     }
 
-    // ── Slack full message construction patterns ────────────────────────
+    // ──── Slack full message construction patterns ────
 
     @Test
     fun `Slack host alert message structure has header and attachment`() {
@@ -540,7 +541,7 @@ class NotificationFormattingTest {
         assertTrue(text.contains("Main.kt:10"))
     }
 
-    // ── Discord full embed construction patterns ────────────────────────
+    // ──── Discord full embed construction patterns ────
 
     @Test
     fun `Discord uptime down embed has correct structure`() {
@@ -614,7 +615,7 @@ class NotificationFormattingTest {
         )
     }
 
-    // ── Round-trip deserialization tests ─────────────────────────────────
+    // ──── Round-trip deserialization tests ────
 
     @Test
     fun `Slack message round-trips through serialization`() {
@@ -678,7 +679,7 @@ class NotificationFormattingTest {
         assertEquals("E2", decoded.embeds?.get(1)?.title)
     }
 
-    // ── Slack severity/color mapping (mirrors SlackService logic) ───────
+    // ──── Slack severity/color mapping (mirrors SlackService logic) ────
 
     @Test
     fun `Slack error alert level determines emoji and color`() {
@@ -741,7 +742,7 @@ class NotificationFormattingTest {
         assertEquals(COLOR_ECB22E, medColor)
     }
 
-    // ── Discord severity color mapping for dashboard alerts ─────────────
+    // ──── Discord severity color mapping for dashboard alerts ────
 
     @Test
     fun `Discord dashboard alert severity determines color`() {
@@ -762,7 +763,7 @@ class NotificationFormattingTest {
         assertEquals(0xECB22E, lowColor)
     }
 
-    // ── Slack uptime alert direction logic ──────────────────────────────
+    // ──── Slack uptime alert direction logic ────
 
     @Test
     fun `Slack uptime alert direction determines emoji and header`() {
@@ -780,7 +781,7 @@ class NotificationFormattingTest {
         assertEquals(MONITOR_RECOVERED, if (isUp) MONITOR_DOWN else MONITOR_RECOVERED)
     }
 
-    // ── EmailService data class construction ────────────────────────────
+    // ──── EmailService data class construction ────
 
     @Test
     fun `ErrorAlertData holds all fields correctly`() {
@@ -868,5 +869,16 @@ class NotificationFormattingTest {
         )
         assertEquals("Frontend", summary.name)
         assertEquals("99.9%", summary.crashFree)
+    }
+
+    @Test
+    fun `ProjectSummary crashFree can be not available placeholder`() {
+        val summary = com.moneat.notifications.services.EmailService.ProjectSummary(
+            name = "Backend",
+            events = "0",
+            issues = "0",
+            crashFree = CRASH_FREE_NOT_AVAILABLE
+        )
+        assertEquals(CRASH_FREE_NOT_AVAILABLE, summary.crashFree)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
@@ -830,7 +830,7 @@ class NotificationFormattingTest {
                     name = "Backend",
                     events = "1.0K",
                     issues = "30",
-                    crashFree = "99.5"
+                    crashFree = "99.5%"
                 )
             ),
             dashboardUrl = "https://app.moneat.io",
@@ -844,6 +844,7 @@ class NotificationFormattingTest {
         assertEquals("NPE", data.topIssues[0].title)
         assertEquals(1, data.projects.size)
         assertEquals("Backend", data.projects[0].name)
+        assertEquals("99.5%", data.projects[0].crashFree)
     }
 
     @Test
@@ -863,9 +864,9 @@ class NotificationFormattingTest {
             name = "Frontend",
             events = "500",
             issues = "10",
-            crashFree = "99.9"
+            crashFree = "99.9%"
         )
         assertEquals("Frontend", summary.name)
-        assertEquals("99.9", summary.crashFree)
+        assertEquals("99.9%", summary.crashFree)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -1,0 +1,211 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.services
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.notifications.services.DiscordService
+import com.moneat.notifications.services.EmailService
+import com.moneat.notifications.services.NotificationService
+import com.moneat.notifications.services.SlackService
+import com.moneat.shared.models.AlertNotificationPreferences
+import com.moneat.shared.models.EmailsSent
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.NotificationPreferences
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
+import com.moneat.shared.models.Users
+import com.moneat.testsupport.MockHttpServer
+import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.testsupport.requestBodyText
+import com.moneat.testsupport.respond
+import com.sun.net.httpserver.HttpExchange
+import io.mockk.clearMocks
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NotificationServiceWeeklySummaryTest {
+    companion object {
+        private var db: Database? = null
+        private const val TEXT_PLAIN = "text/plain"
+        private const val MOCK_CRASH_FREE_RATE = 88.25
+        private const val STATS_TOTAL_EVENTS = 100L
+        private const val STATS_UNIQUE_ISSUES = 4L
+        private const val STATS_UNIQUE_USERS = 20L
+    }
+
+    private val emailService = mockk<EmailService>(relaxed = true)
+    private val slackService = mockk<SlackService>(relaxed = true)
+    private val discordService = mockk<DiscordService>(relaxed = true)
+
+    @BeforeTest
+    fun setupDatabase() {
+        clearMocks(emailService, slackService, discordService)
+
+        if (db == null) {
+            db = Database.connect(
+                url =
+                "jdbc:h2:mem:moneat_weekly_summary;" +
+                    "DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.defaultDatabase = db
+
+        TestDatabaseHelper.resetSchema(
+            Users,
+            Organizations,
+            Memberships,
+            Projects,
+            NotificationPreferences,
+            EmailsSent,
+            AlertNotificationPreferences
+        )
+    }
+
+    private fun seedOrg(name: String = "Weekly Org"): Int =
+        transaction {
+            Organizations.insert {
+                it[Organizations.name] = name
+                it[slug] = name.lowercase().replace(" ", "-")
+            } get Organizations.id
+        }
+
+    private fun seedUser(email: String = "weekly@moneat.io", name: String = "Weekly User"): Int =
+        transaction {
+            Users.insert {
+                it[Users.email] = email
+                it[password_hash] = "hash"
+                it[Users.name] = name
+                it[email_verified] = true
+            } get Users.id
+        }
+
+    private fun seedMembership(userId: Int, orgId: Int) {
+        transaction {
+            Memberships.insert {
+                it[user_id] = userId
+                it[organization_id] = orgId
+                it[role] = "owner"
+            }
+        }
+    }
+
+    private fun seedProject(orgId: Int, name: String = "WeeklyProject"): Long =
+        transaction {
+            Projects.insert {
+                it[organization_id] = orgId
+                it[Projects.name] = name
+                it[slug] = name.lowercase().replace(" ", "-")
+            } get Projects.id
+        }
+
+    private fun weeklySummaryClickHouseHandler(
+        sessionsJson: String,
+        sessionsStatus: Int = 200
+    ): (HttpExchange) -> Unit =
+        { exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("countIf(errors = 0)") -> {
+                    exchange.respond(sessionsStatus, sessionsJson, TEXT_PLAIN)
+                }
+                query.contains("any(message) as title") -> {
+                    exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                }
+                else -> {
+                    val body =
+                        """
+                        {"data":[{
+                            "total_events":$STATS_TOTAL_EVENTS,
+                            "unique_issues":$STATS_UNIQUE_ISSUES,
+                            "unique_users":$STATS_UNIQUE_USERS
+                        }]}
+                        """.trimIndent().replace("\n", "")
+                    exchange.respond(200, body, TEXT_PLAIN)
+                }
+            }
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser includes crash-free rate from sessions query`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser("weeklyuser@moneat.io", "Weekly User")
+            seedMembership(userId, orgId)
+            seedProject(orgId, "P1")
+
+            val sessionsBody = """{"data":[{"rate":$MOCK_CRASH_FREE_RATE}]}"""
+
+            MockHttpServer(weeklySummaryClickHouseHandler(sessionsBody)).use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+                val service = NotificationService(emailService, slackService, discordService)
+                try {
+                    service.sendWeeklySummaryForUser(userId, "weeklyuser@moneat.io")
+                } finally {
+                    service.shutdown()
+                    ClickHouseClient.close()
+                }
+            }
+
+            val dataSlot = slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail("weeklyuser@moneat.io", capture(dataSlot))
+            }
+            assertEquals(1, dataSlot.captured.projects.size)
+            assertEquals(
+                "%.1f%%".format(MOCK_CRASH_FREE_RATE),
+                dataSlot.captured.projects.single().crashFree
+            )
+            assertEquals(STATS_TOTAL_EVENTS.toString(), dataSlot.captured.totalEvents)
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser shows N-A when crash-free query fails`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser("weeklyuser2@moneat.io", "Weekly User 2")
+            seedMembership(userId, orgId)
+            seedProject(orgId, "P2")
+
+            MockHttpServer(weeklySummaryClickHouseHandler("", sessionsStatus = 500)).use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+                val service = NotificationService(emailService, slackService, discordService)
+                try {
+                    service.sendWeeklySummaryForUser(userId, "weeklyuser2@moneat.io")
+                } finally {
+                    service.shutdown()
+                    ClickHouseClient.close()
+                }
+            }
+
+            val dataSlot = slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail("weeklyuser2@moneat.io", capture(dataSlot))
+            }
+            assertEquals("N/A", dataSlot.captured.projects.single().crashFree)
+        }
+}

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -46,6 +46,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class NotificationServiceWeeklySummaryTest {
+    // ──── Constants & Mocks ────
     companion object {
         private var db: Database? = null
         private const val TEXT_PLAIN = "text/plain"
@@ -59,6 +60,7 @@ class NotificationServiceWeeklySummaryTest {
     private val slackService = mockk<SlackService>(relaxed = true)
     private val discordService = mockk<DiscordService>(relaxed = true)
 
+    // ──── Setup & Helpers ────
     @BeforeTest
     fun setupDatabase() {
         clearMocks(emailService, slackService, discordService)
@@ -121,6 +123,7 @@ class NotificationServiceWeeklySummaryTest {
             } get Projects.id
         }
 
+    // ──── HTTP Handlers ────
     private fun weeklySummaryClickHouseHandler(
         sessionsJson: String,
         sessionsStatus: Int = 200
@@ -148,6 +151,7 @@ class NotificationServiceWeeklySummaryTest {
             }
         }
 
+    // ──── Test Cases ────
     @Test
     fun `sendWeeklySummaryForUser includes crash-free rate from sessions query`() =
         runBlocking {


### PR DESCRIPTION
Closes #271

_Automated by moneat-agent._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crash-free metrics in weekly email summaries now include percent signs (e.g., "99.5%") for clearer readability.
  * Unavailable crash-free values are preserved and shown as "N/A" where appropriate.

* **Tests**
  * Added tests verifying percent-formatted crash-free rates and the "N/A" placeholder.
  * Added end-to-end-style tests for weekly summary generation covering both successful and failed data queries; minor non-functional comment updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->