### PR TITLE
chore: enable detekt rule: ImplicitDefaultLocale

### DIFF
--- a/backend/detekt.yml
+++ b/backend/detekt.yml
@@ -84,7 +84,7 @@ empty-blocks:
 
 potential-bugs:
   ImplicitDefaultLocale:
-    active: false
+    active: true
 
 formatting:
   ImportOrdering:

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -57,6 +57,7 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import java.util.Locale
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -1213,15 +1214,15 @@ class MonitorAlertService(
     ): String {
         return when (metric) {
             "cpu_percent", "mem_percent", "disk_percent", "gpu_percent", "battery_percent" -> {
-                String.format("%.1f%%", value)
+                String.format(Locale.US, "%.1f%%", value)
             }
 
             "temp_max" -> {
-                String.format("%.1f°C", value)
+                String.format(Locale.US, "%.1f°C", value)
             }
 
             "load_1", "load_5", "load_15" -> {
-                String.format("%.2f", value)
+                String.format(Locale.US, "%.2f", value)
             }
 
             else -> {

--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -50,6 +50,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -640,8 +641,8 @@ class NotificationService(
 
     private fun formatNumber(num: Long): String {
         return when {
-            num >= 1_000_000 -> String.format("%.1fM", num / 1_000_000.0)
-            num >= 1_000 -> String.format("%.1fK", num / 1_000.0)
+            num >= 1_000_000 -> String.format(Locale.US, "%.1fM", num / 1_000_000.0)
+            num >= 1_000 -> String.format(Locale.US, "%.1fK", num / 1_000.0)
             else -> num.toString()
         }
     }

--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -381,7 +381,7 @@ class NotificationService(
                     name = projectName,
                     events = formatNumber(stats.totalEvents),
                     issues = formatNumber(stats.uniqueIssues),
-                    crashFree = crashFreeRate?.let { "%.1f%%".format(it) } ?: "N/A"
+                    crashFree = crashFreeRate?.let { String.format(Locale.US, "%.1f%%", it) } ?: "N/A"
                 )
             }
 
@@ -650,7 +650,7 @@ class NotificationService(
     private fun formatTimestamp(timestamp: String): String {
         return try {
             val instant = Instant.parse(timestamp)
-            val formatter = DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm 'UTC'")
+            val formatter = DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm 'UTC'", Locale.US)
             formatter.format(instant.atZone(ZoneId.of("UTC")))
         } catch (e: Exception) {
             timestamp
@@ -658,7 +658,7 @@ class NotificationService(
     }
 
     private fun formatDate(instant: Instant): String {
-        val formatter = DateTimeFormatter.ofPattern("MMM dd, yyyy")
+        val formatter = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.US)
         return formatter.format(instant.atZone(ZoneId.of("UTC")))
     }
 


### PR DESCRIPTION
Closes #308

_Automated by auto-agent._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent number, metric, date and time formatting now uses a standardized locale so decimals, percent signs and month representations display reliably across locales.

* **Chores**
  * Static analysis configuration updated to enable the locale-consistency rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->