### PR TITLE
Enable detekt rule: ConstructorParameterNaming

### DIFF
--- a/backend/detekt.yml
+++ b/backend/detekt.yml
@@ -93,7 +93,7 @@ naming:
   MatchingDeclarationName:
     active: true
   ConstructorParameterNaming:
-    active: false
+    active: true
   FunctionNaming:
     active: true
     excludes:

--- a/backend/src/main/kotlin/com/moneat/ai/AiModels.kt
+++ b/backend/src/main/kotlin/com/moneat/ai/AiModels.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.ai
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.datetime.timestamp
@@ -99,9 +100,9 @@ data class AiResponse(
     val message: String = "",
     val actions: List<AiAction> = emptyList(),
     val clarifications: List<AiClarification> = emptyList(),
-    val data_queries: List<AiDataQuery> = emptyList(),
+    @SerialName("data_queries") val dataQueries: List<AiDataQuery> = emptyList(),
     val links: List<AiLink> = emptyList(),
-    val context_needed: List<String> = emptyList()
+    @SerialName("context_needed") val contextNeeded: List<String> = emptyList()
 )
 
 @Serializable
@@ -166,9 +167,9 @@ data class ActionResult(
 data class OpenAiChatRequest(
     val model: String,
     val messages: List<OpenAiMessage>,
-    val max_tokens: Int = 2048,
+    @SerialName("max_tokens") val maxTokens: Int = 2048,
     val temperature: Double = 0.3,
-    val response_format: OpenAiResponseFormat? = null
+    @SerialName("response_format") val responseFormat: OpenAiResponseFormat? = null
 )
 
 @Serializable
@@ -192,12 +193,12 @@ data class OpenAiChatResponse(
 @Serializable
 data class OpenAiChoice(
     val message: OpenAiMessage,
-    val finish_reason: String? = null
+    @SerialName("finish_reason") val finishReason: String? = null
 )
 
 @Serializable
 data class OpenAiUsage(
-    val prompt_tokens: Int = 0,
-    val completion_tokens: Int = 0,
-    val total_tokens: Int = 0
+    @SerialName("prompt_tokens") val promptTokens: Int = 0,
+    @SerialName("completion_tokens") val completionTokens: Int = 0,
+    @SerialName("total_tokens") val totalTokens: Int = 0
 )

--- a/backend/src/main/kotlin/com/moneat/ai/OpenAiClient.kt
+++ b/backend/src/main/kotlin/com/moneat/ai/OpenAiClient.kt
@@ -77,9 +77,9 @@ object OpenAiClient {
             OpenAiChatRequest(
                 model = model,
                 messages = messages,
-                max_tokens = maxTokens,
+                maxTokens = maxTokens,
                 temperature = 0.3,
-                response_format = OpenAiResponseFormat(type = "json_object")
+                responseFormat = OpenAiResponseFormat(type = "json_object")
             )
 
         val response =

--- a/backend/src/main/kotlin/com/moneat/auth/services/OAuthService.kt
+++ b/backend/src/main/kotlin/com/moneat/auth/services/OAuthService.kt
@@ -37,6 +37,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.encodeURLParameter
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.config.ApplicationConfig
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
@@ -57,8 +58,8 @@ private val logger = KotlinLogging.logger {}
 
 @Serializable
 data class GitHubAccessTokenResponse(
-    val access_token: String,
-    val token_type: String,
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String,
     val scope: String
 )
 
@@ -181,7 +182,7 @@ class OAuthService {
         }
 
         val tokenData: GitHubAccessTokenResponse = tokenResponse.body()
-        val accessToken = tokenData.access_token
+        val accessToken = tokenData.accessToken
 
         // Fetch user info
         val userResponse: HttpResponse =

--- a/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
@@ -17,6 +17,7 @@
 package com.moneat.events.models
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -249,7 +250,7 @@ data class EnvelopeItem(
 
 @Serializable
 data class SentryEvent(
-    val event_id: String? = null,
+    @SerialName("event_id") val eventId: String? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
     val timestamp: Double? = null,
     val level: String? = null,
@@ -269,7 +270,7 @@ data class SentryEvent(
     val breadcrumbs: JsonArray? = null,
     val request: JsonObject? = null,
     val fingerprint: List<String>? = null,
-    val server_name: String? = null,
+    @SerialName("server_name") val serverName: String? = null,
     val threads: JsonObject? = null
 )
 
@@ -377,11 +378,11 @@ object FlexibleTimestampSerializer : KSerializer<Double?> {
 
 @Serializable
 data class SentryTransaction(
-    val event_id: String? = null,
+    @SerialName("event_id") val eventId: String? = null,
     val type: String? = null,
     val transaction: String? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
-    val start_timestamp: Double? = null,
+    @SerialName("start_timestamp") val startTimestamp: Double? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
     val timestamp: Double? = null,
     val platform: String? = null,
@@ -393,7 +394,7 @@ data class SentryTransaction(
     val contexts: JsonObject? = null,
     val spans: List<SentrySpan>? = null,
     val sdk: SdkInfo? = null,
-    val server_name: String? = null,
+    @SerialName("server_name") val serverName: String? = null,
     val request: JsonObject? = null,
     @Serializable(with = BreadcrumbsSerializer::class)
     val breadcrumbs: JsonArray? = null,
@@ -402,13 +403,13 @@ data class SentryTransaction(
 
 @Serializable
 data class SentrySpan(
-    val span_id: String? = null,
-    val parent_span_id: String? = null,
-    val trace_id: String? = null,
+    @SerialName("span_id") val spanId: String? = null,
+    @SerialName("parent_span_id") val parentSpanId: String? = null,
+    @SerialName("trace_id") val traceId: String? = null,
     val op: String? = null,
     val description: String? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
-    val start_timestamp: Double? = null,
+    @SerialName("start_timestamp") val startTimestamp: Double? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
     val timestamp: Double? = null,
     val status: String? = null,
@@ -447,11 +448,11 @@ data class StackFrame(
     val module: String? = null,
     val lineno: Int? = null,
     val colno: Int? = null,
-    val abs_path: String? = null,
-    val context_line: String? = null,
-    val pre_context: List<String>? = null,
-    val post_context: List<String>? = null,
-    val in_app: Boolean? = null,
+    @SerialName("abs_path") val absPath: String? = null,
+    @SerialName("context_line") val contextLine: String? = null,
+    @SerialName("pre_context") val preContext: List<String>? = null,
+    @SerialName("post_context") val postContext: List<String>? = null,
+    @SerialName("in_app") val inApp: Boolean? = null,
     val vars: JsonObject? = null
 )
 
@@ -460,20 +461,20 @@ data class UserInfo(
     val id: String? = null,
     val email: String? = null,
     val username: String? = null,
-    val ip_address: String? = null
+    @SerialName("ip_address") val ipAddress: String? = null
 )
 
 @Serializable
 data class SentryReplayEvent(
-    val replay_id: String? = null,
-    val segment_id: Int? = null,
+    @SerialName("replay_id") val replayId: String? = null,
+    @SerialName("segment_id") val segmentId: Int? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
     val timestamp: Double? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
-    val replay_start_timestamp: Double? = null,
+    @SerialName("replay_start_timestamp") val replayStartTimestamp: Double? = null,
     val urls: List<String>? = null,
-    val error_ids: List<String>? = null,
-    val trace_ids: List<String>? = null,
+    @SerialName("error_ids") val errorIds: List<String>? = null,
+    @SerialName("trace_ids") val traceIds: List<String>? = null,
     val platform: String? = null,
     val environment: String? = null,
     val release: String? = null,
@@ -481,12 +482,12 @@ data class SentryReplayEvent(
     val contexts: JsonObject? = null,
     val sdk: SdkInfo? = null,
     val tags: Map<String, String>? = null,
-    val replay_type: String? = null
+    @SerialName("replay_type") val replayType: String? = null
 )
 
 @Serializable
 data class SentryFeedback(
-    val event_id: String? = null,
+    @SerialName("event_id") val eventId: String? = null,
     val timestamp: String? = null,
     val platform: String? = null,
     val level: String? = null,

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
@@ -194,7 +194,7 @@ class DashboardQueryHelper(
         val userEmail = obj["user_email"]?.jsonPrimitive?.contentOrNull
         val userUsername = obj["user_username"]?.jsonPrimitive?.contentOrNull
         return if (userId != null || userEmail != null || userUsername != null) {
-            UserInfo(id = userId, email = userEmail, username = userUsername, ip_address = null)
+            UserInfo(id = userId, email = userEmail, username = userUsername, ipAddress = null)
         } else {
             null
         }

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -173,8 +173,8 @@ class EventService(
 
                 "replay_event" -> {
                     val replayEvent = parseReplayEventPayload(item.payload)
-                    lastReplayId = replayEvent.replay_id
-                    lastSegmentId = replayEvent.segment_id ?: 0
+                    lastReplayId = replayEvent.replayId
+                    lastSegmentId = replayEvent.segmentId ?: 0
                     if (storeReplayEvent(projectId, replayEvent)) {
                         recordUsage(projectId, "replay", item)
                     }
@@ -284,7 +284,7 @@ class EventService(
         projectId: Long,
         transaction: SentryTransaction
     ): Boolean {
-        val rawEventId = transaction.event_id ?: UUID.randomUUID().toString()
+        val rawEventId = transaction.eventId ?: UUID.randomUUID().toString()
         val eventId = normalizeUuid(rawEventId)
         val traceContext = transaction.contexts?.get("trace") as? JsonObject
         val traceId = traceContext?.get("trace_id")?.jsonPrimitive?.contentOrNull ?: ""
@@ -293,7 +293,7 @@ class EventService(
         val transactionLevel = if (traceStatus == null || traceStatus == "ok") "info" else "error"
 
         val endTimestampMs = unixSecondsToMillis(transaction.timestamp ?: (System.currentTimeMillis() / MS_PER_SECOND))
-        val durationMs = durationMs(transaction.start_timestamp, transaction.timestamp)
+        val durationMs = durationMs(transaction.startTimestamp, transaction.timestamp)
 
         val contexts = transaction.contexts?.toString() ?: "{}"
         val breadcrumbs = transaction.breadcrumbs?.toString() ?: "[]"
@@ -310,11 +310,11 @@ class EventService(
             environment = transaction.environment ?: "production",
             release = transaction.release ?: "",
             dist = transaction.dist ?: "",
-            serverName = transaction.server_name ?: "",
+            serverName = transaction.serverName ?: "",
             userId = transaction.user?.id ?: "",
             userEmail = transaction.user?.email ?: "",
             userUsername = transaction.user?.username ?: "",
-            userIpAddress = transaction.user?.ip_address ?: "",
+            userIpAddress = transaction.user?.ipAddress ?: "",
             transactionName = transaction.transaction ?: "",
             transactionOp = transactionOp,
             durationMs = durationMs,
@@ -373,7 +373,7 @@ class EventService(
         projectId: Long,
         event: SentryEvent
     ): Boolean {
-        val eventId = event.event_id ?: UUID.randomUUID().toString()
+        val eventId = event.eventId ?: UUID.randomUUID().toString()
 
         logger.debug {
             "Full event structure - exception: ${event.exception}, message: ${event.message}, " +
@@ -430,11 +430,11 @@ class EventService(
             environment = event.environment ?: "production",
             release = event.release ?: "",
             dist = event.dist ?: "",
-            serverName = event.server_name ?: "",
+            serverName = event.serverName ?: "",
             userId = event.user?.id ?: "",
             userEmail = event.user?.email ?: "",
             userUsername = event.user?.username ?: "",
-            userIpAddress = event.user?.ip_address ?: "",
+            userIpAddress = event.user?.ipAddress ?: "",
             exceptionType = exceptionType,
             exceptionValue = exceptionValue,
             stackTrace = stackTrace,
@@ -489,7 +489,7 @@ class EventService(
             return false
         }
 
-        val feedbackId = feedback.event_id ?: UUID.randomUUID().toString()
+        val feedbackId = feedback.eventId ?: UUID.randomUUID().toString()
         val timestamp =
             feedback.timestamp?.let {
                 suspendRunCatching {
@@ -513,7 +513,7 @@ class EventService(
         val userId = feedback.user?.id ?: ""
         val userEmail = feedback.user?.email ?: contactEmail
         val userUsername = feedback.user?.username ?: ""
-        val userIpAddress = feedback.user?.ip_address ?: ""
+        val userIpAddress = feedback.user?.ipAddress ?: ""
 
         val feedbackData = FeedbackInsertData(
             feedbackId = normalizeUuid(feedbackId),
@@ -558,14 +558,14 @@ class EventService(
             return false
         }
 
-        val replayId = replayEvent.replay_id ?: UUID.randomUUID().toString()
-        val segmentId = replayEvent.segment_id ?: 0
+        val replayId = replayEvent.replayId ?: UUID.randomUUID().toString()
+        val segmentId = replayEvent.segmentId ?: 0
         val ts = replayEvent.timestamp?.let { unixSecondsToMillis(it) } ?: System.currentTimeMillis()
-        val startTs = replayEvent.replay_start_timestamp?.let { unixSecondsToMillis(it) } ?: ts
+        val startTs = replayEvent.replayStartTimestamp?.let { unixSecondsToMillis(it) } ?: ts
 
         val urls = replayEvent.urls?.take(MAX_REPLAY_URLS) ?: emptyList()
-        val errorIds = replayEvent.error_ids ?: emptyList()
-        val traceIds = replayEvent.trace_ids ?: emptyList()
+        val errorIds = replayEvent.errorIds ?: emptyList()
+        val traceIds = replayEvent.traceIds ?: emptyList()
         val tags = replayEvent.tags?.let { JsonObject(it.mapValues { (_, v) -> JsonPrimitive(v) }).toString() } ?: "{}"
 
         val contexts = replayEvent.contexts
@@ -601,7 +601,7 @@ class EventService(
             userId = replayEvent.user?.id ?: "",
             userEmail = replayEvent.user?.email ?: "",
             userUsername = replayEvent.user?.username ?: "",
-            userIpAddress = replayEvent.user?.ip_address ?: "",
+            userIpAddress = replayEvent.user?.ipAddress ?: "",
             sdkName = replayEvent.sdk?.name ?: "",
             sdkVersion = replayEvent.sdk?.version ?: "",
             browserName = browserName,
@@ -812,13 +812,13 @@ class EventService(
 
         // Find the last in_app frame (innermost/actual error location), or fall back to the last frame
         val relevantFrame =
-            firstException?.stacktrace?.frames?.findLast { it.in_app == true }
+            firstException?.stacktrace?.frames?.findLast { it.inApp == true }
                 ?: firstException?.stacktrace?.frames?.lastOrNull()
 
         val function = relevantFrame?.function
         val filename = relevantFrame?.filename
 
-        logger.trace { "Selected frame: filename=$filename, function=$function, in_app=${relevantFrame?.in_app}" }
+        logger.trace { "Selected frame: filename=$filename, function=$function, in_app=${relevantFrame?.inApp}" }
 
         val fingerprint =
             buildList {
@@ -862,7 +862,7 @@ class EventService(
     ) {
         suspendRunCatching {
             val generations = aiSpans.mapNotNull { span ->
-                val spanStart = span.start_timestamp ?: return@mapNotNull null
+                val spanStart = span.startTimestamp ?: return@mapNotNull null
                 val spanEnd = span.timestamp ?: return@mapNotNull null
                 val op = span.op ?: ""
                 val data = span.data
@@ -890,8 +890,8 @@ class EventService(
                     generationId = UUID.randomUUID().toString(),
                     projectId = projectId,
                     traceId = traceId,
-                    spanId = span.span_id ?: "",
-                    parentSpanId = span.parent_span_id ?: "",
+                    spanId = span.spanId ?: "",
+                    parentSpanId = span.parentSpanId ?: "",
                     timestampMs = unixSecondsToMillis(spanEnd),
                     durationMs = durationMs(spanStart, spanEnd),
                     name = span.description ?: op,
@@ -993,10 +993,10 @@ class EventService(
         val ctx = ApmSpanContext(
             orgId = orgId,
             clickhouseDb = ClickHouseClient.getDatabase(),
-            service = transaction.server_name?.takeIf { it.isNotBlank() }
+            service = transaction.serverName?.takeIf { it.isNotBlank() }
                 ?: transaction.sdk?.name?.takeIf { it.isNotBlank() }
                 ?: "sentry",
-            host = transaction.server_name ?: "",
+            host = transaction.serverName ?: "",
             env = transaction.environment ?: "production",
             version = transaction.release ?: "",
             transactionName = transaction.transaction ?: transactionOp.ifBlank { "transaction" },
@@ -1025,7 +1025,7 @@ class EventService(
             ?.get("span_id")?.jsonPrimitive?.contentOrNull ?: ""
         if (rootSpanId.isBlank()) return null
 
-        val startTs = transaction.start_timestamp ?: (System.currentTimeMillis() / MS_PER_SECOND)
+        val startTs = transaction.startTimestamp ?: (System.currentTimeMillis() / MS_PER_SECOND)
         val (traceIdHigh, traceIdLow) = hexToULongPair(traceId)
         val (spanIdHigh, spanIdLow) = hexToULongPair(rootSpanId)
         val rootMetrics = extractMeasurementMetrics(transaction)
@@ -1041,7 +1041,7 @@ class EventService(
             '${escapeSql(ctx.transactionName)}',
             '${escapeSql(transactionOp)}',
             fromUnixTimestamp64Nano(${unixSecondsToNanos(startTs)}),
-            ${durationNanos(transaction.start_timestamp, transaction.timestamp)},
+            ${durationNanos(transaction.startTimestamp, transaction.timestamp)},
             ${sentryStatusToError(traceStatus)},
             ${mapToSqlMap(ctx.baseMeta)},
             ${doubleMapToSqlMap(rootMetrics)},
@@ -1062,14 +1062,14 @@ class EventService(
         fallbackTraceId: String,
         transaction: SentryTransaction
     ): String? {
-        val spanStart = span.start_timestamp ?: transaction.start_timestamp ?: return null
+        val spanStart = span.startTimestamp ?: transaction.startTimestamp ?: return null
         val spanEnd = span.timestamp ?: transaction.timestamp ?: spanStart
-        val spanId = span.span_id?.ifBlank { null } ?: UUID.randomUUID().toString().replace("-", "")
-        val spanTraceId = span.trace_id ?: fallbackTraceId
+        val spanId = span.spanId?.ifBlank { null } ?: UUID.randomUUID().toString().replace("-", "")
+        val spanTraceId = span.traceId ?: fallbackTraceId
 
         val (traceIdHigh, traceIdLow) = hexToULongPair(spanTraceId)
         val (spanIdHigh, spanIdLow) = hexToULongPair(spanId)
-        val parentHex = span.parent_span_id ?: ""
+        val parentHex = span.parentSpanId ?: ""
         val (parentIdHigh, parentIdLow) = hexToULongPair(parentHex)
 
         val spanMeta = extractSpanMeta(span, ctx.baseMeta)

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentIoProvider.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentIoProvider.kt
@@ -31,6 +31,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -93,7 +94,7 @@ class IncidentIoProvider : IncidentProvider {
 
             val payload =
                 AlertEventPayload(
-                    deduplication_key = event.deduplicationKey,
+                    deduplicationKey = event.deduplicationKey,
                     status =
                     when (event.status) {
                         IncidentStatus.FIRING -> "firing"
@@ -113,7 +114,7 @@ class IncidentIoProvider : IncidentProvider {
 
             if (response.status.value in HTTP_SUCCESS_MIN..HTTP_SUCCESS_MAX) {
                 val responseBody = response.body<AlertEventResponse>()
-                Result.success(responseBody.deduplication_key)
+                Result.success(responseBody.deduplicationKey)
             } else {
                 val errorBody = response.bodyAsText()
                 Result.failure(Exception("incident.io API error (${response.status}): $errorBody"))
@@ -135,7 +136,7 @@ class IncidentIoProvider : IncidentProvider {
 
             val payload =
                 AlertEventPayload(
-                    deduplication_key = deduplicationKey,
+                    deduplicationKey = deduplicationKey,
                     status = "resolved",
                     title = "Alert Resolved",
                     description = "This alert has been automatically resolved by Moneat",
@@ -151,7 +152,7 @@ class IncidentIoProvider : IncidentProvider {
 
             if (response.status.value in HTTP_SUCCESS_MIN..HTTP_SUCCESS_MAX) {
                 val responseBody = response.body<AlertEventResponse>()
-                Result.success(responseBody.deduplication_key)
+                Result.success(responseBody.deduplicationKey)
             } else {
                 val errorBody = response.bodyAsText()
                 Result.failure(Exception("incident.io API error (${response.status}): $errorBody"))
@@ -172,7 +173,7 @@ class IncidentIoProvider : IncidentProvider {
             val testDedup = "moneat-test-${System.currentTimeMillis()}"
             val payload =
                 AlertEventPayload(
-                    deduplication_key = testDedup,
+                    deduplicationKey = testDedup,
                     status = "firing",
                     title = "Moneat Test Alert",
                     description = "This is a test alert from Moneat to verify the integration",
@@ -202,7 +203,7 @@ class IncidentIoProvider : IncidentProvider {
 
     @Serializable
     private data class AlertEventPayload(
-        val deduplication_key: String,
+        @SerialName("deduplication_key") val deduplicationKey: String,
         val status: String,
         val title: String,
         val description: String,
@@ -211,7 +212,7 @@ class IncidentIoProvider : IncidentProvider {
 
     @Serializable
     private data class AlertEventResponse(
-        val deduplication_key: String
+        @SerialName("deduplication_key") val deduplicationKey: String
     )
 }
 

--- a/backend/src/main/kotlin/com/moneat/monitor/models/MonitorModels.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/models/MonitorModels.kt
@@ -61,62 +61,62 @@ data class HostResponse(
     val name: String,
     val hostname: String,
     val status: String,
-    val last_seen_at: Long?,
+    @SerialName("last_seen_at") val lastSeenAt: Long?,
     @SerialName("first_seen_at") val firstSeenAt: Long? = null,
-    val agent_version: String?,
+    @SerialName("agent_version") val agentVersion: String?,
     val os: String?,
     val arch: String?,
     val platform: String? = null,
     val processor: String? = null,
     @SerialName("cpu_cores") val cpuCores: Int? = null,
     @SerialName("memory_total_kb") val memoryTotalKb: Long? = null,
-    val created_at: Long,
-    val latest_metrics: LatestMetrics?
+    @SerialName("created_at") val createdAt: Long,
+    @SerialName("latest_metrics") val latestMetrics: LatestMetrics?
 )
 
 @Serializable
 data class LatestMetrics(
-    val cpu_percent: Float,
-    val mem_total: Long,
-    val mem_used: Long,
-    val mem_percent: Float,
-    val disk_total: Long,
-    val disk_used: Long,
-    val disk_percent: Float,
-    val net_recv_bytes: Long,
-    val net_sent_bytes: Long,
-    val net_recv_mbps: Float?,
-    val net_sent_mbps: Float?,
-    val load_1: Float,
-    val temp_max: Float?,
-    val gpu_percent: Float?,
-    val battery_percent: Float?
+    @SerialName("cpu_percent") val cpuPercent: Float,
+    @SerialName("mem_total") val memTotal: Long,
+    @SerialName("mem_used") val memUsed: Long,
+    @SerialName("mem_percent") val memPercent: Float,
+    @SerialName("disk_total") val diskTotal: Long,
+    @SerialName("disk_used") val diskUsed: Long,
+    @SerialName("disk_percent") val diskPercent: Float,
+    @SerialName("net_recv_bytes") val netRecvBytes: Long,
+    @SerialName("net_sent_bytes") val netSentBytes: Long,
+    @SerialName("net_recv_mbps") val netRecvMbps: Float?,
+    @SerialName("net_sent_mbps") val netSentMbps: Float?,
+    @SerialName("load_1") val load1: Float,
+    @SerialName("temp_max") val tempMax: Float?,
+    @SerialName("gpu_percent") val gpuPercent: Float?,
+    @SerialName("battery_percent") val batteryPercent: Float?
 )
 
 @Serializable
 data class HistoricalMetricsResponse(
-    val system_id: String,
-    val host_id: Int? = null,
+    @SerialName("system_id") val systemId: String,
+    @SerialName("host_id") val hostId: Int? = null,
     val from: Long,
     val to: Long,
-    val interval_seconds: Int,
-    val data_points: List<MetricDataPoint>
+    @SerialName("interval_seconds") val intervalSeconds: Int,
+    @SerialName("data_points") val dataPoints: List<MetricDataPoint>
 )
 
 @Serializable
 data class MetricDataPoint(
     val timestamp: Long,
-    val cpu_percent: Float?,
-    val mem_percent: Float?,
-    val disk_percent: Float?,
-    val net_recv_bytes: Long?,
-    val net_sent_bytes: Long?,
-    val load_1: Float?,
-    val load_5: Float?,
-    val load_15: Float?,
-    val temp_max: Float?,
-    val gpu_percent: Float?,
-    val battery_percent: Float?
+    @SerialName("cpu_percent") val cpuPercent: Float?,
+    @SerialName("mem_percent") val memPercent: Float?,
+    @SerialName("disk_percent") val diskPercent: Float?,
+    @SerialName("net_recv_bytes") val netRecvBytes: Long?,
+    @SerialName("net_sent_bytes") val netSentBytes: Long?,
+    @SerialName("load_1") val load1: Float?,
+    @SerialName("load_5") val load5: Float?,
+    @SerialName("load_15") val load15: Float?,
+    @SerialName("temp_max") val tempMax: Float?,
+    @SerialName("gpu_percent") val gpuPercent: Float?,
+    @SerialName("battery_percent") val batteryPercent: Float?
 )
 
 @Serializable
@@ -152,31 +152,31 @@ data class ContainerStats(
     val id: String,
     val image: String,
     val status: String,
-    val cpu_percent: Float,
-    val mem_used: Long,
-    val mem_limit: Long,
-    val net_recv_bytes: Long,
-    val net_sent_bytes: Long,
-    val mem_percent: Float
+    @SerialName("cpu_percent") val cpuPercent: Float,
+    @SerialName("mem_used") val memUsed: Long,
+    @SerialName("mem_limit") val memLimit: Long,
+    @SerialName("net_recv_bytes") val netRecvBytes: Long,
+    @SerialName("net_sent_bytes") val netSentBytes: Long,
+    @SerialName("mem_percent") val memPercent: Float
 )
 
 @Serializable
 data class ContainerMetricsResponse(
-    val container_name: String,
+    @SerialName("container_name") val containerName: String,
     val from: Long,
     val to: Long,
-    val interval_seconds: Int,
-    val data_points: List<ContainerMetricDataPoint>
+    @SerialName("interval_seconds") val intervalSeconds: Int,
+    @SerialName("data_points") val dataPoints: List<ContainerMetricDataPoint>
 )
 
 @Serializable
 data class ContainerMetricDataPoint(
     val timestamp: Long,
-    val cpu_percent: Float?,
-    val mem_used: Long?,
-    val mem_limit: Long?,
-    val net_recv_bytes: Long?,
-    val net_sent_bytes: Long?
+    @SerialName("cpu_percent") val cpuPercent: Float?,
+    @SerialName("mem_used") val memUsed: Long?,
+    @SerialName("mem_limit") val memLimit: Long?,
+    @SerialName("net_recv_bytes") val netRecvBytes: Long?,
+    @SerialName("net_sent_bytes") val netSentBytes: Long?
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/monitor/routes/MonitorRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/routes/MonitorRoutes.kt
@@ -125,17 +125,17 @@ fun Route.monitorRoutes(
                             name = host.displayName ?: host.hostname,
                             hostname = host.hostname,
                             status = host.status,
-                            last_seen_at = host.lastSeenAt?.toEpochMilliseconds(),
+                            lastSeenAt = host.lastSeenAt?.toEpochMilliseconds(),
                             firstSeenAt = host.firstSeenAt.toEpochMilliseconds(),
-                            agent_version = host.agentVersion,
+                            agentVersion = host.agentVersion,
                             os = host.os,
                             arch = host.arch,
                             platform = host.platform,
                             processor = host.processor,
                             cpuCores = host.cpuCores,
                             memoryTotalKb = host.memoryTotalKb,
-                            created_at = host.createdAt.toEpochMilliseconds(),
-                            latest_metrics = latestMetricsByHost[host.id]
+                            createdAt = host.createdAt.toEpochMilliseconds(),
+                            latestMetrics = latestMetricsByHost[host.id]
                         )
                     }
 
@@ -187,17 +187,17 @@ fun Route.monitorRoutes(
                         name = host.displayName ?: host.hostname,
                         hostname = host.hostname,
                         status = host.status,
-                        last_seen_at = host.lastSeenAt?.toEpochMilliseconds(),
+                        lastSeenAt = host.lastSeenAt?.toEpochMilliseconds(),
                         firstSeenAt = host.firstSeenAt.toEpochMilliseconds(),
-                        agent_version = host.agentVersion,
+                        agentVersion = host.agentVersion,
                         os = host.os,
                         arch = host.arch,
                         platform = host.platform,
                         processor = host.processor,
                         cpuCores = host.cpuCores,
                         memoryTotalKb = host.memoryTotalKb,
-                        created_at = host.createdAt.toEpochMilliseconds(),
-                        latest_metrics = monitorService.getLatestMetrics(host.id)
+                        createdAt = host.createdAt.toEpochMilliseconds(),
+                        latestMetrics = monitorService.getLatestMetrics(host.id)
                     )
                 )
             }

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
@@ -313,21 +313,21 @@ class MonitorService(
 
             val effectiveMemUsed = if (memAvailable > 0) memTotal - memAvailable else memUsed
             return LatestMetrics(
-                cpu_percent = cpuPercent,
-                mem_total = memTotal,
-                mem_used = effectiveMemUsed,
-                mem_percent = if (memTotal > 0) (effectiveMemUsed.toFloat() / memTotal * PERCENT_MULTIPLIER) else 0f,
-                disk_total = diskTotal,
-                disk_used = diskUsed,
-                disk_percent = if (diskTotal > 0) (diskUsed.toFloat() / diskTotal * PERCENT_MULTIPLIER) else 0f,
-                net_recv_bytes = netRecvBytes,
-                net_sent_bytes = netSentBytes,
-                net_recv_mbps = null,
-                net_sent_mbps = null,
-                load_1 = load1,
-                temp_max = tempMax,
-                gpu_percent = gpuPercent,
-                battery_percent = batteryPercent
+                cpuPercent = cpuPercent,
+                memTotal = memTotal,
+                memUsed = effectiveMemUsed,
+                memPercent = if (memTotal > 0) (effectiveMemUsed.toFloat() / memTotal * PERCENT_MULTIPLIER) else 0f,
+                diskTotal = diskTotal,
+                diskUsed = diskUsed,
+                diskPercent = if (diskTotal > 0) (diskUsed.toFloat() / diskTotal * PERCENT_MULTIPLIER) else 0f,
+                netRecvBytes = netRecvBytes,
+                netSentBytes = netSentBytes,
+                netRecvMbps = null,
+                netSentMbps = null,
+                load1 = load1,
+                tempMax = tempMax,
+                gpuPercent = gpuPercent,
+                batteryPercent = batteryPercent
             )
         }.getOrElse { e ->
             logger.warn(e) { "Failed to parse latest metrics response" }
@@ -398,23 +398,23 @@ class MonitorService(
                 val batteryPercent = arr.getOrNull(BATCH_COL_BATTERY_PERCENT)?.toString()?.toFloatOrNull()
                 val effectiveMemUsed = if (memAvailable > 0) memTotal - memAvailable else memUsed
                 result[rowHostId] = LatestMetrics(
-                    cpu_percent = cpuPercent,
-                    mem_total = memTotal,
-                    mem_used = effectiveMemUsed,
-                    mem_percent = if (memTotal > 0) {
+                    cpuPercent = cpuPercent,
+                    memTotal = memTotal,
+                    memUsed = effectiveMemUsed,
+                    memPercent = if (memTotal > 0) {
                         effectiveMemUsed.toFloat() / memTotal * PERCENT_MULTIPLIER
                     } else { 0f },
-                    disk_total = diskTotal,
-                    disk_used = diskUsed,
-                    disk_percent = if (diskTotal > 0) (diskUsed.toFloat() / diskTotal * PERCENT_MULTIPLIER) else 0f,
-                    net_recv_bytes = netRecvBytes,
-                    net_sent_bytes = netSentBytes,
-                    net_recv_mbps = null,
-                    net_sent_mbps = null,
-                    load_1 = load1,
-                    temp_max = tempMax,
-                    gpu_percent = gpuPercent,
-                    battery_percent = batteryPercent
+                    diskTotal = diskTotal,
+                    diskUsed = diskUsed,
+                    diskPercent = if (diskTotal > 0) (diskUsed.toFloat() / diskTotal * PERCENT_MULTIPLIER) else 0f,
+                    netRecvBytes = netRecvBytes,
+                    netSentBytes = netSentBytes,
+                    netRecvMbps = null,
+                    netSentMbps = null,
+                    load1 = load1,
+                    tempMax = tempMax,
+                    gpuPercent = gpuPercent,
+                    batteryPercent = batteryPercent
                 )
             }
             hostIds.associateWith { result[it] }
@@ -438,22 +438,22 @@ class MonitorService(
             MONITOR_HISTORY_CACHE_TTL_SECONDS
         ) {
             val host = getHostById(hostId) ?: return@cached HistoricalMetricsResponse(
-                system_id = "",
-                host_id = hostId,
+                systemId = "",
+                hostId = hostId,
                 from = fromTimestamp,
                 to = toTimestamp,
-                interval_seconds = intervalSeconds ?: 3600,
-                data_points = emptyList()
+                intervalSeconds = intervalSeconds ?: 3600,
+                dataPoints = emptyList()
             )
             val clampedWindow = clampRangeToRetention(hostId, fromTimestamp, toTimestamp)
             if (clampedWindow == null) {
                 return@cached HistoricalMetricsResponse(
-                    system_id = "",
-                    host_id = hostId,
+                    systemId = "",
+                    hostId = hostId,
                     from = fromTimestamp,
                     to = toTimestamp,
-                    interval_seconds = intervalSeconds ?: 3600,
-                    data_points = emptyList()
+                    intervalSeconds = intervalSeconds ?: 3600,
+                    dataPoints = emptyList()
                 )
             }
             val (effectiveFrom, effectiveTo) = clampedWindow
@@ -503,39 +503,39 @@ class MonitorService(
                     val result = json.parseToJsonElement(body).jsonObject
                     val data =
                         result["data"]?.jsonArray ?: return@cached HistoricalMetricsResponse(
-                            system_id = "",
-                            host_id = hostId,
+                            systemId = "",
+                            hostId = hostId,
                             from = effectiveFrom,
                             to = effectiveTo,
-                            interval_seconds = calculatedInterval,
-                            data_points = emptyList()
+                            intervalSeconds = calculatedInterval,
+                            dataPoints = emptyList()
                         )
 
                     data.map { row ->
                         val arr = row.jsonArray
                         MetricDataPoint(
                             timestamp = arr[0].toString().replace("\"", "").toLong(),
-                            cpu_percent = arr.getOrNull(1)?.toString()?.toFloatOrNull(),
-                            mem_percent = arr.getOrNull(2)?.toString()?.toFloatOrNull(),
-                            disk_percent = arr.getOrNull(HIST_COL_DISK_PERCENT)?.toString()?.toFloatOrNull(),
-                            net_recv_bytes =
+                            cpuPercent = arr.getOrNull(1)?.toString()?.toFloatOrNull(),
+                            memPercent = arr.getOrNull(2)?.toString()?.toFloatOrNull(),
+                            diskPercent = arr.getOrNull(HIST_COL_DISK_PERCENT)?.toString()?.toFloatOrNull(),
+                            netRecvBytes =
                             arr
                                 .getOrNull(HIST_COL_NET_RECV_BYTES)
                                 ?.toString()
                                 ?.replace("\"", "")
                                 ?.toLongOrNull(),
-                            net_sent_bytes =
+                            netSentBytes =
                             arr
                                 .getOrNull(HIST_COL_NET_SENT_BYTES)
                                 ?.toString()
                                 ?.replace("\"", "")
                                 ?.toLongOrNull(),
-                            load_1 = arr.getOrNull(HIST_COL_LOAD_1)?.toString()?.toFloatOrNull(),
-                            load_5 = arr.getOrNull(HIST_COL_LOAD_5)?.toString()?.toFloatOrNull(),
-                            load_15 = arr.getOrNull(HIST_COL_LOAD_15)?.toString()?.toFloatOrNull(),
-                            temp_max = arr.getOrNull(HIST_COL_TEMP_MAX)?.toString()?.toFloatOrNull(),
-                            gpu_percent = arr.getOrNull(HIST_COL_GPU_PERCENT)?.toString()?.toFloatOrNull(),
-                            battery_percent = arr.getOrNull(HIST_COL_BATTERY_PERCENT)?.toString()?.toFloatOrNull()
+                            load1 = arr.getOrNull(HIST_COL_LOAD_1)?.toString()?.toFloatOrNull(),
+                            load5 = arr.getOrNull(HIST_COL_LOAD_5)?.toString()?.toFloatOrNull(),
+                            load15 = arr.getOrNull(HIST_COL_LOAD_15)?.toString()?.toFloatOrNull(),
+                            tempMax = arr.getOrNull(HIST_COL_TEMP_MAX)?.toString()?.toFloatOrNull(),
+                            gpuPercent = arr.getOrNull(HIST_COL_GPU_PERCENT)?.toString()?.toFloatOrNull(),
+                            batteryPercent = arr.getOrNull(HIST_COL_BATTERY_PERCENT)?.toString()?.toFloatOrNull()
                         )
                     }
                 }.getOrElse { e ->
@@ -544,12 +544,12 @@ class MonitorService(
                 }
 
             HistoricalMetricsResponse(
-                system_id = "",
-                host_id = hostId,
+                systemId = "",
+                hostId = hostId,
                 from = effectiveFrom,
                 to = effectiveTo,
-                interval_seconds = calculatedInterval,
-                data_points = dataPoints
+                intervalSeconds = calculatedInterval,
+                dataPoints = dataPoints
             )
         }
 
@@ -602,12 +602,12 @@ class MonitorService(
                     id = arr[1].toString().replace("\"", ""),
                     image = arr[2].toString().replace("\"", ""),
                     status = arr[3].toString().replace("\"", ""),
-                    cpu_percent = arr[4].toString().toFloatOrNull() ?: 0f,
-                    mem_used = memUsed,
-                    mem_limit = memLimit,
-                    net_recv_bytes = netRecvBytes,
-                    net_sent_bytes = netSentBytes,
-                    mem_percent = if (memLimit > 0) (memUsed.toFloat() / memLimit * PERCENT_MULTIPLIER) else 0f
+                    cpuPercent = arr[4].toString().toFloatOrNull() ?: 0f,
+                    memUsed = memUsed,
+                    memLimit = memLimit,
+                    netRecvBytes = netRecvBytes,
+                    netSentBytes = netSentBytes,
+                    memPercent = if (memLimit > 0) (memUsed.toFloat() / memLimit * PERCENT_MULTIPLIER) else 0f
                 )
             }
         }.getOrElse { e ->
@@ -635,12 +635,12 @@ class MonitorService(
                             id = c.id,
                             image = c.image,
                             status = c.status,
-                            cpuPercent = c.cpu_percent,
-                            memUsed = c.mem_used,
-                            memLimit = c.mem_limit,
-                            netRecvBytes = c.net_recv_bytes,
-                            netSentBytes = c.net_sent_bytes,
-                            memPercent = c.mem_percent
+                            cpuPercent = c.cpuPercent,
+                            memUsed = c.memUsed,
+                            memLimit = c.memLimit,
+                            netRecvBytes = c.netRecvBytes,
+                            netSentBytes = c.netSentBytes,
+                            memPercent = c.memPercent
                         )
                     )
                 }
@@ -741,20 +741,20 @@ class MonitorService(
         intervalSeconds: Int?
     ): ContainerMetricsResponse {
         val host = getHostById(hostId) ?: return ContainerMetricsResponse(
-            container_name = containerName,
+            containerName = containerName,
             from = fromTimestamp,
             to = toTimestamp,
-            interval_seconds = intervalSeconds ?: 3600,
-            data_points = emptyList()
+            intervalSeconds = intervalSeconds ?: 3600,
+            dataPoints = emptyList()
         )
         val clampedWindow = clampRangeToRetention(hostId, fromTimestamp, toTimestamp)
         if (clampedWindow == null) {
             return ContainerMetricsResponse(
-                container_name = containerName,
+                containerName = containerName,
                 from = fromTimestamp,
                 to = toTimestamp,
-                interval_seconds = intervalSeconds ?: 3600,
-                data_points = emptyList()
+                intervalSeconds = intervalSeconds ?: 3600,
+                dataPoints = emptyList()
             )
         }
         val (effectiveFrom, effectiveTo) = clampedWindow
@@ -797,37 +797,37 @@ class MonitorService(
                 val result = json.parseToJsonElement(body).jsonObject
                 val data =
                     result["data"]?.jsonArray ?: return ContainerMetricsResponse(
-                        container_name = containerName,
+                        containerName = containerName,
                         from = effectiveFrom,
                         to = effectiveTo,
-                        interval_seconds = calculatedInterval,
-                        data_points = emptyList()
+                        intervalSeconds = calculatedInterval,
+                        dataPoints = emptyList()
                     )
 
                 data.map { row ->
                     val arr = row.jsonArray
                     ContainerMetricDataPoint(
                         timestamp = arr[0].toString().replace("\"", "").toLong(),
-                        cpu_percent = arr.getOrNull(1)?.toString()?.toFloatOrNull(),
-                        mem_used =
+                        cpuPercent = arr.getOrNull(1)?.toString()?.toFloatOrNull(),
+                        memUsed =
                         arr
                             .getOrNull(2)
                             ?.toString()
                             ?.replace("\"", "")
                             ?.toLongOrNull(),
-                        mem_limit =
+                        memLimit =
                         arr
                             .getOrNull(CONT_HIST_COL_MEM_LIMIT)
                             ?.toString()
                             ?.replace("\"", "")
                             ?.toLongOrNull(),
-                        net_recv_bytes =
+                        netRecvBytes =
                         arr
                             .getOrNull(CONT_HIST_COL_NET_RECV)
                             ?.toString()
                             ?.replace("\"", "")
                             ?.toLongOrNull(),
-                        net_sent_bytes =
+                        netSentBytes =
                         arr
                             .getOrNull(CONT_HIST_COL_NET_SENT)
                             ?.toString()
@@ -841,11 +841,11 @@ class MonitorService(
             }
 
         return ContainerMetricsResponse(
-            container_name = containerName,
+            containerName = containerName,
             from = effectiveFrom,
             to = effectiveTo,
-            interval_seconds = calculatedInterval,
-            data_points = dataPoints
+            intervalSeconds = calculatedInterval,
+            dataPoints = dataPoints
         )
     }
 

--- a/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
@@ -33,6 +33,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.http.contentType
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.and
@@ -94,8 +95,8 @@ class DiscordService(
 
     @Serializable
     data class DiscordOAuthResponse(
-        val access_token: String? = null,
-        val token_type: String? = null,
+        @SerialName("access_token") val accessToken: String? = null,
+        @SerialName("token_type") val tokenType: String? = null,
         val scope: String? = null,
         val guild: DiscordGuild? = null,
         val error: String? = null

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -34,6 +34,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.and
@@ -80,7 +81,7 @@ class SlackService {
         val type: String,
         val text: SlackText? = null,
         val url: String? = null,
-        val action_id: String? = null
+        @SerialName("action_id") val actionId: String? = null
     )
 
     @Serializable
@@ -107,11 +108,11 @@ class SlackService {
     @Serializable
     data class SlackOAuthResponse(
         val ok: Boolean,
-        val access_token: String? = null,
-        val token_type: String? = null,
+        @SerialName("access_token") val accessToken: String? = null,
+        @SerialName("token_type") val tokenType: String? = null,
         val scope: String? = null,
-        val bot_user_id: String? = null,
-        val app_id: String? = null,
+        @SerialName("bot_user_id") val botUserId: String? = null,
+        @SerialName("app_id") val appId: String? = null,
         val team: SlackTeam? = null,
         val error: String? = null
     )
@@ -828,7 +829,7 @@ class SlackService {
     data class SlackChannel(
         val id: String,
         val name: String,
-        val is_private: Boolean? = null
+        @SerialName("is_private") val isPrivate: Boolean? = null
     )
 
     suspend fun listChannels(accessToken: String): List<SlackChannel> {
@@ -961,7 +962,7 @@ class SlackService {
                             SlackElement(
                                 type = "button",
                                 text = SlackText(type = "plain_text", text = "Acknowledge", emoji = false),
-                                action_id = "incident_acknowledge_$incidentId"
+                                actionId = "incident_acknowledge_$incidentId"
                             ),
                             SlackElement(
                                 type = "button",
@@ -970,7 +971,7 @@ class SlackService {
                                     "FRONTEND_URL",
                                     "https://moneat.io"
                                 )}/on-call/incidents/$incidentId",
-                                action_id = "incident_view_$incidentId"
+                                actionId = "incident_view_$incidentId"
                             )
                         )
                     )

--- a/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
@@ -802,7 +802,7 @@ fun Route.integrationCallbackRoutes() {
 
             val oauthResponse = slackService.exchangeOAuthCode(code, clientId, clientSecret, redirectUri)
 
-            if (oauthResponse.ok && oauthResponse.access_token != null) {
+            if (oauthResponse.ok && oauthResponse.accessToken != null) {
                 val now = Clock.System.now()
 
                 transaction {
@@ -820,8 +820,8 @@ fun Route.integrationCallbackRoutes() {
                             (OrganizationIntegrations.organization_id eq organizationId) and
                                 (OrganizationIntegrations.integration_type eq "slack")
                         }) {
-                            it[access_token] = oauthResponse.access_token
-                            it[bot_user_id] = oauthResponse.bot_user_id
+                            it[access_token] = oauthResponse.accessToken
+                            it[bot_user_id] = oauthResponse.botUserId
                             it[team_id] = oauthResponse.team?.id
                             it[team_name] = oauthResponse.team?.name
                             it[enabled] = true
@@ -832,8 +832,8 @@ fun Route.integrationCallbackRoutes() {
                         OrganizationIntegrations.insert {
                             it[organization_id] = organizationId
                             it[integration_type] = "slack"
-                            it[access_token] = oauthResponse.access_token
-                            it[bot_user_id] = oauthResponse.bot_user_id
+                            it[access_token] = oauthResponse.accessToken
+                            it[bot_user_id] = oauthResponse.botUserId
                             it[team_id] = oauthResponse.team?.id
                             it[team_name] = oauthResponse.team?.name
                             it[enabled] = true
@@ -913,7 +913,7 @@ fun Route.integrationCallbackRoutes() {
             // Exchange code for access token
             val oauthResponse = discordService.exchangeOAuthCode(code, clientId, clientSecret, redirectUri)
 
-            if (oauthResponse.access_token != null && oauthResponse.guild != null) {
+            if (oauthResponse.accessToken != null && oauthResponse.guild != null) {
                 val now = Clock.System.now()
 
                 transaction {
@@ -930,7 +930,7 @@ fun Route.integrationCallbackRoutes() {
                             (OrganizationIntegrations.organization_id eq organizationId) and
                                 (OrganizationIntegrations.integration_type eq "discord")
                         }) {
-                            it[access_token] = oauthResponse.access_token
+                            it[access_token] = oauthResponse.accessToken
                             it[team_id] = oauthResponse.guild.id
                             it[team_name] = oauthResponse.guild.name
                             it[enabled] = true
@@ -940,7 +940,7 @@ fun Route.integrationCallbackRoutes() {
                         OrganizationIntegrations.insert {
                             it[organization_id] = organizationId
                             it[integration_type] = "discord"
-                            it[access_token] = oauthResponse.access_token
+                            it[access_token] = oauthResponse.accessToken
                             it[team_id] = oauthResponse.guild.id
                             it[team_name] = oauthResponse.guild.name
                             it[enabled] = true

--- a/backend/src/main/kotlin/com/moneat/shared/services/SdkVersionService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/SdkVersionService.kt
@@ -31,6 +31,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -54,7 +55,7 @@ private data class VersionTarget(
 
 @Serializable
 private data class GitHubLatestReleaseResponse(
-    val tag_name: String? = null,
+    @SerialName("tag_name") val tagName: String? = null,
     val prerelease: Boolean = false,
     val draft: Boolean = false,
 )
@@ -215,7 +216,7 @@ object SdkVersionService {
             return null
         }
 
-        return normalizeVersionTag(release.tag_name.orEmpty())
+        return normalizeVersionTag(release.tagName.orEmpty())
     }
 
     private suspend fun fetchFromTags(repository: String): String? {

--- a/backend/src/main/kotlin/com/moneat/summary/services/SummaryService.kt
+++ b/backend/src/main/kotlin/com/moneat/summary/services/SummaryService.kt
@@ -313,11 +313,11 @@ class SummaryService(
         }
 
         val avgCpu = hostMetrics
-            .map { it.cpu_percent.toDouble() }
+            .map { it.cpuPercent.toDouble() }
             .takeIf { it.isNotEmpty() }?.average() ?: 0.0
 
         val avgMem = hostMetrics
-            .map { it.mem_percent.toDouble() }
+            .map { it.memPercent.toDouble() }
             .takeIf { it.isNotEmpty() }?.average() ?: 0.0
 
         WeeklyReportResponse(
@@ -383,10 +383,10 @@ class SummaryService(
                     hostMetrics = HostMetricsWindow(
                         systemId = host.id.toString(),
                         systemName = host.displayName ?: host.hostname,
-                        avgCpu = metrics.cpu_percent.toDouble(),
-                        maxCpu = metrics.cpu_percent.toDouble(),
-                        avgMemory = metrics.mem_percent.toDouble(),
-                        maxMemory = metrics.mem_percent.toDouble(),
+                        avgCpu = metrics.cpuPercent.toDouble(),
+                        maxCpu = metrics.cpuPercent.toDouble(),
+                        avgMemory = metrics.memPercent.toDouble(),
+                        maxMemory = metrics.memPercent.toDouble(),
                         windowStart = isoFormatter.format(windowStart),
                         windowEnd = isoFormatter.format(now)
                     )
@@ -415,10 +415,10 @@ class SummaryService(
                     hostMetrics = HostMetricsWindow(
                         systemId = host.id.toString(),
                         systemName = host.displayName ?: host.hostname,
-                        avgCpu = metrics.cpu_percent.toDouble(),
-                        maxCpu = metrics.cpu_percent.toDouble(),
-                        avgMemory = metrics.mem_percent.toDouble(),
-                        maxMemory = metrics.mem_percent.toDouble(),
+                        avgCpu = metrics.cpuPercent.toDouble(),
+                        maxCpu = metrics.cpuPercent.toDouble(),
+                        avgMemory = metrics.memPercent.toDouble(),
+                        maxMemory = metrics.memPercent.toDouble(),
                         windowStart = isoFormatter.format(windowStart),
                         windowEnd = isoFormatter.format(now)
                     )

--- a/backend/src/test/kotlin/com/moneat/ai/AiChatServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ai/AiChatServiceTest.kt
@@ -64,10 +64,10 @@ class AiChatServiceTest {
         val parsed =
             service.parseAiResponse("""{"message":"hello","context_needed":["logs"]}""")
         assertEquals("hello", parsed.message)
-        assertEquals(listOf("logs"), parsed.context_needed)
+        assertEquals(listOf("logs"), parsed.contextNeeded)
 
         val fallback = service.parseAiResponse("not-json")
         assertEquals("not-json", fallback.message)
-        assertTrue(fallback.context_needed.isEmpty())
+        assertTrue(fallback.contextNeeded.isEmpty())
     }
 }

--- a/backend/src/test/kotlin/com/moneat/models/SentryTimestampParsingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/models/SentryTimestampParsingTest.kt
@@ -51,12 +51,12 @@ class SentryTimestampParsingTest {
 
         val transaction = json.decodeFromString<SentryTransaction>(payload)
 
-        val startTs = transaction.start_timestamp
+        val startTs = transaction.startTimestamp
         val endTs = transaction.timestamp
         assertNotNull(startTs)
         assertNotNull(endTs)
-        assertTrue(endTs >= startTs)
-        assertNotNull(transaction.spans?.firstOrNull()?.start_timestamp)
+        assertTrue(endTs!! >= startTs!!)
+        assertNotNull(transaction.spans?.firstOrNull()?.startTimestamp)
         assertNotNull(transaction.spans?.firstOrNull()?.timestamp)
     }
 
@@ -75,9 +75,9 @@ class SentryTimestampParsingTest {
         val replayEvent = json.decodeFromString<SentryReplayEvent>(payload)
 
         val replayTs = replayEvent.timestamp
-        val replayStartTs = replayEvent.replay_start_timestamp
+        val replayStartTs = replayEvent.replayStartTimestamp
         assertNotNull(replayTs)
         assertNotNull(replayStartTs)
-        assertTrue(replayTs >= replayStartTs)
+        assertTrue(replayTs!! >= replayStartTs!!)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/routes/MonitorRoutesMockTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/MonitorRoutesMockTest.kt
@@ -285,11 +285,11 @@ class MonitorRoutesMockTest {
             seedMembership(userId, orgId)
             val system = makeHostData(orgId)
             val metricsResponse = HistoricalMetricsResponse(
-                system_id = system.id.toString(),
+                systemId = system.id.toString(),
                 from = 1000L,
                 to = 2000L,
-                interval_seconds = 60,
-                data_points = emptyList()
+                intervalSeconds = 60,
+                dataPoints = emptyList()
             )
 
             every { mockMonitorService.getHostById(system.id) } returns system
@@ -326,12 +326,12 @@ class MonitorRoutesMockTest {
                 id = "abc123",
                 image = "nginx:latest",
                 status = "running",
-                cpu_percent = 1.5f,
-                mem_used = 100L,
-                mem_limit = 512L,
-                net_recv_bytes = 0L,
-                net_sent_bytes = 0L,
-                mem_percent = 0.2f
+                cpuPercent = 1.5f,
+                memUsed = 100L,
+                memLimit = 512L,
+                netRecvBytes = 0L,
+                netSentBytes = 0L,
+                memPercent = 0.2f
             )
 
             every { mockMonitorService.getHostById(system.id) } returns system
@@ -700,11 +700,11 @@ class MonitorRoutesMockTest {
             seedMembership(userId, orgId)
             val system = makeHostData(orgId)
             val containerMetrics = ContainerMetricsResponse(
-                container_name = "my-container",
+                containerName = "my-container",
                 from = 1000L,
                 to = 2000L,
-                interval_seconds = 60,
-                data_points = emptyList()
+                intervalSeconds = 60,
+                dataPoints = emptyList()
             )
 
             every { mockMonitorService.getHostById(system.id) } returns system

--- a/backend/src/test/kotlin/com/moneat/services/DiscordServiceBuildersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/DiscordServiceBuildersTest.kt
@@ -647,7 +647,7 @@ class DiscordServiceBuildersTest {
     @Test
     fun `DiscordOAuthResponse with error`() {
         val resp = DiscordService.DiscordOAuthResponse(error = "invalid_grant")
-        assertNull(resp.access_token)
+        assertNull(resp.accessToken)
         assertNull(resp.guild)
         assertTrue(resp.error == "invalid_grant")
     }

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
@@ -146,7 +146,7 @@ class EventServiceCoverageTest {
     fun `processEnvelope routes event item to storeEvent`() = runBlocking {
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "evt-1",
+                eventId = "evt-1",
                 level = "error",
                 message = "Test error",
                 exception = ExceptionInfo(
@@ -169,9 +169,9 @@ class EventServiceCoverageTest {
     fun `processEnvelope routes transaction item to storeTransaction`() = runBlocking {
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-1",
+                eventId = "txn-1",
                 transaction = "GET /api/users",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000001.0,
                 platform = "jvm",
                 contexts = buildJsonObject {
@@ -199,7 +199,7 @@ class EventServiceCoverageTest {
     fun `processEnvelope routes feedback item to storeFeedback`() = runBlocking {
         val fbJson = Json.encodeToString(
             SentryFeedback(
-                event_id = "fb-1",
+                eventId = "fb-1",
                 timestamp = "2024-01-15T10:30:45Z",
                 contexts = buildJsonObject {
                     put(
@@ -235,13 +235,13 @@ class EventServiceCoverageTest {
     fun `processEnvelope routes replay_event and replay_recording`() = runBlocking {
         val replayEventJson = Json.encodeToString(
             SentryReplayEvent(
-                replay_id = "replay-1",
-                segment_id = 0,
+                replayId = "replay-1",
+                segmentId = 0,
                 timestamp = 1700000000.0,
-                replay_start_timestamp = 1699999990.0,
+                replayStartTimestamp = 1699999990.0,
                 urls = listOf("https://example.com"),
-                error_ids = listOf("err-1"),
-                trace_ids = listOf("trace-1"),
+                errorIds = listOf("err-1"),
+                traceIds = listOf("trace-1"),
                 platform = "javascript",
                 environment = "production",
                 user = UserInfo(id = "u1"),
@@ -339,7 +339,7 @@ class EventServiceCoverageTest {
     fun `processEnvelope with multiple items processes all`() = runBlocking {
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "evt-multi",
+                eventId = "evt-multi",
                 level = "error",
                 message = "Multi test",
                 exception = ExceptionInfo(
@@ -349,9 +349,9 @@ class EventServiceCoverageTest {
         )
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-multi",
+                eventId = "txn-multi",
                 transaction = "test",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000001.0,
                 contexts = buildJsonObject {
                     put(
@@ -386,9 +386,9 @@ class EventServiceCoverageTest {
     fun `storeTransaction inserts spans from transaction`() = runBlocking {
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-spans",
+                eventId = "txn-spans",
                 transaction = "GET /items",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000002.0,
                 platform = "python",
                 environment = "staging",
@@ -405,22 +405,22 @@ class EventServiceCoverageTest {
                 },
                 spans = listOf(
                     SentrySpan(
-                        span_id = "span1",
-                        parent_span_id = "root",
-                        trace_id = "trace-abc",
+                        spanId = "span1",
+                        parentSpanId = "root",
+                        traceId = "trace-abc",
                         op = "db.query",
                         description = "SELECT * FROM items",
-                        start_timestamp = 1700000000.5,
+                        startTimestamp = 1700000000.5,
                         timestamp = 1700000001.0,
                         status = "ok",
                         tags = mapOf("db.system" to "postgresql")
                     ),
                     SentrySpan(
-                        span_id = "span2",
-                        trace_id = "trace-abc",
+                        spanId = "span2",
+                        traceId = "trace-abc",
                         op = "http.client",
                         description = "GET /external",
-                        start_timestamp = 1700000001.0,
+                        startTimestamp = 1700000001.0,
                         timestamp = 1700000001.5,
                         status = "ok"
                     )
@@ -462,9 +462,9 @@ class EventServiceCoverageTest {
 
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-ai",
+                eventId = "txn-ai",
                 transaction = "chat",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000005.0,
                 contexts = buildJsonObject {
                     put(
@@ -477,11 +477,11 @@ class EventServiceCoverageTest {
                 },
                 spans = listOf(
                     SentrySpan(
-                        span_id = "ai-span-1",
-                        trace_id = "trace-ai",
+                        spanId = "ai-span-1",
+                        traceId = "trace-ai",
                         op = "ai.chat_completion",
                         description = "OpenAI Chat",
-                        start_timestamp = 1700000001.0,
+                        startTimestamp = 1700000001.0,
                         timestamp = 1700000003.0,
                         status = "ok",
                         data = buildJsonObject {
@@ -493,11 +493,11 @@ class EventServiceCoverageTest {
                         }
                     ),
                     SentrySpan(
-                        span_id = "ai-span-2",
-                        trace_id = "trace-ai",
+                        spanId = "ai-span-2",
+                        traceId = "trace-ai",
                         op = "ai.embedding",
                         description = "Embed query",
-                        start_timestamp = 1700000003.0,
+                        startTimestamp = 1700000003.0,
                         timestamp = 1700000004.0,
                         status = "ok",
                         data = buildJsonObject {
@@ -533,9 +533,9 @@ class EventServiceCoverageTest {
 
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-err",
+                eventId = "txn-err",
                 transaction = "POST /fail",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000001.0,
                 contexts = buildJsonObject {
                     put(
@@ -563,9 +563,9 @@ class EventServiceCoverageTest {
     fun `storeTransaction upserts release when present`() = runBlocking {
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-rel",
+                eventId = "txn-rel",
                 transaction = "test",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000001.0,
                 release = "v3.0.0",
                 contexts = buildJsonObject {
@@ -599,7 +599,7 @@ class EventServiceCoverageTest {
 
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "crash-1",
+                eventId = "crash-1",
                 exception = ExceptionInfo(
                     values = listOf(
                         ExceptionValue(
@@ -631,7 +631,7 @@ class EventServiceCoverageTest {
 
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "handled-1",
+                eventId = "handled-1",
                 level = "warning",
                 exception = ExceptionInfo(
                     values = listOf(
@@ -663,7 +663,7 @@ class EventServiceCoverageTest {
 
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "fp-1",
+                eventId = "fp-1",
                 exception = ExceptionInfo(
                     values = listOf(
                         ExceptionValue(
@@ -675,13 +675,13 @@ class EventServiceCoverageTest {
                                         filename = "lib.py",
                                         function = "validate",
                                         lineno = 10,
-                                        in_app = false
+                                        inApp = false
                                     ),
                                     StackFrame(
                                         filename = "app.py",
                                         function = "process",
                                         lineno = 42,
-                                        in_app = true
+                                        inApp = true
                                     )
                                 )
                             )
@@ -711,7 +711,7 @@ class EventServiceCoverageTest {
 
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "custom-fp",
+                eventId = "custom-fp",
                 fingerprint = listOf("custom", "group"),
                 exception = ExceptionInfo(
                     values = listOf(ExceptionValue(type = "Error", value = "test"))
@@ -735,7 +735,7 @@ class EventServiceCoverageTest {
 
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "msg-only",
+                eventId = "msg-only",
                 message = "Something went wrong",
                 level = "error"
             )
@@ -757,19 +757,19 @@ class EventServiceCoverageTest {
 
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "full-event",
+                eventId = "full-event",
                 timestamp = 1700000000.0,
                 level = "info",
                 platform = "python",
                 environment = "staging",
                 release = "2.5.0",
                 dist = "abc123",
-                server_name = "web-03",
+                serverName = "web-03",
                 user = UserInfo(
                     id = "uid-1",
                     email = "user@test.com",
                     username = "testuser",
-                    ip_address = "10.0.0.1"
+                    ipAddress = "10.0.0.1"
                 ),
                 tags = mapOf("service" to "api", "region" to "us-east"),
                 sdk = SdkInfo(name = "sentry-python", version = "1.5.0"),
@@ -812,7 +812,7 @@ class EventServiceCoverageTest {
     @Test
     fun `storeFeedback with projectId 0 is rejected`() = runBlocking {
         val fbJson = Json.encodeToString(
-            SentryFeedback(event_id = "fb-bad")
+            SentryFeedback(eventId = "fb-bad")
         )
 
         eventService.processEnvelope(
@@ -833,7 +833,7 @@ class EventServiceCoverageTest {
 
         val fbJson = Json.encodeToString(
             SentryFeedback(
-                event_id = "fb-ts",
+                eventId = "fb-ts",
                 timestamp = "2024-01-15T10:30:45Z",
                 contexts = buildJsonObject {
                     put(
@@ -866,7 +866,7 @@ class EventServiceCoverageTest {
 
         val fbJson = Json.encodeToString(
             SentryFeedback(
-                event_id = "fb-bad-ts",
+                eventId = "fb-bad-ts",
                 timestamp = "not-a-date",
                 contexts = buildJsonObject {
                     put(
@@ -896,7 +896,7 @@ class EventServiceCoverageTest {
     @Test
     fun `storeReplayEvent with projectId 0 is rejected`() = runBlocking {
         val replayJson = Json.encodeToString(
-            SentryReplayEvent(replay_id = "replay-bad")
+            SentryReplayEvent(replayId = "replay-bad")
         )
 
         eventService.processEnvelope(
@@ -917,10 +917,10 @@ class EventServiceCoverageTest {
 
         val replayJson = Json.encodeToString(
             SentryReplayEvent(
-                replay_id = "replay-ctx",
-                segment_id = 3,
+                replayId = "replay-ctx",
+                segmentId = 3,
                 timestamp = 1700000000.0,
-                replay_start_timestamp = 1699999990.0,
+                replayStartTimestamp = 1699999990.0,
                 urls = listOf("https://a.com", "https://b.com"),
                 contexts = buildJsonObject {
                     put(
@@ -983,7 +983,7 @@ class EventServiceCoverageTest {
 
         val body = Json.encodeToString(
             SentryEvent(
-                event_id = "store-1",
+                eventId = "store-1",
                 level = "error",
                 message = "Direct store",
                 exception = ExceptionInfo(
@@ -1029,9 +1029,9 @@ class EventServiceCoverageTest {
 
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-fail",
+                eventId = "txn-fail",
                 transaction = "test",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000001.0,
                 contexts = buildJsonObject {
                     put(
@@ -1065,7 +1065,7 @@ class EventServiceCoverageTest {
 
         val eventJson = Json.encodeToString(
             SentryEvent(
-                event_id = "evt-fail",
+                eventId = "evt-fail",
                 exception = ExceptionInfo(
                     values = listOf(ExceptionValue(type = "Error", value = "fail"))
                 )
@@ -1092,61 +1092,61 @@ class EventServiceCoverageTest {
 
         val aiSpans = listOf(
             SentrySpan(
-                span_id = "s1",
+                spanId = "s1",
                 op = "ai.chat_completion",
                 description = "Chat",
-                start_timestamp = 1700000001.0,
+                startTimestamp = 1700000001.0,
                 timestamp = 1700000002.0
             ),
             SentrySpan(
-                span_id = "s2",
+                spanId = "s2",
                 op = "ai.embedding",
                 description = "Embed",
-                start_timestamp = 1700000002.0,
+                startTimestamp = 1700000002.0,
                 timestamp = 1700000003.0
             ),
             SentrySpan(
-                span_id = "s3",
+                spanId = "s3",
                 op = "ai.tool_call",
                 description = "Tool",
-                start_timestamp = 1700000003.0,
+                startTimestamp = 1700000003.0,
                 timestamp = 1700000004.0
             ),
             SentrySpan(
-                span_id = "s4",
+                spanId = "s4",
                 op = "ai.agent",
                 description = "Agent",
-                start_timestamp = 1700000004.0,
+                startTimestamp = 1700000004.0,
                 timestamp = 1700000005.0
             ),
             SentrySpan(
-                span_id = "s5",
+                spanId = "s5",
                 op = "ai.chain",
                 description = "Chain",
-                start_timestamp = 1700000005.0,
+                startTimestamp = 1700000005.0,
                 timestamp = 1700000006.0
             ),
             SentrySpan(
-                span_id = "s6",
+                spanId = "s6",
                 op = "ai.retriever",
                 description = "Retriever",
-                start_timestamp = 1700000006.0,
+                startTimestamp = 1700000006.0,
                 timestamp = 1700000007.0
             ),
             SentrySpan(
-                span_id = "s7",
+                spanId = "s7",
                 op = "ai.run",
                 description = "Generic",
-                start_timestamp = 1700000007.0,
+                startTimestamp = 1700000007.0,
                 timestamp = 1700000008.0
             ),
         )
 
         val txnJson = Json.encodeToString(
             SentryTransaction(
-                event_id = "txn-ai-types",
+                eventId = "txn-ai-types",
                 transaction = "ai-test",
-                start_timestamp = 1700000000.0,
+                startTimestamp = 1700000000.0,
                 timestamp = 1700000010.0,
                 contexts = buildJsonObject {
                     put(

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceTest.kt
@@ -338,7 +338,7 @@ class EventServiceTest {
                 platform = "javascript"
             )
 
-        assertNotNull(event.event_id, "Event ID should be present")
+        assertNotNull(event.eventId, "Event ID should be present")
         assertNotNull(event.exception, "Exception should be present")
         assertEquals("error", event.level, "Level should be error")
         assertEquals("javascript", event.platform, "Platform should be set")
@@ -365,7 +365,7 @@ class EventServiceTest {
                 id = "user-123",
                 email = "test@example.com",
                 username = "testuser",
-                ip_address = TestIpConstants.IP_1
+                ipAddress = TestIpConstants.IP_1
             )
 
         val tags =
@@ -486,7 +486,7 @@ class EventServiceTest {
                 id = userId,
                 email = userEmail,
                 username = username,
-                ip_address = ipAddress
+                ipAddress = ipAddress
             )
 
         val event = createSentryEvent(user = userInfo)
@@ -494,7 +494,7 @@ class EventServiceTest {
         assertEquals(userId, event.user?.id, "User ID should be extracted")
         assertEquals(userEmail, event.user?.email, "User email should be extracted")
         assertEquals(username, event.user?.username, "Username should be extracted")
-        assertEquals(ipAddress, event.user?.ip_address, "IP address should be extracted")
+        assertEquals(ipAddress, event.user?.ipAddress, "IP address should be extracted")
     }
 
     @Test
@@ -694,7 +694,7 @@ class EventServiceTest {
                 .stacktrace
                 ?.frames
                 ?.get(0)
-                ?.in_app
+                ?.inApp
         )
         assertEquals(
             false,
@@ -702,7 +702,7 @@ class EventServiceTest {
                 .stacktrace
                 ?.frames
                 ?.get(2)
-                ?.in_app
+                ?.inApp
         )
     }
 
@@ -744,7 +744,7 @@ class EventServiceTest {
             }
 
         return SentryEvent(
-            event_id = eventId ?: UUID.randomUUID().toString(),
+            eventId = eventId ?: UUID.randomUUID().toString(),
             timestamp = timestamp,
             level = level,
             message = message,
@@ -772,8 +772,8 @@ class EventServiceTest {
             filename = filename,
             function = function,
             lineno = lineno,
-            in_app = inApp,
-            abs_path = "/app/$filename"
+            inApp = inApp,
+            absPath = "/app/$filename"
         )
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
@@ -127,18 +127,18 @@ class MonitorServiceExtendedTest {
 
         val metrics = service.getLatestMetrics(1)
         assertNotNull(metrics)
-        assertEquals(75.5f, metrics.cpu_percent)
-        assertEquals(8589934592L, metrics.mem_total)
+        assertEquals(75.5f, metrics.cpuPercent)
+        assertEquals(8589934592L, metrics.memTotal)
         // mem_used = memTotal - memAvailable = 8589934592 - 4294967296 = 4294967296
-        assertEquals(4294967296L, metrics.mem_used)
-        assertEquals(107374182400L, metrics.disk_total)
-        assertEquals(53687091200L, metrics.disk_used)
-        assertEquals(123456L, metrics.net_recv_bytes)
-        assertEquals(654321L, metrics.net_sent_bytes)
-        assertEquals(1.5f, metrics.load_1)
-        assertEquals(62.0f, metrics.temp_max)
-        assertEquals(45.0f, metrics.gpu_percent)
-        assertEquals(85.0f, metrics.battery_percent)
+        assertEquals(4294967296L, metrics.memUsed)
+        assertEquals(107374182400L, metrics.diskTotal)
+        assertEquals(53687091200L, metrics.diskUsed)
+        assertEquals(123456L, metrics.netRecvBytes)
+        assertEquals(654321L, metrics.netSentBytes)
+        assertEquals(1.5f, metrics.load1)
+        assertEquals(62.0f, metrics.tempMax)
+        assertEquals(45.0f, metrics.gpuPercent)
+        assertEquals(85.0f, metrics.batteryPercent)
     }
 
     @Test
@@ -172,8 +172,8 @@ class MonitorServiceExtendedTest {
 
         val metrics = service.getLatestMetrics(1)
         assertNotNull(metrics)
-        assertEquals(400L, metrics.mem_used)
-        assertEquals(40.0f, metrics.mem_percent)
+        assertEquals(400L, metrics.memUsed)
+        assertEquals(40.0f, metrics.memPercent)
     }
 
     @Test
@@ -189,7 +189,7 @@ class MonitorServiceExtendedTest {
 
         val metrics = service.getLatestMetrics(1)
         assertNotNull(metrics)
-        assertEquals(800L, metrics.mem_used)
+        assertEquals(800L, metrics.memUsed)
     }
 
     @Test
@@ -237,9 +237,9 @@ class MonitorServiceExtendedTest {
         val result = service.getLatestMetricsForHosts(listOf(1, 2, 3), 10)
         assertEquals(3, result.size)
         assertNotNull(result[1])
-        assertEquals(80.0f, result[1]?.cpu_percent)
+        assertEquals(80.0f, result[1]?.cpuPercent)
         assertNotNull(result[2])
-        assertEquals(60.0f, result[2]?.cpu_percent)
+        assertEquals(60.0f, result[2]?.cpuPercent)
         assertNull(result[3])
     }
 
@@ -292,11 +292,11 @@ class MonitorServiceExtendedTest {
         assertEquals("abc123", containers[0].id)
         assertEquals("nginx:latest", containers[0].image)
         assertEquals("running", containers[0].status)
-        assertEquals(25.5f, containers[0].cpu_percent)
-        assertEquals(524288000L, containers[0].mem_used)
-        assertEquals(1073741824L, containers[0].mem_limit)
-        assertEquals(12345L, containers[0].net_recv_bytes)
-        assertEquals(67890L, containers[0].net_sent_bytes)
+        assertEquals(25.5f, containers[0].cpuPercent)
+        assertEquals(524288000L, containers[0].memUsed)
+        assertEquals(1073741824L, containers[0].memLimit)
+        assertEquals(12345L, containers[0].netRecvBytes)
+        assertEquals(67890L, containers[0].netSentBytes)
     }
 
     @Test
@@ -317,7 +317,7 @@ class MonitorServiceExtendedTest {
         """.trimIndent()
 
         val containers = service.getLatestContainers(1)
-        assertEquals(50.0f, containers[0].mem_percent)
+        assertEquals(50.0f, containers[0].memPercent)
     }
 
     @Test
@@ -370,8 +370,8 @@ class MonitorServiceExtendedTest {
         every { hostRepo.getById(999) } returns null
 
         val result = service.getHistoricalMetrics(999, 1000, 2000, null)
-        assertTrue(result.data_points.isEmpty())
-        assertEquals(999, result.host_id)
+        assertTrue(result.dataPoints.isEmpty())
+        assertEquals(999, result.hostId)
     }
 
     @Test
@@ -383,7 +383,7 @@ class MonitorServiceExtendedTest {
         val nowEpoch = Clock.System.now().epochSeconds
         val farPast = nowEpoch - 86400L * 30
         val result = service.getHistoricalMetrics(1, farPast, farPast + 100, null)
-        assertTrue(result.data_points.isEmpty())
+        assertTrue(result.dataPoints.isEmpty())
     }
 
     @Test
@@ -401,8 +401,8 @@ class MonitorServiceExtendedTest {
             nowEpoch,
             null
         )
-        assertEquals(10, result.interval_seconds)
-        assertTrue(result.data_points.isEmpty())
+        assertEquals(10, result.intervalSeconds)
+        assertTrue(result.dataPoints.isEmpty())
     }
 
     @Test
@@ -413,7 +413,7 @@ class MonitorServiceExtendedTest {
         coEvery { hostRepo.executeClickHouseQuery(any()) } returns DATA_EMPTY_JSON
 
         val result = service.getHistoricalMetrics(1, nowEpoch - 3600, nowEpoch, 120)
-        assertEquals(120, result.interval_seconds)
+        assertEquals(120, result.intervalSeconds)
     }
 
     @Test
@@ -433,10 +433,10 @@ class MonitorServiceExtendedTest {
         """.trimIndent()
 
         val result = service.getHistoricalMetrics(1, nowEpoch - 3600, nowEpoch, 60)
-        assertEquals(2, result.data_points.size)
-        assertEquals(55.0f, result.data_points[0].cpu_percent)
-        assertEquals(70.0f, result.data_points[0].mem_percent)
-        assertEquals(60.0f, result.data_points[1].cpu_percent)
+        assertEquals(2, result.dataPoints.size)
+        assertEquals(55.0f, result.dataPoints[0].cpuPercent)
+        assertEquals(70.0f, result.dataPoints[0].memPercent)
+        assertEquals(60.0f, result.dataPoints[1].cpuPercent)
     }
 
     // ──── getContainerHistoricalMetrics ────
@@ -446,8 +446,8 @@ class MonitorServiceExtendedTest {
         every { hostRepo.getById(999) } returns null
 
         val result = service.getContainerHistoricalMetrics(999, "nginx", 1000, 2000, null)
-        assertTrue(result.data_points.isEmpty())
-        assertEquals("nginx", result.container_name)
+        assertTrue(result.dataPoints.isEmpty())
+        assertEquals("nginx", result.containerName)
     }
 
     @Test
@@ -457,7 +457,7 @@ class MonitorServiceExtendedTest {
         val farPast = Clock.System.now().epochSeconds - 86400L * 30
 
         val result = service.getContainerHistoricalMetrics(1, "nginx", farPast, farPast + 100, null)
-        assertTrue(result.data_points.isEmpty())
+        assertTrue(result.dataPoints.isEmpty())
     }
 
     @Test
@@ -482,10 +482,10 @@ class MonitorServiceExtendedTest {
             nowEpoch,
             60
         )
-        assertEquals(1, result.data_points.size)
-        assertEquals(25.0f, result.data_points[0].cpu_percent)
-        assertEquals(524288000L, result.data_points[0].mem_used)
-        assertEquals(1073741824L, result.data_points[0].mem_limit)
+        assertEquals(1, result.dataPoints.size)
+        assertEquals(25.0f, result.dataPoints[0].cpuPercent)
+        assertEquals(524288000L, result.dataPoints[0].memUsed)
+        assertEquals(1073741824L, result.dataPoints[0].memLimit)
     }
 
     // ──── getLatestInfraContainers ────

--- a/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
@@ -124,7 +124,7 @@ class NotificationFormattingTest {
         val element = SlackService.SlackElement(
             type = "button",
             text = SlackService.SlackText(type = "plain_text", text = "Click"),
-            action_id = "btn_click"
+            actionId = "btn_click"
         )
         val encoded = json.encodeToString(element)
         val obj = Json.parseToJsonElement(encoded).jsonObject
@@ -188,7 +188,7 @@ class NotificationFormattingTest {
         val response = json.decodeFromString<SlackService.SlackOAuthResponse>(responseJson)
 
         assertTrue(response.ok)
-        assertEquals("xoxb-123", response.access_token)
+        assertEquals("xoxb-123", response.accessToken)
         assertEquals("T123", response.team?.id)
         assertEquals("Test Team", response.team?.name)
     }
@@ -200,7 +200,7 @@ class NotificationFormattingTest {
 
         assertEquals(false, response.ok)
         assertEquals("invalid_code", response.error)
-        assertNull(response.access_token)
+        assertNull(response.accessToken)
     }
 
     @Test
@@ -235,7 +235,7 @@ class NotificationFormattingTest {
         assertTrue(response.ok)
         assertEquals(2, response.channels?.size)
         assertEquals("C001", response.channels?.get(0)?.id)
-        assertEquals(true, response.channels?.get(1)?.is_private)
+        assertEquals(true, response.channels?.get(1)?.isPrivate)
     }
 
     @Test
@@ -395,8 +395,8 @@ class NotificationFormattingTest {
         """.trimIndent()
         val response = json.decodeFromString<DiscordService.DiscordOAuthResponse>(responseJson)
 
-        assertEquals("abc123", response.access_token)
-        assertEquals("Bearer", response.token_type)
+        assertEquals("abc123", response.accessToken)
+        assertEquals("Bearer", response.tokenType)
         assertEquals("G123", response.guild?.id)
         assertEquals("Test Guild", response.guild?.name)
         assertNull(response.error)
@@ -408,7 +408,7 @@ class NotificationFormattingTest {
         val response = json.decodeFromString<DiscordService.DiscordOAuthResponse>(responseJson)
 
         assertEquals("invalid_grant", response.error)
-        assertNull(response.access_token)
+        assertNull(response.accessToken)
         assertNull(response.guild)
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceRoutingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceRoutingTest.kt
@@ -163,7 +163,7 @@ class NotificationServiceRoutingTest {
         environment: String? = "production"
     ): SentryEvent =
         SentryEvent(
-            event_id = eventId,
+            eventId = eventId,
             timestamp = Clock.System.now().toEpochMilliseconds() / 1000.0,
             level = level,
             message = message,
@@ -172,7 +172,7 @@ class NotificationServiceRoutingTest {
 
     private fun buildEventWithException(): SentryEvent =
         SentryEvent(
-            event_id = "evt-exc-1",
+            eventId = "evt-exc-1",
             timestamp = Clock.System.now().toEpochMilliseconds() / 1000.0,
             level = "error",
             message = null,
@@ -188,13 +188,13 @@ class NotificationServiceRoutingTest {
                                     filename = "UserService.kt",
                                     function = "getUser",
                                     lineno = 42,
-                                    in_app = true
+                                    inApp = true
                                 ),
                                 StackFrame(
                                     filename = "UserRoute.kt",
                                     function = "handleGet",
                                     lineno = 15,
-                                    in_app = true
+                                    inApp = true
                                 )
                             )
                         )
@@ -521,7 +521,7 @@ class NotificationServiceRoutingTest {
             seedNotificationPrefs(userId, frequencyMinutes = 0)
 
             val event = SentryEvent(
-                event_id = "evt-nots",
+                eventId = "evt-nots",
                 timestamp = null,
                 level = "error",
                 message = "Timestamp-less error"

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceTest.kt
@@ -112,7 +112,7 @@ class NotificationServiceTest {
             try {
                 val event =
                     SentryEvent(
-                        event_id = "evt-1",
+                        eventId = "evt-1",
                         timestamp = Clock.System.now().toEpochMilliseconds() / 1000.0,
                         level = "error",
                         message = "NullPointerException in checkout flow",
@@ -123,7 +123,7 @@ class NotificationServiceTest {
                 waitForEmailRows(expectedCount = 1)
 
                 // Second issue alert for the same project/user should be throttled by alert frequency.
-                notificationService.onNewIssue(projectId, "1002", event.copy(event_id = "evt-2"))
+                notificationService.onNewIssue(projectId, "1002", event.copy(eventId = "evt-2"))
                 waitForEmailRows(expectedCount = 1)
 
                 val sentRows =

--- a/backend/src/test/kotlin/com/moneat/services/SummaryServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SummaryServiceTest.kt
@@ -208,21 +208,21 @@ class SummaryServiceTest {
         cpu: Float = 55.0f,
         mem: Float = 70.0f
     ): LatestMetrics = LatestMetrics(
-        cpu_percent = cpu,
-        mem_total = 16000000L,
-        mem_used = 11200000L,
-        mem_percent = mem,
-        disk_total = 500000000L,
-        disk_used = 250000000L,
-        disk_percent = 50.0f,
-        net_recv_bytes = 1000L,
-        net_sent_bytes = 2000L,
-        net_recv_mbps = 1.0f,
-        net_sent_mbps = 2.0f,
-        load_1 = 1.5f,
-        temp_max = null,
-        gpu_percent = null,
-        battery_percent = null
+        cpuPercent = cpu,
+        memTotal = 16000000L,
+        memUsed = 11200000L,
+        memPercent = mem,
+        diskTotal = 500000000L,
+        diskUsed = 250000000L,
+        diskPercent = 50.0f,
+        netRecvBytes = 1000L,
+        netSentBytes = 2000L,
+        netRecvMbps = 1.0f,
+        netSentMbps = 2.0f,
+        load1 = 1.5f,
+        tempMax = null,
+        gpuPercent = null,
+        batteryPercent = null
     )
 
     private fun mockClickHouseHandler(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/mcp/services/SummaryService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/mcp/services/SummaryService.kt
@@ -273,8 +273,8 @@ class SummaryService(
             HostMetricSnapshot(
                 systemId = sys.id.toString(),
                 systemName = sys.displayName ?: sys.hostname,
-                cpuPercent = metrics?.cpu_percent,
-                memPercent = metrics?.mem_percent,
+                cpuPercent = metrics?.cpuPercent,
+                memPercent = metrics?.memPercent,
                 status = sys.status,
             )
         }


### PR DESCRIPTION
Closes #303

_Automated by auto-agent._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal property naming conventions across backend models and services from snake_case to camelCase for consistency with Kotlin conventions, while maintaining compatibility with external API formats through serialization mappings.
  * Enabled constructor parameter naming validation rule to enforce consistent naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->