### PR TITLE
fix: prevent long issue titles from overflowing Top Issues card

### DIFF
--- a/dashboard/src/routes/releases.$version.tsx
+++ b/dashboard/src/routes/releases.$version.tsx
@@ -144,8 +144,8 @@ function ReleaseDetailPage() {
                         params={{ issueId: issue.issueId }}
                         className="flex items-center justify-between p-2 rounded-lg border hover:bg-accent transition-colors"
                       >
-                        <div className="flex items-center gap-2">
-                          <div className="flex items-center justify-center w-5 h-5 rounded-full bg-primary/10 text-xs font-semibold">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <div className="flex items-center justify-center w-5 h-5 shrink-0 rounded-full bg-primary/10 text-xs font-semibold">
                             {index + 1}
                           </div>
                           <div className="min-w-0">


### PR DESCRIPTION
Closes #336

## Summary
- Added `min-w-0` to the left-side flex container in the Top Issues list so it can shrink below its content width, allowing `truncate` to take effect on long titles
- Added `shrink-0` to the rank number badge to prevent it from collapsing when the title is long

## Test plan
- Open a release with a top issue that has a very long title (e.g. an Android file path)
- Verify the title truncates with an ellipsis and stays within the card
- Verify the events count on the right remains visible and aligned

Made with [Cursor](https://cursor.com)