### PR TITLE
lint: enable NestedBlockDepth detekt rule and fix violations

### DIFF
--- a/backend/detekt.yml
+++ b/backend/detekt.yml
@@ -16,6 +16,8 @@ style:
       - '**/test/**'
       - '**/integrationTest/**'
       - '**/DemoDataReseeder.kt'
+      # Demo reseed modules: many intentional numeric literals (intervals, layout, sample data).
+      - '**/com/moneat/config/DemoReseed*.kt'
     ignorePropertyDeclaration: true
     ignoreEnums: true
     ignoreRanges: true
@@ -73,8 +75,9 @@ complexity:
       - '**/androidInstrumentedTest/**'
       - '**/jsTest/**'
       - '**/iosTest/**'
+  # Enforced (issue #297): flag deeply-nested blocks so functions are kept flat.
   NestedBlockDepth:
-    active: false
+    active: true
   NestedScopeFunctions:
     active: false
 

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/handlers/JdbcHandler.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/handlers/JdbcHandler.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import mu.KotlinLogging
+import java.sql.Connection
 import java.sql.ResultSet
 import java.util.concurrent.ConcurrentHashMap
 
@@ -115,27 +116,29 @@ abstract class JdbcHandler(
         val db = databaseName ?: defaultDatabase()
         val ds = createTempDataSource(host, p, db, credentials.username, credentials.password)
         return try {
-            ds.connection.use { conn ->
-                val fields = mutableListOf<DataSourceField>()
-                val query = schemaFieldsQuery() ?: schemaIntrospectionQuery()
-                conn.createStatement().use { stmt ->
-                    stmt.executeQuery(query).use { rs ->
-                        while (rs.next()) {
-                            fields.add(
-                                DataSourceField(
-                                    rs.getString(1),
-                                    rs.getString(2),
-                                    rs.getString(SCHEMA_COMMENT_COLUMN).orEmpty(),
-                                )
-                            )
-                        }
-                    }
-                }
-                fields
-            }
+            ds.connection.use { conn -> readJdbcSchemaFields(conn) }
         } finally {
             ds.close()
         }
+    }
+
+    private fun readJdbcSchemaFields(conn: Connection): List<DataSourceField> {
+        val fields = mutableListOf<DataSourceField>()
+        val query = schemaFieldsQuery() ?: schemaIntrospectionQuery()
+        conn.createStatement().use { stmt ->
+            stmt.executeQuery(query).use { rs ->
+                while (rs.next()) {
+                    fields.add(
+                        DataSourceField(
+                            rs.getString(1),
+                            rs.getString(2),
+                            rs.getString(SCHEMA_COMMENT_COLUMN).orEmpty(),
+                        )
+                    )
+                }
+            }
+        }
+        return fields
     }
 
     protected open fun defaultDatabase(): String = ""

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
@@ -27,6 +27,7 @@ import io.ktor.client.request.parameter
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -205,34 +206,49 @@ class PrometheusHandler : HttpApiHandler() {
             when (resultType) {
                 "matrix" -> {
                     val values = result.jsonObject["values"]?.jsonArray ?: continue
-                    for (point in values) {
-                        val arr = point.jsonArray
-                        val row = mutableMapOf<String, JsonElement>()
-                        row["time_bucket"] = promTimestampToMs(arr[0])
-                        row[metricName] = promValueToNumber(arr[1])
-                        for ((k, v) in metric) {
-                            if (k != "__name__") row[k] = v
-                        }
-                        rows.add(row)
-                        if (rows.size >= limit) return rows
-                    }
+                    appendPrometheusMatrixPoints(values, metric, metricName, rows, limit)
                 }
-                "vector" -> {
-                    val value = result.jsonObject["value"]?.jsonArray
-                    if (value != null) {
-                        val row = mutableMapOf<String, JsonElement>()
-                        row["time_bucket"] = promTimestampToMs(value[0])
-                        row[metricName] = promValueToNumber(value[1])
-                        for ((k, v) in metric) {
-                            if (k != "__name__") row[k] = v
-                        }
-                        rows.add(row)
-                    }
-                }
+                "vector" -> appendPrometheusVectorRow(result.jsonObject, metric, metricName, rows)
             }
             if (rows.size >= limit) break
         }
         return rows
+    }
+
+    private fun appendPrometheusMatrixPoints(
+        values: JsonArray,
+        metric: JsonObject,
+        metricName: String,
+        rows: MutableList<Map<String, JsonElement>>,
+        limit: Int,
+    ) {
+        for (point in values) {
+            val arr = point.jsonArray
+            val row = mutableMapOf<String, JsonElement>()
+            row["time_bucket"] = promTimestampToMs(arr[0])
+            row[metricName] = promValueToNumber(arr[1])
+            for ((k, v) in metric) {
+                if (k != "__name__") row[k] = v
+            }
+            rows.add(row)
+            if (rows.size >= limit) return
+        }
+    }
+
+    private fun appendPrometheusVectorRow(
+        resultObj: JsonObject,
+        metric: JsonObject,
+        metricName: String,
+        rows: MutableList<Map<String, JsonElement>>,
+    ) {
+        val value = resultObj["value"]?.jsonArray ?: return
+        val row = mutableMapOf<String, JsonElement>()
+        row["time_bucket"] = promTimestampToMs(value[0])
+        row[metricName] = promValueToNumber(value[1])
+        for ((k, v) in metric) {
+            if (k != "__name__") row[k] = v
+        }
+        rows.add(row)
     }
 
     private fun promTimestampToMs(element: JsonElement): JsonElement {

--- a/backend/src/main/kotlin/com/moneat/dashboards/translation/GrafanaTranslator.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/translation/GrafanaTranslator.kt
@@ -352,34 +352,38 @@ class GrafanaTranslator : DashboardTranslator {
             val opts = transform["options"]?.jsonObject ?: continue
 
             when (id) {
-                "filterFieldsByName" -> {
-                    val include = opts["include"]?.jsonObject
-                    val names = include?.get("names")?.jsonArray
-                    if (names != null && names.isNotEmpty()) {
-                        config["visibleFields"] = names.joinToString(",") {
-                            it.jsonPrimitive.content
-                        }
-                    }
-                }
-                "organize" -> {
-                    val renameByName = opts["renameByName"]?.jsonObject
-                    if (renameByName != null && renameByName.isNotEmpty()) {
-                        val renames = renameByName.entries
-                            .filter {
-                                it.value.jsonPrimitive.contentOrNull?.isNotEmpty() == true
-                            }
-                            .associate {
-                                it.key to it.value.jsonPrimitive.content
-                            }
-                        if (renames.isNotEmpty()) {
-                            config["fieldRenames"] = buildJsonObject {
-                                renames.forEach { (k, v) -> put(k, v) }
-                            }.toString()
-                        }
-                    }
-                }
+                "filterFieldsByName" -> applyFilterFieldsByNameTransform(opts, config)
+                "organize" -> applyOrganizeRenameTransform(opts, config)
             }
         }
+    }
+
+    private fun applyFilterFieldsByNameTransform(
+        opts: JsonObject,
+        config: MutableMap<String, String>,
+    ) {
+        val include = opts["include"]?.jsonObject
+        val names = include?.get("names")?.jsonArray
+        if (names != null && names.isNotEmpty()) {
+            config["visibleFields"] = names.joinToString(",") {
+                it.jsonPrimitive.content
+            }
+        }
+    }
+
+    private fun applyOrganizeRenameTransform(
+        opts: JsonObject,
+        config: MutableMap<String, String>,
+    ) {
+        val renameByName = opts["renameByName"]?.jsonObject
+        if (renameByName == null || renameByName.isEmpty()) return
+        val renames = renameByName.entries
+            .filter { it.value.jsonPrimitive.contentOrNull?.isNotEmpty() == true }
+            .associate { it.key to it.value.jsonPrimitive.content }
+        if (renames.isEmpty()) return
+        config["fieldRenames"] = buildJsonObject {
+            renames.forEach { (k, v) -> put(k, v) }
+        }.toString()
     }
 
     internal fun parseGrafanaTargets(

--- a/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
@@ -107,80 +107,132 @@ data class SentryEnvelope(
                 bytePos = itemHeaderEnd + 1
 
                 if (explicitLength != null && explicitLength > 0 && bytePos + explicitLength <= bodyBytes.size) {
-                    // Explicit length provided - read exact bytes
-                    val payloadBytes = bodyBytes.copyOfRange(bytePos, bytePos + explicitLength)
-                    if (itemType == "replay_video" || itemType == "replay_recording") {
-                        val payload =
-                            java.util.Base64
-                                .getEncoder()
-                                .encodeToString(payloadBytes)
-                        items.add(EnvelopeItem(itemType, payload, payloadBytes, itemHeader))
-                    } else {
-                        val payload = payloadBytes.toString(Charsets.UTF_8)
-                        items.add(EnvelopeItem(itemType, payload, null, itemHeader))
-                    }
-                    bytePos += explicitLength
+                    bytePos += appendExplicitLengthEnvelopeItem(
+                        bodyBytes,
+                        bytePos,
+                        explicitLength,
+                        itemType,
+                        itemHeader,
+                        items
+                    )
                 } else if (itemType != "unknown" && itemType in knownItemTypes) {
-                    // No explicit length - scan forward for the next item header or end of envelope.
-                    // This handles SDKs (like Android) that omit `length` for text-based items.
-                    val payloadStart = bytePos
-                    var payloadEnd = bodyBytes.size
-
-                    var scanPos = bytePos
-                    while (scanPos < bodyBytes.size) {
-                        val lineEnd =
-                            (scanPos until bodyBytes.size).firstOrNull { bodyBytes[it] == '\n'.code.toByte() }
-                                ?: bodyBytes.size
-                        val line = bodyBytes.copyOfRange(scanPos, lineEnd).toString(Charsets.UTF_8).trim()
-                        if (line.isNotEmpty()) {
-                            try {
-                                val possibleHeader = Json.parseToJsonElement(line).jsonObject
-                                val possibleType = possibleHeader["type"]?.jsonPrimitive?.content
-                                if (possibleType != null &&
-                                    possibleType in knownItemTypes &&
-                                    possibleType != itemType
-                                ) {
-                                    // Found the next item header - payload ends here
-                                    payloadEnd = scanPos
-                                    break
-                                }
-                                // Also detect next item header if it has the same type but includes a length field
-                                if (possibleType != null &&
-                                    possibleType in knownItemTypes &&
-                                    possibleHeader.containsKey("length")
-                                ) {
-                                    payloadEnd = scanPos
-                                    break
-                                }
-                            } catch (_: SerializationException) {
-                                // Not valid JSON - still part of current payload
-                            }
-                        }
-                        scanPos = if (lineEnd < bodyBytes.size) lineEnd + 1 else bodyBytes.size
-                    }
-
-                    if (payloadStart < payloadEnd) {
-                        // Trim trailing newlines from payload
-                        var trimmedEnd = payloadEnd
-                        while (
-                            trimmedEnd > payloadStart &&
-                            (
-                                bodyBytes[trimmedEnd - 1] == '\n'.code.toByte() ||
-                                    bodyBytes[trimmedEnd - 1] == '\r'.code.toByte()
-                                )
-                        ) {
-                            trimmedEnd--
-                        }
-                        val payloadBytes = bodyBytes.copyOfRange(payloadStart, trimmedEnd)
-                        val payload = payloadBytes.toString(Charsets.UTF_8)
-                        items.add(EnvelopeItem(itemType, payload, null, itemHeader))
-                    }
-                    bytePos = payloadEnd
+                    bytePos = appendImplicitLengthEnvelopeItem(
+                        bodyBytes,
+                        bytePos,
+                        knownItemTypes,
+                        itemType,
+                        itemHeader,
+                        items
+                    )
                 } else {
                     // Unknown type with no length - skip
                 }
             }
             return SentryEnvelope(eventId, items)
+        }
+
+        private fun appendExplicitLengthEnvelopeItem(
+            bodyBytes: ByteArray,
+            bytePos: Int,
+            explicitLength: Int,
+            itemType: String,
+            itemHeader: JsonObject,
+            items: MutableList<EnvelopeItem>,
+        ): Int {
+            val payloadBytes = bodyBytes.copyOfRange(bytePos, bytePos + explicitLength)
+            if (itemType == "replay_video" || itemType == "replay_recording") {
+                val payload =
+                    java.util.Base64
+                        .getEncoder()
+                        .encodeToString(payloadBytes)
+                items.add(EnvelopeItem(itemType, payload, payloadBytes, itemHeader))
+            } else {
+                val payload = payloadBytes.toString(Charsets.UTF_8)
+                items.add(EnvelopeItem(itemType, payload, null, itemHeader))
+            }
+            return explicitLength
+        }
+
+        /**
+         * No explicit length — scan forward for the next item header or end of envelope
+         * (SDKs like Android may omit `length` for text-based items).
+         */
+        private fun appendImplicitLengthEnvelopeItem(
+            bodyBytes: ByteArray,
+            bytePos: Int,
+            knownItemTypes: Set<String>,
+            itemType: String,
+            itemHeader: JsonObject,
+            items: MutableList<EnvelopeItem>,
+        ): Int {
+            val payloadStart = bytePos
+            val payloadEnd = findImplicitEnvelopePayloadEnd(bodyBytes, bytePos, knownItemTypes, itemType)
+            if (payloadStart < payloadEnd) {
+                val trimmedEnd = trimTrailingEnvelopeNewlines(bodyBytes, payloadStart, payloadEnd)
+                val payloadBytes = bodyBytes.copyOfRange(payloadStart, trimmedEnd)
+                val payload = payloadBytes.toString(Charsets.UTF_8)
+                items.add(EnvelopeItem(itemType, payload, null, itemHeader))
+            }
+            return payloadEnd
+        }
+
+        private fun implicitScanStopsAtLine(
+            line: String,
+            knownItemTypes: Set<String>,
+            currentItemType: String,
+        ): Boolean {
+            val possibleHeader = Json.parseToJsonElement(line).jsonObject
+            val possibleType = possibleHeader["type"]?.jsonPrimitive?.content ?: return false
+            if (possibleType !in knownItemTypes) return false
+            if (possibleType != currentItemType) return true
+            return possibleHeader.containsKey("length")
+        }
+
+        private fun findImplicitEnvelopePayloadEnd(
+            bodyBytes: ByteArray,
+            bytePos: Int,
+            knownItemTypes: Set<String>,
+            currentItemType: String,
+        ): Int {
+            var payloadEnd = bodyBytes.size
+            var scanPos = bytePos
+            while (scanPos < bodyBytes.size) {
+                val lineEnd =
+                    (scanPos until bodyBytes.size).firstOrNull { bodyBytes[it] == '\n'.code.toByte() }
+                        ?: bodyBytes.size
+                val line = bodyBytes.copyOfRange(scanPos, lineEnd).toString(Charsets.UTF_8).trim()
+                if (line.isNotEmpty()) {
+                    val stop = try {
+                        implicitScanStopsAtLine(line, knownItemTypes, currentItemType)
+                    } catch (_: SerializationException) {
+                        false
+                    }
+                    if (stop) {
+                        payloadEnd = scanPos
+                        break
+                    }
+                }
+                scanPos = if (lineEnd < bodyBytes.size) lineEnd + 1 else bodyBytes.size
+            }
+            return payloadEnd
+        }
+
+        private fun trimTrailingEnvelopeNewlines(
+            bodyBytes: ByteArray,
+            payloadStart: Int,
+            payloadEnd: Int,
+        ): Int {
+            var trimmedEnd = payloadEnd
+            while (
+                trimmedEnd > payloadStart &&
+                (
+                    bodyBytes[trimmedEnd - 1] == '\n'.code.toByte() ||
+                        bodyBytes[trimmedEnd - 1] == '\r'.code.toByte()
+                    )
+            ) {
+                trimmedEnd--
+            }
+            return trimmedEnd
         }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogQueryParser.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogQueryParser.kt
@@ -424,48 +424,7 @@ class LogQueryParser {
                 QueryNode.FullTextNode(token.value, false, isPhrase = true)
             }
 
-            is Token.Field -> {
-                // Strip @ prefix if present
-                val field = if (token.name.startsWith('@')) token.name.substring(1) else token.name
-
-                if (token.isRange && token.rangeEnd != null) {
-                    QueryNode.RangeNode(field, token.value, token.rangeEnd)
-                } else {
-                    // Existence check: @field:* (value is exactly "*" and not quoted)
-                    if (token.value == "*" && !token.isQuoted) {
-                        // Special case: tags:MY_TAG — check tag key existence
-                        if (token.name == "tags") {
-                            return QueryNode.FullTextNode("*", true)
-                        }
-                        return QueryNode.ExistsNode(field)
-                    }
-
-                    // tags:MY_TAG syntax — tag key existence
-                    if (token.name == "tags") {
-                        return QueryNode.TagExistsNode(token.value)
-                    }
-
-                    // Numerical comparison operators: >N, >=N, <N, <=N (only for non-quoted values)
-                    if (!token.isQuoted) {
-                        val comparisonMatch = Regex("""^(>=|<=|>|<)(.+)$""").find(token.value)
-                        if (comparisonMatch != null) {
-                            val op = comparisonMatch.groupValues[1]
-                            val numValue = comparisonMatch.groupValues[2]
-                            return QueryNode.ComparisonNode(field, op, numValue)
-                        }
-                    }
-
-                    val isFullText = field == "*"
-                    // Quoted values are never treated as wildcards
-                    val isWildcard = !token.isQuoted && (token.value.contains('*') || token.value.contains('?'))
-
-                    if (isFullText) {
-                        QueryNode.FullTextNode(token.value, isWildcard, isPhrase = token.isQuoted)
-                    } else {
-                        QueryNode.FieldNode(field, token.value, isWildcard)
-                    }
-                }
-            }
+            is Token.Field -> parseFieldToken(token)
 
             is Token.FieldGroup -> {
                 // field:(val1 OR val2) — parse group tokens as values for this field
@@ -486,6 +445,44 @@ class LogQueryParser {
             else -> {
                 null
             }
+        }
+    }
+
+    /** Parses a single field token (e.g. `service:api`, `@field:*`, `tags:MY_TAG`). */
+    private fun parseFieldToken(token: Token.Field): QueryNode? {
+        val field = if (token.name.startsWith('@')) token.name.substring(1) else token.name
+
+        if (token.isRange && token.rangeEnd != null) {
+            return QueryNode.RangeNode(field, token.value, token.rangeEnd)
+        }
+
+        if (token.value == "*" && !token.isQuoted) {
+            if (token.name == "tags") {
+                return QueryNode.FullTextNode("*", true)
+            }
+            return QueryNode.ExistsNode(field)
+        }
+
+        if (token.name == "tags") {
+            return QueryNode.TagExistsNode(token.value)
+        }
+
+        if (!token.isQuoted) {
+            val comparisonMatch = Regex("""^(>=|<=|>|<)(.+)$""").find(token.value)
+            if (comparisonMatch != null) {
+                val op = comparisonMatch.groupValues[1]
+                val numValue = comparisonMatch.groupValues[2]
+                return QueryNode.ComparisonNode(field, op, numValue)
+            }
+        }
+
+        val isFullText = field == "*"
+        val isWildcard = !token.isQuoted && (token.value.contains('*') || token.value.contains('?'))
+
+        return if (isFullText) {
+            QueryNode.FullTextNode(token.value, isWildcard, isPhrase = token.isQuoted)
+        } else {
+            QueryNode.FieldNode(field, token.value, isWildcard)
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
@@ -42,11 +42,15 @@ import com.moneat.logs.models.QueuedLogEntry
 import com.moneat.logs.repositories.LogRepository
 import com.moneat.otlp.OtlpParsingUtils
 import com.moneat.otlp.OtlpProtobufParser
+import com.moneat.otlp.ResourceContext
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import io.opentelemetry.proto.logs.v1.LogRecord
+import io.opentelemetry.proto.logs.v1.ResourceLogs
+import io.opentelemetry.proto.logs.v1.ScopeLogs
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -842,42 +846,7 @@ class LogService(private val logRepository: LogRepository) {
             val inClause = normalizedLevels.joinToString(",") { "'${escapeSql(it)}'" }
             conditions += "level IN ($inClause)"
         }
-        if (!query.isNullOrBlank()) {
-            // Use Datadog-compatible query parser
-            try {
-                val parsed = queryParser.parse(query)
-                if (parsed.rootNode != null) {
-                    val queryCondition = queryParser.toClickHouseSql(parsed.rootNode, ::escapeSql)
-                    if (queryCondition.isNotBlank() && queryCondition != "1=1") {
-                        conditions += "($queryCondition)"
-                    }
-                }
-            } catch (e: SerializationException) {
-                logger.error(e) {
-                    "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
-                }
-                // Fallback: treat as simple full-text search
-                conditions += buildSimpleSearchCondition(query)
-            } catch (e: IOException) {
-                logger.error(e) {
-                    "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
-                }
-                // Fallback: treat as simple full-text search
-                conditions += buildSimpleSearchCondition(query)
-            } catch (e: IllegalStateException) {
-                logger.error(e) {
-                    "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
-                }
-                // Fallback: treat as simple full-text search
-                conditions += buildSimpleSearchCondition(query)
-            } catch (e: IllegalArgumentException) {
-                logger.error(e) {
-                    "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
-                }
-                // Fallback: treat as simple full-text search
-                conditions += buildSimpleSearchCondition(query)
-            }
-        }
+        addExportCsvQueryConditions(query, conditions)
         tags.forEach { (key, value) ->
             val condition = buildTagCondition(key, value)
             if (condition.isNotBlank()) {
@@ -952,6 +921,43 @@ class LogService(private val logRepository: LogRepository) {
         }
 
         return sb.toString()
+    }
+
+    /** Applies Datadog-style query parsing to [conditions], or falls back to simple search on parse errors. */
+    private fun addExportCsvQueryConditions(
+        query: String?,
+        conditions: MutableList<String>,
+    ) {
+        if (query.isNullOrBlank()) return
+        try {
+            val parsed = queryParser.parse(query)
+            if (parsed.rootNode != null) {
+                val queryCondition = queryParser.toClickHouseSql(parsed.rootNode, ::escapeSql)
+                if (queryCondition.isNotBlank() && queryCondition != "1=1") {
+                    conditions += "($queryCondition)"
+                }
+            }
+        } catch (e: SerializationException) {
+            logger.error(e) {
+                "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
+            }
+            conditions += buildSimpleSearchCondition(query)
+        } catch (e: IOException) {
+            logger.error(e) {
+                "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
+            }
+            conditions += buildSimpleSearchCondition(query)
+        } catch (e: IllegalStateException) {
+            logger.error(e) {
+                "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
+            }
+            conditions += buildSimpleSearchCondition(query)
+        } catch (e: IllegalArgumentException) {
+            logger.error(e) {
+                "Failed to parse query (query_fp=${utf8Fingerprint(query)}), falling back to simple search"
+            }
+            conditions += buildSimpleSearchCondition(query)
+        }
     }
 
     private fun csvEscape(value: String): String {
@@ -1388,41 +1394,60 @@ class LogService(private val logRepository: LogRepository) {
             }
 
         val entries = mutableListOf<LogIngestEntry>()
-
         request.resourceLogsList.forEach { resourceLogs ->
-            val resourceCtx = OtlpProtobufParser.extractResourceContext(resourceLogs.resource)
-
-            resourceLogs.scopeLogsList.forEach { scopeLogs ->
-                scopeLogs.logRecordsList.forEach { record ->
-                    val attributes = OtlpProtobufParser.attributesToMap(record.attributesList)
-                    val bodyText = OtlpProtobufParser.extractAnyValue(record.body) ?: ""
-                    val message = if (bodyText.isBlank()) "OTLP log record" else bodyText
-                    val severityText = record.severityText.ifEmpty { null }
-                    val timestampNs = record.timeUnixNano.takeIf { it != 0L }
-                        ?: record.observedTimeUnixNano.takeIf { it != 0L }
-                    val timestampMs = timestampNs?.let { OtlpProtobufParser.nanoToEpochMs(it) }
-
-                    entries += LogIngestEntry(
-                        timestampMs = timestampMs,
-                        level = severityText,
-                        message = message,
-                        body = bodyText,
-                        service = resourceCtx.serviceName.ifEmpty { attributes["service.name"] },
-                        environment = resourceCtx.environment.ifEmpty {
-                            attributes["deployment.environment"] ?: attributes["service.environment"]
-                        },
-                        host = resourceCtx.hostName.ifEmpty { attributes["host.name"] },
-                        source = "otlp",
-                        traceId = OtlpProtobufParser.bytesToHex(record.traceId).ifEmpty { null },
-                        spanId = OtlpProtobufParser.bytesToHex(record.spanId).ifEmpty { null },
-                        tags = HashMap(attributes),
-                        resourceAttributes = HashMap(resourceCtx.attributes),
-                    )
-                }
-            }
+            appendOtlpProtobufResourceLogs(resourceLogs, entries)
         }
-
         return entries
+    }
+
+    private fun appendOtlpProtobufResourceLogs(
+        resourceLogs: ResourceLogs,
+        entries: MutableList<LogIngestEntry>,
+    ) {
+        val resourceCtx = OtlpProtobufParser.extractResourceContext(resourceLogs.resource)
+        resourceLogs.scopeLogsList.forEach { scopeLogs ->
+            appendOtlpProtobufScopeLogs(scopeLogs, resourceCtx, entries)
+        }
+    }
+
+    private fun appendOtlpProtobufScopeLogs(
+        scopeLogs: ScopeLogs,
+        resourceCtx: ResourceContext,
+        entries: MutableList<LogIngestEntry>,
+    ) {
+        scopeLogs.logRecordsList.forEach { record ->
+            entries += logIngestEntryFromOtlpProtobuf(record, resourceCtx)
+        }
+    }
+
+    private fun logIngestEntryFromOtlpProtobuf(
+        record: LogRecord,
+        resourceCtx: ResourceContext,
+    ): LogIngestEntry {
+        val attributes = OtlpProtobufParser.attributesToMap(record.attributesList)
+        val bodyText = OtlpProtobufParser.extractAnyValue(record.body) ?: ""
+        val message = if (bodyText.isBlank()) "OTLP log record" else bodyText
+        val severityText = record.severityText.ifEmpty { null }
+        val timestampNs = record.timeUnixNano.takeIf { it != 0L }
+            ?: record.observedTimeUnixNano.takeIf { it != 0L }
+        val timestampMs = timestampNs?.let { OtlpProtobufParser.nanoToEpochMs(it) }
+
+        return LogIngestEntry(
+            timestampMs = timestampMs,
+            level = severityText,
+            message = message,
+            body = bodyText,
+            service = resourceCtx.serviceName.ifEmpty { attributes["service.name"] },
+            environment = resourceCtx.environment.ifEmpty {
+                attributes["deployment.environment"] ?: attributes["service.environment"]
+            },
+            host = resourceCtx.hostName.ifEmpty { attributes["host.name"] },
+            source = "otlp",
+            traceId = OtlpProtobufParser.bytesToHex(record.traceId).ifEmpty { null },
+            spanId = OtlpProtobufParser.bytesToHex(record.spanId).ifEmpty { null },
+            tags = HashMap(attributes),
+            resourceAttributes = HashMap(resourceCtx.attributes),
+        )
     }
 
     fun parseOtlpJson(payload: String): List<LogIngestEntry> {
@@ -1436,7 +1461,14 @@ class LogService(private val logRepository: LogRepository) {
 
         val resourceLogs = parsed["resourceLogs"]?.jsonArray ?: return emptyList()
         val entries = mutableListOf<LogIngestEntry>()
+        appendOtlpJsonResourceLogs(resourceLogs, entries)
+        return entries
+    }
 
+    private fun appendOtlpJsonResourceLogs(
+        resourceLogs: JsonArray,
+        entries: MutableList<LogIngestEntry>,
+    ) {
         resourceLogs.forEach { resourceLogElement ->
             val resourceLog = resourceLogElement.jsonObject
             val resourceCtx = OtlpParsingUtils.extractResourceContext(resourceLog["resource"]?.jsonObject)
@@ -1444,47 +1476,55 @@ class LogService(private val logRepository: LogRepository) {
                 resourceLog["scopeLogs"]?.jsonArray
                     ?: resourceLog["instrumentationLibraryLogs"]?.jsonArray
                     ?: JsonArray(emptyList())
+            appendOtlpJsonScopeLogs(scopeLogs, resourceCtx, entries)
+        }
+    }
 
-            scopeLogs.forEach { scopeElement ->
-                val scopeLog = scopeElement.jsonObject
-                val logRecords = OtlpParsingUtils.safeJsonArray(scopeLog["logRecords"])
-
-                logRecords.forEach { recordElement ->
-                    val record = recordElement.jsonObject
-                    val attributes = OtlpParsingUtils.attributesToMap(record["attributes"])
-                    val bodyText = OtlpParsingUtils.extractAnyValue(record["body"]) ?: ""
-                    val message = if (bodyText.isBlank()) "OTLP log record" else bodyText
-                    val severityText = record["severityText"]?.jsonPrimitive?.contentOrNull
-                    val timestampNs = OtlpParsingUtils.extractTimestampNanos(
-                        record,
-                        "timeUnixNano",
-                        "observedTimeUnixNano"
-                    )
-                    val timestampMs = OtlpParsingUtils.nanoToEpochMs(timestampNs)
-
-                    val entry =
-                        LogIngestEntry(
-                            timestampMs = timestampMs,
-                            level = severityText,
-                            message = message,
-                            body = bodyText,
-                            service = resourceCtx.serviceName.ifEmpty { attributes["service.name"] },
-                            environment = resourceCtx.environment.ifEmpty {
-                                attributes["deployment.environment"] ?: attributes["service.environment"]
-                            },
-                            host = resourceCtx.hostName.ifEmpty { attributes["host.name"] },
-                            source = "otlp",
-                            traceId = record["traceId"]?.jsonPrimitive?.contentOrNull,
-                            spanId = record["spanId"]?.jsonPrimitive?.contentOrNull,
-                            tags = HashMap(attributes),
-                            resourceAttributes = HashMap(resourceCtx.attributes)
-                        )
-                    entries += entry
-                }
+    private fun appendOtlpJsonScopeLogs(
+        scopeLogs: JsonArray,
+        resourceCtx: ResourceContext,
+        entries: MutableList<LogIngestEntry>,
+    ) {
+        scopeLogs.forEach { scopeElement ->
+            val scopeLog = scopeElement.jsonObject
+            val logRecords = OtlpParsingUtils.safeJsonArray(scopeLog["logRecords"])
+            logRecords.forEach { recordElement ->
+                entries += logIngestEntryFromOtlpJson(recordElement.jsonObject, resourceCtx)
             }
         }
+    }
 
-        return entries
+    private fun logIngestEntryFromOtlpJson(
+        record: JsonObject,
+        resourceCtx: ResourceContext,
+    ): LogIngestEntry {
+        val attributes = OtlpParsingUtils.attributesToMap(record["attributes"])
+        val bodyText = OtlpParsingUtils.extractAnyValue(record["body"]) ?: ""
+        val message = if (bodyText.isBlank()) "OTLP log record" else bodyText
+        val severityText = record["severityText"]?.jsonPrimitive?.contentOrNull
+        val timestampNs = OtlpParsingUtils.extractTimestampNanos(
+            record,
+            "timeUnixNano",
+            "observedTimeUnixNano"
+        )
+        val timestampMs = OtlpParsingUtils.nanoToEpochMs(timestampNs)
+
+        return LogIngestEntry(
+            timestampMs = timestampMs,
+            level = severityText,
+            message = message,
+            body = bodyText,
+            service = resourceCtx.serviceName.ifEmpty { attributes["service.name"] },
+            environment = resourceCtx.environment.ifEmpty {
+                attributes["deployment.environment"] ?: attributes["service.environment"]
+            },
+            host = resourceCtx.hostName.ifEmpty { attributes["host.name"] },
+            source = "otlp",
+            traceId = record["traceId"]?.jsonPrimitive?.contentOrNull,
+            spanId = record["spanId"]?.jsonPrimitive?.contentOrNull,
+            tags = HashMap(attributes),
+            resourceAttributes = HashMap(resourceCtx.attributes)
+        )
     }
 
     private fun parseTimeToMillis(value: String?): Long? {

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpIngestionWorkerBase.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpIngestionWorkerBase.kt
@@ -73,47 +73,72 @@ abstract class OtlpIngestionWorkerBase(
         var conn: StatefulRedisConnection<String, String>? = null
         try {
             while (scope.isActive) {
-                try {
-                    if (conn == null || !conn.isOpen) {
-                        conn?.let { disposeRedisConnection(workerId, it) }
-                        conn = RedisConfig.newStatefulBlockingConnection()
-                    }
-                    val redis = conn.sync()
-                    val result = redis.brpop(BRPOP_TIMEOUT_SECONDS, queueKey)
-                    val payload = result?.value ?: continue
-                    try {
-                        processMessage(workerId, payload)
-                    } catch (proc: CancellationException) {
-                        throw proc
-                    } catch (proc: SerializationException) {
-                        onOtlpProcessMessageFailure(workerId, proc)
-                    } catch (proc: IOException) {
-                        onOtlpProcessMessageFailure(workerId, proc)
-                    } catch (proc: SQLException) {
-                        onOtlpProcessMessageFailure(workerId, proc)
-                    } catch (proc: RedisException) {
-                        onOtlpProcessMessageFailure(workerId, proc)
-                    } catch (proc: IllegalStateException) {
-                        onOtlpProcessMessageFailure(workerId, proc)
-                    } catch (proc: IllegalArgumentException) {
-                        onOtlpProcessMessageFailure(workerId, proc)
-                    }
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    onOtlpBrpopLoopFailure(workerId, e, conn) { c ->
-                        disposeRedisConnection(workerId, c)
-                        conn = null
-                    }
-                } catch (e: IOException) {
-                    onOtlpBrpopLoopFailure(workerId, e, conn) { c ->
-                        disposeRedisConnection(workerId, c)
-                        conn = null
+                when (val outcome = runBrpopIteration(workerId, conn)) {
+                    is BrpopIterationOutcome.Break -> break
+                    is BrpopIterationOutcome.Continue -> {
+                        conn = outcome.connection
                     }
                 }
             }
         } finally {
             conn?.let { disposeRedisConnection(workerId, it) }
+        }
+    }
+
+    private sealed class BrpopIterationOutcome {
+        data class Continue(val connection: StatefulRedisConnection<String, String>?) : BrpopIterationOutcome()
+        data object Break : BrpopIterationOutcome()
+    }
+
+    private suspend fun runBrpopIteration(
+        workerId: Int,
+        conn: StatefulRedisConnection<String, String>?,
+    ): BrpopIterationOutcome {
+        var activeConn = conn
+        return try {
+            if (activeConn == null || !activeConn.isOpen) {
+                activeConn?.let { disposeRedisConnection(workerId, it) }
+                activeConn = RedisConfig.newStatefulBlockingConnection()
+            }
+            val redis = activeConn.sync()
+            val result = redis.brpop(BRPOP_TIMEOUT_SECONDS, queueKey)
+            val payload = result?.value ?: return BrpopIterationOutcome.Continue(activeConn)
+            processBrpopPayload(workerId, payload)
+            BrpopIterationOutcome.Continue(activeConn)
+        } catch (e: CancellationException) {
+            BrpopIterationOutcome.Break
+        } catch (e: RedisException) {
+            onOtlpBrpopLoopFailure(workerId, e, activeConn) { c ->
+                disposeRedisConnection(workerId, c)
+                activeConn = null
+            }
+            BrpopIterationOutcome.Continue(activeConn)
+        } catch (e: IOException) {
+            onOtlpBrpopLoopFailure(workerId, e, activeConn) { c ->
+                disposeRedisConnection(workerId, c)
+                activeConn = null
+            }
+            BrpopIterationOutcome.Continue(activeConn)
+        }
+    }
+
+    private suspend fun processBrpopPayload(workerId: Int, payload: String) {
+        try {
+            processMessage(workerId, payload)
+        } catch (proc: CancellationException) {
+            throw proc
+        } catch (proc: SerializationException) {
+            onOtlpProcessMessageFailure(workerId, proc)
+        } catch (proc: IOException) {
+            onOtlpProcessMessageFailure(workerId, proc)
+        } catch (proc: SQLException) {
+            onOtlpProcessMessageFailure(workerId, proc)
+        } catch (proc: RedisException) {
+            onOtlpProcessMessageFailure(workerId, proc)
+        } catch (proc: IllegalStateException) {
+            onOtlpProcessMessageFailure(workerId, proc)
+        } catch (proc: IllegalArgumentException) {
+            onOtlpProcessMessageFailure(workerId, proc)
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
@@ -309,7 +309,14 @@ class OtlpMetricsService(
 
         val resourceMetrics = parsed["resourceMetrics"]?.jsonArray ?: return null
         val results = mutableListOf<OtlpMetricInsert>()
+        appendOtlpJsonMetricsFromResourceMetrics(resourceMetrics, results)
+        return results
+    }
 
+    private fun appendOtlpJsonMetricsFromResourceMetrics(
+        resourceMetrics: JsonArray,
+        results: MutableList<OtlpMetricInsert>,
+    ) {
         resourceMetrics.forEach { rmElement ->
             val rm = rmElement.jsonObject
             val resourceCtx = OtlpParsingUtils.extractResourceContext(
@@ -318,74 +325,84 @@ class OtlpMetricsService(
             val scopeMetrics = rm["scopeMetrics"]?.jsonArray
                 ?: rm["instrumentationLibraryMetrics"]?.jsonArray
                 ?: JsonArray(emptyList())
+            appendOtlpJsonMetricsFromScopeMetrics(scopeMetrics, resourceCtx, results)
+        }
+    }
 
-            scopeMetrics.forEach { smElement ->
-                val sm = smElement.jsonObject
-                val metricsArray = OtlpParsingUtils.safeJsonArray(sm["metrics"])
-
-                metricsArray.forEach { metricElement ->
-                    val metric = metricElement.jsonObject
-                    val name = metric["name"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val description = metric["description"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val unit = metric["unit"]?.jsonPrimitive?.contentOrNull ?: ""
-
-                    when {
-                        metric.containsKey("gauge") -> {
-                            parseGaugeDataPoints(
-                                metric["gauge"]!!.jsonObject,
-                                name,
-                                description,
-                                unit,
-                                resourceCtx,
-                                results
-                            )
-                        }
-                        metric.containsKey("sum") -> {
-                            parseSumDataPoints(
-                                metric["sum"]!!.jsonObject,
-                                name,
-                                description,
-                                unit,
-                                resourceCtx,
-                                results
-                            )
-                        }
-                        metric.containsKey("histogram") -> {
-                            parseHistogramDataPoints(
-                                metric["histogram"]!!.jsonObject,
-                                name,
-                                description,
-                                unit,
-                                resourceCtx,
-                                results
-                            )
-                        }
-                        metric.containsKey("exponentialHistogram") -> {
-                            parseExpHistogramDataPoints(
-                                metric["exponentialHistogram"]!!.jsonObject,
-                                name,
-                                description,
-                                unit,
-                                resourceCtx,
-                                results
-                            )
-                        }
-                        metric.containsKey("summary") -> {
-                            parseSummaryDataPoints(
-                                metric["summary"]!!.jsonObject,
-                                name,
-                                description,
-                                unit,
-                                resourceCtx,
-                                results
-                            )
-                        }
-                    }
-                }
+    private fun appendOtlpJsonMetricsFromScopeMetrics(
+        scopeMetrics: JsonArray,
+        resourceCtx: com.moneat.otlp.ResourceContext,
+        results: MutableList<OtlpMetricInsert>,
+    ) {
+        scopeMetrics.forEach { smElement ->
+            val sm = smElement.jsonObject
+            val metricsArray = OtlpParsingUtils.safeJsonArray(sm["metrics"])
+            metricsArray.forEach { metricElement ->
+                appendOtlpJsonMetric(metricElement.jsonObject, resourceCtx, results)
             }
         }
+    }
 
-        return results
+    private fun appendOtlpJsonMetric(
+        metric: kotlinx.serialization.json.JsonObject,
+        resourceCtx: com.moneat.otlp.ResourceContext,
+        results: MutableList<OtlpMetricInsert>,
+    ) {
+        val name = metric["name"]?.jsonPrimitive?.contentOrNull ?: ""
+        val description = metric["description"]?.jsonPrimitive?.contentOrNull ?: ""
+        val unit = metric["unit"]?.jsonPrimitive?.contentOrNull ?: ""
+        when {
+            metric.containsKey("gauge") -> {
+                parseGaugeDataPoints(
+                    metric["gauge"]!!.jsonObject,
+                    name,
+                    description,
+                    unit,
+                    resourceCtx,
+                    results
+                )
+            }
+            metric.containsKey("sum") -> {
+                parseSumDataPoints(
+                    metric["sum"]!!.jsonObject,
+                    name,
+                    description,
+                    unit,
+                    resourceCtx,
+                    results
+                )
+            }
+            metric.containsKey("histogram") -> {
+                parseHistogramDataPoints(
+                    metric["histogram"]!!.jsonObject,
+                    name,
+                    description,
+                    unit,
+                    resourceCtx,
+                    results
+                )
+            }
+            metric.containsKey("exponentialHistogram") -> {
+                parseExpHistogramDataPoints(
+                    metric["exponentialHistogram"]!!.jsonObject,
+                    name,
+                    description,
+                    unit,
+                    resourceCtx,
+                    results
+                )
+            }
+            metric.containsKey("summary") -> {
+                parseSummaryDataPoints(
+                    metric["summary"]!!.jsonObject,
+                    name,
+                    description,
+                    unit,
+                    resourceCtx,
+                    results
+                )
+            }
+        }
     }
 
     private fun readJsonNumberValue(dpObj: kotlinx.serialization.json.JsonObject): Double? =

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
@@ -21,12 +21,14 @@ import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.otlp.OtlpParsingUtils
 import com.moneat.otlp.OtlpProtobufParser
+import com.moneat.otlp.ResourceContext
 import com.moneat.otlp.calculateBillableBytes
 import com.moneat.otlp.hexToULongPair
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import io.opentelemetry.proto.trace.v1.ScopeSpans
 import io.opentelemetry.proto.common.v1.AnyValue
 import io.opentelemetry.proto.common.v1.KeyValue
 import io.opentelemetry.proto.trace.v1.Span
@@ -108,61 +110,81 @@ class OtlpTraceService(
             }
 
         val spans = mutableListOf<OtlpSpanInsert>()
+        appendProtobufResourceSpans(request, spans)
+        return spans
+    }
 
+    private fun appendProtobufResourceSpans(
+        request: ExportTraceServiceRequest,
+        spans: MutableList<OtlpSpanInsert>,
+    ) {
         request.resourceSpansList.forEach { rs ->
             val resourceCtx = OtlpProtobufParser.extractResourceContext(rs.resource)
-
             rs.scopeSpansList.forEach { ss ->
-                val scopeName = ss.scope?.name ?: ""
-                val scopeVersion = ss.scope?.version ?: ""
-
-                ss.spansList.forEach { span ->
-                    val traceId = OtlpProtobufParser.bytesToHex(span.traceId)
-                    val spanId = OtlpProtobufParser.bytesToHex(span.spanId)
-                    val parentSpanId = OtlpProtobufParser.bytesToHex(span.parentSpanId)
-                    val kind = mapSpanKind(span.kindValue)
-
-                    val startNanos = span.startTimeUnixNano
-                    val endNanos = span.endTimeUnixNano.takeIf { it != 0L } ?: startNanos
-                    val durationNanos = maxOf(0L, endNanos - startNanos)
-
-                    val statusCode = span.status?.codeValue ?: 0
-                    val statusMessage = span.status?.message ?: ""
-                    val error = if (statusCode == OTLP_SPAN_STATUS_ERROR) 1 else 0
-
-                    val attributes = OtlpProtobufParser.attributesToMap(span.attributesList)
-                    val events = protoEventsToJson(span.eventsList)
-                    val links = protoLinksToJson(span.linksList)
-
-                    spans += OtlpSpanInsert(
-                        traceIdHex = traceId,
-                        spanIdHex = spanId,
-                        parentIdHex = parentSpanId,
-                        organizationId = 0,
-                        name = span.name,
-                        service = resourceCtx.serviceName,
-                        resource = span.name,
-                        kind = kind,
-                        startNanos = startNanos,
-                        durationNanos = durationNanos,
-                        error = error,
-                        statusCode = statusCode,
-                        statusMessage = statusMessage,
-                        meta = attributes,
-                        resourceAttributes = resourceCtx.attributes,
-                        host = resourceCtx.hostName,
-                        env = resourceCtx.environment,
-                        version = resourceCtx.serviceVersion,
-                        scopeName = scopeName,
-                        scopeVersion = scopeVersion,
-                        events = events,
-                        links = links,
-                    )
-                }
+                appendProtobufScopeSpans(ss, resourceCtx, spans)
             }
         }
+    }
 
-        return spans
+    private fun appendProtobufScopeSpans(
+        ss: ScopeSpans,
+        resourceCtx: ResourceContext,
+        spans: MutableList<OtlpSpanInsert>,
+    ) {
+        val scopeName = ss.scope?.name ?: ""
+        val scopeVersion = ss.scope?.version ?: ""
+        ss.spansList.forEach { span ->
+            spans += otlpSpanInsertFromProtobuf(span, resourceCtx, scopeName, scopeVersion)
+        }
+    }
+
+    private fun otlpSpanInsertFromProtobuf(
+        span: Span,
+        resourceCtx: ResourceContext,
+        scopeName: String,
+        scopeVersion: String,
+    ): OtlpSpanInsert {
+        val traceId = OtlpProtobufParser.bytesToHex(span.traceId)
+        val spanId = OtlpProtobufParser.bytesToHex(span.spanId)
+        val parentSpanId = OtlpProtobufParser.bytesToHex(span.parentSpanId)
+        val kind = mapSpanKind(span.kindValue)
+
+        val startNanos = span.startTimeUnixNano
+        val endNanos = span.endTimeUnixNano.takeIf { it != 0L } ?: startNanos
+        val durationNanos = maxOf(0L, endNanos - startNanos)
+
+        val statusCode = span.status?.codeValue ?: 0
+        val statusMessage = span.status?.message ?: ""
+        val error = if (statusCode == OTLP_SPAN_STATUS_ERROR) 1 else 0
+
+        val attributes = OtlpProtobufParser.attributesToMap(span.attributesList)
+        val events = protoEventsToJson(span.eventsList)
+        val links = protoLinksToJson(span.linksList)
+
+        return OtlpSpanInsert(
+            traceIdHex = traceId,
+            spanIdHex = spanId,
+            parentIdHex = parentSpanId,
+            organizationId = 0,
+            name = span.name,
+            service = resourceCtx.serviceName,
+            resource = span.name,
+            kind = kind,
+            startNanos = startNanos,
+            durationNanos = durationNanos,
+            error = error,
+            statusCode = statusCode,
+            statusMessage = statusMessage,
+            meta = attributes,
+            resourceAttributes = resourceCtx.attributes,
+            host = resourceCtx.hostName,
+            env = resourceCtx.environment,
+            version = resourceCtx.serviceVersion,
+            scopeName = scopeName,
+            scopeVersion = scopeVersion,
+            events = events,
+            links = links,
+        )
     }
 
     fun parseOtlpTracesJson(payload: String): List<OtlpSpanInsert>? {
@@ -179,7 +201,14 @@ class OtlpTraceService(
 
         val resourceSpans = parsed["resourceSpans"]?.jsonArray ?: return null
         val spans = mutableListOf<OtlpSpanInsert>()
+        appendJsonResourceSpans(resourceSpans, spans)
+        return spans
+    }
 
+    private fun appendJsonResourceSpans(
+        resourceSpans: JsonArray,
+        spans: MutableList<OtlpSpanInsert>,
+    ) {
         resourceSpans.forEach { rsElement ->
             val rs = rsElement.jsonObject
             val resourceCtx = OtlpParsingUtils.extractResourceContext(
@@ -188,69 +217,86 @@ class OtlpTraceService(
             val scopeSpans = rs["scopeSpans"]?.jsonArray
                 ?: rs["instrumentationLibrarySpans"]?.jsonArray
                 ?: JsonArray(emptyList())
+            appendJsonScopeSpans(scopeSpans, resourceCtx, spans)
+        }
+    }
 
-            scopeSpans.forEach { ssElement ->
-                val ss = ssElement.jsonObject
-                val scopeName = OtlpParsingUtils.extractScopeName(ss)
-                val scopeVersion = OtlpParsingUtils.extractScopeVersion(ss)
-                val spanArray = OtlpParsingUtils.safeJsonArray(ss["spans"])
-
-                spanArray.forEach { spanElement ->
-                    val span = spanElement.jsonObject
-                    val traceId = span["traceId"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val spanId = span["spanId"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val parentSpanId = span["parentSpanId"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val name = span["name"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val kindInt = span["kind"]?.jsonPrimitive?.intOrNull ?: 0
-                    val kind = mapSpanKind(kindInt)
-
-                    val startNanos = OtlpParsingUtils.extractTimestampNanos(
-                        span, "startTimeUnixNano"
-                    ) ?: 0L
-                    val endNanos = OtlpParsingUtils.extractTimestampNanos(
-                        span, "endTimeUnixNano"
-                    ) ?: startNanos
-                    val durationNanos = maxOf(0L, endNanos - startNanos)
-
-                    val statusObj = span["status"]?.jsonObject
-                    val statusCode = statusObj?.get("code")?.jsonPrimitive?.intOrNull ?: 0
-                    val statusMessage = statusObj?.get("message")
-                        ?.jsonPrimitive?.contentOrNull ?: ""
-                    val error = if (statusCode == OTLP_SPAN_STATUS_ERROR) 1 else 0
-
-                    val attributes = OtlpParsingUtils.attributesToMap(span["attributes"])
-                    val events = span["events"]?.toString() ?: "[]"
-                    val links = span["links"]?.toString() ?: "[]"
-
-                    spans += OtlpSpanInsert(
-                        traceIdHex = traceId,
-                        spanIdHex = spanId,
-                        parentIdHex = parentSpanId,
-                        organizationId = 0,
-                        name = name,
-                        service = resourceCtx.serviceName,
-                        resource = name,
-                        kind = kind,
-                        startNanos = startNanos,
-                        durationNanos = durationNanos,
-                        error = error,
-                        statusCode = statusCode,
-                        statusMessage = statusMessage,
-                        meta = attributes,
-                        resourceAttributes = resourceCtx.attributes,
-                        host = resourceCtx.hostName,
-                        env = resourceCtx.environment,
-                        version = resourceCtx.serviceVersion,
-                        scopeName = scopeName,
-                        scopeVersion = scopeVersion,
-                        events = events,
-                        links = links,
-                    )
-                }
+    private fun appendJsonScopeSpans(
+        scopeSpans: JsonArray,
+        resourceCtx: ResourceContext,
+        spans: MutableList<OtlpSpanInsert>,
+    ) {
+        scopeSpans.forEach { ssElement ->
+            val ss = ssElement.jsonObject
+            val scopeName = OtlpParsingUtils.extractScopeName(ss)
+            val scopeVersion = OtlpParsingUtils.extractScopeVersion(ss)
+            val spanArray = OtlpParsingUtils.safeJsonArray(ss["spans"])
+            spanArray.forEach { spanElement ->
+                spans += otlpSpanInsertFromJson(
+                    spanElement.jsonObject,
+                    resourceCtx,
+                    scopeName,
+                    scopeVersion
+                )
             }
         }
+    }
 
-        return spans
+    private fun otlpSpanInsertFromJson(
+        span: JsonObject,
+        resourceCtx: ResourceContext,
+        scopeName: String,
+        scopeVersion: String,
+    ): OtlpSpanInsert {
+        val traceId = span["traceId"]?.jsonPrimitive?.contentOrNull ?: ""
+        val spanId = span["spanId"]?.jsonPrimitive?.contentOrNull ?: ""
+        val parentSpanId = span["parentSpanId"]?.jsonPrimitive?.contentOrNull ?: ""
+        val name = span["name"]?.jsonPrimitive?.contentOrNull ?: ""
+        val kindInt = span["kind"]?.jsonPrimitive?.intOrNull ?: 0
+        val kind = mapSpanKind(kindInt)
+
+        val startNanos = OtlpParsingUtils.extractTimestampNanos(
+            span, "startTimeUnixNano"
+        ) ?: 0L
+        val endNanos = OtlpParsingUtils.extractTimestampNanos(
+            span, "endTimeUnixNano"
+        ) ?: startNanos
+        val durationNanos = maxOf(0L, endNanos - startNanos)
+
+        val statusObj = span["status"]?.jsonObject
+        val statusCode = statusObj?.get("code")?.jsonPrimitive?.intOrNull ?: 0
+        val statusMessage = statusObj?.get("message")
+            ?.jsonPrimitive?.contentOrNull ?: ""
+        val error = if (statusCode == OTLP_SPAN_STATUS_ERROR) 1 else 0
+
+        val attributes = OtlpParsingUtils.attributesToMap(span["attributes"])
+        val events = span["events"]?.toString() ?: "[]"
+        val links = span["links"]?.toString() ?: "[]"
+
+        return OtlpSpanInsert(
+            traceIdHex = traceId,
+            spanIdHex = spanId,
+            parentIdHex = parentSpanId,
+            organizationId = 0,
+            name = name,
+            service = resourceCtx.serviceName,
+            resource = name,
+            kind = kind,
+            startNanos = startNanos,
+            durationNanos = durationNanos,
+            error = error,
+            statusCode = statusCode,
+            statusMessage = statusMessage,
+            meta = attributes,
+            resourceAttributes = resourceCtx.attributes,
+            host = resourceCtx.hostName,
+            env = resourceCtx.environment,
+            version = resourceCtx.serviceVersion,
+            scopeName = scopeName,
+            scopeVersion = scopeVersion,
+            events = events,
+            links = links,
+        )
     }
 
     fun enqueueTraces(

--- a/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsCheckExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsCheckExecutor.kt
@@ -552,68 +552,80 @@ open class SyntheticsCheckExecutor {
 
         return try {
             for (step in steps) {
-                val stepUrl = substituteVariables(step.url, variables)
-                try {
-                    UrlValidator.validateExternalUrl(stepUrl)
-                } catch (e: UrlValidator.SsrfException) {
-                    val durationMs = System.currentTimeMillis() - startTime
-                    return SyntheticCheckResult(
-                        status = "failed",
-                        durationMs = durationMs,
-                        errorMessage = "Step '${step.name}' blocked: ${e.message}"
-                    )
-                }
-                val stepBody = step.body?.let { substituteVariables(it, variables) }
-                val stepHeaders = step.headers?.mapValues { (_, v) -> substituteVariables(v, variables) }
-
-                val stepStart = System.currentTimeMillis()
-                val response = suspendRunCatching {
-                    client.request(stepUrl) {
-                        method = resolveHttpMethod(step.method)
-                        stepHeaders?.forEach { (k, v) -> header(k, v) }
-                        stepBody?.let { b -> setBody(b) }
-                    }
-                }.getOrElse { e ->
-                    val durationMs = System.currentTimeMillis() - startTime
-                    return SyntheticCheckResult(
-                        status = "failed",
-                        durationMs = durationMs,
-                        errorMessage = "Step '${step.name}' failed: ${e.message}"
-                    )
-                }
-
-                val stepDurationMs = System.currentTimeMillis() - stepStart
-                val statusCode = response.status.value
-                val body = response.bodyAsText()
-                val responseHeaders = response.headers.entries()
-                    .associate { (k, v) -> k to v.firstOrNull().orEmpty() }
-
-                // Evaluate step assertions
-                val allPassed = step.assertions.all { assertion ->
-                    evaluateAssertion(assertion, statusCode, body, stepDurationMs, responseHeaders)
-                }
-                if (!allPassed) {
-                    val durationMs = System.currentTimeMillis() - startTime
-                    return SyntheticCheckResult(
-                        status = "failed",
-                        durationMs = durationMs,
-                        errorMessage = "Step '${step.name}' assertion failed"
-                    )
-                }
-
-                // Extract variables for subsequent steps
-                step.extractVariables.forEach { extraction ->
-                    val extracted = extractVariable(extraction.source, extraction.path, body, responseHeaders)
-                    if (extracted != null) {
-                        variables[extraction.name] = extracted
-                    }
-                }
+                val stepOutcome = runSingleMultistepStep(step, client, variables, startTime)
+                if (stepOutcome != null) return stepOutcome
             }
 
             SyntheticCheckResult(status = "passed", durationMs = System.currentTimeMillis() - startTime)
         } finally {
             client.close()
         }
+    }
+
+    /**
+     * Runs one synthetic multistep step. Returns a terminal [SyntheticCheckResult] on failure, or null to continue.
+     */
+    private suspend fun runSingleMultistepStep(
+        step: SyntheticStep,
+        client: HttpClient,
+        variables: MutableMap<String, String>,
+        startTime: Long,
+    ): SyntheticCheckResult? {
+        val stepUrl = substituteVariables(step.url, variables)
+        try {
+            UrlValidator.validateExternalUrl(stepUrl)
+        } catch (e: UrlValidator.SsrfException) {
+            val durationMs = System.currentTimeMillis() - startTime
+            return SyntheticCheckResult(
+                status = "failed",
+                durationMs = durationMs,
+                errorMessage = "Step '${step.name}' blocked: ${e.message}"
+            )
+        }
+        val stepBody = step.body?.let { substituteVariables(it, variables) }
+        val stepHeaders = step.headers?.mapValues { (_, v) -> substituteVariables(v, variables) }
+
+        val stepStart = System.currentTimeMillis()
+        val response = suspendRunCatching {
+            client.request(stepUrl) {
+                method = resolveHttpMethod(step.method)
+                stepHeaders?.forEach { (k, v) -> header(k, v) }
+                stepBody?.let { b -> setBody(b) }
+            }
+        }.getOrElse { e ->
+            val durationMs = System.currentTimeMillis() - startTime
+            return SyntheticCheckResult(
+                status = "failed",
+                durationMs = durationMs,
+                errorMessage = "Step '${step.name}' failed: ${e.message}"
+            )
+        }
+
+        val stepDurationMs = System.currentTimeMillis() - stepStart
+        val statusCode = response.status.value
+        val body = response.bodyAsText()
+        val responseHeaders = response.headers.entries()
+            .associate { (k, v) -> k to v.firstOrNull().orEmpty() }
+
+        val allPassed = step.assertions.all { assertion ->
+            evaluateAssertion(assertion, statusCode, body, stepDurationMs, responseHeaders)
+        }
+        if (!allPassed) {
+            val durationMs = System.currentTimeMillis() - startTime
+            return SyntheticCheckResult(
+                status = "failed",
+                durationMs = durationMs,
+                errorMessage = "Step '${step.name}' assertion failed"
+            )
+        }
+
+        step.extractVariables.forEach { extraction ->
+            val extracted = extractVariable(extraction.source, extraction.path, body, responseHeaders)
+            if (extracted != null) {
+                variables[extraction.name] = extracted
+            }
+        }
+        return null
     }
 
     private fun evaluateAssertion(

--- a/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
@@ -360,19 +360,25 @@ class TraceIngestionServiceTest {
                 is Long -> packer.packLong(value)
                 is Int -> packer.packInt(value)
                 is String -> packer.packString(value)
-                is Map<*, *> -> {
-                    packer.packMapHeader(value.size)
-                    for ((mk, mv) in value) {
-                        packer.packString(mk as String)
-                        when (mv) {
-                            is String -> packer.packString(mv)
-                            is Double -> packer.packDouble(mv)
-                            else -> packer.packString(mv.toString())
-                        }
-                    }
-                }
+                is Map<*, *> -> packNestedSpanMetaMap(packer, value)
                 else -> packer.packString(value.toString())
             }
+        }
+    }
+
+    private fun packNestedSpanMetaMap(packer: MessageBufferPacker, value: Map<*, *>) {
+        packer.packMapHeader(value.size)
+        for ((mk, mv) in value) {
+            packer.packString(mk as String)
+            packSpanMetaValue(packer, mv)
+        }
+    }
+
+    private fun packSpanMetaValue(packer: MessageBufferPacker, mv: Any?) {
+        when (mv) {
+            is String -> packer.packString(mv)
+            is Double -> packer.packDouble(mv)
+            else -> packer.packString(mv.toString())
         }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/demo/DemoDataSeeder.kt
+++ b/backend/src/test/kotlin/com/moneat/demo/DemoDataSeeder.kt
@@ -3892,6 +3892,63 @@ object DemoDataSeeder {
         val level: String
     )
 
+    private suspend fun deleteClickHouseDemoDataForOrganization(orgId: Int) {
+        println("Deleting ClickHouse demo data...")
+        val projectIds =
+            transaction {
+                Projects
+                    .selectAll()
+                    .where { Projects.organization_id eq orgId }
+                    .map { it[Projects.id] }
+            }
+
+        if (projectIds.isNotEmpty()) {
+            val projectIdList = projectIds.joinToString(",")
+            println("Deleting ClickHouse data for projects: $projectIdList")
+
+            val clickhouseQueries =
+                listOf(
+                    "ALTER TABLE issues DELETE WHERE project_id IN ($projectIdList)",
+                    "ALTER TABLE events DELETE WHERE project_id IN ($projectIdList)",
+                    "ALTER TABLE logs DELETE WHERE project_id IN ($projectIdList)",
+                    "ALTER TABLE user_feedback DELETE WHERE project_id IN ($projectIdList)",
+                    "ALTER TABLE replay_events DELETE WHERE project_id IN ($projectIdList)",
+                    "ALTER TABLE replay_segments DELETE WHERE project_id IN ($projectIdList)",
+                    "ALTER TABLE sessions DELETE WHERE project_id IN ($projectIdList)",
+                    "ALTER TABLE spans DELETE WHERE project_id IN ($projectIdList)"
+                )
+
+            for (query in clickhouseQueries) {
+                try {
+                    ClickHouseClient.execute(query)
+                } catch (e: Exception) {
+                    // Silently continue
+                }
+            }
+        }
+
+        println("Deleting Datadog agent ClickHouse data...")
+        val ddClickhouseQueries =
+            listOf(
+                "ALTER TABLE apm_spans DELETE WHERE toInt64(organization_id) = $orgId",
+                "ALTER TABLE trace_stats DELETE WHERE toInt64(organization_id) = $orgId",
+                "ALTER TABLE profiles DELETE WHERE toInt64(organization_id) = $orgId",
+                "ALTER TABLE infra_events DELETE WHERE toInt64(organization_id) = $orgId",
+                "ALTER TABLE service_checks DELETE WHERE toInt64(organization_id) = $orgId",
+                "ALTER TABLE processes DELETE WHERE toInt64(organization_id) = $orgId",
+                "ALTER TABLE containers DELETE WHERE toInt64(organization_id) = $orgId",
+                "ALTER TABLE network_connections DELETE WHERE toInt64(organization_id) = $orgId",
+            )
+
+        for (query in ddClickhouseQueries) {
+            try {
+                ClickHouseClient.execute(query)
+            } catch (_: Exception) {
+                // Silently continue - table may not exist
+            }
+        }
+    }
+
     suspend fun deleteDemoData() {
         println("🗑️  Deleting existing demo data...")
 
@@ -3975,64 +4032,7 @@ object DemoDataSeeder {
             }
         }
 
-        // Delete ClickHouse data - get actual project IDs
-        if (orgId != null) {
-            println("Deleting ClickHouse demo data...")
-            val projectIds =
-                transaction {
-                    Projects
-                        .selectAll()
-                        .where { Projects.organization_id eq orgId }
-                        .map { it[Projects.id] }
-                }
-
-            if (projectIds.isNotEmpty()) {
-                val projectIdList = projectIds.joinToString(",")
-                println("Deleting ClickHouse data for projects: $projectIdList")
-
-                val clickhouseQueries =
-                    listOf(
-                        "ALTER TABLE issues DELETE WHERE project_id IN ($projectIdList)",
-                        "ALTER TABLE events DELETE WHERE project_id IN ($projectIdList)",
-                        "ALTER TABLE logs DELETE WHERE project_id IN ($projectIdList)",
-                        "ALTER TABLE user_feedback DELETE WHERE project_id IN ($projectIdList)",
-                        "ALTER TABLE replay_events DELETE WHERE project_id IN ($projectIdList)",
-                        "ALTER TABLE replay_segments DELETE WHERE project_id IN ($projectIdList)",
-                        "ALTER TABLE sessions DELETE WHERE project_id IN ($projectIdList)",
-                        "ALTER TABLE spans DELETE WHERE project_id IN ($projectIdList)"
-                    )
-
-                for (query in clickhouseQueries) {
-                    try {
-                        ClickHouseClient.execute(query)
-                    } catch (e: Exception) {
-                        // Silently continue
-                    }
-                }
-            }
-
-            // Delete Datadog agent ClickHouse data (keyed by organization_id)
-            println("Deleting Datadog agent ClickHouse data...")
-            val ddClickhouseQueries =
-                listOf(
-                    "ALTER TABLE apm_spans DELETE WHERE toInt64(organization_id) = $orgId",
-                    "ALTER TABLE trace_stats DELETE WHERE toInt64(organization_id) = $orgId",
-                    "ALTER TABLE profiles DELETE WHERE toInt64(organization_id) = $orgId",
-                    "ALTER TABLE infra_events DELETE WHERE toInt64(organization_id) = $orgId",
-                    "ALTER TABLE service_checks DELETE WHERE toInt64(organization_id) = $orgId",
-                    "ALTER TABLE processes DELETE WHERE toInt64(organization_id) = $orgId",
-                    "ALTER TABLE containers DELETE WHERE toInt64(organization_id) = $orgId",
-                    "ALTER TABLE network_connections DELETE WHERE toInt64(organization_id) = $orgId",
-                )
-
-            for (query in ddClickhouseQueries) {
-                try {
-                    ClickHouseClient.execute(query)
-                } catch (_: Exception) {
-                    // Silently continue - table may not exist
-                }
-            }
-        }
+        orgId?.let { deleteClickHouseDemoDataForOrganization(it) }
 
         println("✅ Demo data deleted")
     }


### PR DESCRIPTION
Closes #297

## Summary

- Enables the `NestedBlockDepth` detekt rule under `complexity` in `backend/detekt.yml`
- Fixes all pre-existing violations by extracting helper functions and reducing nesting depth
- Adds `MagicNumber` excludes for `DemoReseed*.kt` files (intentional seed data literals, per project conventions)

## Changes

### detekt.yml
- Set `NestedBlockDepth.active: true` with issue #297 reference comment
- Added `DemoReseed*.kt` to MagicNumber excludes (demo seed data)

### Refactored files (reduced block nesting depth)
- `OtlpIngestionWorkerBase.kt` — Extracted `runBrpopIteration`, `processBrpopPayload`, sealed `BrpopIterationOutcome`
- `OtlpTraceService.kt` — Extracted protobuf/JSON span builder helpers
- `OtlpMetricsService.kt` — Extracted JSON resource/scope/metric append helpers
- `LogService.kt` — Extracted CSV query parsing and OTLP log ingestion helpers
- `LogQueryParser.kt` — Extracted `parseFieldToken` helper
- `SentryModels.kt` — Extracted envelope item parsing (explicit/implicit length, trim, scan helpers)
- `SyntheticsCheckExecutor.kt` — Extracted `runSingleMultistepStep`
- `GrafanaTranslator.kt` — Extracted Grafana transform helpers
- `PrometheusHandler.kt` — Extracted Prometheus result flattening helpers
- `JdbcHandler.kt` — Extracted `readJdbcSchemaFields`
- `TraceIngestionServiceTest.kt` — Extracted MessagePack test helpers
- `DemoDataSeeder.kt` — Extracted ClickHouse cleanup helper

## Test plan
- [x] `./gradlew detekt` passes with 0 issues
- [x] `./gradlew test` passes

Made with [Cursor](https://cursor.com)