### PR TITLE
fix: skip weekly summary email when ClickHouse queries fail

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
@@ -474,11 +474,11 @@ class EmailService {
         val startDate: String,
         val endDate: String,
         val totalEvents: String,
-        val eventsTrend: Int,
+        val eventsTrend: Int?,
         val newIssues: String,
-        val issuesTrend: Int,
+        val issuesTrend: Int?,
         val affectedUsers: String,
-        val usersTrend: Int,
+        val usersTrend: Int?,
         val topIssues: List<TopIssue>,
         val projects: List<ProjectSummary>,
         val dashboardUrl: String,
@@ -534,14 +534,17 @@ class EmailService {
         val htmlBody = loadWeeklySummaryTemplate(data)
         val topIssuesList = data.topIssues.take(TOP_ISSUES_COUNT)
             .joinToString("\n") { "- ${it.title} (${it.project}): ${it.count} events" }
+        val eventsTrendText = formatTrendText(data.eventsTrend)
+        val issuesTrendText = formatTrendText(data.issuesTrend)
+        val usersTrendText = formatTrendText(data.usersTrend)
         val textBody =
             """
             Your Weekly Summary (${data.startDate} – ${data.endDate})
             
             KEY STATS:
-            - Total Events: ${data.totalEvents} (${if (data.eventsTrend > 0) "+" else ""}${data.eventsTrend}%)
-            - New Issues: ${data.newIssues} (${if (data.issuesTrend > 0) "+" else ""}${data.issuesTrend}%)
-            - Affected Users: ${data.affectedUsers} (${if (data.usersTrend > 0) "+" else ""}${data.usersTrend}%)
+            - Total Events: ${data.totalEvents} ($eventsTrendText)
+            - New Issues: ${data.newIssues} ($issuesTrendText)
+            - Affected Users: ${data.affectedUsers} ($usersTrendText)
             
             TOP ISSUES:
             $topIssuesList
@@ -856,7 +859,15 @@ class EmailService {
         }
     }
 
-    private fun trendBadgeHtml(trend: Int, positiveIsGood: Boolean): String {
+    private fun formatTrendText(trend: Int?): String {
+        if (trend == null) return "\u2014"
+        return "${if (trend > 0) "+" else ""}$trend%"
+    }
+
+    private fun trendBadgeHtml(trend: Int?, positiveIsGood: Boolean): String {
+        if (trend == null) {
+            return """<p style="$BADGE_STYLE $BADGE_NEUTRAL">&mdash;</p>"""
+        }
         return when {
             trend > 0 && positiveIsGood ->
                 """<p style="$BADGE_STYLE $BADGE_POSITIVE">&uarr; $trend%</p>"""

--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -381,26 +381,46 @@ class NotificationService(
             return false
         }
 
-        val safePriorStats = priorStats ?: PeriodStats(totalEvents = 0, uniqueIssues = 0, uniqueUsers = 0)
-
         val totalEvents = currentStats.totalEvents
-        val eventsTrend = calculateTrend(currentStats.totalEvents, safePriorStats.totalEvents)
+        val eventsTrend = priorStats?.let {
+            calculateTrend(currentStats.totalEvents, it.totalEvents)
+        }
         val newIssues = currentStats.uniqueIssues
-        val issuesTrend = calculateTrend(currentStats.uniqueIssues, safePriorStats.uniqueIssues)
+        val issuesTrend = priorStats?.let {
+            calculateTrend(currentStats.uniqueIssues, it.uniqueIssues)
+        }
         val affectedUsers = currentStats.uniqueUsers
-        val usersTrend = calculateTrend(currentStats.uniqueUsers, safePriorStats.uniqueUsers)
+        val usersTrend = priorStats?.let {
+            calculateTrend(currentStats.uniqueUsers, it.uniqueUsers)
+        }
 
-        val topIssues = getTopIssues(projectIds, startDate, endDate, limit = 5) ?: emptyList()
+        val topIssues = getTopIssues(projectIds, startDate, endDate, limit = 5)
+        if (topIssues == null) {
+            logger.warn {
+                "Skipping weekly summary for $email: ClickHouse top issues query failed"
+            }
+            return false
+        }
+
+        val perProjectStats = getPerProjectStats(projectIds, startDate, endDate)
+        if (perProjectStats == null) {
+            logger.warn {
+                "Skipping weekly summary for $email: ClickHouse per-project stats query failed"
+            }
+            return false
+        }
 
         val projectSummaries =
             projects.map { (projectId, projectName) ->
-                val stats = getStatsForPeriod(listOf(projectId), startDate, endDate)
+                val stats = perProjectStats[projectId]
                 val crashFreeRate = getCrashFreeRate(projectId, startDate, endDate)
                 EmailService.ProjectSummary(
                     name = projectName,
                     events = formatNumber(stats?.totalEvents ?: 0),
                     issues = formatNumber(stats?.uniqueIssues ?: 0),
-                    crashFree = crashFreeRate?.let { String.format(Locale.US, "%.1f%%", it) } ?: "N/A"
+                    crashFree = crashFreeRate?.let {
+                        String.format(Locale.US, "%.1f%%", it)
+                    } ?: "N/A"
                 )
             }
 
@@ -468,6 +488,55 @@ class NotificationService(
             uniqueIssues = data?.get("unique_issues")?.jsonPrimitive?.longOrNull ?: 0,
             uniqueUsers = data?.get("unique_users")?.jsonPrimitive?.longOrNull ?: 0
         )
+    }
+
+    private suspend fun getPerProjectStats(
+        projectIds: List<Long>,
+        startDate: Instant,
+        endDate: Instant
+    ): Map<Long, PeriodStats>? {
+        val startMs = startDate.toEpochMilli()
+        val endMs = endDate.toEpochMilli()
+
+        val query =
+            """
+            SELECT 
+                project_id,
+                count() as total_events,
+                uniqIf(issue_id, issue_id != '') as unique_issues,
+                uniqIf(user_id, user_id != '') as unique_users
+            FROM `$clickhouseDb`.events
+            WHERE project_id IN (${projectIds.joinToString(",")})
+              AND timestamp >= fromUnixTimestamp64Milli($startMs)
+              AND timestamp < fromUnixTimestamp64Milli($endMs)
+            GROUP BY project_id
+            FORMAT JSON
+            """.trimIndent()
+
+        val response = ClickHouseClient.execute(query)
+        val responseBody = response.bodyAsText()
+        if (!response.status.isSuccess()) {
+            val preview = responseBody.take(ERROR_BODY_PREVIEW_CHARS)
+            logger.error(
+                "ClickHouse query failed in getPerProjectStats:" +
+                    " ${response.status} - $preview"
+            )
+            return null
+        }
+        val jsonResponse = Json.parseToJsonElement(responseBody).jsonObject
+        val rows = jsonResponse["data"]?.jsonArray ?: return emptyMap()
+
+        return rows.mapNotNull { row ->
+            val obj = row.jsonObject
+            val projectId =
+                obj["project_id"]?.jsonPrimitive?.longOrNull
+                    ?: return@mapNotNull null
+            projectId to PeriodStats(
+                totalEvents = obj["total_events"]?.jsonPrimitive?.longOrNull ?: 0,
+                uniqueIssues = obj["unique_issues"]?.jsonPrimitive?.longOrNull ?: 0,
+                uniqueUsers = obj["unique_users"]?.jsonPrimitive?.longOrNull ?: 0
+            )
+        }.toMap()
     }
 
     private suspend fun getCrashFreeRate(

--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -71,6 +71,7 @@ class NotificationService(
     private val slackService: SlackService = SlackService(),
     private val discordService: DiscordService = DiscordService(),
 ) {
+    enum class WeeklySummaryResult { SENT, SKIPPED, FAILED }
     private val config = ApplicationConfig("application.conf")
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
     private val frontendUrl = config.property("email.frontendUrl").getString()
@@ -316,20 +317,26 @@ class NotificationService(
             logger.info { "Sending weekly summaries to ${usersToNotify.size} users" }
 
             var sentCount = 0
+            var skippedCount = 0
             var failedCount = 0
 
             for ((userId, email) in usersToNotify) {
-                val success = suspendRunCatching {
+                val result = suspendRunCatching {
                     sendUserWeeklySummary(userId, email, startDate, endDate, priorStartDate)
                 }.getOrElse { e ->
                     logger.error(e) { "Failed to send weekly summary to $email" }
-                    false
+                    WeeklySummaryResult.FAILED
                 }
-                if (success) sentCount++ else failedCount++
+                when (result) {
+                    WeeklySummaryResult.SENT -> sentCount++
+                    WeeklySummaryResult.SKIPPED -> skippedCount++
+                    WeeklySummaryResult.FAILED -> failedCount++
+                }
             }
 
             logger.info {
-                "Weekly summary complete: $sentCount sent, $failedCount failed" +
+                "Weekly summary complete: $sentCount sent," +
+                    " $skippedCount skipped, $failedCount failed" +
                     " out of ${usersToNotify.size} users"
             }
         }.getOrElse { e ->
@@ -337,12 +344,15 @@ class NotificationService(
         }
     }
 
-    suspend fun sendWeeklySummaryForUser(userId: Int, email: String) {
+    suspend fun sendWeeklySummaryForUser(
+        userId: Int,
+        email: String
+    ): WeeklySummaryResult {
         val now = Instant.now()
         val endDate = now
         val startDate = now.minus(Duration.ofDays(WEEKLY_SUMMARY_DAYS))
         val priorStartDate = startDate.minus(Duration.ofDays(WEEKLY_SUMMARY_DAYS))
-        sendUserWeeklySummary(userId, email, startDate, endDate, priorStartDate)
+        return sendUserWeeklySummary(userId, email, startDate, endDate, priorStartDate)
     }
 
     private suspend fun sendUserWeeklySummary(
@@ -351,7 +361,7 @@ class NotificationService(
         startDate: Instant,
         endDate: Instant,
         priorStartDate: Instant
-    ): Boolean {
+    ): WeeklySummaryResult {
         val projects =
             transaction {
                 val orgIds =
@@ -368,7 +378,7 @@ class NotificationService(
 
         if (projects.isEmpty()) {
             logger.debug { "User $userId has no projects, skipping summary" }
-            return false
+            return WeeklySummaryResult.SKIPPED
         }
 
         val projectIds = projects.map { it.first }
@@ -378,7 +388,7 @@ class NotificationService(
 
         if (currentStats == null) {
             logger.warn { "Skipping weekly summary for $email: ClickHouse stats query failed" }
-            return false
+            return WeeklySummaryResult.FAILED
         }
 
         val totalEvents = currentStats.totalEvents
@@ -399,7 +409,7 @@ class NotificationService(
             logger.warn {
                 "Skipping weekly summary for $email: ClickHouse top issues query failed"
             }
-            return false
+            return WeeklySummaryResult.FAILED
         }
 
         val perProjectStats = getPerProjectStats(projectIds, startDate, endDate)
@@ -407,7 +417,7 @@ class NotificationService(
             logger.warn {
                 "Skipping weekly summary for $email: ClickHouse per-project stats query failed"
             }
-            return false
+            return WeeklySummaryResult.FAILED
         }
 
         val projectSummaries =
@@ -443,7 +453,7 @@ class NotificationService(
 
         emailService.sendWeeklySummaryEmail(email, emailData)
         logger.info { "Sent weekly summary to $email" }
-        return true
+        return WeeklySummaryResult.SENT
     }
 
     private data class PeriodStats(

--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -315,14 +315,22 @@ class NotificationService(
 
             logger.info { "Sending weekly summaries to ${usersToNotify.size} users" }
 
-            usersToNotify.forEach { (userId, email) ->
-                scope.launch {
-                    suspendRunCatching {
-                        sendUserWeeklySummary(userId, email, startDate, endDate, priorStartDate)
-                    }.getOrElse { e ->
-                        logger.error(e) { "Failed to send weekly summary to $email" }
-                    }
+            var sentCount = 0
+            var failedCount = 0
+
+            for ((userId, email) in usersToNotify) {
+                val success = suspendRunCatching {
+                    sendUserWeeklySummary(userId, email, startDate, endDate, priorStartDate)
+                }.getOrElse { e ->
+                    logger.error(e) { "Failed to send weekly summary to $email" }
+                    false
                 }
+                if (success) sentCount++ else failedCount++
+            }
+
+            logger.info {
+                "Weekly summary complete: $sentCount sent, $failedCount failed" +
+                    " out of ${usersToNotify.size} users"
             }
         }.getOrElse { e ->
             logger.error(e) { "Error in sendWeeklySummary" }
@@ -343,8 +351,7 @@ class NotificationService(
         startDate: Instant,
         endDate: Instant,
         priorStartDate: Instant
-    ) {
-        // Get user's projects
+    ): Boolean {
         val projects =
             transaction {
                 val orgIds =
@@ -361,34 +368,38 @@ class NotificationService(
 
         if (projects.isEmpty()) {
             logger.debug { "User $userId has no projects, skipping summary" }
-            return
+            return false
         }
 
         val projectIds = projects.map { it.first }
 
-        // Query ClickHouse for stats
         val currentStats = getStatsForPeriod(projectIds, startDate, endDate)
         val priorStats = getStatsForPeriod(projectIds, priorStartDate, startDate)
 
+        if (currentStats == null) {
+            logger.warn { "Skipping weekly summary for $email: ClickHouse stats query failed" }
+            return false
+        }
+
+        val safePriorStats = priorStats ?: PeriodStats(totalEvents = 0, uniqueIssues = 0, uniqueUsers = 0)
+
         val totalEvents = currentStats.totalEvents
-        val eventsTrend = calculateTrend(currentStats.totalEvents, priorStats.totalEvents)
+        val eventsTrend = calculateTrend(currentStats.totalEvents, safePriorStats.totalEvents)
         val newIssues = currentStats.uniqueIssues
-        val issuesTrend = calculateTrend(currentStats.uniqueIssues, priorStats.uniqueIssues)
+        val issuesTrend = calculateTrend(currentStats.uniqueIssues, safePriorStats.uniqueIssues)
         val affectedUsers = currentStats.uniqueUsers
-        val usersTrend = calculateTrend(currentStats.uniqueUsers, priorStats.uniqueUsers)
+        val usersTrend = calculateTrend(currentStats.uniqueUsers, safePriorStats.uniqueUsers)
 
-        // Get top issues
-        val topIssues = getTopIssues(projectIds, startDate, endDate, limit = 5)
+        val topIssues = getTopIssues(projectIds, startDate, endDate, limit = 5) ?: emptyList()
 
-        // Get per-project breakdown
         val projectSummaries =
             projects.map { (projectId, projectName) ->
                 val stats = getStatsForPeriod(listOf(projectId), startDate, endDate)
                 val crashFreeRate = getCrashFreeRate(projectId, startDate, endDate)
                 EmailService.ProjectSummary(
                     name = projectName,
-                    events = formatNumber(stats.totalEvents),
-                    issues = formatNumber(stats.uniqueIssues),
+                    events = formatNumber(stats?.totalEvents ?: 0),
+                    issues = formatNumber(stats?.uniqueIssues ?: 0),
                     crashFree = crashFreeRate?.let { String.format(Locale.US, "%.1f%%", it) } ?: "N/A"
                 )
             }
@@ -412,6 +423,7 @@ class NotificationService(
 
         emailService.sendWeeklySummaryEmail(email, emailData)
         logger.info { "Sent weekly summary to $email" }
+        return true
     }
 
     private data class PeriodStats(
@@ -424,7 +436,7 @@ class NotificationService(
         projectIds: List<Long>,
         startDate: Instant,
         endDate: Instant
-    ): PeriodStats {
+    ): PeriodStats? {
         val startMs = startDate.toEpochMilli()
         val endMs = endDate.toEpochMilli()
 
@@ -432,8 +444,8 @@ class NotificationService(
             """
             SELECT 
                 count() as total_events,
-                uniq(issue_id) as unique_issues,
-                uniq(user_id) as unique_users
+                uniqIf(issue_id, issue_id != '') as unique_issues,
+                uniqIf(user_id, user_id != '') as unique_users
             FROM `$clickhouseDb`.events
             WHERE project_id IN (${projectIds.joinToString(",")})
               AND timestamp >= fromUnixTimestamp64Milli($startMs)
@@ -446,7 +458,7 @@ class NotificationService(
         if (!response.status.isSuccess()) {
             val preview = responseBody.take(ERROR_BODY_PREVIEW_CHARS)
             logger.error("ClickHouse query failed in getStatsForPeriod: ${response.status} - $preview")
-            return PeriodStats(totalEvents = 0, uniqueIssues = 0, uniqueUsers = 0)
+            return null
         }
         val jsonResponse = Json.parseToJsonElement(responseBody).jsonObject
         val data = jsonResponse["data"]?.jsonArray?.firstOrNull()?.jsonObject
@@ -495,7 +507,7 @@ class NotificationService(
         startDate: Instant,
         endDate: Instant,
         limit: Int
-    ): List<EmailService.TopIssue> {
+    ): List<EmailService.TopIssue>? {
         val startMs = startDate.toEpochMilli()
         val endMs = endDate.toEpochMilli()
 
@@ -523,7 +535,7 @@ class NotificationService(
         if (!response.status.isSuccess()) {
             val preview = responseBody.take(ERROR_BODY_PREVIEW_CHARS)
             logger.error("ClickHouse query failed in getTopIssues: ${response.status} - $preview")
-            return emptyList()
+            return null
         }
         val jsonResponse = Json.parseToJsonElement(responseBody).jsonObject
         val rows = jsonResponse["data"]?.jsonArray ?: return emptyList()

--- a/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
@@ -190,4 +190,48 @@ class EmailServiceTest {
             organizationName = "Old Org"
         )
     }
+
+    @Test
+    fun `sendWeeklySummaryEmail handles null trends without throwing`() {
+        val service = EmailService()
+        val data =
+            EmailService.WeeklySummaryData(
+                startDate = "2026-04-06",
+                endDate = "2026-04-13",
+                totalEvents = "500",
+                eventsTrend = null,
+                newIssues = "10",
+                issuesTrend = null,
+                affectedUsers = "50",
+                usersTrend = null,
+                topIssues = emptyList(),
+                projects = emptyList(),
+                dashboardUrl = "https://app.example/dashboard",
+                settingsUrl = "https://app.example/settings",
+                unsubscribeUrl = "https://app.example/unsub"
+            )
+        service.sendWeeklySummaryEmail("lead@example.com", data)
+    }
+
+    @Test
+    fun `sendWeeklySummaryEmail handles mix of null and non-null trends`() {
+        val service = EmailService()
+        val data =
+            EmailService.WeeklySummaryData(
+                startDate = "2026-04-06",
+                endDate = "2026-04-13",
+                totalEvents = "200",
+                eventsTrend = 15,
+                newIssues = "3",
+                issuesTrend = null,
+                affectedUsers = "10",
+                usersTrend = -5,
+                topIssues = emptyList(),
+                projects = emptyList(),
+                dashboardUrl = "https://app.example/dashboard",
+                settingsUrl = "https://app.example/settings",
+                unsubscribeUrl = "https://app.example/unsub"
+            )
+        service.sendWeeklySummaryEmail("lead@example.com", data)
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
@@ -17,8 +17,14 @@
 package com.moneat.services
 
 import com.moneat.notifications.services.EmailService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.slot
+import io.mockk.spyk
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class EmailServiceTest {
 
@@ -233,5 +239,40 @@ class EmailServiceTest {
                 unsubscribeUrl = "https://app.example/unsub"
             )
         service.sendWeeklySummaryEmail("lead@example.com", data)
+    }
+
+    // ──── HTML Rendering Tests ────
+    @Test
+    fun `sendWeeklySummaryEmail renders mdash badge for null trends in HTML`() {
+        val service = spyk(EmailService())
+        val htmlSlot = slot<String>()
+        every {
+            service.sendEmail(
+                any(), any(), capture(htmlSlot), any(), any()
+            )
+        } just Runs
+
+        val data =
+            EmailService.WeeklySummaryData(
+                startDate = "2026-04-06",
+                endDate = "2026-04-13",
+                totalEvents = "500",
+                eventsTrend = null,
+                newIssues = "10",
+                issuesTrend = null,
+                affectedUsers = "50",
+                usersTrend = null,
+                topIssues = emptyList(),
+                projects = emptyList(),
+                dashboardUrl = "https://app.example/dashboard",
+                settingsUrl = "https://app.example/settings",
+                unsubscribeUrl = "https://app.example/unsub"
+            )
+        service.sendWeeklySummaryEmail("lead@example.com", data)
+
+        assertTrue(
+            htmlSlot.captured.contains("&mdash;"),
+            "HTML should contain mdash entity for null trends"
+        )
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import com.moneat.notifications.services.NotificationService.WeeklySummaryResult
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -166,7 +167,9 @@ class NotificationServiceWeeklySummaryTest {
 
             val sessionsBody = """{"data":[{"rate":$MOCK_CRASH_FREE_RATE}]}"""
 
-            MockHttpServer(weeklySummaryClickHouseHandler(sessionsBody)).use { server ->
+            val result = MockHttpServer(
+                weeklySummaryClickHouseHandler(sessionsBody)
+            ).use { server ->
                 ClickHouseClient.close()
                 ClickHouseClient.init(server.baseUrl, "test", "default", "")
                 val service = NotificationService(emailService, slackService, discordService)
@@ -178,6 +181,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
+            assertEquals(WeeklySummaryResult.SENT, result)
             val dataSlot = slot<EmailService.WeeklySummaryData>()
             verify(exactly = 1) {
                 emailService.sendWeeklySummaryEmail("weeklyuser@moneat.io", capture(dataSlot))
@@ -198,7 +202,9 @@ class NotificationServiceWeeklySummaryTest {
             seedMembership(userId, orgId)
             seedProject(orgId, "P2")
 
-            MockHttpServer(weeklySummaryClickHouseHandler("", sessionsStatus = 500)).use { server ->
+            val result = MockHttpServer(
+                weeklySummaryClickHouseHandler("", sessionsStatus = 500)
+            ).use { server ->
                 ClickHouseClient.close()
                 ClickHouseClient.init(server.baseUrl, "test", "default", "")
                 val service = NotificationService(emailService, slackService, discordService)
@@ -210,6 +216,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
+            assertEquals(WeeklySummaryResult.SENT, result)
             val dataSlot = slot<EmailService.WeeklySummaryData>()
             verify(exactly = 1) {
                 emailService.sendWeeklySummaryEmail("weeklyuser2@moneat.io", capture(dataSlot))
@@ -229,7 +236,7 @@ class NotificationServiceWeeklySummaryTest {
                 exchange.respond(500, "Internal Server Error", TEXT_PLAIN)
             }
 
-            MockHttpServer(failHandler).use { server ->
+            val result = MockHttpServer(failHandler).use { server ->
                 ClickHouseClient.close()
                 ClickHouseClient.init(server.baseUrl, "test", "default", "")
                 val service = NotificationService(emailService, slackService, discordService)
@@ -241,6 +248,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
+            assertEquals(WeeklySummaryResult.FAILED, result)
             verify(exactly = 0) {
                 emailService.sendWeeklySummaryEmail(any(), any())
             }
@@ -291,7 +299,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
-            MockHttpServer(handler).use { server ->
+            val result = MockHttpServer(handler).use { server ->
                 ClickHouseClient.close()
                 ClickHouseClient.init(server.baseUrl, "test", "default", "")
                 val service = NotificationService(
@@ -310,6 +318,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
+            assertEquals(WeeklySummaryResult.SENT, result)
             val dataSlot = slot<EmailService.WeeklySummaryData>()
             verify(exactly = 1) {
                 emailService.sendWeeklySummaryEmail(
@@ -358,7 +367,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
-            MockHttpServer(handler).use { server ->
+            val result = MockHttpServer(handler).use { server ->
                 ClickHouseClient.close()
                 ClickHouseClient.init(server.baseUrl, "test", "default", "")
                 val service = NotificationService(
@@ -377,6 +386,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
+            assertEquals(WeeklySummaryResult.FAILED, result)
             verify(exactly = 0) {
                 emailService.sendWeeklySummaryEmail(any(), any())
             }
@@ -417,7 +427,7 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
 
-            MockHttpServer(handler).use { server ->
+            val result = MockHttpServer(handler).use { server ->
                 ClickHouseClient.close()
                 ClickHouseClient.init(server.baseUrl, "test", "default", "")
                 val service = NotificationService(
@@ -434,6 +444,31 @@ class NotificationServiceWeeklySummaryTest {
                     service.shutdown()
                     ClickHouseClient.close()
                 }
+            }
+
+            assertEquals(WeeklySummaryResult.FAILED, result)
+            verify(exactly = 0) {
+                emailService.sendWeeklySummaryEmail(any(), any())
+            }
+        }
+
+    // ──── SKIPPED Result Tests ────
+    @Test
+    fun `sendWeeklySummaryForUser returns SKIPPED for user with no projects`() =
+        runBlocking {
+            val orgId = seedOrg("Empty Org")
+            val userId = seedUser("noproj@moneat.io", "No Proj User")
+            seedMembership(userId, orgId)
+
+            val service = NotificationService(emailService, slackService, discordService)
+            try {
+                val result = service.sendWeeklySummaryForUser(
+                    userId,
+                    "noproj@moneat.io",
+                )
+                assertEquals(WeeklySummaryResult.SKIPPED, result)
+            } finally {
+                service.shutdown()
             }
 
             verify(exactly = 0) {

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -44,6 +44,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class NotificationServiceWeeklySummaryTest {
     // ──── Constants & Mocks ────
@@ -131,6 +132,9 @@ class NotificationServiceWeeklySummaryTest {
         { exchange ->
             val query = exchange.requestBodyText()
             when {
+                query.contains("GROUP BY project_id") -> {
+                    exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                }
                 query.contains("countIf(errors = 0)") -> {
                     exchange.respond(sessionsStatus, sessionsJson, TEXT_PLAIN)
                 }
@@ -231,6 +235,201 @@ class NotificationServiceWeeklySummaryTest {
                 val service = NotificationService(emailService, slackService, discordService)
                 try {
                     service.sendWeeklySummaryForUser(userId, "weeklyskip@moneat.io")
+                } finally {
+                    service.shutdown()
+                    ClickHouseClient.close()
+                }
+            }
+
+            verify(exactly = 0) {
+                emailService.sendWeeklySummaryEmail(any(), any())
+            }
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser sets null trends when prior stats query fails`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser("nulltrend@moneat.io", "Null Trend User")
+            seedMembership(userId, orgId)
+            seedProject(orgId, "PT1")
+
+            var statsCallCount = 0
+            val handler: (HttpExchange) -> Unit = { exchange ->
+                val query = exchange.requestBodyText()
+                when {
+                    query.contains("GROUP BY project_id") -> {
+                        exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                    }
+                    query.contains("count() as total_events") -> {
+                        statsCallCount++
+                        if (statsCallCount == 1) {
+                            val body = """{"data":[{
+                                "total_events":$STATS_TOTAL_EVENTS,
+                                "unique_issues":$STATS_UNIQUE_ISSUES,
+                                "unique_users":$STATS_UNIQUE_USERS
+                            }]}""".replace("\n", "")
+                            exchange.respond(200, body, TEXT_PLAIN)
+                        } else {
+                            exchange.respond(
+                                500,
+                                "Internal Server Error",
+                                TEXT_PLAIN
+                            )
+                        }
+                    }
+                    query.contains("any(message) as title") -> {
+                        exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                    }
+                    query.contains("countIf(errors = 0)") -> {
+                        val body = """{"data":[{"rate":99.0}]}"""
+                        exchange.respond(200, body, TEXT_PLAIN)
+                    }
+                    else -> {
+                        exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                    }
+                }
+            }
+
+            MockHttpServer(handler).use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+                val service = NotificationService(
+                    emailService,
+                    slackService,
+                    discordService,
+                )
+                try {
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "nulltrend@moneat.io",
+                    )
+                } finally {
+                    service.shutdown()
+                    ClickHouseClient.close()
+                }
+            }
+
+            val dataSlot = slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "nulltrend@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+            assertNull(dataSlot.captured.eventsTrend)
+            assertNull(dataSlot.captured.issuesTrend)
+            assertNull(dataSlot.captured.usersTrend)
+            assertEquals(
+                STATS_TOTAL_EVENTS.toString(),
+                dataSlot.captured.totalEvents,
+            )
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser skips email when top issues query fails`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser("topfail@moneat.io", "TopFail User")
+            seedMembership(userId, orgId)
+            seedProject(orgId, "PT2")
+
+            val handler: (HttpExchange) -> Unit = { exchange ->
+                val query = exchange.requestBodyText()
+                when {
+                    query.contains("any(message) as title") -> {
+                        exchange.respond(
+                            500,
+                            "Internal Server Error",
+                            TEXT_PLAIN
+                        )
+                    }
+                    query.contains("count() as total_events") -> {
+                        val body = """{"data":[{
+                            "total_events":$STATS_TOTAL_EVENTS,
+                            "unique_issues":$STATS_UNIQUE_ISSUES,
+                            "unique_users":$STATS_UNIQUE_USERS
+                        }]}""".replace("\n", "")
+                        exchange.respond(200, body, TEXT_PLAIN)
+                    }
+                    else -> {
+                        exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                    }
+                }
+            }
+
+            MockHttpServer(handler).use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+                val service = NotificationService(
+                    emailService,
+                    slackService,
+                    discordService,
+                )
+                try {
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "topfail@moneat.io",
+                    )
+                } finally {
+                    service.shutdown()
+                    ClickHouseClient.close()
+                }
+            }
+
+            verify(exactly = 0) {
+                emailService.sendWeeklySummaryEmail(any(), any())
+            }
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser skips email when per-project stats query fails`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser("projfail@moneat.io", "ProjFail User")
+            seedMembership(userId, orgId)
+            seedProject(orgId, "PT3")
+
+            val handler: (HttpExchange) -> Unit = { exchange ->
+                val query = exchange.requestBodyText()
+                when {
+                    query.contains("GROUP BY project_id") -> {
+                        exchange.respond(
+                            500,
+                            "Internal Server Error",
+                            TEXT_PLAIN
+                        )
+                    }
+                    query.contains("count() as total_events") -> {
+                        val body = """{"data":[{
+                            "total_events":$STATS_TOTAL_EVENTS,
+                            "unique_issues":$STATS_UNIQUE_ISSUES,
+                            "unique_users":$STATS_UNIQUE_USERS
+                        }]}""".replace("\n", "")
+                        exchange.respond(200, body, TEXT_PLAIN)
+                    }
+                    query.contains("any(message) as title") -> {
+                        exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                    }
+                    else -> {
+                        exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                    }
+                }
+            }
+
+            MockHttpServer(handler).use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+                val service = NotificationService(
+                    emailService,
+                    slackService,
+                    discordService,
+                )
+                try {
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "projfail@moneat.io",
+                    )
                 } finally {
                     service.shutdown()
                     ClickHouseClient.close()

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -212,4 +212,33 @@ class NotificationServiceWeeklySummaryTest {
             }
             assertEquals("N/A", dataSlot.captured.projects.single().crashFree)
         }
+
+    @Test
+    fun `sendWeeklySummaryForUser skips email when ClickHouse stats query fails`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser("weeklyskip@moneat.io", "Skip User")
+            seedMembership(userId, orgId)
+            seedProject(orgId, "P3")
+
+            val failHandler: (HttpExchange) -> Unit = { exchange ->
+                exchange.respond(500, "Internal Server Error", TEXT_PLAIN)
+            }
+
+            MockHttpServer(failHandler).use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+                val service = NotificationService(emailService, slackService, discordService)
+                try {
+                    service.sendWeeklySummaryForUser(userId, "weeklyskip@moneat.io")
+                } finally {
+                    service.shutdown()
+                    ClickHouseClient.close()
+                }
+            }
+
+            verify(exactly = 0) {
+                emailService.sendWeeklySummaryEmail(any(), any())
+            }
+        }
 }

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -56,6 +56,21 @@ class NotificationServiceWeeklySummaryTest {
         private const val STATS_TOTAL_EVENTS = 100L
         private const val STATS_UNIQUE_ISSUES = 4L
         private const val STATS_UNIQUE_USERS = 20L
+        private const val MULTI_P1_EVENTS = 75L
+        private const val MULTI_P1_ISSUES = 3L
+        private const val MULTI_P1_USERS = 10L
+        private const val MULTI_P2_EVENTS = 25L
+        private const val MULTI_P2_ISSUES = 1L
+        private const val MULTI_P2_USERS = 5L
+        private const val CRASH_FREE_P1 = 99.5
+        private const val CRASH_FREE_P2 = 95.0
+        private const val TREND_LOW = 50L
+        private const val TREND_HIGH = 100L
+        private const val EXPECTED_NEGATIVE_TREND = -50
+        private const val EXPECTED_POSITIVE_TREND = 100
+        private const val LARGE_K_EVENTS = 1500L
+        private const val LARGE_M_EVENTS = 2_000_000L
+        private const val DEFAULT_CRASH_FREE = 99.0
     }
 
     private val emailService = mockk<EmailService>(relaxed = true)
@@ -155,6 +170,74 @@ class NotificationServiceWeeklySummaryTest {
                 }
             }
         }
+
+    // ──── Reusable Helpers ────
+    private fun statsJson(
+        events: Long,
+        issues: Long,
+        users: Long,
+    ): String = """{"data":[{""" +
+        """"total_events":$events,""" +
+        """"unique_issues":$issues,""" +
+        """"unique_users":$users""" +
+        """}]}"""
+
+    private fun statsHandler(
+        currentStats: String,
+        priorStats: String,
+    ): (HttpExchange) -> Unit {
+        var call = 0
+        return { exchange ->
+            val query = exchange.requestBodyText()
+            val emptyData = """{"data":[]}"""
+            when {
+                query.contains("GROUP BY project_id") ->
+                    exchange.respond(200, emptyData, TEXT_PLAIN)
+                query.contains("count() as total_events") -> {
+                    call++
+                    val body = if (call == 1) {
+                        currentStats
+                    } else {
+                        priorStats
+                    }
+                    exchange.respond(200, body, TEXT_PLAIN)
+                }
+                query.contains("any(message) as title") ->
+                    exchange.respond(200, emptyData, TEXT_PLAIN)
+                query.contains("countIf(errors = 0)") -> {
+                    val body =
+                        """{"data":[{"rate":$DEFAULT_CRASH_FREE}]}"""
+                    exchange.respond(200, body, TEXT_PLAIN)
+                }
+                else ->
+                    exchange.respond(200, emptyData, TEXT_PLAIN)
+            }
+        }
+    }
+
+    private suspend fun <T> withMockClickHouse(
+        handler: (HttpExchange) -> Unit,
+        block: suspend (NotificationService) -> T,
+    ): T = MockHttpServer(handler).use { server ->
+        ClickHouseClient.close()
+        ClickHouseClient.init(
+            server.baseUrl,
+            "test",
+            "default",
+            "",
+        )
+        val service = NotificationService(
+            emailService,
+            slackService,
+            discordService,
+        )
+        try {
+            block(service)
+        } finally {
+            service.shutdown()
+            ClickHouseClient.close()
+        }
+    }
 
     // ──── Test Cases ────
     @Test
@@ -474,5 +557,386 @@ class NotificationServiceWeeklySummaryTest {
             verify(exactly = 0) {
                 emailService.sendWeeklySummaryEmail(any(), any())
             }
+        }
+
+    // ──── Batch sendWeeklySummary Tests ────
+    @Test
+    fun `sendWeeklySummary sends to all eligible users`() =
+        runBlocking {
+            val orgId = seedOrg("Batch Org")
+            val user1Id = seedUser(
+                "batch1@moneat.io",
+                "Batch User 1",
+            )
+            val user2Id = seedUser(
+                "batch2@moneat.io",
+                "Batch User 2",
+            )
+            seedMembership(user1Id, orgId)
+            seedMembership(user2Id, orgId)
+            seedProject(orgId, "BatchProject")
+
+            val sessionsBody =
+                """{"data":[{"rate":$MOCK_CRASH_FREE_RATE}]}"""
+
+            withMockClickHouse(
+                weeklySummaryClickHouseHandler(sessionsBody)
+            ) { service ->
+                service.sendWeeklySummary()
+            }
+
+            verify(exactly = 2) {
+                emailService.sendWeeklySummaryEmail(
+                    any(),
+                    any(),
+                )
+            }
+        }
+
+    // ──── Multi-Project Tests ────
+    @Test
+    fun `sendWeeklySummaryForUser with multiple projects shows per-project stats`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser(
+                "multiproj@moneat.io",
+                "Multi Project User",
+            )
+            seedMembership(userId, orgId)
+            val p1Id = seedProject(orgId, "Frontend App")
+            val p2Id = seedProject(orgId, "Backend API")
+
+            val handler: (HttpExchange) -> Unit =
+                { exchange ->
+                    val query = exchange.requestBodyText()
+                    when {
+                        query.contains(
+                            "GROUP BY project_id"
+                        ) -> {
+                            val body = """{"data":[""" +
+                                """{"project_id":$p1Id,""" +
+                                """"total_events":""" +
+                                """$MULTI_P1_EVENTS,""" +
+                                """"unique_issues":""" +
+                                """$MULTI_P1_ISSUES,""" +
+                                """"unique_users":""" +
+                                """$MULTI_P1_USERS},""" +
+                                """{"project_id":$p2Id,""" +
+                                """"total_events":""" +
+                                """$MULTI_P2_EVENTS,""" +
+                                """"unique_issues":""" +
+                                """$MULTI_P2_ISSUES,""" +
+                                """"unique_users":""" +
+                                """$MULTI_P2_USERS}""" +
+                                """]}"""
+                            exchange.respond(
+                                200,
+                                body,
+                                TEXT_PLAIN,
+                            )
+                        }
+                        query.contains(
+                            "countIf(errors = 0)"
+                        ) -> {
+                            val isP1 = query.contains(
+                                "project_id = $p1Id"
+                            )
+                            val rate =
+                                if (isP1) {
+                                    CRASH_FREE_P1
+                                } else {
+                                    CRASH_FREE_P2
+                                }
+                            exchange.respond(
+                                200,
+                                """{"data":[{"rate":$rate}]}""",
+                                TEXT_PLAIN,
+                            )
+                        }
+                        query.contains(
+                            "any(message) as title"
+                        ) -> {
+                            exchange.respond(
+                                200,
+                                """{"data":[]}""",
+                                TEXT_PLAIN,
+                            )
+                        }
+                        else -> {
+                            exchange.respond(
+                                200,
+                                statsJson(
+                                    STATS_TOTAL_EVENTS,
+                                    STATS_UNIQUE_ISSUES,
+                                    STATS_UNIQUE_USERS,
+                                ),
+                                TEXT_PLAIN,
+                            )
+                        }
+                    }
+                }
+
+            val result =
+                withMockClickHouse(handler) { svc ->
+                    svc.sendWeeklySummaryForUser(
+                        userId,
+                        "multiproj@moneat.io",
+                    )
+                }
+
+            assertEquals(WeeklySummaryResult.SENT, result)
+            val dataSlot =
+                slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "multiproj@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+            val projects = dataSlot.captured.projects
+            assertEquals(2, projects.size)
+
+            val frontend =
+                projects.first { it.name == "Frontend App" }
+            assertEquals(
+                MULTI_P1_EVENTS.toString(),
+                frontend.events,
+            )
+            assertEquals(
+                MULTI_P1_ISSUES.toString(),
+                frontend.issues,
+            )
+            assertEquals("99.5%", frontend.crashFree)
+
+            val backend =
+                projects.first { it.name == "Backend API" }
+            assertEquals(
+                MULTI_P2_EVENTS.toString(),
+                backend.events,
+            )
+            assertEquals(
+                MULTI_P2_ISSUES.toString(),
+                backend.issues,
+            )
+            assertEquals("95.0%", backend.crashFree)
+        }
+
+    // ──── Trend Calculation Tests ────
+    @Test
+    fun `sendWeeklySummaryForUser calculates negative trend`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser(
+                "negtrend@moneat.io",
+                "Neg Trend",
+            )
+            seedMembership(userId, orgId)
+            seedProject(orgId, "TrendP1")
+
+            val handler = statsHandler(
+                currentStats = statsJson(
+                    TREND_LOW,
+                    TREND_LOW,
+                    TREND_LOW,
+                ),
+                priorStats = statsJson(
+                    TREND_HIGH,
+                    TREND_HIGH,
+                    TREND_HIGH,
+                ),
+            )
+
+            val result =
+                withMockClickHouse(handler) { service ->
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "negtrend@moneat.io",
+                    )
+                }
+
+            assertEquals(WeeklySummaryResult.SENT, result)
+            val dataSlot =
+                slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "negtrend@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+            assertEquals(
+                EXPECTED_NEGATIVE_TREND,
+                dataSlot.captured.eventsTrend,
+            )
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser calculates positive trend`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser(
+                "postrend@moneat.io",
+                "Pos Trend",
+            )
+            seedMembership(userId, orgId)
+            seedProject(orgId, "TrendP2")
+
+            val handler = statsHandler(
+                currentStats = statsJson(
+                    TREND_HIGH,
+                    TREND_HIGH,
+                    TREND_HIGH,
+                ),
+                priorStats = statsJson(
+                    TREND_LOW,
+                    TREND_LOW,
+                    TREND_LOW,
+                ),
+            )
+
+            val result =
+                withMockClickHouse(handler) { service ->
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "postrend@moneat.io",
+                    )
+                }
+
+            assertEquals(WeeklySummaryResult.SENT, result)
+            val dataSlot =
+                slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "postrend@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+            assertEquals(
+                EXPECTED_POSITIVE_TREND,
+                dataSlot.captured.eventsTrend,
+            )
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser shows zero trend for zero-to-zero`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser(
+                "zerotrend@moneat.io",
+                "Zero Trend",
+            )
+            seedMembership(userId, orgId)
+            seedProject(orgId, "TrendP3")
+
+            val zeroStats = statsJson(
+                0,
+                0,
+                0,
+            )
+            val handler =
+                statsHandler(zeroStats, zeroStats)
+
+            val result =
+                withMockClickHouse(handler) { service ->
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "zerotrend@moneat.io",
+                    )
+                }
+
+            assertEquals(WeeklySummaryResult.SENT, result)
+            val dataSlot =
+                slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "zerotrend@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+            assertEquals(0, dataSlot.captured.eventsTrend)
+            assertEquals(0, dataSlot.captured.issuesTrend)
+            assertEquals(0, dataSlot.captured.usersTrend)
+        }
+
+    // ──── Number Formatting Tests ────
+    @Test
+    fun `sendWeeklySummaryForUser formats thousands with K suffix`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser(
+                "fmtk@moneat.io",
+                "FmtK User",
+            )
+            seedMembership(userId, orgId)
+            seedProject(orgId, "FmtKProj")
+
+            val stats = statsJson(
+                LARGE_K_EVENTS,
+                STATS_UNIQUE_ISSUES,
+                STATS_UNIQUE_USERS,
+            )
+            val handler = statsHandler(stats, stats)
+
+            val result =
+                withMockClickHouse(handler) { service ->
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "fmtk@moneat.io",
+                    )
+                }
+
+            assertEquals(WeeklySummaryResult.SENT, result)
+            val dataSlot =
+                slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "fmtk@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+            assertEquals(
+                "1.5K",
+                dataSlot.captured.totalEvents,
+            )
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser formats millions with M suffix`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser(
+                "fmtm@moneat.io",
+                "FmtM User",
+            )
+            seedMembership(userId, orgId)
+            seedProject(orgId, "FmtMProj")
+
+            val stats = statsJson(
+                LARGE_M_EVENTS,
+                STATS_UNIQUE_ISSUES,
+                STATS_UNIQUE_USERS,
+            )
+            val handler = statsHandler(stats, stats)
+
+            val result =
+                withMockClickHouse(handler) { service ->
+                    service.sendWeeklySummaryForUser(
+                        userId,
+                        "fmtm@moneat.io",
+                    )
+                }
+
+            assertEquals(WeeklySummaryResult.SENT, result)
+            val dataSlot =
+                slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "fmtm@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+            assertEquals(
+                "2.0M",
+                dataSlot.captured.totalEvents,
+            )
         }
 }

--- a/backend/src/test/resources/email-templates/weekly-summary.html
+++ b/backend/src/test/resources/email-templates/weekly-summary.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>{{ startDate }} &ndash; {{ endDate }}</p>
+<p>Events: {{ totalEvents }} EVENTS_TREND_PLACEHOLDER</p>
+<p>Issues: {{ newIssues }} ISSUES_TREND_PLACEHOLDER</p>
+<p>Users: {{ affectedUsers }} USERS_TREND_PLACEHOLDER</p>
+<table>ISSUES_PLACEHOLDER</table>
+<div>PROJECTS_PLACEHOLDER</div>
+<p><a href="{{ dashboardUrl }}">Dashboard</a></p>
+<p><a href="{{ settingsUrl }}">Settings</a></p>
+<p><a href="{{ unsubscribeUrl }}">Unsubscribe</a></p>
+<p>&copy; {{ year }}</p>
+</body>
+</html>


### PR DESCRIPTION
Closes #341

## Root cause

`getStatsForPeriod()` silently returned `PeriodStats(0, 0, 0)` when ClickHouse queries failed (HTTP error), and the email was sent regardless — producing a misleading all-zeros weekly summary.

## Changes

- **Propagate ClickHouse errors**: `getStatsForPeriod` and `getTopIssues` now return `null` on HTTP failure instead of zeros/empty lists
- **Skip email on failure**: `sendUserWeeklySummary` skips sending when the primary stats query fails, and returns a success/failure flag
- **Track send results**: `sendWeeklySummary` logs sent/failed counts for observability
- **Fix empty-string counting**: Use `uniqIf(issue_id, issue_id != '')` and `uniqIf(user_id, user_id != '')` instead of `uniq()` to avoid counting empty-string issue/user IDs from transactions
- **Sequential execution**: Changed from parallel coroutine launches to sequential loop for reliable result tracking

## Test plan

- [x] Existing tests pass (crash-free rate, happy path)
- [x] New test: ClickHouse HTTP 500 → email not sent
- [ ] Manual: trigger test email via admin route with ClickHouse down → verify no email sent

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Weekly summary now skips users when required stats fail, avoiding incomplete emails.
  * Data retrieval errors are propagated and handled via nullable results to prevent false success.
  * Trend calculations and per-project breakdowns handle missing prior or per-project data and show a neutral indicator when trends are unavailable.

* **Tests**
  * Added tests covering various data-service failure scenarios and null-trend rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->