### PR TITLE
fix: quota notification threshold selection

### DIFF
--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingBackgroundService.kt
@@ -158,13 +158,20 @@ class BillingBackgroundService(
     private fun quotaNotificationTypesFor(usage: BillingUsageResponse): List<String> {
         val percentages = quotaUsagePercentages(usage)
         return listOfNotNull(
-            BASE_WARNING_NOTIFICATION.takeIf { percentages.base >= QUOTA_WARNING_THRESHOLD },
-            BASE_CRITICAL_NOTIFICATION.takeIf { percentages.base >= QUOTA_CRITICAL_THRESHOLD },
-            BASE_EXCEEDED_NOTIFICATION.takeIf { percentages.base >= QUOTA_EXCEEDED_THRESHOLD },
+            baseNotificationTypeFor(percentages.base),
             PAYG_WARNING_NOTIFICATION.takeIf {
                 hasPaygLimit(usage) && percentages.payg >= QUOTA_WARNING_THRESHOLD
             },
         )
+    }
+
+    private fun baseNotificationTypeFor(basePercentage: Double): String? {
+        return when {
+            basePercentage >= QUOTA_EXCEEDED_THRESHOLD -> BASE_EXCEEDED_NOTIFICATION
+            basePercentage >= QUOTA_CRITICAL_THRESHOLD -> BASE_CRITICAL_NOTIFICATION
+            basePercentage >= QUOTA_WARNING_THRESHOLD -> BASE_WARNING_NOTIFICATION
+            else -> null
+        }
     }
 
     private fun quotaUsagePercentages(usage: BillingUsageResponse): QuotaUsagePercentages {

--- a/backend/src/test/kotlin/com/moneat/services/BillingBackgroundServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/BillingBackgroundServiceTest.kt
@@ -181,7 +181,7 @@ class BillingBackgroundServiceTest {
     }
 
     @Test
-    fun `process quota threshold notifications sends each threshold once per period`() {
+    fun `process quota threshold notifications sends highest base threshold once per period`() {
         val service = BillingBackgroundService()
 
         invokeQuotaNotificationPass(service)
@@ -195,12 +195,20 @@ class BillingBackgroundServiceTest {
                     .map { it[QuotaNotificationsSent.notification_type] }
                     .toSet()
 
-            assertEquals(4, types.size)
-            assertTrue("base_80" in types)
-            assertTrue("base_90" in types)
+            assertEquals(2, types.size)
             assertTrue("base_100" in types)
             assertTrue("payg_80" in types)
         }
+    }
+
+    @Test
+    fun `base notification type uses highest matching threshold`() {
+        val service = BillingBackgroundService()
+
+        assertEquals("base_80", invokeBaseNotificationTypeFor(service, 0.8))
+        assertEquals("base_90", invokeBaseNotificationTypeFor(service, 0.9))
+        assertEquals("base_100", invokeBaseNotificationTypeFor(service, 1.0))
+        assertEquals("base_100", invokeBaseNotificationTypeFor(service, 1.2))
     }
 
     @Test
@@ -338,8 +346,7 @@ class BillingBackgroundServiceTest {
                     .map { it[QuotaNotificationsSent.notification_type] }
                     .toSet()
 
-            assertTrue("base_80" in types, "Expected base_80 notification for bytes-only tier")
-            assertTrue("base_90" in types, "Expected base_90 notification for bytes-only tier")
+            assertEquals(setOf("base_100"), types)
             assertTrue("base_100" in types, "Expected base_100 notification for bytes-only tier")
         }
     }
@@ -630,8 +637,7 @@ class BillingBackgroundServiceTest {
                     .map { it[QuotaNotificationsSent.notification_type] }
                     .toSet()
 
-            assertTrue("base_80" in types, "Expected base_80 (base limit exceeded)")
-            assertTrue("base_90" in types, "Expected base_90 (base limit exceeded)")
+            assertEquals(2, types.size)
             assertTrue("base_100" in types, "Expected base_100 (base limit exceeded)")
             assertTrue("payg_80" in types, "Expected payg_80 for byte-based PAYG budget")
         }
@@ -774,14 +780,7 @@ class BillingBackgroundServiceTest {
                     .map { it[QuotaNotificationsSent.notification_type] }
                     .toSet()
 
-            assertTrue(
-                "base_80" in types,
-                "Expected base_80 notification when bytes exceed 80% of GB limit (unit limit is Long.MAX_VALUE)"
-            )
-            assertTrue(
-                "base_90" in types,
-                "Expected base_90 notification when bytes exceed 90% of GB limit (unit limit is Long.MAX_VALUE)"
-            )
+            assertEquals(setOf("base_100"), types)
             assertTrue(
                 "base_100" in types,
                 "Expected base_100 notification when bytes exceed GB limit (unit limit is Long.MAX_VALUE)"
@@ -793,5 +792,14 @@ class BillingBackgroundServiceTest {
         val method = BillingBackgroundService::class.java.getDeclaredMethod("processQuotaThresholdNotifications")
         method.isAccessible = true
         method.invoke(service)
+    }
+
+    private fun invokeBaseNotificationTypeFor(service: BillingBackgroundService, percentage: Double): String? {
+        val method = BillingBackgroundService::class.java.getDeclaredMethod(
+            "baseNotificationTypeFor",
+            java.lang.Double.TYPE
+        )
+        method.isAccessible = true
+        return method.invoke(service, percentage) as String?
     }
 }


### PR DESCRIPTION
## Summary
- Send only the highest applicable base quota notification per billing pass
- Keep PAYG warning behavior unchanged
- Update billing background service tests for 80%, 90%, and exceeded threshold selection

## Root cause
At 100% usage the billing job attempted the 80%, 90%, and 100% base notifications in the same pass, which could surface a misleading 90% subject even when usage was already at the quota.

## Validation
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.services.BillingBackgroundServiceTest -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quota notifications now display only the highest applicable threshold per billing period instead of multiple notifications for each threshold, improving clarity and reducing notification fatigue.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->