### PR TITLE
fix: keep Datadog host liveness on quota rejection

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogEventRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogEventRoutes.kt
@@ -79,10 +79,10 @@ private suspend fun RoutingContext.handleV1CheckRun(
     ) ?: return
     val batch = mapServiceChecks(orgId, checks)
 
+    touchServiceCheckHosts(orgId, checks)
     if (!reserveEventQuota(quotaService, orgId, batch.serviceChecks.size, body)) return
 
     insertServiceCheckBatchIfPresent(batch)
-    touchServiceCheckHosts(orgId, checks)
     logger.debug {
         "Accepted ${batch.serviceChecks.size} DD V1 check_run service checks for org $orgId"
     }
@@ -120,10 +120,10 @@ private suspend fun RoutingContext.handleV2ServiceChecks(
     ) ?: return
     val batch = mapServiceChecks(orgId, payload.serviceChecks)
 
+    touchServiceCheckHosts(orgId, payload.serviceChecks)
     if (!reserveEventQuota(quotaService, orgId, batch.serviceChecks.size, body)) return
 
     insertServiceCheckBatchIfPresent(batch)
-    touchServiceCheckHosts(orgId, payload.serviceChecks)
     logger.debug { "Accepted ${batch.serviceChecks.size} DD service checks for org $orgId" }
     call.respondAccepted()
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogMetricRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogMetricRoutes.kt
@@ -116,13 +116,13 @@ private suspend fun RoutingContext.acceptMetricSeries(
     apiVersion: String
 ) {
     val requestedUnits = countV1MetricPoints(payload)
+    touchMetricHosts(orgId, payload)
     if (!reserveMetricQuota(quotaService, orgId, requestedUnits, body)) return
 
     val count = DatadogMetricService.enqueueMetrics(
         organizationId = orgId.toLong(),
         payload = payload
     )
-    touchMetricHosts(orgId, payload)
     logger.debug { "Accepted $count DD $apiVersion metrics for org $orgId" }
     call.respondAccepted()
 }
@@ -189,6 +189,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSketches(
         payload = payload
     )
 
+    touchSketchHosts(orgId, payload)
     if (!reserveMetricQuota(quotaService, orgId, batch.sketches.size, body)) return
 
     insertSketchBatchIfPresent(batch)
@@ -225,6 +226,14 @@ private suspend fun RoutingContext.reserveMetricQuota(
 
 private fun touchMetricHosts(orgId: Int, payload: DatadogMetricSeriesV1) {
     val hosts = payload.series
+        .map { it.host }
+        .filter { it.isNotBlank() }
+        .toSet()
+    DatadogHostService.touchHostLastSeen(orgId, hosts)
+}
+
+private fun touchSketchHosts(orgId: Int, payload: DatadogSketchPayload) {
+    val hosts = payload.sketches
         .map { it.host }
         .filter { it.isNotBlank() }
         .toSet()

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -53,6 +53,8 @@ import com.moneat.datadog.services.DdHostInfo
 import com.moneat.datadog.services.DebuggerIngestionService
 import com.moneat.datadog.services.MiscIngestionService
 import com.moneat.datadog.services.OrchestratorIngestionService
+import com.moneat.datadog.services.QueuedServiceCheckBatch
+import com.moneat.datadog.services.QueuedServiceCheckEntry
 import com.moneat.datadog.services.TelemetryProxyService
 import com.moneat.datadog.services.TraceIngestionService
 import com.moneat.shared.models.Memberships
@@ -783,7 +785,7 @@ class DatadogRoutesExtendedTest {
     @Test
     fun `POST dd metrics returns 429 before enqueue when quota is exceeded`() = testApplication {
         val quotaService = rejectingQuotaService()
-        val body = """{"series":[{"metric":"system.cpu","points":[[1700000000,42.0]]}]}"""
+        val body = """{"series":[{"metric":"system.cpu","host":"h1","points":[[1700000000,42.0]]}]}"""
 
         application {
             install(ContentNegotiation) { json() }
@@ -805,7 +807,49 @@ class DatadogRoutesExtendedTest {
                 requestedBytes = body.toByteArray().size.toLong(),
             )
         }
+        verify { DatadogHostService.touchHostLastSeen(TEST_ORG_ID, setOf("h1")) }
         coVerify(exactly = 0) { DatadogMetricService.enqueueMetrics(any(), any()) }
+    }
+
+    @Test
+    fun `POST dd service checks touches host before quota rejection`() = testApplication {
+        val quotaService = rejectingQuotaService()
+        val body = """{"service_checks":[{"check":"disk","host_name":"h1","status":0}]}"""
+        every {
+            DatadogEventService.mapServiceChecks(any(), any())
+        } returns QueuedServiceCheckBatch(
+            organizationId = TEST_ORG_ID.toLong(),
+            serviceChecks = listOf(
+                QueuedServiceCheckEntry(
+                    checkName = "disk",
+                    host = "h1",
+                    timestampMs = 0L
+                )
+            )
+        )
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing { datadogEventRoutes(quotaService) }
+        }
+
+        val response = client.post("/dd/api/v2/service_checks") {
+            header(DD_API_KEY_HEADER, TEST_API_KEY)
+            contentType(ContentType.Application.Json)
+            setBody(body)
+        }
+
+        assertEquals(HttpStatusCode.TooManyRequests, response.status)
+        verify {
+            quotaService.reserveUnits(
+                organizationId = TEST_ORG_ID,
+                requestedUnits = 1,
+                eventType = "dd_event",
+                requestedBytes = body.toByteArray().size.toLong(),
+            )
+        }
+        verify { DatadogHostService.touchHostLastSeen(TEST_ORG_ID, setOf("h1")) }
+        coVerify(exactly = 0) { DatadogEventService.insertServiceCheckBatch(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Touch Datadog metric, sketch, and service-check hosts before quota enforcement rejects ingestion
- Keep rejected payloads from enqueueing billable data
- Add route coverage for host liveness updates when quota reservation returns 429

## Root cause
Datadog liveness was updated only after quota reservation. Once an organization was over quota, the agent could keep sending health-related payloads but those requests returned before updating `last_seen_at`, causing stale hosts to transition into host-down alerts.

## Validation
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.routes.DatadogRoutesExtendedTest -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host activity tracking now occurs before quota validation, ensuring hosts are marked as seen even when requests are rejected due to quota limits.

* **Tests**
  * Added test coverage to verify host tracking behavior during quota rejection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->