### PR TITLE
fix: auto-resolve cleared alerts

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -330,7 +330,7 @@ class DashboardAlertService(
                 }
                 sendRecoveryNotification(alert, currentValue)
                 suspendRunCatching {
-                    incidentService.resolveAlert(
+                    incidentService.autoResolveAlert(
                         organizationId = alert.orgId.toInt(),
                         source = AlertSource.DASHBOARD_ALERT,
                         deduplicationKey = "moneat-dashboard-alert-${alert.alertId}"

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
@@ -50,6 +50,16 @@ class IncidentService {
     private val logger = LoggerFactory.getLogger(IncidentService::class.java)
     private val json = Json { ignoreUnknownKeys = true }
 
+    companion object {
+        private val AUTO_RESOLVABLE_SOURCES =
+            setOf(
+                AlertSource.HOST_ALERT,
+                AlertSource.HOST_DOWN,
+                AlertSource.UPTIME_MONITOR,
+                AlertSource.DASHBOARD_ALERT
+            )
+    }
+
     /**
      * Fire an alert to all enabled incident providers for the organization.
      * Severity is resolved in order: per-monitor override > routing rule default > skip
@@ -179,6 +189,26 @@ class IncidentService {
         }.getOrElse { e ->
             logger.error("Error resolving alert", e)
         }
+    }
+
+    /**
+     * Resolve only alert sources with deterministic clear signals.
+     */
+    suspend fun autoResolveAlert(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String
+    ) {
+        if (!isAutoResolvableSource(source)) {
+            logger.warn("Skipping auto-resolve for source without clear signal: $source")
+            return
+        }
+
+        resolveAlert(organizationId, source, deduplicationKey)
+    }
+
+    internal fun isAutoResolvableSource(source: AlertSource): Boolean {
+        return source in AUTO_RESOLVABLE_SOURCES
     }
 
     /**

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -828,14 +828,16 @@ class MonitorAlertService(
             "Host ${host.hostId} (${host.hostName}) status changed: ${host.currentStatus} -> $newStatus"
         }
 
+        if (host.currentStatus == "down" && newStatus == "up" &&
+            !resolveHostDownIncident(host.hostId, host.organizationId)
+        ) {
+            return
+        }
+
         transaction {
             Hosts.update({ Hosts.id eq host.hostId }) {
                 it[status] = newStatus
             }
-        }
-
-        if (host.currentStatus == "down" && newStatus == "up") {
-            resolveHostDownIncident(host.hostId, host.organizationId)
         }
 
         if (isAnySilenceActive(host.organizationId)) return
@@ -1042,17 +1044,18 @@ class MonitorAlertService(
     private suspend fun resolveHostDownIncident(
         hostId: Int,
         organizationId: Int
-    ) {
+    ): Boolean =
         suspendRunCatching {
             incidentService.autoResolveAlert(
                 organizationId = organizationId,
                 source = AlertSource.HOST_DOWN,
                 deduplicationKey = hostDownDedupKey(hostId)
             )
+            true
         }.getOrElse { e ->
             logger.error(e) { "Failed to resolve incident alert for host up" }
+            false
         }
-    }
 
     private fun hostAlertRedisKey(alert: AlertData): String {
         return "alert_state:${alert.hostId}:${hostAlertIdPart(alert)}"

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -97,6 +97,14 @@ class MonitorAlertService(
         private const val SECONDS_PER_MINUTE = 60
     }
 
+    private data class HostStatusSnapshot(
+        val hostId: Int,
+        val hostName: String,
+        val organizationId: Int,
+        val currentStatus: String,
+        val lastSeenAt: Instant
+    )
+
     /**
      * Start the background jobs for alert evaluation and status checking.
      */
@@ -789,60 +797,60 @@ class MonitorAlertService(
         val now = Clock.System.now()
         val downThreshold = now - HOST_DOWN_THRESHOLD_SECONDS.seconds
 
-        // Get all hosts and check their last_seen_at
         val hosts =
             transaction {
                 Hosts.selectAll().map { row ->
-                    Triple(
-                        row[Hosts.id],
-                        row[Hosts.display_name] ?: row[Hosts.hostname],
-                        row[Hosts.organization_id]
-                    ) to
-                        Pair(
-                            row[Hosts.status],
-                            row[Hosts.last_seen_at]
-                        )
+                    HostStatusSnapshot(
+                        hostId = row[Hosts.id],
+                        hostName = row[Hosts.display_name] ?: row[Hosts.hostname],
+                        organizationId = row[Hosts.organization_id],
+                        currentStatus = row[Hosts.status],
+                        lastSeenAt = row[Hosts.last_seen_at]
+                    )
                 }
             }
 
-        for ((hostInfo, statusInfo) in hosts) {
-            val (hostId, hostName, organizationId) = hostInfo
-            val (currentStatus, lastSeenAt) = statusInfo
+        for (host in hosts) {
+            checkHostStatus(host, downThreshold)
+        }
+    }
 
-            val isDown = lastSeenAt < downThreshold
+    private suspend fun checkHostStatus(
+        host: HostStatusSnapshot,
+        downThreshold: Instant
+    ) {
+        if (host.currentStatus == "pending") return
 
-            // Skip pending hosts that have never reported
-            if (currentStatus == "pending") {
-                continue
+        val newStatus = if (host.lastSeenAt < downThreshold) "down" else "up"
+        if (host.currentStatus == newStatus) return
+
+        logger.info {
+            "Host ${host.hostId} (${host.hostName}) status changed: ${host.currentStatus} -> $newStatus"
+        }
+
+        transaction {
+            Hosts.update({ Hosts.id eq host.hostId }) {
+                it[status] = newStatus
             }
+        }
 
-            val newStatus = if (isDown) "down" else "up"
+        if (host.currentStatus == "down" && newStatus == "up") {
+            resolveHostDownIncident(host.hostId, host.organizationId)
+        }
 
-            // Only send notification if status changed
-            if (currentStatus != newStatus) {
-                logger.info { "Host $hostId ($hostName) status changed: $currentStatus -> $newStatus" }
+        if (isAnySilenceActive(host.organizationId)) return
 
-                // Update status in database (last_seen_at is only updated by heartbeat/metrics code)
-                transaction {
-                    Hosts.update({ Hosts.id eq hostId }) {
-                        it[status] = newStatus
-                    }
-                }
+        sendHostStatusNotification(host, newStatus)
+    }
 
-                if (currentStatus == "down" && newStatus == "up") {
-                    resolveHostDownIncident(hostId, organizationId)
-                }
-
-                if (isAnySilenceActive(organizationId)) {
-                    continue
-                }
-
-                if (newStatus == "down") {
-                    sendHostDownNotification(hostId, hostName, organizationId, lastSeenAt)
-                } else {
-                    sendHostUpNotification(hostId, hostName, organizationId)
-                }
-            }
+    private suspend fun sendHostStatusNotification(
+        host: HostStatusSnapshot,
+        newStatus: String
+    ) {
+        if (newStatus == "down") {
+            sendHostDownNotification(host.hostId, host.hostName, host.organizationId, host.lastSeenAt)
+        } else {
+            sendHostUpNotification(host.hostId, host.hostName, host.organizationId)
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -18,6 +18,7 @@ package com.moneat.monitor.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
+import com.moneat.incident.models.AlertSource
 import com.moneat.incident.services.IncidentService
 import com.moneat.monitor.models.AlertData
 import com.moneat.monitor.models.CreateSilencePeriodRequest
@@ -306,8 +307,7 @@ class MonitorAlertService(
         hostName: String,
         organizationId: Int
     ) {
-        val idPart = if (alert.templateAlertId != null) "tpl_${alert.templateAlertId}" else "id_${alert.id}"
-        val alertKey = "alert_state:${alert.hostId}:$idPart"
+        val alertKey = hostAlertRedisKey(alert)
 
         // Get recent metrics for the host
         val currentValue = getCurrentMetricValue(alert.hostId, alert.organizationId, alert.metric) ?: return
@@ -341,14 +341,11 @@ class MonitorAlertService(
 
                 // Send recovery notification
                 sendRecoveryNotification(alert, hostName, organizationId)
-                // Resolve incident for metric alerts (same dedup key used when firing)
-                val dedupKey =
-                    "moneat-host-alert-${alert.hostId}-$idPart"
                 suspendRunCatching {
-                    incidentService.resolveAlert(
+                    incidentService.autoResolveAlert(
                         organizationId = organizationId,
-                        source = com.moneat.incident.models.AlertSource.HOST_ALERT,
-                        deduplicationKey = dedupKey
+                        source = AlertSource.HOST_ALERT,
+                        deduplicationKey = hostAlertDedupKey(alert)
                     )
                 }.getOrElse { e ->
                     logger.error(e) { "Failed to resolve incident for recovered alert ${alert.id}" }
@@ -766,14 +763,7 @@ class MonitorAlertService(
                         severity = incidentSeverity,
                         status = com.moneat.incident.models.IncidentStatus.FIRING,
                         source = com.moneat.incident.models.AlertSource.HOST_ALERT,
-                        deduplicationKey = run {
-                            val idPart = if (alert.templateAlertId != null) {
-                                "tpl_${alert.templateAlertId}"
-                            } else {
-                                "id_${alert.id}"
-                            }
-                            "moneat-host-alert-${alert.hostId}-$idPart"
-                        },
+                        deduplicationKey = hostAlertDedupKey(alert),
                         organizationId = organizationId,
                         metadata =
                         mapOf(
@@ -839,12 +829,14 @@ class MonitorAlertService(
                     }
                 }
 
-                // Skip notifications if alerts are silenced for this organization
+                if (currentStatus == "down" && newStatus == "up") {
+                    resolveHostDownIncident(hostId, organizationId)
+                }
+
                 if (isAnySilenceActive(organizationId)) {
                     continue
                 }
 
-                // Send notification
                 if (newStatus == "down") {
                     sendHostDownNotification(hostId, hostName, organizationId, lastSeenAt)
                 } else {
@@ -948,7 +940,7 @@ class MonitorAlertService(
                     severity = com.moneat.incident.models.IncidentSeverity.CRITICAL,
                     status = com.moneat.incident.models.IncidentStatus.FIRING,
                     source = com.moneat.incident.models.AlertSource.HOST_DOWN,
-                    deduplicationKey = "moneat-host-down-$hostId",
+                    deduplicationKey = hostDownDedupKey(hostId),
                     organizationId = organizationId,
                     metadata =
                     mapOf(
@@ -1037,17 +1029,41 @@ class MonitorAlertService(
                 logger.error(e) { "Failed to send Discord notification for host up" }
             }
         }
+    }
 
-        // Resolve incident alert for host up
+    private suspend fun resolveHostDownIncident(
+        hostId: Int,
+        organizationId: Int
+    ) {
         suspendRunCatching {
-            incidentService.resolveAlert(
+            incidentService.autoResolveAlert(
                 organizationId = organizationId,
-                source = com.moneat.incident.models.AlertSource.HOST_DOWN,
-                deduplicationKey = "moneat-host-down-$hostId"
+                source = AlertSource.HOST_DOWN,
+                deduplicationKey = hostDownDedupKey(hostId)
             )
         }.getOrElse { e ->
             logger.error(e) { "Failed to resolve incident alert for host up" }
         }
+    }
+
+    private fun hostAlertRedisKey(alert: AlertData): String {
+        return "alert_state:${alert.hostId}:${hostAlertIdPart(alert)}"
+    }
+
+    private fun hostAlertDedupKey(alert: AlertData): String {
+        return "moneat-host-alert-${alert.hostId}-${hostAlertIdPart(alert)}"
+    }
+
+    private fun hostAlertIdPart(alert: AlertData): String {
+        return if (alert.templateAlertId != null) {
+            "tpl_${alert.templateAlertId}"
+        } else {
+            "id_${alert.id}"
+        }
+    }
+
+    private fun hostDownDedupKey(hostId: Int): String {
+        return "moneat-host-down-$hostId"
     }
 
     private fun getConditionText(condition: String): String {

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
@@ -17,6 +17,7 @@
 package com.moneat.uptime.services
 
 import com.moneat.billing.services.BillingQuotaService
+import com.moneat.incident.models.AlertSource
 import com.moneat.incident.services.IncidentService
 import com.moneat.notifications.services.AlertNotificationPreferencesService
 import com.moneat.notifications.services.DiscordService
@@ -415,9 +416,9 @@ class UptimeScheduler(
                 incidentService.fireAlert(incidentEvent)
             } else if (newStatus == "up") {
                 // Resolve the incident
-                incidentService.resolveAlert(
+                incidentService.autoResolveAlert(
                     organizationId = monitor.organizationId,
-                    source = com.moneat.incident.models.AlertSource.UPTIME_MONITOR,
+                    source = AlertSource.UPTIME_MONITOR,
                     deduplicationKey = "moneat-uptime-${monitor.id}"
                 )
             }

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -69,6 +69,7 @@ class DashboardAlertServiceTest {
     private val prefsService: AlertNotificationPreferencesService = mockk(relaxed = true)
     private val queryEngine: DashboardQueryEngine = mockk(relaxed = true)
     private val retentionPolicyService: RetentionPolicyService = mockk(relaxed = true)
+    private var redisConfigMocked = false
 
     private val service = DashboardAlertService(
         emailService = emailService,
@@ -84,6 +85,11 @@ class DashboardAlertServiceTest {
         private var db: Database? = null
         private const val ORG_ID = 1L
         private const val CREATED_BY = 100L
+        private const val DEFAULT_PROJECT_ID = 1L
+        private const val RECOVERY_RETENTION_DAYS = 90
+        private const val RECOVERED_TOTAL = 50.0
+        private const val RECOVERY_THRESHOLD = 100.0
+        private const val REDIS_DELETE_COUNT = 1L
     }
 
     @BeforeTest
@@ -190,10 +196,9 @@ class DashboardAlertServiceTest {
 
     @AfterTest
     fun tearDown() {
-        try {
+        if (redisConfigMocked) {
             unmockkObject(RedisConfig)
-        } catch (_: Exception) {
-            // RedisConfig may not have been mocked in every test.
+            redisConfigMocked = false
         }
     }
 
@@ -208,7 +213,7 @@ class DashboardAlertServiceTest {
 
     private fun seedDashboard(
         title: String = "Test Dashboard",
-        projectId: Long? = 1L
+        projectId: Long? = DEFAULT_PROJECT_ID
     ): Long =
         transaction {
             val now = Clock.System.now()
@@ -627,13 +632,16 @@ class DashboardAlertServiceTest {
     fun `evaluateAlerts auto resolves recovered dashboard alert`() =
         runBlocking {
             mockkObject(RedisConfig)
+            redisConfigMocked = true
             val redis = mockk<RedisCommands<String, String>>(relaxed = true)
             every { RedisConfig.isConnected() } returns true
             every { RedisConfig.sync() } returns redis
-            coEvery { retentionPolicyService.getRetentionDaysForProject(any()) } returns 90
+            coEvery {
+                retentionPolicyService.getRetentionDaysForProject(any())
+            } returns RECOVERY_RETENTION_DAYS
             coEvery {
                 queryEngine.executeQuery(any(), any(), any(), any())
-            } returns listOf(mapOf("total" to JsonPrimitive(50.0)))
+            } returns listOf(mapOf("total" to JsonPrimitive(RECOVERED_TOTAL)))
 
             val dashboardId = seedDashboard()
             val widgetId =
@@ -646,10 +654,13 @@ class DashboardAlertServiceTest {
                     dashboardId,
                     ORG_ID,
                     CREATED_BY,
-                    buildCreateRequest(widgetId, AlertRequestOverrides(condition = ">", threshold = 100.0)),
+                    buildCreateRequest(
+                        widgetId,
+                        AlertRequestOverrides(condition = ">", threshold = RECOVERY_THRESHOLD),
+                    ),
                 )
             every { redis.get("dashboard_alert_state:${created.id}") } returns "TRIGGERED"
-            every { redis.del(any<String>()) } returns 1L
+            every { redis.del(any<String>()) } returns REDIS_DELETE_COUNT
 
             callPrivateSuspend("evaluateAlerts")
 

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -16,12 +16,14 @@
 
 package com.moneat.dashboards
 
+import com.moneat.config.RedisConfig
 import com.moneat.dashboards.models.CreateDashboardAlertRequest
 import com.moneat.dashboards.models.DashboardWidgetAlerts
 import com.moneat.dashboards.models.DashboardWidgets
 import com.moneat.dashboards.models.Dashboards
 import com.moneat.dashboards.models.NotificationChannels
 import com.moneat.dashboards.models.UpdateDashboardAlertRequest
+import com.moneat.incident.models.AlertSource
 import com.moneat.dashboards.services.DashboardAlertService
 import com.moneat.dashboards.services.DashboardQueryEngine
 import com.moneat.incident.services.IncidentService
@@ -31,11 +33,23 @@ import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.testsupport.TestDatabaseHelper
+import io.lettuce.core.api.sync.RedisCommands
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.jvm.isAccessible
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -174,6 +188,24 @@ class DashboardAlertServiceTest {
         }
     }
 
+    @AfterTest
+    fun tearDown() {
+        try {
+            unmockkObject(RedisConfig)
+        } catch (_: Exception) {
+            // RedisConfig may not have been mocked in every test.
+        }
+    }
+
+    private suspend fun callPrivateSuspend(name: String, vararg args: Any?): Any? {
+        val fn =
+            DashboardAlertService::class.declaredFunctions.single { f ->
+                f.name == name && f.parameters.drop(1).size == args.size
+            }
+        fn.isAccessible = true
+        return fn.callSuspend(service, *args)
+    }
+
     private fun seedDashboard(
         title: String = "Test Dashboard",
         projectId: Long? = 1L
@@ -192,7 +224,8 @@ class DashboardAlertServiceTest {
 
     private fun seedWidget(
         dashboardId: Long,
-        title: String? = "Test Widget"
+        title: String? = "Test Widget",
+        queryConfigs: String = "[]"
     ): Long =
         transaction {
             val now = Clock.System.now()
@@ -201,7 +234,7 @@ class DashboardAlertServiceTest {
                 it[DashboardWidgets.title] = title
                 it[widgetType] = "timeseries"
                 it[queryConfig] = "{}"
-                it[queryConfigs] = "[]"
+                it[DashboardWidgets.queryConfigs] = queryConfigs
                 it[displayConfig] = "{}"
                 it[createdAt] = now
                 it[updatedAt] = now
@@ -589,6 +622,45 @@ class DashboardAlertServiceTest {
         val alerts = service.listAlerts(dashboardId, ORG_ID)
         assertEquals(1, alerts.size)
     }
+
+    @Test
+    fun `evaluateAlerts auto resolves recovered dashboard alert`() =
+        runBlocking {
+            mockkObject(RedisConfig)
+            val redis = mockk<RedisCommands<String, String>>(relaxed = true)
+            every { RedisConfig.isConnected() } returns true
+            every { RedisConfig.sync() } returns redis
+            coEvery { retentionPolicyService.getRetentionDaysForProject(any()) } returns 90
+            coEvery {
+                queryEngine.executeQuery(any(), any(), any(), any())
+            } returns listOf(mapOf("total" to JsonPrimitive(50.0)))
+
+            val dashboardId = seedDashboard()
+            val widgetId =
+                seedWidget(
+                    dashboardId,
+                    queryConfigs = """[{"dataSource":"events"}]"""
+                )
+            val created =
+                service.createAlert(
+                    dashboardId,
+                    ORG_ID,
+                    CREATED_BY,
+                    buildCreateRequest(widgetId, AlertRequestOverrides(condition = ">", threshold = 100.0)),
+                )
+            every { redis.get("dashboard_alert_state:${created.id}") } returns "TRIGGERED"
+            every { redis.del(any<String>()) } returns 1L
+
+            callPrivateSuspend("evaluateAlerts")
+
+            coVerify(exactly = 1) {
+                incidentService.autoResolveAlert(
+                    organizationId = ORG_ID.toInt(),
+                    source = AlertSource.DASHBOARD_ALERT,
+                    deduplicationKey = "moneat-dashboard-alert-${created.id}"
+                )
+            }
+        }
 
     // ──── CRUD round-trip ────
 

--- a/backend/src/test/kotlin/com/moneat/services/IncidentServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/IncidentServiceExtendedTest.kt
@@ -49,6 +49,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
@@ -319,6 +320,54 @@ class IncidentServiceExtendedTest {
         service.resolveAlert(emptyOrgId, AlertSource.UPTIME_MONITOR, "dedup-5")
 
         assertEquals(0L, IncidentTestHelper.getEventLogCount(emptyOrgId))
+    }
+
+    @Test
+    fun `autoResolveAlert resolves allowlisted source`() = runBlocking {
+        IncidentTestHelper.registerMockProvider(
+            testProviderType,
+            resolveAlertResult = Result.success("auto-resolved-1")
+        )
+
+        service.autoResolveAlert(orgId, AlertSource.UPTIME_MONITOR, "dedup-auto")
+
+        val logs = IncidentTestHelper.getEventLogs(orgId)
+        assertEquals(1, logs.size)
+        assertTrue(logs[0][IncidentEventLog.success])
+        assertEquals(AlertSource.UPTIME_MONITOR.name, logs[0][IncidentEventLog.alertSource])
+        assertEquals(IncidentStatus.RESOLVED.name, logs[0][IncidentEventLog.incidentStatus])
+        assertEquals("auto-resolved-1", logs[0][IncidentEventLog.providerIncidentId])
+    }
+
+    @Test
+    fun `autoResolveAlert skips source without deterministic clear signal`() = runBlocking {
+        IncidentTestHelper.registerMockProvider(
+            testProviderType,
+            resolveAlertResult = Result.success("should-not-resolve")
+        )
+        transaction {
+            IncidentRoutingRules.insert {
+                it[providerConfigId] = this@IncidentServiceExtendedTest.providerConfigId
+                it[alertSource] = AlertSource.ERROR_ALERT.name
+                it[alertType] = null
+                it[incidentSeverity] = "high"
+                it[createdAt] = Clock.System.now()
+                it[updatedAt] = Clock.System.now()
+            }
+        }
+
+        service.autoResolveAlert(orgId, AlertSource.ERROR_ALERT, "dedup-error")
+
+        assertEquals(0L, IncidentTestHelper.getEventLogCount(orgId))
+    }
+
+    @Test
+    fun `autoResolve source allowlist only includes deterministic recovery sources`() {
+        assertTrue(service.isAutoResolvableSource(AlertSource.HOST_ALERT))
+        assertTrue(service.isAutoResolvableSource(AlertSource.HOST_DOWN))
+        assertTrue(service.isAutoResolvableSource(AlertSource.UPTIME_MONITOR))
+        assertTrue(service.isAutoResolvableSource(AlertSource.DASHBOARD_ALERT))
+        assertFalse(service.isAutoResolvableSource(AlertSource.ERROR_ALERT))
     }
 
     // ──── resolveIncidentSeverity edge cases ────

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -136,6 +136,15 @@ class MonitorAlertServiceCoverageTest {
         return fn.callSuspend(service, *args)
     }
 
+    private fun callPrivate(name: String, vararg args: Any?): Any? {
+        val fn =
+            MonitorAlertService::class.declaredFunctions.single { f ->
+                f.name == name && f.parameters.drop(1).size == args.size
+            }
+        fn.isAccessible = true
+        return fn.call(service, *args)
+    }
+
     @Test
     fun `evaluateAlerts completes with no alerts in database`() =
         runBlocking {
@@ -182,6 +191,32 @@ class MonitorAlertServiceCoverageTest {
                 )
             callPrivateSuspend("sendAlertNotification", alert, "host-a", 1, 91.0)
         }
+
+    @Test
+    fun `host alert keys use stable alert identity`() {
+        val now = Clock.System.now()
+        val directAlert =
+            AlertData(
+                id = 7,
+                hostId = 42,
+                organizationId = 1,
+                metric = "cpu_percent",
+                condition = ">",
+                threshold = 80.0,
+                durationSeconds = 0,
+                enabled = true,
+                lastTriggeredAt = null,
+                createdAt = now,
+                scope = MonitorService.ALERT_SCOPE_HOST,
+                templateAlertId = null,
+            )
+        val templateAlert = directAlert.copy(id = 8, templateAlertId = 17)
+
+        assertEquals("alert_state:42:id_7", callPrivate("hostAlertRedisKey", directAlert))
+        assertEquals("moneat-host-alert-42-id_7", callPrivate("hostAlertDedupKey", directAlert))
+        assertEquals("alert_state:42:tpl_17", callPrivate("hostAlertRedisKey", templateAlert))
+        assertEquals("moneat-host-alert-42-tpl_17", callPrivate("hostAlertDedupKey", templateAlert))
+    }
 
     @Test
     fun `checkHostStatuses transitions stale host to down`() =

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -18,6 +18,7 @@ package com.moneat.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
+import com.moneat.incident.models.AlertSource
 import com.moneat.incident.services.IncidentService
 import com.moneat.monitor.models.AlertData
 import com.moneat.monitor.models.CreateSilencePeriodRequest
@@ -40,6 +41,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -210,6 +212,97 @@ class MonitorAlertServiceCoverageTest {
                     Hosts.selectAll().where { Hosts.id eq hostId }.first()[Hosts.status]
                 }
             assertEquals("down", status)
+        }
+
+    @Test
+    fun `checkHostStatuses resolves host down incident when host recovers`() =
+        runBlocking {
+            val orgId =
+                transaction {
+                    Organizations.insert {
+                        it[name] = "Recovered Host Org"
+                        it[slug] = "recovered-host-org"
+                    } get Organizations.id
+                }
+            val now = Clock.System.now()
+            val hostId =
+                transaction {
+                    Hosts.insert {
+                        it[hostname] = "recovered"
+                        it[organization_id] = orgId
+                        it[status] = "down"
+                        it[first_seen_at] = now - 10.minutes
+                        it[last_seen_at] = now
+                    } get Hosts.id
+                }
+
+            callPrivateSuspend("checkHostStatuses")
+
+            val status =
+                transaction {
+                    Hosts.selectAll().where { Hosts.id eq hostId }.first()[Hosts.status]
+                }
+            assertEquals("up", status)
+            coVerify(exactly = 1) {
+                incidentService.autoResolveAlert(orgId, AlertSource.HOST_DOWN, "moneat-host-down-$hostId")
+            }
+
+            callPrivateSuspend("checkHostStatuses")
+
+            coVerify(exactly = 1) {
+                incidentService.autoResolveAlert(orgId, AlertSource.HOST_DOWN, "moneat-host-down-$hostId")
+            }
+        }
+
+    @Test
+    fun `checkHostStatuses resolves recovered host while notifications are silenced`() =
+        runBlocking {
+            val orgId =
+                transaction {
+                    Organizations.insert {
+                        it[name] = "Silenced Recovery Org"
+                        it[slug] = "silenced-recovery-org"
+                    } get Organizations.id
+                }
+            val userId =
+                transaction {
+                    Users.insert {
+                        it[email] = "silenced-recovery@test.com"
+                        it[password_hash] = "x"
+                        it[name] = "Silenced Recovery"
+                        it[email_verified] = true
+                    } get Users.id
+                }
+            val now = Clock.System.now()
+            val hostId =
+                transaction {
+                    AlertSilencePeriods.insert {
+                        it[organization_id] = orgId
+                        it[reason] = "maintenance"
+                        it[starts_at] = now - 1.minutes
+                        it[ends_at] = now + 1.hours
+                        it[created_by] = userId
+                        it[created_at] = now
+                    }
+                    Hosts.insert {
+                        it[hostname] = "silenced-recovery"
+                        it[organization_id] = orgId
+                        it[status] = "down"
+                        it[first_seen_at] = now - 10.minutes
+                        it[last_seen_at] = now
+                    } get Hosts.id
+                }
+
+            callPrivateSuspend("checkHostStatuses")
+
+            val status =
+                transaction {
+                    Hosts.selectAll().where { Hosts.id eq hostId }.first()[Hosts.status]
+                }
+            assertEquals("up", status)
+            coVerify(exactly = 1) {
+                incidentService.autoResolveAlert(orgId, AlertSource.HOST_DOWN, "moneat-host-down-$hostId")
+            }
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -192,6 +192,8 @@ class MonitorAlertServiceCoverageTest {
             callPrivateSuspend("sendAlertNotification", alert, "host-a", 1, 91.0)
         }
 
+    // ──── Key helpers ────
+
     @Test
     fun `host alert keys use stable alert identity`() {
         val now = Clock.System.now()
@@ -217,6 +219,8 @@ class MonitorAlertServiceCoverageTest {
         assertEquals("alert_state:42:tpl_17", callPrivate("hostAlertRedisKey", templateAlert))
         assertEquals("moneat-host-alert-42-tpl_17", callPrivate("hostAlertDedupKey", templateAlert))
     }
+
+    // ──── Host status recovery ────
 
     @Test
     fun `checkHostStatuses transitions stale host to down`() =
@@ -339,6 +343,58 @@ class MonitorAlertServiceCoverageTest {
                 incidentService.autoResolveAlert(orgId, AlertSource.HOST_DOWN, "moneat-host-down-$hostId")
             }
         }
+
+    @Test
+    fun `checkHostStatuses retries host down incident resolution before marking recovered`() =
+        runBlocking {
+            val orgId =
+                transaction {
+                    Organizations.insert {
+                        it[name] = "Retry Recovery Org"
+                        it[slug] = "retry-recovery-org"
+                    } get Organizations.id
+                }
+            val now = Clock.System.now()
+            val hostId =
+                transaction {
+                    Hosts.insert {
+                        it[hostname] = "retry-recovered"
+                        it[organization_id] = orgId
+                        it[status] = "down"
+                        it[first_seen_at] = now - 10.minutes
+                        it[last_seen_at] = now
+                    } get Hosts.id
+                }
+            val deduplicationKey = "moneat-host-down-$hostId"
+            coEvery {
+                incidentService.autoResolveAlert(orgId, AlertSource.HOST_DOWN, deduplicationKey)
+            } throws RuntimeException("resolve failed")
+
+            callPrivateSuspend("checkHostStatuses")
+
+            val failedStatus =
+                transaction {
+                    Hosts.selectAll().where { Hosts.id eq hostId }.first()[Hosts.status]
+                }
+            assertEquals("down", failedStatus)
+
+            coEvery {
+                incidentService.autoResolveAlert(orgId, AlertSource.HOST_DOWN, deduplicationKey)
+            } returns Unit
+
+            callPrivateSuspend("checkHostStatuses")
+
+            val recoveredStatus =
+                transaction {
+                    Hosts.selectAll().where { Hosts.id eq hostId }.first()[Hosts.status]
+                }
+            assertEquals("up", recoveredStatus)
+            coVerify(exactly = 2) {
+                incidentService.autoResolveAlert(orgId, AlertSource.HOST_DOWN, deduplicationKey)
+            }
+        }
+
+    // ──── Silence cleanup ────
 
     @Test
     fun `cleanupExpiredSilencePeriods removes ended rows`() {

--- a/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
@@ -251,6 +251,8 @@ class UptimeSchedulerTest {
             }
         }
 
+    // ──── Recovery ────
+
     @Test
     fun `notifyStatusChange auto resolves incident when monitor recovers`() =
         runBlocking {

--- a/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.services
 
+import com.moneat.incident.models.AlertSource
 import com.moneat.incident.services.IncidentService
 import com.moneat.notifications.services.AlertNotificationPreferencesService
 import com.moneat.notifications.services.DiscordService
@@ -38,6 +39,9 @@ import kotlinx.coroutines.runBlocking
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.jvm.isAccessible
 import kotlin.time.Instant
 
 class UptimeSchedulerTest {
@@ -103,6 +107,15 @@ class UptimeSchedulerTest {
             val block = it.invocation.args[3] as suspend () -> Unit
             block()
         }
+    }
+
+    private suspend fun callPrivateSuspend(name: String, vararg args: Any?): Any? {
+        val fn =
+            UptimeScheduler::class.declaredFunctions.single { f ->
+                f.name == name && f.parameters.drop(1).size == args.size
+            }
+        fn.isAccessible = true
+        return fn.callSuspend(scheduler, *args)
     }
 
     @Test
@@ -235,6 +248,28 @@ class UptimeSchedulerTest {
 
             coVerify(atLeast = 1) {
                 uptimeService.recordHeartbeat(monitor.id, any())
+            }
+        }
+
+    @Test
+    fun `notifyStatusChange auto resolves incident when monitor recovers`() =
+        runBlocking {
+            val monitor = testMonitor(status = "down")
+
+            callPrivateSuspend(
+                "notifyStatusChange",
+                monitor,
+                "down",
+                "up",
+                CheckResult(status = 1, responseTimeMs = 50, statusCode = 200, message = "recovered")
+            )
+
+            coVerify(exactly = 1) {
+                incidentService.autoResolveAlert(
+                    organizationId = monitor.organizationId,
+                    source = AlertSource.UPTIME_MONITOR,
+                    deduplicationKey = "moneat-uptime-${monitor.id}"
+                )
             }
         }
 }


### PR DESCRIPTION
## Summary
- add an explicit incident auto-resolve allowlist for alert sources with deterministic recovery signals
- resolve HOST_DOWN incidents on down-to-up transitions before notification silence checks
- route host metric, dashboard, and uptime recoveries through the auto-resolve path

## Verification
- `cd backend && GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew detekt test jacocoTestReport testClasses integrationTestClasses --no-daemon -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`

Closes #371


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic resolution for incidents from host monitoring, uptime monitoring, and dashboard alerts when recovery signals are detected.

* **Bug Fixes**
  * More reliable host-status transition handling to ensure recovered hosts clear their incidents consistently.

* **Tests**
  * Expanded tests covering auto-resolution behavior and validation of which alert sources are auto-resolvable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->