### PR TITLE
feat: add apm span usage breakdown

### DIFF
--- a/backend/src/main/kotlin/com/moneat/billing/models/BillingModels.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/models/BillingModels.kt
@@ -22,6 +22,10 @@ import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.datetime.date
 import org.jetbrains.exposed.v1.datetime.timestamp
 
+const val APM_SPAN_USAGE_DEBUG_DEFAULT_LIMIT = 20
+const val APM_SPAN_USAGE_DEBUG_MIN_LIMIT = 1
+const val APM_SPAN_USAGE_DEBUG_MAX_LIMIT = 100
+
 object PricingTierConfigs : Table("pricing_tier_configs") {
     val id = integer("id").autoIncrement()
     val tier_name = varchar("tier_name", 50)
@@ -320,10 +324,6 @@ data class AdminQuotaUsageResetResponse(
     val targetPercent: Double?,
     val usage: BillingUsageResponse
 )
-
-const val APM_SPAN_USAGE_DEBUG_DEFAULT_LIMIT = 20
-const val APM_SPAN_USAGE_DEBUG_MIN_LIMIT = 1
-const val APM_SPAN_USAGE_DEBUG_MAX_LIMIT = 100
 
 @Serializable
 data class ApmSpanUsageDebugResponse(

--- a/backend/src/main/kotlin/com/moneat/billing/models/BillingModels.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/models/BillingModels.kt
@@ -321,6 +321,43 @@ data class AdminQuotaUsageResetResponse(
     val usage: BillingUsageResponse
 )
 
+const val APM_SPAN_USAGE_DEBUG_DEFAULT_LIMIT = 20
+const val APM_SPAN_USAGE_DEBUG_MIN_LIMIT = 1
+const val APM_SPAN_USAGE_DEBUG_MAX_LIMIT = 100
+
+@Serializable
+data class ApmSpanUsageDebugResponse(
+    val organizationId: Int,
+    val periodStart: String,
+    val periodEnd: String,
+    val totalSpans: Long,
+    val groups: List<ApmSpanUsageDebugGroup>
+)
+
+@Serializable
+data class ApmSpanUsageDebugGroup(
+    val source: String,
+    val service: String,
+    val operation: String,
+    val resource: String,
+    val spanType: String,
+    val env: String,
+    val kind: String,
+    val scopeName: String,
+    val scopeVersion: String,
+    val projectId: Long?,
+    val projectName: String?,
+    val projectSlug: String?,
+    val spanCount: Long,
+    val traceCount: Long,
+    val errorCount: Long,
+    val avgDurationMs: Double,
+    val maxDurationMs: Double,
+    val percentage: Double,
+    val sampleTraceId: String,
+    val latestSpanAt: String
+)
+
 @Serializable
 data class CheckoutSessionRequest(
     val tierName: String,

--- a/backend/src/main/kotlin/com/moneat/billing/routes/BillingRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/routes/BillingRoutes.kt
@@ -16,9 +16,9 @@
 
 package com.moneat.billing.routes
 
-import kotlinx.serialization.SerializationException
-import java.io.IOException
-
+import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_DEFAULT_LIMIT
+import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_MAX_LIMIT
+import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_MIN_LIMIT
 import com.moneat.billing.models.BillingPlansListResponse
 import com.moneat.billing.models.CheckoutSessionRequest
 import com.moneat.billing.models.UpdateOnCallSeatsRequest
@@ -31,6 +31,7 @@ import com.moneat.shared.models.Subscriptions
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.BooleanResponse
 import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -52,7 +53,8 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.koin.core.context.GlobalContext
-import com.moneat.utils.suspendRunCatching
+import kotlinx.serialization.SerializationException
+import java.io.IOException
 
 private val logger = KotlinLogging.logger {}
 private const val FAILED_TO_CREATE_CHECKOUT_SESSION = "Failed to create checkout session"
@@ -61,8 +63,6 @@ private const val FAILED_TO_UPDATE_ON_CALL_SEATS = "Failed to update on-call sea
 private const val FAILED_TO_UPDATE_SEATS = "Failed to update seats"
 private const val PAYG_INCREMENT_CENTS = 500
 private const val MAX_ONCALL_SEATS = 200
-private const val DEFAULT_APM_SPAN_DEBUG_LIMIT = 20
-private const val MAX_APM_SPAN_DEBUG_LIMIT = 100
 private const val AUTH_REQUIRED = "Authentication required"
 private const val NO_ORG_ACCESS = "No organization access"
 
@@ -163,8 +163,8 @@ fun Route.billingRoutes(
                 }
             val limit = call.request.queryParameters["limit"]
                 ?.toIntOrNull()
-                ?.coerceIn(1, MAX_APM_SPAN_DEBUG_LIMIT)
-                ?: DEFAULT_APM_SPAN_DEBUG_LIMIT
+                ?.coerceIn(APM_SPAN_USAGE_DEBUG_MIN_LIMIT, APM_SPAN_USAGE_DEBUG_MAX_LIMIT)
+                ?: APM_SPAN_USAGE_DEBUG_DEFAULT_LIMIT
             val usage = quotaService.getUsageForOrganization(orgId)
             val debug = quotaService.getApmSpanUsageDebug(
                 organizationId = orgId,

--- a/backend/src/main/kotlin/com/moneat/billing/routes/BillingRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/routes/BillingRoutes.kt
@@ -61,6 +61,8 @@ private const val FAILED_TO_UPDATE_ON_CALL_SEATS = "Failed to update on-call sea
 private const val FAILED_TO_UPDATE_SEATS = "Failed to update seats"
 private const val PAYG_INCREMENT_CENTS = 500
 private const val MAX_ONCALL_SEATS = 200
+private const val DEFAULT_APM_SPAN_DEBUG_LIMIT = 20
+private const val MAX_APM_SPAN_DEBUG_LIMIT = 100
 private const val AUTH_REQUIRED = "Authentication required"
 private const val NO_ORG_ACCESS = "No organization access"
 
@@ -124,7 +126,7 @@ fun Route.billingRoutes(
                         orgId,
                         startDate,
                         endDate,
-                        listOf("apm_span", "apm")
+                        listOf("apm_span", "apm", "otlp_trace", "dd_trace", "sentry_trace")
                     )
                 val computedCustomMetrics =
                     usageTrackingService.getEventCountForOrg(
@@ -145,6 +147,32 @@ fun Route.billingRoutes(
                 logger.warn(e) { "Failed to compute bytes for org $orgId, falling back to original usage response" }
                 call.respond(usage)
             }
+        }
+
+        get("/usage/apm-spans") {
+            val principal =
+                call.principal<JWTPrincipal>() ?: run {
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
+                    return@get
+                }
+            val userId = principal.payload.getClaim("userId").asInt()
+            val orgId =
+                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
+                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
+                    return@get
+                }
+            val limit = call.request.queryParameters["limit"]
+                ?.toIntOrNull()
+                ?.coerceIn(1, MAX_APM_SPAN_DEBUG_LIMIT)
+                ?: DEFAULT_APM_SPAN_DEBUG_LIMIT
+            val usage = quotaService.getUsageForOrganization(orgId)
+            val debug = quotaService.getApmSpanUsageDebug(
+                organizationId = orgId,
+                periodStart = LocalDate.parse(usage.periodStart),
+                periodEnd = LocalDate.parse(usage.periodEnd),
+                limit = limit
+            )
+            call.respond(debug)
         }
 
         post("/checkout") {

--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
@@ -16,15 +16,23 @@
 
 package com.moneat.billing.services
 
+import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_MAX_LIMIT
+import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_MIN_LIMIT
 import com.moneat.billing.models.AdminQuotaUsageResetResponse
+import com.moneat.billing.models.ApmSpanUsageDebugGroup
+import com.moneat.billing.models.ApmSpanUsageDebugResponse
 import com.moneat.billing.models.BillingUsageResponse
 import com.moneat.billing.models.OrgUsageCounters
 import com.moneat.billing.models.PricingTier
 import com.moneat.billing.models.PricingTierConfigResponse
 import com.moneat.billing.models.PricingTierConfigs
+import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
 import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Subscriptions
+import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.SentryUtils
 import com.moneat.utils.suspendRunCatching
 import kotlinx.datetime.LocalDate
@@ -32,6 +40,12 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.todayIn
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -48,6 +62,7 @@ import kotlin.math.roundToLong
 import kotlin.time.Clock
 
 private val logger = KotlinLogging.logger {}
+private val billingQuotaJson = Json { ignoreUnknownKeys = true }
 
 data class QuotaReservationResult(
     val allowed: Boolean,
@@ -76,6 +91,8 @@ class BillingQuotaService(
         private const val MIN_QUOTA_TARGET_PERCENT = 0.0
         private const val MAX_QUOTA_TARGET_PERCENT = 500.0
         private const val ORGANIZATION_NOT_FOUND_MESSAGE = "Organization not found"
+        private const val NANOS_PER_MILLISECOND = 1_000_000.0
+        private const val DURATION_DECIMAL_PLACES = 3
         private val NON_AGGREGATE_UNIT_TYPES = setOf(
             "llm",
             "log",
@@ -98,6 +115,73 @@ class BillingQuotaService(
         return transaction {
             val state = loadQuotaState(organizationId, lockRows = false)
             toUsageResponse(state)
+        }
+    }
+
+    suspend fun getApmSpanUsageDebug(
+        organizationId: Int,
+        periodStart: LocalDate,
+        periodEnd: LocalDate,
+        limit: Int
+    ): ApmSpanUsageDebugResponse {
+        val safeLimit = limit.coerceIn(APM_SPAN_USAGE_DEBUG_MIN_LIMIT, APM_SPAN_USAGE_DEBUG_MAX_LIMIT)
+        return suspendRunCatching {
+            val whereClause = apmSpanDebugWhereClause(organizationId, periodStart, periodEnd)
+            val totalSpans = queryApmSpanDebugTotal(whereClause)
+            val rawGroups = if (totalSpans > 0) {
+                queryApmSpanDebugGroups(whereClause, safeLimit)
+            } else {
+                emptyList()
+            }
+            val projectLabels = loadApmSpanProjectLabels(
+                organizationId = organizationId,
+                projectIds = rawGroups.mapNotNull { it.projectId }.toSet()
+            )
+
+            ApmSpanUsageDebugResponse(
+                organizationId = organizationId,
+                periodStart = periodStart.toString(),
+                periodEnd = periodEnd.toString(),
+                totalSpans = totalSpans,
+                groups = rawGroups.map { group ->
+                    val project = group.projectId?.let { projectLabels[it] }
+                    ApmSpanUsageDebugGroup(
+                        source = group.source,
+                        service = group.service,
+                        operation = group.operation,
+                        resource = group.resource,
+                        spanType = group.spanType,
+                        env = group.env,
+                        kind = group.kind,
+                        scopeName = group.scopeName,
+                        scopeVersion = group.scopeVersion,
+                        projectId = group.projectId,
+                        projectName = project?.name,
+                        projectSlug = project?.slug,
+                        spanCount = group.spanCount,
+                        traceCount = group.traceCount,
+                        errorCount = group.errorCount,
+                        avgDurationMs = group.avgDurationMs,
+                        maxDurationMs = group.maxDurationMs,
+                        percentage = if (totalSpans > 0) {
+                            group.spanCount.toDouble() / totalSpans.toDouble() * PERCENT_MULTIPLIER
+                        } else {
+                            0.0
+                        },
+                        sampleTraceId = group.sampleTraceId,
+                        latestSpanAt = group.latestSpanAt
+                    )
+                }
+            )
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to query APM span usage debug for org $organizationId" }
+            ApmSpanUsageDebugResponse(
+                organizationId = organizationId,
+                periodStart = periodStart.toString(),
+                periodEnd = periodEnd.toString(),
+                totalSpans = 0,
+                groups = emptyList()
+            )
         }
     }
 
@@ -719,6 +803,153 @@ class BillingQuotaService(
         val usedLlmBytes: Long,
         val usedProfilerBytes: Long
     )
+
+    private data class RawApmSpanDebugGroup(
+        val source: String,
+        val service: String,
+        val operation: String,
+        val resource: String,
+        val spanType: String,
+        val env: String,
+        val kind: String,
+        val scopeName: String,
+        val scopeVersion: String,
+        val projectId: Long?,
+        val spanCount: Long,
+        val traceCount: Long,
+        val errorCount: Long,
+        val avgDurationMs: Double,
+        val maxDurationMs: Double,
+        val sampleTraceId: String,
+        val latestSpanAt: String
+    )
+
+    private data class ApmSpanProjectLabel(
+        val name: String,
+        val slug: String
+    )
+
+    private fun apmSpanDebugWhereClause(
+        organizationId: Int,
+        periodStart: LocalDate,
+        periodEnd: LocalDate
+    ): String {
+        val endExclusive = periodEnd.plus(DatePeriod(days = 1))
+        return listOf(
+            ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
+            "start >= toDateTime64('${escapeSql(periodStart.toString())} 00:00:00', 9, 'UTC')",
+            "start < toDateTime64('${escapeSql(endExclusive.toString())} 00:00:00', 9, 'UTC')"
+        ).joinToString(" AND\n    ")
+    }
+
+    private suspend fun queryApmSpanDebugTotal(whereClause: String): Long {
+        val query = """
+            SELECT count()
+            FROM `${ClickHouseClient.getDatabase()}`.apm_spans
+            WHERE $whereClause
+        """.trimIndent()
+        return ClickHouseClient.executeWithFormat(query, "TabSeparated").trim().toLongOrNull() ?: 0L
+    }
+
+    private suspend fun queryApmSpanDebugGroups(
+        whereClause: String,
+        limit: Int
+    ): List<RawApmSpanDebugGroup> {
+        val query = """
+            SELECT
+                if(source = '', 'datadog', source) AS source_value,
+                service,
+                name AS operation,
+                resource,
+                type AS span_type,
+                env,
+                kind,
+                scope_name,
+                scope_version,
+                toUInt64OrNull(meta['sentry.project_id']) AS project_id,
+                count() AS span_count,
+                uniqExact(
+                    if(trace_id_hex != '', trace_id_hex, concat(toString(trace_id_high), ':', toString(trace_id)))
+                ) AS trace_count,
+                countIf(error != 0) AS error_count,
+                round(avg(duration) / $NANOS_PER_MILLISECOND, $DURATION_DECIMAL_PLACES) AS avg_duration_ms,
+                round(max(duration) / $NANOS_PER_MILLISECOND, $DURATION_DECIMAL_PLACES) AS max_duration_ms,
+                argMax(if(trace_id_hex != '', trace_id_hex, toString(trace_id)), start) AS sample_trace_id,
+                toString(max(start)) AS latest_span_at
+            FROM `${ClickHouseClient.getDatabase()}`.apm_spans
+            WHERE $whereClause
+            GROUP BY
+                source_value,
+                service,
+                operation,
+                resource,
+                span_type,
+                env,
+                kind,
+                scope_name,
+                scope_version,
+                project_id
+            ORDER BY span_count DESC
+            LIMIT $limit
+            FORMAT JSONEachRow
+        """.trimIndent()
+        val body = ClickHouseClient.executeWithFormat(query, "")
+        return parseApmSpanDebugGroups(body)
+    }
+
+    private fun parseApmSpanDebugGroups(body: String): List<RawApmSpanDebugGroup> {
+        if (body.isBlank()) return emptyList()
+        return body.trim().lines()
+            .filter { it.isNotBlank() }
+            .mapNotNull { line ->
+                suspendRunCatching {
+                    val obj = billingQuotaJson.parseToJsonElement(line).jsonObject
+                    RawApmSpanDebugGroup(
+                        source = obj["source_value"]?.jsonPrimitive?.contentOrNull ?: "datadog",
+                        service = obj["service"]?.jsonPrimitive?.contentOrNull ?: "",
+                        operation = obj["operation"]?.jsonPrimitive?.contentOrNull ?: "",
+                        resource = obj["resource"]?.jsonPrimitive?.contentOrNull ?: "",
+                        spanType = obj["span_type"]?.jsonPrimitive?.contentOrNull ?: "",
+                        env = obj["env"]?.jsonPrimitive?.contentOrNull ?: "",
+                        kind = obj["kind"]?.jsonPrimitive?.contentOrNull ?: "",
+                        scopeName = obj["scope_name"]?.jsonPrimitive?.contentOrNull ?: "",
+                        scopeVersion = obj["scope_version"]?.jsonPrimitive?.contentOrNull ?: "",
+                        projectId = obj["project_id"]?.jsonPrimitive?.longOrNull,
+                        spanCount = obj["span_count"]?.jsonPrimitive?.longOrNull ?: 0L,
+                        traceCount = obj["trace_count"]?.jsonPrimitive?.longOrNull ?: 0L,
+                        errorCount = obj["error_count"]?.jsonPrimitive?.longOrNull ?: 0L,
+                        avgDurationMs = obj["avg_duration_ms"]?.jsonPrimitive?.doubleOrNull ?: 0.0,
+                        maxDurationMs = obj["max_duration_ms"]?.jsonPrimitive?.doubleOrNull ?: 0.0,
+                        sampleTraceId = obj["sample_trace_id"]?.jsonPrimitive?.contentOrNull ?: "",
+                        latestSpanAt = obj["latest_span_at"]?.jsonPrimitive?.contentOrNull ?: ""
+                    )
+                }.getOrElse { e ->
+                    logger.warn(e) { "Failed to parse APM span debug row" }
+                    null
+                }
+            }
+    }
+
+    private fun loadApmSpanProjectLabels(
+        organizationId: Int,
+        projectIds: Set<Long>
+    ): Map<Long, ApmSpanProjectLabel> {
+        if (projectIds.isEmpty()) return emptyMap()
+        return transaction {
+            Projects
+                .selectAll()
+                .where {
+                    (Projects.organization_id eq organizationId) and
+                        (Projects.id inList projectIds.toList())
+                }
+                .associate { row ->
+                    row[Projects.id] to ApmSpanProjectLabel(
+                        name = row[Projects.name],
+                        slug = row[Projects.slug]
+                    )
+                }
+        }
+    }
 
     private fun loadQuotaState(
         organizationId: Int,
@@ -1706,7 +1937,7 @@ class BillingQuotaService(
             "feedback" -> "feedback"
             "llm" -> "llm"
             "log", "logs", "dd_log" -> "log"
-            "apm_span", "apm", "otlp_trace", "dd_trace" -> "apm_span"
+            "apm_span", "apm", "otlp_trace", "dd_trace", "sentry_trace" -> "apm_span"
             "custom_metric", "metric", "otlp_metric", "dd_metric" -> "custom_metric"
             "analytics_pageview" -> "analytics_pageview"
             "sourcemap", "artifact" -> "artifact"

--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
@@ -834,11 +834,11 @@ class BillingQuotaService(
         periodStart: LocalDate,
         periodEnd: LocalDate
     ): String {
-        val endExclusive = periodEnd.plus(DatePeriod(days = 1))
+        val endExclusive = java.time.LocalDate.parse(periodEnd.toString()).plusDays(1).toString()
         return listOf(
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
             "start >= toDateTime64('${escapeSql(periodStart.toString())} 00:00:00', 9, 'UTC')",
-            "start < toDateTime64('${escapeSql(endExclusive.toString())} 00:00:00', 9, 'UTC')"
+            "start < toDateTime64('${escapeSql(endExclusive)} 00:00:00', 9, 'UTC')"
         ).joinToString(" AND\n    ")
     }
 

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -201,7 +201,7 @@ object TraceIngestionService {
                     e.key.length + e.value.length
                 }
         }
-        usageTracking.recordOrgUsage(organizationId, "dd_trace", totalBytes)
+        usageTracking.recordOrgUsage(organizationId, "dd_trace", allSpans.size, totalBytes)
     }
 
     /**

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -1177,7 +1177,7 @@ class EventService(
 
         val response = ClickHouseClient.execute(insert)
         if (response.status.isSuccess()) {
-            usageTracker.recordOrgUsage(ctx.orgId, "sentry_trace", rows.sumOf { it.length })
+            usageTracker.recordOrgUsage(ctx.orgId, "sentry_trace", rows.size, rows.sumOf { it.length })
         } else {
             logger.error { "Failed to insert Sentry spans into apm_spans for transaction $eventId" }
         }

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
@@ -382,6 +382,7 @@ class OtlpTraceService(
         usageTracking.recordOrgUsage(
             batch.organizationId.toInt(),
             "otlp_trace",
+            batch.spans.size,
             totalBytes
         )
     }

--- a/backend/src/test/kotlin/com/moneat/routes/BillingRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/BillingRoutesTest.kt
@@ -54,10 +54,12 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.clearMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import kotlinx.datetime.LocalDate
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
@@ -200,6 +202,35 @@ class BillingRoutesTest {
         withinQuota = true,
     )
 
+    private fun makeApmSpanDebugResponse(
+        orgId: Int,
+        usage: BillingUsageResponse,
+        totalSpans: Long = 0
+    ) = ApmSpanUsageDebugResponse(
+        organizationId = orgId,
+        periodStart = usage.periodStart,
+        periodEnd = usage.periodEnd,
+        totalSpans = totalSpans,
+        groups = emptyList()
+    )
+
+    private fun stubApmSpanDebug(
+        orgId: Int,
+        usage: BillingUsageResponse,
+        expectedLimit: Int
+    ): ApmSpanUsageDebugResponse {
+        val response = makeApmSpanDebugResponse(orgId, usage)
+        coEvery {
+            mockQuotaService.getApmSpanUsageDebug(
+                organizationId = orgId,
+                periodStart = LocalDate.parse(usage.periodStart),
+                periodEnd = LocalDate.parse(usage.periodEnd),
+                limit = expectedLimit
+            )
+        } returns response
+        return response
+    }
+
     // ──── Auth ────
 
     @Test
@@ -207,6 +238,14 @@ class BillingRoutesTest {
         testApplication {
             application { installRoutes(this) }
             val r = client.get(BILLING_USAGE)
+            assertEquals(HttpStatusCode.Unauthorized, r.status)
+        }
+
+    @Test
+    fun `GET usage apm spans returns 401 when unauthenticated`() =
+        testApplication {
+            application { installRoutes(this) }
+            val r = client.get(BILLING_APM_SPAN_DEBUG)
             assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
@@ -275,6 +314,18 @@ class BillingRoutesTest {
             every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
             application { installRoutes(this) }
             val r = client.get(BILLING_USAGE) {
+                withAuth(token(userId))
+            }
+            assertEquals(HttpStatusCode.Forbidden, r.status)
+        }
+
+    @Test
+    fun `GET usage apm spans returns 403 when user has no org`() =
+        testApplication {
+            val userId = seedUser()
+            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
+            application { installRoutes(this) }
+            val r = client.get(BILLING_APM_SPAN_DEBUG) {
                 withAuth(token(userId))
             }
             assertEquals(HttpStatusCode.Forbidden, r.status)
@@ -396,6 +447,81 @@ class BillingRoutesTest {
             val body = r.bodyAsText()
             assertTrue(body.contains("\"totalSpans\":42"))
             assertTrue(body.contains("\"service\":\"api\""))
+        }
+
+    @Test
+    fun `GET usage apm spans clamps low limit to one`() =
+        testApplication {
+            val (userId, orgId) = seedUserAndOrg()
+            val usage = makeUsageResponse(orgId)
+            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
+            every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
+            stubApmSpanDebug(orgId, usage, expectedLimit = 1)
+            application { installRoutes(this) }
+
+            val r = client.get("$BILLING_APM_SPAN_DEBUG?limit=0") {
+                withAuth(token(userId))
+            }
+
+            assertEquals(HttpStatusCode.OK, r.status)
+            coVerify(exactly = 1) {
+                mockQuotaService.getApmSpanUsageDebug(
+                    organizationId = orgId,
+                    periodStart = LocalDate.parse(usage.periodStart),
+                    periodEnd = LocalDate.parse(usage.periodEnd),
+                    limit = 1
+                )
+            }
+        }
+
+    @Test
+    fun `GET usage apm spans clamps high limit to max`() =
+        testApplication {
+            val (userId, orgId) = seedUserAndOrg()
+            val usage = makeUsageResponse(orgId)
+            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
+            every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
+            stubApmSpanDebug(orgId, usage, expectedLimit = 100)
+            application { installRoutes(this) }
+
+            val r = client.get("$BILLING_APM_SPAN_DEBUG?limit=500") {
+                withAuth(token(userId))
+            }
+
+            assertEquals(HttpStatusCode.OK, r.status)
+            coVerify(exactly = 1) {
+                mockQuotaService.getApmSpanUsageDebug(
+                    organizationId = orgId,
+                    periodStart = LocalDate.parse(usage.periodStart),
+                    periodEnd = LocalDate.parse(usage.periodEnd),
+                    limit = 100
+                )
+            }
+        }
+
+    @Test
+    fun `GET usage apm spans defaults non-numeric limit`() =
+        testApplication {
+            val (userId, orgId) = seedUserAndOrg()
+            val usage = makeUsageResponse(orgId)
+            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
+            every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
+            stubApmSpanDebug(orgId, usage, expectedLimit = 20)
+            application { installRoutes(this) }
+
+            val r = client.get("$BILLING_APM_SPAN_DEBUG?limit=abc") {
+                withAuth(token(userId))
+            }
+
+            assertEquals(HttpStatusCode.OK, r.status)
+            coVerify(exactly = 1) {
+                mockQuotaService.getApmSpanUsageDebug(
+                    organizationId = orgId,
+                    periodStart = LocalDate.parse(usage.periodStart),
+                    periodEnd = LocalDate.parse(usage.periodEnd),
+                    limit = 20
+                )
+            }
         }
 
     // ──── POST /billing/checkout ────

--- a/backend/src/test/kotlin/com/moneat/routes/BillingRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/BillingRoutesTest.kt
@@ -16,6 +16,8 @@
 
 package com.moneat.routes
 
+import com.moneat.billing.models.ApmSpanUsageDebugGroup
+import com.moneat.billing.models.ApmSpanUsageDebugResponse
 import com.moneat.billing.models.BillingUsageResponse
 import com.moneat.billing.models.CancelSubscriptionResponse
 import com.moneat.billing.models.CheckoutSessionResponse
@@ -51,6 +53,7 @@ import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.clearMocks
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -68,6 +71,7 @@ import kotlin.test.assertTrue
 class BillingRoutesTest {
     companion object {
         private const val BILLING_USAGE = "/v1/billing/usage"
+        private const val BILLING_APM_SPAN_DEBUG = "/v1/billing/usage/apm-spans"
         private const val BILLING_CHECKOUT = "/v1/billing/checkout"
         private const val BILLING_INVOICES = "/v1/billing/invoices"
         private const val BILLING_PAYMENT_METHOD = "/v1/billing/payment-method"
@@ -337,6 +341,61 @@ class BillingRoutesTest {
             val body = r.bodyAsText()
             assertTrue(body.contains("\"organizationId\""))
             assertTrue(body.contains("\"withinQuota\""))
+        }
+
+    @Test
+    fun `GET usage apm spans returns 200 with debug groups`() =
+        testApplication {
+            val (userId, orgId) = seedUserAndOrg()
+            val usage = makeUsageResponse(orgId)
+            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
+            every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
+            coEvery {
+                mockQuotaService.getApmSpanUsageDebug(
+                    organizationId = orgId,
+                    periodStart = kotlinx.datetime.LocalDate.parse(usage.periodStart),
+                    periodEnd = kotlinx.datetime.LocalDate.parse(usage.periodEnd),
+                    limit = 20
+                )
+            } returns ApmSpanUsageDebugResponse(
+                organizationId = orgId,
+                periodStart = usage.periodStart,
+                periodEnd = usage.periodEnd,
+                totalSpans = 42,
+                groups = listOf(
+                    ApmSpanUsageDebugGroup(
+                        source = "otlp",
+                        service = "api",
+                        operation = "GET /checkout",
+                        resource = "GET /checkout",
+                        spanType = "",
+                        env = "prod",
+                        kind = "SERVER",
+                        scopeName = "opentelemetry.instrumentation.ktor",
+                        scopeVersion = "1.0.0",
+                        projectId = null,
+                        projectName = null,
+                        projectSlug = null,
+                        spanCount = 42,
+                        traceCount = 12,
+                        errorCount = 1,
+                        avgDurationMs = 12.5,
+                        maxDurationMs = 200.0,
+                        percentage = 100.0,
+                        sampleTraceId = "trace-1",
+                        latestSpanAt = "2024-01-15 12:00:00"
+                    )
+                )
+            )
+            application { installRoutes(this) }
+
+            val r = client.get(BILLING_APM_SPAN_DEBUG) {
+                withAuth(token(userId))
+            }
+            assertEquals(HttpStatusCode.OK, r.status)
+            val body = r.bodyAsText()
+            assertTrue(body.contains("\"totalSpans\":42"))
+            assertTrue(body.contains("\"service\":\"api\""))
         }
 
     // ──── POST /billing/checkout ────

--- a/backend/src/test/kotlin/com/moneat/services/BillingQuotaServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/BillingQuotaServiceExtendedTest.kt
@@ -19,17 +19,23 @@ package com.moneat.services
 import com.moneat.billing.models.OrgUsageCounters
 import com.moneat.billing.models.PricingTierConfigs
 import com.moneat.billing.services.BillingQuotaService
+import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
 import com.moneat.shared.models.OnCallParticipants
 import com.moneat.shared.models.OnCallSchedules
 import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Subscriptions
 import com.moneat.shared.models.Users
 import com.moneat.testsupport.TestDatabaseHelper
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
@@ -44,6 +50,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -79,6 +86,7 @@ class BillingQuotaServiceExtendedTest {
             Subscriptions,
             OrgUsageCounters,
             PricingTierConfigs,
+            Projects,
             OnCallSchedules,
             OnCallParticipants,
         )
@@ -170,6 +178,12 @@ class BillingQuotaServiceExtendedTest {
         }
     }
 
+    private fun jsonRow(vararg fields: String): String = fields.joinToString(
+        separator = ",",
+        prefix = "{",
+        postfix = "}"
+    )
+
     @Test
     fun `refundUnits decrements error counters after reservation`() {
         val before = service.getUsageForOrganization(testOrgId)
@@ -212,6 +226,257 @@ class BillingQuotaServiceExtendedTest {
         assertEquals(2L, row[OrgUsageCounters.used_synthetic_runs])
         assertEquals(3L, row[OrgUsageCounters.used_uptime_checks])
         assertEquals(100L, row[OrgUsageCounters.used_ai_tokens])
+    }
+
+    @Test
+    fun `getApmSpanUsageDebug groups span rows and enriches project labels`() = runBlocking {
+        val projectId = transaction {
+            Projects.insert {
+                it[organization_id] = testOrgId
+                it[name] = "Checkout API"
+                it[slug] = "checkout-api"
+            } get Projects.id
+        }
+        val groupRows = listOf(
+            jsonRow(
+                "\"source_value\":\"otlp\"",
+                "\"service\":\"checkout\"",
+                "\"operation\":\"GET /orders\"",
+                "\"resource\":\"GET /orders\"",
+                "\"span_type\":\"web\"",
+                "\"env\":\"prod\"",
+                "\"kind\":\"SERVER\"",
+                "\"scope_name\":\"ktor\"",
+                "\"scope_version\":\"1.0.0\"",
+                "\"project_id\":$projectId",
+                "\"span_count\":10",
+                "\"trace_count\":4",
+                "\"error_count\":1",
+                "\"avg_duration_ms\":12.5",
+                "\"max_duration_ms\":80.0",
+                "\"sample_trace_id\":\"trace-a\"",
+                "\"latest_span_at\":\"2026-04-15 12:00:00\""
+            ),
+            jsonRow(
+                "\"service\":\"worker\"",
+                "\"operation\":\"queue.process\"",
+                "\"resource\":\"order-created\"",
+                "\"span_type\":\"\"",
+                "\"env\":\"\"",
+                "\"kind\":\"CONSUMER\"",
+                "\"scope_name\":\"\"",
+                "\"scope_version\":\"\"",
+                "\"span_count\":15",
+                "\"trace_count\":5",
+                "\"error_count\":0",
+                "\"avg_duration_ms\":2.0",
+                "\"max_duration_ms\":8.0",
+                "\"sample_trace_id\":\"\"",
+                "\"latest_span_at\":\"\""
+            )
+        ).joinToString("\n")
+        var groupedQuery = ""
+
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat_test"
+            coEvery {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("SELECT count()") },
+                    match { it == "TabSeparated" }
+                )
+            } returns "25"
+            coEvery {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("GROUP BY") },
+                    match { it == "" }
+                )
+            } coAnswers {
+                groupedQuery = invocation.args[0] as String
+                groupRows
+            }
+
+            val result = service.getApmSpanUsageDebug(
+                organizationId = testOrgId,
+                periodStart = LocalDate.parse("2026-04-01"),
+                periodEnd = LocalDate.parse("2026-04-30"),
+                limit = 500
+            )
+
+            assertEquals(testOrgId, result.organizationId)
+            assertEquals("2026-04-01", result.periodStart)
+            assertEquals("2026-04-30", result.periodEnd)
+            assertEquals(25, result.totalSpans)
+            assertEquals(2, result.groups.size)
+            assertTrue(groupedQuery.contains("LIMIT 100"))
+            assertTrue(groupedQuery.contains("2026-05-01 00:00:00"))
+
+            val checkout = result.groups.first()
+            assertEquals("otlp", checkout.source)
+            assertEquals("checkout", checkout.service)
+            assertEquals("GET /orders", checkout.operation)
+            assertEquals(projectId, checkout.projectId)
+            assertEquals("Checkout API", checkout.projectName)
+            assertEquals("checkout-api", checkout.projectSlug)
+            assertEquals(10, checkout.spanCount)
+            assertEquals(4, checkout.traceCount)
+            assertEquals(1, checkout.errorCount)
+            assertEquals(40.0, checkout.percentage)
+
+            val worker = result.groups.last()
+            assertEquals("datadog", worker.source)
+            assertNull(worker.projectName)
+            assertEquals(60.0, worker.percentage)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getApmSpanUsageDebug returns empty groups without querying grouped rows when total is zero`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat_test"
+            coEvery {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("SELECT count()") },
+                    match { it == "TabSeparated" }
+                )
+            } returns "0"
+
+            val result = service.getApmSpanUsageDebug(
+                organizationId = testOrgId,
+                periodStart = LocalDate.parse("2026-04-01"),
+                periodEnd = LocalDate.parse("2026-04-30"),
+                limit = 20
+            )
+
+            assertEquals(0, result.totalSpans)
+            assertTrue(result.groups.isEmpty())
+            coVerify(exactly = 0) {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("GROUP BY") },
+                    match { it == "" }
+                )
+            }
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getApmSpanUsageDebug treats non numeric totals as zero`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat_test"
+            coEvery {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("SELECT count()") },
+                    match { it == "TabSeparated" }
+                )
+            } returns "not-a-number"
+
+            val result = service.getApmSpanUsageDebug(
+                organizationId = testOrgId,
+                periodStart = LocalDate.parse("2026-04-01"),
+                periodEnd = LocalDate.parse("2026-04-30"),
+                limit = 20
+            )
+
+            assertEquals(0, result.totalSpans)
+            assertTrue(result.groups.isEmpty())
+            coVerify(exactly = 0) {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("GROUP BY") },
+                    match { it == "" }
+                )
+            }
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getApmSpanUsageDebug skips malformed rows and defaults missing fields`() = runBlocking {
+        val groupRows = listOf(
+            "not-json",
+            "",
+            jsonRow("\"span_count\":2")
+        ).joinToString("\n")
+
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat_test"
+            coEvery {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("SELECT count()") },
+                    match { it == "TabSeparated" }
+                )
+            } returns "5"
+            coEvery {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("GROUP BY") },
+                    match { it == "" }
+                )
+            } returns groupRows
+
+            val result = service.getApmSpanUsageDebug(
+                organizationId = testOrgId,
+                periodStart = LocalDate.parse("2026-04-01"),
+                periodEnd = LocalDate.parse("2026-04-30"),
+                limit = 20
+            )
+
+            assertEquals(5, result.totalSpans)
+            assertEquals(1, result.groups.size)
+            val group = result.groups.single()
+            assertEquals("datadog", group.source)
+            assertEquals("", group.service)
+            assertEquals("", group.operation)
+            assertEquals("", group.resource)
+            assertEquals("", group.spanType)
+            assertEquals("", group.env)
+            assertEquals("", group.kind)
+            assertEquals("", group.scopeName)
+            assertEquals("", group.scopeVersion)
+            assertEquals(2, group.spanCount)
+            assertEquals(0, group.traceCount)
+            assertEquals(0, group.errorCount)
+            assertEquals(0.0, group.avgDurationMs)
+            assertEquals(0.0, group.maxDurationMs)
+            assertEquals("", group.sampleTraceId)
+            assertEquals("", group.latestSpanAt)
+            assertEquals(40.0, group.percentage)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getApmSpanUsageDebug falls back to empty response on ClickHouse failure`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat_test"
+            coEvery {
+                ClickHouseClient.executeWithFormat(
+                    match { it.contains("SELECT count()") },
+                    match { it == "TabSeparated" }
+                )
+            } throws IllegalStateException("ClickHouse unavailable")
+
+            val result = service.getApmSpanUsageDebug(
+                organizationId = testOrgId,
+                periodStart = LocalDate.parse("2026-04-01"),
+                periodEnd = LocalDate.parse("2026-04-30"),
+                limit = 20
+            )
+
+            assertEquals(testOrgId, result.organizationId)
+            assertEquals(0, result.totalSpans)
+            assertTrue(result.groups.isEmpty())
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
     }
 
     @Test

--- a/dashboard/src/components/settings/ApmSpanUsageBreakdown.tsx
+++ b/dashboard/src/components/settings/ApmSpanUsageBreakdown.tsx
@@ -1,0 +1,228 @@
+import {useState} from 'react'
+import {ChevronRight} from 'lucide-react'
+import {type ApmSpanUsageDebugGroup, type ApmSpanUsageDebugResponse} from '@/lib/api'
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
+import {formatDateTime as formatDateTimeUtil} from '@/lib/date-format'
+
+const TRACE_ID_PREVIEW_LENGTH = 12
+const FULL_PERCENT = 100
+const CLICKHOUSE_DATETIME_PATTERN = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(?:\.(\d+))?$/
+
+function formatOptionalText(value: string | null | undefined, fallback = 'None'): string {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : fallback
+}
+
+function formatApmSource(source: string): string {
+  const normalized = formatOptionalText(source, 'datadog')
+  if (normalized.toLowerCase() === 'otlp') return 'OTLP'
+  if (normalized.toLowerCase() === 'sentry') return 'Sentry'
+  if (normalized.toLowerCase() === 'datadog') return 'Datadog'
+  return normalized
+}
+
+function formatSpanDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0 ms'
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)} s`
+  return `${ms.toFixed(ms >= 10 ? 0 : 1)} ms`
+}
+
+function normalizeClickHouseDateTime(value: string): string {
+  const match = CLICKHOUSE_DATETIME_PATTERN.exec(value)
+  if (!match) return value
+  const millis = (match[3] ?? '').padEnd(3, '0').slice(0, 3)
+  return `${match[1]}T${match[2]}.${millis}Z`
+}
+
+function formatSpanDebugDate(value: string, timezone: string): string {
+  if (!value) return 'None'
+  return formatDateTimeUtil(normalizeClickHouseDateTime(value), timezone)
+}
+
+function formatTracePreview(traceId: string): string {
+  if (!traceId) return 'None'
+  if (traceId.length <= TRACE_ID_PREVIEW_LENGTH) return traceId
+  return `${traceId.slice(0, TRACE_ID_PREVIEW_LENGTH)}...`
+}
+
+function spanDebugRowKey(row: ApmSpanUsageDebugGroup): string {
+  return [
+    row.source,
+    row.service,
+    row.operation,
+    row.resource,
+    row.spanType,
+    row.env,
+    row.kind,
+    row.scopeName,
+    row.scopeVersion,
+    row.projectId ?? 'org',
+  ].join('|')
+}
+
+function boundedPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(FULL_PERCENT, value))
+}
+
+function formatScope(row: ApmSpanUsageDebugGroup): string {
+  const scopeName = row.scopeName.trim()
+  const scopeVersion = row.scopeVersion.trim()
+  if (scopeName && scopeVersion) return `${scopeName}@${scopeVersion}`
+  if (scopeName) return scopeName
+  return formatOptionalText(row.kind, 'No scope')
+}
+
+interface ApmSpanUsageBreakdownProps {
+  readonly debug?: ApmSpanUsageDebugResponse
+  readonly isLoading: boolean
+  readonly error?: unknown
+  readonly timezone: string
+}
+
+export function ApmSpanUsageBreakdown({debug, isLoading, error, timezone}: ApmSpanUsageBreakdownProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const groups = debug?.groups ?? []
+
+  return (
+    <div className="mt-2 space-y-3">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs"
+          aria-expanded={isExpanded}
+          aria-controls="apm-span-source-breakdown"
+          onClick={() => setIsExpanded((current) => !current)}
+        >
+          <ChevronRight
+            className={`h-3.5 w-3.5 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+          />
+          {isExpanded ? 'Hide sources' : 'Show sources'}
+        </Button>
+      </div>
+      {isExpanded && (isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading APM span sources...</p>
+      ) : error ? (
+        <div
+          id="apm-span-source-breakdown"
+          className="rounded-md border border-destructive/40 p-4 text-center text-sm text-destructive"
+        >
+          Unable to load APM span sources.
+        </div>
+      ) : groups.length > 0 ? (
+        <div id="apm-span-source-breakdown" className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>Source</TableHead>
+                <TableHead>Service</TableHead>
+                <TableHead>Operation</TableHead>
+                <TableHead>Resource</TableHead>
+                <TableHead>Scope</TableHead>
+                <TableHead className="text-right">Spans</TableHead>
+                <TableHead className="text-right">Share</TableHead>
+                <TableHead className="text-right">Traces</TableHead>
+                <TableHead className="text-right">Errors</TableHead>
+                <TableHead className="text-right">Latency</TableHead>
+                <TableHead className="text-right">Latest</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {groups.map((row) => {
+                const share = boundedPercent(row.percentage)
+                const projectLabel = row.projectName ?? row.projectSlug
+
+                return (
+                  <TableRow key={spanDebugRowKey(row)}>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <Badge variant="outline" className="capitalize">
+                          {formatApmSource(row.source)}
+                        </Badge>
+                        {projectLabel && (
+                          <p className="max-w-[160px] truncate text-xs text-muted-foreground" title={projectLabel}>
+                            {projectLabel}
+                          </p>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className="max-w-[180px] truncate font-medium"
+                        title={formatOptionalText(row.service, 'Unknown service')}
+                      >
+                        {formatOptionalText(row.service, 'Unknown service')}
+                      </div>
+                      <p className="text-xs text-muted-foreground">{formatOptionalText(row.env, 'No env')}</p>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className="max-w-[220px] truncate font-medium"
+                        title={formatOptionalText(row.operation, 'Unknown operation')}
+                      >
+                        {formatOptionalText(row.operation, 'Unknown operation')}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {formatOptionalText(row.spanType, formatOptionalText(row.kind, 'No type'))}
+                      </p>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className="max-w-[260px] truncate font-mono text-xs"
+                        title={formatOptionalText(row.resource)}
+                      >
+                        {formatOptionalText(row.resource)}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="max-w-[220px] truncate text-xs" title={formatScope(row)}>
+                        {formatScope(row)}
+                      </div>
+                      <p className="text-xs text-muted-foreground" title={row.sampleTraceId}>
+                        {formatTracePreview(row.sampleTraceId)}
+                      </p>
+                    </TableCell>
+                    <TableCell className="text-right font-semibold tabular-nums">
+                      {row.spanCount.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <div className="h-1.5 w-16 rounded-full bg-secondary overflow-hidden">
+                          <div
+                            className="h-full rounded-full bg-purple-500"
+                            style={{width: `${share}%`}}
+                          />
+                        </div>
+                        <span className="min-w-[3rem] text-xs tabular-nums">{share.toFixed(1)}%</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{row.traceCount.toLocaleString()}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.errorCount.toLocaleString()}</TableCell>
+                    <TableCell className="text-right text-xs tabular-nums">
+                      <div>{formatSpanDuration(row.avgDurationMs)} avg</div>
+                      <div className="text-muted-foreground">{formatSpanDuration(row.maxDurationMs)} max</div>
+                    </TableCell>
+                    <TableCell className="text-right text-xs text-muted-foreground whitespace-nowrap">
+                      {formatSpanDebugDate(row.latestSpanAt, timezone)}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <div
+          id="apm-span-source-breakdown"
+          className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground"
+        >
+          No APM spans stored for this billing period.
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/dashboard/src/components/settings/__tests__/ApmSpanUsageBreakdown.test.tsx
+++ b/dashboard/src/components/settings/__tests__/ApmSpanUsageBreakdown.test.tsx
@@ -1,0 +1,121 @@
+import {fireEvent, render, screen} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+import {ApmSpanUsageBreakdown} from '../ApmSpanUsageBreakdown'
+
+const apmSpanDebugResponse = {
+  organizationId: 1,
+  periodStart: '2026-04-01',
+  periodEnd: '2026-04-30',
+  totalSpans: 2180,
+  groups: [
+    {
+      source: 'datadog',
+      service: 'checkout-api',
+      operation: 'rack.request',
+      resource: 'GET /checkout',
+      spanType: 'web',
+      env: 'prod',
+      kind: 'server',
+      scopeName: 'rails',
+      scopeVersion: '7.1.0',
+      projectId: null,
+      projectName: null,
+      projectSlug: null,
+      spanCount: 1200,
+      traceCount: 450,
+      errorCount: 3,
+      avgDurationMs: 82.4,
+      maxDurationMs: 1205.25,
+      percentage: 55.05,
+      sampleTraceId: '1234567890abcdef',
+      latestSpanAt: '2026-04-20 14:12:44.123456',
+    },
+    {
+      source: 'sentry',
+      service: '',
+      operation: '',
+      resource: '',
+      spanType: '',
+      env: '',
+      kind: '',
+      scopeName: '',
+      scopeVersion: '',
+      projectId: 10,
+      projectName: 'Web App',
+      projectSlug: 'web-app',
+      spanCount: 980,
+      traceCount: 120,
+      errorCount: 0,
+      avgDurationMs: 4.2,
+      maxDurationMs: 9.8,
+      percentage: 144.95,
+      sampleTraceId: '',
+      latestSpanAt: '',
+    },
+  ],
+}
+
+describe('ApmSpanUsageBreakdown', () => {
+  it('keeps sources collapsed until expanded', () => {
+    render(
+      <ApmSpanUsageBreakdown
+        debug={apmSpanDebugResponse}
+        error={undefined}
+        isLoading={false}
+        timezone="UTC"
+      />
+    )
+
+    expect(screen.queryByText('checkout-api')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: /show sources/i}))
+
+    expect(screen.getByText('checkout-api')).toBeInTheDocument()
+    expect(screen.getByText('Datadog')).toBeInTheDocument()
+    expect(screen.getByText('Sentry')).toBeInTheDocument()
+    expect(screen.getByText('GET /checkout')).toBeInTheDocument()
+    expect(screen.getByText('rails@7.1.0')).toBeInTheDocument()
+    expect(screen.getByText('1234567890ab...')).toBeInTheDocument()
+    expect(screen.getByText('82 ms avg')).toBeInTheDocument()
+    expect(screen.getByText('1.21 s max')).toBeInTheDocument()
+    expect(screen.getByText('Web App')).toBeInTheDocument()
+    expect(screen.getByText('Unknown service')).toBeInTheDocument()
+    expect(screen.getByText('No scope')).toBeInTheDocument()
+    expect(screen.getByText('100.0%')).toBeInTheDocument()
+    expect(screen.getAllByText('None').length).toBeGreaterThan(0)
+  })
+
+  it('shows loading, error, and empty states after expansion', () => {
+    const {rerender} = render(
+      <ApmSpanUsageBreakdown
+        debug={undefined}
+        error={undefined}
+        isLoading
+        timezone="UTC"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: /show sources/i}))
+    expect(screen.getByText('Loading APM span sources...')).toBeInTheDocument()
+
+    rerender(
+      <ApmSpanUsageBreakdown
+        debug={undefined}
+        error={new Error('failed')}
+        isLoading={false}
+        timezone="UTC"
+      />
+    )
+    expect(screen.getByText('Unable to load APM span sources.')).toBeInTheDocument()
+
+    rerender(
+      <ApmSpanUsageBreakdown
+        debug={{...apmSpanDebugResponse, groups: []}}
+        error={undefined}
+        isLoading={false}
+        timezone="UTC"
+      />
+    )
+    expect(screen.getByText('No APM spans stored for this billing period.')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/lib/api/modules/__tests__/billing.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/billing.test.ts
@@ -69,6 +69,50 @@ describe('Billing API', () => {
     expect(result).toEqual(mockUsage)
   })
 
+  it('fetches APM span usage debug groups', async () => {
+    const mockDebug = {
+      organizationId: 1,
+      periodStart: '2026-01-01',
+      periodEnd: '2026-01-31',
+      totalSpans: 42,
+      groups: [
+        {
+          source: 'otlp',
+          service: 'api',
+          operation: 'GET /checkout',
+          resource: 'GET /checkout',
+          spanType: '',
+          env: 'prod',
+          kind: 'SERVER',
+          scopeName: 'opentelemetry.instrumentation.ktor',
+          scopeVersion: '1.0.0',
+          projectId: null,
+          projectName: null,
+          projectSlug: null,
+          spanCount: 42,
+          traceCount: 12,
+          errorCount: 1,
+          avgDurationMs: 12.5,
+          maxDurationMs: 200,
+          percentage: 100,
+          sampleTraceId: 'trace-1',
+          latestSpanAt: '2026-01-15 12:00:00',
+        },
+      ],
+    }
+
+    server.use(
+      http.get(`${API_BASE}/v1/billing/usage/apm-spans`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('limit')).toBe('20')
+        return HttpResponse.json(mockDebug)
+      })
+    )
+
+    const result = await api.getBillingApmSpanUsageDebug()
+    expect(result).toEqual(mockDebug)
+  })
+
   // ──── createBillingCheckoutSession ────
 
   it('creates a billing checkout session', async () => {

--- a/dashboard/src/lib/api/modules/__tests__/billing.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/billing.test.ts
@@ -113,6 +113,31 @@ describe('Billing API', () => {
     expect(result).toEqual(mockDebug)
   })
 
+  it('normalizes APM span usage debug limits', async () => {
+    const seenLimits: string[] = []
+    const mockDebug = {
+      organizationId: 1,
+      periodStart: '2026-01-01',
+      periodEnd: '2026-01-31',
+      totalSpans: 0,
+      groups: [],
+    }
+
+    server.use(
+      http.get(`${API_BASE}/v1/billing/usage/apm-spans`, ({ request }) => {
+        const url = new URL(request.url)
+        seenLimits.push(url.searchParams.get('limit') ?? '')
+        return HttpResponse.json(mockDebug)
+      })
+    )
+
+    await api.getBillingApmSpanUsageDebug(3.8)
+    await api.getBillingApmSpanUsageDebug(0)
+    await api.getBillingApmSpanUsageDebug(Number.NaN)
+
+    expect(seenLimits).toEqual(['3', '1', '20'])
+  })
+
   // ──── createBillingCheckoutSession ────
 
   it('creates a billing checkout session', async () => {

--- a/dashboard/src/lib/api/modules/billing.ts
+++ b/dashboard/src/lib/api/modules/billing.ts
@@ -16,6 +16,7 @@
 
 import type { ApiClientCore } from '../client'
 import type {
+  ApmSpanUsageDebugResponse,
   BillingPlansResponse,
   BillingUsage,
   CheckoutSessionRequest,
@@ -26,6 +27,7 @@ import type {
   CancelSubscriptionResponse,
   UpdateOnCallSeatsResponse,
 } from '../types'
+import { urlWithQuery } from '../utils'
 
 export function billingMethods(core: ApiClientCore) {
   const base = core.API_BASE
@@ -36,6 +38,13 @@ export function billingMethods(core: ApiClientCore) {
 
     getBillingUsage: () =>
       core.request<BillingUsage>(`${base}/billing/usage`),
+
+    getBillingApmSpanUsageDebug: (limit = 20) => {
+      const params = new URLSearchParams({ limit: String(limit) })
+      return core.request<ApmSpanUsageDebugResponse>(
+        urlWithQuery(`${base}/billing/usage/apm-spans`, params.toString())
+      )
+    },
 
     createBillingCheckoutSession: (body: CheckoutSessionRequest) =>
       core.request<CheckoutSessionResponse>(`${base}/billing/checkout`, {

--- a/dashboard/src/lib/api/modules/billing.ts
+++ b/dashboard/src/lib/api/modules/billing.ts
@@ -40,7 +40,9 @@ export function billingMethods(core: ApiClientCore) {
       core.request<BillingUsage>(`${base}/billing/usage`),
 
     getBillingApmSpanUsageDebug: (limit = 20) => {
-      const params = new URLSearchParams({ limit: String(limit) })
+      const numericLimit = Number(limit)
+      const safeLimit = Number.isFinite(numericLimit) ? Math.max(1, Math.floor(numericLimit)) : 20
+      const params = new URLSearchParams({ limit: String(safeLimit) })
       return core.request<ApmSpanUsageDebugResponse>(
         urlWithQuery(`${base}/billing/usage/apm-spans`, params.toString())
       )

--- a/dashboard/src/lib/api/types/billing.ts
+++ b/dashboard/src/lib/api/types/billing.ts
@@ -156,6 +156,37 @@ export interface BillingUsage {
   bonusReason?: string
 }
 
+export interface ApmSpanUsageDebugGroup {
+  source: string
+  service: string
+  operation: string
+  resource: string
+  spanType: string
+  env: string
+  kind: string
+  scopeName: string
+  scopeVersion: string
+  projectId?: number | null
+  projectName?: string | null
+  projectSlug?: string | null
+  spanCount: number
+  traceCount: number
+  errorCount: number
+  avgDurationMs: number
+  maxDurationMs: number
+  percentage: number
+  sampleTraceId: string
+  latestSpanAt: string
+}
+
+export interface ApmSpanUsageDebugResponse {
+  organizationId: number
+  periodStart: string
+  periodEnd: string
+  totalSpans: number
+  groups: ApmSpanUsageDebugGroup[]
+}
+
 export interface CheckoutSessionRequest {
   tierName: string
   billingInterval?: string

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -19,7 +19,14 @@ import {createFileRoute, Link, redirect, useNavigate, useSearch} from '@tanstack
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {loadStripe} from '@stripe/stripe-js'
 import {Elements, PaymentElement, useElements, useStripe} from '@stripe/react-stripe-js'
-import {type AlertNotificationPreference, type AlertSource, api, type AuthToken} from '@/lib/api'
+import {
+  type AlertNotificationPreference,
+  type AlertSource,
+  type ApmSpanUsageDebugGroup,
+  type ApmSpanUsageDebugResponse,
+  api,
+  type AuthToken,
+} from '@/lib/api'
 import {OtlpApiKeysTab} from '@/components/settings/OtlpApiKeysTab'
 import {AgentApiKeysTab} from '@/components/settings/AgentApiKeysTab'
 import {trackEvent} from '@/lib/analytics'
@@ -52,6 +59,7 @@ import {
   Calendar,
   Check,
   CheckCircle2,
+  ChevronRight,
   Clock,
   Copy,
   CreditCard,
@@ -114,6 +122,11 @@ const EXPIRATION_OPTIONS = [
   { label: 'Custom', value: 'custom' },
 ] as const
 
+const APM_SPAN_DEBUG_LIMIT = 20
+const TRACE_ID_PREVIEW_LENGTH = 12
+const FULL_PERCENT = 100
+const CLICKHOUSE_DATETIME_PATTERN = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(?:\.(\d+))?$/
+
 function formatDate(iso: string | null | undefined, timezone: string): string {
   if (!iso) return '—'
   try {
@@ -130,6 +143,71 @@ function isExpired(expiresAt: string | null | undefined): boolean {
   } catch {
     return false
   }
+}
+
+function formatOptionalText(value: string | null | undefined, fallback = 'None'): string {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : fallback
+}
+
+function formatApmSource(source: string): string {
+  const normalized = formatOptionalText(source, 'datadog')
+  if (normalized.toLowerCase() === 'otlp') return 'OTLP'
+  if (normalized.toLowerCase() === 'sentry') return 'Sentry'
+  if (normalized.toLowerCase() === 'datadog') return 'Datadog'
+  return normalized
+}
+
+function formatSpanDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0 ms'
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)} s`
+  return `${ms.toFixed(ms >= 10 ? 0 : 1)} ms`
+}
+
+function normalizeClickHouseDateTime(value: string): string {
+  const match = CLICKHOUSE_DATETIME_PATTERN.exec(value)
+  if (!match) return value
+  const millis = (match[3] ?? '').padEnd(3, '0').slice(0, 3)
+  return `${match[1]}T${match[2]}.${millis}Z`
+}
+
+function formatSpanDebugDate(value: string, timezone: string): string {
+  if (!value) return 'None'
+  return formatDateTimeUtil(normalizeClickHouseDateTime(value), timezone)
+}
+
+function formatTracePreview(traceId: string): string {
+  if (!traceId) return 'None'
+  if (traceId.length <= TRACE_ID_PREVIEW_LENGTH) return traceId
+  return `${traceId.slice(0, TRACE_ID_PREVIEW_LENGTH)}...`
+}
+
+function spanDebugRowKey(row: ApmSpanUsageDebugGroup): string {
+  return [
+    row.source,
+    row.service,
+    row.operation,
+    row.resource,
+    row.spanType,
+    row.env,
+    row.kind,
+    row.scopeName,
+    row.scopeVersion,
+    row.projectId ?? 'org',
+  ].join('|')
+}
+
+function boundedPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(FULL_PERCENT, value))
+}
+
+function formatScope(row: ApmSpanUsageDebugGroup): string {
+  const scopeName = row.scopeName.trim()
+  const scopeVersion = row.scopeVersion.trim()
+  if (scopeName && scopeVersion) return `${scopeName}@${scopeVersion}`
+  if (scopeName) return scopeName
+  return formatOptionalText(row.kind, 'No scope')
 }
 
 export const Route = createFileRoute('/settings')({
@@ -801,12 +879,161 @@ function RevokeTokenDialog({ token, onClose, onConfirm, isRevoking }: RevokeToke
   )
 }
 
+interface ApmSpanUsageBreakdownProps {
+  readonly debug?: ApmSpanUsageDebugResponse
+  readonly isLoading: boolean
+  readonly timezone: string
+}
+
+function ApmSpanUsageBreakdown({debug, isLoading, timezone}: ApmSpanUsageBreakdownProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const groups = debug?.groups ?? []
+
+  return (
+    <div className="mt-2 space-y-3">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs"
+          aria-expanded={isExpanded}
+          aria-controls="apm-span-source-breakdown"
+          onClick={() => setIsExpanded((current) => !current)}
+        >
+          <ChevronRight
+            className={`h-3.5 w-3.5 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+          />
+          {isExpanded ? 'Hide sources' : 'Show sources'}
+        </Button>
+      </div>
+      {isExpanded && (isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading APM span sources...</p>
+      ) : groups.length > 0 ? (
+        <div id="apm-span-source-breakdown" className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead>Source</TableHead>
+                <TableHead>Service</TableHead>
+                <TableHead>Operation</TableHead>
+                <TableHead>Resource</TableHead>
+                <TableHead>Scope</TableHead>
+                <TableHead className="text-right">Spans</TableHead>
+                <TableHead className="text-right">Share</TableHead>
+                <TableHead className="text-right">Traces</TableHead>
+                <TableHead className="text-right">Errors</TableHead>
+                <TableHead className="text-right">Latency</TableHead>
+                <TableHead className="text-right">Latest</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {groups.map((row) => {
+                const share = boundedPercent(row.percentage)
+                const projectLabel = row.projectName ?? row.projectSlug
+
+                return (
+                  <TableRow key={spanDebugRowKey(row)}>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <Badge variant="outline" className="capitalize">
+                          {formatApmSource(row.source)}
+                        </Badge>
+                        {projectLabel && (
+                          <p className="max-w-[160px] truncate text-xs text-muted-foreground" title={projectLabel}>
+                            {projectLabel}
+                          </p>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className="max-w-[180px] truncate font-medium"
+                        title={formatOptionalText(row.service, 'Unknown service')}
+                      >
+                        {formatOptionalText(row.service, 'Unknown service')}
+                      </div>
+                      <p className="text-xs text-muted-foreground">{formatOptionalText(row.env, 'No env')}</p>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className="max-w-[220px] truncate font-medium"
+                        title={formatOptionalText(row.operation, 'Unknown operation')}
+                      >
+                        {formatOptionalText(row.operation, 'Unknown operation')}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {formatOptionalText(row.spanType, formatOptionalText(row.kind, 'No type'))}
+                      </p>
+                    </TableCell>
+                    <TableCell>
+                      <div
+                        className="max-w-[260px] truncate font-mono text-xs"
+                        title={formatOptionalText(row.resource)}
+                      >
+                        {formatOptionalText(row.resource)}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="max-w-[220px] truncate text-xs" title={formatScope(row)}>
+                        {formatScope(row)}
+                      </div>
+                      <p className="text-xs text-muted-foreground" title={row.sampleTraceId}>
+                        {formatTracePreview(row.sampleTraceId)}
+                      </p>
+                    </TableCell>
+                    <TableCell className="text-right font-semibold tabular-nums">
+                      {row.spanCount.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <div className="h-1.5 w-16 rounded-full bg-secondary overflow-hidden">
+                          <div
+                            className="h-full rounded-full bg-purple-500"
+                            style={{ width: `${share}%` }}
+                          />
+                        </div>
+                        <span className="min-w-[3rem] text-xs tabular-nums">{share.toFixed(1)}%</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{row.traceCount.toLocaleString()}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.errorCount.toLocaleString()}</TableCell>
+                    <TableCell className="text-right text-xs tabular-nums">
+                      <div>{formatSpanDuration(row.avgDurationMs)} avg</div>
+                      <div className="text-muted-foreground">{formatSpanDuration(row.maxDurationMs)} max</div>
+                    </TableCell>
+                    <TableCell className="text-right text-xs text-muted-foreground whitespace-nowrap">
+                      {formatSpanDebugDate(row.latestSpanAt, timezone)}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <div
+          id="apm-span-source-breakdown"
+          className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground"
+        >
+          No APM spans stored for this billing period.
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function UsageTab() {
   const { timezone } = useTimezone()
   const { data: usage, isLoading } = useQuery({
     queryKey: ['billingUsage'],
     queryFn: () => api.getBillingUsage(),
     enabled: api.isAuthenticated(),
+  })
+  const { data: apmSpanDebug, isLoading: isApmSpanDebugLoading } = useQuery({
+    queryKey: ['billingApmSpanUsageDebug', usage?.periodStart, usage?.periodEnd],
+    queryFn: () => api.getBillingApmSpanUsageDebug(APM_SPAN_DEBUG_LIMIT),
+    enabled: api.isAuthenticated() && usage !== undefined,
   })
 
   if (isLoading || !usage) {
@@ -1034,6 +1261,14 @@ function UsageTab() {
                     )}
                   </div>
                 )}
+
+                {row.key === 'apm_span' && (
+                  <ApmSpanUsageBreakdown
+                    debug={apmSpanDebug}
+                    isLoading={isApmSpanDebugLoading}
+                    timezone={timezone}
+                  />
+                )}
               </div>
             )
           })}
@@ -1059,6 +1294,7 @@ function UsageTab() {
           </div>
         </CardContent>
       </Card>
+
     </div>
   )
 }

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -22,13 +22,12 @@ import {Elements, PaymentElement, useElements, useStripe} from '@stripe/react-st
 import {
   type AlertNotificationPreference,
   type AlertSource,
-  type ApmSpanUsageDebugGroup,
-  type ApmSpanUsageDebugResponse,
   api,
   type AuthToken,
 } from '@/lib/api'
 import {OtlpApiKeysTab} from '@/components/settings/OtlpApiKeysTab'
 import {AgentApiKeysTab} from '@/components/settings/AgentApiKeysTab'
+import {ApmSpanUsageBreakdown} from '@/components/settings/ApmSpanUsageBreakdown'
 import {trackEvent} from '@/lib/analytics'
 import {buildPricingCardModel} from '@/lib/pricing-display'
 import {Button} from '@/components/ui/button'
@@ -59,7 +58,6 @@ import {
   Calendar,
   Check,
   CheckCircle2,
-  ChevronRight,
   Clock,
   Copy,
   CreditCard,
@@ -123,9 +121,6 @@ const EXPIRATION_OPTIONS = [
 ] as const
 
 const APM_SPAN_DEBUG_LIMIT = 20
-const TRACE_ID_PREVIEW_LENGTH = 12
-const FULL_PERCENT = 100
-const CLICKHOUSE_DATETIME_PATTERN = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(?:\.(\d+))?$/
 
 function formatDate(iso: string | null | undefined, timezone: string): string {
   if (!iso) return '—'
@@ -143,71 +138,6 @@ function isExpired(expiresAt: string | null | undefined): boolean {
   } catch {
     return false
   }
-}
-
-function formatOptionalText(value: string | null | undefined, fallback = 'None'): string {
-  const trimmed = value?.trim()
-  return trimmed ? trimmed : fallback
-}
-
-function formatApmSource(source: string): string {
-  const normalized = formatOptionalText(source, 'datadog')
-  if (normalized.toLowerCase() === 'otlp') return 'OTLP'
-  if (normalized.toLowerCase() === 'sentry') return 'Sentry'
-  if (normalized.toLowerCase() === 'datadog') return 'Datadog'
-  return normalized
-}
-
-function formatSpanDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms <= 0) return '0 ms'
-  if (ms >= 1000) return `${(ms / 1000).toFixed(2)} s`
-  return `${ms.toFixed(ms >= 10 ? 0 : 1)} ms`
-}
-
-function normalizeClickHouseDateTime(value: string): string {
-  const match = CLICKHOUSE_DATETIME_PATTERN.exec(value)
-  if (!match) return value
-  const millis = (match[3] ?? '').padEnd(3, '0').slice(0, 3)
-  return `${match[1]}T${match[2]}.${millis}Z`
-}
-
-function formatSpanDebugDate(value: string, timezone: string): string {
-  if (!value) return 'None'
-  return formatDateTimeUtil(normalizeClickHouseDateTime(value), timezone)
-}
-
-function formatTracePreview(traceId: string): string {
-  if (!traceId) return 'None'
-  if (traceId.length <= TRACE_ID_PREVIEW_LENGTH) return traceId
-  return `${traceId.slice(0, TRACE_ID_PREVIEW_LENGTH)}...`
-}
-
-function spanDebugRowKey(row: ApmSpanUsageDebugGroup): string {
-  return [
-    row.source,
-    row.service,
-    row.operation,
-    row.resource,
-    row.spanType,
-    row.env,
-    row.kind,
-    row.scopeName,
-    row.scopeVersion,
-    row.projectId ?? 'org',
-  ].join('|')
-}
-
-function boundedPercent(value: number): number {
-  if (!Number.isFinite(value)) return 0
-  return Math.max(0, Math.min(FULL_PERCENT, value))
-}
-
-function formatScope(row: ApmSpanUsageDebugGroup): string {
-  const scopeName = row.scopeName.trim()
-  const scopeVersion = row.scopeVersion.trim()
-  if (scopeName && scopeVersion) return `${scopeName}@${scopeVersion}`
-  if (scopeName) return scopeName
-  return formatOptionalText(row.kind, 'No scope')
 }
 
 export const Route = createFileRoute('/settings')({
@@ -879,150 +809,6 @@ function RevokeTokenDialog({ token, onClose, onConfirm, isRevoking }: RevokeToke
   )
 }
 
-interface ApmSpanUsageBreakdownProps {
-  readonly debug?: ApmSpanUsageDebugResponse
-  readonly isLoading: boolean
-  readonly timezone: string
-}
-
-function ApmSpanUsageBreakdown({debug, isLoading, timezone}: ApmSpanUsageBreakdownProps) {
-  const [isExpanded, setIsExpanded] = useState(false)
-  const groups = debug?.groups ?? []
-
-  return (
-    <div className="mt-2 space-y-3">
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1 px-2 text-xs"
-          aria-expanded={isExpanded}
-          aria-controls="apm-span-source-breakdown"
-          onClick={() => setIsExpanded((current) => !current)}
-        >
-          <ChevronRight
-            className={`h-3.5 w-3.5 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-          />
-          {isExpanded ? 'Hide sources' : 'Show sources'}
-        </Button>
-      </div>
-      {isExpanded && (isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading APM span sources...</p>
-      ) : groups.length > 0 ? (
-        <div id="apm-span-source-breakdown" className="overflow-x-auto rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow className="hover:bg-transparent">
-                <TableHead>Source</TableHead>
-                <TableHead>Service</TableHead>
-                <TableHead>Operation</TableHead>
-                <TableHead>Resource</TableHead>
-                <TableHead>Scope</TableHead>
-                <TableHead className="text-right">Spans</TableHead>
-                <TableHead className="text-right">Share</TableHead>
-                <TableHead className="text-right">Traces</TableHead>
-                <TableHead className="text-right">Errors</TableHead>
-                <TableHead className="text-right">Latency</TableHead>
-                <TableHead className="text-right">Latest</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {groups.map((row) => {
-                const share = boundedPercent(row.percentage)
-                const projectLabel = row.projectName ?? row.projectSlug
-
-                return (
-                  <TableRow key={spanDebugRowKey(row)}>
-                    <TableCell>
-                      <div className="space-y-1">
-                        <Badge variant="outline" className="capitalize">
-                          {formatApmSource(row.source)}
-                        </Badge>
-                        {projectLabel && (
-                          <p className="max-w-[160px] truncate text-xs text-muted-foreground" title={projectLabel}>
-                            {projectLabel}
-                          </p>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <div
-                        className="max-w-[180px] truncate font-medium"
-                        title={formatOptionalText(row.service, 'Unknown service')}
-                      >
-                        {formatOptionalText(row.service, 'Unknown service')}
-                      </div>
-                      <p className="text-xs text-muted-foreground">{formatOptionalText(row.env, 'No env')}</p>
-                    </TableCell>
-                    <TableCell>
-                      <div
-                        className="max-w-[220px] truncate font-medium"
-                        title={formatOptionalText(row.operation, 'Unknown operation')}
-                      >
-                        {formatOptionalText(row.operation, 'Unknown operation')}
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        {formatOptionalText(row.spanType, formatOptionalText(row.kind, 'No type'))}
-                      </p>
-                    </TableCell>
-                    <TableCell>
-                      <div
-                        className="max-w-[260px] truncate font-mono text-xs"
-                        title={formatOptionalText(row.resource)}
-                      >
-                        {formatOptionalText(row.resource)}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <div className="max-w-[220px] truncate text-xs" title={formatScope(row)}>
-                        {formatScope(row)}
-                      </div>
-                      <p className="text-xs text-muted-foreground" title={row.sampleTraceId}>
-                        {formatTracePreview(row.sampleTraceId)}
-                      </p>
-                    </TableCell>
-                    <TableCell className="text-right font-semibold tabular-nums">
-                      {row.spanCount.toLocaleString()}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex items-center justify-end gap-2">
-                        <div className="h-1.5 w-16 rounded-full bg-secondary overflow-hidden">
-                          <div
-                            className="h-full rounded-full bg-purple-500"
-                            style={{ width: `${share}%` }}
-                          />
-                        </div>
-                        <span className="min-w-[3rem] text-xs tabular-nums">{share.toFixed(1)}%</span>
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">{row.traceCount.toLocaleString()}</TableCell>
-                    <TableCell className="text-right tabular-nums">{row.errorCount.toLocaleString()}</TableCell>
-                    <TableCell className="text-right text-xs tabular-nums">
-                      <div>{formatSpanDuration(row.avgDurationMs)} avg</div>
-                      <div className="text-muted-foreground">{formatSpanDuration(row.maxDurationMs)} max</div>
-                    </TableCell>
-                    <TableCell className="text-right text-xs text-muted-foreground whitespace-nowrap">
-                      {formatSpanDebugDate(row.latestSpanAt, timezone)}
-                    </TableCell>
-                  </TableRow>
-                )
-              })}
-            </TableBody>
-          </Table>
-        </div>
-      ) : (
-        <div
-          id="apm-span-source-breakdown"
-          className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground"
-        >
-          No APM spans stored for this billing period.
-        </div>
-      ))}
-    </div>
-  )
-}
-
 function UsageTab() {
   const { timezone } = useTimezone()
   const { data: usage, isLoading } = useQuery({
@@ -1030,7 +816,11 @@ function UsageTab() {
     queryFn: () => api.getBillingUsage(),
     enabled: api.isAuthenticated(),
   })
-  const { data: apmSpanDebug, isLoading: isApmSpanDebugLoading } = useQuery({
+  const {
+    data: apmSpanDebug,
+    error: apmSpanDebugError,
+    isLoading: isApmSpanDebugLoading,
+  } = useQuery({
     queryKey: ['billingApmSpanUsageDebug', usage?.periodStart, usage?.periodEnd],
     queryFn: () => api.getBillingApmSpanUsageDebug(APM_SPAN_DEBUG_LIMIT),
     enabled: api.isAuthenticated() && usage !== undefined,
@@ -1265,6 +1055,7 @@ function UsageTab() {
                 {row.key === 'apm_span' && (
                   <ApmSpanUsageBreakdown
                     debug={apmSpanDebug}
+                    error={apmSpanDebugError}
                     isLoading={isApmSpanDebugLoading}
                     timezone={timezone}
                   />


### PR DESCRIPTION
## Summary
- add an APM span usage breakdown endpoint grouped by span source, service, operation, and resource
- show span sources as a collapsed, expandable section inside the existing APM Spans usage row
- count Datadog, OTLP, and Sentry trace ingestion by span count for billing usage

## Validation
- backend: ./gradlew compileKotlin
- backend: ./gradlew detekt
- backend: GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.routes.BillingRoutesTest -Dkotlin.compiler.execution.strategy=in-process
- dashboard: npm test -- src/lib/api/modules/__tests__/billing.test.ts
- dashboard: npm run lint
- git diff --check origin/develop..HEAD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New APM span usage debug endpoint, dashboard API call, and expandable Usage-tab breakdown showing span counts, traces/errors, latency stats, and per-source/service/operation/resource details.

* **Improvements**
  * Client/UI normalize, floor, clamp and default the debug query limit for predictable results.
  * Ingestion now records span counts alongside payload sizes for more accurate usage tracking.
  * Small spacing/UI tweaks in Usage view.

* **Tests**
  * Added tests for the endpoint, API client limit handling, UI component, and server-side grouping/enrichment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->