### PR TITLE
fix: correct billing period rollover

### DIFF
--- a/backend/src/main/kotlin/com/moneat/billing/repositories/SubscriptionRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/repositories/SubscriptionRepositoryImpl.kt
@@ -161,6 +161,7 @@ class SubscriptionRepositoryImpl : SubscriptionRepository {
                     it[payg_used_units] = 0
                     it[payg_used_micros] = 0
                     it[pending_meter_units] = 0
+                    it[pending_overage_bytes] = 0
                     it[pending_meter_batch_id] = null
                     it[pending_meter_batch_units] = 0
                     it[pending_apm_span_overage_units] = 0

--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingPeriod.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingPeriod.kt
@@ -1,0 +1,134 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.billing.services
+
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
+import kotlinx.datetime.plus
+
+internal data class BillingPeriod(
+    val start: LocalDate,
+    val end: LocalDate,
+)
+
+private const val MIN_DAY_OF_MONTH = 1
+private const val LAST_UNIVERSAL_MONTH_DAY = 28
+private const val MAX_DAY_OF_MONTH = 31
+private const val MONTHS_PER_YEAR = 12
+private const val MONTHS_PER_MONTH = 1
+
+internal fun resolveCurrentBillingPeriod(
+    storedStart: LocalDate?,
+    storedEnd: LocalDate?,
+    billingInterval: String?,
+    today: LocalDate,
+): BillingPeriod {
+    if (storedStart == null) {
+        val start = LocalDate(today.year, today.month, MIN_DAY_OF_MONTH)
+        return BillingPeriod(start = start, end = endForPeriodStart(start, MONTHS_PER_MONTH, MIN_DAY_OF_MONTH))
+    }
+
+    val monthsPerPeriod = monthsPerBillingPeriod(billingInterval)
+    val anchorDay = storedStart.day
+    val normalizedStoredEnd =
+        storedEnd
+            ?.takeIf { it >= storedStart }
+            ?: endForPeriodStart(storedStart, monthsPerPeriod, anchorDay)
+
+    if (today >= storedStart && today <= normalizedStoredEnd) {
+        return BillingPeriod(start = storedStart, end = normalizedStoredEnd)
+    }
+
+    return if (today > normalizedStoredEnd) {
+        advancePeriodUntilCurrent(storedStart, today, monthsPerPeriod, anchorDay)
+    } else {
+        rewindPeriodUntilCurrent(storedStart, today, monthsPerPeriod, anchorDay)
+    }
+}
+
+private fun advancePeriodUntilCurrent(
+    storedStart: LocalDate,
+    today: LocalDate,
+    monthsPerPeriod: Int,
+    anchorDay: Int,
+): BillingPeriod {
+    var periodStart = storedStart
+    var periodEnd = endForPeriodStart(periodStart, monthsPerPeriod, anchorDay)
+
+    while (today > periodEnd) {
+        periodStart = shiftBillingAnchor(periodStart, monthsPerPeriod, anchorDay)
+        periodEnd = endForPeriodStart(periodStart, monthsPerPeriod, anchorDay)
+    }
+
+    return BillingPeriod(start = periodStart, end = periodEnd)
+}
+
+private fun rewindPeriodUntilCurrent(
+    storedStart: LocalDate,
+    today: LocalDate,
+    monthsPerPeriod: Int,
+    anchorDay: Int,
+): BillingPeriod {
+    var periodStart = storedStart
+
+    while (today < periodStart) {
+        periodStart = shiftBillingAnchor(periodStart, -monthsPerPeriod, anchorDay)
+    }
+
+    return BillingPeriod(start = periodStart, end = endForPeriodStart(periodStart, monthsPerPeriod, anchorDay))
+}
+
+private fun endForPeriodStart(
+    periodStart: LocalDate,
+    monthsPerPeriod: Int,
+    anchorDay: Int,
+): LocalDate {
+    return shiftBillingAnchor(periodStart, monthsPerPeriod, anchorDay).plus(DatePeriod(days = -1))
+}
+
+private fun shiftBillingAnchor(
+    date: LocalDate,
+    months: Int,
+    anchorDay: Int,
+): LocalDate {
+    val targetMonth = LocalDate(date.year, date.month, MIN_DAY_OF_MONTH).plus(DatePeriod(months = months))
+    return dateWithClampedDay(targetMonth.year, targetMonth.month, anchorDay)
+}
+
+private fun dateWithClampedDay(
+    year: Int,
+    month: Month,
+    anchorDay: Int,
+): LocalDate {
+    var day = anchorDay.coerceIn(MIN_DAY_OF_MONTH, MAX_DAY_OF_MONTH)
+    while (day > LAST_UNIVERSAL_MONTH_DAY) {
+        try {
+            return LocalDate(year, month, day)
+        } catch (_: IllegalArgumentException) {
+            day--
+        }
+    }
+    return LocalDate(year, month, day)
+}
+
+private fun monthsPerBillingPeriod(billingInterval: String?): Int {
+    return when (billingInterval?.lowercase()) {
+        "annual", "annually", "year", "yearly" -> MONTHS_PER_YEAR
+        else -> MONTHS_PER_MONTH
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
@@ -27,10 +27,8 @@ import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Subscriptions
 import com.moneat.utils.SentryUtils
 import com.moneat.utils.suspendRunCatching
-import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.todayIn
 import kotlinx.serialization.Serializable
@@ -782,12 +780,15 @@ class BillingQuotaService(
                     else -> tierFromEnum(sub?.get(Subscriptions.plan) ?: "FREE")
                 }
             }
-        val periodStart =
-            sub?.get(Subscriptions.current_period_start)?.toLocalDateTime(TimeZone.UTC)?.date
-                ?: LocalDate(now.year, now.month, 1)
-        val periodEnd =
-            sub?.get(Subscriptions.current_period_end)?.toLocalDateTime(TimeZone.UTC)?.date
-                ?: periodStart.plus(DatePeriod(months = 1, days = -1))
+        val billingPeriod =
+            resolveCurrentBillingPeriod(
+                storedStart = sub?.get(Subscriptions.current_period_start)?.toLocalDateTime(TimeZone.UTC)?.date,
+                storedEnd = sub?.get(Subscriptions.current_period_end)?.toLocalDateTime(TimeZone.UTC)?.date,
+                billingInterval = sub?.get(Subscriptions.billing_interval),
+                today = now,
+            )
+        val periodStart = billingPeriod.start
+        val periodEnd = billingPeriod.end
 
         val existingCounter =
             OrgUsageCounters

--- a/backend/src/test/kotlin/com/moneat/billing/services/BillingPeriodResolverTest.kt
+++ b/backend/src/test/kotlin/com/moneat/billing/services/BillingPeriodResolverTest.kt
@@ -1,0 +1,136 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.billing.services
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BillingPeriodResolverTest {
+    // ──── Billing Period Resolver Tests ────
+    @Test
+    fun `missing stored start falls back to current calendar month`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = null,
+                storedEnd = null,
+                billingInterval = "monthly",
+                today = LocalDate(2026, 5, 23),
+            )
+
+        assertEquals(LocalDate(2026, 5, 1), period.start)
+        assertEquals(LocalDate(2026, 5, 31), period.end)
+    }
+
+    @Test
+    fun `stale monthly period advances to period containing today`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = LocalDate(2026, 3, 14),
+                storedEnd = LocalDate(2026, 4, 13),
+                billingInterval = "monthly",
+                today = LocalDate(2026, 5, 23),
+            )
+
+        assertEquals(LocalDate(2026, 5, 14), period.start)
+        assertEquals(LocalDate(2026, 6, 13), period.end)
+    }
+
+    @Test
+    fun `current stored period is preserved`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = LocalDate(2026, 5, 14),
+                storedEnd = LocalDate(2026, 6, 13),
+                billingInterval = "monthly",
+                today = LocalDate(2026, 5, 23),
+            )
+
+        assertEquals(LocalDate(2026, 5, 14), period.start)
+        assertEquals(LocalDate(2026, 6, 13), period.end)
+    }
+
+    @Test
+    fun `missing stored end derives period end from start`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = LocalDate(2026, 3, 14),
+                storedEnd = null,
+                billingInterval = "monthly",
+                today = LocalDate(2026, 3, 20),
+            )
+
+        assertEquals(LocalDate(2026, 3, 14), period.start)
+        assertEquals(LocalDate(2026, 4, 13), period.end)
+    }
+
+    @Test
+    fun `invalid stored end derives period end from start`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = LocalDate(2026, 3, 14),
+                storedEnd = LocalDate(2026, 3, 1),
+                billingInterval = "monthly",
+                today = LocalDate(2026, 3, 20),
+            )
+
+        assertEquals(LocalDate(2026, 3, 14), period.start)
+        assertEquals(LocalDate(2026, 4, 13), period.end)
+    }
+
+    @Test
+    fun `future stored period rewinds to period containing today`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = LocalDate(2026, 5, 14),
+                storedEnd = LocalDate(2026, 6, 13),
+                billingInterval = "monthly",
+                today = LocalDate(2026, 4, 20),
+            )
+
+        assertEquals(LocalDate(2026, 4, 14), period.start)
+        assertEquals(LocalDate(2026, 5, 13), period.end)
+    }
+
+    @Test
+    fun `month end anchor clamps to last day of shorter month`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = LocalDate(2026, 1, 31),
+                storedEnd = LocalDate(2026, 2, 27),
+                billingInterval = "monthly",
+                today = LocalDate(2026, 3, 1),
+            )
+
+        assertEquals(LocalDate(2026, 2, 28), period.start)
+        assertEquals(LocalDate(2026, 3, 30), period.end)
+    }
+
+    @Test
+    fun `yearly period advances by yearly interval`() {
+        val period =
+            resolveCurrentBillingPeriod(
+                storedStart = LocalDate(2024, 3, 14),
+                storedEnd = LocalDate(2025, 3, 13),
+                billingInterval = "yearly",
+                today = LocalDate(2026, 5, 23),
+            )
+
+        assertEquals(LocalDate(2026, 3, 14), period.start)
+        assertEquals(LocalDate(2027, 3, 13), period.end)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/services/BillingQuotaServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/BillingQuotaServiceTest.kt
@@ -26,8 +26,11 @@ import com.moneat.shared.models.Subscriptions
 import com.moneat.shared.models.Users
 import com.moneat.testsupport.TestDatabaseHelper
 import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.plus
+import kotlinx.datetime.todayIn
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -954,6 +957,36 @@ class BillingQuotaServiceTest {
     }
 
     @Test
+    fun `usage response advances stale subscription period to include today`() {
+        val today = Clock.System.todayIn(TimeZone.UTC)
+        val staleMonth = today.plus(DatePeriod(months = -2))
+        val staleStart = LocalDate(staleMonth.year, staleMonth.month, 14)
+        val staleEnd = staleStart.plus(DatePeriod(months = 1, days = -1))
+
+        transaction {
+            Subscriptions.update({ Subscriptions.id eq testSubId }) {
+                it[current_period_start] = staleStart.atStartOfDayIn(TimeZone.UTC)
+                it[current_period_end] = staleEnd.atStartOfDayIn(TimeZone.UTC)
+                it[billing_interval] = "monthly"
+            }
+            insertTestUsageCounter(
+                organizationId = testOrgId,
+                periodStart = staleStart,
+                usedErrors = 200,
+            )
+        }
+
+        val usage = billingQuotaService.getUsageForOrganization(testOrgId)
+        val periodStart = LocalDate.parse(usage.periodStart)
+        val periodEnd = LocalDate.parse(usage.periodEnd)
+
+        assertTrue(today >= periodStart, "Current billing period should start on or before today")
+        assertTrue(today <= periodEnd, "Current billing period should end on or after today")
+        assertTrue(periodStart > staleStart, "Stale subscription period should be advanced")
+        assertEquals(0, usage.usedErrors, "Usage should be read from the advanced period, not stale counters")
+    }
+
+    @Test
     fun `usage response includes correct limits`() {
         val usage = billingQuotaService.getUsageForOrganization(testOrgId)
 
@@ -1544,10 +1577,10 @@ class BillingQuotaServiceTest {
         usedTransactions: Long = 0,
         usedReplays: Long = 0,
         usedFeedback: Long = 0,
-        usedBytes: Long = 0
+        usedBytes: Long = 0,
+        periodStart: LocalDate = Clock.System.now().toLocalDateTime(TimeZone.UTC).date,
     ): Int {
         val now = Clock.System.now()
-        val periodStart = now.toLocalDateTime(TimeZone.UTC).date
         val periodEnd = periodStart.plus(DatePeriod(months = 1, days = -1))
 
         return OrgUsageCounters.insert {

--- a/backend/src/test/kotlin/com/moneat/services/StripeServiceWebhookTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/StripeServiceWebhookTest.kt
@@ -50,6 +50,7 @@ class StripeServiceWebhookTest {
     private val mockSubscriptionId = "sub_test_456"
 
     companion object {
+        private const val TEST_PENDING_OVERAGE_BYTES = 123_456L
         private var db: org.jetbrains.exposed.v1.jdbc.Database? = null
     }
 
@@ -600,6 +601,8 @@ class StripeServiceWebhookTest {
                 it[Subscriptions.stripe_customer_id] = mockCustomerId
                 it[Subscriptions.payg_used_units] = 500
                 it[Subscriptions.payg_used_micros] = 200000000
+                it[Subscriptions.pending_meter_units] = 100
+                it[Subscriptions.pending_overage_bytes] = TEST_PENDING_OVERAGE_BYTES
                 it[Subscriptions.status] = "past_due"
                 it[Subscriptions.billing_grace_until] =
                     Instant.fromEpochSeconds(Clock.System.now().epochSeconds + 86_400)
@@ -627,6 +630,7 @@ class StripeServiceWebhookTest {
             assertEquals(0L, record[Subscriptions.payg_used_units])
             assertEquals(0L, record[Subscriptions.payg_used_micros])
             assertEquals(0L, record[Subscriptions.pending_meter_units])
+            assertEquals(0L, record[Subscriptions.pending_overage_bytes])
             assertEquals(null, record[Subscriptions.billing_grace_until])
         }
     }
@@ -640,6 +644,7 @@ class StripeServiceWebhookTest {
                 it[Subscriptions.payg_used_units] = 500
                 it[Subscriptions.payg_used_micros] = 200000000
                 it[Subscriptions.pending_meter_units] = 100
+                it[Subscriptions.pending_overage_bytes] = TEST_PENDING_OVERAGE_BYTES
                 it[Subscriptions.status] = "past_due"
                 it[Subscriptions.billing_grace_until] =
                     Instant.fromEpochSeconds(Clock.System.now().epochSeconds + 86_400)
@@ -669,6 +674,7 @@ class StripeServiceWebhookTest {
             assertEquals(500L, record[Subscriptions.payg_used_units])
             assertEquals(200000000L, record[Subscriptions.payg_used_micros])
             assertEquals(100L, record[Subscriptions.pending_meter_units])
+            assertEquals(TEST_PENDING_OVERAGE_BYTES, record[Subscriptions.pending_overage_bytes])
         }
     }
 


### PR DESCRIPTION
## Summary
- resolve stale subscription billing periods to the period containing the current date
- reset raw pending overage bytes on subscription-cycle invoice rollover
- add regression tests for stale billing periods and byte rollover

## Validation
- ./gradlew compileKotlin
- ./gradlew detekt
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.billing.services.BillingPeriodResolverTest --tests com.moneat.services.BillingQuotaServiceTest --tests com.moneat.services.StripeServiceWebhookTest -Dkotlin.compiler.execution.strategy=in-process
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed billing cycle rollover to properly reset pending overage charges.
  * Enhanced billing period determination to correctly identify and advance stale subscription periods, ensuring usage data aligns with the active billing cycle.

* **Tests**
  * Added comprehensive tests for billing period resolution and stale period advancement.
  * Extended webhook tests to verify overage charge handling across billing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->