### PR TITLE
fix: weekly summary email query

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -595,7 +595,7 @@ class NotificationService(
             SELECT 
                 issue_id,
                 any(message) as title,
-                any(culprit) as culprit,
+                any(exception_type) as culprit,
                 any(project_id) as project_id,
                 count() as event_count
             FROM `$clickhouseDb`.events

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -148,6 +148,9 @@ class NotificationServiceWeeklySummaryTest {
         { exchange ->
             val query = exchange.requestBodyText()
             when {
+                query.contains("any(culprit)") -> {
+                    exchange.respond(500, "Code: 47. Unknown expression identifier culprit", TEXT_PLAIN)
+                }
                 query.contains("GROUP BY project_id") -> {
                     exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
                 }
@@ -193,6 +196,8 @@ class NotificationServiceWeeklySummaryTest {
             when {
                 query.contains("GROUP BY project_id") ->
                     exchange.respond(200, emptyData, TEXT_PLAIN)
+                query.contains("any(culprit)") ->
+                    exchange.respond(500, "Code: 47. Unknown expression identifier culprit", TEXT_PLAIN)
                 query.contains("count() as total_events") -> {
                     call++
                     val body = if (call == 1) {

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -71,6 +71,7 @@ class NotificationServiceWeeklySummaryTest {
         private const val LARGE_K_EVENTS = 1500L
         private const val LARGE_M_EVENTS = 2_000_000L
         private const val DEFAULT_CRASH_FREE = 99.0
+        private const val CLICKHOUSE_ERROR_STATUS = 500
     }
 
     private val emailService = mockk<EmailService>(relaxed = true)
@@ -149,7 +150,11 @@ class NotificationServiceWeeklySummaryTest {
             val query = exchange.requestBodyText()
             when {
                 query.contains("any(culprit)") -> {
-                    exchange.respond(500, "Code: 47. Unknown expression identifier culprit", TEXT_PLAIN)
+                    exchange.respond(
+                        CLICKHOUSE_ERROR_STATUS,
+                        "Code: 47. Unknown expression identifier culprit",
+                        TEXT_PLAIN
+                    )
                 }
                 query.contains("GROUP BY project_id") -> {
                     exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
@@ -197,7 +202,11 @@ class NotificationServiceWeeklySummaryTest {
                 query.contains("GROUP BY project_id") ->
                     exchange.respond(200, emptyData, TEXT_PLAIN)
                 query.contains("any(culprit)") ->
-                    exchange.respond(500, "Code: 47. Unknown expression identifier culprit", TEXT_PLAIN)
+                    exchange.respond(
+                        CLICKHOUSE_ERROR_STATUS,
+                        "Code: 47. Unknown expression identifier culprit",
+                        TEXT_PLAIN
+                    )
                 query.contains("count() as total_events") -> {
                     call++
                     val body = if (call == 1) {


### PR DESCRIPTION
## Summary
- fix weekly summary top-issues query to use the events exception_type column
- add test guardrails for the previous nonexistent culprit column regression

## Verification
- ./gradlew :test --tests com.moneat.services.NotificationServiceWeeklySummaryTest
- ./gradlew compileKotlin
- ./gradlew detekt
- git diff --check
- ./gradlew detekt test jacocoTestReport testClasses integrationTestClasses --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how the "culprit" is determined when ranking top issues in notifications, improving accuracy of prioritized items.

* **Tests**
  * Enhanced tests to deterministically simulate database query failures for the affected issue-ranking paths, validating error handling and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->