### PR TITLE
fix: guard stripe metering and apm usage debug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,8 @@ STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 STRIPE_PUBLISHABLE_KEY=
 STRIPE_METER_EVENT_NAME=moneat_overage_units
+STRIPE_CUSTOM_METRIC_METER_EVENT_NAME=moneat_custom_metric_overage_units
+STRIPE_APM_SPAN_METER_EVENT_NAME=moneat_apm_span_overage_units
 
 # ----------------------------------------------------------------------------
 # Legal document versions

--- a/backend/src/main/kotlin/com/moneat/config/EnvConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/EnvConfig.kt
@@ -85,7 +85,7 @@ object EnvConfig {
     // Demo mode configuration
     object Demo {
         val enabled: Boolean
-            get() = get("DEMO_ENABLED", "true").toBoolean()
+            get() = get("DEMO_ENABLED", "false").toBoolean()
 
         /**
          * Demo epoch timestamp in milliseconds.

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -67,6 +67,10 @@ stripe {
     publishableKey = ${?STRIPE_PUBLISHABLE_KEY}
     meterEventName = "moneat_overage_units"
     meterEventName = ${?STRIPE_METER_EVENT_NAME}
+    customMetricMeterEventName = "moneat_custom_metric_overage_units"
+    customMetricMeterEventName = ${?STRIPE_CUSTOM_METRIC_METER_EVENT_NAME}
+    apmSpanMeterEventName = "moneat_apm_span_overage_units"
+    apmSpanMeterEventName = ${?STRIPE_APM_SPAN_METER_EVENT_NAME}
 }
 
 ingest {

--- a/dashboard/src/components/settings/ApmSpanUsageBreakdown.tsx
+++ b/dashboard/src/components/settings/ApmSpanUsageBreakdown.tsx
@@ -79,11 +79,22 @@ interface ApmSpanUsageBreakdownProps {
   readonly debug?: ApmSpanUsageDebugResponse
   readonly isLoading: boolean
   readonly error?: unknown
+  readonly expanded?: boolean
+  readonly onExpandedChange?: (expanded: boolean) => void
   readonly timezone: string
 }
 
-export function ApmSpanUsageBreakdown({debug, isLoading, error, timezone}: ApmSpanUsageBreakdownProps) {
-  const [isExpanded, setIsExpanded] = useState(false)
+export function ApmSpanUsageBreakdown({
+  debug,
+  isLoading,
+  error,
+  expanded,
+  onExpandedChange,
+  timezone,
+}: ApmSpanUsageBreakdownProps) {
+  const [internalExpanded, setInternalExpanded] = useState(false)
+  const isExpanded = expanded ?? internalExpanded
+  const setIsExpanded = onExpandedChange ?? setInternalExpanded
   const groups = debug?.groups ?? []
 
   return (
@@ -96,7 +107,7 @@ export function ApmSpanUsageBreakdown({debug, isLoading, error, timezone}: ApmSp
           className="h-7 gap-1 px-2 text-xs"
           aria-expanded={isExpanded}
           aria-controls="apm-span-source-breakdown"
-          onClick={() => setIsExpanded((current) => !current)}
+          onClick={() => setIsExpanded(!isExpanded)}
         >
           <ChevronRight
             className={`h-3.5 w-3.5 transition-transform ${isExpanded ? 'rotate-90' : ''}`}

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -811,6 +811,7 @@ function RevokeTokenDialog({ token, onClose, onConfirm, isRevoking }: RevokeToke
 
 function UsageTab() {
   const { timezone } = useTimezone()
+  const [isApmSpanSourceExpanded, setIsApmSpanSourceExpanded] = useState(false)
   const { data: usage, isLoading } = useQuery({
     queryKey: ['billingUsage'],
     queryFn: () => api.getBillingUsage(),
@@ -823,7 +824,7 @@ function UsageTab() {
   } = useQuery({
     queryKey: ['billingApmSpanUsageDebug', usage?.periodStart, usage?.periodEnd],
     queryFn: () => api.getBillingApmSpanUsageDebug(APM_SPAN_DEBUG_LIMIT),
-    enabled: api.isAuthenticated() && usage !== undefined,
+    enabled: api.isAuthenticated() && usage !== undefined && isApmSpanSourceExpanded,
   })
 
   if (isLoading || !usage) {
@@ -1056,7 +1057,9 @@ function UsageTab() {
                   <ApmSpanUsageBreakdown
                     debug={apmSpanDebug}
                     error={apmSpanDebugError}
+                    expanded={isApmSpanSourceExpanded}
                     isLoading={isApmSpanDebugLoading}
+                    onExpandedChange={setIsApmSpanSourceExpanded}
                     timezone={timezone}
                   />
                 )}


### PR DESCRIPTION
## Summary
- add configurable Stripe meter event names for custom metric and APM span overage usage
- make demo data reseeding opt-in by default
- defer the expensive APM span usage breakdown query until the user expands the source table

## Validation
- backend: ./gradlew compileKotlin
- backend: ./gradlew detekt
- backend: GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.services.StripeServiceExtendedTest -Dkotlin.compiler.execution.strategy=in-process
- dashboard: npm test -- src/components/settings/__tests__/ApmSpanUsageBreakdown.test.tsx src/lib/api/modules/__tests__/billing.test.ts
- dashboard: npm run lint
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * APM Span Usage Breakdown section now supports expand/collapse functionality for improved usability.

* **Improvements**
  * APM span debug usage data loads conditionally, improving performance.

* **Chores**
  * Demo mode is disabled by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->