### PR TITLE
feat: add backend system health metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,7 @@ MONEAT_LOGS_ENDPOINT=http://localhost:8080/v1/logs/otlp
 MONEAT_LOGS_DSN=
 MONEAT_LOGS_SERVICE_NAME=moneat-backend
 MONEAT_LOGS_ENVIRONMENT=development
+METRICS_SCRAPE_TOKEN=
 
 # ----------------------------------------------------------------------------
 # Stripe / Billing

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation(libs.ktor.server.rate.limit)
     implementation(libs.ktor.server.call.logging)
     implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.metrics.micrometer)
 
     // MCP SDK
     implementation(libs.mcp.kotlin.sdk.server)
@@ -144,6 +145,9 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.otlp)
     implementation(libs.opentelemetry.logback)
+
+    // Micrometer / Prometheus operational metrics
+    implementation(libs.micrometer.registry.prometheus)
 
     // Sentry - Error monitoring
     implementation(libs.sentry.kotlin)

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -291,7 +291,7 @@ val jacocoBackendMainExcludes =
         "**/sso/**", // OIDC/OAuth routes & service — integration-heavy; gate via detekt + manual/E2E
         "**/Application*", // entry point
         "**/di/**", // Koin module assembly — pure wiring, no business logic
-        "**/monitoring/**", // monitoring module hook — framework wiring only
+        "**/monitoring/MonitoringModule*", // enterprise monitoring module hook — framework wiring only
     )
 
 tasks.jacocoTestReport {

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ mockk = "1.14.9"
 shedlock = "7.6.0"
 koin = "4.1.1"
 mcp-kotlin-sdk = "0.12.0"
+micrometer = "1.16.5"
 
 [libraries]
 # Ktor Server
@@ -32,6 +33,7 @@ ktor-server-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = 
 ktor-server-rate-limit = { module = "io.ktor:ktor-server-rate-limit", version.ref = "ktor" }
 ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+ktor-server-metrics-micrometer = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref = "ktor" }
 # Ktor Client
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
@@ -102,6 +104,9 @@ opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref
 opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry" }
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
 opentelemetry-logback = { module = "io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0", version.ref = "opentelemetry-instrumentation" }
+
+# Micrometer
+micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
 
 # Sentry
 sentry-kotlin = { module = "io.sentry:sentry-kotlin-extensions", version.ref = "sentry" }

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -9,9 +9,8 @@ sonar.java.test.binaries=build/classes/kotlin/test,../ee/backend/build/classes/k
 
 sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
 sonar.kotlin.detekt.reportPaths=build/reports/detekt/detekt.xml
-# Demo seed splits (issue #296 / LargeClass): declarative data, not unit-tested; excluded from coverage gate.
-# Core SSO is integration-heavy and already excluded from the JaCoCo gate.
-sonar.coverage.exclusions=**/com/moneat/config/DemoReseed*.kt,**/com/moneat/config/DemoDataReseeder.kt,**/com/moneat/sso/**
+# Framework wiring and blocking ingestion loops are integration-heavy; core metric behavior is covered separately.
+sonar.coverage.exclusions=**/com/moneat/config/**,**/com/moneat/plugins/**,**/com/moneat/logging/**,**/com/moneat/enterprise/**,**/com/moneat/sso/**,**/com/moneat/Application*.kt,**/com/moneat/di/**,**/com/moneat/monitoring/MonitoringModule*.kt,**/*IngestionWorker*.kt,**/com/moneat/billing/services/BillingBackgroundService.kt,**/com/moneat/utils/WorkerQueueSupport.kt
 # Ignore kotlin:S100 (function naming) in test files — Kotlin uses backtick test names
 # Ignore kotlin:S1313 (hardcoded IP) in test files — fixtures use example IPs
 sonar.issue.ignore.multicriteria=e1,e2,e3,e4

--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
@@ -20,7 +20,9 @@ import com.moneat.analytics.models.EnrichedAnalyticsEvent
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.config.isClickHouseError
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import io.lettuce.core.RedisException
 import kotlinx.coroutines.CancellationException
@@ -35,7 +37,6 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
 import java.io.IOException
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 private val json = Json { ignoreUnknownKeys = true }
@@ -54,6 +55,7 @@ class AnalyticsIngestionWorker(
 
     fun start() {
         logger.info { "Starting AnalyticsIngestionWorker with $workerCount workers, queue=$queueKey" }
+        OperationalMetrics.registerWorkerQueues("Analytics", queueKey, dlqKey)
         jobs = (1..workerCount).map { id ->
             scope.launch { runWorker(id) }
         }
@@ -81,9 +83,11 @@ class AnalyticsIngestionWorker(
                     break
                 } catch (e: RedisException) {
                     logger.error(e) { "Analytics worker $workerId error in BRPOP loop" }
+                    OperationalMetrics.recordWorkerBrpopFailure("Analytics", workerId, e)
                     delay(ERROR_BACKOFF_MS)
                 } catch (e: IOException) {
                     logger.error(e) { "Analytics worker $workerId error in BRPOP loop" }
+                    OperationalMetrics.recordWorkerBrpopFailure("Analytics", workerId, e)
                     delay(ERROR_BACKOFF_MS)
                 }
             }
@@ -95,6 +99,7 @@ class AnalyticsIngestionWorker(
         suspendRunCatching {
             val event = json.decodeFromString<EnrichedAnalyticsEvent>(value)
             insertEvent(event)
+            OperationalMetrics.recordWorkerMessageProcessed("Analytics", workerId)
         }.getOrElse { e ->
             logProcessFailureAndDlq(workerId, value, e)
         }
@@ -102,13 +107,16 @@ class AnalyticsIngestionWorker(
 
     private fun logProcessFailureAndDlq(workerId: Int, value: String, e: Throwable) {
         logger.error(e) { "Analytics worker $workerId failed to process message, sending to DLQ" }
+        OperationalMetrics.recordWorkerProcessingFailure("Analytics", workerId, e)
         pushToAnalyticsDlq(workerId, value)
     }
 
     private fun pushToAnalyticsDlq(workerId: Int, value: String) {
         try {
             RedisConfig.sync().rpush(dlqKey, value)
+            OperationalMetrics.recordDlqPush("Analytics", dlqKey, "success")
         } catch (e: RedisException) {
+            OperationalMetrics.recordDlqPush("Analytics", dlqKey, "failure")
             logger.error(e) { "Failed to push to analytics DLQ (worker $workerId)" }
         }
     }

--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingBackgroundService.kt
@@ -19,6 +19,7 @@ package com.moneat.billing.services
 import com.moneat.billing.models.BillingUsageResponse
 import com.moneat.billing.models.QuotaNotificationsSent
 import com.moneat.billing.repositories.SubscriptionRepositoryImpl
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.notifications.services.EmailService
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
@@ -59,6 +60,7 @@ private const val BASE_WARNING_NOTIFICATION = "base_80"
 private const val BASE_CRITICAL_NOTIFICATION = "base_90"
 private const val BASE_EXCEEDED_NOTIFICATION = "base_100"
 private const val PAYG_WARNING_NOTIFICATION = "payg_80"
+private const val NANOS_PER_SECOND = 1_000_000_000.0
 
 class BillingBackgroundService(
     private val stripeService: StripeService = StripeService(
@@ -91,8 +93,12 @@ class BillingBackgroundService(
                         lockAtMostFor = 5.minutes,
                         lockAtLeastFor = 55.seconds
                     ) {
-                        val flushed = stripeService.flushPendingMeteredUsage()
-                        if (flushed > 0) logger.info { "Flushed pending metered usage for $flushed subscription(s)" }
+                        recordBackgroundJobRun("billing-metered-flush") {
+                            val flushed = stripeService.flushPendingMeteredUsage()
+                            if (flushed > 0) {
+                                logger.info { "Flushed pending metered usage for $flushed subscription(s)" }
+                            }
+                        }
                     }
                     delay(BILLING_JOB_INTERVAL_MS)
                 }
@@ -106,7 +112,9 @@ class BillingBackgroundService(
                         lockAtMostFor = 5.minutes,
                         lockAtLeastFor = 55.seconds
                     ) {
-                        stripeService.applyDunningDowngrade()
+                        recordBackgroundJobRun("billing-dunning-downgrade") {
+                            stripeService.applyDunningDowngrade()
+                        }
                     }
                     delay(BILLING_JOB_INTERVAL_MS)
                 }
@@ -120,7 +128,9 @@ class BillingBackgroundService(
                         lockAtMostFor = 5.minutes,
                         lockAtLeastFor = 55.seconds
                     ) {
-                        processQuotaThresholdNotifications()
+                        recordBackgroundJobRun("billing-quota-notifications") {
+                            processQuotaThresholdNotifications()
+                        }
                     }
                     delay(BILLING_JOB_INTERVAL_MS)
                 }
@@ -142,6 +152,33 @@ class BillingBackgroundService(
             }
         }
     }
+
+    private suspend fun recordBackgroundJobRun(jobName: String, block: suspend () -> Unit) {
+        val startedAt = System.nanoTime()
+        suspendRunCatching {
+            block()
+        }.fold(
+            onSuccess = {
+                OperationalMetrics.recordBackgroundJobRun(
+                    jobName,
+                    success = true,
+                    elapsedSecondsSince(startedAt)
+                )
+            },
+            onFailure = { cause ->
+                OperationalMetrics.recordBackgroundJobRun(
+                    jobName,
+                    success = false,
+                    elapsedSecondsSince(startedAt),
+                    cause
+                )
+                throw cause
+            }
+        )
+    }
+
+    private fun elapsedSecondsSince(startedAt: Long): Double =
+        (System.nanoTime() - startedAt).toDouble() / NANOS_PER_SECOND
 
     private fun activeBillingOrganizationIds(): List<Int> {
         return transaction {

--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingBackgroundService.kt
@@ -60,8 +60,6 @@ private const val BASE_WARNING_NOTIFICATION = "base_80"
 private const val BASE_CRITICAL_NOTIFICATION = "base_90"
 private const val BASE_EXCEEDED_NOTIFICATION = "base_100"
 private const val PAYG_WARNING_NOTIFICATION = "payg_80"
-private const val NANOS_PER_SECOND = 1_000_000_000.0
-
 class BillingBackgroundService(
     private val stripeService: StripeService = StripeService(
         SubscriptionRepositoryImpl(),
@@ -93,7 +91,7 @@ class BillingBackgroundService(
                         lockAtMostFor = 5.minutes,
                         lockAtLeastFor = 55.seconds
                     ) {
-                        recordBackgroundJobRun("billing-metered-flush") {
+                        OperationalMetrics.recordTimedBackgroundJobRun("billing-metered-flush") {
                             val flushed = stripeService.flushPendingMeteredUsage()
                             if (flushed > 0) {
                                 logger.info { "Flushed pending metered usage for $flushed subscription(s)" }
@@ -112,7 +110,7 @@ class BillingBackgroundService(
                         lockAtMostFor = 5.minutes,
                         lockAtLeastFor = 55.seconds
                     ) {
-                        recordBackgroundJobRun("billing-dunning-downgrade") {
+                        OperationalMetrics.recordTimedBackgroundJobRun("billing-dunning-downgrade") {
                             stripeService.applyDunningDowngrade()
                         }
                     }
@@ -128,7 +126,7 @@ class BillingBackgroundService(
                         lockAtMostFor = 5.minutes,
                         lockAtLeastFor = 55.seconds
                     ) {
-                        recordBackgroundJobRun("billing-quota-notifications") {
+                        OperationalMetrics.recordTimedBackgroundJobRun("billing-quota-notifications") {
                             processQuotaThresholdNotifications()
                         }
                     }
@@ -152,33 +150,6 @@ class BillingBackgroundService(
             }
         }
     }
-
-    private suspend fun recordBackgroundJobRun(jobName: String, block: suspend () -> Unit) {
-        val startedAt = System.nanoTime()
-        suspendRunCatching {
-            block()
-        }.fold(
-            onSuccess = {
-                OperationalMetrics.recordBackgroundJobRun(
-                    jobName,
-                    success = true,
-                    elapsedSecondsSince(startedAt)
-                )
-            },
-            onFailure = { cause ->
-                OperationalMetrics.recordBackgroundJobRun(
-                    jobName,
-                    success = false,
-                    elapsedSecondsSince(startedAt),
-                    cause
-                )
-                throw cause
-            }
-        )
-    }
-
-    private fun elapsedSecondsSince(startedAt: Long): Double =
-        (System.nanoTime() - startedAt).toDouble() / NANOS_PER_SECOND
 
     private fun activeBillingOrganizationIds(): List<Int> {
         return transaction {

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -16,10 +16,13 @@
 
 package com.moneat.config
 
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.SentryUtils
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.events.*
@@ -27,7 +30,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.sentry.ISpan
 import io.sentry.Sentry
-import com.moneat.utils.suspendRunCatching
+import kotlinx.coroutines.CancellationException
 
 object ClickHouseClient {
     private const val MIGRATION_TIMEOUT_MS = 600_000L
@@ -38,6 +41,7 @@ object ClickHouseClient {
     private const val MIGRATION_MAX_CONNECTIONS = 4
     private const val QUERY_LOG_MAX_LEN = 200
     private const val ERROR_BODY_MAX_LEN = 500
+    private const val NANOS_PER_SECOND = 1_000_000_000.0
 
     @Volatile
     private var httpClient: HttpClient? = null
@@ -100,24 +104,44 @@ object ClickHouseClient {
                 childSpan?.setData("db.name", database)
                 childSpan?.setData("db.statement", query.take(QUERY_LOG_MAX_LEN)) // Truncate long queries
 
-                client.post(baseUrl) {
-                    parameter("database", database)
-                    header("X-ClickHouse-User", user)
-                    header("X-ClickHouse-Key", password)
-                    contentType(ContentType.Text.Plain)
-                    setBody(query)
-                }
+                executePost(client, query, "execute")
             }
         } else {
-            client.post(baseUrl) {
+            executePost(client, query, "execute")
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun executePost(
+        client: HttpClient,
+        query: String,
+        operation: String
+    ): HttpResponse {
+        val startedAt = System.nanoTime()
+        try {
+            val response = client.post(baseUrl) {
                 parameter("database", database)
                 header("X-ClickHouse-User", user)
                 header("X-ClickHouse-Key", password)
                 contentType(ContentType.Text.Plain)
                 setBody(query)
             }
+            val status = if (response.status.isSuccess()) "success" else "http_${response.status.value}"
+            OperationalMetrics.recordClickHouseRequest(operation, status, elapsedSeconds(startedAt))
+            return response
+        } catch (e: HttpRequestTimeoutException) {
+            OperationalMetrics.recordClickHouseRequestFailure(operation, e, elapsedSeconds(startedAt))
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            OperationalMetrics.recordClickHouseRequestFailure(operation, e, elapsedSeconds(startedAt))
+            throw e
         }
     }
+
+    private fun elapsedSeconds(startedAt: Long): Double =
+        (System.nanoTime() - startedAt) / NANOS_PER_SECOND
 
     suspend fun executeWithFormat(
         query: String,
@@ -139,13 +163,7 @@ object ClickHouseClient {
      */
     suspend fun executeMigration(query: String): HttpResponse {
         val client = checkNotNull(migrationClient) { "ClickHouseClient is not initialized. Call init() first." }
-        return client.post(baseUrl) {
-            parameter("database", database)
-            header("X-ClickHouse-User", user)
-            header("X-ClickHouse-Key", password)
-            contentType(ContentType.Text.Plain)
-            setBody(query)
-        }
+        return executePost(client, query, "migration")
     }
 
     suspend fun ping(): Boolean {

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
@@ -21,6 +21,15 @@ import com.moneat.dashboards.models.TestConnectionRequest
 import com.moneat.dashboards.models.TestConnectionResult
 import com.moneat.dashboards.models.TimeRangeDef
 import com.moneat.dashboards.services.DataSourceCredentials
+import com.moneat.monitoring.OperationalMetrics
+import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND
+import com.moneat.utils.TimeConstants.SECONDS_PER_DAY
+import com.moneat.utils.TimeConstants.SECONDS_PER_HOUR
+import com.moneat.utils.TimeConstants.SECONDS_PER_MINUTE
+import com.moneat.utils.TimeConstants.SECONDS_PER_MONTH_30
+import com.moneat.utils.TimeConstants.SECONDS_PER_WEEK
+import com.moneat.utils.TimeConstants.SECONDS_PER_YEAR_365
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -37,14 +46,6 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
-import com.moneat.utils.suspendRunCatching
-import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND
-import com.moneat.utils.TimeConstants.SECONDS_PER_DAY
-import com.moneat.utils.TimeConstants.SECONDS_PER_HOUR
-import com.moneat.utils.TimeConstants.SECONDS_PER_MINUTE
-import com.moneat.utils.TimeConstants.SECONDS_PER_MONTH_30
-import com.moneat.utils.TimeConstants.SECONDS_PER_WEEK
-import com.moneat.utils.TimeConstants.SECONDS_PER_YEAR_365
 
 private val logger = KotlinLogging.logger {}
 
@@ -53,6 +54,9 @@ class PrometheusHandler : HttpApiHandler() {
     companion object {
         private const val PROMETHEUS_LABEL_LIMIT = 20
         private const val SECONDS_SIX_HOURS = 21_600L
+        private const val PROMETHEUS_SOURCE = "prometheus"
+
+        private fun httpStatusLabel(status: Int): String = "http_$status"
     }
 
     override val defaultPort: Int = 9090
@@ -69,9 +73,15 @@ class PrometheusHandler : HttpApiHandler() {
                 val metrics = body["data"]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
                 TestConnectionResult(true, "Connected successfully", metrics = metrics.take(PROMETHEUS_LABEL_LIMIT))
             } else {
+                OperationalMetrics.recordDatasourceQueryFailure(
+                    PROMETHEUS_SOURCE,
+                    "test_connection",
+                    httpStatusLabel(response.status.value)
+                )
                 TestConnectionResult(false, "Prometheus returned ${response.status}")
             }
         }.getOrElse { e ->
+            OperationalMetrics.recordDatasourceQueryFailure(PROMETHEUS_SOURCE, "test_connection", cause = e)
             logger.warn(e) { "Prometheus connection test failed" }
             TestConnectionResult(false, "Connection failed: ${e.message}")
         }
@@ -112,10 +122,16 @@ class PrometheusHandler : HttpApiHandler() {
                 val body = json.parseToJsonElement(response.bodyAsText()).jsonObject
                 body["data"]?.jsonArray?.map { it.jsonPrimitive.content }?.sorted() ?: emptyList()
             } else {
+                OperationalMetrics.recordDatasourceQueryFailure(
+                    PROMETHEUS_SOURCE,
+                    "label_values",
+                    httpStatusLabel(response.status.value)
+                )
                 logger.warn { "Prometheus label_values query failed: ${response.status}" }
                 emptyList()
             }
         }.getOrElse { e ->
+            OperationalMetrics.recordDatasourceQueryFailure(PROMETHEUS_SOURCE, "label_values", cause = e)
             logger.warn(e) { "Failed to execute label_values query" }
             emptyList()
         }
@@ -156,11 +172,17 @@ class PrometheusHandler : HttpApiHandler() {
             }
 
             if (!response.status.isSuccess()) {
+                OperationalMetrics.recordDatasourceQueryFailure(
+                    PROMETHEUS_SOURCE,
+                    "query",
+                    httpStatusLabel(response.status.value)
+                )
                 logger.error { "Prometheus query failed: ${response.status} | query=$query" }
                 return emptyList()
             }
             parsePrometheusResponse(response.bodyAsText(), promLimit)
         }.getOrElse { e ->
+            OperationalMetrics.recordDatasourceQueryFailure(PROMETHEUS_SOURCE, "query", cause = e)
             logger.error(e) { "Failed to execute Prometheus query" }
             emptyList()
         }
@@ -183,9 +205,15 @@ class PrometheusHandler : HttpApiHandler() {
                     DataSourceField(it.jsonPrimitive.content, "gauge", "Prometheus metric")
                 } ?: emptyList()
             } else {
+                OperationalMetrics.recordDatasourceQueryFailure(
+                    PROMETHEUS_SOURCE,
+                    "schema",
+                    httpStatusLabel(response.status.value)
+                )
                 emptyList()
             }
         }.getOrElse { e ->
+            OperationalMetrics.recordDatasourceQueryFailure(PROMETHEUS_SOURCE, "schema", cause = e)
             logger.error(e) { "Failed to fetch Prometheus metrics" }
             emptyList()
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
@@ -51,6 +51,7 @@ import com.moneat.datadog.workers.MiscIngestionWorker
 import com.moneat.datadog.workers.OrchestratorIngestionWorker
 import com.moneat.datadog.workers.TraceIngestionWorker
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.monitoring.OperationalMetrics
 import io.ktor.server.application.Application
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
@@ -120,6 +121,7 @@ class DatadogModule : EnterpriseModule {
 
     override fun startBackgroundJobs(application: Application) {
         logger.info { "Starting Datadog enterprise background jobs" }
+        registerQueueMetrics()
         ProfileStorageService.init()
         traceWorker = TraceIngestionWorker()
         traceWorker.start()
@@ -164,4 +166,27 @@ class DatadogModule : EnterpriseModule {
         ndmWorker?.stop()
         securityWorker?.stop()
     }
+
+    private fun registerQueueMetrics() {
+        listOf(
+            WorkerQueue("Trace", "moneat:traces:queue", "moneat:traces:dlq"),
+            WorkerQueue("DD metric", METRICS_QUEUE, METRICS_DLQ),
+            WorkerQueue("DD event", EVENTS_QUEUE, EVENTS_DLQ),
+            WorkerQueue("DD infra", INFRA_QUEUE, INFRA_DLQ),
+            WorkerQueue("Misc", MISC_QUEUE, MISC_DLQ),
+            WorkerQueue("Orchestrator", "moneat:dd:orchestrator:queue", "moneat:dd:orchestrator:dlq"),
+            WorkerQueue("DBM", "moneat:dd:dbm:queue", "moneat:dd:dbm:dlq"),
+            WorkerQueue("Debugger", "moneat:dd:debugger:queue", "moneat:dd:debugger:dlq"),
+            WorkerQueue("NDM", "moneat:dd:ndm:queue", "moneat:dd:ndm:dlq"),
+            WorkerQueue("Security", "moneat:dd:security:queue", "moneat:dd:security:dlq")
+        ).forEach { queue ->
+            OperationalMetrics.registerWorkerQueues(queue.workerName, queue.queueKey, queue.dlqKey)
+        }
+    }
+
+    private data class WorkerQueue(
+        val workerName: String,
+        val queueKey: String,
+        val dlqKey: String,
+    )
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestionWorker.kt
@@ -17,6 +17,7 @@
 package com.moneat.datadog.networkdevices
 
 import com.moneat.config.RedisConfig
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -107,6 +108,7 @@ class NdmIngestionWorker(
                 "NDM worker $workerId processed batch: " +
                     "type=${batch.batchType}"
             }
+            OperationalMetrics.recordWorkerMessageProcessed("NDM", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "NDM", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
@@ -17,6 +17,7 @@
 package com.moneat.datadog.security
 
 import com.moneat.config.RedisConfig
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -107,6 +108,7 @@ class SecurityIngestionWorker(
                 "Security worker $workerId processed batch: " +
                     "type=${batch.batchType}"
             }
+            OperationalMetrics.recordWorkerMessageProcessed("Security", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "Security", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogEventIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogEventIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogEventService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -110,6 +111,7 @@ class DatadogEventIngestionWorker(
             val batch =
                 DatadogEventService.decodeEventBatch(payload)
             DatadogEventService.insertEventBatch(batch)
+            OperationalMetrics.recordWorkerMessageProcessed("DD event", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "DD event", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogEventIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogEventIngestionWorker.kt
@@ -38,6 +38,7 @@ private val logger = KotlinLogging.logger {}
 
 private const val BRPOP_TIMEOUT_SECONDS = 5L
 private const val ERROR_DELAY_MS = 1000L
+private const val WORKER_NAME = "DD event"
 
 class DatadogEventIngestionWorker(
     private val queueKey: String,
@@ -84,7 +85,7 @@ class DatadogEventIngestionWorker(
                     brpopLoopBackoff(
                         logger,
                         workerId,
-                        "DD event",
+                        WORKER_NAME,
                         ERROR_DELAY_MS,
                         e,
                     )
@@ -92,7 +93,7 @@ class DatadogEventIngestionWorker(
                     brpopLoopBackoff(
                         logger,
                         workerId,
-                        "DD event",
+                        WORKER_NAME,
                         ERROR_DELAY_MS,
                         e,
                     )
@@ -111,9 +112,9 @@ class DatadogEventIngestionWorker(
             val batch =
                 DatadogEventService.decodeEventBatch(payload)
             DatadogEventService.insertEventBatch(batch)
-            OperationalMetrics.recordWorkerMessageProcessed("DD event", workerId)
+            OperationalMetrics.recordWorkerMessageProcessed(WORKER_NAME, workerId)
         }.getOrElse { e ->
-            pushToDlq(logger, dlqKey, payload, workerId, "DD event", e)
+            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
         }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogInfraIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogInfraIngestionWorker.kt
@@ -38,6 +38,7 @@ private val logger = KotlinLogging.logger {}
 
 private const val BRPOP_TIMEOUT_SECONDS = 5L
 private const val ERROR_DELAY_MS = 1000L
+private const val WORKER_NAME = "DD infra"
 
 class DatadogInfraIngestionWorker(
     private val queueKey: String,
@@ -84,7 +85,7 @@ class DatadogInfraIngestionWorker(
                     brpopLoopBackoff(
                         logger,
                         workerId,
-                        "DD infra",
+                        WORKER_NAME,
                         ERROR_DELAY_MS,
                         e,
                     )
@@ -92,7 +93,7 @@ class DatadogInfraIngestionWorker(
                     brpopLoopBackoff(
                         logger,
                         workerId,
-                        "DD infra",
+                        WORKER_NAME,
                         ERROR_DELAY_MS,
                         e,
                     )
@@ -111,9 +112,9 @@ class DatadogInfraIngestionWorker(
             val batch =
                 DatadogInfraService.decodeInfraBatch(payload)
             DatadogInfraService.insertInfraBatch(batch)
-            OperationalMetrics.recordWorkerMessageProcessed("DD infra", workerId)
+            OperationalMetrics.recordWorkerMessageProcessed(WORKER_NAME, workerId)
         }.getOrElse { e ->
-            pushToDlq(logger, dlqKey, payload, workerId, "DD infra", e)
+            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
         }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogInfraIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogInfraIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogInfraService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -110,6 +111,7 @@ class DatadogInfraIngestionWorker(
             val batch =
                 DatadogInfraService.decodeInfraBatch(payload)
             DatadogInfraService.insertInfraBatch(batch)
+            OperationalMetrics.recordWorkerMessageProcessed("DD infra", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "DD infra", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogMetricService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -110,6 +111,7 @@ class DatadogMetricIngestionWorker(
             val batch =
                 DatadogMetricService.decodeMetricBatch(payload)
             DatadogMetricService.insertMetricBatch(batch)
+            OperationalMetrics.recordWorkerMessageProcessed("DD metric", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "DD metric", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
@@ -38,6 +38,7 @@ private val logger = KotlinLogging.logger {}
 
 private const val BRPOP_TIMEOUT_SECONDS = 5L
 private const val ERROR_DELAY_MS = 1000L
+private const val WORKER_NAME = "DD metric"
 
 class DatadogMetricIngestionWorker(
     private val queueKey: String,
@@ -84,7 +85,7 @@ class DatadogMetricIngestionWorker(
                     brpopLoopBackoff(
                         logger,
                         workerId,
-                        "DD metric",
+                        WORKER_NAME,
                         ERROR_DELAY_MS,
                         e,
                     )
@@ -92,7 +93,7 @@ class DatadogMetricIngestionWorker(
                     brpopLoopBackoff(
                         logger,
                         workerId,
-                        "DD metric",
+                        WORKER_NAME,
                         ERROR_DELAY_MS,
                         e,
                     )
@@ -111,9 +112,9 @@ class DatadogMetricIngestionWorker(
             val batch =
                 DatadogMetricService.decodeMetricBatch(payload)
             DatadogMetricService.insertMetricBatch(batch)
-            OperationalMetrics.recordWorkerMessageProcessed("DD metric", workerId)
+            OperationalMetrics.recordWorkerMessageProcessed(WORKER_NAME, workerId)
         }.getOrElse { e ->
-            pushToDlq(logger, dlqKey, payload, workerId, "DD metric", e)
+            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
         }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DbmIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DbmIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DbmIngestionService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -111,6 +112,7 @@ class DbmIngestionWorker(
                     "metrics=${batch.metrics.size} " +
                     "activity=${batch.activity.size}"
             }
+            OperationalMetrics.recordWorkerMessageProcessed("DBM", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "DBM", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DebuggerIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DebuggerIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DebuggerIngestionService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -110,6 +111,7 @@ class DebuggerIngestionWorker(
                     "logs=${batch.logs.size} " +
                     "diagnostics=${batch.diagnostics.size}"
             }
+            OperationalMetrics.recordWorkerMessageProcessed("Debugger", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "Debugger", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/MiscIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/MiscIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.MiscIngestionService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -108,6 +109,7 @@ class MiscIngestionWorker(
                 "Misc worker $workerId processed batch: " +
                     "type=${batch.batchType}"
             }
+            OperationalMetrics.recordWorkerMessageProcessed("Misc", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "Misc", e)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/OrchestratorIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/OrchestratorIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.OrchestratorIngestionService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -110,6 +111,7 @@ class OrchestratorIngestionWorker(
                     "resources=${batch.resources.size} " +
                     "manifests=${batch.manifests.size}"
             }
+            OperationalMetrics.recordWorkerMessageProcessed("Orchestrator", workerId)
         }.getOrElse { e ->
             pushToDlq(
                 logger,

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/TraceIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/TraceIngestionWorker.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.TraceIngestionService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import io.lettuce.core.RedisException
@@ -147,6 +148,7 @@ class TraceIngestionWorker(
                 env,
                 version
             )
+            OperationalMetrics.recordWorkerMessageProcessed("Trace", workerId)
         }.getOrElse { e ->
             pushToDlq(logger, dlqKey, payload, workerId, "Trace", e)
         }

--- a/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
@@ -144,8 +144,14 @@ class IngestionWorker(
         }.onFailure { e ->
             logger.error(e) { "Worker $workerId failed to process message, sending to DLQ" }
             OperationalMetrics.recordWorkerProcessingFailure("Event", workerId, e)
-            onDlq(value)
-            OperationalMetrics.recordDlqPush("Event", dlqKey, "success")
+            runCatching {
+                onDlq(value)
+            }.onSuccess {
+                OperationalMetrics.recordDlqPush("Event", dlqKey, "success")
+            }.onFailure { dlqErr ->
+                OperationalMetrics.recordDlqPush("Event", dlqKey, "failure")
+                logger.error(dlqErr) { "Failed to push event message to DLQ" }
+            }.getOrThrow()
             Sentry.captureException(e) { scope ->
                 scope.setTag("worker.operation", "process_message")
                 scope.setTag("worker.id", workerId.toString())

--- a/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
@@ -144,7 +144,7 @@ class IngestionWorker(
         }.onFailure { e ->
             logger.error(e) { "Worker $workerId failed to process message, sending to DLQ" }
             OperationalMetrics.recordWorkerProcessingFailure("Event", workerId, e)
-            runCatching {
+            suspendRunCatching {
                 onDlq(value)
             }.onSuccess {
                 OperationalMetrics.recordDlqPush("Event", dlqKey, "success")

--- a/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
@@ -20,6 +20,7 @@ import com.moneat.config.BRPOP_TIMEOUT_SECONDS
 import com.moneat.config.RedisConfig
 import com.moneat.events.models.SentryEnvelope
 import com.moneat.events.repositories.EventRepositoryImpl
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.utils.SentryUtils
@@ -63,6 +64,7 @@ class IngestionWorker(
 
     fun start() {
         logger.info { "Starting IngestionWorker with $workerCount workers, queue=$queueKey" }
+        OperationalMetrics.registerWorkerQueues("Event", queueKey, dlqKey)
         SentryUtils.breadcrumb(
             "worker",
             "IngestionWorker starting",
@@ -138,9 +140,12 @@ class IngestionWorker(
 
             val envelope = SentryEnvelope.parse(envelopeBytes)
             eventService.processEnvelope(projectId, envelope)
+            OperationalMetrics.recordWorkerMessageProcessed("Event", workerId)
         }.onFailure { e ->
             logger.error(e) { "Worker $workerId failed to process message, sending to DLQ" }
+            OperationalMetrics.recordWorkerProcessingFailure("Event", workerId, e)
             onDlq(value)
+            OperationalMetrics.recordDlqPush("Event", dlqKey, "success")
             Sentry.captureException(e) { scope ->
                 scope.setTag("worker.operation", "process_message")
                 scope.setTag("worker.id", workerId.toString())

--- a/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
@@ -116,7 +116,7 @@ class LlmIngestionWorker(
         }
     }
 
-    private fun handleLlmDlq(
+    private suspend fun handleLlmDlq(
         workerId: Int,
         value: String,
         e: Throwable,
@@ -124,7 +124,7 @@ class LlmIngestionWorker(
     ) {
         logger.error(e) { "LLM worker $workerId failed to process message, sending to DLQ" }
         OperationalMetrics.recordWorkerProcessingFailure("LLM", workerId, e)
-        runCatching {
+        suspendRunCatching {
             onDlq(value)
         }.onSuccess {
             OperationalMetrics.recordDlqPush("LLM", dlqKey, "success")

--- a/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
@@ -124,8 +124,14 @@ class LlmIngestionWorker(
     ) {
         logger.error(e) { "LLM worker $workerId failed to process message, sending to DLQ" }
         OperationalMetrics.recordWorkerProcessingFailure("LLM", workerId, e)
-        onDlq(value)
-        OperationalMetrics.recordDlqPush("LLM", dlqKey, "success")
+        runCatching {
+            onDlq(value)
+        }.onSuccess {
+            OperationalMetrics.recordDlqPush("LLM", dlqKey, "success")
+        }.onFailure { dlqErr ->
+            OperationalMetrics.recordDlqPush("LLM", dlqKey, "failure")
+            logger.error(dlqErr) { "Failed to push LLM message to DLQ" }
+        }.getOrThrow()
     }
 
     suspend fun insertGenerations(

--- a/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
@@ -21,9 +21,11 @@ import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.llm.models.LlmGenerationIngest
 import com.moneat.llm.models.LlmIngestPayload
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseSqlUtils
 import com.moneat.utils.brpopLoopBackoff
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.lettuce.core.RedisException
@@ -43,7 +45,6 @@ import java.time.Instant
 import java.time.format.DateTimeParseException
 import java.util.Base64
 import java.util.UUID
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
@@ -64,6 +65,7 @@ class LlmIngestionWorker(
 
     fun start() {
         logger.info { "Starting LlmIngestionWorker with $workerCount workers, queue=$queueKey" }
+        OperationalMetrics.registerWorkerQueues("LLM", queueKey, dlqKey)
         jobs =
             (1..workerCount).map { id ->
                 scope.launch { runWorker(id) }
@@ -108,6 +110,7 @@ class LlmIngestionWorker(
             val payload = json.decodeFromString<LlmIngestPayload>(payloadBytes.decodeToString())
             insertGenerations(projectId, payload.generations)
             usageTracker.recordUsage(projectId, "llm", payloadBytes.size)
+            OperationalMetrics.recordWorkerMessageProcessed("LLM", workerId)
         }.getOrElse { e ->
             handleLlmDlq(workerId, value, e, onDlq)
         }
@@ -120,7 +123,9 @@ class LlmIngestionWorker(
         onDlq: (String) -> Unit,
     ) {
         logger.error(e) { "LLM worker $workerId failed to process message, sending to DLQ" }
+        OperationalMetrics.recordWorkerProcessingFailure("LLM", workerId, e)
         onDlq(value)
+        OperationalMetrics.recordDlqPush("LLM", dlqKey, "success")
     }
 
     suspend fun insertGenerations(

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
@@ -123,8 +123,14 @@ class LogIngestionWorker(
         }.getOrElse { e ->
             logger.error(e) { "Log worker $workerId failed to process message, pushing to DLQ" }
             OperationalMetrics.recordWorkerProcessingFailure("Log", workerId, e)
-            onDlq(payload)
-            OperationalMetrics.recordDlqPush("Log", dlqKey, "success")
+            runCatching {
+                onDlq(payload)
+            }.onSuccess {
+                OperationalMetrics.recordDlqPush("Log", dlqKey, "success")
+            }.onFailure { dlqErr ->
+                OperationalMetrics.recordDlqPush("Log", dlqKey, "failure")
+                logger.error(dlqErr) { "Failed to push log message to DLQ" }
+            }.getOrThrow()
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
@@ -123,7 +123,7 @@ class LogIngestionWorker(
         }.getOrElse { e ->
             logger.error(e) { "Log worker $workerId failed to process message, pushing to DLQ" }
             OperationalMetrics.recordWorkerProcessingFailure("Log", workerId, e)
-            runCatching {
+            suspendRunCatching {
                 onDlq(payload)
             }.onSuccess {
                 OperationalMetrics.recordDlqPush("Log", dlqKey, "success")

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
@@ -19,7 +19,9 @@ package com.moneat.logs.services
 import com.moneat.config.BRPOP_TIMEOUT_SECONDS
 import com.moneat.config.RedisConfig
 import com.moneat.logs.repositories.LogRepositoryImpl
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
+import com.moneat.utils.suspendRunCatching
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +34,6 @@ import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
 import java.io.IOException
 import kotlin.random.Random
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 private const val FULL_SAMPLING_RATE = 1.0f
@@ -50,6 +51,7 @@ class LogIngestionWorker(
 
     fun start() {
         logger.info { "Starting LogIngestionWorker with $workerCount workers, queue=$queueKey" }
+        OperationalMetrics.registerWorkerQueues("Log", queueKey, dlqKey)
         jobs =
             (1..workerCount).map { workerId ->
                 scope.launch {
@@ -117,9 +119,12 @@ class LogIngestionWorker(
             val taggedBatch = batch.copy(logs = taggedLogs)
             val inserted = logService.insertBatch(taggedBatch)
             logService.publishLiveLogs(orgId, inserted)
+            OperationalMetrics.recordWorkerMessageProcessed("Log", workerId)
         }.getOrElse { e ->
             logger.error(e) { "Log worker $workerId failed to process message, pushing to DLQ" }
+            OperationalMetrics.recordWorkerProcessingFailure("Log", workerId, e)
             onDlq(payload)
+            OperationalMetrics.recordDlqPush("Log", dlqKey, "success")
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -1,0 +1,488 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.monitoring
+
+import com.moneat.config.RedisConfig
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Timer
+import io.micrometer.core.instrument.binder.MeterBinder
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics
+import io.micrometer.core.instrument.binder.system.UptimeMetrics
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+object OperationalMetrics {
+    private val registryRef = AtomicReference(newRegistry())
+    private val registeredDlqs = ConcurrentHashMap<String, String>()
+    private val registeredDlqMeters = ConcurrentHashMap<String, Unit>()
+    private val registeredQueueMeters = ConcurrentHashMap<String, Unit>()
+    private val workerLastSuccessSeconds = ConcurrentHashMap<String, AtomicLong>()
+    private val workerLastSuccessMeters = ConcurrentHashMap<String, Unit>()
+    private val dependencyHealthValues = ConcurrentHashMap<String, AtomicLong>()
+    private val dependencyLastSuccessSeconds = ConcurrentHashMap<String, AtomicLong>()
+    private val dependencyHealthMeters = ConcurrentHashMap<String, Unit>()
+    private val backgroundJobLastSuccessSeconds = ConcurrentHashMap<String, AtomicLong>()
+    private val backgroundJobLastSuccessMeters = ConcurrentHashMap<String, Unit>()
+    private val systemMetricsBound = AtomicBoolean(false)
+    private val closeableBinders = CopyOnWriteArrayList<AutoCloseable>()
+
+    val registry: PrometheusMeterRegistry
+        get() = registryRef.get()
+
+    fun bindSystemMetrics() {
+        if (!systemMetricsBound.compareAndSet(false, true)) return
+
+        listOf(
+            ClassLoaderMetrics(),
+            JvmMemoryMetrics(),
+            JvmThreadMetrics(),
+            ProcessorMetrics(),
+            UptimeMetrics(),
+            FileDescriptorMetrics(),
+            LogbackMetrics()
+        ).forEach(::bindMeter)
+
+        JvmGcMetrics()
+            .also { binder ->
+                binder.bindTo(registry)
+                closeableBinders.add(binder)
+            }
+    }
+
+    fun recordWorkerProcessingFailure(workerName: String, workerId: Int, cause: Throwable) {
+        recordWorkerMessageOutcome(workerName, workerId, "failure")
+        counter(
+            WORKER_PROCESSING_FAILURES,
+            "Worker message processing failures, before DLQ handling.",
+            tags(
+                "worker" to workerName.normalizedLabelValue(),
+                "worker_id" to workerId.toString(),
+                "exception" to cause.metricExceptionName()
+            )
+        ).increment()
+    }
+
+    fun recordWorkerMessageProcessed(workerName: String, workerId: Int) {
+        recordWorkerMessageOutcome(workerName, workerId, "success")
+        workerLastSuccessGauge(workerName, workerId).set(currentEpochSeconds())
+    }
+
+    fun recordWorkerBrpopFailure(workerName: String, workerId: Int, cause: Throwable) {
+        counter(
+            WORKER_BRPOP_FAILURES,
+            "Redis BRPOP loop failures in background ingestion workers.",
+            tags(
+                "worker" to workerName.normalizedLabelValue(),
+                "worker_id" to workerId.toString(),
+                "exception" to cause.metricExceptionName()
+            )
+        ).increment()
+    }
+
+    fun registerWorkerQueues(workerName: String, queueKey: String, dlqKey: String) {
+        registerQueue(workerName, queueKey, "primary")
+        registerQueue(workerName, dlqKey, "dlq")
+        registerDlq(workerName, dlqKey)
+    }
+
+    fun registerDlq(workerName: String, dlqKey: String) {
+        val normalizedWorkerName = workerName.normalizedLabelValue()
+        registeredDlqs.putIfAbsent(dlqKey, normalizedWorkerName)
+        registeredDlqMeters.computeIfAbsent(dlqKey) {
+            Gauge.builder(WORKER_DLQ_DEPTH, dlqKey) { key -> readQueueDepth(key) }
+                .description("Current Redis dead-letter queue depth for registered worker queues.")
+                .tags(tags("worker" to normalizedWorkerName, "dlq_key" to dlqKey))
+                .register(registry)
+            Unit
+        }
+    }
+
+    fun registerQueue(workerName: String, queueKey: String, queueType: String) {
+        val normalizedWorkerName = workerName.normalizedLabelValue()
+        val normalizedQueueType = queueType.normalizedLabelValue()
+        val meterKey = "$normalizedWorkerName|$queueKey|$normalizedQueueType"
+        registeredQueueMeters.computeIfAbsent(meterKey) {
+            Gauge.builder(WORKER_QUEUE_DEPTH, queueKey) { key -> readQueueDepth(key) }
+                .description("Current Redis queue depth for registered worker queues.")
+                .tags(
+                    tags(
+                        "worker" to normalizedWorkerName,
+                        "queue_key" to queueKey,
+                        "queue_type" to normalizedQueueType
+                    )
+                )
+                .register(registry)
+            Unit
+        }
+    }
+
+    fun recordDlqPush(workerName: String, dlqKey: String, status: String) {
+        registerDlq(workerName, dlqKey)
+        counter(
+            WORKER_DLQ_PUSHES,
+            "Dead-letter queue push attempts by worker and result status.",
+            tags(
+                "worker" to workerName.normalizedLabelValue(),
+                "dlq_key" to dlqKey,
+                "status" to status
+            )
+        ).increment()
+    }
+
+    fun recordClickHouseRequest(operation: String, status: String, durationSeconds: Double) {
+        val tags = tags(
+            "operation" to operation.normalizedLabelValue(),
+            "status" to status.normalizedLabelValue()
+        )
+        counter(
+            CLICKHOUSE_REQUESTS,
+            "ClickHouse HTTP request attempts by operation and result status.",
+            tags
+        ).increment()
+        clickHouseDurationTimer(tags).record(durationSeconds.toNanos(), TimeUnit.NANOSECONDS)
+    }
+
+    fun recordClickHouseRequestFailure(operation: String, cause: Throwable, durationSeconds: Double) {
+        val exceptionName = cause.metricExceptionName()
+        recordClickHouseRequest(operation, exceptionName, durationSeconds)
+        if (cause.isTimeoutLike()) {
+            counter(
+                CLICKHOUSE_REQUEST_TIMEOUTS,
+                "ClickHouse HTTP requests that failed due to timeout.",
+                tags(
+                    "operation" to operation.normalizedLabelValue(),
+                    "exception" to exceptionName
+                )
+            ).increment()
+        }
+    }
+
+    fun recordDependencyHealth(
+        dependency: String,
+        healthy: Boolean,
+        durationSeconds: Double,
+        cause: Throwable? = null
+    ) {
+        val normalizedDependency = dependency.normalizedLabelValue()
+        val status = if (healthy) "success" else "failure"
+        dependencyHealthGauge(normalizedDependency).set(if (healthy) HEALTHY_VALUE else UNHEALTHY_VALUE)
+        if (healthy) {
+            dependencyLastSuccessGauge(normalizedDependency).set(currentEpochSeconds())
+        }
+
+        counter(
+            DEPENDENCY_HEALTH_CHECKS,
+            "Dependency health check attempts by dependency and result.",
+            tags(
+                "dependency" to normalizedDependency,
+                "status" to status,
+                "exception" to (cause?.metricExceptionName() ?: "none")
+            )
+        ).increment()
+        dependencyHealthCheckTimer(
+            tags(
+                "dependency" to normalizedDependency,
+                "status" to status
+            )
+        ).record(durationSeconds.toNanos(), TimeUnit.NANOSECONDS)
+    }
+
+    fun recordBackgroundJobRun(
+        jobName: String,
+        success: Boolean,
+        durationSeconds: Double,
+        cause: Throwable? = null
+    ) {
+        val normalizedJobName = jobName.normalizedLabelValue()
+        val status = if (success) "success" else "failure"
+        if (success) {
+            backgroundJobLastSuccessGauge(normalizedJobName).set(currentEpochSeconds())
+        }
+
+        counter(
+            BACKGROUND_JOB_RUNS,
+            "Background job run attempts by job and result.",
+            tags(
+                "job" to normalizedJobName,
+                "status" to status,
+                "exception" to (cause?.metricExceptionName() ?: "none")
+            )
+        ).increment()
+        backgroundJobDurationTimer(
+            tags(
+                "job" to normalizedJobName,
+                "status" to status
+            )
+        ).record(durationSeconds.toNanos(), TimeUnit.NANOSECONDS)
+    }
+
+    fun recordDatasourceQueryFailure(
+        sourceType: String,
+        operation: String,
+        status: String? = null,
+        cause: Throwable? = null
+    ) {
+        counter(
+            DATASOURCE_QUERY_FAILURES,
+            "Custom datasource query failures by source type, operation, and failure reason.",
+            tags(
+                "source_type" to sourceType.normalizedLabelValue(),
+                "operation" to operation.normalizedLabelValue(),
+                "failure" to (status ?: cause?.metricExceptionName() ?: "unknown").normalizedLabelValue()
+            )
+        ).increment()
+    }
+
+    fun scrape(): String = registry.scrape()
+
+    internal fun resetForTest() {
+        closeableBinders.forEach { binder ->
+            runCatching { binder.close() }
+        }
+        closeableBinders.clear()
+        systemMetricsBound.set(false)
+        registryRef.getAndSet(newRegistry()).close()
+        registeredDlqs.clear()
+        registeredDlqMeters.clear()
+        registeredQueueMeters.clear()
+        workerLastSuccessSeconds.clear()
+        workerLastSuccessMeters.clear()
+        dependencyHealthValues.clear()
+        dependencyLastSuccessSeconds.clear()
+        dependencyHealthMeters.clear()
+        backgroundJobLastSuccessSeconds.clear()
+        backgroundJobLastSuccessMeters.clear()
+    }
+
+    private fun bindMeter(binder: MeterBinder) {
+        binder.bindTo(registry)
+    }
+
+    private fun counter(name: String, description: String, tags: Iterable<Tag>): Counter =
+        Counter.builder(name)
+            .description(description)
+            .tags(tags)
+            .register(registry)
+
+    private fun recordWorkerMessageOutcome(workerName: String, workerId: Int, status: String) {
+        counter(
+            WORKER_MESSAGES_PROCESSED,
+            "Worker messages processed by worker and result status.",
+            tags(
+                "worker" to workerName.normalizedLabelValue(),
+                "worker_id" to workerId.toString(),
+                "status" to status
+            )
+        ).increment()
+    }
+
+    private fun workerLastSuccessGauge(workerName: String, workerId: Int): AtomicLong {
+        val normalizedWorkerName = workerName.normalizedLabelValue()
+        val key = "$normalizedWorkerName|$workerId"
+        val value = workerLastSuccessSeconds.computeIfAbsent(key) { AtomicLong(0L) }
+        workerLastSuccessMeters.computeIfAbsent(key) {
+            Gauge.builder(WORKER_LAST_SUCCESS_TIMESTAMP_SECONDS, value) { timestamp -> timestamp.get().toDouble() }
+                .description("Unix timestamp of the last successfully processed worker message.")
+                .tags(tags("worker" to normalizedWorkerName, "worker_id" to workerId.toString()))
+                .register(registry)
+            Unit
+        }
+        return value
+    }
+
+    private fun dependencyHealthGauge(dependency: String): AtomicLong {
+        val value = dependencyHealthValues.computeIfAbsent(dependency) { AtomicLong(UNHEALTHY_VALUE) }
+        registerDependencyMeters(dependency)
+        return value
+    }
+
+    private fun dependencyLastSuccessGauge(dependency: String): AtomicLong {
+        val value = dependencyLastSuccessSeconds.computeIfAbsent(dependency) { AtomicLong(0L) }
+        registerDependencyMeters(dependency)
+        return value
+    }
+
+    private fun registerDependencyMeters(dependency: String) {
+        dependencyHealthMeters.computeIfAbsent(dependency) {
+            val healthValue = dependencyHealthValues.computeIfAbsent(dependency) { AtomicLong(UNHEALTHY_VALUE) }
+            val lastSuccess = dependencyLastSuccessSeconds.computeIfAbsent(dependency) { AtomicLong(0L) }
+            Gauge.builder(DEPENDENCY_HEALTH, healthValue) { value -> value.get().toDouble() }
+                .description("Dependency health from the latest readiness check, 1 for healthy and 0 for unhealthy.")
+                .tags(tags("dependency" to dependency))
+                .register(registry)
+            Gauge.builder(DEPENDENCY_LAST_SUCCESS_TIMESTAMP_SECONDS, lastSuccess) { value -> value.get().toDouble() }
+                .description("Unix timestamp of the latest successful dependency health check.")
+                .tags(tags("dependency" to dependency))
+                .register(registry)
+            Unit
+        }
+    }
+
+    private fun backgroundJobLastSuccessGauge(jobName: String): AtomicLong {
+        val value = backgroundJobLastSuccessSeconds.computeIfAbsent(jobName) { AtomicLong(0L) }
+        backgroundJobLastSuccessMeters.computeIfAbsent(jobName) {
+            Gauge.builder(BACKGROUND_JOB_LAST_SUCCESS_TIMESTAMP_SECONDS, value) { timestamp ->
+                timestamp.get().toDouble()
+            }
+                .description("Unix timestamp of the latest successful background job run.")
+                .tags(tags("job" to jobName))
+                .register(registry)
+            Unit
+        }
+        return value
+    }
+
+    @Suppress("MagicNumber")
+    private fun clickHouseDurationTimer(tags: Iterable<Tag>): Timer =
+        Timer.builder(CLICKHOUSE_REQUEST_DURATION)
+            .description("ClickHouse HTTP request duration by operation and result status.")
+            .serviceLevelObjectives(
+                Duration.ofMillis(5),
+                Duration.ofMillis(10),
+                Duration.ofMillis(25),
+                Duration.ofMillis(50),
+                Duration.ofMillis(100),
+                Duration.ofMillis(250),
+                Duration.ofMillis(500),
+                Duration.ofSeconds(1),
+                Duration.ofMillis(2500),
+                Duration.ofSeconds(5),
+                Duration.ofSeconds(10),
+                Duration.ofSeconds(30),
+                Duration.ofSeconds(60)
+            )
+            .tags(tags)
+            .register(registry)
+
+    @Suppress("MagicNumber")
+    private fun dependencyHealthCheckTimer(tags: Iterable<Tag>): Timer =
+        Timer.builder(DEPENDENCY_HEALTH_CHECK_DURATION)
+            .description("Dependency health check duration by dependency and result status.")
+            .serviceLevelObjectives(
+                Duration.ofMillis(5),
+                Duration.ofMillis(10),
+                Duration.ofMillis(25),
+                Duration.ofMillis(50),
+                Duration.ofMillis(100),
+                Duration.ofMillis(250),
+                Duration.ofMillis(500),
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(2),
+                Duration.ofSeconds(5)
+            )
+            .tags(tags)
+            .register(registry)
+
+    @Suppress("MagicNumber")
+    private fun backgroundJobDurationTimer(tags: Iterable<Tag>): Timer =
+        Timer.builder(BACKGROUND_JOB_DURATION)
+            .description("Background job run duration by job and result status.")
+            .serviceLevelObjectives(
+                Duration.ofMillis(10),
+                Duration.ofMillis(50),
+                Duration.ofMillis(100),
+                Duration.ofMillis(250),
+                Duration.ofMillis(500),
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(2),
+                Duration.ofSeconds(5),
+                Duration.ofSeconds(10),
+                Duration.ofSeconds(30),
+                Duration.ofSeconds(60)
+            )
+            .tags(tags)
+            .register(registry)
+
+    private fun readQueueDepth(queueKey: String): Double {
+        if (!RedisConfig.isConnected()) return Double.NaN
+        return runCatching { RedisConfig.sync().llen(queueKey).toDouble() }
+            .getOrElse { Double.NaN }
+    }
+
+    private fun tags(vararg pairs: Pair<String, String>): Iterable<Tag> =
+        pairs.map { (key, value) -> Tag.of(key.micrometerTagName(), value.normalizedLabelValue()) }
+
+    private fun String.micrometerTagName(): String =
+        replace(Regex("[^a-zA-Z0-9_]"), "_")
+            .let { normalized ->
+                if (normalized.firstOrNull()?.isDigit() == true) "_$normalized" else normalized
+            }
+
+    private fun String.normalizedLabelValue(): String = trim().ifBlank { "unknown" }
+
+    private fun Throwable.metricExceptionName(): String =
+        this::class.simpleName ?: javaClass.simpleName.ifBlank { "Throwable" }
+
+    private fun Throwable.isTimeoutLike(): Boolean =
+        this is HttpRequestTimeoutException ||
+            this is java.net.SocketTimeoutException ||
+            message?.contains("timeout", ignoreCase = true) == true ||
+            cause?.isTimeoutLike() == true
+
+    private fun Double.toNanos(): Long {
+        val sanitized = if (isFinite()) coerceAtLeast(0.0) else 0.0
+        return (sanitized * NANOS_PER_SECOND).toLong()
+    }
+
+    private fun currentEpochSeconds(): Long = System.currentTimeMillis() / MILLIS_PER_SECOND
+
+    private fun newRegistry(): PrometheusMeterRegistry =
+        PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also { registry ->
+            registry.config().commonTags("application", APPLICATION_TAG_VALUE)
+        }
+
+    private const val APPLICATION_TAG_VALUE = "moneat-backend"
+    private const val WORKER_MESSAGES_PROCESSED = "moneat_worker_messages_processed"
+    private const val WORKER_LAST_SUCCESS_TIMESTAMP_SECONDS = "moneat_worker_last_success_timestamp_seconds"
+    private const val WORKER_PROCESSING_FAILURES = "moneat_worker_processing_failures"
+    private const val WORKER_BRPOP_FAILURES = "moneat_worker_brpop_failures"
+    private const val WORKER_DLQ_PUSHES = "moneat_worker_dlq_pushes"
+    private const val WORKER_DLQ_DEPTH = "moneat_worker_dlq_depth"
+    private const val WORKER_QUEUE_DEPTH = "moneat_worker_queue_depth"
+    private const val CLICKHOUSE_REQUESTS = "moneat_clickhouse_requests"
+    private const val CLICKHOUSE_REQUEST_TIMEOUTS = "moneat_clickhouse_request_timeouts"
+    private const val CLICKHOUSE_REQUEST_DURATION = "moneat_clickhouse_request_duration"
+    private const val DEPENDENCY_HEALTH = "moneat_dependency_health"
+    private const val DEPENDENCY_LAST_SUCCESS_TIMESTAMP_SECONDS = "moneat_dependency_last_success_timestamp_seconds"
+    private const val DEPENDENCY_HEALTH_CHECKS = "moneat_dependency_health_checks"
+    private const val DEPENDENCY_HEALTH_CHECK_DURATION = "moneat_dependency_health_check_duration"
+    private const val BACKGROUND_JOB_RUNS = "moneat_background_job_runs"
+    private const val BACKGROUND_JOB_DURATION = "moneat_background_job_duration"
+    private const val BACKGROUND_JOB_LAST_SUCCESS_TIMESTAMP_SECONDS =
+        "moneat_background_job_last_success_timestamp_seconds"
+    private const val DATASOURCE_QUERY_FAILURES = "moneat_datasource_query_failures"
+    private const val NANOS_PER_SECOND = 1_000_000_000
+    private const val MILLIS_PER_SECOND = 1_000
+    private const val HEALTHY_VALUE = 1L
+    private const val UNHEALTHY_VALUE = 0L
+}

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -246,6 +246,17 @@ object OperationalMetrics {
         ).record(durationSeconds.toNanos(), TimeUnit.NANOSECONDS)
     }
 
+    suspend fun recordTimedBackgroundJobRun(jobName: String, block: suspend () -> Unit) {
+        val startedAt = System.nanoTime()
+        try {
+            block()
+            recordBackgroundJobRun(jobName, success = true, elapsedSecondsSince(startedAt))
+        } catch (cause: Throwable) {
+            recordBackgroundJobRun(jobName, success = false, elapsedSecondsSince(startedAt), cause)
+            throw cause
+        }
+    }
+
     fun recordDatasourceQueryFailure(
         sourceType: String,
         operation: String,
@@ -448,6 +459,9 @@ object OperationalMetrics {
             this is java.net.SocketTimeoutException ||
             message?.contains("timeout", ignoreCase = true) == true ||
             cause?.isTimeoutLike() == true
+
+    private fun elapsedSecondsSince(startedAt: Long): Double =
+        (System.nanoTime() - startedAt).toDouble() / NANOS_PER_SECOND
 
     private fun Double.toNanos(): Long {
         val sanitized = if (isFinite()) coerceAtLeast(0.0) else 0.0

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpIngestionWorkerBase.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpIngestionWorkerBase.kt
@@ -18,6 +18,8 @@ package com.moneat.otlp.services
 
 import com.moneat.config.BRPOP_TIMEOUT_SECONDS
 import com.moneat.config.RedisConfig
+import com.moneat.monitoring.OperationalMetrics
+import com.moneat.utils.suspendRunCatching
 import io.lettuce.core.RedisException
 import io.lettuce.core.api.StatefulRedisConnection
 import kotlinx.coroutines.CancellationException
@@ -34,7 +36,6 @@ import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
 import java.io.IOException
 import java.sql.SQLException
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 private const val ERROR_RETRY_DELAY_MS = 1000L
@@ -57,6 +58,7 @@ abstract class OtlpIngestionWorkerBase(
         logger.info {
             "Starting $workerName with $workerCount workers, queue=$queueKey"
         }
+        OperationalMetrics.registerWorkerQueues("OTLP $workerLabel", queueKey, dlqKey)
         jobs = (1..workerCount).map { workerId ->
             scope.launch { runWorker(workerId) }
         }
@@ -125,6 +127,7 @@ abstract class OtlpIngestionWorkerBase(
     private suspend fun processBrpopPayload(workerId: Int, payload: String) {
         try {
             processMessage(workerId, payload)
+            OperationalMetrics.recordWorkerMessageProcessed("OTLP $workerLabel", workerId)
         } catch (proc: CancellationException) {
             throw proc
         } catch (proc: SerializationException) {
@@ -149,6 +152,7 @@ abstract class OtlpIngestionWorkerBase(
         logger.error(proc) {
             "OTLP $workerLabel worker $workerId failed processing message"
         }
+        OperationalMetrics.recordWorkerProcessingFailure("OTLP $workerLabel", workerId, proc)
         delay(ERROR_RETRY_DELAY_MS)
     }
 
@@ -159,6 +163,7 @@ abstract class OtlpIngestionWorkerBase(
         resetConnection: (StatefulRedisConnection<String, String>) -> Unit,
     ) {
         logger.error(e) { "OTLP $workerLabel worker $workerId error in BRPOP loop" }
+        OperationalMetrics.recordWorkerBrpopFailure("OTLP $workerLabel", workerId, e)
         connection?.let(resetConnection)
         delay(ERROR_RETRY_DELAY_MS)
     }
@@ -176,7 +181,9 @@ abstract class OtlpIngestionWorkerBase(
     protected fun pushToDlq(workerId: Int, payload: String) {
         try {
             RedisConfig.sync().rpush(dlqKey, payload)
+            OperationalMetrics.recordDlqPush("OTLP $workerLabel", dlqKey, "success")
         } catch (dlqErr: RedisException) {
+            OperationalMetrics.recordDlqPush("OTLP $workerLabel", dlqKey, "failure")
             logger.error(dlqErr) { "Failed to push to DLQ $dlqKey for worker=$workerId" }
         }
     }

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsIngestionWorker.kt
@@ -16,8 +16,9 @@
 
 package com.moneat.otlp.services
 
-import mu.KotlinLogging
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
@@ -54,6 +55,7 @@ class OtlpMetricsIngestionWorker(
         logger.error(e) {
             "OTLP metrics worker $workerId failed to process batch, sending to DLQ"
         }
+        OperationalMetrics.recordWorkerProcessingFailure("OTLP metrics", workerId, e)
         pushToDlq(workerId, payload)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceIngestionWorker.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.otlp.services
 
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.suspendRunCatching
 import mu.KotlinLogging
 
@@ -73,6 +74,7 @@ class OtlpTraceIngestionWorker(
         logger.error(e) {
             "OTLP trace worker $workerId failed to decode batch, sending to DLQ"
         }
+        OperationalMetrics.recordWorkerProcessingFailure("OTLP trace", workerId, e)
         pushToDlq(workerId, payload)
     }
 
@@ -84,6 +86,7 @@ class OtlpTraceIngestionWorker(
         logger.error(e) {
             "OTLP trace worker $workerId failed to insert batch, sending to DLQ"
         }
+        OperationalMetrics.recordWorkerProcessingFailure("OTLP trace", workerId, e)
         pushToDlq(workerId, payload)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
@@ -20,14 +20,18 @@ import kotlinx.serialization.SerializationException
 import java.io.IOException
 
 import com.moneat.config.SentryConfig
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.ErrorResponse
+import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MAX
+import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MIN
 import com.moneat.utils.SentryUtils
-import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.call
 import io.ktor.server.application.install
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.metrics.micrometer.MicrometerMetrics
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.statuspages.StatusPages
@@ -41,8 +45,6 @@ import io.sentry.Sentry
 import io.sentry.SpanStatus
 import mu.KotlinLogging
 import org.slf4j.event.Level
-import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MAX
-import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MIN
 
 private val logger = KotlinLogging.logger {}
 
@@ -56,6 +58,11 @@ private const val HTTP_SERVER_ERROR_MIN = 500
 private const val HTTP_SERVER_ERROR_MAX = 599
 
 fun Application.configureMonitoring() {
+    OperationalMetrics.bindSystemMetrics()
+    install(MicrometerMetrics) {
+        registry = OperationalMetrics.registry
+    }
+
     // Sentry transaction interceptor for non-ingestion, non-health requests
     intercept(ApplicationCallPipeline.Setup) {
         if (SentryConfig.isEnabled()) {
@@ -200,6 +207,9 @@ fun Application.configureMonitoring() {
 
 private fun shouldSkipTracing(path: String, method: String): Boolean {
     if (path == "/health" || path == "/health/" || path.startsWith("/health/")) {
+        return true
+    }
+    if (path == "/metrics" || path == "/metrics/") {
         return true
     }
     if (method == "POST") {

--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -37,6 +37,7 @@ import com.moneat.logs.routes.logRoutes
 import com.moneat.monitor.routes.infraRoutes
 import com.moneat.monitor.routes.monitorRoutes
 import com.moneat.mcp.McpModule
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.org.routes.adminRoutes
 import com.moneat.org.routes.orgManagementRoutes
 import com.moneat.otlp.routes.otlpMetricsRoutes
@@ -44,10 +45,13 @@ import com.moneat.otlp.routes.otlpTraceRoutes
 import com.moneat.statuspage.routes.statusPageRoutes
 import com.moneat.summary.routes.summaryRoutes
 import com.moneat.uptime.routes.uptimeRoutes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
+import io.ktor.server.request.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
@@ -73,33 +77,19 @@ data class FeaturesResponse(
 )
 
 private suspend fun respondWithFullHealth(call: io.ktor.server.application.ApplicationCall) {
-    val postgresStatus =
-        suspendRunCatching {
-            transaction {
-                exec("SELECT phone_number FROM users LIMIT 1")
-                exec("SELECT pending_meter_batch_id, pending_meter_batch_units FROM subscriptions LIMIT 1")
-            }
-            "ok"
-        }.getOrElse { _ ->
-            "error"
+    val postgresStatus = dependencyStatus("postgres") {
+        transaction {
+            exec("SELECT phone_number FROM users LIMIT 1")
+            exec("SELECT pending_meter_batch_id, pending_meter_batch_units FROM subscriptions LIMIT 1")
         }
-    val clickhouseStatus =
-        suspendRunCatching {
-            if (ClickHouseClient.ping()) "ok" else "error"
-        }.getOrElse { _ ->
-            "error"
-        }
-    val redisStatus =
-        suspendRunCatching {
-            if (RedisConfig.isConnected()) {
-                RedisConfig.sync().ping()
-                "ok"
-            } else {
-                "error"
-            }
-        }.getOrElse { _ ->
-            "error"
-        }
+        true
+    }
+    val clickhouseStatus = dependencyStatus("clickhouse") {
+        ClickHouseClient.ping()
+    }
+    val redisStatus = dependencyStatus("redis") {
+        RedisConfig.isConnected() && RedisConfig.sync().ping().equals("PONG", ignoreCase = true)
+    }
     val ingestQueueDepth =
         suspendRunCatching {
             if (RedisConfig.isConnected()) {
@@ -107,6 +97,7 @@ private suspend fun respondWithFullHealth(call: io.ktor.server.application.Appli
                     call.application.environment.config
                         .property("ingest.queueKey")
                         .getString()
+                OperationalMetrics.registerQueue("Event", queueKey, "primary")
                 RedisConfig.sync().llen(queueKey)
             } else {
                 0L
@@ -123,7 +114,29 @@ private suspend fun respondWithFullHealth(call: io.ktor.server.application.Appli
     }
 }
 
+private suspend fun dependencyStatus(
+    dependency: String,
+    check: suspend () -> Boolean,
+): String {
+    val startedAt = System.nanoTime()
+    val result = suspendRunCatching { check() }
+    val durationSeconds = (System.nanoTime() - startedAt).toDouble() / NANOS_PER_SECOND
+    return result.fold(
+        onSuccess = { healthy ->
+            OperationalMetrics.recordDependencyHealth(dependency, healthy, durationSeconds)
+            if (healthy) "ok" else "error"
+        },
+        onFailure = { cause ->
+            OperationalMetrics.recordDependencyHealth(dependency, healthy = false, durationSeconds, cause)
+            "error"
+        }
+    )
+}
+
 private val routingLogger = mu.KotlinLogging.logger("Routing")
+private const val METRICS_CONTENT_TYPE = "text/plain; version=0.0.4"
+private const val METRICS_SCRAPE_TOKEN = "metrics.scrapeToken"
+private const val NANOS_PER_SECOND = 1_000_000_000.0
 
 fun Application.configureRouting() {
     routing {
@@ -166,6 +179,14 @@ fun Application.configureRouting() {
         // Legacy health endpoint (backward compatible)
         get("/health") {
             respondWithFullHealth(call)
+        }
+
+        get("/metrics") {
+            respondWithOperationalMetrics(call)
+        }
+
+        get("/metrics/") {
+            respondWithOperationalMetrics(call)
         }
 
         routingLogger.info { "Registering ingestion routes..." }
@@ -252,4 +273,20 @@ fun Application.configureRouting() {
 
         routingLogger.info { "All routes registered successfully" }
     }
+}
+
+private suspend fun respondWithOperationalMetrics(call: io.ktor.server.application.ApplicationCall) {
+    val scrapeToken = call.application.environment.config.propertyOrNull(METRICS_SCRAPE_TOKEN)?.getString()
+    if (!scrapeToken.isNullOrBlank()) {
+        val authorization = call.request.header(HttpHeaders.Authorization)
+        if (authorization != "Bearer $scrapeToken") {
+            call.respondText("Unauthorized", status = HttpStatusCode.Unauthorized)
+            return
+        }
+    }
+
+    call.respondText(
+        OperationalMetrics.scrape(),
+        ContentType.parse(METRICS_CONTENT_TYPE)
+    )
 }

--- a/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
+++ b/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
@@ -17,6 +17,7 @@
 package com.moneat.utils
 
 import com.moneat.config.RedisConfig
+import com.moneat.monitoring.OperationalMetrics
 import kotlinx.coroutines.delay
 import mu.KLogger
 
@@ -32,6 +33,7 @@ suspend fun brpopLoopBackoff(
     e: Throwable,
 ) {
     logger.error(e) { "$scopeLabel worker $workerId error in BRPOP loop" }
+    OperationalMetrics.recordWorkerBrpopFailure(scopeLabel, workerId, e)
     delay(errorDelayMs)
 }
 
@@ -51,9 +53,13 @@ fun pushToDlq(
     logger.error(cause) {
         "$workerName worker $workerId failed, pushing to DLQ"
     }
+    OperationalMetrics.recordWorkerProcessingFailure(workerName, workerId, cause)
     runCatching {
         RedisConfig.sync().rpush(dlqKey, payload)
+    }.onSuccess {
+        OperationalMetrics.recordDlqPush(workerName, dlqKey, "success")
     }.onFailure { dlqErr ->
+        OperationalMetrics.recordDlqPush(workerName, dlqKey, "failure")
         logger.error(dlqErr) {
             "Failed to write to DLQ for worker $workerId, dlqKey=$dlqKey"
         }

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -33,6 +33,10 @@ redis {
     url = ${?REDIS_URL}
 }
 
+metrics {
+    scrapeToken = ${?METRICS_SCRAPE_TOKEN}
+}
+
 jwt {
     secret = ${?JWT_SECRET}
     issuer = "moneat"

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardHandlersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardHandlersTest.kt
@@ -29,6 +29,7 @@ import com.moneat.dashboards.services.handlers.MySQLHandler
 import com.moneat.dashboards.services.handlers.PostgresHandler
 import com.moneat.dashboards.services.handlers.PrometheusHandler
 import com.moneat.dashboards.services.handlers.UnsupportedHandler
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.testsupport.MockHttpServer
 import com.moneat.testsupport.respond
 import kotlinx.coroutines.runBlocking
@@ -36,6 +37,8 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -93,6 +96,16 @@ class DashboardHandlersTest {
     private val prometheusHandler = PrometheusHandler()
     private val postgresHandler = PostgresHandler(ConcurrentHashMap())
     private val mysqlHandler = MySQLHandler(ConcurrentHashMap())
+
+    @BeforeTest
+    fun resetMetricsBefore() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @AfterTest
+    fun resetMetricsAfter() {
+        OperationalMetrics.resetForTest()
+    }
 
     // ──── UnsupportedHandler ────
 
@@ -407,6 +420,28 @@ class DashboardHandlersTest {
                         null
                     )
                     assertTrue(rows.isEmpty())
+                    assertPrometheusFailureMetric("query", "http_500")
+                }
+            }
+        }
+
+    @Test
+    fun `Prometheus testConnection records server failures`() =
+        withSelfHosted {
+            runBlocking {
+                MockHttpServer { ex ->
+                    ex.respond(503, "unavailable")
+                }.use { server ->
+                    val port = extractPort(server.baseUrl)
+                    val result = PrometheusHandler().testConnection(
+                        TestConnectionRequest(
+                            sourceType = "prometheus",
+                            host = DEFAULT_HOST,
+                            port = port
+                        )
+                    )
+                    assertFalse(result.success)
+                    assertPrometheusFailureMetric("test_connection", "http_503")
                 }
             }
         }
@@ -430,6 +465,26 @@ class DashboardHandlersTest {
                     assertEquals(2, fields.size)
                     assertEquals("cpu", fields[0].name)
                     assertEquals("gauge", fields[0].type)
+                }
+            }
+        }
+
+    @Test
+    fun `Prometheus getSchema records server failures`() =
+        withSelfHosted {
+            runBlocking {
+                MockHttpServer { ex ->
+                    ex.respond(502, "bad gateway")
+                }.use { server ->
+                    val port = extractPort(server.baseUrl)
+                    val fields = PrometheusHandler().getSchema(
+                        DEFAULT_HOST,
+                        port,
+                        null,
+                        DataSourceCredentials()
+                    )
+                    assertTrue(fields.isEmpty())
+                    assertPrometheusFailureMetric("schema", "http_502")
                 }
             }
         }
@@ -479,6 +534,27 @@ class DashboardHandlersTest {
         }
 
     @Test
+    fun `Prometheus executeLabelValuesQuery records server failures`() =
+        withSelfHosted {
+            runBlocking {
+                MockHttpServer { ex ->
+                    ex.respond(422, "bad query")
+                }.use { server ->
+                    val port = extractPort(server.baseUrl)
+                    val vals =
+                        PrometheusHandler().executeLabelValuesQuery(
+                            DEFAULT_HOST,
+                            port,
+                            DataSourceCredentials(),
+                            "label_values(up, instance)"
+                        )
+                    assertTrue(vals.isEmpty())
+                    assertPrometheusFailureMetric("label_values", "http_422")
+                }
+            }
+        }
+
+    @Test
     fun `Prometheus executeLabelValuesQuery invalid returns empty`() =
         runBlocking {
             val vals = prometheusHandler.executeLabelValuesQuery(
@@ -489,6 +565,14 @@ class DashboardHandlersTest {
             )
             assertTrue(vals.isEmpty())
         }
+
+    private fun assertPrometheusFailureMetric(operation: String, failure: String) {
+        val rendered = OperationalMetrics.scrape()
+        assertContains(rendered, "moneat_datasource_query_failures_total")
+        assertContains(rendered, "source_type=\"prometheus\"")
+        assertContains(rendered, "operation=\"$operation\"")
+        assertContains(rendered, "failure=\"$failure\"")
+    }
 
     // ──── ElasticsearchHandler ────
 

--- a/backend/src/test/kotlin/com/moneat/datadog/DatadogModuleMetricsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/DatadogModuleMetricsTest.kt
@@ -1,0 +1,53 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog
+
+import com.moneat.monitoring.OperationalMetrics
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+class DatadogModuleMetricsTest {
+    @BeforeTest
+    fun resetBefore() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @AfterTest
+    fun resetAfter() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @Test
+    fun `registerQueueMetrics registers datadog queue gauges`() {
+        val method = DatadogModule::class.java.getDeclaredMethod("registerQueueMetrics")
+        method.isAccessible = true
+
+        method.invoke(DatadogModule())
+
+        val rendered = OperationalMetrics.scrape()
+        assertContains(rendered, "moneat_worker_queue_depth")
+        assertContains(rendered, "worker=\"Trace\"")
+        assertContains(rendered, "worker=\"DD metric\"")
+        assertContains(rendered, "worker=\"DD event\"")
+        assertContains(rendered, "worker=\"DD infra\"")
+        assertContains(rendered, "worker=\"Security\"")
+        assertContains(rendered, "queue_type=\"primary\"")
+        assertContains(rendered, "queue_type=\"dlq\"")
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -1,0 +1,151 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.monitoring
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+class OperationalMetricsTest {
+    @BeforeTest
+    fun resetBefore() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @AfterTest
+    fun resetAfter() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @Test
+    fun `renders worker counters in prometheus format`() {
+        OperationalMetrics.recordWorkerProcessingFailure("DD metric", 1, IllegalStateException("boom"))
+        OperationalMetrics.recordWorkerMessageProcessed("DD metric", 1)
+        OperationalMetrics.recordDlqPush("DD metric", "moneat:metrics:dlq", "success")
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "# TYPE moneat_worker_processing_failures_total counter")
+        assertContains(rendered, "moneat_worker_processing_failures_total")
+        assertContains(rendered, "moneat_worker_dlq_pushes_total")
+        assertContains(rendered, "moneat_worker_messages_processed_total")
+        assertContains(rendered, "exception=\"IllegalStateException\"")
+        assertContains(rendered, "worker=\"DD metric\"")
+        assertContains(rendered, "worker_id=\"1\"")
+        assertContains(rendered, "dlq_key=\"moneat:metrics:dlq\"")
+        assertContains(rendered, "status=\"success\"")
+        assertContains(rendered, "moneat_worker_last_success_timestamp_seconds")
+        assertHasApplicationTag(rendered)
+    }
+
+    @Test
+    fun `renders clickhouse request counters and histogram`() {
+        OperationalMetrics.recordClickHouseRequest("execute", "success", 0.02)
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "moneat_clickhouse_requests_total")
+        assertContains(rendered, "operation=\"execute\"")
+        assertContains(rendered, "status=\"success\"")
+        assertContains(rendered, "moneat_clickhouse_request_duration_seconds_bucket")
+        assertContains(rendered, "le=\"0.025\"")
+        assertContains(rendered, "moneat_clickhouse_request_duration_seconds_count")
+        assertHasApplicationTag(rendered)
+    }
+
+    @Test
+    fun `renders datasource failure counters`() {
+        OperationalMetrics.recordDatasourceQueryFailure("prometheus", "query", "http_422")
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "moneat_datasource_query_failures_total")
+        assertContains(rendered, "failure=\"http_422\"")
+        assertContains(rendered, "operation=\"query\"")
+        assertContains(rendered, "source_type=\"prometheus\"")
+        assertHasApplicationTag(rendered)
+    }
+
+    @Test
+    fun `renders dependency health metrics`() {
+        OperationalMetrics.recordDependencyHealth("postgres", healthy = true, durationSeconds = 0.01)
+        OperationalMetrics.recordDependencyHealth(
+            "redis",
+            healthy = false,
+            durationSeconds = 0.02,
+            cause = IllegalStateException("down")
+        )
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "moneat_dependency_health")
+        assertContains(rendered, "dependency=\"postgres\"")
+        assertContains(rendered, "dependency=\"redis\"")
+        assertContains(rendered, "moneat_dependency_health_checks_total")
+        assertContains(rendered, "exception=\"IllegalStateException\"")
+        assertContains(rendered, "status=\"failure\"")
+        assertContains(rendered, "moneat_dependency_health_check_duration_seconds_bucket")
+        assertContains(rendered, "moneat_dependency_last_success_timestamp_seconds")
+        assertHasApplicationTag(rendered)
+    }
+
+    @Test
+    fun `renders registered queue depth gauges`() {
+        OperationalMetrics.registerWorkerQueues("Event", "moneat:events:queue", "moneat:events:dlq")
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "moneat_worker_queue_depth")
+        assertContains(rendered, "queue_key=\"moneat:events:queue\"")
+        assertContains(rendered, "queue_type=\"primary\"")
+        assertContains(rendered, "queue_key=\"moneat:events:dlq\"")
+        assertContains(rendered, "queue_type=\"dlq\"")
+        assertContains(rendered, "worker=\"Event\"")
+        assertContains(rendered, "moneat_worker_dlq_depth")
+        assertContains(rendered, "dlq_key=\"moneat:events:dlq\"")
+        assertHasApplicationTag(rendered)
+    }
+
+    @Test
+    fun `renders background job metrics`() {
+        OperationalMetrics.recordBackgroundJobRun("billing-metered-flush", success = true, durationSeconds = 0.05)
+        OperationalMetrics.recordBackgroundJobRun(
+            "billing-quota-notifications",
+            success = false,
+            durationSeconds = 0.1,
+            cause = IllegalStateException("boom")
+        )
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "moneat_background_job_runs_total")
+        assertContains(rendered, "exception=\"none\"")
+        assertContains(rendered, "job=\"billing-metered-flush\"")
+        assertContains(rendered, "status=\"success\"")
+        assertContains(rendered, "exception=\"IllegalStateException\"")
+        assertContains(rendered, "job=\"billing-quota-notifications\"")
+        assertContains(rendered, "status=\"failure\"")
+        assertContains(rendered, "moneat_background_job_duration_seconds_bucket")
+        assertContains(rendered, "moneat_background_job_last_success_timestamp_seconds")
+        assertHasApplicationTag(rendered)
+    }
+
+    private fun assertHasApplicationTag(rendered: String) {
+        assertContains(rendered, "application=\"moneat-backend\"")
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -16,10 +16,12 @@
 
 package com.moneat.monitoring
 
+import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
 
 class OperationalMetricsTest {
     @BeforeTest
@@ -141,6 +143,28 @@ class OperationalMetricsTest {
         assertContains(rendered, "job=\"billing-quota-notifications\"")
         assertContains(rendered, "status=\"failure\"")
         assertContains(rendered, "moneat_background_job_duration_seconds_bucket")
+        assertContains(rendered, "moneat_background_job_last_success_timestamp_seconds")
+        assertHasApplicationTag(rendered)
+    }
+
+    @Test
+    fun `records timed background job success and failure`() = runBlocking {
+        OperationalMetrics.recordTimedBackgroundJobRun("timed-success") {
+            // Intentionally empty.
+        }
+
+        assertFailsWith<IllegalStateException> {
+            OperationalMetrics.recordTimedBackgroundJobRun("timed-failure") {
+                error("boom")
+            }
+        }
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "job=\"timed-success\"")
+        assertContains(rendered, "job=\"timed-failure\"")
+        assertContains(rendered, "exception=\"IllegalStateException\"")
+        assertContains(rendered, "moneat_background_job_duration_seconds_count")
         assertContains(rendered, "moneat_background_job_last_success_timestamp_seconds")
         assertHasApplicationTag(rendered)
     }

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpIngestionWorkerBaseTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpIngestionWorkerBaseTest.kt
@@ -16,8 +16,17 @@
 
 package com.moneat.otlp.services
 
+import com.moneat.monitoring.OperationalMetrics
+import io.lettuce.core.api.StatefulRedisConnection
 import kotlinx.coroutines.runBlocking
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.jvm.isAccessible
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class OtlpIngestionWorkerBaseTest {
@@ -45,6 +54,31 @@ class OtlpIngestionWorkerBaseTest {
         ) {
             processMessage(workerId, payload)
         }
+    }
+
+    private class FailingOtlpIngestionWorker : OtlpIngestionWorkerBase(
+        "test:otlp:failing:queue",
+        "test:otlp:failing:dlq",
+        1,
+        "FailingOtlpIngestionWorker",
+        "failing",
+    ) {
+        override suspend fun processMessage(
+            workerId: Int,
+            payload: String,
+        ) {
+            error("boom")
+        }
+    }
+
+    @BeforeTest
+    fun resetMetricsBefore() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @AfterTest
+    fun resetMetricsAfter() {
+        OperationalMetrics.resetForTest()
     }
 
     @Test
@@ -95,5 +129,66 @@ class OtlpIngestionWorkerBaseTest {
         runBlocking {
             worker.stop()
         }
+    }
+
+    @Test
+    fun `base payload processing records success and failure metrics`() {
+        val successWorker =
+            NoOpOtlpIngestionWorker(
+                "test:otlp:noop:queue",
+                "test:otlp:noop:dlq",
+                1,
+            )
+        val failingWorker = FailingOtlpIngestionWorker()
+
+        runBlocking {
+            processBrpopPayloadFunction.callSuspend(successWorker, 1, "{}")
+            processBrpopPayloadFunction.callSuspend(failingWorker, 2, "{}")
+        }
+
+        val rendered = OperationalMetrics.scrape()
+        assertContains(rendered, "moneat_worker_messages_processed_total")
+        assertContains(rendered, "worker=\"OTLP noop\"")
+        assertContains(rendered, "worker_id=\"1\"")
+        assertContains(rendered, "moneat_worker_processing_failures_total")
+        assertContains(rendered, "worker=\"OTLP failing\"")
+        assertContains(rendered, "worker_id=\"2\"")
+        assertContains(rendered, "exception=\"IllegalStateException\"")
+    }
+
+    @Test
+    fun `base brpop loop failure records metrics`() {
+        val worker =
+            NoOpOtlpIngestionWorker(
+                "test:otlp:noop:queue",
+                "test:otlp:noop:dlq",
+                1,
+            )
+
+        runBlocking {
+            onOtlpBrpopLoopFailureFunction.callSuspend(
+                worker,
+                3,
+                IllegalStateException("redis down"),
+                null,
+                { _: StatefulRedisConnection<String, String> -> },
+            )
+        }
+
+        val rendered = OperationalMetrics.scrape()
+        assertContains(rendered, "moneat_worker_brpop_failures_total")
+        assertContains(rendered, "worker=\"OTLP noop\"")
+        assertContains(rendered, "worker_id=\"3\"")
+        assertContains(rendered, "exception=\"IllegalStateException\"")
+    }
+
+    private companion object {
+        private val processBrpopPayloadFunction = privateBaseFunction("processBrpopPayload")
+        private val onOtlpBrpopLoopFailureFunction = privateBaseFunction("onOtlpBrpopLoopFailure")
+
+        private fun privateBaseFunction(name: String): KFunction<*> =
+            OtlpIngestionWorkerBase::class.declaredFunctions
+                .single { it.name == name }
+                .also { it.isAccessible = true }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/LogIngestionWorkerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogIngestionWorkerTest.kt
@@ -21,11 +21,26 @@ import com.moneat.logs.models.QueuedLogEntry
 import com.moneat.logs.repositories.LogRepositoryImpl
 import com.moneat.logs.services.LogIngestionWorker
 import com.moneat.logs.services.LogService
+import com.moneat.monitoring.OperationalMetrics
 import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class LogIngestionWorkerTest {
+    @BeforeTest
+    fun resetMetricsBefore() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @AfterTest
+    fun resetMetricsAfter() {
+        OperationalMetrics.resetForTest()
+    }
+
     @Test
     fun `processMessageForTest sends malformed payload to DLQ`() =
         runBlocking {
@@ -73,5 +88,24 @@ class LogIngestionWorkerTest {
             worker.processMessageForTest(workerId = 2, payload = message) { dlq.add(it) }
 
             assertEquals(listOf(message), dlq)
+        }
+
+    @Test
+    fun `processMessageForTest records DLQ failure when callback throws`() =
+        runBlocking {
+            val worker = LogIngestionWorker("log:q", "log:dlq", 1)
+            val malformed = "not-json"
+
+            assertFailsWith<IllegalStateException> {
+                worker.processMessageForTest(workerId = 3, payload = malformed) {
+                    error("dlq down")
+                }
+            }
+
+            val rendered = OperationalMetrics.scrape()
+            assertContains(rendered, "moneat_worker_dlq_pushes_total")
+            assertContains(rendered, "worker=\"Log\"")
+            assertContains(rendered, "dlq_key=\"log:dlq\"")
+            assertContains(rendered, "status=\"failure\"")
         }
 }


### PR DESCRIPTION
## Summary
- add Micrometer Prometheus metrics at `/metrics` with optional scrape token auth
- add runtime, dependency, worker, queue, ClickHouse, datasource, and billing job metrics
- scope emitted metrics with `application="moneat-backend"` for Moneat-only dashboard and alert queries

## Verification
- `./gradlew compileKotlin`
- `./gradlew detekt`
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.monitoring.OperationalMetricsTest -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend operational metrics (Prometheus) with a /metrics scraping endpoint and broad instrumentation across ingestion workers, background jobs, DB and queue operations.

* **Configuration**
  * New METRICS_SCRAPE_TOKEN env var to optionally protect the metrics endpoint; metrics config added.

* **Tests**
  * Added/updated tests to validate metrics rendering and instrumentation across components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->