### PR TITLE
fix: improve dashboard queue legend rendering

### DIFF
--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {memo, type ReactNode, useEffect, useId, useMemo, useRef, useState} from 'react'
+import {memo, type CSSProperties, type ReactNode, useEffect, useId, useMemo, useRef, useState} from 'react'
 import {useQuery} from '@tanstack/react-query'
 import type {DashboardWidget, TimeRangeDef} from '@/lib/api'
 import {api} from '@/lib/api'
@@ -42,6 +42,7 @@ import {HeatmapWidget} from './HeatmapWidget'
 import ReactMarkdown from 'react-markdown'
 import type {ValueMapping} from './formatValue'
 import {formatValue} from './formatValue'
+import {pivotData, valueKeySeries} from './widgetSeries'
 
 const COLORS = [
   'hsl(var(--chart-1))',
@@ -283,14 +284,29 @@ function formatTooltipLabel(v?: string | number) {
   return `${month}/${day} ${hours}:${mins}`
 }
 
-function formatTooltipValue(value?: number | string) {
+type TooltipValue = number | string | readonly (number | string)[] | undefined
+type TooltipFormatterFn = (value: TooltipValue, name?: number | string) => ReactNode
+
+function formatTooltipValue(value?: TooltipValue): string {
   if (value === undefined) return ''
-  if (typeof value !== 'number') return value
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value.map((item) => formatTooltipValue(item)).join(' - ')
   if (Number.isInteger(value)) return value.toLocaleString()
   return value.toLocaleString(undefined, {maximumFractionDigits: 2})
 }
 
 type DisplayConfig = Record<string, string>
+
+interface LegendPayloadItem {
+  color?: string
+  inactive?: boolean
+  value?: string | number
+}
+
+interface ChartLegendProps {
+  payload?: LegendPayloadItem[]
+  placement?: 'bottom' | 'right'
+}
 
 const GRAFANA_COLORS: Record<string, string> = {
   green: '#73BF69', 'semi-dark-green': '#56A64B', 'dark-green': '#37872D', 'light-green': '#96D98D', 'super-light-green': '#C8F2C2',
@@ -368,14 +384,61 @@ function getLegendProps(dc: DisplayConfig) {
   const mode = dc.legendMode || 'list'
   if (mode === 'hidden') return null
   const placement = dc.legendPlacement || 'bottom'
+  const isRight = placement === 'right'
+  const wrapperStyle: CSSProperties = {
+    fontSize: '10px',
+    maxHeight: isRight ? '100%' : '56px',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    paddingLeft: isRight ? '8px' : undefined,
+    paddingTop: isRight ? undefined : '4px',
+  }
   return {
-    wrapperStyle: {fontSize: '10px', paddingTop: '4px'},
+    wrapperStyle,
+    content: <ChartLegend placement={isRight ? 'right' : 'bottom'} />,
+    height: isRight ? undefined : 56,
     iconType: 'line' as const,
     iconSize: 8,
-    layout: (placement === 'right' ? 'vertical' : 'horizontal') as 'vertical' | 'horizontal',
-    verticalAlign: (placement === 'right' ? 'middle' : 'bottom') as 'top' | 'middle' | 'bottom',
-    align: (placement === 'right' ? 'right' : 'center') as 'left' | 'center' | 'right',
+    layout: (isRight ? 'vertical' : 'horizontal') as 'vertical' | 'horizontal',
+    verticalAlign: (isRight ? 'middle' : 'bottom') as 'top' | 'middle' | 'bottom',
+    align: (isRight ? 'right' : 'center') as 'left' | 'center' | 'right',
+    width: isRight ? 180 : undefined,
   }
+}
+
+function ChartLegend({payload, placement = 'bottom'}: ChartLegendProps) {
+  const items = payload ?? []
+  if (items.length === 0) return null
+
+  const isRight = placement === 'right'
+  const containerClass = isRight
+    ? 'flex h-full max-h-full flex-col gap-1 overflow-y-auto overflow-x-hidden pr-1'
+    : 'flex max-h-14 flex-wrap gap-x-3 gap-y-1 overflow-y-auto overflow-x-hidden px-1 pt-1'
+  const itemClass = isRight
+    ? 'flex min-w-0 max-w-44 items-center gap-1.5 text-[10px] leading-3 text-muted-foreground'
+    : 'flex min-w-0 max-w-56 items-center gap-1.5 text-[10px] leading-3 text-muted-foreground'
+
+  return (
+    <div className={containerClass}>
+      {items.map((item, index) => {
+        const label = String(item.value ?? '')
+        return (
+          <div
+            key={`${label}-${index}`}
+            className={itemClass}
+            style={item.inactive ? {opacity: 0.45} : undefined}
+            title={label}
+          >
+            <span
+              className="h-0.5 w-3 shrink-0 rounded-full"
+              style={{backgroundColor: item.color ?? 'currentColor'}}
+            />
+            <span className="min-w-0 truncate">{label}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
 }
 
 function getDotProp(showPoints: string | undefined) {
@@ -418,45 +481,6 @@ function classifyColumns(data: Record<string, unknown>[]) {
   return {timeKey, labelKeys, valueKeys}
 }
 
-/**
- * Pivots flat multi-series data into one-row-per-timestamp format for recharts.
- * Input:  [{time_bucket: 100, platform: "android", value: 5}, {time_bucket: 100, platform: "ios", value: 3}]
- * Output: [{time_bucket: 100, "android": 5, "ios": 3}]
- */
-function pivotData(data: Record<string, unknown>[], timeKey: string, labelKeys: string[], valueKeys: string[]) {
-  if (labelKeys.length === 0 || valueKeys.length === 0) {
-    return {pivoted: data, seriesKeys: valueKeys}
-  }
-
-  const grouped = new Map<string | number, Record<string, unknown>>()
-  const seriesSet = new Set<string>()
-
-  for (const row of data) {
-    const t = row[timeKey] as string | number
-    if (!grouped.has(t)) {
-      grouped.set(t, {[timeKey]: t})
-    }
-    const entry = grouped.get(t)!
-
-    const labelParts = labelKeys.map(k => String(row[k] ?? '')).filter(Boolean)
-    const seriesLabel = labelParts.join(', ') || 'value'
-
-    for (const vk of valueKeys) {
-      const key = valueKeys.length > 1 ? `${seriesLabel} (${vk})` : seriesLabel
-      entry[key] = row[vk]
-      seriesSet.add(key)
-    }
-  }
-
-  const pivoted = Array.from(grouped.values()).sort((a, b) => {
-    const ta = a[timeKey] as number
-    const tb = b[timeKey] as number
-    return ta - tb
-  })
-
-  return {pivoted, seriesKeys: Array.from(seriesSet)}
-}
-
 const CHART_MARGIN = {top: 5, right: 5, left: 20, bottom: 20}
 const TOOLTIP_STYLE = {
   backgroundColor: 'hsl(var(--popover))',
@@ -472,8 +496,8 @@ const TimeseriesChart = memo(function TimeseriesChart({data, timeRange, displayC
   const spanMs = getTimeSpanMs(timeRange)
 
   const hasLabels = labelKeys.length > 0 && valueKeys.length > 0
-  const {pivoted, seriesKeys} = useMemo(
-    () => hasLabels ? pivotData(data, xKey, labelKeys, valueKeys) : {pivoted: data, seriesKeys: valueKeys},
+  const {pivoted, series} = useMemo(
+    () => hasLabels ? pivotData(data, xKey, labelKeys, valueKeys) : {pivoted: data, series: valueKeySeries(valueKeys)},
     [data, xKey, labelKeys, valueKeys, hasLabels]
   )
 
@@ -506,8 +530,8 @@ const TimeseriesChart = memo(function TimeseriesChart({data, timeRange, displayC
   const tickFormatter = unit && unit !== 'none'
     ? (v: number) => formatValue(v, unit, decimals)
     : undefined
-  const tooltipFormatter = unit && unit !== 'none'
-    ? (v?: number | string) => (v !== undefined && typeof v === 'number' ? formatValue(v, unit, decimals) : (v ?? ''))
+  const tooltipFormatter: TooltipFormatterFn = unit && unit !== 'none'
+    ? (v) => (v !== undefined && typeof v === 'number' ? formatValue(v, unit, decimals) : formatTooltipValue(v))
     : formatTooltipValue
 
   const useArea = fillOpacity > 0 || stackMode !== 'none'
@@ -537,17 +561,18 @@ const TimeseriesChart = memo(function TimeseriesChart({data, timeRange, displayC
             contentStyle={TOOLTIP_STYLE}
             wrapperStyle={TOOLTIP_WRAPPER_STYLE}
             labelFormatter={(label) => formatTooltipLabel(label as string | number)}
-            formatter={tooltipFormatter as (value: string | number | undefined, name: string | undefined, props: unknown) => ReactNode}
+            formatter={tooltipFormatter}
           />
           {legendProps && <Legend {...legendProps} />}
           {thresholds.map((t, i) => (
             <ReferenceLine key={`t-${i}`} y={t.value} stroke={t.color} strokeDasharray="4 4" label={t.label} />
           ))}
-          {seriesKeys.map((key, i) => (
+          {series.map((s, i) => (
             <Area
-              key={key}
+              key={s.key}
               type={interpolation}
-              dataKey={key}
+              dataKey={s.key}
+              name={s.name}
               stroke={COLORS[i % COLORS.length]}
               strokeWidth={lineWidth}
               fill={COLORS[i % COLORS.length]}
@@ -582,17 +607,18 @@ const TimeseriesChart = memo(function TimeseriesChart({data, timeRange, displayC
             contentStyle={TOOLTIP_STYLE}
             wrapperStyle={TOOLTIP_WRAPPER_STYLE}
             labelFormatter={(label) => formatTooltipLabel(label as string | number)}
-            formatter={tooltipFormatter as (value: string | number | undefined, name: string | undefined, props: unknown) => ReactNode}
+            formatter={tooltipFormatter}
           />
           {legendProps && <Legend {...legendProps} />}
           {thresholds.map((t, i) => (
             <ReferenceLine key={`t-${i}`} y={t.value} stroke={t.color} strokeDasharray="4 4" label={t.label} />
           ))}
-          {seriesKeys.map((key, i) => (
+          {series.map((s, i) => (
             <Line
-              key={key}
+              key={s.key}
               type={interpolation}
-              dataKey={key}
+              dataKey={s.key}
+              name={s.name}
               stroke={COLORS[i % COLORS.length]}
               strokeWidth={lineWidth}
               dot={dotProp}
@@ -621,12 +647,12 @@ const BarChartWidget = memo(function BarChartWidget({data, timeRange, displayCon
   const tickFormatter = unit && unit !== 'none'
     ? (v: number) => formatValue(v, unit, decimals)
     : undefined
-  const tooltipFormatter = unit && unit !== 'none'
-    ? (v?: number | string) => (v !== undefined && typeof v === 'number' ? formatValue(v, unit, decimals) : (v ?? ''))
+  const tooltipFormatter: TooltipFormatterFn = unit && unit !== 'none'
+    ? (v) => (v !== undefined && typeof v === 'number' ? formatValue(v, unit, decimals) : formatTooltipValue(v))
     : formatTooltipValue
 
   if (hasTime && labelKeys.length > 0 && valueKeys.length > 0) {
-    const {pivoted: rawPivoted, seriesKeys} = pivotData(data, timeKey!, labelKeys, valueKeys)
+    const {pivoted: rawPivoted, series} = pivotData(data, timeKey!, labelKeys, valueKeys)
     const pivoted = rawPivoted.map(row => {
       const v = row[timeKey!]
       if (typeof v === 'string') { const ms = parseUtcTimestamp(v); return isNaN(ms) ? row : {...row, [timeKey!]: ms} }
@@ -658,14 +684,20 @@ const BarChartWidget = memo(function BarChartWidget({data, timeRange, displayCon
               contentStyle={TOOLTIP_STYLE}
               wrapperStyle={TOOLTIP_WRAPPER_STYLE}
               labelFormatter={(label) => formatTooltipLabel(label as string | number)}
-              formatter={tooltipFormatter as (value: string | number | undefined, name: string | undefined, props: unknown) => ReactNode}
+              formatter={tooltipFormatter}
             />
             {legendProps && <Legend {...legendProps} iconSize={8} />}
             {thresholds.map((t, i) => (
               <ReferenceLine key={`t-${i}`} y={t.value} stroke={t.color} strokeDasharray="4 4" label={t.label} />
             ))}
-            {seriesKeys.map((key, i) => (
-              <Bar key={key} dataKey={key} fill={COLORS[i % COLORS.length]} stackId={barMode === 'stacked' ? 'stack' : undefined} />
+            {series.map((s, i) => (
+              <Bar
+                key={s.key}
+                dataKey={s.key}
+                name={s.name}
+                fill={COLORS[i % COLORS.length]}
+                stackId={barMode === 'stacked' ? 'stack' : undefined}
+              />
             ))}
           </BarChart>
         )}
@@ -697,7 +729,14 @@ const BarChartWidget = memo(function BarChartWidget({data, timeRange, displayCon
             <ReferenceLine key={`t-${i}`} y={t.value} stroke={t.color} strokeDasharray="4 4" label={t.label} />
           ))}
           {barKeys.map((key, i) => (
-            <Bar key={key} dataKey={key} fill={COLORS[i % COLORS.length]} radius={[2, 2, 0, 0]} stackId={barMode === 'stacked' ? 'stack' : undefined} />
+            <Bar
+              key={key}
+              dataKey={key}
+              name={key.replace(/_/g, ' ')}
+              fill={COLORS[i % COLORS.length]}
+              radius={[2, 2, 0, 0]}
+              stackId={barMode === 'stacked' ? 'stack' : undefined}
+            />
           ))}
         </BarChart>
       )}
@@ -737,7 +776,10 @@ const DonutChartWidget = memo(function DonutChartWidget({data, displayConfig: dc
           {legendProps && (
             <Legend
               {...legendProps}
-              wrapperStyle={{fontSize: '11px'}}
+              wrapperStyle={{
+                ...legendProps.wrapperStyle,
+                fontSize: '11px',
+              }}
               iconSize={10}
             />
           )}

--- a/dashboard/src/components/dashboards/__tests__/widgetSeries.test.ts
+++ b/dashboard/src/components/dashboards/__tests__/widgetSeries.test.ts
@@ -1,0 +1,93 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {pivotData, valueKeySeries} from '../widgetSeries'
+
+describe('widgetSeries', () => {
+  it('keeps full data keys while displaying the shortest unique label dimensions', () => {
+    const data = [
+      {
+        time_bucket: 1,
+        service: 'moneat-backend',
+        endpoint: 'api.moneat.io:443',
+        environment: 'moneat-prod-backend',
+        queue: 'moneat:dd:dbm:dlq',
+        queue_type: 'dlq',
+        worker: 'DBM',
+        depth: 12,
+      },
+      {
+        time_bucket: 1,
+        service: 'moneat-backend',
+        endpoint: 'api.moneat.io:443',
+        environment: 'moneat-prod-backend',
+        queue: 'moneat:dd:dbm:queue',
+        queue_type: 'primary',
+        worker: 'DBM',
+        depth: 4,
+      },
+      {
+        time_bucket: 1,
+        service: 'moneat-backend',
+        endpoint: 'api.moneat.io:443',
+        environment: 'moneat-prod-backend',
+        queue: 'moneat:analytics:queue',
+        queue_type: 'primary',
+        worker: 'Analytics',
+        depth: 7,
+      },
+    ]
+
+    const result = pivotData(
+      data,
+      'time_bucket',
+      ['service', 'endpoint', 'environment', 'queue', 'queue_type', 'worker'],
+      ['depth'],
+    )
+
+    expect(result.series.map((series) => series.name)).toEqual([
+      'dlq, DBM',
+      'primary, DBM',
+      'primary, Analytics',
+    ])
+    expect(result.series[0].key).toBe(
+      'moneat-backend, api.moneat.io:443, moneat-prod-backend, moneat:dd:dbm:dlq, dlq, DBM',
+    )
+    expect(result.series[0].name).not.toContain('moneat-backend')
+    expect(result.pivoted[0][result.series[0].key]).toBe(12)
+  })
+
+  it('falls back to the available label when every label value is constant', () => {
+    const result = pivotData(
+      [{time_bucket: 1, worker: 'DBM', depth: 12}],
+      'time_bucket',
+      ['worker'],
+      ['depth'],
+    )
+
+    expect(result.series).toEqual([
+      {key: 'DBM', name: 'DBM'},
+    ])
+  })
+
+  it('uses readable names for unpivoted numeric series', () => {
+    expect(valueKeySeries(['queue_depth', 'dlq_depth'])).toEqual([
+      {key: 'queue_depth', name: 'queue depth'},
+      {key: 'dlq_depth', name: 'dlq depth'},
+    ])
+  })
+})

--- a/dashboard/src/components/dashboards/widgetSeries.ts
+++ b/dashboard/src/components/dashboards/widgetSeries.ts
@@ -1,0 +1,147 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+export interface SeriesDef {
+  key: string
+  name: string
+}
+
+export function valueKeySeries(valueKeys: string[]): SeriesDef[] {
+  return valueKeys.map((key) => ({
+    key,
+    name: key.replace(/_/g, ' '),
+  }))
+}
+
+function valueToLegendPart(value: unknown): string {
+  return String(value ?? '').trim()
+}
+
+function getVariableLabelKeys(data: Record<string, unknown>[], labelKeys: string[]) {
+  const variableKeys = labelKeys.filter((key) => {
+    const values = new Set(data.map((row) => valueToLegendPart(row[key])).filter(Boolean))
+    return values.size > 1
+  })
+
+  return variableKeys.length > 0 ? variableKeys : labelKeys
+}
+
+function getKeySubsets(keys: string[]): string[][] {
+  const subsets: string[][] = []
+  const count = 1 << keys.length
+  for (let mask = 1; mask < count; mask += 1) {
+    subsets.push(keys.filter((_, index) => (mask & (1 << index)) !== 0))
+  }
+  return subsets
+}
+
+function buildSeriesName(
+  row: Record<string, unknown>,
+  labelKeys: string[],
+  valueKey: string,
+  hasMultipleValues: boolean,
+) {
+  const labelParts = labelKeys.map((key) => valueToLegendPart(row[key])).filter(Boolean)
+  const label = labelParts.join(', ') || 'value'
+  return hasMultipleValues ? `${label} (${valueKey})` : label
+}
+
+function getDisplayLabelKeys(
+  data: Record<string, unknown>[],
+  labelKeys: string[],
+  valueKeys: string[],
+) {
+  const candidates = getVariableLabelKeys(data, labelKeys)
+  if (candidates.length <= 1 || candidates.length > 10) return candidates
+
+  const hasMultipleValues = valueKeys.length > 1
+  const sampleSeries = new Map<string, {row: Record<string, unknown>; valueKey: string}>()
+  for (const row of data) {
+    const rowKey = labelKeys.map((key) => valueToLegendPart(row[key])).join('\u0001')
+    for (const valueKey of valueKeys) {
+      sampleSeries.set(`${rowKey}\u0002${valueKey}`, {row, valueKey})
+    }
+  }
+
+  const series = Array.from(sampleSeries.values())
+  let best: {keys: string[]; score: number} | null = null
+
+  for (const keys of getKeySubsets(candidates)) {
+    const names = series.map(({row, valueKey}) => buildSeriesName(row, keys, valueKey, hasMultipleValues))
+    if (new Set(names).size !== names.length) continue
+
+    const score = names.reduce((sum, name) => sum + name.length, 0)
+    if (
+      best == null ||
+      score < best.score ||
+      (score === best.score && keys.length < best.keys.length)
+    ) {
+      best = {keys, score}
+    }
+  }
+
+  return best?.keys ?? candidates
+}
+
+/**
+ * Pivots flat multi-series data into one-row-per-timestamp format for Recharts.
+ * Input:  [{time_bucket: 100, platform: "android", value: 5}, {time_bucket: 100, platform: "ios", value: 3}]
+ * Output: [{time_bucket: 100, "android": 5, "ios": 3}]
+ */
+export function pivotData(
+  data: Record<string, unknown>[],
+  timeKey: string,
+  labelKeys: string[],
+  valueKeys: string[],
+) {
+  if (labelKeys.length === 0 || valueKeys.length === 0) {
+    return {pivoted: data, series: valueKeySeries(valueKeys)}
+  }
+
+  const grouped = new Map<string | number, Record<string, unknown>>()
+  const series = new Map<string, SeriesDef>()
+  const displayLabelKeys = getDisplayLabelKeys(data, labelKeys, valueKeys)
+  const hasMultipleValues = valueKeys.length > 1
+
+  for (const row of data) {
+    const t = row[timeKey] as string | number
+    if (!grouped.has(t)) {
+      grouped.set(t, {[timeKey]: t})
+    }
+    const entry = grouped.get(t)!
+
+    const keyBase = labelKeys.map((key) => valueToLegendPart(row[key])).filter(Boolean).join(', ') || 'value'
+
+    for (const valueKey of valueKeys) {
+      const key = hasMultipleValues ? `${keyBase} (${valueKey})` : keyBase
+      entry[key] = row[valueKey]
+      if (!series.has(key)) {
+        series.set(key, {
+          key,
+          name: buildSeriesName(row, displayLabelKeys, valueKey, hasMultipleValues),
+        })
+      }
+    }
+  }
+
+  const pivoted = Array.from(grouped.values()).sort((a, b) => {
+    const ta = a[timeKey] as number
+    const tb = b[timeKey] as number
+    return ta - tb
+  })
+
+  return {pivoted, series: Array.from(series.values())}
+}


### PR DESCRIPTION
## Summary
- constrain chart legends so high-cardinality series cannot consume the whole widget
- shorten pivoted series display names to the shortest unique label dimensions while preserving full data keys
- add focused coverage for queue-depth style label generation

## Validation
- `npm run test -- src/components/dashboards/__tests__/widgetSeries.test.ts`
- `npx eslint src/components/dashboards/WidgetRenderer.tsx src/components/dashboards/widgetSeries.ts src/components/dashboards/__tests__/widgetSeries.test.ts --max-warnings 0`
- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chart tooltip formatting to display complex data values and arrays more effectively.

* **Bug Fixes**
  * Improved legend rendering behavior and styling consistency across various chart types.

* **Tests**
  * Added comprehensive test coverage for data transformation and series naming functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->