### PR TITLE
fix: handle oidc discovery errors

### DIFF
--- a/backend/src/main/kotlin/com/moneat/sso/services/SsoService.kt
+++ b/backend/src/main/kotlin/com/moneat/sso/services/SsoService.kt
@@ -73,12 +73,18 @@ import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
 
 private val logger = KotlinLogging.logger {}
 
 private const val DISCOVERY_CACHE_TTL_MS = 3_600_000L // 1 hour
 private const val ERROR_OIDC_ISSUER_URL_NOT_CONFIGURED = "OIDC issuer URL not configured"
+private const val OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration"
+private const val OIDC_DISCOVERY_ERROR =
+    "OIDC discovery failed. Use the provider issuer URL from its openid-configuration document. " +
+        "For Authentik this looks like https://auth.example.com/application/o/<application-slug>/, " +
+        "not just the Authentik domain."
 
 @Serializable
 data class SsoStateData(
@@ -653,29 +659,49 @@ open class SsoService {
      * Results are cached in-memory with a 1-hour TTL.
      */
     private suspend fun discoverOidcEndpoints(issuerUrl: String): OidcDiscoveryCache {
-        val cached = discoveryCache[issuerUrl]
+        val discoveryUrl = oidcDiscoveryUrl(issuerUrl)
+        val cached = discoveryCache[discoveryUrl]
         val now = System.currentTimeMillis()
         if (cached != null && (now - cached.fetchedAt) < DISCOVERY_CACHE_TTL_MS) {
             return cached
         }
 
-        val discoveryUrl = "${issuerUrl.trimEnd('/')}/.well-known/openid-configuration"
         logger.info { "Fetching OIDC discovery from $discoveryUrl" }
 
-        val response = httpClient.get(discoveryUrl).bodyAsText()
-        val json = Json.parseToJsonElement(response) as JsonObject
-        val authEndpoint = json["authorization_endpoint"]?.jsonPrimitive?.content
-            ?: throw IllegalArgumentException(
-                "OIDC discovery missing authorization_endpoint"
-            )
-        val tokenEndpoint = json["token_endpoint"]?.jsonPrimitive?.content
-            ?: throw IllegalArgumentException(
-                "OIDC discovery missing token_endpoint"
-            )
+        val authEndpoint: String
+        val tokenEndpoint: String
+        try {
+            val response = httpClient.get(discoveryUrl).bodyAsText()
+            val json = Json.parseToJsonElement(response) as JsonObject
+            authEndpoint = json["authorization_endpoint"]?.jsonPrimitive?.content
+                ?: throw IllegalArgumentException(
+                    "OIDC discovery missing authorization_endpoint"
+                )
+            tokenEndpoint = json["token_endpoint"]?.jsonPrimitive?.content
+                ?: throw IllegalArgumentException(
+                    "OIDC discovery missing token_endpoint"
+                )
+            UrlValidator.validateExternalUrl(authEndpoint)
+            UrlValidator.validateExternalUrl(tokenEndpoint)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "OIDC discovery failed for $discoveryUrl" }
+            throw IllegalArgumentException(OIDC_DISCOVERY_ERROR)
+        }
 
         val entry = OidcDiscoveryCache(authEndpoint, tokenEndpoint, now)
-        discoveryCache[issuerUrl] = entry
+        discoveryCache[discoveryUrl] = entry
         return entry
+    }
+
+    private fun oidcDiscoveryUrl(issuerUrl: String): String {
+        val trimmed = issuerUrl.trim()
+        return if (trimmed.endsWith(OIDC_DISCOVERY_PATH)) {
+            trimmed
+        } else {
+            trimmed.trimEnd('/') + OIDC_DISCOVERY_PATH
+        }
     }
 
     private suspend fun generateOidcRequest(

--- a/dashboard/src/components/SsoSettings.tsx
+++ b/dashboard/src/components/SsoSettings.tsx
@@ -260,12 +260,12 @@ export function SsoTab({
                       className="h-8"
                       value={formData.oidcIssuerUrl}
                       onChange={(e) => setFormData({ ...formData, oidcIssuerUrl: e.target.value })}
-                      placeholder="https://your-domain.okta.com"
+                      placeholder="https://auth.example.com/application/o/app-slug/"
                       required={providerType === 'oidc'}
                       disabled={readOnly}
                     />
                     <p className="text-xs text-muted-foreground">
-                      The base URL of your OIDC provider
+                      The issuer URL from your provider's openid-configuration document
                     </p>
                   </div>
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/sso/services/SsoServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/sso/services/SsoServiceTest.kt
@@ -262,6 +262,33 @@ class SsoServiceTest {
     }
 
     @Test
+    fun `initSso reports helpful error when OIDC discovery is not JSON`() {
+        MockOidcDiscoveryServer("<!DOCTYPE html><html lang=\"en\"></html>").use { server ->
+            withSelfHosted {
+                val (orgId, ownerId) = seedOrgReadyForSsoConfigure()
+                service.configureSso(
+                    orgId,
+                    ownerId,
+                    SsoConfigRequest(
+                        providerType = "oidc",
+                        isEnabled = true,
+                        oidcIssuerUrl = server.baseUrl,
+                        oidcClientId = "client-id",
+                        oidcClientSecret = "client-secret",
+                        emailDomain = "html.example",
+                    ),
+                )
+
+                val ex = assertFailsWith<IllegalArgumentException> {
+                    initSso("alice@html.example", null)
+                }
+                assertTrue(ex.message!!.contains("OIDC discovery failed"))
+                assertTrue(ex.message!!.contains("Authentik"))
+            }
+        }
+    }
+
+    @Test
     fun `initSso returns OIDC redirect when resolving by organization slug`() = withOidcDiscoveryServer { issuerUrl ->
         val (orgId, ownerId) = seedOrgReadyForSsoConfigure()
         service.configureSso(

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/sso/support/MockOidcDiscoveryServer.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/sso/support/MockOidcDiscoveryServer.kt
@@ -11,7 +11,9 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-class MockOidcDiscoveryServer : AutoCloseable {
+class MockOidcDiscoveryServer(
+    private val discoveryBody: String? = null,
+) : AutoCloseable {
     private val executor: ExecutorService = Executors.newCachedThreadPool()
     private val server: HttpServer =
         HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
@@ -29,13 +31,13 @@ class MockOidcDiscoveryServer : AutoCloseable {
 
     private fun respondWithDiscovery(exchange: HttpExchange) {
         val requestBaseUrl = "http://127.0.0.1:${exchange.localAddress.port}"
-        val body =
-            """
-            {
-              "authorization_endpoint": "$requestBaseUrl/protocol/openid-connect/auth",
-              "token_endpoint": "$requestBaseUrl/protocol/openid-connect/token"
-            }
-            """.trimIndent()
+        val body = discoveryBody
+            ?: """
+                {
+                  "authorization_endpoint": "$requestBaseUrl/protocol/openid-connect/auth",
+                  "token_endpoint": "$requestBaseUrl/protocol/openid-connect/token"
+                }
+                """.trimIndent()
         val bytes = body.toByteArray(StandardCharsets.UTF_8)
         exchange.responseHeaders.add("Content-Type", "application/json")
         exchange.sendResponseHeaders(200, bytes.size.toLong())


### PR DESCRIPTION
## Summary
- normalize OIDC discovery URLs and support direct openid-configuration URLs
- return a clear Authentik-oriented discovery error instead of leaking HTML JSON parse failures
- update SSO settings copy and add regression coverage for HTML discovery responses

## Validation
- ./gradlew compileKotlin detekt
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :ee:test --tests com.moneat.enterprise.sso.services.SsoServiceTest --tests com.moneat.enterprise.sso.routes.SsoRoutesTest -Dkotlin.compiler.execution.strategy=in-process
- npm run lint
- git diff --check