### PR TITLE
fix: store sentry feedback as feedback

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
@@ -248,9 +248,20 @@ data class EnvelopeItem(
     val headers: JsonObject? = null
 )
 
+internal fun EnvelopeItem.isFeedbackEventPayload(): Boolean {
+    if (type != "event") return false
+    return payloadEventType() == "feedback"
+}
+
+private fun EnvelopeItem.payloadEventType(): String? =
+    runCatching {
+        Json.parseToJsonElement(payload).jsonObject["type"]?.jsonPrimitive?.contentOrNull
+    }.getOrNull()
+
 @Serializable
 data class SentryEvent(
     @SerialName("event_id") val eventId: String? = null,
+    val type: String? = null,
     @Serializable(with = FlexibleTimestampSerializer::class)
     val timestamp: Double? = null,
     val level: String? = null,
@@ -494,6 +505,7 @@ data class SentryFeedback(
     val level: String? = null,
     val environment: String? = null,
     val release: String? = null,
+    @Serializable(with = SentryMessageSerializer::class)
     val message: String? = null,
     val comments: String? = null,
     @SerialName("contact_email") val contactEmail: String? = null,

--- a/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
@@ -20,13 +20,16 @@ import com.moneat.billing.services.BillingQuotaService
 import com.moneat.billing.services.QuotaReservationResult
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.decompression.DecompressionService
+import com.moneat.events.models.EnvelopeItem
 import com.moneat.events.models.SentryEnvelope
+import com.moneat.events.models.isFeedbackEventPayload
 import com.moneat.events.services.EventService
 import com.moneat.events.services.IngestionWorker
 import com.moneat.logs.models.LogIngestEntry
 import com.moneat.logs.services.LogService
 import com.moneat.utils.DetailedErrorResponse
 import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.header
@@ -40,7 +43,6 @@ import io.ktor.server.routing.route
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
 import org.koin.core.context.GlobalContext
-import com.moneat.utils.suspendRunCatching
 import java.security.MessageDigest
 
 private val logger = KotlinLogging.logger {}
@@ -121,13 +123,13 @@ fun Route.ingestRoutes(
                     }
                     val groupedReservations =
                         envelope.items
-                            .groupingBy { mapEnvelopeItemTypeToQuotaType(it.type) }
+                            .groupingBy { mapEnvelopeItemToQuotaType(it) }
                             .eachCount()
 
                     // Calculate bytes per type for GB quota tracking
                     val groupedBytes =
                         envelope.items
-                            .groupBy { mapEnvelopeItemTypeToQuotaType(it.type) }
+                            .groupBy { mapEnvelopeItemToQuotaType(it) }
                             .mapValues { (_, items) ->
                                 items.sumOf { item ->
                                     (item.payloadBytes?.size ?: item.payload.toByteArray(Charsets.UTF_8).size).toLong()
@@ -269,7 +271,8 @@ fun Route.ingestRoutes(
                         return@post
                     }
                     val bodyBytes = body.toByteArray(Charsets.UTF_8).size.toLong()
-                    val reservation = reserveSingleQuota(orgId, 1, "error", bodyBytes)
+                    val quotaType = mapEnvelopeItemToQuotaType(EnvelopeItem("event", body))
+                    val reservation = reserveSingleQuota(orgId, 1, quotaType, bodyBytes)
                     if (!reservation.allowed) {
                         call.respond(
                             HttpStatusCode.TooManyRequests,
@@ -327,4 +330,9 @@ internal fun mapEnvelopeItemTypeToQuotaType(itemType: String): String {
         "llm_generation" -> "llm"
         else -> "error"
     }
+}
+
+internal fun mapEnvelopeItemToQuotaType(item: EnvelopeItem): String {
+    if (item.isFeedbackEventPayload()) return "feedback"
+    return mapEnvelopeItemTypeToQuotaType(item.type)
 }

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -26,6 +26,7 @@ import com.moneat.events.models.SentryFeedback
 import com.moneat.events.models.SentryReplayEvent
 import com.moneat.events.models.SentrySpan
 import com.moneat.events.models.SentryTransaction
+import com.moneat.events.models.isFeedbackEventPayload
 import com.moneat.events.repositories.EventRepository
 import com.moneat.events.repositories.models.ErrorEventInsertData
 import com.moneat.events.repositories.models.FeedbackInsertData
@@ -42,6 +43,7 @@ import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseSqlUtils.doubleMapToSqlMap
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.ClickHouseSqlUtils.mapToSqlMap
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -63,7 +65,6 @@ import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
@@ -150,13 +151,7 @@ class EventService(
         for (item in envelope.items) {
             logger.debug { "Processing envelope item type: ${item.type}" }
             when (item.type) {
-                "event" -> {
-                    logger.debug { "Event payload: ${item.payload.take(LOG_PAYLOAD_PREVIEW_CHARS)}" }
-                    val event = json.decodeFromString<SentryEvent>(item.payload)
-                    if (storeEvent(projectId, event)) {
-                        recordUsage(projectId, "error", item)
-                    }
-                }
+                "event" -> handleEventItem(projectId, item)
 
                 "transaction" -> {
                     logger.debug { "Transaction payload: ${item.payload.take(LOG_PAYLOAD_PREVIEW_CHARS)}" }
@@ -208,6 +203,19 @@ class EventService(
                     logger.debug { "Unknown item type: ${item.type}" }
                 }
             }
+        }
+    }
+
+    private suspend fun handleEventItem(projectId: Long, item: EnvelopeItem) {
+        logger.debug { "Event payload: ${item.payload.take(LOG_PAYLOAD_PREVIEW_CHARS)}" }
+        if (item.isFeedbackEventPayload()) {
+            handleFeedbackItem(projectId, item)
+            return
+        }
+
+        val event = json.decodeFromString<SentryEvent>(item.payload)
+        if (storeEvent(projectId, event)) {
+            recordUsage(projectId, "error", item)
         }
     }
 
@@ -265,6 +273,15 @@ class EventService(
         projectId: Long,
         body: String
     ) {
+        if (EnvelopeItem("event", body).isFeedbackEventPayload()) {
+            val feedback = json.decodeFromString<SentryFeedback>(body)
+            val byteSize = body.toByteArray(StandardCharsets.UTF_8).size
+            if (storeFeedback(projectId, feedback, "event")) {
+                usageTracker.recordUsage(projectId, "feedback", byteSize)
+            }
+            return
+        }
+
         val event = json.decodeFromString<SentryEvent>(body)
         if (storeEvent(projectId, event)) {
             usageTracker.recordUsage(projectId, "error", body.toByteArray(StandardCharsets.UTF_8).size)

--- a/backend/src/test/kotlin/com/moneat/routes/IngestRoutesEnvelopeTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IngestRoutesEnvelopeTest.kt
@@ -18,8 +18,12 @@ package com.moneat.routes
 
 import com.moneat.billing.models.BillingUsageResponse
 import com.moneat.billing.services.QuotaReservationResult
+import com.moneat.events.models.EnvelopeItem
+import com.moneat.events.repositories.models.ProjectKeyVerification
 import com.moneat.events.routes.ingestRoutes
+import com.moneat.events.routes.mapEnvelopeItemToQuotaType
 import com.moneat.events.routes.mapEnvelopeItemTypeToQuotaType
+import com.moneat.events.services.EventService
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.ProjectKeys
 import com.moneat.shared.models.Projects
@@ -39,6 +43,9 @@ import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -146,6 +153,106 @@ class IngestRoutesEnvelopeTest {
         }
 
     @Test
+    fun `envelope endpoint reserves event feedback payload as feedback quota`() =
+        testApplication {
+            val reservations = mutableListOf<Map<String, Int>>()
+
+            environment {
+                config =
+                    MapApplicationConfig(
+                        "ingest.queueKey" to "test:ingest:q",
+                        "logs.queueKey" to "test:logs:q"
+                    )
+            }
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    ingestRoutes(
+                        enqueueEnvelope = { _, _ -> },
+                        isQuotaEnforcementEnabled = { true },
+                        reserveEnvelopeQuota = { orgId, requestedUnitsByType, _ ->
+                            reservations.add(requestedUnitsByType)
+                            QuotaReservationResult(allowed = true, usage = emptyUsage(orgId))
+                        }
+                    )
+                }
+            }
+
+            val feedbackPayload =
+                """
+                {
+                    "event_id":"44bad9a2e3774046977a21440ddb39b2",
+                    "type":"feedback",
+                    "contexts":{"feedback":{"message":"Great app"}}
+                }
+                """.trimIndent()
+
+            val response =
+                client.post("/api/$testProjectId/envelope/") {
+                    contentType(ContentType.Application.OctetStream)
+                    header("X-Sentry-Auth", "Sentry sentry_key=$testPublicKey, sentry_version=7")
+                    setBody(
+                        buildEnvelope(
+                            eventId = "evt-feedback-1",
+                            items = listOf("event" to feedbackPayload.toByteArray())
+                        )
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Accepted, response.status)
+            assertEquals(1, reservations.size)
+            assertEquals(1, reservations[0]["feedback"])
+            assertEquals(null, reservations[0]["error"])
+        }
+
+    @Test
+    fun `store endpoint reserves feedback event payload as feedback quota`() =
+        testApplication {
+            val eventService = mockk<EventService>()
+            val reservedTypes = mutableListOf<String>()
+
+            every { eventService.verifyProjectKey(testProjectId, testPublicKey) } returns
+                ProjectKeyVerification(true, "jvm")
+            every { eventService.getOrganizationIdForProject(testProjectId) } returns testOrgId
+            coEvery { eventService.processStoreEvent(testProjectId, any()) } returns Unit
+
+            environment {
+                config = MapApplicationConfig("ingest.queueKey" to "test:ingest:q")
+            }
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    ingestRoutes(
+                        eventService = eventService,
+                        isQuotaEnforcementEnabled = { true },
+                        reserveSingleQuota = { orgId, _, eventType, _ ->
+                            reservedTypes.add(eventType)
+                            QuotaReservationResult(allowed = true, usage = emptyUsage(orgId))
+                        }
+                    )
+                }
+            }
+
+            val response =
+                client.post("/api/$testProjectId/store/") {
+                    contentType(ContentType.Application.Json)
+                    header("X-Sentry-Auth", "Sentry sentry_key=$testPublicKey, sentry_version=7")
+                    setBody(
+                        """
+                        {
+                            "event_id":"64bad9a2e3774046977a21440ddb39b2",
+                            "type":"feedback",
+                            "contexts":{"feedback":{"message":"Legacy store feedback"}}
+                        }
+                        """.trimIndent()
+                    )
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(listOf("feedback"), reservedTypes)
+        }
+
+    @Test
     fun `envelope endpoint returns 429 when quota reservation rejects`() =
         testApplication {
             environment {
@@ -220,6 +327,21 @@ class IngestRoutesEnvelopeTest {
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("session"))
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("check_in"))
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("unknown_type"))
+    }
+
+    @Test
+    fun `envelope item quota mapping detects feedback event payloads`() {
+        val feedbackPayload =
+            """
+            {
+                "event_id": "44bad9a2e3774046977a21440ddb39b2",
+                "type": "feedback",
+                "contexts": {"feedback": {"message": "Great app"}}
+            }
+            """.trimIndent()
+
+        assertEquals("feedback", mapEnvelopeItemToQuotaType(EnvelopeItem("event", feedbackPayload)))
+        assertEquals("error", mapEnvelopeItemToQuotaType(EnvelopeItem("event", """{"message":"User Feedback"}""")))
     }
 
     private fun buildEnvelope(

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
@@ -308,6 +308,50 @@ class EventServiceCoverageTest {
     }
 
     @Test
+    fun `processEnvelope stores feedback payload in event item as feedback`() = runBlocking {
+        val feedbackSlot = slot<FeedbackInsertData>()
+        coEvery { eventRepository.insertFeedback(capture(feedbackSlot)) } returns true
+
+        val fbJson =
+            """
+            {
+                "event_id": "44bad9a2e3774046977a21440ddb39b2",
+                "type": "feedback",
+                "level": "info",
+                "message": "User Feedback",
+                "timestamp": 1705329045.123,
+                "platform": "java",
+                "contexts": {
+                    "feedback": {
+                        "message": "The sync button is confusing",
+                        "contact_email": "android-user@example.com",
+                        "name": "Android User",
+                        "associated_event_id": "54bad9a2e3774046977a21440ddb39b2"
+                    }
+                },
+                "sdk": {"name": "sentry.java.android", "version": "8.35.0"}
+            }
+            """.trimIndent()
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "44bad9a2e3774046977a21440ddb39b2",
+                items = listOf(EnvelopeItem("event", fbJson))
+            )
+        )
+
+        assertTrue(feedbackSlot.isCaptured)
+        assertEquals("44bad9a2-e377-4046-977a-21440ddb39b2", feedbackSlot.captured.feedbackId)
+        assertEquals("The sync button is confusing", feedbackSlot.captured.message)
+        assertEquals("android-user@example.com", feedbackSlot.captured.contactEmail)
+        assertEquals("Android User", feedbackSlot.captured.name)
+        assertEquals("54bad9a2e3774046977a21440ddb39b2", feedbackSlot.captured.associatedEventId)
+        assertEquals("sentry.java.android", feedbackSlot.captured.sdkName)
+        coVerify(exactly = 0) { eventRepository.insertErrorEvent(any()) }
+    }
+
+    @Test
     fun `processEnvelope routes replay_event and replay_recording`() = runBlocking {
         val replayEventJson = Json.encodeToString(
             SentryReplayEvent(
@@ -1068,6 +1112,34 @@ class EventServiceCoverageTest {
 
         assertTrue(errorSlot.isCaptured)
         assertEquals("IOError", errorSlot.captured.exceptionType)
+    }
+
+    @Test
+    fun `processStoreEvent stores feedback event payload as feedback`() = runBlocking {
+        val feedbackSlot = slot<FeedbackInsertData>()
+        coEvery { eventRepository.insertFeedback(capture(feedbackSlot)) } returns true
+
+        val body =
+            """
+            {
+                "event_id": "64bad9a2e3774046977a21440ddb39b2",
+                "type": "feedback",
+                "contexts": {
+                    "feedback": {
+                        "message": "Legacy store feedback",
+                        "contact_email": "legacy@example.com"
+                    }
+                }
+            }
+            """.trimIndent()
+
+        eventService.processStoreEvent(testProjectId, body)
+
+        assertTrue(feedbackSlot.isCaptured)
+        assertEquals("64bad9a2-e377-4046-977a-21440ddb39b2", feedbackSlot.captured.feedbackId)
+        assertEquals("Legacy store feedback", feedbackSlot.captured.message)
+        assertEquals("legacy@example.com", feedbackSlot.captured.contactEmail)
+        coVerify(exactly = 0) { eventRepository.insertErrorEvent(any()) }
     }
 
     // ===================== verifyProjectKey caching =====================


### PR DESCRIPTION
## Summary
- route Sentry feedback payloads sent through generic event ingestion into `user_feedback`
- reserve feedback quota for feedback-shaped envelope and store payloads
- add regression coverage for envelope and legacy store ingestion paths

## Root Cause
Modern Sentry SDKs can send feedback as an event-shaped payload with `type: "feedback"`. Moneat only classified by the envelope item header, so those payloads were handled as normal error events and created issues.

## Validation
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon compileKotlin detekt :test --tests com.moneat.services.EventServiceCoverageTest --tests com.moneat.routes.IngestRoutesEnvelopeTest -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event ingestion system to properly detect and route feedback events separately from error events.
  * Improved quota reservation logic to accurately classify and reserve quota for feedback versus error events.

* **Bug Fixes**
  * Refined feedback event serialization handling to ensure consistent data processing.

* **Tests**
  * Added comprehensive test coverage for feedback event detection, quota mapping, and processing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->