### PR TITLE
fix: expose issue investigation context in MCP

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
@@ -128,7 +128,10 @@ data class EventResponse(
     val tags: HashMap<String, String> = hashMapOf(),
     val contexts: String,
     val exception: String?,
-    val breadcrumbs: String?
+    val breadcrumbs: String?,
+    val stackTrace: String? = null,
+    val contextsJson: JsonElement? = null,
+    val breadcrumbsJson: JsonElement? = null
 )
 
 @Serializable
@@ -233,6 +236,16 @@ data class TraceDetailResponse(
     val startTimestamp: Double,
     val endTimestamp: Double,
     val duration: Double
+)
+
+@Serializable
+data class EventTraceResponse(
+    val eventId: String?,
+    val eventType: String?,
+    val projectId: Long,
+    val traceId: String,
+    val transaction: TransactionDetailResponse? = null,
+    val spans: List<SpanResponse> = emptyList()
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepositoryImpl.kt
@@ -216,7 +216,8 @@ class IssueRepositoryImpl(
                 tags,
                 contexts,
                 exception_value as exception,
-                breadcrumbs
+                breadcrumbs,
+                stack_trace
             FROM `$clickhouseDb`.events
             WHERE $projectIdClause AND issue_id = '$escapedIssueId' AND event_type = 'error'
                 AND $retentionClause
@@ -247,8 +248,17 @@ class IssueRepositoryImpl(
                 JSONExtractString(contexts, 'trace', 'status') as status,
                 JSONExtractString(contexts, 'trace', 'trace_id') as trace_id
             FROM `$clickhouseDb`.events
-            WHERE $projectIdClause AND issue_id = '$escapedIssueId'
+            WHERE $projectIdClause
                 AND event_type = 'transaction'
+                AND JSONExtractString(contexts, 'trace', 'trace_id') IN (
+                    SELECT DISTINCT JSONExtractString(contexts, 'trace', 'trace_id')
+                    FROM `$clickhouseDb`.events
+                    WHERE $projectIdClause
+                        AND issue_id = '$escapedIssueId'
+                        AND event_type = 'error'
+                        AND JSONExtractString(contexts, 'trace', 'trace_id') != ''
+                        AND $retentionClause
+                )
                 AND $retentionClause
             ORDER BY timestamp DESC
             LIMIT $limit

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
@@ -90,6 +90,15 @@ class DashboardQueryHelper(
             else -> json.encodeToString(JsonElement.serializer(), el)
         }
 
+    fun jsonFieldAsJsonElementOrNull(obj: JsonObject, key: String): JsonElement? =
+        when (val el = obj[key]) {
+            null -> null
+            is JsonPrimitive -> el.contentOrNull?.let { raw ->
+                runCatching { json.parseToJsonElement(raw) }.getOrDefault(el)
+            }
+            else -> el
+        }
+
     /**
      * Reads the response body and returns it when ClickHouse returned a successful
      * result. Returns `null` (and logs) when the HTTP status is outside the 2xx
@@ -216,7 +225,10 @@ class DashboardQueryHelper(
             tags = HashMap(tagsMap),
             contexts = jsonFieldAsStoredString(obj, "contexts", "{}"),
             exception = obj["exception"]?.jsonPrimitive?.contentOrNull,
-            breadcrumbs = jsonFieldAsStoredStringOrNull(obj, "breadcrumbs")
+            breadcrumbs = jsonFieldAsStoredStringOrNull(obj, "breadcrumbs"),
+            stackTrace = obj["stack_trace"]?.jsonPrimitive?.contentOrNull,
+            contextsJson = jsonFieldAsJsonElementOrNull(obj, "contexts"),
+            breadcrumbsJson = jsonFieldAsJsonElementOrNull(obj, "breadcrumbs")
         )
     }
 

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -17,6 +17,7 @@
 package com.moneat.events.services
 
 import com.moneat.events.models.EventResponse
+import com.moneat.events.models.EventTraceResponse
 import com.moneat.events.models.FeedbackDetailResponse
 import com.moneat.events.models.FeedbackListItem
 import com.moneat.events.models.IssueDetailResponse
@@ -182,6 +183,12 @@ class DashboardService(
 
     suspend fun getTransactionSpans(eventId: String): TransactionWithSpansResponse? =
         transactionService.getTransactionSpans(eventId)
+
+    suspend fun getTraceForEvent(eventId: String): EventTraceResponse? =
+        transactionService.getTraceForEvent(eventId)
+
+    suspend fun getTraceForTraceId(projectId: Long, traceId: String): EventTraceResponse? =
+        transactionService.getTraceForTraceId(projectId, traceId)
 
     suspend fun getTraceDetails(
         projectId: Long,

--- a/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
@@ -406,14 +406,14 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
     }
 
     suspend fun getTraceForTraceId(projectId: Long, traceId: String): EventTraceResponse? {
-        val trace = getTraceDetails(projectId, traceId)
+        val trace = getTraceDetails(projectId, traceId) ?: return null
         return EventTraceResponse(
             eventId = null,
             eventType = null,
             projectId = projectId,
             traceId = traceId,
             transaction = null,
-            spans = trace?.spans.orEmpty()
+            spans = trace.spans
         )
     }
 

--- a/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
@@ -18,6 +18,7 @@ package com.moneat.events.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.events.models.EventResponse
+import com.moneat.events.models.EventTraceResponse
 import com.moneat.events.models.PerformanceStatsResponse
 import com.moneat.events.models.SpanDetailResponse
 import com.moneat.events.models.SpanResponse
@@ -34,6 +35,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -46,6 +48,13 @@ private val logger = KotlinLogging.logger {}
 class TransactionService(private val queryHelper: DashboardQueryHelper) {
     private val clickhouseDb: String get() = queryHelper.clickhouseDb
     private val json get() = queryHelper.json
+
+    private data class EventTraceLookup(
+        val eventId: String,
+        val eventType: String,
+        val projectId: Long,
+        val traceId: String
+    )
 
     companion object {
         private const val APDEX_THRESHOLD_MS = 500
@@ -98,6 +107,29 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
             FORMAT JSONEachRow
         """.trimIndent()
         return queryHelper.executeProjectIdQuery(query, "Transaction", eventId)?.takeIf { it > 0 }
+    }
+
+    private suspend fun getTraceLookupForEvent(eventId: String): EventTraceLookup? {
+        val normalizedEventId = queryHelper.normalizeUuid(eventId) ?: return null
+        val query = """
+            SELECT
+                toString(event_id) as event_id,
+                event_type,
+                toInt64(project_id) as project_id,
+                JSONExtractString(contexts, 'trace', 'trace_id') as trace_id
+            FROM `$clickhouseDb`.events
+            WHERE toString(event_id) = '$normalizedEventId'
+            LIMIT 1
+            FORMAT JSONEachRow
+        """.trimIndent()
+
+        val obj = queryHelper.executeJsonEachRowQuery(query, "Event trace lookup")?.firstOrNull() ?: return null
+        return EventTraceLookup(
+            eventId = obj["event_id"]?.jsonPrimitive?.content ?: normalizedEventId,
+            eventType = obj["event_type"]?.jsonPrimitive?.content ?: "",
+            projectId = obj["project_id"]?.jsonPrimitive?.longOrNull ?: return null,
+            traceId = obj["trace_id"]?.jsonPrimitive?.contentOrNull ?: ""
+        )
     }
 
     suspend fun getTransactions(
@@ -343,6 +375,48 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
         return TransactionWithSpansResponse(transaction, spans)
     }
 
+    suspend fun getTraceForEvent(eventId: String): EventTraceResponse? {
+        val lookup = getTraceLookupForEvent(eventId) ?: return null
+        if (lookup.traceId.isBlank()) {
+            return EventTraceResponse(
+                eventId = lookup.eventId,
+                eventType = lookup.eventType,
+                projectId = lookup.projectId,
+                traceId = "",
+                transaction = null,
+                spans = emptyList()
+            )
+        }
+
+        val transactionWithSpans = if (lookup.eventType == "transaction") {
+            getTransactionSpans(lookup.eventId)
+        } else {
+            null
+        }
+        val traceSpans = getTraceDetails(lookup.projectId, lookup.traceId)?.spans.orEmpty()
+
+        return EventTraceResponse(
+            eventId = lookup.eventId,
+            eventType = lookup.eventType,
+            projectId = lookup.projectId,
+            traceId = lookup.traceId,
+            transaction = transactionWithSpans?.transaction,
+            spans = transactionWithSpans?.spans?.takeIf { it.isNotEmpty() } ?: traceSpans
+        )
+    }
+
+    suspend fun getTraceForTraceId(projectId: Long, traceId: String): EventTraceResponse? {
+        val trace = getTraceDetails(projectId, traceId)
+        return EventTraceResponse(
+            eventId = null,
+            eventType = null,
+            projectId = projectId,
+            traceId = traceId,
+            transaction = null,
+            spans = trace?.spans.orEmpty()
+        )
+    }
+
     suspend fun getTraceDetails(
         projectId: Long,
         traceId: String
@@ -453,7 +527,8 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
                 tags,
                 contexts,
                 exception_value as exception,
-                breadcrumbs
+                breadcrumbs,
+                stack_trace
             FROM `$clickhouseDb`.events
             WHERE $projectIdClause
                 AND event_type = 'error'

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ApmTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ApmTool.kt
@@ -22,8 +22,10 @@ import com.moneat.mcp.protocol.McpTool
 import com.moneat.mcp.protocol.ToolCallResult
 import com.moneat.events.services.DashboardService
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
 
 private val dashboardService = DashboardService.create()
 
@@ -68,24 +70,39 @@ class ListTransactionsTool : McpTool {
 class GetTraceTool : McpTool {
     override val name = "get_trace"
     override val description =
-        "Get a full transaction/trace by event ID with all spans"
+        "Get a full trace by transaction event ID, error event ID, or trace ID"
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "event_id" to schemaString("Transaction event ID")
+                "event_id" to schemaString("Transaction or error event ID"),
+                "trace_id" to schemaString("Trace ID"),
+                "project_id" to schemaNumber("Project ID for trace_id lookups")
             )
-        ),
-        required = listOf("event_id")
+        )
     )
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val eventId = args["event_id"]?.jsonPrimitive?.content
-            ?: return errorResult("event_id is required")
-        val txn = dashboardService.getTransaction(eventId)
-            ?: return errorResult("Transaction not found: $eventId")
-        return jsonResult(txn)
+        val eventId = args["event_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        val traceId = args["trace_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        val projectId = args["project_id"]?.jsonPrimitive?.longOrNull
+
+        if (eventId == null && traceId == null) {
+            return errorResult("event_id or trace_id is required")
+        }
+        if (eventId == null && projectId == null) {
+            return errorResult("project_id is required when trace_id is used without event_id")
+        }
+
+        val trace = if (eventId != null) {
+            dashboardService.getTraceForEvent(eventId)
+        } else {
+            val requiredProjectId = projectId ?: return errorResult("project_id is required")
+            dashboardService.getTraceForTraceId(requiredProjectId, traceId.orEmpty())
+        } ?: return errorResult("Trace not found")
+
+        return jsonResult(trace)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/CorrelatedTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/CorrelatedTool.kt
@@ -56,7 +56,7 @@ class GetIssueTransactionsTool : McpTool {
             args["limit"]?.jsonPrimitive?.intOrNull
                 ?: DEFAULT_FEEDBACK_LIMIT
             ).coerceIn(1, MAX_FEEDBACK_LIMIT)
-        val events = correlatedService.getIssueEvents(
+        val events = correlatedService.getIssueTransactions(
             issueId,
             limit
         )

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -223,6 +223,7 @@ class McpToolValidationTest {
             ),
             case("create_uptime_name", CreateUptimeMonitorTool(), obj(), "name is required"),
             case("create_uptime_url", CreateUptimeMonitorTool(), obj("name" to "API"), "url is required"),
+            case("get_trace_lookup", GetTraceTool(), obj(), "event_id or trace_id is required"),
             case("create_datasource_name", CreateDataSourceTool(), obj(), "name is required"),
             case(
                 "create_datasource_type",

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -16,16 +16,38 @@
 
 package com.moneat.mcp.tools
 
+import com.moneat.billing.models.PricingTierConfigs
+import com.moneat.config.ClickHouseClient
 import com.moneat.mcp.models.McpContext
 import com.moneat.mcp.protocol.McpTool
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
+import com.moneat.shared.models.Subscriptions
+import com.moneat.testsupport.MockHttpServer
+import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.testsupport.requestBodyText
+import com.moneat.testsupport.respond
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class McpToolValidationTest {
+    companion object {
+        private const val CONTENT_TYPE_TEXT_PLAIN = "text/plain"
+        private const val EVENT_ID = "01234567-89ab-cdef-0123-456789abcdef"
+        private const val TRACE_ID = "trace-1"
+        private var db: Database? = null
+    }
+
     private val context = McpContext(
         organizationId = 1,
         userId = 2,
@@ -33,6 +55,34 @@ class McpToolValidationTest {
         scopes = setOf("project:write"),
         sessionId = "validation-test",
     )
+
+    @BeforeEach
+    fun setupDatabase() {
+        db = db ?: Database.connect(
+            url = "jdbc:h2:mem:moneat_mcp_tool_validation;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver",
+        )
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.resetSchema(
+            Organizations,
+            Projects,
+            Subscriptions,
+            PricingTierConfigs,
+        )
+        transaction {
+            Organizations.insert {
+                it[id] = 1
+                it[name] = "Test Org"
+                it[slug] = "test-org"
+            }
+            Projects.insert {
+                it[id] = 1
+                it[organization_id] = 1
+                it[name] = "Test Project"
+                it[slug] = "test-project"
+            }
+        }
+    }
 
     @Test
     fun `tools return validation errors before calling services`() = runBlocking {
@@ -46,6 +96,91 @@ class McpToolValidationTest {
                 errorText.contains(case.expectedError),
                 "${case.name} expected '${case.expectedError}' but got '$errorText'"
             )
+        }
+    }
+
+    @Test
+    fun `getTrace tool returns trace by event id`() = runBlocking {
+        MockHttpServer { exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("event_type,") -> {
+                    exchange.respond(
+                        200,
+                        """{"event_id":"$EVENT_ID","event_type":"error","project_id":1,"trace_id":"$TRACE_ID"}""",
+                        CONTENT_TYPE_TEXT_PLAIN
+                    )
+                }
+
+                query.contains("FROM `test`.apm_spans") && query.contains("trace_id_hex = '$TRACE_ID'") -> {
+                    exchange.respond(200, spanRow(), CONTENT_TYPE_TEXT_PLAIN)
+                }
+
+                else -> exchange.respond(200, "", CONTENT_TYPE_TEXT_PLAIN)
+            }
+        }.use { server ->
+            ClickHouseClient.close()
+            ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+            val result = GetTraceTool().execute(obj("event_id" to EVENT_ID), context)
+
+            assertFalse(result.isError)
+            assertTrue(result.content.first().text.orEmpty().contains("TrimFrameWorker"))
+        }
+    }
+
+    @Test
+    fun `getTrace tool returns trace by trace id and project id`() = runBlocking {
+        MockHttpServer { exchange ->
+            val query = exchange.requestBodyText()
+            if (query.contains("FROM `test`.apm_spans") && query.contains("trace_id_hex = '$TRACE_ID'")) {
+                exchange.respond(200, spanRow(), CONTENT_TYPE_TEXT_PLAIN)
+            } else {
+                exchange.respond(200, "", CONTENT_TYPE_TEXT_PLAIN)
+            }
+        }.use { server ->
+            ClickHouseClient.close()
+            ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+            val result = GetTraceTool().execute(
+                obj("trace_id" to TRACE_ID, "project_id" to 1),
+                context
+            )
+
+            assertFalse(result.isError)
+            assertTrue(result.content.first().text.orEmpty().contains(TRACE_ID))
+        }
+    }
+
+    @Test
+    fun `getIssueTransactions tool returns correlated transaction rows`() = runBlocking {
+        MockHttpServer { exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("FROM `test`.issues") && query.contains("WHERE issue_id = 'issue-1'") -> {
+                    exchange.respond(200, """{"project_id":1}""", CONTENT_TYPE_TEXT_PLAIN)
+                }
+
+                query.contains("event_type = 'transaction'") && query.contains("issue_id = 'issue-1'") -> {
+                    exchange.respond(
+                        200,
+                        """{"event_id":"txn-1","name":"ProjectWorkChain","op":"project.workchain",""" +
+                            """"duration":1250.0,"event_ts":"2026-02-03T00:00:00.000Z",""" +
+                            """"status":"internal_error","trace_id":"$TRACE_ID"}""",
+                        CONTENT_TYPE_TEXT_PLAIN
+                    )
+                }
+
+                else -> exchange.respond(200, "", CONTENT_TYPE_TEXT_PLAIN)
+            }
+        }.use { server ->
+            ClickHouseClient.close()
+            ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+            val result = GetIssueTransactionsTool().execute(obj("issue_id" to "issue-1"), context)
+
+            assertFalse(result.isError)
+            assertTrue(result.content.first().text.orEmpty().contains("txn-1"))
         }
     }
 
@@ -224,6 +359,12 @@ class McpToolValidationTest {
             case("create_uptime_name", CreateUptimeMonitorTool(), obj(), "name is required"),
             case("create_uptime_url", CreateUptimeMonitorTool(), obj("name" to "API"), "url is required"),
             case("get_trace_lookup", GetTraceTool(), obj(), "event_id or trace_id is required"),
+            case(
+                "get_trace_project_id",
+                GetTraceTool(),
+                obj("trace_id" to TRACE_ID),
+                "project_id is required when trace_id is used without event_id",
+            ),
             case("create_datasource_name", CreateDataSourceTool(), obj(), "name is required"),
             case(
                 "create_datasource_type",
@@ -281,6 +422,12 @@ class McpToolValidationTest {
         is Number -> JsonPrimitive(value)
         else -> JsonPrimitive(value.toString())
     }
+
+    private fun spanRow(): String =
+        """{"span_id":"s1","parent_span_id":"","trace_id":"$TRACE_ID",""" +
+            """"meta":{"sentry.project_id":"1"},"op":"worker",""" +
+            """"description":"TrimFrameWorker","start_ns":"1000000000",""" +
+            """"duration_ns":"500000000","error":1}"""
 
     private data class ValidationCase(
         val name: String,

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -100,6 +100,14 @@ class McpToolValidationTest {
     }
 
     @Test
+    fun `getTrace tool reports not found for invalid event id`() = runBlocking {
+        val result = GetTraceTool().execute(obj("event_id" to "not-a-uuid"), context)
+
+        assertTrue(result.isError)
+        assertTrue(result.content.first().text.orEmpty().contains("Trace not found"))
+    }
+
+    @Test
     fun `getTrace tool returns trace by event id`() = runBlocking {
         MockHttpServer { exchange ->
             val query = exchange.requestBodyText()

--- a/backend/src/test/kotlin/com/moneat/services/DashboardServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/DashboardServiceTest.kt
@@ -28,6 +28,9 @@ import com.moneat.testsupport.TestDatabaseHelper
 import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -182,6 +185,50 @@ class DashboardServiceTest {
                 assertNotNull(issue.latestEvent)
                 assertEquals("evt-1", issue.latestEvent.eventId)
                 assertEquals("prod", issue.latestEvent.tags["env"])
+                assertEquals("stack", issue.latestEvent.stackTrace)
+                val traceContext = issue.latestEvent.contextsJson?.jsonObject?.get("trace")?.jsonObject
+                assertEquals("t1", traceContext?.get("trace_id")?.jsonPrimitive?.contentOrNull)
+            }
+        }
+
+    @Test
+    fun `getIssueTransactions returns transactions linked by issue error trace id`() =
+        runBlocking {
+            val queries = Collections.synchronizedList(mutableListOf<String>())
+            MockHttpServer { exchange ->
+                val query = exchange.requestBodyText()
+                queries += query
+                when {
+                    query.contains("FROM `test`.issues") && query.contains("WHERE issue_id = 'issue-1'") -> {
+                        exchange.respond(200, """{"project_id":-1}""", contentType = "text/plain")
+                    }
+
+                    query.contains("event_type = 'transaction'") && query.contains("issue_id = 'issue-1'") -> {
+                        exchange.respond(
+                            200,
+                            """{"event_id":"txn-1","name":"ProjectWorkChain","op":"project.workchain",""" +
+                                """"duration":1250.0,"event_ts":"2026-02-03T00:00:00.000Z",""" +
+                                """"status":"internal_error","trace_id":"trace-1"}""",
+                            contentType = "text/plain"
+                        )
+                    }
+
+                    else -> {
+                        exchange.respond(200, "", contentType = "text/plain")
+                    }
+                }
+            }.use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+                val service = DashboardService.create()
+                val transactions = service.getIssueTransactions("issue-1", limit = 10)
+
+                assertEquals(1, transactions.size)
+                assertEquals("txn-1", transactions.first().eventId)
+                assertEquals("trace-1", transactions.first().traceId)
+                val traceSubquery = "SELECT DISTINCT JSONExtractString(contexts, 'trace', 'trace_id')"
+                assertTrue(queries.any { it.contains(traceSubquery) })
             }
         }
 

--- a/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
@@ -309,6 +309,56 @@ class TransactionServiceTest {
     }
 
     @Test
+    fun `getTraceForEvent returns transaction spans for transaction event`() = runBlocking {
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("event_type,") -> {
+                    exchange.respond(
+                        200,
+                        """{"event_id":"$TXN_UUID","event_type":"transaction","project_id":1,"trace_id":"$TRACE_1"}""",
+                        CONTENT_TYPE_TEXT_PLAIN
+                    )
+                }
+
+                query.contains("transaction_name as name") -> {
+                    exchange.respond(
+                        200,
+                        """{"event_id":"$TXN_UUID","name":"GET /api","op":"http.server",""" +
+                            """"start_ts_ms":1000,"duration":250.0,"trace_id":"$TRACE_1",""" +
+                            """"timestamp":"2026-01-01T00:00:00.000Z","environment":"prod",""" +
+                            """"release":"1.0","status":"ok","tags":{},"contexts":{},""" +
+                            """"breadcrumbs":[],"request":{}}""",
+                        CONTENT_TYPE_TEXT_PLAIN
+                    )
+                }
+
+                query.contains("toInt64(project_id) as project_id") -> {
+                    exchange.respond(200, """{"project_id":1}""", CONTENT_TYPE_TEXT_PLAIN)
+                }
+
+                query.contains("meta['sentry.transaction_id']") -> {
+                    exchange.respond(200, apmSpanRow(), CONTENT_TYPE_TEXT_PLAIN)
+                }
+
+                query.contains("trace_id_hex = '$TRACE_1'") -> {
+                    exchange.respond(200, apmSpanRow(), CONTENT_TYPE_TEXT_PLAIN)
+                }
+
+                else -> exchange.respond(200, "", CONTENT_TYPE_TEXT_PLAIN)
+            }
+        }) {
+            val trace = service.getTraceForEvent(TXN_UUID)
+
+            assertNotNull(trace)
+            assertEquals("transaction", trace.eventType)
+            assertNotNull(trace.transaction)
+            assertEquals(1, trace.spans.size)
+            assertEquals("TrimFrameWorker", trace.spans.first().description)
+        }
+    }
+
+    @Test
     fun `getTraceForEvent returns empty trace response when event has no trace id`() = runBlocking {
         withClickHouseMockServer({ exchange ->
             exchange.respond(
@@ -424,4 +474,10 @@ class TransactionServiceTest {
         val result = service.getRelatedErrorsForTransaction("not-a-uuid")
         assertTrue(result.isEmpty())
     }
+
+    private fun apmSpanRow(): String =
+        """{"span_id":"s1","parent_span_id":"","trace_id":"$TRACE_1",""" +
+            """"meta":{"sentry.project_id":"1","sentry.transaction_id":"$TXN_UUID"},""" +
+            """"op":"worker","description":"TrimFrameWorker","start_ns":"1000000000",""" +
+            """"duration_ns":"500000000","error":1}"""
 }

--- a/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
@@ -308,6 +308,41 @@ class TransactionServiceTest {
         }
     }
 
+    @Test
+    fun `getTraceForEvent returns empty trace response when event has no trace id`() = runBlocking {
+        withClickHouseMockServer({ exchange ->
+            exchange.respond(
+                200,
+                """{"event_id":"$TXN_UUID","event_type":"error","project_id":1,"trace_id":""}""",
+                CONTENT_TYPE_TEXT_PLAIN
+            )
+        }) {
+            val trace = service.getTraceForEvent(TXN_UUID)
+
+            assertNotNull(trace)
+            assertEquals(TXN_UUID, trace.eventId)
+            assertEquals("error", trace.eventType)
+            assertEquals("", trace.traceId)
+            assertTrue(trace.spans.isEmpty())
+        }
+    }
+
+    @Test
+    fun `getTraceForTraceId returns empty response when trace is missing`() = runBlocking {
+        withClickHouseMockServer({ exchange ->
+            exchange.respond(200, "", CONTENT_TYPE_TEXT_PLAIN)
+        }) {
+            val trace = service.getTraceForTraceId(projectId = 1, traceId = "missing-trace")
+
+            assertNotNull(trace)
+            assertNull(trace.eventId)
+            assertNull(trace.eventType)
+            assertEquals(1, trace.projectId)
+            assertEquals("missing-trace", trace.traceId)
+            assertTrue(trace.spans.isEmpty())
+        }
+    }
+
     // ──── getSpanDetails Tests ────
     @Test
     fun `getSpanDetails returns span with transaction`() = runBlocking {

--- a/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
@@ -378,18 +378,13 @@ class TransactionServiceTest {
     }
 
     @Test
-    fun `getTraceForTraceId returns empty response when trace is missing`() = runBlocking {
+    fun `getTraceForTraceId returns null when trace is missing`() = runBlocking {
         withClickHouseMockServer({ exchange ->
             exchange.respond(200, "", CONTENT_TYPE_TEXT_PLAIN)
         }) {
             val trace = service.getTraceForTraceId(projectId = 1, traceId = "missing-trace")
 
-            assertNotNull(trace)
-            assertNull(trace.eventId)
-            assertNull(trace.eventType)
-            assertEquals(1, trace.projectId)
-            assertEquals("missing-trace", trace.traceId)
-            assertTrue(trace.spans.isEmpty())
+            assertNull(trace)
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
@@ -269,6 +269,45 @@ class TransactionServiceTest {
         }
     }
 
+    @Test
+    fun `getTraceForEvent returns spans for error event trace context`() = runBlocking {
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("Event trace lookup") || query.contains("event_type,") -> {
+                    exchange.respond(
+                        200,
+                        """
+                    {"event_id":"$TXN_UUID","event_type":"error","project_id":1,"trace_id":"$TRACE_1"}
+                        """.trimIndent(),
+                        CONTENT_TYPE_TEXT_PLAIN
+                    )
+                }
+
+                query.contains("FROM `test`.apm_spans") && query.contains("trace_id_hex = '$TRACE_1'") -> {
+                    exchange.respond(
+                        200,
+                        """{"span_id":"s1","parent_span_id":"","trace_id":"$TRACE_1",""" +
+                            """"meta":{"sentry.project_id":"1"},"op":"worker",""" +
+                            """"description":"TrimFrameWorker","start_ns":"1000000000",""" +
+                            """"duration_ns":"500000000","error":1}""",
+                        CONTENT_TYPE_TEXT_PLAIN
+                    )
+                }
+
+                else -> exchange.respond(200, "", CONTENT_TYPE_TEXT_PLAIN)
+            }
+        }) {
+            val trace = service.getTraceForEvent(TXN_UUID)
+
+            assertNotNull(trace)
+            assertEquals("error", trace.eventType)
+            assertEquals(TRACE_1, trace.traceId)
+            assertEquals(1, trace.spans.size)
+            assertEquals("TrimFrameWorker", trace.spans.first().description)
+        }
+    }
+
     // ──── getSpanDetails Tests ────
     @Test
     fun `getSpanDetails returns span with transaction`() = runBlocking {


### PR DESCRIPTION
## Summary
- include stack traces and parsed contexts/breadcrumbs in issue event payloads for MCP investigations
- return trace-linked transactions from `get_issue_transactions` instead of duplicating issue events
- let `get_trace` resolve traces from transaction event ids, error event ids, or `trace_id` plus project id

## Validation
- `./gradlew compileKotlin`
- `./gradlew detekt`
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.services.DashboardServiceTest --tests com.moneat.services.TransactionServiceTest --tests com.moneat.mcp.tools.McpToolValidationTest -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events now include stack trace plus parsed trace/context/breadcrumb JSON and a dedicated trace response to return transactions and spans
  * Added endpoints to fetch trace data by event ID or by project+trace ID

* **Bug Fixes / Improvements**
  * Transaction lookup refined to correlate transactions with related error trace IDs for more accurate results

* **Tests**
  * Added test coverage for trace lookup, trace-by-trace-id, and issue→transaction correlation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->