### PR TITLE
fix: admin tier unlimited quotas

### DIFF
--- a/backend/src/main/kotlin/com/moneat/billing/services/PricingTierService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/PricingTierService.kt
@@ -60,6 +60,7 @@ private const val MAX_RETENTION_DAYS = 90
 private const val MAX_TRIAL_DAYS = 60
 private const val MAX_ANALYTICS_RETENTION_DAYS = 3650
 private const val DEFAULT_TRIAL_DAYS_NON_FREE = 14
+private const val JS_SAFE_UNLIMITED_QUOTA_LIMIT = 9_007_199_254_740_000L
 
 class PricingTierService {
     private data class DefaultFeatureFlags(
@@ -205,12 +206,25 @@ class PricingTierService {
     ): PricingTierConfigResponse {
         val canonicalName = tierName.uppercase()
         validateCreateTierRequest(request)
+        val monthlyUnitLimitFallback = normalizeUnlimitedQuotaLimit(request.monthlyUnitLimit)
         val monthlyErrorLimit =
-            if (request.monthlyErrorLimit > 0) request.monthlyErrorLimit else request.monthlyUnitLimit
-        val monthlyTransactionLimit = request.monthlyTransactionLimit
-        val monthlyReplayLimit = request.monthlyReplayLimit
-        val monthlyFeedbackLimit = request.monthlyFeedbackLimit
-        val monthlyUnitLimit = monthlyErrorLimit + monthlyTransactionLimit + monthlyReplayLimit + monthlyFeedbackLimit
+            if (request.monthlyErrorLimit > 0) {
+                normalizeUnlimitedQuotaLimit(request.monthlyErrorLimit)
+            } else {
+                monthlyUnitLimitFallback
+            }
+        val monthlyTransactionLimit = normalizeUnlimitedQuotaLimit(request.monthlyTransactionLimit)
+        val monthlyReplayLimit =
+            if (request.monthlyReplayLimit < 0) {
+                request.monthlyReplayLimit
+            } else {
+                normalizeUnlimitedQuotaLimit(request.monthlyReplayLimit)
+            }
+        val monthlyFeedbackLimit = normalizeUnlimitedQuotaLimit(request.monthlyFeedbackLimit)
+        val monthlyLlmEventLimit = normalizeUnlimitedQuotaLimit(request.monthlyLlmEventLimit)
+        val monthlyUnitLimit = totalMonthlyUnitLimit(
+            listOf(monthlyErrorLimit, monthlyTransactionLimit, monthlyReplayLimit, monthlyFeedbackLimit)
+        )
         return transaction {
             val current =
                 PricingTierConfigs
@@ -252,22 +266,25 @@ class PricingTierService {
                     ?: currentConfig?.analyticsRetentionDays
                     ?: DEFAULT_ANALYTICS_RETENTION_DAYS
             val resolvedMonthlyAnalyticsPageviewLimit =
-                request.monthlyAnalyticsPageviewLimit ?: currentConfig?.monthlyAnalyticsPageviewLimit ?: 0
+                request.monthlyAnalyticsPageviewLimit?.let(::normalizeUnlimitedQuotaLimit)
+                    ?: currentConfig?.monthlyAnalyticsPageviewLimit ?: 0
             val resolvedAnalyticsPageviewOverageRateCentsPer100k =
                 request.analyticsPageviewOverageRateCentsPer100k
                     ?: currentConfig?.analyticsPageviewOverageRateCentsPer100k ?: 0
-            val resolvedMonthlyApmSpanLimit = request.monthlyApmSpanLimit
+            val resolvedMonthlyApmSpanLimit = request.monthlyApmSpanLimit?.let(::normalizeUnlimitedQuotaLimit)
                 ?: currentConfig?.monthlyApmSpanLimit ?: 0
             val resolvedApmSpanOverageRateCentsPer1m = request.apmSpanOverageRateCentsPer1m
                 ?: currentConfig?.apmSpanOverageRateCentsPer1m ?: 0
-            val resolvedMonthlyCustomMetricLimit = request.monthlyCustomMetricLimit
-                ?: currentConfig?.monthlyCustomMetricLimit ?: 0
+            val resolvedMonthlyCustomMetricLimit =
+                request.monthlyCustomMetricLimit?.let(::normalizeUnlimitedQuotaLimit)
+                    ?: currentConfig?.monthlyCustomMetricLimit ?: 0
             val resolvedCustomMetricOverageRateCentsPer100k =
                 request.customMetricOverageRateCentsPer100k
                     ?: currentConfig?.customMetricOverageRateCentsPer100k ?: 0
             val resolvedMonthlyInfraMetricSeriesHourLimit =
                 when {
-                    request.monthlyInfraMetricSeriesHourLimit != null -> request.monthlyInfraMetricSeriesHourLimit
+                    request.monthlyInfraMetricSeriesHourLimit != null ->
+                        normalizeUnlimitedQuotaLimit(request.monthlyInfraMetricSeriesHourLimit)
                     currentConfig != null -> currentConfig.monthlyInfraMetricSeriesHourLimit
                     else -> fallbackConfig.monthlyInfraMetricSeriesHourLimit
                 }
@@ -354,7 +371,7 @@ class PricingTierService {
                     it[monthly_transaction_limit] = monthlyTransactionLimit
                     it[monthly_replay_limit] = monthlyReplayLimit
                     it[monthly_feedback_limit] = monthlyFeedbackLimit
-                    it[monthly_llm_event_limit] = request.monthlyLlmEventLimit
+                    it[monthly_llm_event_limit] = monthlyLlmEventLimit
                     it[monthly_gb_limit] = resolvedMonthlyGbLimit
                     it[retention_days] = request.retentionDays
                     it[log_retention_days] = resolvedLogRetentionDays
@@ -417,6 +434,17 @@ class PricingTierService {
                 } get PricingTierConfigs.id
 
             rowToResponse(PricingTierConfigs.selectAll().where { PricingTierConfigs.id eq id }.first())
+        }
+    }
+
+    private fun normalizeUnlimitedQuotaLimit(limit: Long): Long {
+        return if (limit >= JS_SAFE_UNLIMITED_QUOTA_LIMIT) Long.MAX_VALUE else limit
+    }
+
+    private fun totalMonthlyUnitLimit(limits: List<Long>): Long {
+        if (limits.any { it < 0 || it == Long.MAX_VALUE }) return Long.MAX_VALUE
+        return limits.fold(0L) { total, limit ->
+            if (Long.MAX_VALUE - total < limit) Long.MAX_VALUE else total + limit
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/PricingTierServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/PricingTierServiceTest.kt
@@ -208,6 +208,49 @@ class PricingTierServiceTest {
     }
 
     @Test
+    fun `createTierVersion normalizes fallback and optional unlimited limits`() {
+        seedTier("PRO", version = 1)
+
+        val safeUnlimitedLimit = 9_007_199_254_740_000L
+        val created =
+            service.createTierVersion(
+                "PRO",
+                CreateTierVersionRequest(
+                    monthlyUnitLimit = safeUnlimitedLimit,
+                    monthlyErrorLimit = 0,
+                    monthlyTransactionLimit = 100,
+                    monthlyReplayLimit = -1,
+                    monthlyFeedbackLimit = 200,
+                    monthlyLlmEventLimit = 300,
+                    monthlyGbLimit = 1_073_741_824,
+                    retentionDays = 7,
+                    logRetentionDays = 7,
+                    maxProjects = 5,
+                    maxSystems = 5,
+                    monitorIntervalSeconds = 60,
+                    monthlyPriceCents = 2900,
+                    yearlyPriceCents = 24900,
+                    trialDays = 14,
+                    paygEnabled = false,
+                    paygRateMicrosPerUnit = 0,
+                    monthlyApmSpanLimit = safeUnlimitedLimit,
+                    monthlyCustomMetricLimit = safeUnlimitedLimit,
+                    monthlyInfraMetricSeriesHourLimit = safeUnlimitedLimit
+                )
+            )
+
+        assertEquals(Long.MAX_VALUE, created.monthlyUnitLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyErrorLimit)
+        assertEquals(100, created.monthlyTransactionLimit)
+        assertEquals(-1, created.monthlyReplayLimit)
+        assertEquals(200, created.monthlyFeedbackLimit)
+        assertEquals(300, created.monthlyLlmEventLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyApmSpanLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyCustomMetricLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyInfraMetricSeriesHourLimit)
+    }
+
+    @Test
     fun `createTierVersion preserves infrastructure metric billing from current tier`() {
         seedTier(
             "PRO",

--- a/backend/src/test/kotlin/com/moneat/services/PricingTierServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/PricingTierServiceTest.kt
@@ -167,6 +167,47 @@ class PricingTierServiceTest {
     }
 
     @Test
+    fun `createTierVersion treats JavaScript safe unlimited sentinel as unlimited`() {
+        seedTier("FREE", version = 1)
+
+        val safeUnlimitedLimit = 9_007_199_254_740_000L
+        val created =
+            service.createTierVersion(
+                "FREE",
+                CreateTierVersionRequest(
+                    monthlyUnitLimit = safeUnlimitedLimit,
+                    monthlyErrorLimit = safeUnlimitedLimit,
+                    monthlyTransactionLimit = safeUnlimitedLimit,
+                    monthlyReplayLimit = safeUnlimitedLimit,
+                    monthlyFeedbackLimit = safeUnlimitedLimit,
+                    monthlyLlmEventLimit = safeUnlimitedLimit,
+                    monthlyGbLimit = 1_073_741_824,
+                    retentionDays = 30,
+                    logRetentionDays = 30,
+                    replayRetentionDays = 30,
+                    llmRetentionDays = 30,
+                    maxProjects = 1,
+                    maxSystems = 3,
+                    monitorIntervalSeconds = 60,
+                    monthlyPriceCents = 0,
+                    yearlyPriceCents = 0,
+                    trialDays = 0,
+                    paygEnabled = false,
+                    paygRateMicrosPerUnit = 0,
+                    monthlyAnalyticsPageviewLimit = safeUnlimitedLimit
+                )
+            )
+
+        assertEquals(Long.MAX_VALUE, created.monthlyUnitLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyErrorLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyTransactionLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyReplayLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyFeedbackLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyLlmEventLimit)
+        assertEquals(Long.MAX_VALUE, created.monthlyAnalyticsPageviewLimit)
+    }
+
+    @Test
     fun `createTierVersion preserves infrastructure metric billing from current tier`() {
         seedTier(
             "PRO",

--- a/dashboard/src/lib/__tests__/admin-billing-limits.test.ts
+++ b/dashboard/src/lib/__tests__/admin-billing-limits.test.ts
@@ -1,0 +1,55 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {
+  formatQuotaLimit,
+  formatTotalQuotaLimit,
+  normalizeQuotaForForm,
+  normalizeQuotaForRequest,
+  totalQuotaForRequest,
+} from '../admin-billing-limits'
+
+const JS_ROUNDED_LONG_MAX = 9_223_372_036_854_776_000
+const SAFE_UNLIMITED_SENTINEL = 9_007_199_254_740_000
+
+describe('admin billing limit helpers', () => {
+  it('normalizes JavaScript-rounded Long.MAX_VALUE into a safe unlimited sentinel', () => {
+    expect(normalizeQuotaForForm(JS_ROUNDED_LONG_MAX)).toBe(SAFE_UNLIMITED_SENTINEL)
+    expect(normalizeQuotaForRequest(JS_ROUNDED_LONG_MAX)).toBe(SAFE_UNLIMITED_SENTINEL)
+  })
+
+  it('formats unlimited sentinels instead of showing giant integers', () => {
+    expect(formatQuotaLimit(JS_ROUNDED_LONG_MAX)).toBe('Unlimited')
+    expect(formatTotalQuotaLimit([JS_ROUNDED_LONG_MAX, 0, 0, 0])).toBe('Unlimited')
+  })
+
+  it('uses the safe sentinel for total request limits when any component is unlimited', () => {
+    expect(totalQuotaForRequest([SAFE_UNLIMITED_SENTINEL, 1, 2, 3])).toBe(SAFE_UNLIMITED_SENTINEL)
+  })
+
+  it('caps oversized aggregate request limits at the safe sentinel', () => {
+    const almostUnlimited = SAFE_UNLIMITED_SENTINEL - 1
+
+    expect(totalQuotaForRequest([almostUnlimited, 10])).toBe(SAFE_UNLIMITED_SENTINEL)
+    expect(formatTotalQuotaLimit([almostUnlimited, 10])).toBe('Unlimited')
+  })
+
+  it('keeps finite totals numeric', () => {
+    expect(formatTotalQuotaLimit([10, 20, 30, 40])).toBe('100')
+    expect(totalQuotaForRequest([10, 20, 30, 40])).toBe(100)
+  })
+})

--- a/dashboard/src/lib/admin-billing-limits.ts
+++ b/dashboard/src/lib/admin-billing-limits.ts
@@ -1,0 +1,69 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const UNLIMITED_QUOTA_SENTINEL = 9_007_199_254_740_000
+
+function finiteInteger(value: number | null | undefined, fallback: number): number {
+  if (value == null || !Number.isFinite(value)) return fallback
+  return Math.round(value)
+}
+
+export function isUnlimitedQuota(value: number | null | undefined): boolean {
+  return value != null && value >= UNLIMITED_QUOTA_SENTINEL
+}
+
+export function isUnlimitedReplayQuota(value: number | null | undefined): boolean {
+  return value != null && (value < 0 || isUnlimitedQuota(value))
+}
+
+export function normalizeQuotaForForm(value: number | null | undefined, fallback = 0): number {
+  const integer = finiteInteger(value, fallback)
+  if (integer >= UNLIMITED_QUOTA_SENTINEL) return UNLIMITED_QUOTA_SENTINEL
+  return Math.max(0, integer)
+}
+
+export function normalizeReplayQuotaForForm(value: number | null | undefined, fallback = 0): number {
+  const integer = finiteInteger(value, fallback)
+  if (integer < 0) return -1
+  return normalizeQuotaForForm(integer, fallback)
+}
+
+export function normalizeQuotaForRequest(value: number): number {
+  return normalizeQuotaForForm(value)
+}
+
+export function normalizeReplayQuotaForRequest(value: number): number {
+  return normalizeReplayQuotaForForm(value)
+}
+
+export function totalQuotaForRequest(limits: number[]): number {
+  if (limits.some((limit) => limit < 0 || isUnlimitedQuota(limit))) {
+    return UNLIMITED_QUOTA_SENTINEL
+  }
+  const total = limits.reduce((sum, limit) => sum + normalizeQuotaForRequest(limit), 0)
+  return total >= UNLIMITED_QUOTA_SENTINEL ? UNLIMITED_QUOTA_SENTINEL : total
+}
+
+export function formatQuotaLimit(value: number | null | undefined): string {
+  if (isUnlimitedReplayQuota(value)) return 'Unlimited'
+  return normalizeQuotaForForm(value).toLocaleString()
+}
+
+export function formatTotalQuotaLimit(limits: number[]): string {
+  if (limits.some((limit) => isUnlimitedReplayQuota(limit))) return 'Unlimited'
+  const total = limits.reduce((sum, limit) => sum + normalizeQuotaForForm(limit), 0)
+  return total >= UNLIMITED_QUOTA_SENTINEL ? 'Unlimited' : total.toLocaleString()
+}

--- a/dashboard/src/routes/admin.billing.tsx
+++ b/dashboard/src/routes/admin.billing.tsx
@@ -17,7 +17,13 @@
 import {useMemo, useState} from 'react'
 import {createFileRoute} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
-import {type AdminBillingSubscription, api, type BillingPlan, type BillingTierConfig} from '@/lib/api'
+import {
+    api,
+    type AdminBillingSubscription,
+    type BillingPlan,
+    type BillingTierConfig,
+    type CreateTierVersionRequest,
+} from '@/lib/api'
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
@@ -40,6 +46,15 @@ import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/compon
 import {useToast} from '@/hooks/useToast'
 import {AdminSkeleton, PlanBadge, SectionHeader} from '@/components/AdminComponents'
 import {type BillingInterval, buildPricingCardModel, type PricingCardTierInput} from '@/lib/pricing-display'
+import {
+    formatQuotaLimit,
+    formatTotalQuotaLimit,
+    normalizeQuotaForForm,
+    normalizeQuotaForRequest,
+    normalizeReplayQuotaForForm,
+    normalizeReplayQuotaForRequest,
+    totalQuotaForRequest,
+} from '@/lib/admin-billing-limits'
 import {AlertTriangle, Check, HelpCircle, Info} from 'lucide-react'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDate} from '@/lib/date-format'
@@ -253,11 +268,11 @@ const DEFAULT_FORM: CreateFormState = {
 
 function buildCreateFormFromConfig(config: BillingTierConfig): CreateFormState {
   return {
-    monthlyErrorLimit: config.monthlyErrorLimit,
-    monthlyTransactionLimit: config.monthlyTransactionLimit,
-    monthlyReplayLimit: config.monthlyReplayLimit,
-    monthlyFeedbackLimit: config.monthlyFeedbackLimit,
-    monthlyLlmEventLimit: config.monthlyLlmEventLimit ?? 0,
+    monthlyErrorLimit: normalizeQuotaForForm(config.monthlyErrorLimit),
+    monthlyTransactionLimit: normalizeQuotaForForm(config.monthlyTransactionLimit),
+    monthlyReplayLimit: normalizeReplayQuotaForForm(config.monthlyReplayLimit),
+    monthlyFeedbackLimit: normalizeQuotaForForm(config.monthlyFeedbackLimit),
+    monthlyLlmEventLimit: normalizeQuotaForForm(config.monthlyLlmEventLimit ?? 0),
     retentionDays: config.retentionDays,
     logRetentionDays: config.logRetentionDays ?? config.retentionDays,
     replayRetentionDays: config.replayRetentionDays ?? config.retentionDays,
@@ -280,7 +295,7 @@ function buildCreateFormFromConfig(config: BillingTierConfig): CreateFormState {
     oncallPerUserYearlyCents: config.oncallPerUserYearlyCents ?? 5000,
     maxAnalyticsSites: config.maxAnalyticsSites != null ? String(config.maxAnalyticsSites) : '',
     analyticsRetentionDays: config.analyticsRetentionDays ?? 1095,
-    monthlyAnalyticsPageviewLimit: config.monthlyAnalyticsPageviewLimit ?? 0,
+    monthlyAnalyticsPageviewLimit: normalizeQuotaForForm(config.monthlyAnalyticsPageviewLimit ?? 0),
     analyticsPageviewOverageRateCentsPer100k: config.analyticsPageviewOverageRateCentsPer100k ?? 0,
     stripeBasePriceId: config.stripeBasePriceId ?? '',
     stripeOveragePriceId: config.stripeOveragePriceId ?? '',
@@ -288,6 +303,58 @@ function buildCreateFormFromConfig(config: BillingTierConfig): CreateFormState {
     stripeYearlyOveragePriceId: config.stripeYearlyOveragePriceId ?? '',
     stripeOncallPriceId: config.stripeOncallPriceId ?? '',
     stripeOncallYearlyPriceId: config.stripeOncallYearlyPriceId ?? '',
+  }
+}
+
+function buildCreateTierVersionRequest(form: CreateFormState): CreateTierVersionRequest {
+  const monthlyErrorLimit = normalizeQuotaForRequest(form.monthlyErrorLimit)
+  const monthlyTransactionLimit = normalizeQuotaForRequest(form.monthlyTransactionLimit)
+  const monthlyReplayLimit = normalizeReplayQuotaForRequest(form.monthlyReplayLimit)
+  const monthlyFeedbackLimit = normalizeQuotaForRequest(form.monthlyFeedbackLimit)
+  const totalLimits = [
+    monthlyErrorLimit,
+    monthlyTransactionLimit,
+    monthlyReplayLimit,
+    monthlyFeedbackLimit,
+  ]
+
+  return {
+    monthlyUnitLimit: totalQuotaForRequest(totalLimits),
+    monthlyErrorLimit,
+    monthlyTransactionLimit,
+    monthlyReplayLimit,
+    monthlyFeedbackLimit,
+    monthlyLlmEventLimit: normalizeQuotaForRequest(form.monthlyLlmEventLimit),
+    retentionDays: Number(form.retentionDays),
+    logRetentionDays: Number(form.logRetentionDays),
+    replayRetentionDays: Number(form.replayRetentionDays),
+    llmRetentionDays: Number(form.llmRetentionDays),
+    maxProjects: form.maxProjects.trim() ? Number(form.maxProjects) : null,
+    maxSystems: Number(form.maxSystems),
+    monitorIntervalSeconds: Number(form.monitorIntervalSeconds),
+    monthlyPriceCents: Number(form.monthlyPriceCents),
+    yearlyPriceCents: Number(form.yearlyPriceCents),
+    monthlyGbLimit: Math.max(0, Math.round(form.monthlyGbLimitGb * BYTES_PER_GB)),
+    trialDays: Number(form.trialDays),
+    paygEnabled: Boolean(form.paygEnabled),
+    paygRateMicrosPerUnit: Number(form.paygRateMicrosPerUnit),
+    overageRateCentsPerGb: Number(form.overageRateCentsPerGb),
+    errorOverageRateCentsPer1k: Number(form.errorOverageRateCentsPer1k),
+    replayOverageRateCentsPerGb: Number(form.replayOverageRateCentsPerGb),
+    llmOverageRateCentsPer1k: Number(form.llmOverageRateCentsPer1k),
+    oncallEnabled: Boolean(form.oncallEnabled),
+    oncallPerUserMonthlyCents: Number(form.oncallPerUserMonthlyCents),
+    oncallPerUserYearlyCents: Number(form.oncallPerUserYearlyCents),
+    maxAnalyticsSites: form.maxAnalyticsSites.trim() ? Number(form.maxAnalyticsSites) : null,
+    analyticsRetentionDays: Number(form.analyticsRetentionDays),
+    monthlyAnalyticsPageviewLimit: normalizeQuotaForRequest(form.monthlyAnalyticsPageviewLimit),
+    analyticsPageviewOverageRateCentsPer100k: Number(form.analyticsPageviewOverageRateCentsPer100k),
+    stripeBasePriceId: form.stripeBasePriceId.trim() || null,
+    stripeOveragePriceId: form.stripeOveragePriceId.trim() || null,
+    stripeYearlyBasePriceId: form.stripeYearlyBasePriceId.trim() || null,
+    stripeYearlyOveragePriceId: form.stripeYearlyOveragePriceId.trim() || null,
+    stripeOncallPriceId: form.stripeOncallPriceId.trim() || null,
+    stripeOncallYearlyPriceId: form.stripeOncallYearlyPriceId.trim() || null,
   }
 }
 
@@ -509,48 +576,7 @@ function AdminBillingPage() {
 
   const createVersionMutation = useMutation({
     mutationFn: () =>
-      api.createAdminBillingTierVersion(createTier, {
-        monthlyUnitLimit:
-          Number(createForm.monthlyErrorLimit) +
-          Number(createForm.monthlyTransactionLimit) +
-          Number(createForm.monthlyReplayLimit) +
-          Number(createForm.monthlyFeedbackLimit),
-        monthlyErrorLimit: Number(createForm.monthlyErrorLimit),
-        monthlyTransactionLimit: Number(createForm.monthlyTransactionLimit),
-        monthlyReplayLimit: Number(createForm.monthlyReplayLimit),
-        monthlyFeedbackLimit: Number(createForm.monthlyFeedbackLimit),
-        monthlyLlmEventLimit: Number(createForm.monthlyLlmEventLimit),
-        retentionDays: Number(createForm.retentionDays),
-        logRetentionDays: Number(createForm.logRetentionDays),
-        replayRetentionDays: Number(createForm.replayRetentionDays),
-        llmRetentionDays: Number(createForm.llmRetentionDays),
-        maxProjects: createForm.maxProjects.trim() ? Number(createForm.maxProjects) : null,
-        maxSystems: Number(createForm.maxSystems),
-        monitorIntervalSeconds: Number(createForm.monitorIntervalSeconds),
-        monthlyPriceCents: Number(createForm.monthlyPriceCents),
-        yearlyPriceCents: Number(createForm.yearlyPriceCents),
-        monthlyGbLimit: Math.max(0, Math.round(createForm.monthlyGbLimitGb * BYTES_PER_GB)),
-        trialDays: Number(createForm.trialDays),
-        paygEnabled: Boolean(createForm.paygEnabled),
-        paygRateMicrosPerUnit: Number(createForm.paygRateMicrosPerUnit),
-        overageRateCentsPerGb: Number(createForm.overageRateCentsPerGb),
-        errorOverageRateCentsPer1k: Number(createForm.errorOverageRateCentsPer1k),
-        replayOverageRateCentsPerGb: Number(createForm.replayOverageRateCentsPerGb),
-        llmOverageRateCentsPer1k: Number(createForm.llmOverageRateCentsPer1k),
-        oncallEnabled: Boolean(createForm.oncallEnabled),
-        oncallPerUserMonthlyCents: Number(createForm.oncallPerUserMonthlyCents),
-        oncallPerUserYearlyCents: Number(createForm.oncallPerUserYearlyCents),
-        maxAnalyticsSites: createForm.maxAnalyticsSites.trim() ? Number(createForm.maxAnalyticsSites) : null,
-        analyticsRetentionDays: Number(createForm.analyticsRetentionDays),
-        monthlyAnalyticsPageviewLimit: Number(createForm.monthlyAnalyticsPageviewLimit),
-        analyticsPageviewOverageRateCentsPer100k: Number(createForm.analyticsPageviewOverageRateCentsPer100k),
-        stripeBasePriceId: createForm.stripeBasePriceId.trim() || null,
-        stripeOveragePriceId: createForm.stripeOveragePriceId.trim() || null,
-        stripeYearlyBasePriceId: createForm.stripeYearlyBasePriceId.trim() || null,
-        stripeYearlyOveragePriceId: createForm.stripeYearlyOveragePriceId.trim() || null,
-        stripeOncallPriceId: createForm.stripeOncallPriceId.trim() || null,
-        stripeOncallYearlyPriceId: createForm.stripeOncallYearlyPriceId.trim() || null,
-      }),
+      api.createAdminBillingTierVersion(createTier, buildCreateTierVersionRequest(createForm)),
     onSuccess: (tier) => {
       queryClient.invalidateQueries({queryKey: ['admin-billing-current-plans']})
       queryClient.invalidateQueries({queryKey: ['admin-billing-tier-versions', createTier]})
@@ -673,12 +699,12 @@ function AdminBillingPage() {
                       </TableCell>
                       <TableCell>v{plan.tier.version}</TableCell>
                       <TableCell>${centsToDollars(plan.tier.monthlyPriceCents)}/mo</TableCell>
-                      <TableCell>{plan.tier.monthlyUnitLimit.toLocaleString()}</TableCell>
-                      <TableCell>{plan.tier.monthlyErrorLimit.toLocaleString()}</TableCell>
-                      <TableCell>{plan.tier.monthlyTransactionLimit.toLocaleString()}</TableCell>
-                      <TableCell>{plan.tier.monthlyReplayLimit.toLocaleString()}</TableCell>
-                      <TableCell>{plan.tier.monthlyFeedbackLimit.toLocaleString()}</TableCell>
-                      <TableCell>{(plan.tier.monthlyLlmEventLimit ?? 0).toLocaleString()}</TableCell>
+                      <TableCell>{formatQuotaLimit(plan.tier.monthlyUnitLimit)}</TableCell>
+                      <TableCell>{formatQuotaLimit(plan.tier.monthlyErrorLimit)}</TableCell>
+                      <TableCell>{formatQuotaLimit(plan.tier.monthlyTransactionLimit)}</TableCell>
+                      <TableCell>{formatQuotaLimit(plan.tier.monthlyReplayLimit)}</TableCell>
+                      <TableCell>{formatQuotaLimit(plan.tier.monthlyFeedbackLimit)}</TableCell>
+                      <TableCell>{formatQuotaLimit(plan.tier.monthlyLlmEventLimit ?? 0)}</TableCell>
                       <TableCell>{plan.tier.retentionDays}d</TableCell>
                       <TableCell>{plan.tier.maxSystems}</TableCell>
                       <TableCell>{formatInterval(plan.tier.monitorIntervalSeconds)}</TableCell>
@@ -859,7 +885,7 @@ function AdminBillingPage() {
                       }
                     />
                     <FieldHint>
-                      {createForm.monthlyLlmEventLimit.toLocaleString()} AI observability events/month
+                      {formatQuotaLimit(createForm.monthlyLlmEventLimit)} AI observability events/month
                     </FieldHint>
                     {validationErrors.monthlyLlmEventLimit && (
                       <p className="text-xs text-destructive">{validationErrors.monthlyLlmEventLimit}</p>
@@ -956,12 +982,12 @@ function AdminBillingPage() {
                     />
                     <FieldHint>
                       Total base limit:{' '}
-                      {(
-                        createForm.monthlyErrorLimit +
-                        createForm.monthlyTransactionLimit +
-                        createForm.monthlyReplayLimit +
-                        createForm.monthlyFeedbackLimit
-                      ).toLocaleString()}{' '}
+                      {formatTotalQuotaLimit([
+                        createForm.monthlyErrorLimit,
+                        createForm.monthlyTransactionLimit,
+                        createForm.monthlyReplayLimit,
+                        createForm.monthlyFeedbackLimit,
+                      ])}{' '}
                       units/month
                     </FieldHint>
                     {validationErrors.monthlyFeedbackLimit && (
@@ -1287,7 +1313,7 @@ function AdminBillingPage() {
                       setCreateForm((p) => ({...p, monthlyAnalyticsPageviewLimit: Number(e.target.value)}))
                     }
                   />
-                  <FieldHint>{createForm.monthlyAnalyticsPageviewLimit >= 1_000_000 ? `${(createForm.monthlyAnalyticsPageviewLimit / 1_000_000).toFixed(1)}M` : `${(createForm.monthlyAnalyticsPageviewLimit / 1_000).toFixed(0)}K`} pageviews/mo</FieldHint>
+                  <FieldHint>{formatQuotaLimit(createForm.monthlyAnalyticsPageviewLimit)} pageviews/mo</FieldHint>
                 </div>
                 <div className="space-y-1.5">
                   <Label htmlFor="analyticsPageviewOverageRateCentsPer100k">
@@ -1535,17 +1561,17 @@ function AdminBillingPage() {
                 <p><strong>Yearly Price:</strong> ${centsToDollars(createForm.yearlyPriceCents)}/yr</p>
                 <p><strong>Monthly Data Limit:</strong> {createForm.monthlyGbLimitGb} GB</p>
                 <p><strong>Trial:</strong> {createForm.trialDays} day(s)</p>
-                <p><strong>Total Limit:</strong> {(
-                  createForm.monthlyErrorLimit +
-                  createForm.monthlyTransactionLimit +
-                  createForm.monthlyReplayLimit +
-                  createForm.monthlyFeedbackLimit
-                ).toLocaleString()}</p>
-                <p><strong>Errors:</strong> {createForm.monthlyErrorLimit.toLocaleString()}</p>
-                <p><strong>Transactions:</strong> {createForm.monthlyTransactionLimit.toLocaleString()}</p>
-                <p><strong>Replays:</strong> {createForm.monthlyReplayLimit.toLocaleString()}</p>
-                <p><strong>Feedback:</strong> {createForm.monthlyFeedbackLimit.toLocaleString()}</p>
-                <p><strong>LLM Events:</strong> {createForm.monthlyLlmEventLimit.toLocaleString()}</p>
+                <p><strong>Total Limit:</strong> {formatTotalQuotaLimit([
+                  createForm.monthlyErrorLimit,
+                  createForm.monthlyTransactionLimit,
+                  createForm.monthlyReplayLimit,
+                  createForm.monthlyFeedbackLimit,
+                ])}</p>
+                <p><strong>Errors:</strong> {formatQuotaLimit(createForm.monthlyErrorLimit)}</p>
+                <p><strong>Transactions:</strong> {formatQuotaLimit(createForm.monthlyTransactionLimit)}</p>
+                <p><strong>Replays:</strong> {formatQuotaLimit(createForm.monthlyReplayLimit)}</p>
+                <p><strong>Feedback:</strong> {formatQuotaLimit(createForm.monthlyFeedbackLimit)}</p>
+                <p><strong>LLM Events:</strong> {formatQuotaLimit(createForm.monthlyLlmEventLimit)}</p>
                 <p><strong>Retention:</strong> {createForm.retentionDays}d errors, {createForm.logRetentionDays}d logs, {createForm.replayRetentionDays}d replays, {createForm.llmRetentionDays}d LLM</p>
                 <p><strong>Max Projects:</strong> {createForm.maxProjects || 'Unlimited'}</p>
                 <p><strong>Max Systems:</strong> {createForm.maxSystems}</p>
@@ -1794,7 +1820,9 @@ function AdminBillingPage() {
                     <SelectContent>
                       {migrateTierVersions.map((v) => (
                         <SelectItem key={v.id} value={String(v.version)}>
-                          v{v.version} {v.isCurrent ? '(current)' : '(legacy)'} &mdash; ${centsToDollars(v.monthlyPriceCents)}/mo, {v.monthlyUnitLimit.toLocaleString()} total units
+                          v{v.version} {v.isCurrent ? '(current)' : '(legacy)'} &mdash;{' '}
+                          {'$' + centsToDollars(v.monthlyPriceCents) + '/mo, '}
+                          {formatQuotaLimit(v.monthlyUnitLimit)} total units
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -1810,12 +1838,12 @@ function AdminBillingPage() {
               <div className="rounded border bg-muted/50 p-3 text-sm space-y-1">
                 <p className="font-medium mb-1">Target v{targetTierConfig.version} details:</p>
                 <p>Price: ${centsToDollars(targetTierConfig.monthlyPriceCents)}/mo</p>
-                <p>Total Limit: {targetTierConfig.monthlyUnitLimit.toLocaleString()}</p>
-                <p>Errors: {targetTierConfig.monthlyErrorLimit.toLocaleString()}</p>
-                <p>Transactions: {targetTierConfig.monthlyTransactionLimit.toLocaleString()}</p>
-                <p>Replays: {targetTierConfig.monthlyReplayLimit.toLocaleString()}</p>
-                <p>Feedback: {targetTierConfig.monthlyFeedbackLimit.toLocaleString()}</p>
-                <p>LLM Events: {(targetTierConfig.monthlyLlmEventLimit ?? 0).toLocaleString()}</p>
+                <p>Total Limit: {formatQuotaLimit(targetTierConfig.monthlyUnitLimit)}</p>
+                <p>Errors: {formatQuotaLimit(targetTierConfig.monthlyErrorLimit)}</p>
+                <p>Transactions: {formatQuotaLimit(targetTierConfig.monthlyTransactionLimit)}</p>
+                <p>Replays: {formatQuotaLimit(targetTierConfig.monthlyReplayLimit)}</p>
+                <p>Feedback: {formatQuotaLimit(targetTierConfig.monthlyFeedbackLimit)}</p>
+                <p>LLM Events: {formatQuotaLimit(targetTierConfig.monthlyLlmEventLimit ?? 0)}</p>
                 <p>Retention: {targetTierConfig.retentionDays}d errors, {targetTierConfig.replayRetentionDays ?? targetTierConfig.retentionDays}d replays, {targetTierConfig.llmRetentionDays ?? targetTierConfig.retentionDays}d LLM</p>
                 <p>Max Systems: {targetTierConfig.maxSystems}</p>
                 <p>PAYG: {targetTierConfig.paygEnabled ? 'Enabled' : 'Disabled'}</p>
@@ -2003,58 +2031,64 @@ function AdminBillingPage() {
 
 function ChangeSummary({current, form}: {current: BillingTierConfig; form: CreateFormState}) {
   const changes: Array<{field: string; from: string; to: string}> = []
-  const currentTotalLimit =
-    current.monthlyErrorLimit +
-    current.monthlyTransactionLimit +
-    current.monthlyReplayLimit +
-    current.monthlyFeedbackLimit
-  const formTotalLimit =
-    form.monthlyErrorLimit +
-    form.monthlyTransactionLimit +
-    form.monthlyReplayLimit +
-    form.monthlyFeedbackLimit
+  const currentErrorLimit = normalizeQuotaForForm(current.monthlyErrorLimit)
+  const currentTransactionLimit = normalizeQuotaForForm(current.monthlyTransactionLimit)
+  const currentReplayLimit = normalizeReplayQuotaForForm(current.monthlyReplayLimit)
+  const currentFeedbackLimit = normalizeQuotaForForm(current.monthlyFeedbackLimit)
+  const currentTotalLimit = formatTotalQuotaLimit([
+    currentErrorLimit,
+    currentTransactionLimit,
+    currentReplayLimit,
+    currentFeedbackLimit,
+  ])
+  const formTotalLimit = formatTotalQuotaLimit([
+    form.monthlyErrorLimit,
+    form.monthlyTransactionLimit,
+    form.monthlyReplayLimit,
+    form.monthlyFeedbackLimit,
+  ])
 
   if (currentTotalLimit !== formTotalLimit) {
     changes.push({
       field: 'Total Unit Limit',
-      from: currentTotalLimit.toLocaleString(),
-      to: Number(formTotalLimit).toLocaleString(),
+      from: currentTotalLimit,
+      to: formTotalLimit,
     })
   }
-  if (current.monthlyErrorLimit !== form.monthlyErrorLimit) {
+  if (currentErrorLimit !== form.monthlyErrorLimit) {
     changes.push({
       field: 'Error Limit',
-      from: current.monthlyErrorLimit.toLocaleString(),
-      to: form.monthlyErrorLimit.toLocaleString(),
+      from: formatQuotaLimit(currentErrorLimit),
+      to: formatQuotaLimit(form.monthlyErrorLimit),
     })
   }
-  if (current.monthlyTransactionLimit !== form.monthlyTransactionLimit) {
+  if (currentTransactionLimit !== form.monthlyTransactionLimit) {
     changes.push({
       field: 'Transaction Limit',
-      from: current.monthlyTransactionLimit.toLocaleString(),
-      to: form.monthlyTransactionLimit.toLocaleString(),
+      from: formatQuotaLimit(currentTransactionLimit),
+      to: formatQuotaLimit(form.monthlyTransactionLimit),
     })
   }
-  if (current.monthlyReplayLimit !== form.monthlyReplayLimit) {
+  if (currentReplayLimit !== form.monthlyReplayLimit) {
     changes.push({
       field: 'Replay Limit',
-      from: current.monthlyReplayLimit.toLocaleString(),
-      to: form.monthlyReplayLimit.toLocaleString(),
+      from: formatQuotaLimit(currentReplayLimit),
+      to: formatQuotaLimit(form.monthlyReplayLimit),
     })
   }
-  if (current.monthlyFeedbackLimit !== form.monthlyFeedbackLimit) {
+  if (currentFeedbackLimit !== form.monthlyFeedbackLimit) {
     changes.push({
       field: 'Feedback Limit',
-      from: current.monthlyFeedbackLimit.toLocaleString(),
-      to: form.monthlyFeedbackLimit.toLocaleString(),
+      from: formatQuotaLimit(currentFeedbackLimit),
+      to: formatQuotaLimit(form.monthlyFeedbackLimit),
     })
   }
-  const currentLlm = current.monthlyLlmEventLimit ?? 0
+  const currentLlm = normalizeQuotaForForm(current.monthlyLlmEventLimit ?? 0)
   if (currentLlm !== form.monthlyLlmEventLimit) {
     changes.push({
       field: 'LLM Event Limit',
-      from: currentLlm.toLocaleString(),
-      to: form.monthlyLlmEventLimit.toLocaleString(),
+      from: formatQuotaLimit(currentLlm),
+      to: formatQuotaLimit(form.monthlyLlmEventLimit),
     })
   }
   if (current.retentionDays !== form.retentionDays) {


### PR DESCRIPTION
## Summary
- normalize effectively unlimited admin billing quotas to a JavaScript-safe sentinel before sending create-version requests
- canonicalize that sentinel back to Long.MAX_VALUE in backend tier version creation
- format unlimited admin billing quotas as Unlimited instead of rounded Long.MAX_VALUE numbers

## Verification
- git diff --check
- cd dashboard && npm run test -- admin-billing-limits.test.ts
- cd dashboard && npx eslint src/lib/admin-billing-limits.ts src/lib/__tests__/admin-billing-limits.test.ts src/routes/admin.billing.tsx --max-warnings 0
- cd dashboard && npm run lint
- cd backend && GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.services.PricingTierServiceTest -Dkotlin.compiler.execution.strategy=in-process
- cd backend && ./gradlew detekt --no-daemon
- local Sonar PR analysis: quality gate OK, new coverage 95.9%, open issues 0
- remote GitHub checks on cf080851: backend-unit, frontend-unit, coverage-check, SonarQube Analysis, cla-check, CodeRabbit all passed