### PR TITLE
fix: improve log histogram bucket sizing

### DIFF
--- a/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
@@ -90,7 +90,10 @@ private const val WARN_BODY_PREVIEW_CHARS = 500
 private const val MILLIS_PER_HOUR = 3_600_000L
 private const val MILLIS_PER_6_HOURS = 21_600_000L
 private const val MILLIS_PER_DAY = 86_400_000L
-private const val MILLIS_PER_WEEK = 604_800_000L
+private const val MILLIS_PER_10_DAYS = 10 * MILLIS_PER_DAY
+private const val MILLIS_PER_21_DAYS = 21 * MILLIS_PER_DAY
+private const val MILLIS_PER_45_DAYS = 45 * MILLIS_PER_DAY
+private const val MILLIS_PER_90_DAYS = 90 * MILLIS_PER_DAY
 private const val MAX_LOG_MESSAGE_CHARS = 8192
 private const val MAX_LOG_BODY_CHARS = 32768
 private const val MAX_LOG_SERVICE_CHARS = 256
@@ -489,18 +492,13 @@ class LogService(private val logRepository: LogRepository) {
         val rangeMs = toMs - fromMs
         return when {
             rangeMs <= MILLIS_PER_HOUR -> "1m"
-
-            // ≤1h → 1m
             rangeMs <= MILLIS_PER_6_HOURS -> "5m"
-
-            // ≤6h → 5m
             rangeMs <= MILLIS_PER_DAY -> "15m"
-
-            // ≤24h → 15m
-            rangeMs <= MILLIS_PER_WEEK -> "1h"
-
-            // ≤7d → 1h
-            else -> "1d" // >7d → 1d
+            rangeMs <= MILLIS_PER_10_DAYS -> "1h"
+            rangeMs <= MILLIS_PER_21_DAYS -> "2h"
+            rangeMs <= MILLIS_PER_45_DAYS -> "4h"
+            rangeMs <= MILLIS_PER_90_DAYS -> "12h"
+            else -> "1d"
         }
     }
 
@@ -510,6 +508,9 @@ class LogService(private val logRepository: LogRepository) {
             "5m" -> "5 MINUTE"
             "15m" -> "15 MINUTE"
             "1h" -> "1 HOUR"
+            "2h" -> "2 HOUR"
+            "4h" -> "4 HOUR"
+            "12h" -> "12 HOUR"
             "1d" -> "1 DAY"
             else -> "1 HOUR"
         }

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/LogAnalyticsTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/LogAnalyticsTool.kt
@@ -57,7 +57,7 @@ class AggregateLogsTool : McpTool {
                 "to" to schemaString("End time (ISO 8601)"),
                 "interval" to schemaEnum(
                     "Bucket interval",
-                    listOf("1m", "5m", "15m", "1h", "1d")
+                    listOf("1m", "5m", "15m", "1h", "2h", "4h", "12h", "1d")
                 ),
                 "query" to schemaString("Search query"),
                 "levels" to schemaString(

--- a/backend/src/test/kotlin/com/moneat/services/LogServicePureLogicTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogServicePureLogicTest.kt
@@ -348,9 +348,30 @@ class LogServicePureLogicTest {
     }
 
     @Test
-    fun `autoInterval returns 1d for range over 7d`() {
+    fun `autoInterval returns 2h for range over 10d`() {
         val from = 0L
         val to = 14 * 86_400_000L // 14 days
+        assertEquals("2h", service.autoInterval(from, to))
+    }
+
+    @Test
+    fun `autoInterval returns 4h for range around 30d`() {
+        val from = 0L
+        val to = 30 * 86_400_000L // 30 days
+        assertEquals("4h", service.autoInterval(from, to))
+    }
+
+    @Test
+    fun `autoInterval returns 12h for range around 90d`() {
+        val from = 0L
+        val to = 75 * 86_400_000L // 75 days
+        assertEquals("12h", service.autoInterval(from, to))
+    }
+
+    @Test
+    fun `autoInterval returns 1d for range over 90d`() {
+        val from = 0L
+        val to = 120 * 86_400_000L // 120 days
         assertEquals("1d", service.autoInterval(from, to))
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/LogServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogServicesExtendedTest.kt
@@ -869,6 +869,10 @@ class LogServicesExtendedTest {
         assertEquals("15m", service.autoInterval(0L, 86_400_000L))
         // Exactly 7 days
         assertEquals("1h", service.autoInterval(0L, 604_800_000L))
+        // A slightly stale client "now" should not jump a 7-day dashboard to daily buckets.
+        assertEquals("1h", service.autoInterval(0L, 604_800_000L + 3_600_000L))
+        // Exactly 30 days
+        assertEquals("4h", service.autoInterval(0L, 2_592_000_000L))
     }
 
     // ──── Helper classes ────

--- a/dashboard/src/components/logs/LogExplorer.tsx
+++ b/dashboard/src/components/logs/LogExplorer.tsx
@@ -38,6 +38,7 @@ import {
   parseLevelsFromUrl,
   serializeLogViewState,
 } from '@/components/logs/logViewUrlState'
+import {logIntervalToMs} from '@/components/logs/logInterval'
 import {getNowDate} from '@/lib/demo'
 
 interface LogExplorerProps {
@@ -94,23 +95,6 @@ function formatLogCount(n: number): string {
 function toDateTimeLocalValue(date: Date): string {
   const pad = (value: number) => String(value).padStart(2, '0')
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
-}
-
-function intervalToMs(interval: string | undefined): number {
-  switch (interval) {
-    case '1m':
-      return 60_000
-    case '5m':
-      return 5 * 60_000
-    case '15m':
-      return 15 * 60_000
-    case '1h':
-      return 60 * 60_000
-    case '1d':
-      return 24 * 60 * 60_000
-    default:
-      return 60 * 60_000
-  }
 }
 
 export function LogExplorer({
@@ -527,7 +511,7 @@ export function LogExplorer({
   const handleHistogramBucketClick = useCallback((bucketStartIso: string) => {
     const bucketStart = new Date(bucketStartIso)
     if (Number.isNaN(bucketStart.getTime())) return
-    const bucketMs = intervalToMs(aggregateData?.interval)
+    const bucketMs = logIntervalToMs(aggregateData?.interval)
     const bucketEnd = new Date(bucketStart.getTime() + bucketMs)
     setTimePreset('custom')
     setCustomFrom(toDateTimeLocalValue(bucketStart))
@@ -806,6 +790,9 @@ export function LogExplorer({
                     buckets={aggregateData.buckets}
                     grouped={true}
                     height={72}
+                    interval={aggregateData.interval}
+                    rangeFrom={timeRange.from}
+                    rangeTo={timeRange.to ?? getNowDate().toISOString()}
                     onBucketClick={handleHistogramBucketClick}
                   />
                 </div>

--- a/dashboard/src/components/logs/LogHistogram.tsx
+++ b/dashboard/src/components/logs/LogHistogram.tsx
@@ -19,11 +19,15 @@ import {Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis
 import type {LogAggregateBucket} from '@/lib/api'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDateTime, formatMonthDay, formatTimeHM} from '@/lib/date-format'
+import {logIntervalToMs} from '@/components/logs/logInterval'
 
 interface LogHistogramProps {
   buckets: LogAggregateBucket[]
   grouped?: boolean
   height?: number
+  interval?: string
+  rangeFrom?: string
+  rangeTo?: string
   onBucketClick?: (timestamp: string) => void
 }
 
@@ -44,6 +48,7 @@ const LEVEL_COLORS: Record<string, string> = {
 }
 
 const GROUP_COLORS = ['#ef4444', '#f59e0b', '#6366f1', '#14b8a6', '#a855f7', '#22c55e', '#ec4899', '#0ea5e9']
+const MAX_BAR_WIDTH_PX = 14
 
 const levelOrder = ['fatal', 'error', 'warn', 'info', 'debug', 'trace']
 
@@ -56,7 +61,27 @@ function colorForGroup(key: string): string {
   return GROUP_COLORS[hash % GROUP_COLORS.length]
 }
 
-export function LogHistogram({buckets, grouped = true, height = 120, onBucketClick}: LogHistogramProps) {
+function toTimestampMs(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const timestamp = new Date(value).getTime()
+  return Number.isNaN(timestamp) ? undefined : timestamp
+}
+
+function formatTooltipValue(value: unknown, name: unknown): [string, string] {
+  const numericValue = typeof value === 'number' ? value : Number(value ?? 0)
+  const displayValue = Number.isFinite(numericValue) ? numericValue.toLocaleString() : '0'
+  return [displayValue, name === 'total' ? 'logs' : String(name ?? '')]
+}
+
+export function LogHistogram({
+  buckets,
+  grouped = true,
+  height = 120,
+  interval,
+  rangeFrom,
+  rangeTo,
+  onBucketClick,
+}: LogHistogramProps) {
   const { timezone } = useTimezone()
   const formatAxisTime = (ts: number, totalRangeMs: number): string => {
     const date = new Date(ts)
@@ -67,22 +92,25 @@ export function LogHistogram({buckets, grouped = true, height = 120, onBucketCli
     return formatMonthDay(date, timezone)
   }
   const formatTooltipTime = (ts: number): string => formatDateTime(new Date(ts), timezone)
-  const {chartData, groupKeys, totalRangeMs, domainMin, domainMax} = useMemo(() => {
+  const {chartData, groupKeys, totalRangeMs, domainMin, domainMax, estimatedBucketCount} = useMemo(() => {
     const keys = new Set<string>()
-    const data: HistogramPoint[] = buckets.map((b) => {
-      const point: HistogramPoint = {
-        timestamp: b.timestamp,
-        timestampMs: new Date(b.timestamp).getTime(),
-        total: b.count,
-      }
-      if (grouped && Object.keys(b.groups).length > 0) {
-        for (const [key, val] of Object.entries(b.groups)) {
-          keys.add(key)
-          point[key] = val
+    const data: HistogramPoint[] = buckets
+      .map((b) => {
+        const point: HistogramPoint = {
+          timestamp: b.timestamp,
+          timestampMs: new Date(b.timestamp).getTime(),
+          total: b.count,
         }
-      }
-      return point
-    })
+        if (grouped && Object.keys(b.groups).length > 0) {
+          for (const [key, val] of Object.entries(b.groups)) {
+            keys.add(key)
+            point[key] = val
+          }
+        }
+        return point
+      })
+      .filter((point) => !Number.isNaN(point.timestampMs))
+      .sort((a, b) => a.timestampMs - b.timestampMs)
     const sortedKeys = [...keys].sort((a, b) => {
       const ai = levelOrder.indexOf(a)
       const bi = levelOrder.indexOf(b)
@@ -91,20 +119,28 @@ export function LogHistogram({buckets, grouped = true, height = 120, onBucketCli
     })
     const firstTs = data[0]?.timestampMs ?? 0
     const lastTs = data[data.length - 1]?.timestampMs ?? firstTs
-    const bucketInterval = data.length > 1 ? data[1].timestampMs - data[0].timestampMs : 60_000
+    const bucketInterval = logIntervalToMs(interval)
+    const rangeStartMs = toTimestampMs(rangeFrom)
+    const rangeEndMs = toTimestampMs(rangeTo)
+    const minFromData = firstTs - bucketInterval / 2
+    const maxFromData = lastTs + bucketInterval / 2
+    const min = Math.min(rangeStartMs ?? minFromData, minFromData)
+    const max = Math.max(rangeEndMs ?? maxFromData, maxFromData)
+    const range = Math.max(max - min, bucketInterval)
     return {
       chartData: data,
       groupKeys: sortedKeys,
-      totalRangeMs: Math.max(lastTs - firstTs, 60_000),
-      domainMin: firstTs - bucketInterval / 2,
-      domainMax: lastTs + bucketInterval / 2,
+      totalRangeMs: range,
+      domainMin: min,
+      domainMax: max,
+      estimatedBucketCount: Math.max(1, Math.ceil(range / bucketInterval)),
     }
-  }, [buckets, grouped])
+  }, [buckets, grouped, interval, rangeFrom, rangeTo])
 
   if (chartData.length === 0) return null
 
   const useGroups = grouped && groupKeys.length > 0
-  const tickCount = Math.min(8, Math.max(3, Math.floor(chartData.length / 12)))
+  const tickCount = Math.min(8, Math.max(3, Math.floor(estimatedBucketCount / 12)))
 
   return (
     <div className="w-full" style={{height}}>
@@ -150,13 +186,7 @@ export function LogHistogram({buckets, grouped = true, height = 120, onBucketCli
           <Tooltip
             cursor={false}
             labelFormatter={(ts) => formatTooltipTime(ts as number)}
-            formatter={(value: unknown, name: unknown) => {
-              const numericValue = typeof value === 'number' ? value : Number(value)
-              return [
-                Number.isFinite(numericValue) ? numericValue.toLocaleString() : '0',
-                name === 'total' ? 'logs' : String(name ?? ''),
-              ]
-            }}
+            formatter={formatTooltipValue}
             contentStyle={{
               backgroundColor: 'hsl(var(--popover) / 0.95)',
               border: '1px solid hsl(var(--border))',
@@ -174,6 +204,7 @@ export function LogHistogram({buckets, grouped = true, height = 120, onBucketCli
                 stackId="1"
                 fill={colorForGroup(key)}
                 isAnimationActive={false}
+                maxBarSize={MAX_BAR_WIDTH_PX}
                 radius={[1, 1, 0, 0]}
               />
             ))
@@ -182,6 +213,7 @@ export function LogHistogram({buckets, grouped = true, height = 120, onBucketCli
               dataKey="total"
               fill={LEVEL_COLORS.error}
               isAnimationActive={false}
+              maxBarSize={MAX_BAR_WIDTH_PX}
               radius={[1, 1, 0, 0]}
             />
           )}

--- a/dashboard/src/components/logs/logInterval.test.ts
+++ b/dashboard/src/components/logs/logInterval.test.ts
@@ -1,0 +1,36 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {logIntervalToMs} from './logInterval'
+
+describe('logIntervalToMs', () => {
+  it('maps supported log aggregate intervals to milliseconds', () => {
+    expect(logIntervalToMs('1m')).toBe(60_000)
+    expect(logIntervalToMs('5m')).toBe(300_000)
+    expect(logIntervalToMs('15m')).toBe(900_000)
+    expect(logIntervalToMs('1h')).toBe(3_600_000)
+    expect(logIntervalToMs('2h')).toBe(7_200_000)
+    expect(logIntervalToMs('4h')).toBe(14_400_000)
+    expect(logIntervalToMs('12h')).toBe(43_200_000)
+    expect(logIntervalToMs('1d')).toBe(86_400_000)
+  })
+
+  it('defaults to one hour for missing or unknown intervals', () => {
+    expect(logIntervalToMs(undefined)).toBe(3_600_000)
+    expect(logIntervalToMs('bogus')).toBe(3_600_000)
+  })
+})

--- a/dashboard/src/components/logs/logInterval.ts
+++ b/dashboard/src/components/logs/logInterval.ts
@@ -1,0 +1,42 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+export function logIntervalToMs(interval: string | undefined): number {
+  switch (interval) {
+    case '1m':
+      return MINUTE_MS
+    case '5m':
+      return 5 * MINUTE_MS
+    case '15m':
+      return 15 * MINUTE_MS
+    case '1h':
+      return HOUR_MS
+    case '2h':
+      return 2 * HOUR_MS
+    case '4h':
+      return 4 * HOUR_MS
+    case '12h':
+      return 12 * HOUR_MS
+    case '1d':
+      return DAY_MS
+    default:
+      return HOUR_MS
+  }
+}

--- a/dashboard/src/docs/pages/mcp-server/tools-reference.md
+++ b/dashboard/src/docs/pages/mcp-server/tools-reference.md
@@ -92,7 +92,7 @@ Aggregate log volume and error rate over time buckets.
 |-----------|------|----------|-------------|
 | `from` | string | No | Start time (ISO 8601) |
 | `to` | string | No | End time (ISO 8601) |
-| `interval` | string | No | `1m`, `5m`, `15m`, `1h`, `1d` |
+| `interval` | string | No | `1m`, `5m`, `15m`, `1h`, `2h`, `4h`, `12h`, `1d` |
 | `query` | string | No | Search query |
 | `levels` | string | No | Comma-separated log levels |
 | `service` | string | No | Service filter |


### PR DESCRIPTION
## Summary
- adjust log aggregate auto-bucketing so 7-day views stay hourly and longer views use 2h/4h/12h intervals before daily buckets
- cap rendered log histogram bars at 14px and keep sparse buckets positioned against the selected time range
- share interval-to-milliseconds handling between histogram rendering and click-to-zoom behavior

## Validation
- `npm run test -- logInterval.test.ts`
- `npm run lint`
- `./gradlew compileKotlin detekt`
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.services.LogServicePureLogicTest --tests com.moneat.services.LogServicesExtendedTest -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`