### PR TITLE
fix: add sentry session release health

### DIFF
--- a/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/BillingQuotaService.kt
@@ -1901,6 +1901,7 @@ class BillingQuotaService(
     private fun normalizeEventType(eventType: String): String {
         return when (eventType.lowercase()) {
             "error" -> "error"
+            "session", "sessions" -> "session"
             "transaction" -> "transaction"
             "replay" -> "replay"
             "feedback" -> "feedback"

--- a/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/SentryModels.kt
@@ -65,7 +65,7 @@ data class SentryEnvelope(
             // Known Sentry item types that indicate an item header line
             val knownItemTypes =
                 setOf(
-                    "event", "transaction", "session", "attachment",
+                    "event", "transaction", "session", "sessions", "attachment",
                     "replay_event", "replay_recording", "replay_video",
                     "feedback", "check_in", "statsd", "metric_buckets",
                     "profile", "client_report", "user_report"
@@ -473,6 +473,44 @@ data class UserInfo(
     val email: String? = null,
     val username: String? = null,
     @SerialName("ip_address") val ipAddress: String? = null
+)
+
+@Serializable
+data class SentrySession(
+    @SerialName("sid") val sessionId: String? = null,
+    @SerialName("did") val distinctId: String? = null,
+    @Serializable(with = FlexibleTimestampSerializer::class)
+    val started: Double? = null,
+    @Serializable(with = FlexibleTimestampSerializer::class)
+    val timestamp: Double? = null,
+    val duration: Double? = null,
+    val status: String? = null,
+    val errors: Int? = null,
+    val attrs: SentrySessionAttrs? = null
+)
+
+@Serializable
+data class SentrySessionAttrs(
+    val release: String? = null,
+    val environment: String? = null
+)
+
+@Serializable
+data class SentrySessionAggregatesPayload(
+    val aggregates: List<SentrySessionAggregate> = emptyList()
+)
+
+@Serializable
+data class SentrySessionAggregate(
+    @Serializable(with = FlexibleTimestampSerializer::class)
+    val started: Double? = null,
+    val exited: Int = 0,
+    val errored: Int = 0,
+    val crashed: Int = 0,
+    val abnormal: Int = 0,
+    val ok: Int = 0,
+    @SerialName("did") val distinctId: String? = null,
+    val attrs: SentrySessionAttrs? = null
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/events/repositories/EventRepository.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/EventRepository.kt
@@ -23,6 +23,7 @@ import com.moneat.events.repositories.models.ProfileInsertData
 import com.moneat.events.repositories.models.ProjectKeyVerification
 import com.moneat.events.repositories.models.ReplayEventInsertData
 import com.moneat.events.repositories.models.ReplayRecordingInsertData
+import com.moneat.events.repositories.models.SessionInsertData
 import com.moneat.events.repositories.models.SpanInsertData
 import com.moneat.events.repositories.models.TransactionEventInsertData
 
@@ -37,6 +38,7 @@ interface EventRepository {
 
     suspend fun insertErrorEvent(data: ErrorEventInsertData): Boolean
     suspend fun insertTransaction(data: TransactionEventInsertData): Boolean
+    suspend fun insertSessions(rows: List<SessionInsertData>): Boolean
     suspend fun insertSpans(rows: List<SpanInsertData>)
     suspend fun insertFeedback(data: FeedbackInsertData): Boolean
     suspend fun insertReplayEvent(data: ReplayEventInsertData): Boolean

--- a/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
@@ -24,6 +24,7 @@ import com.moneat.events.repositories.models.ProfileInsertData
 import com.moneat.events.repositories.models.ProjectKeyVerification
 import com.moneat.events.repositories.models.ReplayEventInsertData
 import com.moneat.events.repositories.models.ReplayRecordingInsertData
+import com.moneat.events.repositories.models.SessionInsertData
 import com.moneat.events.repositories.models.SpanInsertData
 import com.moneat.events.repositories.models.TransactionEventInsertData
 import com.moneat.shared.models.ProjectKeys
@@ -184,6 +185,32 @@ class EventRepositoryImpl : EventRepository {
                 '${escapeSql(data.sdkName)}',
                 '${escapeSql(data.sdkVersion)}'
             )
+        """.trimIndent()
+        return executeInsert(sql)
+    }
+
+    override suspend fun insertSessions(rows: List<SessionInsertData>): Boolean {
+        if (rows.isEmpty()) return true
+        val valueRows = rows.joinToString(",\n") { session ->
+            """(
+                toUUID('${escapeSql(session.sessionId)}'),
+                ${session.projectId},
+                fromUnixTimestamp64Milli(${session.startedMs}),
+                ${session.durationMs},
+                '${escapeSql(session.status)}',
+                ${session.errors},
+                '${escapeSql(session.release)}',
+                '${escapeSql(session.environment)}',
+                '${escapeSql(session.userId)}',
+                fromUnixTimestamp64Milli(${session.receivedAtMs})
+            )"""
+        }
+        val sql = """
+            INSERT INTO `$db`.sessions (
+                session_id, project_id, started, duration_ms, status, errors,
+                release, environment, user_id, received_at
+            ) VALUES
+            $valueRows
         """.trimIndent()
         return executeInsert(sql)
     }

--- a/backend/src/main/kotlin/com/moneat/events/repositories/models/EventInsertData.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/models/EventInsertData.kt
@@ -70,6 +70,19 @@ data class TransactionEventInsertData(
     val sdkVersion: String
 )
 
+data class SessionInsertData(
+    val sessionId: String,
+    val projectId: Long,
+    val startedMs: Long,
+    val durationMs: Double,
+    val status: String,
+    val errors: Int,
+    val release: String,
+    val environment: String,
+    val userId: String,
+    val receivedAtMs: Long
+)
+
 data class SpanInsertData(
     val spanId: String,
     val parentSpanId: String,

--- a/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
@@ -325,6 +325,7 @@ fun extractPublicKeyFromDsn(dsnLikeHeader: String?): String? {
 internal fun mapEnvelopeItemTypeToQuotaType(itemType: String): String {
     return when (itemType) {
         "transaction" -> "transaction"
+        "session", "sessions" -> "session"
         "replay_event", "replay_recording", "replay_video" -> "replay"
         "feedback", "user_report" -> "feedback"
         "llm_generation" -> "llm"

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -227,7 +227,7 @@ class EventService(
         logger.debug { "Session payload: ${item.payload.take(LOG_PAYLOAD_PREVIEW_CHARS)}" }
         val session = json.decodeFromString<SentrySession>(item.payload)
         if (storeSession(projectId, session)) {
-            recordUsage(projectId, "error", item)
+            recordUsage(projectId, "session", item)
         }
     }
 
@@ -236,7 +236,7 @@ class EventService(
         val payload = json.decodeFromString<SentrySessionAggregatesPayload>(item.payload)
         val rows = payload.aggregates.flatMap { aggregate -> aggregate.toSessionRows(projectId) }
         if (storeSessionRows(projectId, rows)) {
-            recordUsage(projectId, "error", item)
+            recordUsage(projectId, "session", item)
         }
     }
 
@@ -664,7 +664,7 @@ class EventService(
 
         return buildList {
             addAggregateSessionRows(defaults, status = "exited", count = exited, errors = 0)
-            addAggregateSessionRows(defaults, status = "abnormal", count = errored, errors = 1)
+            addAggregateSessionRows(defaults, status = "errored", count = errored, errors = 1)
             addAggregateSessionRows(defaults, status = "crashed", count = crashed, errors = 1)
             addAggregateSessionRows(defaults, status = "abnormal", count = abnormal, errors = 1)
             addAggregateSessionRows(defaults, status = "ok", count = ok, errors = 0)
@@ -699,6 +699,7 @@ class EventService(
         return when (status?.lowercase()) {
             "ok" -> "ok"
             "exited" -> "exited"
+            "errored" -> "errored"
             "crashed" -> "crashed"
             "abnormal" -> "abnormal"
             else -> if (errors > 0) "abnormal" else "ok"

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -24,6 +24,9 @@ import com.moneat.events.models.SentryEnvelope
 import com.moneat.events.models.SentryEvent
 import com.moneat.events.models.SentryFeedback
 import com.moneat.events.models.SentryReplayEvent
+import com.moneat.events.models.SentrySession
+import com.moneat.events.models.SentrySessionAggregate
+import com.moneat.events.models.SentrySessionAggregatesPayload
 import com.moneat.events.models.SentrySpan
 import com.moneat.events.models.SentryTransaction
 import com.moneat.events.models.isFeedbackEventPayload
@@ -35,6 +38,7 @@ import com.moneat.events.repositories.models.ProfileInsertData
 import com.moneat.events.repositories.models.ProjectKeyVerification
 import com.moneat.events.repositories.models.ReplayEventInsertData
 import com.moneat.events.repositories.models.ReplayRecordingInsertData
+import com.moneat.events.repositories.models.SessionInsertData
 import com.moneat.events.repositories.models.TransactionEventInsertData
 import com.moneat.notifications.services.NotificationService
 import com.moneat.otlp.hexToULongPair
@@ -89,6 +93,7 @@ class EventService(
 
         /** Keys set by the server for apm_spans; must not be overwritten by SDK tag maps. */
         private val SENTRY_APM_META_RESERVED_KEYS = setOf("sentry.transaction_id", "sentry.project_id")
+        private val SESSION_ERROR_STATUSES = setOf("abnormal", "crashed", "errored")
     }
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -161,10 +166,9 @@ class EventService(
                     }
                 }
 
-                "session" -> {
-                    // Session envelope items are accepted for usage accounting only; persistence not implemented.
-                    logger.debug { "Received session (not yet implemented)" }
-                }
+                "session" -> handleSessionItem(projectId, item)
+
+                "sessions" -> handleSessionAggregatesItem(projectId, item)
 
                 "replay_event" -> {
                     val replayEvent = parseReplayEventPayload(item.payload)
@@ -215,6 +219,23 @@ class EventService(
 
         val event = json.decodeFromString<SentryEvent>(item.payload)
         if (storeEvent(projectId, event)) {
+            recordUsage(projectId, "error", item)
+        }
+    }
+
+    private suspend fun handleSessionItem(projectId: Long, item: EnvelopeItem) {
+        logger.debug { "Session payload: ${item.payload.take(LOG_PAYLOAD_PREVIEW_CHARS)}" }
+        val session = json.decodeFromString<SentrySession>(item.payload)
+        if (storeSession(projectId, session)) {
+            recordUsage(projectId, "error", item)
+        }
+    }
+
+    private suspend fun handleSessionAggregatesItem(projectId: Long, item: EnvelopeItem) {
+        logger.debug { "Session aggregates payload: ${item.payload.take(LOG_PAYLOAD_PREVIEW_CHARS)}" }
+        val payload = json.decodeFromString<SentrySessionAggregatesPayload>(item.payload)
+        val rows = payload.aggregates.flatMap { aggregate -> aggregate.toSessionRows(projectId) }
+        if (storeSessionRows(projectId, rows)) {
             recordUsage(projectId, "error", item)
         }
     }
@@ -568,7 +589,141 @@ class EventService(
         }
     }
 
+    private suspend fun storeSession(
+        projectId: Long,
+        session: SentrySession
+    ): Boolean {
+        val row = session.toInsertData(projectId) ?: return false
+        return storeSessionRows(projectId, listOf(row))
+    }
+
+    private suspend fun storeSessionRows(
+        projectId: Long,
+        rows: List<SessionInsertData>
+    ): Boolean {
+        if (projectId == 0L) {
+            logger.error { "Invalid projectId $projectId for session, skipping insert" }
+            return false
+        }
+        if (rows.isEmpty()) return false
+
+        suspendRunCatching {
+            val success = eventRepository.insertSessions(rows)
+            if (!success) return false
+
+            for (row in rows.distinctBy { it.release }) {
+                suspendRunCatching {
+                    releaseService.upsertReleaseFromEvent(projectId, row.release, row.startedMs)
+                }.getOrElse { e ->
+                    logger.warn(e) { "Failed to upsert release ${row.release} for project $projectId" }
+                }
+            }
+
+            logger.debug { "Stored ${rows.size} session rows for project $projectId" }
+            return true
+        }.getOrElse { e ->
+            logger.error(e) { "Error storing sessions in ClickHouse" }
+            return false
+        }
+    }
+
     private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull
+
+    private fun SentrySession.toInsertData(projectId: Long): SessionInsertData? {
+        val release = attrs?.release?.takeIf { it.isNotBlank() } ?: return null
+        val startedMs =
+            started?.let { unixSecondsToMillis(it) }
+                ?: timestamp?.let { unixSecondsToMillis(it) }
+                ?: System.currentTimeMillis()
+        val errors = sessionErrorCount(status, this.errors)
+
+        return SessionInsertData(
+            sessionId = normalizeUuid(sessionId ?: UUID.randomUUID().toString()),
+            projectId = projectId,
+            startedMs = startedMs,
+            durationMs = durationToMillis(duration),
+            status = normalizeSessionStatus(status, errors),
+            errors = errors,
+            release = release,
+            environment = attrs.environment ?: "production",
+            userId = distinctId ?: "",
+            receivedAtMs = System.currentTimeMillis()
+        )
+    }
+
+    private fun SentrySessionAggregate.toSessionRows(projectId: Long): List<SessionInsertData> {
+        val release = attrs?.release?.takeIf { it.isNotBlank() } ?: return emptyList()
+        val defaults = SessionAggregateDefaults(
+            projectId = projectId,
+            startedMs = started?.let { unixSecondsToMillis(it) } ?: System.currentTimeMillis(),
+            release = release,
+            environment = attrs.environment ?: "production",
+            userId = distinctId ?: "",
+            receivedAtMs = System.currentTimeMillis()
+        )
+
+        return buildList {
+            addAggregateSessionRows(defaults, status = "exited", count = exited, errors = 0)
+            addAggregateSessionRows(defaults, status = "abnormal", count = errored, errors = 1)
+            addAggregateSessionRows(defaults, status = "crashed", count = crashed, errors = 1)
+            addAggregateSessionRows(defaults, status = "abnormal", count = abnormal, errors = 1)
+            addAggregateSessionRows(defaults, status = "ok", count = ok, errors = 0)
+        }
+    }
+
+    private fun MutableList<SessionInsertData>.addAggregateSessionRows(
+        defaults: SessionAggregateDefaults,
+        status: String,
+        count: Int,
+        errors: Int
+    ) {
+        repeat(count.coerceAtLeast(0)) {
+            add(
+                SessionInsertData(
+                    sessionId = UUID.randomUUID().toString(),
+                    projectId = defaults.projectId,
+                    startedMs = defaults.startedMs,
+                    durationMs = 0.0,
+                    status = status,
+                    errors = errors,
+                    release = defaults.release,
+                    environment = defaults.environment,
+                    userId = defaults.userId,
+                    receivedAtMs = defaults.receivedAtMs
+                )
+            )
+        }
+    }
+
+    private fun normalizeSessionStatus(status: String?, errors: Int): String {
+        return when (status?.lowercase()) {
+            "ok" -> "ok"
+            "exited" -> "exited"
+            "crashed" -> "crashed"
+            "abnormal" -> "abnormal"
+            else -> if (errors > 0) "abnormal" else "ok"
+        }
+    }
+
+    private fun sessionErrorCount(status: String?, errors: Int?): Int {
+        val explicitErrors = errors?.coerceAtLeast(0) ?: 0
+        val normalizedStatus = status?.lowercase()
+        val minimumErrors =
+            if (normalizedStatus != null && normalizedStatus in SESSION_ERROR_STATUSES) 1 else 0
+        return maxOf(explicitErrors, minimumErrors)
+    }
+
+    private fun durationToMillis(durationSeconds: Double?): Double =
+        ((durationSeconds ?: 0.0) * MS_PER_SECOND).coerceAtLeast(0.0)
+
+    private data class SessionAggregateDefaults(
+        val projectId: Long,
+        val startedMs: Long,
+        val release: String,
+        val environment: String,
+        val userId: String,
+        val receivedAtMs: Long
+    )
 
     private suspend fun storeReplayEvent(
         projectId: Long,

--- a/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
@@ -304,7 +304,7 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 AND ${queryHelper.timestampRetentionClause("started", retentionDays)}
             FORMAT JSONEachRow
             """.trimIndent()
-        return executeNullableRateQuery(query)
+        return executeNullableRateQuery(query, "crash-free session rate for project $projectId release $version")
     }
 
     private suspend fun getCrashFreeUserRateForRelease(
@@ -325,10 +325,13 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
             )
             FORMAT JSONEachRow
             """.trimIndent()
-        return executeNullableRateQuery(query)
+        return executeNullableRateQuery(query, "crash-free user rate for project $projectId release $version")
     }
 
-    private suspend fun executeNullableRateQuery(query: String): Double? {
+    private suspend fun executeNullableRateQuery(
+        query: String,
+        errorContext: String
+    ): Double? {
         return suspendRunCatching {
             val response = ClickHouseClient.execute(query)
             val body = response.bodyAsText()
@@ -339,7 +342,8 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 val rate = obj["rate"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()
                 rate?.takeUnless { it.isNaN() || it.isInfinite() }
             }
-        }.getOrElse { _ ->
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to fetch $errorContext" }
             null
         }
     }

--- a/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
@@ -128,14 +128,17 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
             val newIssues = getNewIssueCountForRelease(projectId, version, retentionDays)
             val resolvedIssues = 0L
             val crashFreeSessionRate = getCrashFreeRateForRelease(projectId, version, retentionDays)
-            // Crash-free user rate stays null until a user-based ClickHouse query is implemented.
-            val crashFreeUserRate: Double? = null
+            val crashFreeUserRate = getCrashFreeUserRateForRelease(projectId, version, retentionDays)
 
             val intervalMinutes = RELEASE_STATS_INTERVAL_MINUTES
             val eventsTimelineQuery =
                 """
                 SELECT
-                    formatDateTime(toStartOfInterval(timestamp, INTERVAL $intervalMinutes MINUTE), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as time,
+                    formatDateTime(
+                        toStartOfInterval(timestamp, INTERVAL $intervalMinutes MINUTE),
+                        '%Y-%m-%dT%H:%i:%S.000Z',
+                        'UTC'
+                    ) as time,
                     count() as count
                 FROM `$clickhouseDb`.events
                 WHERE project_id = $projectId AND release = '$escapedVersion'
@@ -299,6 +302,36 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
             FROM `$clickhouseDb`.sessions
             WHERE project_id = $projectId AND release = '$escapedVersion'
                 AND ${queryHelper.timestampRetentionClause("started", retentionDays)}
+            FORMAT JSONEachRow
+            """.trimIndent()
+        return suspendRunCatching {
+            val response = ClickHouseClient.execute(query)
+            val body = response.bodyAsText()
+            if (body.isBlank()) return null
+            val obj = json.parseToJsonElement(body.lines().first()).jsonObject
+            val rate = obj["rate"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: return null
+            if (rate.isNaN() || rate.isInfinite()) null else rate
+        }.getOrElse { _ ->
+            null
+        }
+    }
+
+    private suspend fun getCrashFreeUserRateForRelease(
+        projectId: Long,
+        version: String,
+        retentionDays: Int
+    ): Double? {
+        val escapedVersion = escapeSql(version)
+        val query =
+            """
+            SELECT countIf(errors = 0) * 100.0 / count() as rate
+            FROM (
+                SELECT user_id, sum(errors) as errors
+                FROM `$clickhouseDb`.sessions
+                WHERE project_id = $projectId AND release = '$escapedVersion' AND user_id != ''
+                    AND ${queryHelper.timestampRetentionClause("started", retentionDays)}
+                GROUP BY user_id
+            )
             FORMAT JSONEachRow
             """.trimIndent()
         return suspendRunCatching {

--- a/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
@@ -304,16 +304,7 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 AND ${queryHelper.timestampRetentionClause("started", retentionDays)}
             FORMAT JSONEachRow
             """.trimIndent()
-        return suspendRunCatching {
-            val response = ClickHouseClient.execute(query)
-            val body = response.bodyAsText()
-            if (body.isBlank()) return null
-            val obj = json.parseToJsonElement(body.lines().first()).jsonObject
-            val rate = obj["rate"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: return null
-            if (rate.isNaN() || rate.isInfinite()) null else rate
-        }.getOrElse { _ ->
-            null
-        }
+        return executeNullableRateQuery(query)
     }
 
     private suspend fun getCrashFreeUserRateForRelease(
@@ -334,13 +325,20 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
             )
             FORMAT JSONEachRow
             """.trimIndent()
+        return executeNullableRateQuery(query)
+    }
+
+    private suspend fun executeNullableRateQuery(query: String): Double? {
         return suspendRunCatching {
             val response = ClickHouseClient.execute(query)
             val body = response.bodyAsText()
-            if (body.isBlank()) return null
-            val obj = json.parseToJsonElement(body.lines().first()).jsonObject
-            val rate = obj["rate"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: return null
-            if (rate.isNaN() || rate.isInfinite()) null else rate
+            if (body.isBlank()) {
+                null
+            } else {
+                val obj = json.parseToJsonElement(body.lines().first()).jsonObject
+                val rate = obj["rate"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()
+                rate?.takeUnless { it.isNaN() || it.isInfinite() }
+            }
         }.getOrElse { _ ->
             null
         }

--- a/backend/src/test/kotlin/com/moneat/events/repositories/EventRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/repositories/EventRepositoryTest.kt
@@ -139,31 +139,35 @@ class EventRepositoryTest {
     @Test
     fun `insertSessions writes ClickHouse session rows`() = runBlocking {
         val queries = mutableListOf<String>()
-        MockHttpServer { exchange ->
-            queries += exchange.requestBodyText()
-            exchange.respond(200, "", contentType = "text/plain")
-        }.use { server ->
-            ClickHouseClient.close()
-            ClickHouseClient.init(server.baseUrl, "test", "default", "")
+        try {
+            MockHttpServer { exchange ->
+                queries += exchange.requestBodyText()
+                exchange.respond(200, "", contentType = "text/plain")
+            }.use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
 
-            val result = repository.insertSessions(
-                listOf(
-                    SessionInsertData(
-                        sessionId = "11111111-1111-1111-1111-111111111111",
-                        projectId = 42L,
-                        startedMs = 1767225600000L,
-                        durationMs = 1500.0,
-                        status = "ok",
-                        errors = 0,
-                        release = "1.0.0",
-                        environment = "production",
-                        userId = "user-123",
-                        receivedAtMs = 1767225601000L
+                val result = repository.insertSessions(
+                    listOf(
+                        SessionInsertData(
+                            sessionId = "11111111-1111-1111-1111-111111111111",
+                            projectId = 42L,
+                            startedMs = 1767225600000L,
+                            durationMs = 1500.0,
+                            status = "ok",
+                            errors = 0,
+                            release = "1.0.0",
+                            environment = "production",
+                            userId = "user-123",
+                            receivedAtMs = 1767225601000L
+                        )
                     )
                 )
-            )
 
-            assertTrue(result)
+                assertTrue(result)
+            }
+        } finally {
+            ClickHouseClient.close()
         }
 
         val sql = queries.single()

--- a/backend/src/test/kotlin/com/moneat/events/repositories/EventRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/repositories/EventRepositoryTest.kt
@@ -16,10 +16,16 @@
 
 package com.moneat.events.repositories
 
+import com.moneat.config.ClickHouseClient
+import com.moneat.events.repositories.models.SessionInsertData
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.ProjectKeys
 import com.moneat.shared.models.Projects
+import com.moneat.testsupport.MockHttpServer
 import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.testsupport.requestBodyText
+import com.moneat.testsupport.respond
+import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -121,5 +127,53 @@ class EventRepositoryTest {
     fun `getOrganizationIdForProject returns null for unknown project`() {
         val result = repository.getOrganizationIdForProject(999999L)
         assertNull(result)
+    }
+
+    // ──── insertSessions ────
+
+    @Test
+    fun `insertSessions returns true for empty rows`() = runBlocking {
+        assertTrue(repository.insertSessions(emptyList()))
+    }
+
+    @Test
+    fun `insertSessions writes ClickHouse session rows`() = runBlocking {
+        val queries = mutableListOf<String>()
+        MockHttpServer { exchange ->
+            queries += exchange.requestBodyText()
+            exchange.respond(200, "", contentType = "text/plain")
+        }.use { server ->
+            ClickHouseClient.close()
+            ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+            val result = repository.insertSessions(
+                listOf(
+                    SessionInsertData(
+                        sessionId = "11111111-1111-1111-1111-111111111111",
+                        projectId = 42L,
+                        startedMs = 1767225600000L,
+                        durationMs = 1500.0,
+                        status = "ok",
+                        errors = 0,
+                        release = "1.0.0",
+                        environment = "production",
+                        userId = "user-123",
+                        receivedAtMs = 1767225601000L
+                    )
+                )
+            )
+
+            assertTrue(result)
+        }
+
+        val sql = queries.single()
+        assertTrue(sql.contains("INSERT INTO `test`.sessions"))
+        assertTrue(sql.contains("toUUID('11111111-1111-1111-1111-111111111111')"))
+        assertTrue(sql.contains("fromUnixTimestamp64Milli(1767225600000)"))
+        assertTrue(sql.contains("1500.0"))
+        assertTrue(sql.contains("'ok'"))
+        assertTrue(sql.contains("'1.0.0'"))
+        assertTrue(sql.contains("'production'"))
+        assertTrue(sql.contains("'user-123'"))
     }
 }

--- a/backend/src/test/kotlin/com/moneat/routes/IngestRoutesEnvelopeTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IngestRoutesEnvelopeTest.kt
@@ -149,7 +149,8 @@ class IngestRoutesEnvelopeTest {
             assertEquals(HttpStatusCode.Accepted, response.status)
             assertEquals(1, reservations.size)
             assertEquals(1, reservations[0]["transaction"])
-            assertEquals(2, reservations[0]["error"])
+            assertEquals(1, reservations[0]["session"])
+            assertEquals(1, reservations[0]["error"])
         }
 
     @Test
@@ -324,8 +325,8 @@ class IngestRoutesEnvelopeTest {
         assertEquals("feedback", mapEnvelopeItemTypeToQuotaType("feedback"))
         assertEquals("feedback", mapEnvelopeItemTypeToQuotaType("user_report"))
         assertEquals("llm", mapEnvelopeItemTypeToQuotaType("llm_generation"))
-        assertEquals("error", mapEnvelopeItemTypeToQuotaType("session"))
-        assertEquals("error", mapEnvelopeItemTypeToQuotaType("sessions"))
+        assertEquals("session", mapEnvelopeItemTypeToQuotaType("session"))
+        assertEquals("session", mapEnvelopeItemTypeToQuotaType("sessions"))
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("check_in"))
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("unknown_type"))
     }

--- a/backend/src/test/kotlin/com/moneat/routes/IngestRoutesEnvelopeTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IngestRoutesEnvelopeTest.kt
@@ -325,6 +325,7 @@ class IngestRoutesEnvelopeTest {
         assertEquals("feedback", mapEnvelopeItemTypeToQuotaType("user_report"))
         assertEquals("llm", mapEnvelopeItemTypeToQuotaType("llm_generation"))
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("session"))
+        assertEquals("error", mapEnvelopeItemTypeToQuotaType("sessions"))
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("check_in"))
         assertEquals("error", mapEnvelopeItemTypeToQuotaType("unknown_type"))
     }

--- a/backend/src/test/kotlin/com/moneat/services/BillingServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/BillingServicesExtendedTest.kt
@@ -983,6 +983,25 @@ class BillingServicesExtendedTest {
     }
 
     @Test
+    fun `reserveUnits tracks session as aggregate ingestion without error counter`() {
+        transaction {
+            insertTestUsageCounter(organizationId = testOrgId)
+        }
+
+        val result = billingQuotaService.reserveUnits(
+            organizationId = testOrgId,
+            requestedUnits = 2,
+            eventType = "session",
+            requestedBytes = 500
+        )
+        assertTrue(result.allowed)
+        assertEquals(2L, result.usage.usedUnits, "sessions should count toward aggregate ingestion")
+        assertEquals(0L, result.usage.usedErrors, "sessions should not be normalized to errors")
+        assertEquals(500L, result.usage.usedBytes, "session bytes should count toward ingestion bytes")
+        assertEquals(0L, result.usage.usedErrorBytes, "session bytes should not be stored as error bytes")
+    }
+
+    @Test
     fun `reserveUnits normalizes apm to apm_span event type`() {
         transaction {
             PricingTierConfigs.update({ PricingTierConfigs.id eq proTierId }) {

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
@@ -489,6 +489,156 @@ class EventServiceCoverageTest {
     }
 
     @Test
+    fun `processEnvelope ignores session without release`() = runBlocking {
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-no-release",
+                items = listOf(
+                    EnvelopeItem(
+                        "session",
+                        """
+                        {
+                          "sid": "22222222-2222-2222-2222-222222222222",
+                          "started": "2026-01-01T00:00:00Z",
+                          "status": "ok",
+                          "attrs": {}
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        coVerify(exactly = 0) { eventRepository.insertSessions(any()) }
+    }
+
+    @Test
+    fun `processEnvelope normalizes session defaults and error statuses`() = runBlocking {
+        val rowsSlot = slot<List<SessionInsertData>>()
+        coEvery { eventRepository.insertSessions(capture(rowsSlot)) } returns true
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-defaults",
+                items = listOf(
+                    EnvelopeItem(
+                        "session",
+                        """
+                        {
+                          "sid": "33333333-3333-3333-3333-333333333333",
+                          "timestamp": "2026-01-01T00:00:01Z",
+                          "duration": -2.0,
+                          "status": "errored",
+                          "errors": -1,
+                          "attrs": {
+                            "release": "1.1.0"
+                          }
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        val row = rowsSlot.captured.single()
+        assertEquals("33333333-3333-3333-3333-333333333333", row.sessionId)
+        assertEquals(0.0, row.durationMs)
+        assertEquals("abnormal", row.status)
+        assertEquals(1, row.errors)
+        assertEquals("1.1.0", row.release)
+        assertEquals("production", row.environment)
+        assertEquals("", row.userId)
+    }
+
+    @Test
+    fun `processEnvelope skips session inserts for invalid project`() = runBlocking {
+        eventService.processEnvelope(
+            0L,
+            SentryEnvelope(
+                eventId = "sess-invalid-project",
+                items = listOf(
+                    EnvelopeItem(
+                        "session",
+                        """
+                        {
+                          "sid": "44444444-4444-4444-4444-444444444444",
+                          "started": "2026-01-01T00:00:00Z",
+                          "attrs": {
+                            "release": "1.2.0"
+                          }
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        coVerify(exactly = 0) { eventRepository.insertSessions(any()) }
+    }
+
+    @Test
+    fun `processEnvelope handles session repository failures`() = runBlocking {
+        coEvery { eventRepository.insertSessions(any()) } throws IllegalStateException("clickhouse down")
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-insert-failure",
+                items = listOf(
+                    EnvelopeItem(
+                        "session",
+                        """
+                        {
+                          "sid": "55555555-5555-5555-5555-555555555555",
+                          "started": "2026-01-01T00:00:00Z",
+                          "attrs": {
+                            "release": "1.3.0"
+                          }
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        verify(exactly = 0) { releaseService.upsertReleaseFromEvent(any(), any(), any()) }
+    }
+
+    @Test
+    fun `processEnvelope stores session when release upsert fails`() = runBlocking {
+        val rowsSlot = slot<List<SessionInsertData>>()
+        coEvery { eventRepository.insertSessions(capture(rowsSlot)) } returns true
+        every {
+            releaseService.upsertReleaseFromEvent(testProjectId, "warn-release", any())
+        } throws IllegalStateException("release write failed")
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-release-failure",
+                items = listOf(
+                    EnvelopeItem(
+                        "session",
+                        """
+                        {
+                          "sid": "66666666-6666-6666-6666-666666666666",
+                          "started": "2026-01-01T00:00:00Z",
+                          "attrs": {
+                            "release": "warn-release"
+                          }
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        assertEquals("warn-release", rowsSlot.captured.single().release)
+    }
+
+    @Test
     fun `processEnvelope persists session aggregate items`() = runBlocking {
         val rowsSlot = slot<List<SessionInsertData>>()
         coEvery { eventRepository.insertSessions(capture(rowsSlot)) } returns true
@@ -526,6 +676,77 @@ class EventServiceCoverageTest {
         assertEquals(1, rows.count { it.status == "crashed" && it.errors == 1 })
         assertTrue(rows.all { it.release == "2.0.0" })
         assertTrue(rows.all { it.environment == "production" })
+    }
+
+    @Test
+    fun `processEnvelope persists all session aggregate statuses`() = runBlocking {
+        val rowsSlot = slot<List<SessionInsertData>>()
+        coEvery { eventRepository.insertSessions(capture(rowsSlot)) } returns true
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-aggregate-statuses",
+                items = listOf(
+                    EnvelopeItem(
+                        "sessions",
+                        """
+                        {
+                          "aggregates": [
+                            {
+                              "started": "2026-01-01T00:00:00Z",
+                              "exited": -1,
+                              "errored": 1,
+                              "abnormal": 1,
+                              "ok": 1,
+                              "did": "device-1",
+                              "attrs": {
+                                "release": "3.0.0"
+                              }
+                            }
+                          ]
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        val rows = rowsSlot.captured
+        assertEquals(3, rows.size)
+        assertEquals(2, rows.count { it.status == "abnormal" && it.errors == 1 })
+        assertEquals(1, rows.count { it.status == "ok" && it.errors == 0 })
+        assertTrue(rows.all { it.release == "3.0.0" })
+        assertTrue(rows.all { it.environment == "production" })
+        assertTrue(rows.all { it.userId == "device-1" })
+    }
+
+    @Test
+    fun `processEnvelope ignores empty session aggregate rows`() = runBlocking {
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-aggregate-no-release",
+                items = listOf(
+                    EnvelopeItem(
+                        "sessions",
+                        """
+                        {
+                          "aggregates": [
+                            {
+                              "started": "2026-01-01T00:00:00Z",
+                              "exited": 1,
+                              "attrs": {}
+                            }
+                          ]
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        coVerify(exactly = 0) { eventRepository.insertSessions(any()) }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
@@ -38,6 +38,7 @@ import com.moneat.events.repositories.models.FeedbackInsertData
 import com.moneat.events.repositories.models.LlmGenerationInsertData
 import com.moneat.events.repositories.models.ProjectKeyVerification
 import com.moneat.events.repositories.models.ReplayEventInsertData
+import com.moneat.events.repositories.models.SessionInsertData
 import com.moneat.events.repositories.models.TransactionEventInsertData
 import com.moneat.events.services.EventService
 import com.moneat.events.services.ReleaseService
@@ -126,6 +127,7 @@ class EventServiceCoverageTest {
 
         coEvery { eventRepository.insertErrorEvent(any()) } returns true
         coEvery { eventRepository.insertTransaction(any()) } returns true
+        coEvery { eventRepository.insertSessions(any()) } returns true
         coEvery { eventRepository.insertSpans(any()) } returns Unit
         coEvery { eventRepository.insertFeedback(any()) } returns true
         coEvery { eventRepository.insertReplayEvent(any()) } returns true
@@ -441,6 +443,89 @@ class EventServiceCoverageTest {
             )
         )
         // No crash - session items are skipped
+    }
+
+    @Test
+    fun `processEnvelope persists session items`() = runBlocking {
+        val rowsSlot = slot<List<SessionInsertData>>()
+        coEvery { eventRepository.insertSessions(capture(rowsSlot)) } returns true
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-2",
+                items = listOf(
+                    EnvelopeItem(
+                        "session",
+                        """
+                        {
+                          "sid": "11111111-1111-1111-1111-111111111111",
+                          "did": "user-123",
+                          "started": "2026-01-01T00:00:00Z",
+                          "duration": 1.5,
+                          "status": "ok",
+                          "errors": 0,
+                          "attrs": {
+                            "release": "1.0.0",
+                            "environment": "production"
+                          }
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        val row = rowsSlot.captured.single()
+        assertEquals("11111111-1111-1111-1111-111111111111", row.sessionId)
+        assertEquals(testProjectId, row.projectId)
+        assertEquals(1_500.0, row.durationMs)
+        assertEquals("ok", row.status)
+        assertEquals(0, row.errors)
+        assertEquals("1.0.0", row.release)
+        assertEquals("production", row.environment)
+        assertEquals("user-123", row.userId)
+        verify { releaseService.upsertReleaseFromEvent(testProjectId, "1.0.0", row.startedMs) }
+    }
+
+    @Test
+    fun `processEnvelope persists session aggregate items`() = runBlocking {
+        val rowsSlot = slot<List<SessionInsertData>>()
+        coEvery { eventRepository.insertSessions(capture(rowsSlot)) } returns true
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-aggregate-1",
+                items = listOf(
+                    EnvelopeItem(
+                        "sessions",
+                        """
+                        {
+                          "aggregates": [
+                            {
+                              "started": "2026-01-01T00:00:00Z",
+                              "exited": 2,
+                              "crashed": 1,
+                              "attrs": {
+                                "release": "2.0.0",
+                                "environment": "production"
+                              }
+                            }
+                          ]
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        val rows = rowsSlot.captured
+        assertEquals(3, rows.size)
+        assertEquals(2, rows.count { it.status == "exited" && it.errors == 0 })
+        assertEquals(1, rows.count { it.status == "crashed" && it.errors == 1 })
+        assertTrue(rows.all { it.release == "2.0.0" })
+        assertTrue(rows.all { it.environment == "production" })
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
@@ -545,11 +545,44 @@ class EventServiceCoverageTest {
         val row = rowsSlot.captured.single()
         assertEquals("33333333-3333-3333-3333-333333333333", row.sessionId)
         assertEquals(0.0, row.durationMs)
-        assertEquals("abnormal", row.status)
+        assertEquals("errored", row.status)
         assertEquals(1, row.errors)
         assertEquals("1.1.0", row.release)
         assertEquals("production", row.environment)
         assertEquals("", row.userId)
+    }
+
+    @Test
+    fun `processEnvelope normalizes unknown session status with errors to abnormal`() = runBlocking {
+        val rowsSlot = slot<List<SessionInsertData>>()
+        coEvery { eventRepository.insertSessions(capture(rowsSlot)) } returns true
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "sess-unknown-status",
+                items = listOf(
+                    EnvelopeItem(
+                        "session",
+                        """
+                        {
+                          "sid": "33333333-3333-3333-3333-333333333334",
+                          "started": "2026-01-01T00:00:00Z",
+                          "status": "failed",
+                          "errors": 2,
+                          "attrs": {
+                            "release": "1.1.1"
+                          }
+                        }
+                        """.trimIndent()
+                    )
+                )
+            )
+        )
+
+        val row = rowsSlot.captured.single()
+        assertEquals("abnormal", row.status)
+        assertEquals(2, row.errors)
     }
 
     @Test
@@ -714,7 +747,8 @@ class EventServiceCoverageTest {
 
         val rows = rowsSlot.captured
         assertEquals(3, rows.size)
-        assertEquals(2, rows.count { it.status == "abnormal" && it.errors == 1 })
+        assertEquals(1, rows.count { it.status == "errored" && it.errors == 1 })
+        assertEquals(1, rows.count { it.status == "abnormal" && it.errors == 1 })
         assertEquals(1, rows.count { it.status == "ok" && it.errors == 0 })
         assertTrue(rows.all { it.release == "3.0.0" })
         assertTrue(rows.all { it.environment == "production" })

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceTest.kt
@@ -656,6 +656,25 @@ class EventServiceTest {
     }
 
     @Test
+    fun `SentryEnvelope parses implicit sessions item`() {
+        val envelope =
+            SentryEnvelope.parse(
+                """
+                {"event_id":"sessions-env"}
+                {"type":"sessions"}
+                {"aggregates":[]}
+                {"type":"event"}
+                {"event_id":"evt-1"}
+                """.trimIndent().toByteArray()
+            )
+
+        assertEquals(2, envelope.items.size)
+        assertEquals("sessions", envelope.items[0].type)
+        assertEquals("""{"aggregates":[]}""", envelope.items[0].payload)
+        assertEquals("event", envelope.items[1].type)
+    }
+
+    @Test
     fun `exception with multiple stack frames is parsed correctly`() {
         val frames =
             listOf(

--- a/backend/src/test/kotlin/com/moneat/services/ReleaseStatsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReleaseStatsServiceTest.kt
@@ -75,8 +75,15 @@ class ReleaseStatsServiceTest {
                 else -> {
                     exchange.respond(
                         200,
-                        """{"version":"1.0.0","first_seen":"2026-01-01T00:00:00.000Z","last_seen":"2026-01-02T00:00:00.000Z","event_count":10,"user_count":5}
-                        """.trimIndent(),
+                        """
+                        {
+                          "version":"1.0.0",
+                          "first_seen":"2026-01-01T00:00:00.000Z",
+                          "last_seen":"2026-01-02T00:00:00.000Z",
+                          "event_count":10,
+                          "user_count":5
+                        }
+                        """.trimIndent().replace("\n", ""),
                         contentType = TEXT_PLAIN
                     )
                 }
@@ -122,6 +129,13 @@ class ReleaseStatsServiceTest {
                         contentType = TEXT_PLAIN
                     )
                 }
+                query.contains("GROUP BY user_id") && query.contains("sessions") -> {
+                    exchange.respond(
+                        200,
+                        """{"rate":87.5}""",
+                        contentType = TEXT_PLAIN
+                    )
+                }
                 query.contains(COUNT_IF_ERRORS_0) && query.contains("sessions") -> {
                     exchange.respond(
                         200,
@@ -154,8 +168,14 @@ class ReleaseStatsServiceTest {
                 else -> {
                     exchange.respond(
                         200,
-                        """{"first_seen":"2026-01-01T00:00:00.000Z","last_seen":"2026-01-02T00:00:00.000Z","total_events":20,"user_count":8}
-                        """.trimIndent(),
+                        """
+                        {
+                          "first_seen":"2026-01-01T00:00:00.000Z",
+                          "last_seen":"2026-01-02T00:00:00.000Z",
+                          "total_events":20,
+                          "user_count":8
+                        }
+                        """.trimIndent().replace("\n", ""),
                         contentType = TEXT_PLAIN
                     )
                 }
@@ -172,7 +192,7 @@ class ReleaseStatsServiceTest {
             assertEquals(8L, stats.userCount)
             assertEquals(3L, stats.newIssues)
             assertEquals(95.0, stats.crashFreeSessionRate)
-            assertNull(stats.crashFreeUserRate)
+            assertEquals(87.5, stats.crashFreeUserRate)
             assertTrue(stats.eventsTimeline.isNotEmpty())
             assertTrue(stats.eventsByLevel.isNotEmpty())
             assertTrue(stats.topIssues.isNotEmpty())
@@ -223,8 +243,14 @@ class ReleaseStatsServiceTest {
                 else -> {
                     exchange.respond(
                         200,
-                        """{"first_seen":"2026-01-01T00:00:00.000Z","last_seen":"2026-01-02T00:00:00.000Z","total_events":5,"user_count":2}
-                        """.trimIndent(),
+                        """
+                        {
+                          "first_seen":"2026-01-01T00:00:00.000Z",
+                          "last_seen":"2026-01-02T00:00:00.000Z",
+                          "total_events":5,
+                          "user_count":2
+                        }
+                        """.trimIndent().replace("\n", ""),
                         contentType = TEXT_PLAIN
                     )
                 }

--- a/backend/src/test/kotlin/com/moneat/services/ReleaseStatsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReleaseStatsServiceTest.kt
@@ -217,6 +217,13 @@ class ReleaseStatsServiceTest {
         MockHttpServer { exchange ->
             val query = exchange.requestBodyText()
             when {
+                query.contains("GROUP BY user_id") && query.contains("sessions") -> {
+                    exchange.respond(
+                        200,
+                        """{"rate":"nan"}""",
+                        contentType = TEXT_PLAIN
+                    )
+                }
                 query.contains(COUNT_IF_ERRORS_0) && query.contains("sessions") -> {
                     exchange.respond(
                         200,
@@ -261,6 +268,7 @@ class ReleaseStatsServiceTest {
             val stats = service.getReleaseStats(1L, "1.0.0")
             assertNotNull(stats)
             assertNull(stats.crashFreeSessionRate)
+            assertNull(stats.crashFreeUserRate)
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist Sentry session and aggregate session envelope items into ClickHouse sessions
- compute release detail crash-free user rate from stored session users
- cover session parsing, persistence, and release-health stats with focused backend tests

## Validation
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon compileKotlin -Dkotlin.compiler.execution.strategy=in-process`
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.services.ReleaseStatsServiceTest --tests com.moneat.services.EventServiceCoverageTest --tests com.moneat.services.EventServiceTest --tests com.moneat.routes.IngestRoutesEnvelopeTest -Dkotlin.compiler.execution.strategy=in-process`
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon detekt -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`

Fixes #274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session event ingestion and bulk storage
  * Added crash-free user rate calculation per release

* **Bug Fixes**
  * Recognize and correctly handle "sessions" envelope items during ingestion
  * Normalize session status and error counts for storage

* **Tests**
  * Added extensive tests for session items, aggregates, persistence, and rate calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->