### PR TITLE
feat: add datadog dashboard import

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/translation/DataDogTranslator.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/translation/DataDogTranslator.kt
@@ -47,9 +47,11 @@ private const val DD_GRID_COLS = 12
 private const val DD_SECTION_HEIGHT = 1
 private const val DD_AUTO_WIDGETS_PER_ROW = 2
 private const val DD_DEFAULT_TABLE_LIMIT = 100
+private const val DD_GROUP_BY_MATCH_GROUP_INDEX = 4
 
-private val DD_METRIC_QUERY_REGEX = Regex("""([A-Za-z_][A-Za-z0-9_]*):([A-Za-z0-9_.]+)\{([^}]*)}""")
-private val DD_GROUP_BY_REGEX = Regex("""\s+by\s+\{([^}]*)}""")
+private val DD_METRIC_QUERY_REGEX = Regex(
+    """^\s*([A-Za-z_][A-Za-z0-9_]*):([A-Za-z0-9_.]+)\{([^}]*)}\s*(?:by\s+\{([^}]*)})?\s*$"""
+)
 private val DD_SIMPLE_FORMULA_REGEX = Regex("""^[A-Za-z_][A-Za-z0-9_]*$""")
 
 private data class DataDogLayout(
@@ -179,7 +181,7 @@ class DataDogTranslator : DashboardTranslator {
         }
 
         if (ddType == "group") {
-            return importGroupWidget(definition, index, warnings, layout)
+            return importGroupWidget(definition, index, warnings, layout, parentLayout)
         }
 
         val resolvedLayout = resolveLayout(layout, parentLayout)
@@ -208,8 +210,10 @@ class DataDogTranslator : DashboardTranslator {
         definition: JsonObject,
         index: Int,
         warnings: MutableList<String>,
-        layout: DataDogLayout
+        layout: DataDogLayout,
+        parentLayout: DataDogLayout? = null
     ): List<WidgetResponse> {
+        val resolvedLayout = resolveLayout(layout, parentLayout)
         val title = definition["title"]?.jsonPrimitive?.contentOrNull ?: "Section"
         val children = definition["widgets"]?.jsonArray ?: JsonArray(emptyList())
         val section = WidgetResponse(
@@ -217,9 +221,9 @@ class DataDogTranslator : DashboardTranslator {
             dashboardId = 0,
             title = title,
             widgetType = "section",
-            gridX = 0,
-            gridY = layout.y,
-            gridW = DD_GRID_COLS,
+            gridX = resolvedLayout.x.coerceIn(0, DD_MAX_GRID_COL),
+            gridY = resolvedLayout.y,
+            gridW = resolvedLayout.width.coerceIn(1, DD_GRID_COLS),
             gridH = DD_SECTION_HEIGHT,
             queryConfigs = emptyList(),
             displayConfig = mapOf(
@@ -229,7 +233,7 @@ class DataDogTranslator : DashboardTranslator {
             ),
             sortOrder = index
         )
-        val childParentLayout = layout.copy(y = layout.y + DD_SECTION_HEIGHT)
+        val childParentLayout = resolvedLayout.copy(y = resolvedLayout.y + DD_SECTION_HEIGHT)
         return listOf(section) + importWidgets(children, warnings, childParentLayout)
     }
 
@@ -377,8 +381,8 @@ class DataDogTranslator : DashboardTranslator {
     }
 
     private fun parseMetricQuery(queryStr: String): ParsedDataDogQuery? {
-        val match = DD_METRIC_QUERY_REGEX.find(queryStr) ?: return null
-        val groupByText = DD_GROUP_BY_REGEX.find(queryStr)?.groupValues?.get(1)
+        val match = DD_METRIC_QUERY_REGEX.matchEntire(queryStr) ?: return null
+        val groupByText = match.groupValues.getOrNull(DD_GROUP_BY_MATCH_GROUP_INDEX)?.takeIf { it.isNotBlank() }
         return ParsedDataDogQuery(
             function = mapDdFunction(match.groupValues[1]),
             metricName = match.groupValues[2].trim(),

--- a/backend/src/main/kotlin/com/moneat/dashboards/translation/DataDogTranslator.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/translation/DataDogTranslator.kt
@@ -27,6 +27,7 @@ import com.moneat.dashboards.models.GroupByType
 import com.moneat.dashboards.models.MetricDef
 import com.moneat.dashboards.models.QueryDsl
 import com.moneat.dashboards.models.WidgetResponse
+import com.moneat.utils.suspendRunCatching
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -38,12 +39,32 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import com.moneat.utils.suspendRunCatching
 
 private const val DD_DEFAULT_WIDGET_W = 6
 private const val DD_DEFAULT_WIDGET_H = 4
 private const val DD_MAX_GRID_COL = 11
 private const val DD_GRID_COLS = 12
+private const val DD_SECTION_HEIGHT = 1
+private const val DD_AUTO_WIDGETS_PER_ROW = 2
+private const val DD_DEFAULT_TABLE_LIMIT = 100
+
+private val DD_METRIC_QUERY_REGEX = Regex("""([A-Za-z_][A-Za-z0-9_]*):([A-Za-z0-9_.]+)\{([^}]*)}""")
+private val DD_GROUP_BY_REGEX = Regex("""\s+by\s+\{([^}]*)}""")
+private val DD_SIMPLE_FORMULA_REGEX = Regex("""^[A-Za-z_][A-Za-z0-9_]*$""")
+
+private data class DataDogLayout(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int
+)
+
+private data class ParsedDataDogQuery(
+    val function: AggFunction,
+    val metricName: String,
+    val tagText: String?,
+    val groupByText: String?
+)
 
 class DataDogTranslator : DashboardTranslator {
 
@@ -52,32 +73,42 @@ class DataDogTranslator : DashboardTranslator {
         "toplist" to "toplist",
         "query_value" to "stat",
         "table" to "table",
+        "query_table" to "table",
         "heatmap" to "heatmap",
         "distribution" to "bar",
         "pie" to "donut",
+        "sunburst" to "donut",
         "note" to "text",
         "free_text" to "text",
-        "group" to "text"
+        "image" to "text",
+        "group" to "section"
     )
 
     private val reverseWidgetTypeMap = mapOf(
         "timeseries" to "timeseries",
         "toplist" to "toplist",
         "stat" to "query_value",
-        "table" to "table",
+        "table" to "query_table",
         "heatmap" to "heatmap",
         "bar" to "distribution",
         "donut" to "pie",
         "text" to "note"
     )
 
-    // Maps DD metric namespace prefixes to Moneat data sources
     private val metricNamespaceMap = mapOf(
         "system." to "metrics",
         "trace." to "spans",
         "logs." to "logs",
         "container." to "containers",
+        "docker." to "containers",
         "network." to "metrics"
+    )
+
+    private val filterFieldsBySource = mapOf(
+        "metrics" to setOf("metric_name", "host"),
+        "containers" to setOf("host", "name"),
+        "spans" to setOf("op", "status", "environment"),
+        "logs" to setOf("level", "message", "service", "environment", "host")
     )
 
     override fun import(json: JsonObject): DashboardImportResult {
@@ -85,17 +116,9 @@ class DataDogTranslator : DashboardTranslator {
 
         val title = json["title"]?.jsonPrimitive?.contentOrNull ?: "Imported DataDog Dashboard"
         val description = json["description"]?.jsonPrimitive?.contentOrNull
-
         val ddWidgets = json["widgets"]?.jsonArray ?: JsonArray(emptyList())
-
-        val widgets = ddWidgets.mapIndexedNotNull { index, element ->
-            suspendRunCatching {
-                importWidget(element.jsonObject, index, warnings)
-            }.getOrElse { e ->
-                warnings.add("Widget $index: failed to import - ${e.message}")
-                null
-            }
-        }
+        val widgets = importWidgets(ddWidgets, warnings)
+            .mapIndexed { index, widget -> widget.copy(sortOrder = index) }
 
         val dashboard = DashboardResponse(
             id = 0,
@@ -114,42 +137,143 @@ class DataDogTranslator : DashboardTranslator {
         return DashboardImportResult(dashboard, warnings, variables)
     }
 
+    private fun importWidgets(
+        ddWidgets: JsonArray,
+        warnings: MutableList<String>,
+        parentLayout: DataDogLayout? = null
+    ): List<WidgetResponse> {
+        var autoColumn = 0
+        var nextAutoY = 0
+        return ddWidgets.flatMapIndexed { index, element ->
+            val widgetJson = element.jsonObject
+            val explicitLayout = readLayout(widgetJson["layout"]?.jsonObject)
+            val layout = explicitLayout ?: autoLayout(autoColumn, nextAutoY).also {
+                autoColumn = (autoColumn + 1) % DD_AUTO_WIDGETS_PER_ROW
+                if (autoColumn == 0) nextAutoY += DD_DEFAULT_WIDGET_H
+            }
+            if (explicitLayout != null) {
+                nextAutoY = maxOf(nextAutoY, explicitLayout.y + explicitLayout.height)
+            }
+
+            suspendRunCatching {
+                importWidget(widgetJson, index, warnings, layout, parentLayout)
+            }.getOrElse { e ->
+                warnings.add("Widget $index: failed to import - ${e.message}")
+                emptyList()
+            }
+        }
+    }
+
     private fun importWidget(
         widgetJson: JsonObject,
         index: Int,
-        warnings: MutableList<String>
-    ): WidgetResponse {
+        warnings: MutableList<String>,
+        layout: DataDogLayout,
+        parentLayout: DataDogLayout? = null
+    ): List<WidgetResponse> {
         val definition = widgetJson["definition"]?.jsonObject ?: JsonObject(emptyMap())
-        val layout = widgetJson["layout"]?.jsonObject
-
         val ddType = definition["type"]?.jsonPrimitive?.contentOrNull ?: "timeseries"
         val moneatType = widgetTypeMap[ddType]
         if (moneatType == null) {
             warnings.add("Widget $index: unsupported type '$ddType', imported as 'text'")
         }
 
+        if (ddType == "group") {
+            return importGroupWidget(definition, index, warnings, layout)
+        }
+
+        val resolvedLayout = resolveLayout(layout, parentLayout)
         val widgetTitle = definition["title"]?.jsonPrimitive?.contentOrNull
+        val queryConfigs = parseDataDogQueries(definition, warnings, index)
+        val displayConfig = extractDisplayConfig(definition, ddType)
 
-        // Parse grid position from DD layout (DD uses 12-col grid)
-        val gridX = layout?.get("x")?.jsonPrimitive?.intOrNull ?: 0
-        val gridY = layout?.get("y")?.jsonPrimitive?.intOrNull ?: 0
-        val gridW = layout?.get("width")?.jsonPrimitive?.intOrNull ?: DD_DEFAULT_WIDGET_W
-        val gridH = layout?.get("height")?.jsonPrimitive?.intOrNull ?: DD_DEFAULT_WIDGET_H
+        return listOf(
+            WidgetResponse(
+                id = 0,
+                dashboardId = 0,
+                title = widgetTitle,
+                widgetType = moneatType ?: "text",
+                gridX = resolvedLayout.x.coerceIn(0, DD_MAX_GRID_COL),
+                gridY = resolvedLayout.y,
+                gridW = resolvedLayout.width.coerceIn(1, DD_GRID_COLS),
+                gridH = resolvedLayout.height.coerceIn(1, DD_GRID_COLS),
+                queryConfigs = queryConfigs,
+                displayConfig = displayConfig,
+                sortOrder = index
+            )
+        )
+    }
 
-        val queryConfig = parseDataDogQuery(definition, warnings, index)
-
-        return WidgetResponse(
+    private fun importGroupWidget(
+        definition: JsonObject,
+        index: Int,
+        warnings: MutableList<String>,
+        layout: DataDogLayout
+    ): List<WidgetResponse> {
+        val title = definition["title"]?.jsonPrimitive?.contentOrNull ?: "Section"
+        val children = definition["widgets"]?.jsonArray ?: JsonArray(emptyList())
+        val section = WidgetResponse(
             id = 0,
             dashboardId = 0,
-            title = widgetTitle,
-            widgetType = moneatType ?: "text",
-            gridX = gridX.coerceIn(0, DD_MAX_GRID_COL),
-            gridY = gridY,
-            gridW = gridW.coerceIn(1, DD_GRID_COLS),
-            gridH = gridH.coerceIn(1, DD_GRID_COLS),
-            queryConfigs = listOf(queryConfig),
+            title = title,
+            widgetType = "section",
+            gridX = 0,
+            gridY = layout.y,
+            gridW = DD_GRID_COLS,
+            gridH = DD_SECTION_HEIGHT,
+            queryConfigs = emptyList(),
+            displayConfig = mapOf(
+                "source_format" to "datadog",
+                "datadog_widget_type" to "group",
+                "collapsed" to "false"
+            ),
             sortOrder = index
         )
+        val childParentLayout = layout.copy(y = layout.y + DD_SECTION_HEIGHT)
+        return listOf(section) + importWidgets(children, warnings, childParentLayout)
+    }
+
+    private fun readLayout(layout: JsonObject?): DataDogLayout? {
+        if (layout == null) return null
+        return DataDogLayout(
+            x = layout["x"]?.jsonPrimitive?.intOrNull ?: 0,
+            y = layout["y"]?.jsonPrimitive?.intOrNull ?: 0,
+            width = layout["width"]?.jsonPrimitive?.intOrNull ?: DD_DEFAULT_WIDGET_W,
+            height = layout["height"]?.jsonPrimitive?.intOrNull ?: DD_DEFAULT_WIDGET_H
+        )
+    }
+
+    private fun autoLayout(column: Int, y: Int): DataDogLayout {
+        val x = column * DD_DEFAULT_WIDGET_W
+        return DataDogLayout(x, y, DD_DEFAULT_WIDGET_W, DD_DEFAULT_WIDGET_H)
+    }
+
+    private fun resolveLayout(layout: DataDogLayout, parentLayout: DataDogLayout?): DataDogLayout {
+        if (parentLayout == null) return layout
+        return DataDogLayout(
+            x = parentLayout.x + layout.x,
+            y = parentLayout.y + layout.y,
+            width = layout.width.coerceAtMost((DD_GRID_COLS - parentLayout.x).coerceAtLeast(1)),
+            height = layout.height
+        )
+    }
+
+    private fun extractDisplayConfig(definition: JsonObject, ddType: String): Map<String, String> {
+        val config = mutableMapOf(
+            "source_format" to "datadog",
+            "datadog_widget_type" to ddType
+        )
+        definition["content"]?.jsonPrimitive?.contentOrNull?.let { content ->
+            config["content"] = content
+        }
+        definition["url"]?.jsonPrimitive?.contentOrNull?.let { url ->
+            config["content"] = "![]($url)"
+            config["image_url"] = url
+        }
+        definition["legend_layout"]?.jsonPrimitive?.contentOrNull?.let { config["legendLayout"] = it }
+        definition["display_type"]?.jsonPrimitive?.contentOrNull?.let { config["displayType"] = it }
+        definition["background_color"]?.jsonPrimitive?.contentOrNull?.let { config["backgroundColor"] = it }
+        return config
     }
 
     internal fun parseDataDogQuery(
@@ -157,83 +281,175 @@ class DataDogTranslator : DashboardTranslator {
         warnings: MutableList<String>,
         widgetIndex: Int
     ): QueryDsl {
+        return parseDataDogQueries(definition, warnings, widgetIndex).first()
+    }
+
+    internal fun parseDataDogQueries(
+        definition: JsonObject,
+        warnings: MutableList<String>,
+        widgetIndex: Int
+    ): List<QueryDsl> {
         val requests = definition["requests"]?.jsonArray
 
         if (requests.isNullOrEmpty()) {
-            return QueryDsl(
-                dataSource = "events",
-                metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count"))
+            return listOf(
+                QueryDsl(
+                    dataSource = "events",
+                    metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count"))
+                )
             )
         }
 
-        val firstRequest = requests.first().jsonObject
-        val queryStr = firstRequest["q"]?.jsonPrimitive?.contentOrNull
-            ?: firstRequest["queries"]?.jsonArray?.firstOrNull()
-                ?.jsonObject?.get("query")?.jsonPrimitive?.contentOrNull
+        val parsedQueries = requests.flatMap { requestElement ->
+            parseRequestQueries(requestElement.jsonObject, warnings, widgetIndex)
+        }
 
-        if (queryStr == null) {
+        if (parsedQueries.isEmpty()) {
             warnings.add("Widget $widgetIndex: no query string found, using default")
-            return QueryDsl(
-                dataSource = "events",
-                metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count"))
+            return listOf(
+                QueryDsl(
+                    dataSource = "events",
+                    metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count"))
+                )
             )
         }
 
-        return parseDataDogQueryString(queryStr, warnings, widgetIndex)
+        return parsedQueries
+    }
+
+    private fun parseRequestQueries(
+        request: JsonObject,
+        warnings: MutableList<String>,
+        widgetIndex: Int
+    ): List<QueryDsl> {
+        request["q"]?.jsonPrimitive?.contentOrNull?.let { queryStr ->
+            return listOf(parseDataDogQueryString(queryStr, warnings, widgetIndex))
+        }
+
+        val formulaAliases = extractFormulaAliases(request)
+        val queries = request["queries"]?.jsonArray ?: return emptyList()
+        return queries.mapNotNull { queryElement ->
+            val queryObj = queryElement.jsonObject
+            val queryStr = queryObj["query"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            val queryName = queryObj["name"]?.jsonPrimitive?.contentOrNull
+            val alias = queryName?.let { formulaAliases[it] } ?: queryName
+            parseDataDogQueryString(queryStr, warnings, widgetIndex, alias, queryName)
+        }
+    }
+
+    private fun extractFormulaAliases(request: JsonObject): Map<String, String> {
+        val formulas = request["formulas"]?.jsonArray ?: return emptyMap()
+        return formulas.mapNotNull { formulaElement ->
+            val formula = formulaElement.jsonObject
+            val expression = formula["formula"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            if (!DD_SIMPLE_FORMULA_REGEX.matches(expression)) return@mapNotNull null
+            val alias = formula["alias"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            expression to alias
+        }.toMap()
     }
 
     internal fun parseDataDogQueryString(
         queryStr: String,
         warnings: MutableList<String>,
-        widgetIndex: Int
+        widgetIndex: Int,
+        alias: String? = null,
+        refId: String? = null
     ): QueryDsl {
-        // DD query format: "function:metric.name{tag:value,tag2:value2}.as_count()"
-        val functionMatch = Regex("""^(\w+):(.+)$""").find(queryStr)
-        val aggFunction: AggFunction
-        val metricPart: String
-
-        if (functionMatch != null) {
-            aggFunction = mapDdFunction(functionMatch.groupValues[1])
-            metricPart = functionMatch.groupValues[2]
-        } else {
-            aggFunction = AggFunction.AVG
-            metricPart = queryStr
+        val parsed = parseMetricQuery(queryStr)
+        if (parsed == null) {
+            warnings.add("Widget $widgetIndex: unable to parse Datadog query, preserving as raw query")
+            return rawQueryDsl(queryStr, alias, refId)
         }
 
-        // Extract metric name and tags: metric.name{tag:value}
-        val metricMatch = Regex("""^([^{]+)(?:\{([^}]*)\})?""").find(metricPart)
-        val metricName = metricMatch?.groupValues?.get(1)?.trim()?.removeSuffix(".as_count()") ?: "count"
-        val tagStr = metricMatch?.groupValues?.get(2)
-
-        val dataSource = resolveDataSource(metricName)
-        val field = mapMetricField(metricName, dataSource)
-
-        val filters = mutableListOf<FilterDef>()
-        if (!tagStr.isNullOrBlank() && tagStr != "*") {
-            tagStr.split(",").forEach { tag ->
-                val parts = tag.trim().split(":", limit = 2)
-                if (parts.size == 2) {
-                    filters.add(FilterDef(parts[0].trim(), FilterOp.EQ, parts[1].trim()))
-                }
-            }
-        }
-
-        if (field == null && metricName.isNotBlank()) {
-            warnings.add("Widget $widgetIndex: metric '$metricName' mapped as raw query")
-            return QueryDsl(
-                dataSource = dataSource,
-                metrics = listOf(MetricDef(aggFunction, alias = "value")),
-                filters = filters,
-                rawQuery = queryStr
-            )
-        }
+        val dataSource = resolveDataSource(parsed.metricName)
+        val field = mapMetricField(dataSource)
+        val filters = parseDataDogTags(parsed.tagText, dataSource, parsed.metricName)
+        val groupBy = parseDataDogGroupBy(parsed.groupByText, dataSource)
 
         return QueryDsl(
             dataSource = dataSource,
-            metrics = listOf(MetricDef(aggFunction, field, alias = "value")),
-            groupBy = listOf(GroupByDef("timestamp", GroupByType.TIME, "auto")),
-            filters = filters
+            metrics = listOf(MetricDef(parsed.function, field, alias ?: "value")),
+            groupBy = groupBy,
+            filters = filters,
+            limit = DD_DEFAULT_TABLE_LIMIT,
+            refId = refId
         )
+    }
+
+    private fun parseMetricQuery(queryStr: String): ParsedDataDogQuery? {
+        val match = DD_METRIC_QUERY_REGEX.find(queryStr) ?: return null
+        val groupByText = DD_GROUP_BY_REGEX.find(queryStr)?.groupValues?.get(1)
+        return ParsedDataDogQuery(
+            function = mapDdFunction(match.groupValues[1]),
+            metricName = match.groupValues[2].trim(),
+            tagText = match.groupValues[3],
+            groupByText = groupByText
+        )
+    }
+
+    private fun rawQueryDsl(queryStr: String, alias: String?, refId: String?): QueryDsl {
+        return QueryDsl(
+            dataSource = "metrics",
+            metrics = listOf(MetricDef(AggFunction.AVG, "value", alias ?: "value")),
+            groupBy = listOf(GroupByDef("timestamp", GroupByType.TIME, "auto")),
+            rawQuery = queryStr,
+            refId = refId
+        )
+    }
+
+    private fun parseDataDogTags(
+        tagText: String?,
+        dataSource: String,
+        metricName: String
+    ): List<FilterDef> {
+        val filters = mutableListOf<FilterDef>()
+        if (dataSource == "metrics") {
+            filters.add(FilterDef("metric_name", FilterOp.EQ, metricName))
+        }
+        if (tagText.isNullOrBlank() || tagText == "*") return filters
+
+        tagText.split(",")
+            .map { it.trim() }
+            .filter { it.isNotBlank() && it != "*" }
+            .forEach { tag -> addDataDogTagFilter(tag, dataSource, filters) }
+        return filters
+    }
+
+    private fun addDataDogTagFilter(tag: String, dataSource: String, filters: MutableList<FilterDef>) {
+        val filter = parseTagFilter(tag) ?: return
+        if (isSupportedFilterField(dataSource, filter.field)) {
+            filters.add(filter)
+        }
+    }
+
+    private fun parseTagFilter(tag: String): FilterDef? {
+        if (tag.startsWith("$")) {
+            val name = tag.removePrefix("$")
+            return FilterDef(name, FilterOp.EQ, tag)
+        }
+
+        val normalized = tag.removePrefix("!")
+        val parts = normalized.split(":", limit = 2)
+        if (parts.size != 2 || parts[1] == "*") return null
+
+        return FilterDef(
+            field = parts[0].trim(),
+            op = if (tag.startsWith("!")) FilterOp.NEQ else FilterOp.EQ,
+            value = parts[1].trim()
+        )
+    }
+
+    private fun parseDataDogGroupBy(groupByText: String?, dataSource: String): List<GroupByDef> {
+        val groupFields = groupByText?.split(",")
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() && isSupportedFilterField(dataSource, it) }
+            ?: emptyList()
+        return listOf(GroupByDef("timestamp", GroupByType.TIME, "auto")) +
+            groupFields.map { GroupByDef(it, GroupByType.FIELD) }
+    }
+
+    private fun isSupportedFilterField(dataSource: String, field: String): Boolean {
+        return filterFieldsBySource[dataSource]?.contains(field) ?: false
     }
 
     private fun mapDdFunction(fn: String): AggFunction = when (fn.lowercase()) {
@@ -251,23 +467,20 @@ class DataDogTranslator : DashboardTranslator {
     }
 
     private fun resolveDataSource(metricName: String): String {
+        if (metricName == "events") return "events"
         for ((prefix, source) in metricNamespaceMap) {
             if (metricName.startsWith(prefix)) return source
         }
-        return "events"
+        return "metrics"
     }
 
-    private fun mapMetricField(metricName: String, dataSource: String): String? {
-        return when {
-            metricName.contains("cpu") -> "cpu_percent"
-            metricName.contains("mem") -> "mem_used"
-            metricName.contains("disk") -> "disk_used"
-            metricName.contains("net.recv") || metricName.contains("net_recv") -> "net_recv_bytes"
-            metricName.contains("net.sent") || metricName.contains("net_sent") -> "net_sent_bytes"
-            metricName.contains("duration") || metricName.contains("latency") -> "duration_ms"
-            metricName.contains("load") -> "load_1"
-            dataSource == "events" -> null
-            else -> null
+    private fun mapMetricField(dataSource: String): String? {
+        return when (dataSource) {
+            "metrics" -> "value"
+            "spans" -> "duration_ms"
+            "logs" -> null
+            "containers" -> "cpu_percent"
+            else -> "value"
         }
     }
 
@@ -307,6 +520,7 @@ class DataDogTranslator : DashboardTranslator {
                     buildJsonObject {
                         put("type", reverseWidgetTypeMap[widget.widgetType] ?: "timeseries")
                         widget.title?.let { put("title", it) }
+                        widget.displayConfig["content"]?.let { put("content", it) }
                         put(
                             "requests",
                             buildJsonArray {
@@ -373,12 +587,17 @@ class DataDogTranslator : DashboardTranslator {
     }
 
     internal fun buildDdQueryString(dsl: QueryDsl): String {
+        dsl.rawQuery?.let { return it }
         val metric = dsl.metrics.firstOrNull() ?: return "count:events{*}"
         val fn = metric.function.value
-        val field = metric.field ?: dsl.dataSource
-        val filterStr = dsl.filters.joinToString(",") { f ->
-            "${f.field}:${f.value ?: f.values?.firstOrNull() ?: "*"}"
-        }.ifEmpty { "*" }
-        return "$fn:$field{$filterStr}"
+        val metricName = dsl.filters.firstOrNull { it.field == "metric_name" }?.value
+            ?: metric.field
+            ?: dsl.dataSource
+        val filterStr = dsl.filters
+            .filter { it.field != "metric_name" }
+            .joinToString(",") { f ->
+                "${f.field}:${f.value ?: f.values?.firstOrNull() ?: "*"}"
+            }.ifEmpty { "*" }
+        return "$fn:$metricName{$filterStr}"
     }
 }

--- a/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
@@ -49,6 +49,46 @@ class DataDogTranslatorTest {
             }.readText()
         ).jsonObject
 
+    private fun datadogLayout(x: Int, y: Int, width: Int, height: Int) = buildJsonObject {
+        put("x", x)
+        put("y", y)
+        put("width", width)
+        put("height", height)
+    }
+
+    private fun nestedGroupWidget() = buildJsonObject {
+        put(
+            "definition",
+            buildJsonObject {
+                put("type", "group")
+                put("title", "Inner")
+                put(
+                    "widgets",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put(
+                                    "definition",
+                                    buildJsonObject {
+                                        put("type", "timeseries")
+                                        put(
+                                            "requests",
+                                            buildJsonArray {
+                                                add(buildJsonObject { put("q", "count:events{*}") })
+                                            }
+                                        )
+                                    }
+                                )
+                                put("layout", datadogLayout(1, 1, 3, 2))
+                            }
+                        )
+                    }
+                )
+            }
+        )
+        put("layout", datadogLayout(1, 2, 4, 3))
+    }
+
     // ──── Import ────
 
     @Test
@@ -388,6 +428,49 @@ class DataDogTranslatorTest {
     }
 
     @Test
+    fun `import applies parent offsets to nested Datadog group layouts`() {
+        val json = buildJsonObject {
+            put("title", "Nested Groups")
+            put(
+                "widgets",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put(
+                                "definition",
+                                buildJsonObject {
+                                    put("type", "group")
+                                    put("title", "Outer")
+                                    put(
+                                        "widgets",
+                                        buildJsonArray {
+                                            add(nestedGroupWidget())
+                                        }
+                                    )
+                                }
+                            )
+                            put("layout", datadogLayout(2, 3, 8, 6))
+                        }
+                    )
+                }
+            )
+        }
+
+        val widgets = translator.import(json).dashboard.widgets
+
+        assertEquals(3, widgets.size)
+        assertEquals("Outer", widgets[0].title)
+        assertEquals(2, widgets[0].gridX)
+        assertEquals(3, widgets[0].gridY)
+        assertEquals(8, widgets[0].gridW)
+        assertEquals("Inner", widgets[1].title)
+        assertEquals(3, widgets[1].gridX)
+        assertEquals(6, widgets[1].gridY)
+        assertEquals(4, widgets[2].gridX)
+        assertEquals(8, widgets[2].gridY)
+    }
+
+    @Test
     fun `import parses all Datadog request queries from integration fixture`() {
         val fixture = loadFixture("dashboards/datadog/postgres-integration-overview.json")
         val result = translator.import(fixture)
@@ -549,15 +632,16 @@ class DataDogTranslatorTest {
     @Test
     fun `parseDataDogQueryString preserves unparseable queries as raw queries`() {
         val warnings = mutableListOf<String>()
+        val rawQuery = "avg:system.cpu.user{host:web01} / max:system.cpu.user{host:web01} * 100"
 
-        val dsl = translator.parseDataDogQueryString("query1 / query2", warnings, 7, "ratio", "query3")
+        val dsl = translator.parseDataDogQueryString(rawQuery, warnings, 7, "ratio", "query3")
 
         assertEquals("metrics", dsl.dataSource)
         assertEquals(AggFunction.AVG, dsl.metrics.single().function)
         assertEquals("value", dsl.metrics.single().field)
         assertEquals("ratio", dsl.metrics.single().alias)
         assertEquals(GroupByType.TIME, dsl.groupBy.single().type)
-        assertEquals("query1 / query2", dsl.rawQuery)
+        assertEquals(rawQuery, dsl.rawQuery)
         assertEquals("query3", dsl.refId)
         assertTrue(warnings.any { it.contains("unable to parse Datadog query") })
     }

--- a/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
@@ -20,10 +20,12 @@ import com.moneat.dashboards.models.AggFunction
 import com.moneat.dashboards.models.DashboardResponse
 import com.moneat.dashboards.models.FilterDef
 import com.moneat.dashboards.models.FilterOp
+import com.moneat.dashboards.models.GroupByType
 import com.moneat.dashboards.models.MetricDef
 import com.moneat.dashboards.models.QueryDsl
 import com.moneat.dashboards.models.WidgetResponse
 import com.moneat.dashboards.translation.DataDogTranslator
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -38,6 +40,14 @@ import kotlin.test.assertTrue
 class DataDogTranslatorTest {
 
     private val translator = DataDogTranslator()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun loadFixture(path: String) =
+        json.parseToJsonElement(
+            requireNotNull(javaClass.classLoader.getResource(path)) {
+                "Missing test fixture: $path"
+            }.readText()
+        ).jsonObject
 
     // ──── Import ────
 
@@ -264,6 +274,153 @@ class DataDogTranslatorTest {
         assertEquals(0, result.dashboard.widgets[0].gridX)
     }
 
+    @Test
+    fun `import flattens Datadog integration groups into sections and child widgets`() {
+        val fixture = loadFixture("dashboards/datadog/postgres-integration-overview.json")
+        val result = translator.import(fixture)
+
+        assertEquals("Postgres - Overview", result.dashboard.title)
+        assertEquals(6, result.dashboard.widgets.size)
+        assertEquals("section", result.dashboard.widgets[0].widgetType)
+        assertEquals("Resource Utilization", result.dashboard.widgets[0].title)
+        assertEquals("text", result.dashboard.widgets[1].widgetType)
+        assertEquals("stat", result.dashboard.widgets[2].widgetType)
+        assertEquals("timeseries", result.dashboard.widgets[3].widgetType)
+        assertEquals("table", result.dashboard.widgets[4].widgetType)
+        assertEquals("timeseries", result.dashboard.widgets[5].widgetType)
+    }
+
+    @Test
+    fun `import offsets child widget layout below Datadog group section`() {
+        val fixture = loadFixture("dashboards/datadog/postgres-integration-overview.json")
+        val result = translator.import(fixture)
+        val note = result.dashboard.widgets[1]
+        val table = result.dashboard.widgets[4]
+        val standalone = result.dashboard.widgets[5]
+
+        assertEquals(1, note.gridY)
+        assertEquals(6, table.gridW)
+        assertEquals(3, table.gridY)
+        assertTrue(standalone.gridY >= 6)
+    }
+
+    @Test
+    fun `import auto-places Datadog group children after explicit child layouts`() {
+        val json = buildJsonObject {
+            put("title", "Grouped")
+            put(
+                "widgets",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put(
+                                "definition",
+                                buildJsonObject {
+                                    put("type", "group")
+                                    put("title", "Group")
+                                    put(
+                                        "widgets",
+                                        buildJsonArray {
+                                            add(
+                                                buildJsonObject {
+                                                    put(
+                                                        "definition",
+                                                        buildJsonObject {
+                                                            put("type", "timeseries")
+                                                            put(
+                                                                "requests",
+                                                                buildJsonArray {
+                                                                    add(buildJsonObject { put("q", "count:events{*}") })
+                                                                }
+                                                            )
+                                                        }
+                                                    )
+                                                    put(
+                                                        "layout",
+                                                        buildJsonObject {
+                                                            put("x", 0)
+                                                            put("y", 2)
+                                                            put("width", 6)
+                                                            put("height", 3)
+                                                        }
+                                                    )
+                                                }
+                                            )
+                                            add(
+                                                buildJsonObject {
+                                                    put(
+                                                        "definition",
+                                                        buildJsonObject {
+                                                            put("type", "query_value")
+                                                            put(
+                                                                "requests",
+                                                                buildJsonArray {
+                                                                    add(buildJsonObject { put("q", "count:events{*}") })
+                                                                }
+                                                            )
+                                                        }
+                                                    )
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            )
+                            put(
+                                "layout",
+                                buildJsonObject {
+                                    put("x", 0)
+                                    put("y", 0)
+                                    put("width", 12)
+                                    put("height", 6)
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+
+        val widgets = translator.import(json).dashboard.widgets
+
+        assertEquals(3, widgets[1].gridY)
+        assertTrue(widgets[2].gridY >= 6)
+    }
+
+    @Test
+    fun `import parses all Datadog request queries from integration fixture`() {
+        val fixture = loadFixture("dashboards/datadog/postgres-integration-overview.json")
+        val result = translator.import(fixture)
+        val timeseries = result.dashboard.widgets.first { it.title == "Rows fetched / returned" }
+        val table = result.dashboard.widgets.first { it.title == "Locks by host" }
+
+        assertEquals(2, timeseries.queryConfigs.size)
+        assertEquals("rows fetched", timeseries.queryConfigs[0].metrics[0].alias)
+        assertEquals("rows returned", timeseries.queryConfigs[1].metrics[0].alias)
+        assertEquals(2, table.queryConfigs.size)
+        assertTrue(
+            table.queryConfigs.all { query ->
+                query.filters.any { it.field == "metric_name" && it.value?.startsWith("postgresql.") == true }
+            }
+        )
+    }
+
+    @Test
+    fun `import supports Datadog effective dashboard fixture shapes`() {
+        val fixture = loadFixture("dashboards/datadog/kubernetes-capacity-planning.json")
+        val result = translator.import(fixture)
+
+        assertEquals("Kubernetes Capacity Planning", result.dashboard.title)
+        assertEquals(6, result.dashboard.widgets.size)
+        assertEquals("text", result.dashboard.widgets[0].widgetType)
+        assertEquals("text", result.dashboard.widgets[1].widgetType)
+        assertEquals("section", result.dashboard.widgets[2].widgetType)
+        assertEquals("table", result.dashboard.widgets[3].widgetType)
+        assertEquals("heatmap", result.dashboard.widgets[4].widgetType)
+        assertEquals("text", result.dashboard.widgets[5].widgetType)
+        assertTrue(result.warnings.any { it.contains("unsupported type 'scatterplot'") })
+    }
+
     // ──── parseDataDogQueryString ────
 
     @Test
@@ -272,7 +429,8 @@ class DataDogTranslatorTest {
         val dsl = translator.parseDataDogQueryString("avg:system.cpu.user{host:web01}", warnings, 0)
         assertEquals("metrics", dsl.dataSource)
         assertEquals(AggFunction.AVG, dsl.metrics[0].function)
-        assertEquals("cpu_percent", dsl.metrics[0].field)
+        assertEquals("value", dsl.metrics[0].field)
+        assertTrue(dsl.filters.any { it.field == "metric_name" && it.value == "system.cpu.user" })
         assertTrue(dsl.filters.any { it.field == "host" && it.value == "web01" })
     }
 
@@ -298,6 +456,73 @@ class DataDogTranslatorTest {
         val warnings = mutableListOf<String>()
         val dsl = translator.parseDataDogQueryString("sum:system.disk.used{host:web01,env:prod}", warnings, 0)
         assertEquals(2, dsl.filters.size)
+        assertTrue(dsl.filters.any { it.field == "metric_name" && it.value == "system.disk.used" })
+        assertTrue(dsl.filters.any { it.field == "host" && it.value == "web01" })
+    }
+
+    @Test
+    fun `parseDataDogQueryString extracts supported group by fields`() {
+        val warnings = mutableListOf<String>()
+        val dsl = translator.parseDataDogQueryString("sum:postgresql.locks{host:web01} by {host,env}", warnings, 0)
+        assertTrue(dsl.groupBy.any { it.field == "timestamp" && it.type == GroupByType.TIME })
+        assertTrue(dsl.groupBy.any { it.field == "host" && it.type == GroupByType.FIELD })
+        assertTrue(dsl.groupBy.none { it.field == "env" })
+    }
+
+    @Test
+    fun `parseDataDogQuery handles Datadog queries array and formula aliases`() {
+        val warnings = mutableListOf<String>()
+        val definition = buildJsonObject {
+            put("type", "query_table")
+            put(
+                "requests",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put(
+                                "queries",
+                                buildJsonArray {
+                                    add(
+                                        buildJsonObject {
+                                            put("name", "query1")
+                                            put("query", "sum:mysql.net.connections{host:db01}")
+                                        }
+                                    )
+                                    add(
+                                        buildJsonObject {
+                                            put("name", "query2")
+                                            put("query", "max:mysql.net.max_connections{host:db01}")
+                                        }
+                                    )
+                                }
+                            )
+                            put(
+                                "formulas",
+                                buildJsonArray {
+                                    add(
+                                        buildJsonObject {
+                                            put("formula", "query1")
+                                            put("alias", "connections")
+                                        }
+                                    )
+                                    add(
+                                        buildJsonObject {
+                                            put("formula", "query2")
+                                            put("alias", "max connections")
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+
+        val queries = translator.parseDataDogQueries(definition, warnings, 0)
+        assertEquals(2, queries.size)
+        assertEquals("connections", queries[0].metrics[0].alias)
+        assertEquals("max connections", queries[1].metrics[0].alias)
     }
 
     // ──── Export ────

--- a/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
@@ -525,6 +525,74 @@ class DataDogTranslatorTest {
         assertEquals("max connections", queries[1].metrics[0].alias)
     }
 
+    @Test
+    fun `parseDataDogQueries uses default query when requests have no query string`() {
+        val warnings = mutableListOf<String>()
+        val definition = buildJsonObject {
+            put("type", "timeseries")
+            put(
+                "requests",
+                buildJsonArray {
+                    add(buildJsonObject { put("display_type", "line") })
+                }
+            )
+        }
+
+        val queries = translator.parseDataDogQueries(definition, warnings, 12)
+
+        assertEquals(1, queries.size)
+        assertEquals("events", queries.single().dataSource)
+        assertEquals(AggFunction.COUNT, queries.single().metrics.single().function)
+        assertTrue(warnings.any { it.contains("no query string found") })
+    }
+
+    @Test
+    fun `parseDataDogQueryString preserves unparseable queries as raw queries`() {
+        val warnings = mutableListOf<String>()
+
+        val dsl = translator.parseDataDogQueryString("query1 / query2", warnings, 7, "ratio", "query3")
+
+        assertEquals("metrics", dsl.dataSource)
+        assertEquals(AggFunction.AVG, dsl.metrics.single().function)
+        assertEquals("value", dsl.metrics.single().field)
+        assertEquals("ratio", dsl.metrics.single().alias)
+        assertEquals(GroupByType.TIME, dsl.groupBy.single().type)
+        assertEquals("query1 / query2", dsl.rawQuery)
+        assertEquals("query3", dsl.refId)
+        assertTrue(warnings.any { it.contains("unable to parse Datadog query") })
+    }
+
+    @Test
+    fun `parseDataDogQueryString maps Datadog aggregation functions`() {
+        val cases = listOf(
+            "min:system.cpu.user{*}" to AggFunction.MIN,
+            "p50:system.cpu.user{*}" to AggFunction.P50,
+            "p75:system.cpu.user{*}" to AggFunction.P75,
+            "p90:system.cpu.user{*}" to AggFunction.P90,
+            "p99:system.cpu.user{*}" to AggFunction.P99,
+            "median:system.cpu.user{*}" to AggFunction.AVG
+        )
+
+        cases.forEach { (query, expectedFunction) ->
+            val dsl = translator.parseDataDogQueryString(query, mutableListOf(), 0)
+            assertEquals(expectedFunction, dsl.metrics.single().function)
+        }
+    }
+
+    @Test
+    fun `parseDataDogQueryString resolves logs and container metric fields`() {
+        val logs = translator.parseDataDogQueryString("count:logs.error{service:api}", mutableListOf(), 0)
+        val container = translator.parseDataDogQueryString("avg:container.cpu.usage{host:web01}", mutableListOf(), 0)
+
+        assertEquals("logs", logs.dataSource)
+        assertEquals(null, logs.metrics.single().field)
+        assertTrue(logs.filters.any { it.field == "service" && it.value == "api" })
+
+        assertEquals("containers", container.dataSource)
+        assertEquals("cpu_percent", container.metrics.single().field)
+        assertTrue(container.filters.any { it.field == "host" && it.value == "web01" })
+    }
+
     // ──── Export ────
 
     @Test
@@ -610,6 +678,23 @@ class DataDogTranslatorTest {
         )
         val query = translator.buildDdQueryString(dsl)
         assertEquals("count:events{*}", query)
+    }
+
+    @Test
+    fun `buildDdQueryString uses list filter values and wildcard fallbacks`() {
+        val dsl = QueryDsl(
+            dataSource = "metrics",
+            metrics = listOf(MetricDef(AggFunction.SUM, "value", "cpu")),
+            filters = listOf(
+                FilterDef("metric_name", FilterOp.EQ, "system.cpu.user"),
+                FilterDef("host", FilterOp.IN, values = listOf("web01")),
+                FilterDef("env", FilterOp.EQ)
+            )
+        )
+
+        val query = translator.buildDdQueryString(dsl)
+
+        assertEquals("sum:system.cpu.user{host:web01,env:*}", query)
     }
 
     @Test

--- a/backend/src/test/resources/dashboards/datadog/kubernetes-capacity-planning.json
+++ b/backend/src/test/resources/dashboards/datadog/kubernetes-capacity-planning.json
@@ -1,0 +1,159 @@
+{
+  "title": "Kubernetes Capacity Planning",
+  "description": "Synthetic fixture modeled after Datadog effective dashboard layouts.",
+  "layout_type": "ordered",
+  "reflow_type": "fixed",
+  "template_variables": [
+    {
+      "name": "env",
+      "prefix": "env",
+      "default": "*",
+      "available_values": ["production", "staging"]
+    },
+    {
+      "name": "kube_cluster_name",
+      "prefix": "kube_cluster_name",
+      "default": "*",
+      "available_values": []
+    },
+    {
+      "name": "kube_namespace",
+      "prefix": "kube_namespace",
+      "default": "*",
+      "available_values": []
+    }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "note",
+        "content": "# Kubernetes Capacity Planning\n\nReview requests, limits, and actual use by cluster."
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 5,
+        "height": 3
+      }
+    },
+    {
+      "definition": {
+        "type": "image",
+        "url": "/static/images/integration_dashboard/kubernetes_hero_2.jpeg",
+        "sizing": "cover",
+        "has_background": true,
+        "has_border": true
+      },
+      "layout": {
+        "x": 5,
+        "y": 0,
+        "width": 7,
+        "height": 3
+      }
+    },
+    {
+      "definition": {
+        "type": "group",
+        "title": "CPU Utilization",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "CPU by host",
+              "type": "query_table",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "sum:kubernetes.cpu.requests{$env,$kube_namespace,$kube_cluster_name} by {host}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "query": "sum:kubernetes.cpu.usage.total{$env,$kube_namespace,$kube_cluster_name} by {host}",
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "requests"
+                    },
+                    {
+                      "formula": "query2",
+                      "alias": "usage"
+                    }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 3
+            }
+          },
+          {
+            "definition": {
+              "title": "Overprovisioned deployments",
+              "type": "heatmap",
+              "requests": [
+                {
+                  "q": "sum:kubernetes.cpu.usage.total{kube_deployment:*,$env,$kube_namespace,$kube_cluster_name} by {host} / (sum:kubernetes.cpu.requests{kube_deployment:*,$env,$kube_namespace,$kube_cluster_name} by {host} * 1000000000) * 100",
+                  "style": {
+                    "palette": "dog_classic"
+                  }
+                }
+              ],
+              "yaxis": {
+                "min": "0",
+                "max": "200"
+              }
+            },
+            "layout": {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 4
+            }
+          },
+          {
+            "definition": {
+              "title": "CPU request scatter",
+              "type": "scatterplot",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "query": "avg:kubernetes.cpu.requests{$env,$kube_namespace,$kube_cluster_name} by {host}",
+                      "data_source": "metrics",
+                      "name": "query1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 4
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 3,
+        "width": 12,
+        "height": 8
+      }
+    }
+  ]
+}

--- a/backend/src/test/resources/dashboards/datadog/postgres-integration-overview.json
+++ b/backend/src/test/resources/dashboards/datadog/postgres-integration-overview.json
@@ -1,0 +1,180 @@
+{
+  "title": "Postgres - Overview",
+  "description": "Synthetic fixture modeled after Datadog integration dashboards.",
+  "layout_type": "ordered",
+  "template_variables": [
+    {
+      "name": "scope",
+      "prefix": "scope",
+      "default": "*",
+      "available_values": []
+    },
+    {
+      "name": "host",
+      "prefix": "host",
+      "default": "*",
+      "available_values": []
+    }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "group",
+        "title": "Resource Utilization",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "type": "note",
+              "content": "## About Postgres\n\nKey database health signals for a Postgres integration."
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 2
+            }
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Connections",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "sum:postgresql.connections{$scope,host:$host}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "connections"
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": {
+              "x": 4,
+              "y": 0,
+              "width": 4,
+              "height": 2
+            }
+          },
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "Rows fetched / returned",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:postgresql.rows_fetched{$scope,host:$host}",
+                      "semantic_mode": "combined"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "rows fetched"
+                    }
+                  ]
+                },
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:postgresql.rows_returned{$scope,host:$host}",
+                      "semantic_mode": "combined"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "rows returned"
+                    }
+                  ]
+                }
+              ]
+            },
+            "layout": {
+              "x": 0,
+              "y": 2,
+              "width": 6,
+              "height": 3
+            }
+          },
+          {
+            "definition": {
+              "type": "query_table",
+              "title": "Locks by host",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "sum:postgresql.locks{$scope,host:$host} by {host}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "sum:postgresql.deadlocks{$scope,host:$host} by {host}"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "locks"
+                    },
+                    {
+                      "formula": "query2",
+                      "alias": "deadlocks"
+                    }
+                  ]
+                }
+              ],
+              "has_search_bar": "auto"
+            },
+            "layout": {
+              "x": 6,
+              "y": 2,
+              "width": 6,
+              "height": 3
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 12,
+        "height": 6
+      }
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "Standalone CPU",
+        "requests": [
+          {
+            "q": "avg:system.cpu.user{host:web01}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dashboard/src/components/dashboards/ImportExportModal.tsx
+++ b/dashboard/src/components/dashboards/ImportExportModal.tsx
@@ -24,6 +24,28 @@ import {CopyBlock} from '@/components/ui/copy-block'
 import {AlertTriangle, Check, Download, Upload} from 'lucide-react'
 import {DataSourceMapperModal} from './DataSourceMapperModal'
 
+type DashboardImportFormat = 'grafana' | 'datadog'
+
+const IMPORT_FORMAT_DETAILS: Record<DashboardImportFormat, {
+  title: string
+  description: string
+  uploadLabel: string
+  placeholder: string
+}> = {
+  grafana: {
+    title: 'Grafana Dashboard Import',
+    description: 'Upload or paste your Grafana JSON export',
+    uploadLabel: 'Upload Grafana JSON File',
+    placeholder: '{"title": "My Dashboard", "widgets": [...]}',
+  },
+  datadog: {
+    title: 'Datadog Dashboard Import',
+    description: 'Upload or paste your Datadog dashboard JSON export',
+    uploadLabel: 'Upload Datadog JSON File',
+    placeholder: '{"title": "My Dashboard", "layout_type": "ordered", "widgets": [...]}',
+  },
+}
+
 interface ImportExportModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -36,7 +58,7 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
   const navigate = useNavigate()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [jsonInput, setJsonInput] = useState('')
-  const format = 'grafana' // Only support Grafana for now
+  const [format, setFormat] = useState<DashboardImportFormat>('grafana')
   const [warnings, setWarnings] = useState<string[]>([])
   const [importSuccess, setImportSuccess] = useState(false)
   const [importedDashboardId, setImportedDashboardId] = useState<number | null>(null)
@@ -45,6 +67,7 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
   const [unmappedDataSources, setUnmappedDataSources] = useState<string[]>([])
   const [pendingImport, setPendingImport] = useState<{format: string; json: string} | null>(null)
   const [autoMappings, setAutoMappings] = useState<Record<string, string>>({})
+  const formatDetails = IMPORT_FORMAT_DETAILS[format]
   
   // Fetch custom data sources for mapping
   const {data: customDataSourcesData} = useQuery({
@@ -360,7 +383,7 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
           </h2>
           <p className="text-xs text-muted-foreground mt-0.5">
             {mode === 'import'
-              ? 'Import a dashboard from Grafana JSON format'
+              ? `Import a dashboard from ${format === 'datadog' ? 'Datadog' : 'Grafana'} JSON format`
               : 'Export this dashboard in various formats'}
           </p>
         </div>
@@ -369,7 +392,24 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
         <div className="flex-1 overflow-auto px-5 py-4 space-y-4">
           {mode === 'import' ? (
             <>
-              {/* Grafana logo/info */}
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  variant={format === 'grafana' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setFormat('grafana')}
+                >
+                  Grafana
+                </Button>
+                <Button
+                  variant={format === 'datadog' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setFormat('datadog')}
+                >
+                  Datadog
+                </Button>
+              </div>
+
+              {/* Format logo/info */}
               <div className="flex items-center gap-3 p-3 rounded-lg border bg-muted/30">
                 <svg className="h-8 w-8" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M57.9 13.4c-.7-2.2-1.8-4.3-3.3-6.1-.8-.9-1.6-1.7-2.6-2.4-1.3-1-2.7-1.8-4.2-2.4-2.2-.9-4.5-1.4-6.9-1.4-2 0-4 .3-5.9.9-1.6.5-3.2 1.2-4.6 2.1-1.1.7-2.1 1.5-3 2.4-1.3 1.3-2.4 2.7-3.3 4.3-1 1.7-1.7 3.6-2.1 5.5-.3 1.3-.4 2.7-.3 4 .1 1.6.4 3.1.9 4.6.6 1.7 1.4 3.3 2.5 4.7.9 1.2 2 2.3 3.2 3.2 1.5 1.2 3.2 2.1 5 2.7 2.1.7 4.3 1 6.5.9 2-.1 3.9-.5 5.7-1.2 1.5-.6 2.9-1.4 4.2-2.4 1-.8 1.9-1.7 2.7-2.7 1.2-1.5 2.1-3.2 2.8-4.9.7-1.9 1.1-3.9 1.1-5.9 0-2-.3-4-.9-5.9z" fill="#F05A28"/>
@@ -377,8 +417,8 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
                   <circle cx="41.2" cy="22" r="3" fill="#FFF"/>
                 </svg>
                 <div className="flex-1">
-                  <div className="text-sm font-medium">Grafana Dashboard Import</div>
-                  <div className="text-xs text-muted-foreground">Upload or paste your Grafana JSON export</div>
+                  <div className="text-sm font-medium">{formatDetails.title}</div>
+                  <div className="text-xs text-muted-foreground">{formatDetails.description}</div>
                 </div>
               </div>
 
@@ -397,7 +437,7 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
                   onClick={() => fileInputRef.current?.click()}
                   className="w-full"
                 >
-                  <Upload className="h-4 w-4 mr-2" /> Upload Grafana JSON File
+                  <Upload className="h-4 w-4 mr-2" /> {formatDetails.uploadLabel}
                 </Button>
               </div>
 
@@ -411,7 +451,7 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
                   rows={10}
                   value={jsonInput}
                   onChange={setJsonInput}
-                  placeholder='{"title": "My Dashboard", "widgets": [...]}'
+                  placeholder={formatDetails.placeholder}
                 />
               </div>
 
@@ -470,6 +510,9 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
                   <Download className="h-4 w-4 mr-2" /> Export as Grafana JSON
                 </Button>
               </div>
+              <Button variant="outline" className="w-full justify-start" onClick={() => handleExport('datadog')}>
+                <Download className="h-4 w-4 mr-2" /> Export as Datadog JSON
+              </Button>
 
               {exportData && (
                 <div>

--- a/dashboard/src/components/dashboards/ImportExportModal.tsx
+++ b/dashboard/src/components/dashboards/ImportExportModal.tsx
@@ -392,10 +392,11 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
         <div className="flex-1 overflow-auto px-5 py-4 space-y-4">
           {mode === 'import' ? (
             <>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-2 gap-2" role="group" aria-label="Import format">
                 <Button
                   variant={format === 'grafana' ? 'default' : 'outline'}
                   size="sm"
+                  aria-pressed={format === 'grafana'}
                   onClick={() => setFormat('grafana')}
                 >
                   Grafana
@@ -403,6 +404,7 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
                 <Button
                   variant={format === 'datadog' ? 'default' : 'outline'}
                   size="sm"
+                  aria-pressed={format === 'datadog'}
                   onClick={() => setFormat('datadog')}
                 >
                   Datadog

--- a/dashboard/src/components/dashboards/__tests__/ImportExportModal-extended.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/ImportExportModal-extended.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@/lib/api', () => ({
 const mockedApi = vi.mocked(api)
 
 const IMPORT_PLACEHOLDER = '{"title": "My Dashboard", "widgets": [...]}'
+const DATADOG_IMPORT_PLACEHOLDER = '{"title": "My Dashboard", "layout_type": "ordered", "widgets": [...]}'
 
 const makeDashboard = (id: number): CustomDashboard => ({
   id,
@@ -291,6 +292,37 @@ describe('ImportExportModal – extended branch coverage', () => {
     })
   })
 
+  // ──── Import: Datadog format skips Grafana datasource mapper ────
+  describe('import – Datadog format', () => {
+    it('imports Datadog JSON directly with datadog format', async () => {
+      const user = userEvent.setup()
+      const json = JSON.stringify({
+        title: 'Datadog dashboard',
+        layout_type: 'ordered',
+        widgets: [
+          {
+            definition: {
+              type: 'timeseries',
+              requests: [{q: 'avg:system.cpu.user{host:web01}'}],
+            },
+          },
+        ],
+      })
+      renderImportModal()
+
+      await user.click(screen.getByText('Datadog'))
+      fireEvent.change(screen.getByPlaceholderText(DATADOG_IMPORT_PLACEHOLDER), {
+        target: {value: json},
+      })
+      await user.click(screen.getByText('Import'))
+
+      await waitFor(() => {
+        expect(mockedApi.importDashboard).toHaveBeenCalledWith('datadog', json)
+      })
+      expect(screen.queryByText('Map Data Sources')).not.toBeInTheDocument()
+    })
+  })
+
   // ──── Import: auto-mapping with single matching custom datasource ────
   describe('import – auto-mapping', () => {
     it('auto-maps when exactly one custom datasource matches the expected type', async () => {
@@ -381,6 +413,21 @@ describe('ImportExportModal – extended branch coverage', () => {
 
       await waitFor(() => {
         expect(mockedApi.exportDashboard).toHaveBeenCalledWith(3, 'grafana')
+      })
+    })
+
+    it('calls exportDashboard with datadog format', async () => {
+      mockedApi.exportDashboard.mockResolvedValue({title: 'Datadog Export'})
+
+      globalThis.URL.createObjectURL = vi.fn().mockReturnValue('blob:mock')
+      globalThis.URL.revokeObjectURL = vi.fn()
+
+      renderExportModal({dashboardId: 4})
+
+      await userEvent.setup().click(screen.getByText('Export as Datadog JSON'))
+
+      await waitFor(() => {
+        expect(mockedApi.exportDashboard).toHaveBeenCalledWith(4, 'datadog')
       })
     })
   })

--- a/dashboard/src/components/dashboards/__tests__/ImportExportModal.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/ImportExportModal.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('@/lib/api', () => ({
   api: {
-    importDashboard: vi.fn().mockResolvedValue({warnings: []}),
+    importDashboard: vi.fn().mockResolvedValue({dashboard: {id: 42, widgets: []}, warnings: []}),
     exportDashboard: vi.fn().mockResolvedValue({title: 'Test', widgets: []}),
     listCustomDataSources: vi.fn().mockResolvedValue([]),
   },
@@ -110,6 +110,34 @@ describe('ImportExportModal', () => {
       expect(screen.getByText('Grafana Dashboard Import')).toBeInTheDocument()
     })
 
+    it('switches format when clicking Datadog import', async () => {
+      const user = userEvent.setup()
+      renderWithQuery(
+        <ImportExportModal open={true} onOpenChange={vi.fn()} mode="import" />
+      )
+      await user.click(screen.getByText('Datadog'))
+      expect(screen.getByText('Datadog Dashboard Import')).toBeInTheDocument()
+      expect(screen.getByText('Upload Datadog JSON File')).toBeInTheDocument()
+    })
+
+    it('imports Datadog JSON using datadog format', async () => {
+      const {api} = await import('@/lib/api')
+      const user = userEvent.setup()
+      renderWithQuery(
+        <ImportExportModal open={true} onOpenChange={vi.fn()} mode="import" />
+      )
+      await user.click(screen.getByText('Datadog'))
+      const textarea = screen.getByPlaceholderText(
+        '{"title": "My Dashboard", "layout_type": "ordered", "widgets": [...]}'
+      )
+      const {fireEvent, waitFor} = await import('@testing-library/react')
+      fireEvent.change(textarea, {target: {value: '{"title": "Datadog", "widgets": []}'}})
+      await user.click(screen.getByText('Import'))
+      await waitFor(() => {
+        expect(api.importDashboard).toHaveBeenCalledWith('datadog', '{"title": "Datadog", "widgets": []}')
+      })
+    })
+
     it('shows datasource mapper when Grafana JSON has __inputs with datasources', async () => {
       renderWithQuery(
         <ImportExportModal open={true} onOpenChange={vi.fn()} mode="import" />
@@ -142,12 +170,13 @@ describe('ImportExportModal', () => {
       expect(screen.getByText('Export Dashboard')).toBeInTheDocument()
     })
 
-    it('renders two export format buttons', () => {
+    it('renders export format buttons', () => {
       renderWithQuery(
         <ImportExportModal open={true} onOpenChange={vi.fn()} mode="export" dashboardId={1} />
       )
       expect(screen.getByText('Export as Moneat JSON')).toBeInTheDocument()
       expect(screen.getByText('Export as Grafana JSON')).toBeInTheDocument()
+      expect(screen.getByText('Export as Datadog JSON')).toBeInTheDocument()
     })
 
     it('does not show Import button in export mode', () => {

--- a/dashboard/src/components/dashboards/__tests__/ImportExportModal.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/ImportExportModal.test.tsx
@@ -115,7 +115,16 @@ describe('ImportExportModal', () => {
       renderWithQuery(
         <ImportExportModal open={true} onOpenChange={vi.fn()} mode="import" />
       )
-      await user.click(screen.getByText('Datadog'))
+      const grafanaButton = screen.getByRole('button', {name: 'Grafana'})
+      const datadogButton = screen.getByRole('button', {name: 'Datadog'})
+      expect(screen.getByRole('group', {name: 'Import format'})).toBeInTheDocument()
+      expect(grafanaButton).toHaveAttribute('aria-pressed', 'true')
+      expect(datadogButton).toHaveAttribute('aria-pressed', 'false')
+
+      await user.click(datadogButton)
+
+      expect(grafanaButton).toHaveAttribute('aria-pressed', 'false')
+      expect(datadogButton).toHaveAttribute('aria-pressed', 'true')
       expect(screen.getByText('Datadog Dashboard Import')).toBeInTheDocument()
       expect(screen.getByText('Upload Datadog JSON File')).toBeInTheDocument()
     })


### PR DESCRIPTION
## Summary

- expand the Datadog dashboard translator to handle grouped dashboards, integration-style widget layouts, multi-query requests, formula aliases, template variables, and additional widget mappings
- add synthetic Datadog-style fixtures for integration dashboard shapes and effective-dashboard-style layouts
- expose Datadog as an import/export option in the dashboard import/export modal while keeping Grafana datasource mapping scoped to Grafana imports

## Testing

- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon compileKotlin detekt :test --tests com.moneat.dashboards.DataDogTranslatorTest -Dkotlin.compiler.execution.strategy=in-process`
- `npm test -- --run src/components/dashboards/__tests__/ImportExportModal.test.tsx src/components/dashboards/__tests__/ImportExportModal-extended.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## Follow-up

- #440 tracks the remaining long-tail Datadog widget coverage needed for near-universal customer dashboard imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DataDog dashboard import and export capabilities are now available to users.
  * Users can select DataDog or Grafana format during the dashboard import process.
  * A new "Export as DataDog JSON" export option has been added alongside existing Grafana and Moneat export formats.
  * Dashboard import process now handles DataDog-specific widget configurations and layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->