### PR TITLE
feat: add public helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,49 @@ permissions:
 env:
   JAVA_VERSION: '21'
   NODE_VERSION: '24'
+  HELM_VERSION: '3.15.4'
   REGISTRY: ghcr.io
+  CHART_REPOSITORY_URL: https://charts.moneat.io
 
 jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 0
+
+      - name: Validate target branch
+        env:
+          TARGET_BRANCH: ${{ contains(github.ref_name, '-') && 'develop' || 'main' }}
+        run: |
+          git fetch origin "$TARGET_BRANCH"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/$TARGET_BRANCH"; then
+            echo "::error::Tag ${{ github.ref_name }} does not point to a commit on $TARGET_BRANCH"
+            exit 1
+          fi
+
+          echo "Validated ${{ github.ref_name }} against $TARGET_BRANCH"
+
   test:
+    needs: validate-tag
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - name: Install Helm
+        run: |
+          curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+          tar -xzf helm.tar.gz
+          sudo mv linux-amd64/helm /usr/local/bin/helm
+          helm version
+
+      - name: Validate Helm chart source
+        run: |
+          helm lint --strict charts/moneat
+          helm template moneat charts/moneat --namespace moneat >/tmp/moneat-chart-rendered.yaml
 
       - name: Set up JDK
         uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b
@@ -100,6 +135,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/moneat-backend
           tags: |
+            type=raw,value=${{ github.ref_name }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
@@ -148,6 +184,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/moneat-dashboard
           tags: |
+            type=raw,value=${{ github.ref_name }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
@@ -165,8 +202,116 @@ jobs:
           cache-from: type=gha,scope=dashboard
           cache-to: type=gha,mode=max,scope=dashboard
 
-  release:
+  publish-chart:
     needs: [build-backend, build-dashboard]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        run: |
+          curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz
+          tar -xzf helm.tar.gz
+          sudo mv linux-amd64/helm /usr/local/bin/helm
+          helm version
+
+      - name: Package Helm chart
+        id: chart
+        run: |
+          set -euo pipefail
+
+          chart_version="${GITHUB_REF_NAME#v}"
+          app_version="${GITHUB_REF_NAME}"
+          image_tag="${GITHUB_REF_NAME}"
+
+          chart_dir="$(mktemp -d)"
+          package_dir="$(mktemp -d)"
+          cp -R charts/moneat "${chart_dir}/moneat"
+
+          sed -i "s/^version:.*/version: ${chart_version}/" "${chart_dir}/moneat/Chart.yaml"
+          sed -i "s/^appVersion:.*/appVersion: \"${app_version}\"/" "${chart_dir}/moneat/Chart.yaml"
+          awk -v image_tag="${image_tag}" '
+            $0 == "image:" && !patched {
+              in_image = 1
+              print
+              next
+            }
+            in_image && $1 == "tag:" && !patched {
+              print "  tag: \"" image_tag "\""
+              patched = 1
+              in_image = 0
+              next
+            }
+            { print }
+          ' "${chart_dir}/moneat/values.yaml" > "${chart_dir}/moneat/values.yaml.tmp"
+          mv "${chart_dir}/moneat/values.yaml.tmp" "${chart_dir}/moneat/values.yaml"
+
+          if grep -q 'tag: "latest"' "${chart_dir}/moneat/values.yaml"; then
+            echo "::error::Packaged public chart must not default to image.tag=latest"
+            exit 1
+          fi
+
+          helm lint --strict "${chart_dir}/moneat"
+          helm template moneat "${chart_dir}/moneat" --namespace moneat >/tmp/moneat-chart-rendered.yaml
+          helm package "${chart_dir}/moneat" --destination "${package_dir}"
+
+          package_path="$(find "${package_dir}" -name 'moneat-*.tgz' -print -quit)"
+          if [ -z "${package_path}" ]; then
+            echo "::error::Helm package was not created"
+            exit 1
+          fi
+
+          echo "package_path=${package_path}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Helm chart repository
+        env:
+          PACKAGE_PATH: ${{ steps.chart.outputs.package_path }}
+        run: |
+          set -euo pipefail
+
+          publish_dir="$(mktemp -d)"
+          rm -rf "${publish_dir}"
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git fetch origin gh-pages
+            git worktree add --detach "${publish_dir}" FETCH_HEAD
+          else
+            git worktree add --detach "${publish_dir}"
+            git -C "${publish_dir}" checkout --orphan gh-pages
+            git -C "${publish_dir}" rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          cp "${PACKAGE_PATH}" "${publish_dir}/"
+          if [ -f "${publish_dir}/index.yaml" ]; then
+            helm repo index "${publish_dir}" --url "${CHART_REPOSITORY_URL}" --merge "${publish_dir}/index.yaml"
+          else
+            helm repo index "${publish_dir}" --url "${CHART_REPOSITORY_URL}"
+          fi
+
+          if [ ! -f "${publish_dir}/CNAME" ]; then
+            printf '%s\n' "${CHART_REPOSITORY_URL#https://}" > "${publish_dir}/CNAME"
+          fi
+
+          git -C "${publish_dir}" config user.name "github-actions[bot]"
+          git -C "${publish_dir}" config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C "${publish_dir}" add .
+
+          if git -C "${publish_dir}" diff --cached --quiet; then
+            echo "No Helm chart repository changes to publish"
+            exit 0
+          fi
+
+          git -C "${publish_dir}" commit -m "publish moneat chart ${GITHUB_REF_NAME}"
+          git -C "${publish_dir}" push origin HEAD:gh-pages
+
+  release:
+    needs: [build-backend, build-dashboard, publish-chart]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -223,15 +368,3 @@ jobs:
           generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Validate target branch
-        env:
-          TARGET_BRANCH: ${{ contains(github.ref_name, '-') && 'develop' || 'main' }}
-        run: |
-          git fetch origin "$TARGET_BRANCH"
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/$TARGET_BRANCH"; then
-            echo "::error::Tag ${{ github.ref_name }} does not point to a commit on $TARGET_BRANCH"
-            exit 1
-          fi
-
-          echo "Validated ${{ github.ref_name }} against $TARGET_BRANCH"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@
 
 ## Self-Hosting
 
+Moneat supports two self-hosting paths:
+
+- **Docker Compose** - quickest path for a single server.
+- **Helm** - Kubernetes install with optional in-cluster Postgres, ClickHouse, and Redis, or external services.
+
+### Docker Compose
+
 The interactive installer handles version selection, secrets, port allocation, and Docker setup. No need to clone the repo.
 
 **curl:**
@@ -57,6 +64,23 @@ docker compose up -d
 ```
 
 </details>
+
+### Kubernetes / Helm
+
+The public Helm chart is available at `https://charts.moneat.io`:
+
+```bash
+helm repo add moneat https://charts.moneat.io
+helm repo update
+
+helm upgrade --install moneat moneat/moneat \
+  --namespace moneat \
+  --create-namespace \
+  --set app.frontendUrl=https://moneat.example.com \
+  --set app.backendUrl=https://api.moneat.example.com
+```
+
+For production, create a Kubernetes Secret or ExternalSecret and set `secrets.existingSecret`. The chart can run a single-node persistent ClickHouse StatefulSet for simple installs, but production environments with existing ClickHouse operations can set `clickhouse.enabled=false` and provide `externalClickHouse.url`.
 
 <details>
 <summary><b>Local Development</b></summary>

--- a/charts/moneat/Chart.yaml
+++ b/charts/moneat/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: moneat
+description: Self-hosted Moneat observability platform
+type: application
+version: 0.1.0
+appVersion: "v1.0.0"
+home: https://moneat.io
+icon: https://moneat.io/favicon.svg
+sources:
+  - https://github.com/moneat-io/moneat
+keywords:
+  - observability
+  - sentry
+  - opentelemetry
+  - datadog
+  - clickhouse
+maintainers:
+  - name: Moneat
+    url: https://moneat.io

--- a/charts/moneat/examples/external-services.yaml
+++ b/charts/moneat/examples/external-services.yaml
@@ -1,0 +1,50 @@
+app:
+  frontendUrl: https://moneat.example.com
+  backendUrl: https://api.moneat.example.com
+
+postgresql:
+  enabled: false
+externalPostgresql:
+  host: postgres.example.internal
+  port: 5432
+  database: moneat
+  username: moneat
+
+clickhouse:
+  enabled: false
+externalClickHouse:
+  url: https://clickhouse.example.internal:8123
+  database: moneat
+  username: moneat
+
+redis:
+  enabled: false
+externalRedis:
+  host: redis.example.internal
+  port: 6379
+
+secrets:
+  create: false
+  existingSecret: moneat-env
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: moneat.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dashboard
+    - host: api.moneat.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: backend
+  tls:
+    - secretName: moneat-tls
+      hosts:
+        - moneat.example.com
+        - api.moneat.example.com

--- a/charts/moneat/examples/production-like.yaml
+++ b/charts/moneat/examples/production-like.yaml
@@ -1,0 +1,91 @@
+image:
+  tag: v1.0.0
+
+app:
+  frontendUrl: https://moneat.example.com
+  backendUrl: https://api.moneat.example.com
+  trustedProxies: 10.0.0.0/8
+
+backend:
+  replicaCount: 1
+  persistence:
+    split:
+      enabled: true
+      profiles:
+        size: 50Gi
+        storageClass: block-storage
+      sourcemaps:
+        size: 100Gi
+        storageClass: block-storage
+      chunks:
+        size: 100Gi
+        storageClass: block-storage
+      artifactBundles:
+        size: 100Gi
+        storageClass: block-storage
+  resources:
+    requests:
+      cpu: "500m"
+      memory: 1Gi
+    limits:
+      memory: 2Gi
+
+postgresql:
+  persistence:
+    storageClass: block-storage
+    size: 100Gi
+  resources:
+    requests:
+      cpu: "500m"
+      memory: 1Gi
+    limits:
+      memory: 2Gi
+
+clickhouse:
+  persistence:
+    storageClass: block-storage
+    size: 500Gi
+  config:
+    loggerLevel: warning
+    logSize: 100M
+    logCount: 10
+    systemLogsTtlDays: 3
+    removeTextLog: true
+  resources:
+    requests:
+      cpu: "1"
+      memory: 4Gi
+    limits:
+      memory: 8Gi
+
+redis:
+  maxMemory: 3gb
+  persistence:
+    storageClass: block-storage
+    size: 20Gi
+
+secrets:
+  create: false
+  existingSecret: moneat-env
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: moneat.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dashboard
+    - host: api.moneat.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: backend
+  tls:
+    - secretName: moneat-tls
+      hosts:
+        - moneat.example.com
+        - api.moneat.example.com

--- a/charts/moneat/templates/NOTES.txt
+++ b/charts/moneat/templates/NOTES.txt
@@ -1,0 +1,22 @@
+Moneat has been rendered for namespace {{ .Release.Namespace }}.
+
+Backend service:
+  {{ include "moneat.fullname" . }}-backend:{{ .Values.backend.service.port }}
+
+Dashboard service:
+  {{ include "moneat.fullname" . }}-dashboard:{{ .Values.dashboard.service.port }}
+
+{{- if .Values.ingress.enabled }}
+Ingress is enabled. Public URLs should match:
+  FRONTEND_URL={{ .Values.app.frontendUrl }}
+  BACKEND_URL={{ .Values.app.backendUrl }}
+{{- else }}
+Ingress is disabled. For local access:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "moneat.fullname" . }}-dashboard 3000:{{ .Values.dashboard.service.port }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "moneat.fullname" . }}-backend 8080:{{ .Values.backend.service.port }}
+{{- end }}
+
+Run the Helm test after pods are ready:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Data PVCs are retained by default. Delete them manually only after backups are verified.

--- a/charts/moneat/templates/_helpers.tpl
+++ b/charts/moneat/templates/_helpers.tpl
@@ -1,0 +1,163 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "moneat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "moneat.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "moneat.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "moneat.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{- define "moneat.labels" -}}
+helm.sh/chart: {{ include "moneat.chart" .root }}
+{{ include "moneat.selectorLabels" . }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+{{- with .root.Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "moneat.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-env" (include "moneat.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.secretDataValue" -}}
+{{- $root := .root -}}
+{{- $key := .key -}}
+{{- $value := default "" .value -}}
+{{- $length := default 32 .length -}}
+{{- $secretName := include "moneat.secretName" $root -}}
+{{- $existing := lookup "v1" "Secret" $root.Release.Namespace $secretName -}}
+{{- if $value -}}
+{{- $value | b64enc -}}
+{{- else if and $existing (hasKey $existing.data $key) -}}
+{{- index $existing.data $key -}}
+{{- else -}}
+{{- randAlphaNum $length | b64enc -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.image" -}}
+{{- printf "%s:%s" .image.repository (include "moneat.imageTag" .) -}}
+{{- end -}}
+
+{{- define "moneat.imageTag" -}}
+{{- $root := .root -}}
+{{- $image := .image -}}
+{{- $globalTag := default $root.Chart.AppVersion $root.Values.image.tag -}}
+{{- default $globalTag $image.tag -}}
+{{- end -}}
+
+{{- define "moneat.pullPolicy" -}}
+{{- default .root.Values.image.pullPolicy .image.pullPolicy -}}
+{{- end -}}
+
+{{- define "moneat.postgresqlHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql" (include "moneat.fullname" .) -}}
+{{- else -}}
+{{- required "externalPostgresql.host is required when postgresql.enabled=false and externalPostgresql.url is empty" .Values.externalPostgresql.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.databaseUrl" -}}
+{{- if .Values.externalPostgresql.url -}}
+{{- .Values.externalPostgresql.url -}}
+{{- else -}}
+{{- $database := ternary .Values.postgresql.auth.database .Values.externalPostgresql.database .Values.postgresql.enabled -}}
+{{- $port := ternary .Values.postgresql.service.port .Values.externalPostgresql.port .Values.postgresql.enabled -}}
+{{- printf "jdbc:postgresql://%s:%v/%s" (include "moneat.postgresqlHost" .) $port $database -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.databaseUser" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.username -}}
+{{- else -}}
+{{- .Values.externalPostgresql.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.clickhouseUrl" -}}
+{{- if .Values.clickhouse.enabled -}}
+{{- printf "http://%s-clickhouse:%v" (include "moneat.fullname" .) .Values.clickhouse.service.httpPort -}}
+{{- else -}}
+{{- required "externalClickHouse.url is required when clickhouse.enabled=false" .Values.externalClickHouse.url -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.clickhouseDatabase" -}}
+{{- if .Values.clickhouse.enabled -}}
+{{- .Values.clickhouse.auth.database -}}
+{{- else -}}
+{{- .Values.externalClickHouse.database -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.clickhouseUser" -}}
+{{- if .Values.clickhouse.enabled -}}
+{{- .Values.clickhouse.auth.username -}}
+{{- else -}}
+{{- .Values.externalClickHouse.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.redisHost" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "%s-redis" (include "moneat.fullname" .) -}}
+{{- else -}}
+{{- required "externalRedis.host is required when redis.enabled=false and externalRedis.url is empty" .Values.externalRedis.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.redisUrl" -}}
+{{- if .Values.externalRedis.url -}}
+{{- .Values.externalRedis.url -}}
+{{- else -}}
+{{- printf "redis://:$(REDIS_PASSWORD)@%s:%v" (include "moneat.redisHost" .) .Values.externalRedis.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moneat.backendPvcName" -}}
+{{- printf "%s-backend-storage" (include "moneat.fullname" .) -}}
+{{- end -}}
+
+{{- define "moneat.backendSplitPvcName" -}}
+{{- printf "%s-backend-%s" (include "moneat.fullname" .root) .name -}}
+{{- end -}}
+
+{{- define "moneat.datadogServiceAccountName" -}}
+{{- if .Values.datadog.serviceAccount.create -}}
+{{- printf "%s-datadog-agent" (include "moneat.fullname" .) -}}
+{{- else -}}
+{{- default (printf "%s-datadog-agent" (include "moneat.fullname" .)) .Values.datadog.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/moneat/templates/backend-deployment.yaml
+++ b/charts/moneat/templates/backend-deployment.yaml
@@ -1,0 +1,196 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "moneat.fullname" . }}-backend
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "backend") | nindent 4 }}
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "moneat.selectorLabels" (dict "root" . "component" "backend") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moneat.selectorLabels" (dict "root" . "component" "backend") | nindent 8 }}
+        {{- with .Values.backend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.backend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ include "moneat.image" (dict "root" . "image" .Values.backend.image) | quote }}
+          imagePullPolicy: {{ include "moneat.pullPolicy" (dict "root" . "image" .Values.backend.image) }}
+          {{- with .Values.backend.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ include "moneat.secretName" . }}
+            {{- with .Values.backend.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: PORT
+              value: "8080"
+            - name: DATABASE_URL
+              value: {{ include "moneat.databaseUrl" . | quote }}
+            - name: DATABASE_USER
+              value: {{ include "moneat.databaseUser" . | quote }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: DATABASE_PASSWORD
+            - name: CLICKHOUSE_URL
+              value: {{ include "moneat.clickhouseUrl" . | quote }}
+            - name: CLICKHOUSE_USER
+              value: {{ include "moneat.clickhouseUser" . | quote }}
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: CLICKHOUSE_PASSWORD
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: REDIS_PASSWORD
+            - name: REDIS_URL
+              value: {{ include "moneat.redisUrl" . | quote }}
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: JWT_SECRET
+            - name: DATA_SOURCE_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: DATA_SOURCE_ENCRYPTION_KEY
+            - name: FRONTEND_URL
+              value: {{ .Values.app.frontendUrl | quote }}
+            - name: BACKEND_URL
+              value: {{ .Values.app.backendUrl | quote }}
+            {{- if .Values.app.allowedOrigins }}
+            - name: ALLOWED_ORIGINS
+              value: {{ .Values.app.allowedOrigins | quote }}
+            {{- end }}
+            {{- if .Values.app.trustedProxies }}
+            - name: TRUSTED_PROXIES
+              value: {{ .Values.app.trustedProxies | quote }}
+            {{- end }}
+            - name: MONEAT_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: MONEAT_LICENSE_KEY
+                  optional: true
+            {{- if .Values.datadog.enabled }}
+            - name: DD_AGENT_HOST
+              value: {{ printf "%s-datadog-agent" (include "moneat.fullname" .) | quote }}
+            - name: DD_VERSION
+              value: {{ include "moneat.imageTag" (dict "root" . "image" .Values.backend.image) | quote }}
+            {{- range $name, $value := .Values.datadog.backendEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $name, $value := .Values.backend.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.backend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.backend.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.backend.persistence.enabled }}
+          volumeMounts:
+            {{- if .Values.backend.persistence.split.enabled }}
+            - name: profiles
+              mountPath: /app/storage/profiles
+            - name: sourcemaps
+              mountPath: /app/storage/sourcemaps
+            - name: chunks
+              mountPath: /app/storage/chunks
+            - name: artifact-bundles
+              mountPath: /app/storage/artifact_bundles
+            {{- else }}
+            - name: backend-storage
+              mountPath: /app/storage
+            {{- end }}
+          {{- end }}
+      {{- if .Values.backend.persistence.enabled }}
+      volumes:
+        {{- if .Values.backend.persistence.split.enabled }}
+        - name: profiles
+          persistentVolumeClaim:
+            claimName: {{ default (include "moneat.backendSplitPvcName" (dict "root" . "name" "profiles")) .Values.backend.persistence.split.profiles.existingClaim }}
+        - name: sourcemaps
+          persistentVolumeClaim:
+            claimName: {{ default (include "moneat.backendSplitPvcName" (dict "root" . "name" "sourcemaps")) .Values.backend.persistence.split.sourcemaps.existingClaim }}
+        - name: chunks
+          persistentVolumeClaim:
+            claimName: {{ default (include "moneat.backendSplitPvcName" (dict "root" . "name" "chunks")) .Values.backend.persistence.split.chunks.existingClaim }}
+        - name: artifact-bundles
+          persistentVolumeClaim:
+            claimName: {{ default (include "moneat.backendSplitPvcName" (dict "root" . "name" "artifact-bundles")) .Values.backend.persistence.split.artifactBundles.existingClaim }}
+        {{- else }}
+        - name: backend-storage
+          persistentVolumeClaim:
+            claimName: {{ default (include "moneat.backendPvcName" .) .Values.backend.persistence.existingClaim }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/moneat/templates/backend-pvc.yaml
+++ b/charts/moneat/templates/backend-pvc.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.backend.persistence.enabled (not .Values.backend.persistence.split.enabled) (not .Values.backend.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "moneat.backendPvcName" . }}
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "backend") | nindent 4 }}
+  {{- if .Values.backend.persistence.keepPvc }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.backend.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.backend.persistence.size | quote }}
+  {{- if .Values.backend.persistence.storageClass }}
+  storageClassName: {{ .Values.backend.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.backend.persistence.enabled .Values.backend.persistence.split.enabled }}
+{{- $root := . }}
+{{- $volumes := dict "profiles" .Values.backend.persistence.split.profiles "sourcemaps" .Values.backend.persistence.split.sourcemaps "chunks" .Values.backend.persistence.split.chunks "artifact-bundles" .Values.backend.persistence.split.artifactBundles }}
+{{- range $name, $cfg := $volumes }}
+{{- if not $cfg.existingClaim }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "moneat.backendSplitPvcName" (dict "root" $root "name" $name) }}
+  labels:
+    {{- include "moneat.labels" (dict "root" $root "component" "backend") | nindent 4 }}
+  {{- if $root.Values.backend.persistence.keepPvc }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml $cfg.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ $cfg.size | quote }}
+  {{- if $cfg.storageClass }}
+  storageClassName: {{ $cfg.storageClass | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/moneat/templates/backend-service.yaml
+++ b/charts/moneat/templates/backend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moneat.fullname" . }}-backend
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "backend") | nindent 4 }}
+  {{- with .Values.backend.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "moneat.selectorLabels" (dict "root" . "component" "backend") | nindent 4 }}

--- a/charts/moneat/templates/clickhouse-configmap.yaml
+++ b/charts/moneat/templates/clickhouse-configmap.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.clickhouse.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "moneat.fullname" . }}-clickhouse-config
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "clickhouse") | nindent 4 }}
+data:
+  logging.xml: |
+    <clickhouse>
+        <logger>
+            <level>{{ .Values.clickhouse.config.loggerLevel }}</level>
+            <log>/var/lib/clickhouse/log/clickhouse-server.log</log>
+            <errorlog>/var/lib/clickhouse/log/clickhouse-server.err.log</errorlog>
+            <size>{{ .Values.clickhouse.config.logSize }}</size>
+            <count>{{ .Values.clickhouse.config.logCount }}</count>
+        </logger>
+        {{- if .Values.clickhouse.config.removeTextLog }}
+        <text_log remove="1" />
+        {{- end }}
+    </clickhouse>
+  system-log-ttl.xml: |
+    <clickhouse>
+        <trace_log>
+            <database>system</database>
+            <table>trace_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </trace_log>
+        <query_log>
+            <database>system</database>
+            <table>query_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </query_log>
+        <query_thread_log>
+            <database>system</database>
+            <table>query_thread_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </query_thread_log>
+        <query_views_log>
+            <database>system</database>
+            <table>query_views_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </query_views_log>
+        <query_metric_log>
+            <database>system</database>
+            <table>query_metric_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </query_metric_log>
+        <metric_log>
+            <database>system</database>
+            <table>metric_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </metric_log>
+        <asynchronous_metric_log>
+            <database>system</database>
+            <table>asynchronous_metric_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </asynchronous_metric_log>
+        <part_log>
+            <database>system</database>
+            <table>part_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </part_log>
+        <processors_profile_log>
+            <database>system</database>
+            <table>processors_profile_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </processors_profile_log>
+        <error_log>
+            <database>system</database>
+            <table>error_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <ttl>event_date + INTERVAL {{ .Values.clickhouse.config.systemLogsTtlDays }} DAY</ttl>
+        </error_log>
+    </clickhouse>
+  00-create-database.sql: |
+    CREATE DATABASE IF NOT EXISTS {{ .Values.clickhouse.auth.database }};
+{{- end }}

--- a/charts/moneat/templates/clickhouse-service.yaml
+++ b/charts/moneat/templates/clickhouse-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.clickhouse.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moneat.fullname" . }}-clickhouse
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "clickhouse") | nindent 4 }}
+  {{- with .Values.clickhouse.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.clickhouse.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+    - name: native
+      port: {{ .Values.clickhouse.service.nativePort }}
+      targetPort: native
+      protocol: TCP
+  selector:
+    {{- include "moneat.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 4 }}
+{{- end }}

--- a/charts/moneat/templates/clickhouse-statefulset.yaml
+++ b/charts/moneat/templates/clickhouse-statefulset.yaml
@@ -1,0 +1,150 @@
+{{- if .Values.clickhouse.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "moneat.fullname" . }}-clickhouse
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "clickhouse") | nindent 4 }}
+spec:
+  serviceName: {{ include "moneat.fullname" . }}-clickhouse
+  replicas: 1
+  {{- if and .Values.clickhouse.persistence.enabled (not .Values.clickhouse.persistence.existingClaim) }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.clickhouse.persistence.retention.whenDeleted }}
+    whenScaled: {{ .Values.clickhouse.persistence.retention.whenScaled }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "moneat.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moneat.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}
+        {{- with .Values.clickhouse.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.clickhouse.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clickhouse.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: clickhouse
+          image: {{ printf "%s:%s" .Values.clickhouse.image.repository .Values.clickhouse.image.tag | quote }}
+          imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
+          {{- with .Values.clickhouse.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8123
+              protocol: TCP
+            - name: native
+              containerPort: 9000
+              protocol: TCP
+          env:
+            - name: CLICKHOUSE_DB
+              value: {{ .Values.clickhouse.auth.database | quote }}
+            - name: CLICKHOUSE_USER
+              value: {{ .Values.clickhouse.auth.username | quote }}
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: CLICKHOUSE_PASSWORD
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.clickhouse.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d/logging.xml
+              subPath: logging.xml
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d/system-log-ttl.xml
+              subPath: system-log-ttl.xml
+            {{- if .Values.clickhouse.initdb.enabled }}
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "moneat.fullname" . }}-clickhouse-config
+        {{- if .Values.clickhouse.initdb.enabled }}
+        - name: initdb
+          configMap:
+            name: {{ include "moneat.fullname" . }}-clickhouse-config
+            items:
+              - key: 00-create-database.sql
+                path: 00-create-database.sql
+        {{- end }}
+        {{- if not .Values.clickhouse.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- else if .Values.clickhouse.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.clickhouse.persistence.existingClaim }}
+        {{- end }}
+      {{- with .Values.clickhouse.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clickhouse.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clickhouse.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if and .Values.clickhouse.persistence.enabled (not .Values.clickhouse.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "moneat.labels" (dict "root" . "component" "clickhouse") | nindent 10 }}
+        {{- if .Values.clickhouse.persistence.keepPvc }}
+        annotations:
+          helm.sh/resource-policy: keep
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.clickhouse.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.clickhouse.persistence.size | quote }}
+        {{- if .Values.clickhouse.persistence.storageClass }}
+        storageClassName: {{ .Values.clickhouse.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/moneat/templates/dashboard-deployment.yaml
+++ b/charts/moneat/templates/dashboard-deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "moneat.fullname" . }}-dashboard
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "dashboard") | nindent 4 }}
+spec:
+  replicas: {{ .Values.dashboard.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "moneat.selectorLabels" (dict "root" . "component" "dashboard") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moneat.selectorLabels" (dict "root" . "component" "dashboard") | nindent 8 }}
+        {{- with .Values.dashboard.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.dashboard.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dashboard
+          image: {{ include "moneat.image" (dict "root" . "image" .Values.dashboard.image) | quote }}
+          imagePullPolicy: {{ include "moneat.pullPolicy" (dict "root" . "image" .Values.dashboard.image) }}
+          {{- with .Values.dashboard.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: VITE_BACKEND_URL
+              value: {{ .Values.app.backendUrl | quote }}
+            {{- range $name, $value := .Values.dashboard.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.dashboard.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.dashboard.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.dashboard.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.dashboard.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/moneat/templates/dashboard-service.yaml
+++ b/charts/moneat/templates/dashboard-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moneat.fullname" . }}-dashboard
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "dashboard") | nindent 4 }}
+  {{- with .Values.dashboard.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.dashboard.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "moneat.selectorLabels" (dict "root" . "component" "dashboard") | nindent 4 }}

--- a/charts/moneat/templates/datadog-agent.yaml
+++ b/charts/moneat/templates/datadog-agent.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.datadog.enabled }}
+{{- $endpointUrl := default (printf "http://%s-backend:%v/dd" (include "moneat.fullname" .) .Values.backend.service.port) .Values.datadog.endpointUrl }}
+{{- if .Values.datadog.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "moneat.datadogServiceAccountName" . }}
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "datadog-agent") | nindent 4 }}
+  {{- with .Values.datadog.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.datadog.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "moneat.fullname" . }}-datadog-agent
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "datadog-agent") | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "services", "endpoints", "events", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "moneat.fullname" . }}-datadog-agent
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "datadog-agent") | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "moneat.fullname" . }}-datadog-agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "moneat.datadogServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+{{- end }}
+{{- if .Values.datadog.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moneat.fullname" . }}-datadog-agent
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "datadog-agent") | nindent 4 }}
+  {{- with .Values.datadog.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: apm
+      port: {{ .Values.datadog.service.apmPort }}
+      targetPort: apm
+      protocol: TCP
+    - name: dogstatsd
+      port: {{ .Values.datadog.service.dogstatsdPort }}
+      targetPort: dogstatsd
+      protocol: UDP
+  selector:
+    {{- include "moneat.selectorLabels" (dict "root" . "component" "datadog-agent") | nindent 4 }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "moneat.fullname" . }}-datadog-agent
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "datadog-agent") | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "moneat.selectorLabels" (dict "root" . "component" "datadog-agent") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moneat.selectorLabels" (dict "root" . "component" "datadog-agent") | nindent 8 }}
+        {{- with .Values.datadog.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.datadog.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "moneat.datadogServiceAccountName" . }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.datadog.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent
+          image: {{ printf "%s:%s" .Values.datadog.image.repository .Values.datadog.image.tag | quote }}
+          imagePullPolicy: {{ .Values.datadog.image.pullPolicy }}
+          {{- with .Values.datadog.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: apm
+              containerPort: 8126
+              protocol: TCP
+            - name: dogstatsd
+              containerPort: 8125
+              protocol: UDP
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: DD_API_KEY
+            - name: DD_DD_URL
+              value: {{ $endpointUrl | quote }}
+            - name: DD_APM_DD_URL
+              value: {{ $endpointUrl | quote }}
+            - name: DD_PROCESS_CONFIG_PROCESS_DD_URL
+              value: {{ $endpointUrl | quote }}
+            - name: DD_KUBERNETES_KUBELET_NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DD_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- range $name, $value := .Values.datadog.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.datadog.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.datadog.hostPaths.proc .Values.datadog.hostPaths.cgroup .Values.datadog.hostPaths.dockerSocket }}
+          volumeMounts:
+            {{- if .Values.datadog.hostPaths.proc }}
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            {{- end }}
+            {{- if .Values.datadog.hostPaths.cgroup }}
+            - name: cgroup
+              mountPath: /host/sys/fs/cgroup
+              readOnly: true
+            {{- end }}
+            {{- if .Values.datadog.hostPaths.dockerSocket }}
+            - name: docker-socket
+              mountPath: /var/run/docker.sock
+              readOnly: true
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.datadog.hostPaths.proc .Values.datadog.hostPaths.cgroup .Values.datadog.hostPaths.dockerSocket }}
+      volumes:
+        {{- if .Values.datadog.hostPaths.proc }}
+        - name: proc
+          hostPath:
+            path: {{ .Values.datadog.hostPaths.proc | quote }}
+        {{- end }}
+        {{- if .Values.datadog.hostPaths.cgroup }}
+        - name: cgroup
+          hostPath:
+            path: {{ .Values.datadog.hostPaths.cgroup | quote }}
+        {{- end }}
+        {{- if .Values.datadog.hostPaths.dockerSocket }}
+        - name: docker-socket
+          hostPath:
+            path: {{ .Values.datadog.hostPaths.dockerSocket | quote }}
+            type: Socket
+        {{- end }}
+      {{- end }}
+      {{- with .Values.datadog.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.datadog.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.datadog.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/moneat/templates/ingress.yaml
+++ b/charts/moneat/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "moneat.fullname" . }}
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "ingress") | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                {{- if eq .service "backend" }}
+                name: {{ include "moneat.fullname" $ }}-backend
+                port:
+                  number: {{ $.Values.backend.service.port }}
+                {{- else if eq .service "dashboard" }}
+                name: {{ include "moneat.fullname" $ }}-dashboard
+                port:
+                  number: {{ $.Values.dashboard.service.port }}
+                {{- else }}
+                {{- fail "ingress.hosts[].paths[].service must be either backend or dashboard" }}
+                {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/moneat/templates/postgresql-configmap.yaml
+++ b/charts/moneat/templates/postgresql-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.initdb.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "moneat.fullname" . }}-postgresql-init
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "postgresql") | nindent 4 }}
+data:
+  00-moneat-init.sql: |
+    {{- .Values.postgresql.initdb.sql | nindent 4 }}
+{{- end }}

--- a/charts/moneat/templates/postgresql-service.yaml
+++ b/charts/moneat/templates/postgresql-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moneat.fullname" . }}-postgresql
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "postgresql") | nindent 4 }}
+  {{- with .Values.postgresql.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgresql
+      port: {{ .Values.postgresql.service.port }}
+      targetPort: postgresql
+      protocol: TCP
+  selector:
+    {{- include "moneat.selectorLabels" (dict "root" . "component" "postgresql") | nindent 4 }}
+{{- end }}

--- a/charts/moneat/templates/postgresql-statefulset.yaml
+++ b/charts/moneat/templates/postgresql-statefulset.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "moneat.fullname" . }}-postgresql
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "postgresql") | nindent 4 }}
+spec:
+  serviceName: {{ include "moneat.fullname" . }}-postgresql
+  replicas: 1
+  {{- if and .Values.postgresql.persistence.enabled (not .Values.postgresql.persistence.existingClaim) }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.postgresql.persistence.retention.whenDeleted }}
+    whenScaled: {{ .Values.postgresql.persistence.retention.whenScaled }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "moneat.selectorLabels" (dict "root" . "component" "postgresql") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moneat.selectorLabels" (dict "root" . "component" "postgresql") | nindent 8 }}
+        {{- with .Values.postgresql.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.postgresql.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: {{ printf "%s:%s" .Values.postgresql.image.repository .Values.postgresql.image.tag | quote }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          {{- with .Values.postgresql.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: DATABASE_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.postgresql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            {{- if .Values.postgresql.initdb.enabled }}
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
+      {{- if or .Values.postgresql.initdb.enabled (not .Values.postgresql.persistence.enabled) .Values.postgresql.persistence.existingClaim }}
+      volumes:
+        {{- if .Values.postgresql.initdb.enabled }}
+        - name: initdb
+          configMap:
+            name: {{ include "moneat.fullname" . }}-postgresql-init
+        {{- end }}
+        {{- if not .Values.postgresql.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- else if .Values.postgresql.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.postgresql.persistence.existingClaim }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if and .Values.postgresql.persistence.enabled (not .Values.postgresql.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "moneat.labels" (dict "root" . "component" "postgresql") | nindent 10 }}
+        {{- if .Values.postgresql.persistence.keepPvc }}
+        annotations:
+          helm.sh/resource-policy: keep
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgresql.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size | quote }}
+        {{- if .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/moneat/templates/redis-service.yaml
+++ b/charts/moneat/templates/redis-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moneat.fullname" . }}-redis
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "redis") | nindent 4 }}
+  {{- with .Values.redis.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port }}
+      targetPort: redis
+      protocol: TCP
+  selector:
+    {{- include "moneat.selectorLabels" (dict "root" . "component" "redis") | nindent 4 }}
+{{- end }}

--- a/charts/moneat/templates/redis-statefulset.yaml
+++ b/charts/moneat/templates/redis-statefulset.yaml
@@ -1,0 +1,141 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "moneat.fullname" . }}-redis
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "redis") | nindent 4 }}
+spec:
+  serviceName: {{ include "moneat.fullname" . }}-redis
+  replicas: 1
+  {{- if and .Values.redis.persistence.enabled (not .Values.redis.persistence.existingClaim) }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.redis.persistence.retention.whenDeleted }}
+    whenScaled: {{ .Values.redis.persistence.retention.whenScaled }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "moneat.selectorLabels" (dict "root" . "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moneat.selectorLabels" (dict "root" . "component" "redis") | nindent 8 }}
+        {{- with .Values.redis.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.redis.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: {{ printf "%s:%s" .Values.redis.image.repository .Values.redis.image.tag | quote }}
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          {{- with .Values.redis.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "moneat.secretName" . }}
+                  key: REDIS_PASSWORD
+          command:
+            - redis-server
+          args:
+            - --appendonly
+            - {{ ternary "yes" "no" .Values.redis.appendOnly | quote }}
+            - --requirepass
+            - $(REDIS_PASSWORD)
+            {{- if .Values.redis.maxMemory }}
+            - --maxmemory
+            - {{ .Values.redis.maxMemory | quote }}
+            {{- end }}
+            {{- if .Values.redis.maxMemoryPolicy }}
+            - --maxmemory-policy
+            - {{ .Values.redis.maxMemoryPolicy | quote }}
+            {{- end }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      {{- if or (not .Values.redis.persistence.enabled) .Values.redis.persistence.existingClaim }}
+      volumes:
+        {{- if not .Values.redis.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- else }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.persistence.existingClaim }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if and .Values.redis.persistence.enabled (not .Values.redis.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "moneat.labels" (dict "root" . "component" "redis") | nindent 10 }}
+        {{- if .Values.redis.persistence.keepPvc }}
+        annotations:
+          helm.sh/resource-policy: keep
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.redis.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size | quote }}
+        {{- if .Values.redis.persistence.storageClass }}
+        storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/moneat/templates/secret.yaml
+++ b/charts/moneat/templates/secret.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "moneat.secretName" . }}
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "secrets") | nindent 4 }}
+  {{- with .Values.secrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  JWT_SECRET: {{ include "moneat.secretDataValue" (dict "root" . "key" "JWT_SECRET" "value" .Values.secrets.values.jwtSecret "length" 64) | quote }}
+  DATA_SOURCE_ENCRYPTION_KEY: {{ include "moneat.secretDataValue" (dict "root" . "key" "DATA_SOURCE_ENCRYPTION_KEY" "value" .Values.secrets.values.dataSourceEncryptionKey "length" 64) | quote }}
+  DATABASE_PASSWORD: {{ include "moneat.secretDataValue" (dict "root" . "key" "DATABASE_PASSWORD" "value" .Values.secrets.values.databasePassword "length" 32) | quote }}
+  CLICKHOUSE_PASSWORD: {{ include "moneat.secretDataValue" (dict "root" . "key" "CLICKHOUSE_PASSWORD" "value" .Values.secrets.values.clickhousePassword "length" 32) | quote }}
+  REDIS_PASSWORD: {{ include "moneat.secretDataValue" (dict "root" . "key" "REDIS_PASSWORD" "value" .Values.secrets.values.redisPassword "length" 32) | quote }}
+  {{- with .Values.secrets.values.moneatLicenseKey }}
+  MONEAT_LICENSE_KEY: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.secrets.values.ddApiKey }}
+  DD_API_KEY: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.secrets.values.ddPostgresPassword }}
+  DD_POSTGRES_PASSWORD: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- range $name, $value := .Values.secrets.extraEnv }}
+  {{ $name }}: {{ $value | toString | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/moneat/templates/tests-backend-health.yaml
+++ b/charts/moneat/templates/tests-backend-health.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "moneat.fullname" . }}-backend-health-test
+  labels:
+    {{- include "moneat.labels" (dict "root" . "component" "test") | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command:
+        - sh
+        - -c
+        - wget -q -O - http://{{ include "moneat.fullname" . }}-backend:{{ .Values.backend.service.port }}/health/ready

--- a/charts/moneat/templates/validate.yaml
+++ b/charts/moneat/templates/validate.yaml
@@ -1,0 +1,6 @@
+{{- if and (not .Values.secrets.create) (not .Values.secrets.existingSecret) -}}
+{{- fail "secrets.existingSecret is required when secrets.create=false" -}}
+{{- end -}}
+{{- if and .Values.datadog.enabled .Values.secrets.create (not .Values.secrets.values.ddApiKey) -}}
+{{- fail "datadog.enabled=true requires secrets.values.ddApiKey, or set secrets.existingSecret to a Secret containing DD_API_KEY" -}}
+{{- end -}}

--- a/charts/moneat/values.schema.json
+++ b/charts/moneat/values.schema.json
@@ -1,0 +1,407 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Moneat Helm values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {"type": "string"},
+    "fullnameOverride": {"type": "string"},
+    "global": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "imagePullSecrets": {"type": "array"},
+        "commonLabels": {"type": "object"}
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tag": {"type": "string"},
+        "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never"]}
+      }
+    },
+    "app": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["frontendUrl", "backendUrl"],
+      "properties": {
+        "frontendUrl": {"type": "string", "minLength": 1},
+        "backendUrl": {"type": "string", "minLength": 1},
+        "allowedOrigins": {"type": "string"},
+        "trustedProxies": {"type": "string"}
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {"type": "boolean"},
+        "existingSecret": {"type": "string"},
+        "annotations": {"type": "object"},
+        "values": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "jwtSecret": {"type": "string"},
+            "dataSourceEncryptionKey": {"type": "string"},
+            "databasePassword": {"type": "string"},
+            "clickhousePassword": {"type": "string"},
+            "redisPassword": {"type": "string"},
+            "moneatLicenseKey": {"type": "string"},
+            "ddApiKey": {"type": "string"},
+            "ddPostgresPassword": {"type": "string"}
+          }
+        },
+        "extraEnv": {"type": "object"}
+      }
+    },
+    "backend": {"$ref": "#/definitions/appDeployment"},
+    "dashboard": {"$ref": "#/definitions/appDeployment"},
+    "postgresql": {"$ref": "#/definitions/postgresql"},
+    "externalPostgresql": {"$ref": "#/definitions/externalPostgresql"},
+    "clickhouse": {"$ref": "#/definitions/clickhouse"},
+    "externalClickHouse": {"$ref": "#/definitions/externalClickHouse"},
+    "redis": {"$ref": "#/definitions/redis"},
+    "externalRedis": {"$ref": "#/definitions/externalRedis"},
+    "ingress": {"$ref": "#/definitions/ingress"},
+    "datadog": {"$ref": "#/definitions/datadog"}
+  },
+  "definitions": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "tag", "pullPolicy"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string"},
+        "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never", ""]}
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "podPlacement": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "podAnnotations": {"type": "object"},
+        "podLabels": {"type": "object"},
+        "podSecurityContext": {"type": "object"},
+        "securityContext": {"type": "object"},
+        "resources": {"$ref": "#/definitions/resources"},
+        "nodeSelector": {"type": "object"},
+        "tolerations": {"type": "array"},
+        "affinity": {"type": "object"}
+      }
+    },
+    "accessModes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string"}
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "keepPvc": {"type": "boolean"},
+        "storageClass": {"type": "string"},
+        "accessModes": {"$ref": "#/definitions/accessModes"},
+        "size": {"type": "string", "minLength": 1},
+        "existingClaim": {"type": "string"},
+        "retention": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "whenDeleted": {"type": "string", "enum": ["Retain", "Delete"]},
+            "whenScaled": {"type": "string", "enum": ["Retain", "Delete"]}
+          }
+        }
+      }
+    },
+    "backendSplitVolume": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "size": {"type": "string", "minLength": 1},
+        "storageClass": {"type": "string"},
+        "accessModes": {"$ref": "#/definitions/accessModes"},
+        "existingClaim": {"type": "string"}
+      }
+    },
+    "appDeployment": {
+      "allOf": [
+        {"$ref": "#/definitions/podPlacement"},
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "replicaCount": {"type": "integer", "minimum": 1},
+            "image": {"$ref": "#/definitions/image"},
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {"type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"]},
+                "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "annotations": {"type": "object"}
+              }
+            },
+            "env": {"type": "object"},
+            "extraEnv": {"type": "array"},
+            "extraEnvFrom": {"type": "array"},
+            "persistence": {
+              "allOf": [
+                {"$ref": "#/definitions/persistence"},
+                {
+                  "type": "object",
+                  "properties": {
+                    "split": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "enabled": {"type": "boolean"},
+                        "profiles": {"$ref": "#/definitions/backendSplitVolume"},
+                        "sourcemaps": {"$ref": "#/definitions/backendSplitVolume"},
+                        "chunks": {"$ref": "#/definitions/backendSplitVolume"},
+                        "artifactBundles": {"$ref": "#/definitions/backendSplitVolume"}
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "postgresql": {
+      "allOf": [
+        {"$ref": "#/definitions/podPlacement"},
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "image": {"$ref": "#/definitions/image"},
+            "auth": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["database", "username"],
+              "properties": {
+                "database": {"type": "string", "minLength": 1},
+                "username": {"type": "string", "minLength": 1}
+              }
+            },
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "annotations": {"type": "object"}
+              }
+            },
+            "persistence": {"$ref": "#/definitions/persistence"},
+            "initdb": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {"type": "boolean"},
+                "sql": {"type": "string"}
+              }
+            }
+          }
+        }
+      ]
+    },
+    "externalPostgresql": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "database": {"type": "string"},
+        "username": {"type": "string"}
+      }
+    },
+    "clickhouse": {
+      "allOf": [
+        {"$ref": "#/definitions/podPlacement"},
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "image": {"$ref": "#/definitions/image"},
+            "auth": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["database", "username"],
+              "properties": {
+                "database": {"type": "string", "minLength": 1},
+                "username": {"type": "string", "minLength": 1}
+              }
+            },
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "httpPort": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "nativePort": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "annotations": {"type": "object"}
+              }
+            },
+            "persistence": {"$ref": "#/definitions/persistence"},
+            "config": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "loggerLevel": {"type": "string"},
+                "logSize": {"type": "string"},
+                "logCount": {"type": "integer", "minimum": 1},
+                "systemLogsTtlDays": {"type": "integer", "minimum": 1},
+                "removeTextLog": {"type": "boolean"}
+              }
+            },
+            "initdb": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {"enabled": {"type": "boolean"}}
+            }
+          }
+        }
+      ]
+    },
+    "externalClickHouse": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {"type": "string"},
+        "database": {"type": "string"},
+        "username": {"type": "string"}
+      }
+    },
+    "redis": {
+      "allOf": [
+        {"$ref": "#/definitions/podPlacement"},
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "image": {"$ref": "#/definitions/image"},
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "annotations": {"type": "object"}
+              }
+            },
+            "persistence": {"$ref": "#/definitions/persistence"},
+            "appendOnly": {"type": "boolean"},
+            "maxMemory": {"type": "string"},
+            "maxMemoryPolicy": {"type": "string"}
+          }
+        }
+      ]
+    },
+    "externalRedis": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535}
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "className": {"type": "string"},
+        "annotations": {"type": "object"},
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["host", "paths"],
+            "properties": {
+              "host": {"type": "string", "minLength": 1},
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["path", "service"],
+                  "properties": {
+                    "path": {"type": "string", "minLength": 1},
+                    "pathType": {"type": "string", "enum": ["Prefix", "Exact", "ImplementationSpecific"]},
+                    "service": {"type": "string", "enum": ["backend", "dashboard"]}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {"type": "array"}
+      }
+    },
+    "datadog": {
+      "allOf": [
+        {"$ref": "#/definitions/podPlacement"},
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "image": {"$ref": "#/definitions/image"},
+            "serviceAccount": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "create": {"type": "boolean"},
+                "name": {"type": "string"},
+                "annotations": {"type": "object"}
+              }
+            },
+            "rbac": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {"create": {"type": "boolean"}}
+            },
+            "service": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {"type": "boolean"},
+                "annotations": {"type": "object"},
+                "apmPort": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "dogstatsdPort": {"type": "integer", "minimum": 1, "maximum": 65535}
+              }
+            },
+            "endpointUrl": {"type": "string"},
+            "env": {"type": "object"},
+            "backendEnv": {"type": "object"},
+            "hostPaths": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "proc": {"type": "string"},
+                "cgroup": {"type": "string"},
+                "dockerSocket": {"type": "string"}
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/charts/moneat/values.yaml
+++ b/charts/moneat/values.yaml
@@ -1,0 +1,311 @@
+# Default values for the Moneat Helm chart.
+
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  imagePullSecrets: []
+  commonLabels: {}
+
+image:
+  tag: ""
+  pullPolicy: IfNotPresent
+
+backend:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/moneat-io/moneat-backend
+    tag: ""
+    pullPolicy: ""
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext:
+    fsGroup: 999
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  env:
+    SELF_HOSTED: "true"
+    STRIPE_ENABLED: "false"
+    BILLING_BACKGROUND_JOBS_ENABLED: "true"
+    TELEMETRY_ENABLED: "true"
+    PROFILE_STORAGE_PATH: /app/storage/profiles
+  extraEnv: []
+  extraEnvFrom: []
+  persistence:
+    enabled: true
+    keepPvc: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 20Gi
+    existingClaim: ""
+    split:
+      enabled: false
+      profiles:
+        size: 20Gi
+        storageClass: ""
+        accessModes:
+          - ReadWriteOnce
+        existingClaim: ""
+      sourcemaps:
+        size: 20Gi
+        storageClass: ""
+        accessModes:
+          - ReadWriteOnce
+        existingClaim: ""
+      chunks:
+        size: 50Gi
+        storageClass: ""
+        accessModes:
+          - ReadWriteOnce
+        existingClaim: ""
+      artifactBundles:
+        size: 50Gi
+        storageClass: ""
+        accessModes:
+          - ReadWriteOnce
+        existingClaim: ""
+
+dashboard:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/moneat-io/moneat-dashboard
+    tag: ""
+    pullPolicy: ""
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+  env:
+    VITE_ANALYTICS_KEY: ""
+    VITE_SENTRY_DSN: ""
+    VITE_SENTRY_ENVIRONMENT: production
+    VITE_SENTRY_TRACES_SAMPLE_RATE: "0.1"
+  extraEnv: []
+  extraEnvFrom: []
+
+app:
+  frontendUrl: http://localhost:3000
+  backendUrl: http://localhost:8080
+  allowedOrigins: ""
+  trustedProxies: ""
+
+secrets:
+  create: true
+  existingSecret: ""
+  annotations: {}
+  values:
+    jwtSecret: ""
+    dataSourceEncryptionKey: ""
+    databasePassword: ""
+    clickhousePassword: ""
+    redisPassword: ""
+    moneatLicenseKey: ""
+    ddApiKey: ""
+    ddPostgresPassword: ""
+  extraEnv: {}
+
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "18-alpine"
+    pullPolicy: IfNotPresent
+  auth:
+    database: moneat
+    username: moneat
+  service:
+    port: 5432
+    annotations: {}
+  persistence:
+    enabled: true
+    keepPvc: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 20Gi
+    existingClaim: ""
+    retention:
+      whenDeleted: Retain
+      whenScaled: Retain
+  initdb:
+    enabled: true
+    sql: |
+      -- Moneat runs Flyway migrations on backend startup.
+      CREATE EXTENSION IF NOT EXISTS pgcrypto;
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+externalPostgresql:
+  url: ""
+  host: ""
+  port: 5432
+  database: moneat
+  username: moneat
+
+clickhouse:
+  enabled: true
+  image:
+    repository: clickhouse/clickhouse-server
+    tag: "26.2-alpine"
+    pullPolicy: IfNotPresent
+  auth:
+    database: moneat
+    username: moneat
+  service:
+    httpPort: 8123
+    nativePort: 9000
+    annotations: {}
+  persistence:
+    enabled: true
+    keepPvc: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 100Gi
+    existingClaim: ""
+    retention:
+      whenDeleted: Retain
+      whenScaled: Retain
+  config:
+    loggerLevel: warning
+    logSize: 100M
+    logCount: 10
+    systemLogsTtlDays: 3
+    removeTextLog: true
+  initdb:
+    enabled: true
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+externalClickHouse:
+  url: ""
+  database: moneat
+  username: moneat
+
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "8-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    port: 6379
+    annotations: {}
+  persistence:
+    enabled: true
+    keepPvc: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    existingClaim: ""
+    retention:
+      whenDeleted: Retain
+      whenScaled: Retain
+  appendOnly: true
+  maxMemory: ""
+  maxMemoryPolicy: allkeys-lru
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+externalRedis:
+  url: ""
+  host: ""
+  port: 6379
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: moneat.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dashboard
+    - host: api.moneat.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: backend
+  tls: []
+
+datadog:
+  enabled: false
+  image:
+    repository: datadog/agent
+    tag: "7"
+    pullPolicy: IfNotPresent
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
+  rbac:
+    create: true
+  service:
+    enabled: true
+    annotations: {}
+    apmPort: 8126
+    dogstatsdPort: 8125
+  endpointUrl: ""
+  env:
+    DD_APM_ENABLED: "true"
+    DD_APM_NON_LOCAL_TRAFFIC: "true"
+    DD_PROCESS_AGENT_ENABLED: "true"
+    DD_LOGS_ENABLED: "true"
+    DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "true"
+    DD_LEADER_ELECTION: "true"
+    DD_COLLECT_KUBERNETES_EVENTS: "true"
+  backendEnv:
+    DD_SERVICE: moneat-backend
+    DD_ENV: production
+    DD_PROFILING_ENABLED: "true"
+    DD_TRACE_ENABLED: "true"
+    DD_LOGS_INJECTION: "true"
+    DD_RUNTIME_METRICS_ENABLED: "true"
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  hostPaths:
+    proc: /proc
+    cgroup: /sys/fs/cgroup
+    dockerSocket: ""

--- a/dashboard/src/docs/pages/datadog-agent/kubernetes.mdx
+++ b/dashboard/src/docs/pages/datadog-agent/kubernetes.mdx
@@ -9,6 +9,10 @@ description: Monitor Kubernetes cluster resources including pods, nodes, service
 
 Moneat's Kubernetes monitoring gives you visibility into your cluster resources and workloads. View the status of pods, nodes, services, deployments, DaemonSets, and ReplicaSets - all collected automatically by the Datadog Agent running inside your cluster.
 
+:::info[Installing Moneat on Kubernetes]
+This page is about monitoring Kubernetes workloads with Moneat through the Datadog Agent. To install Moneat itself on Kubernetes, use the [Kubernetes / Helm](/docs/kubernetes-helm) guide.
+:::
+
 :::info[Enterprise feature]
 Kubernetes monitoring requires the Datadog Agent integration, available on Enterprise plans.
 :::

--- a/dashboard/src/docs/pages/kubernetes-helm.mdx
+++ b/dashboard/src/docs/pages/kubernetes-helm.mdx
@@ -1,0 +1,225 @@
+---
+title: Kubernetes / Helm
+description: Install Moneat on Kubernetes with the public Helm chart.
+---
+
+# Kubernetes / Helm
+
+The Moneat Helm chart is published at `https://charts.moneat.io`. It installs the backend, dashboard, optional in-cluster Postgres, optional in-cluster ClickHouse, optional in-cluster Redis, persistent backend storage, Kubernetes Secrets, Ingress, optional TLS, and an optional Datadog Agent integration.
+
+## Prerequisites
+
+- Kubernetes 1.27+
+- Helm 3.13+
+- A default StorageClass or explicit `*.persistence.storageClass` values
+- An Ingress controller when `ingress.enabled=true`
+- cert-manager when using the TLS examples below
+
+## Quick Install
+
+```bash
+helm repo add moneat https://charts.moneat.io
+helm repo update
+
+helm upgrade --install moneat moneat/moneat \
+  --namespace moneat \
+  --create-namespace \
+  --set app.frontendUrl=https://moneat.example.com \
+  --set app.backendUrl=https://api.moneat.example.com
+```
+
+The default chart creates random critical secrets on first install and keeps those values on later upgrades with Helm's `lookup` function. For production, provide your own Secret or ExternalSecret.
+
+Published chart packages are tied to a Moneat release tag. For example, the `v1.0.1` app release publishes chart version `1.0.1`, sets `appVersion` to `v1.0.1`, and defaults `image.tag` to `v1.0.1`. This keeps installs reproducible instead of pulling `latest`.
+
+## Secrets
+
+The generated Secret contains these keys:
+
+| Key | Purpose |
+|-----|---------|
+| `JWT_SECRET` | JWT signing secret. |
+| `DATA_SOURCE_ENCRYPTION_KEY` | Encryption key for custom data source credentials. |
+| `DATABASE_PASSWORD` | Postgres password. |
+| `CLICKHOUSE_PASSWORD` | ClickHouse password. |
+| `REDIS_PASSWORD` | Redis password. |
+| `MONEAT_LICENSE_KEY` | Optional enterprise license key. |
+| `DD_API_KEY` | Optional Datadog Agent API key created in Moneat. |
+
+To bring your own Secret:
+
+```yaml
+secrets:
+  create: false
+  existingSecret: moneat-env
+```
+
+The existing Secret must be in the release namespace and contain the keys above that your enabled services need.
+
+## Ingress and TLS
+
+The chart does not install nginx or certbot containers. Kubernetes should provide routing and certificate automation through an Ingress controller and cert-manager:
+
+```yaml
+app:
+  frontendUrl: https://moneat.example.com
+  backendUrl: https://api.moneat.example.com
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: moneat.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dashboard
+    - host: api.moneat.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: backend
+  tls:
+    - secretName: moneat-tls
+      hosts:
+        - moneat.example.com
+        - api.moneat.example.com
+```
+
+## Persistence
+
+The default install creates retained PVCs for Postgres, ClickHouse, Redis, and backend storage. The backend mounts `/app/storage` and sets `PROFILE_STORAGE_PATH=/app/storage/profiles`, so profiles, source maps, chunks, and artifact bundles are persistent.
+
+For production-style split backend storage:
+
+```yaml
+backend:
+  persistence:
+    split:
+      enabled: true
+      profiles:
+        size: 50Gi
+      sourcemaps:
+        size: 100Gi
+      chunks:
+        size: 100Gi
+      artifactBundles:
+        size: 100Gi
+```
+
+PVCs are retained by default through `helm.sh/resource-policy: keep` and StatefulSet `persistentVolumeClaimRetentionPolicy: Retain`.
+
+## ClickHouse
+
+The bundled ClickHouse mode is intentionally single-node and persistence-focused. It includes:
+
+- A StatefulSet with a data PVC mounted at `/var/lib/clickhouse`
+- File logs redirected to `/var/lib/clickhouse/log`
+- Log rotation settings
+- `system.*_log` TTL settings
+- `system.text_log` disabled by default
+- A small init script that creates the database
+
+The backend still runs ClickHouse schema migrations on startup under a PostgreSQL advisory lock. For larger production installs, run ClickHouse separately and use external mode:
+
+```yaml
+clickhouse:
+  enabled: false
+externalClickHouse:
+  url: https://clickhouse.internal:8123
+  database: moneat
+  username: moneat
+```
+
+## External Database Mode
+
+Disable bundled data services and point Moneat at managed or separately operated services:
+
+```yaml
+postgresql:
+  enabled: false
+externalPostgresql:
+  host: postgres.internal
+  port: 5432
+  database: moneat
+  username: moneat
+
+clickhouse:
+  enabled: false
+externalClickHouse:
+  url: https://clickhouse.internal:8123
+  database: moneat
+  username: moneat
+
+redis:
+  enabled: false
+externalRedis:
+  host: redis.internal
+  port: 6379
+
+secrets:
+  create: false
+  existingSecret: moneat-env
+```
+
+## Optional Datadog Agent
+
+The Helm chart can deploy a Datadog Agent DaemonSet that sends telemetry to the Moneat backend. It is disabled by default.
+
+Create an Agent API key in Moneat, store it as `DD_API_KEY` in the Helm Secret, then enable:
+
+```yaml
+datadog:
+  enabled: true
+```
+
+This is separate from [Kubernetes Monitoring](/docs/datadog-agent/kubernetes), which explains how Moneat displays Kubernetes resources collected by the Datadog Agent.
+
+## Upgrade and Rollback
+
+Upgrade to a new image tag:
+
+```bash
+helm repo update
+
+helm upgrade moneat moneat/moneat \
+  --namespace moneat \
+  --reuse-values \
+  --set image.tag=v1.0.1
+```
+
+Rollback:
+
+```bash
+helm rollback moneat 1 --namespace moneat
+```
+
+Database migrations run on backend startup. Back up persistent data before upgrades.
+
+## Backup and Restore
+
+Back up these stores before upgrades or migrations:
+
+| Store | Contents |
+|-------|----------|
+| Postgres | Users, organizations, projects, auth tokens, billing state, release metadata. |
+| ClickHouse | Events, logs, traces, metrics, profiles metadata, analytics, monitoring data. |
+| Redis | Queues, cache, rate-limit state. |
+| Backend storage | Profiles, source maps, chunks, artifact bundles. |
+
+Use `pg_dump` or your managed Postgres backup tooling, ClickHouse backups or snapshots for ClickHouse, Redis RDB/AOF snapshots, and CSI snapshots or object storage backups for PVCs.
+
+## Uninstall
+
+```bash
+helm uninstall moneat --namespace moneat
+```
+
+By default, data PVCs are retained. Delete PVCs manually only after confirming backups:
+
+```bash
+kubectl get pvc -n moneat
+kubectl delete pvc -n moneat <claim-name>
+```

--- a/dashboard/src/docs/pages/self-hosting.mdx
+++ b/dashboard/src/docs/pages/self-hosting.mdx
@@ -1,11 +1,20 @@
 ---
 title: Self-Hosting
-description: Deploy Moneat on your own infrastructure with Docker Compose.
+description: Deploy Moneat on your own infrastructure with Docker Compose or Helm.
 ---
 
 # Self-Hosting
 
-Moneat can be self-hosted using Docker Compose. The self-hosted edition includes all core features with no event limits. Enterprise features (On-Call, SSO) require a license.
+Moneat can be self-hosted with Docker Compose or Helm. The self-hosted edition includes all core features with no event limits. Enterprise features such as On-Call and SAML SSO require a license.
+
+## Choose an Install Path
+
+| Path | Best for | Notes |
+|------|----------|-------|
+| Docker Compose | Single-server installs and quick evaluation | Fastest path. Includes Postgres, ClickHouse, Redis, backend, and dashboard. |
+| Helm | Kubernetes installs | Use bundled single-node data services for simple installs, or point Moneat at externally managed Postgres, ClickHouse, and Redis. |
+
+For Kubernetes, see [Kubernetes / Helm](/docs/kubernetes-helm).
 
 ## Requirements
 
@@ -13,7 +22,7 @@ Moneat can be self-hosted using Docker Compose. The self-hosted edition includes
 - 2 CPU cores and 2 GB RAM minimum (4 GB recommended)
 - A Linux server (Ubuntu 22.04+, Debian 12+, or similar)
 
-## Install
+## Docker Compose Install
 
 The interactive installer handles version selection, secrets, port allocation, and Docker setup:
 
@@ -56,7 +65,7 @@ Then start:
 docker compose up -d
 ```
 
-## Upgrading
+## Docker Compose Upgrading
 
 ```bash
 docker compose pull
@@ -64,6 +73,23 @@ docker compose up -d
 ```
 
 Database migrations run automatically on backend startup.
+
+## Kubernetes / Helm
+
+The Helm chart is published at `https://charts.moneat.io`:
+
+```bash
+helm repo add moneat https://charts.moneat.io
+helm repo update
+
+helm upgrade --install moneat moneat/moneat \
+  --namespace moneat \
+  --create-namespace \
+  --set app.frontendUrl=https://moneat.example.com \
+  --set app.backendUrl=https://api.moneat.example.com
+```
+
+Use the Helm path when you already operate Kubernetes, need Ingress/cert-manager integration, or want external managed databases. Continue with [Kubernetes / Helm](/docs/kubernetes-helm).
 
 ## Telemetry
 

--- a/dashboard/src/docs/sidebar.ts
+++ b/dashboard/src/docs/sidebar.ts
@@ -86,7 +86,7 @@ export const docsSidebar: SidebarCategory[] = [
   {
     label: 'Self-Hosting',
     collapsed: false,
-    items: ['self-hosting'],
+    items: ['self-hosting', 'kubernetes-helm'],
   },
   {
     label: 'Account',


### PR DESCRIPTION
## Summary
- add the public self-hosted Helm chart under charts/moneat
- document Docker Compose and Helm as separate self-hosting paths
- update release automation to package and publish charts to charts.moneat.io with release-pinned image tags

## Validation
- helm lint --strict charts/moneat
- helm template charts/moneat defaults, external services, and production-like examples
- simulated release chart packaging for v9.8.7
- ruby YAML parse for .github/workflows/release.yml
- npm run lint in dashboard
- npx vite build in dashboard