### PR TITLE
feat: add datadog widget import support

### DIFF
--- a/backend/src/main/kotlin/com/moneat/config/DemoDataReseeder.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoDataReseeder.kt
@@ -93,7 +93,7 @@ private data class ReseedSnapshot(
                 freshDatadogCount > 0,
                 freshSecurityCount > 0,
                 freshSyntheticsCount > 0,
-                demoDashboardCount >= 4,
+                demoDashboardCount >= DEMO_DASHBOARD_SEED_COUNT,
             ).all { it }
         return coreDataFresh && hasFreshInfra
     }
@@ -275,7 +275,7 @@ private suspend fun maybeReseedSbom(freshSbomCount: Long) {
 }
 
 private suspend fun maybeReseedDashboards(demoDashboardCount: Long) {
-    if (demoDashboardCount >= 4) {
+    if (demoDashboardCount >= DEMO_DASHBOARD_SEED_COUNT) {
         logger.info { "Demo dashboards are present ($demoDashboardCount), skipping dashboard reseed" }
         return
     }

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedDashboards.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedDashboards.kt
@@ -108,6 +108,7 @@ private val json = Json {
 
 private const val DEMO_ORG_ID = -1L
 private const val DEMO_USER_ID = -1L
+internal const val DEMO_DASHBOARD_SEED_COUNT = 5
 
 internal fun seedDemoDashboards() {
     runCatching {
@@ -128,6 +129,7 @@ internal fun seedDemoDashboards() {
             seedPerformanceDashboard()
             seedLlmMonitoringDashboard()
             seedWebAnalyticsDashboard()
+            seedWidgetGalleryDashboard()
         }
         logger.info { "Demo dashboards seeded successfully" }
     }.getOrElse { e ->
@@ -904,4 +906,356 @@ internal fun seedWebAnalyticsDashboard() {
         ),
         order = 10,
     )
+}
+
+// ── Widget Gallery Dashboard ──────────────────────────────────────────
+
+private data class DemoGalleryQuerySpec(
+    val dataSource: String,
+    val groupByFields: List<String>,
+    val metricAlias: String = "count",
+    val filters: List<FilterDef> = emptyList(),
+    val orderBy: OrderByDef? = null,
+    val limit: Int = 20,
+)
+
+private fun countByFieldsQuery(spec: DemoGalleryQuerySpec): QueryDsl =
+    QueryDsl(
+        dataSource = spec.dataSource,
+        metrics = listOf(MetricDef(AggFunction.COUNT, alias = spec.metricAlias)),
+        groupBy = spec.groupByFields.map { GroupByDef(it, GroupByType.FIELD) },
+        filters = spec.filters,
+        orderBy = spec.orderBy ?: OrderByDef(spec.metricAlias, "desc"),
+        timeRange = defaultTimeRange,
+        limit = spec.limit,
+    )
+
+private fun countByTimeAndFieldsQuery(spec: DemoGalleryQuerySpec): QueryDsl =
+    countByFieldsQuery(spec).copy(
+        groupBy = listOf(GroupByDef("timestamp", GroupByType.TIME, DEMO_DASHBOARD_TIME_BUCKET)) +
+            spec.groupByFields.map { GroupByDef(it, GroupByType.FIELD) },
+        orderBy = spec.orderBy ?: OrderByDef("time_bucket", "desc"),
+    )
+
+private fun insertWidgetGallerySection(dashboardId: Long, row: Int, order: Int): Int =
+    insertDemoDashboardSectionRow(dashboardId, "Generic widget previews", row, order)
+
+private fun insertWidgetGalleryTopRow(dashboardId: Long, row: Int) {
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Event Stream",
+                type = "stream",
+                grid = DemoWidgetGrid(0, row, 6, 4),
+            ),
+            queries = listOf(
+                countByTimeAndFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "events",
+                        groupByFields = listOf("level", "environment", "message"),
+                        limit = 40,
+                    ),
+                ),
+            ),
+            order = 1,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Incident Timeline",
+                type = "timeline",
+                grid = DemoWidgetGrid(6, row, 6, 4),
+            ),
+            queries = listOf(
+                countByTimeAndFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "events",
+                        groupByFields = listOf("message", "platform"),
+                        limit = 24,
+                    ),
+                ),
+            ),
+            order = 2,
+        ),
+    )
+}
+
+private fun insertWidgetGalleryMapRow(dashboardId: Long, row: Int) {
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Traffic Geography",
+                type = "geo_map",
+                grid = DemoWidgetGrid(0, row, 4, 4),
+            ),
+            queries = listOf(
+                countByFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "analytics_events",
+                        groupByFields = listOf("country_code", "city"),
+                        orderBy = OrderByDef("views", "desc"),
+                        metricAlias = "views",
+                        limit = 50,
+                    ),
+                ),
+            ),
+            order = 3,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Host Load Map",
+                type = "host_map",
+                grid = DemoWidgetGrid(4, row, 4, 4),
+            ),
+            queries = listOf(
+                countByFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "events",
+                        groupByFields = listOf("server_name", "environment"),
+                        limit = 80,
+                    ),
+                ),
+            ),
+            order = 4,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Service Topology",
+                type = "topology_map",
+                grid = DemoWidgetGrid(8, row, 4, 4),
+            ),
+            queries = listOf(
+                countByFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "events",
+                        groupByFields = listOf("platform", "server_name"),
+                        limit = 18,
+                    ),
+                ),
+            ),
+            order = 5,
+        ),
+    )
+}
+
+private fun insertWidgetGalleryBreakdownRow(dashboardId: Long, row: Int) {
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Service to Host Flow",
+                type = "sankey",
+                grid = DemoWidgetGrid(0, row, 4, 4),
+            ),
+            queries = listOf(
+                countByFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "events",
+                        groupByFields = listOf("platform", "server_name"),
+                        limit = 40,
+                    ),
+                ),
+            ),
+            order = 6,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Event Treemap",
+                type = "treemap",
+                grid = DemoWidgetGrid(4, row, 4, 4),
+            ),
+            queries = listOf(
+                countByFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "events",
+                        groupByFields = listOf("platform", "environment"),
+                        limit = 40,
+                    ),
+                ),
+            ),
+            order = 7,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Endpoint Status",
+                type = "status",
+                grid = DemoWidgetGrid(8, row, 4, 4),
+            ),
+            queries = listOf(
+                countByFieldsQuery(
+                    DemoGalleryQuerySpec(
+                        dataSource = "events",
+                        groupByFields = listOf("transaction_name", "level", "environment"),
+                        limit = 36,
+                    ),
+                ),
+            ),
+            order = 8,
+        ),
+    )
+}
+
+private fun insertWidgetGalleryAnalysisRow(dashboardId: Long, row: Int) {
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Latency vs Volume",
+                type = "scatter",
+                grid = DemoWidgetGrid(0, row, 4, 4),
+            ),
+            queries = listOf(
+                QueryDsl(
+                    dataSource = "events",
+                    metrics = listOf(
+                        MetricDef(AggFunction.AVG, "duration_ms", "avg_ms"),
+                        MetricDef(AggFunction.COUNT, alias = "events"),
+                    ),
+                    groupBy = listOf(GroupByDef("transaction_name", GroupByType.FIELD)),
+                    filters = listOf(FilterDef("event_type", FilterOp.EQ, "transaction")),
+                    orderBy = OrderByDef("events", "desc"),
+                    timeRange = defaultTimeRange,
+                    limit = 40,
+                ),
+            ),
+            display = mapOf("unit" to "ms"),
+            order = 9,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Request Change",
+                type = "change",
+                grid = DemoWidgetGrid(4, row, 4, 4),
+            ),
+            queries = listOf(
+                QueryDsl(
+                    dataSource = "events",
+                    metrics = listOf(MetricDef(AggFunction.COUNT, alias = "requests")),
+                    groupBy = listOf(GroupByDef("timestamp", GroupByType.TIME, DEMO_DASHBOARD_TIME_BUCKET)),
+                    filters = listOf(FilterDef("event_type", FilterOp.EQ, "transaction")),
+                    timeRange = defaultTimeRange,
+                    limit = 1000,
+                ),
+            ),
+            display = mapOf("unit" to "short"),
+            order = 10,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Trace Flame Graph",
+                type = "flame_graph",
+                grid = DemoWidgetGrid(8, row, 4, 4),
+            ),
+            queries = listOf(
+                QueryDsl(
+                    dataSource = "events",
+                    metrics = listOf(MetricDef(AggFunction.P95, "duration_ms", "p95_ms")),
+                    groupBy = listOf(
+                        GroupByDef("transaction_name", GroupByType.FIELD),
+                        GroupByDef("transaction_op", GroupByType.FIELD),
+                    ),
+                    filters = listOf(FilterDef("event_type", FilterOp.EQ, "transaction")),
+                    orderBy = OrderByDef("p95_ms", "desc"),
+                    timeRange = defaultTimeRange,
+                    limit = 40,
+                ),
+            ),
+            order = 11,
+        ),
+    )
+}
+
+private fun insertWidgetGalleryContentRow(dashboardId: Long, row: Int) {
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Model Cost Summary",
+                type = "cost_summary",
+                grid = DemoWidgetGrid(0, row, 4, 4),
+            ),
+            queries = listOf(
+                QueryDsl(
+                    dataSource = "llm_generations",
+                    metrics = listOf(MetricDef(AggFunction.SUM, "cost_usd", "cost")),
+                    groupBy = listOf(
+                        GroupByDef("model", GroupByType.FIELD),
+                        GroupByDef("provider", GroupByType.FIELD),
+                    ),
+                    orderBy = OrderByDef("cost", "desc"),
+                    timeRange = defaultTimeRange,
+                    limit = 12,
+                ),
+            ),
+            display = mapOf("decimals" to "4"),
+            order = 12,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Import Notes",
+                type = "custom",
+                grid = DemoWidgetGrid(4, row, 4, 4),
+            ),
+            queries = emptyList(),
+            display = mapOf(
+                "content" to "### Widget gallery\n\nThis dashboard previews the generic widget shapes used by imports.",
+            ),
+            order = 13,
+        ),
+    )
+    insertWidget(
+        DemoWidgetInsertSpec(
+            dashboardId = dashboardId,
+            presentation = DemoWidgetPresentation(
+                title = "Embedded Runbook",
+                type = "iframe",
+                grid = DemoWidgetGrid(8, row, 4, 4),
+            ),
+            queries = emptyList(),
+            display = mapOf("iframe_url" to "/demo/widget-preview-embed.html"),
+            order = 14,
+        ),
+    )
+}
+
+internal fun seedWidgetGalleryDashboard() {
+    val id = insertDashboard(
+        "Widget Gallery",
+        "Preview of generic Moneat widget types using the demo telemetry dataset",
+    )
+    var row = insertWidgetGallerySection(id, row = 0, order = 0)
+    insertWidgetGalleryTopRow(id, row)
+    row += 4
+    insertWidgetGalleryMapRow(id, row)
+    row += 4
+    insertWidgetGalleryBreakdownRow(id, row)
+    row += 4
+    insertWidgetGalleryAnalysisRow(id, row)
+    row += 4
+    insertWidgetGalleryContentRow(id, row)
 }

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedDashboards.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedDashboards.kt
@@ -1053,7 +1053,7 @@ private fun insertWidgetGalleryBreakdownRow(dashboardId: Long, row: Int) {
         DemoWidgetInsertSpec(
             dashboardId = dashboardId,
             presentation = DemoWidgetPresentation(
-                title = "Service to Host Flow",
+                title = "Platform to Environment Flow",
                 type = "sankey",
                 grid = DemoWidgetGrid(0, row, 4, 4),
             ),
@@ -1061,7 +1061,7 @@ private fun insertWidgetGalleryBreakdownRow(dashboardId: Long, row: Int) {
                 countByFieldsQuery(
                     DemoGalleryQuerySpec(
                         dataSource = "events",
-                        groupByFields = listOf("platform", "server_name"),
+                        groupByFields = listOf("platform", "environment"),
                         limit = 40,
                     ),
                 ),
@@ -1124,17 +1124,29 @@ private fun insertWidgetGalleryAnalysisRow(dashboardId: Long, row: Int) {
                 QueryDsl(
                     dataSource = "events",
                     metrics = listOf(
-                        MetricDef(AggFunction.AVG, "duration_ms", "avg_ms"),
                         MetricDef(AggFunction.COUNT, alias = "events"),
+                        MetricDef(AggFunction.AVG, "duration_ms", "avg_ms"),
                     ),
-                    groupBy = listOf(GroupByDef("transaction_name", GroupByType.FIELD)),
+                    groupBy = listOf(
+                        GroupByDef("transaction_name", GroupByType.FIELD),
+                        GroupByDef("platform", GroupByType.FIELD),
+                        GroupByDef("environment", GroupByType.FIELD),
+                    ),
                     filters = listOf(FilterDef("event_type", FilterOp.EQ, "transaction")),
                     orderBy = OrderByDef("events", "desc"),
                     timeRange = defaultTimeRange,
                     limit = 40,
                 ),
             ),
-            display = mapOf("unit" to "ms"),
+            display = mapOf(
+                "unit" to "ms",
+                "x_key" to "events",
+                "x_label" to "event count",
+                "x_unit" to "short",
+                "y_key" to "avg_ms",
+                "y_label" to "avg latency",
+                "y_unit" to "ms",
+            ),
             order = 9,
         ),
     )

--- a/backend/src/main/kotlin/com/moneat/dashboards/translation/DataDogTranslator.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/translation/DataDogTranslator.kt
@@ -49,10 +49,17 @@ private const val DD_AUTO_WIDGETS_PER_ROW = 2
 private const val DD_DEFAULT_TABLE_LIMIT = 100
 private const val DD_GROUP_BY_MATCH_GROUP_INDEX = 4
 
+private const val DD_IMPORT_STRATEGY_NATIVE = "native"
+private const val DD_IMPORT_STRATEGY_UNSUPPORTED = "unsupported"
+private const val SOURCE_DEFINITION_JSON_KEY = "source_definition_json"
+private const val SOURCE_LAYOUT_JSON_KEY = "source_layout_json"
+
 private val DD_METRIC_QUERY_REGEX = Regex(
     """^\s*([A-Za-z_][A-Za-z0-9_]*):([A-Za-z0-9_.]+)\{([^}]*)}\s*(?:by\s+\{([^}]*)})?\s*$"""
 )
 private val DD_SIMPLE_FORMULA_REGEX = Regex("""^[A-Za-z_][A-Za-z0-9_]*$""")
+private val DD_IN_TAG_REGEX = Regex("""^([A-Za-z0-9_.-]+)\s+IN\s+\(([^)]*)\)$""", RegexOption.IGNORE_CASE)
+private val DD_NOT_IN_TAG_REGEX = Regex("""^([A-Za-z0-9_.-]+)\s+NOT\s+IN\s+\(([^)]*)\)$""", RegexOption.IGNORE_CASE)
 
 private data class DataDogLayout(
     val x: Int,
@@ -68,22 +75,54 @@ private data class ParsedDataDogQuery(
     val groupByText: String?
 )
 
+private data class DataDogWidgetImportSupport(
+    val moneatType: String,
+    val strategy: String = DD_IMPORT_STRATEGY_NATIVE
+)
+
+private fun native(moneatType: String): DataDogWidgetImportSupport {
+    return DataDogWidgetImportSupport(moneatType)
+}
+
+private data class NamedDataDogQuery(
+    val name: String?,
+    val dsl: QueryDsl
+)
+
 class DataDogTranslator : DashboardTranslator {
 
-    private val widgetTypeMap = mapOf(
-        "timeseries" to "timeseries",
-        "toplist" to "toplist",
-        "query_value" to "stat",
-        "table" to "table",
-        "query_table" to "table",
-        "heatmap" to "heatmap",
-        "distribution" to "bar",
-        "pie" to "donut",
-        "sunburst" to "donut",
-        "note" to "text",
-        "free_text" to "text",
-        "image" to "text",
-        "group" to "section"
+    private val widgetImportSupportByType = mapOf(
+        "timeseries" to native("timeseries"),
+        "toplist" to native("toplist"),
+        "query_value" to native("stat"),
+        "table" to native("table"),
+        "query_table" to native("table"),
+        "heatmap" to native("heatmap"),
+        "distribution" to native("bar"),
+        "pie" to native("donut"),
+        "sunburst" to native("donut"),
+        "note" to native("text"),
+        "free_text" to native("text"),
+        "image" to native("text"),
+        "group" to native("section"),
+        "bar_chart" to native("bar"),
+        "list_stream" to native("stream"),
+        "log_stream" to native("stream"),
+        "event_stream" to native("stream"),
+        "event_timeline" to native("timeline"),
+        "geomap" to native("geo_map"),
+        "hostmap" to native("host_map"),
+        "topology_map" to native("topology_map"),
+        "sankey" to native("sankey"),
+        "treemap" to native("treemap"),
+        "scatterplot" to native("scatter"),
+        "check_status" to native("status"),
+        "manage_status" to native("status"),
+        "change" to native("change"),
+        "wildcard" to native("custom"),
+        "flame_graph" to native("flame_graph"),
+        "cloud_cost_summary" to native("cost_summary"),
+        "iframe" to native("iframe")
     )
 
     private val reverseWidgetTypeMap = mapOf(
@@ -94,7 +133,21 @@ class DataDogTranslator : DashboardTranslator {
         "heatmap" to "heatmap",
         "bar" to "distribution",
         "donut" to "pie",
-        "text" to "note"
+        "text" to "note",
+        "stream" to "list_stream",
+        "timeline" to "event_timeline",
+        "geo_map" to "geomap",
+        "host_map" to "hostmap",
+        "topology_map" to "topology_map",
+        "sankey" to "sankey",
+        "treemap" to "treemap",
+        "scatter" to "scatterplot",
+        "status" to "check_status",
+        "change" to "change",
+        "custom" to "wildcard",
+        "flame_graph" to "flame_graph",
+        "cost_summary" to "cloud_cost_summary",
+        "iframe" to "iframe"
     )
 
     private val metricNamespaceMap = mapOf(
@@ -175,9 +228,12 @@ class DataDogTranslator : DashboardTranslator {
     ): List<WidgetResponse> {
         val definition = widgetJson["definition"]?.jsonObject ?: JsonObject(emptyMap())
         val ddType = definition["type"]?.jsonPrimitive?.contentOrNull ?: "timeseries"
-        val moneatType = widgetTypeMap[ddType]
-        if (moneatType == null) {
-            warnings.add("Widget $index: unsupported type '$ddType', imported as 'text'")
+        val support = widgetImportSupportByType[ddType]
+        if (support == null) {
+            warnings.add(
+                "Widget $index: unsupported Datadog widget type '$ddType', imported as 'text'; " +
+                    "original definition was preserved in displayConfig.$SOURCE_DEFINITION_JSON_KEY"
+            )
         }
 
         if (ddType == "group") {
@@ -187,14 +243,14 @@ class DataDogTranslator : DashboardTranslator {
         val resolvedLayout = resolveLayout(layout, parentLayout)
         val widgetTitle = definition["title"]?.jsonPrimitive?.contentOrNull
         val queryConfigs = parseDataDogQueries(definition, warnings, index)
-        val displayConfig = extractDisplayConfig(definition, ddType)
+        val displayConfig = extractDisplayConfig(definition, layout, ddType, support)
 
         return listOf(
             WidgetResponse(
                 id = 0,
                 dashboardId = 0,
                 title = widgetTitle,
-                widgetType = moneatType ?: "text",
+                widgetType = support?.moneatType ?: "text",
                 gridX = resolvedLayout.x.coerceIn(0, DD_MAX_GRID_COL),
                 gridY = resolvedLayout.y,
                 gridW = resolvedLayout.width.coerceIn(1, DD_GRID_COLS),
@@ -228,7 +284,8 @@ class DataDogTranslator : DashboardTranslator {
             queryConfigs = emptyList(),
             displayConfig = mapOf(
                 "source_format" to "datadog",
-                "datadog_widget_type" to "group",
+                "source_widget_type" to "group",
+                "source_import_strategy" to DD_IMPORT_STRATEGY_NATIVE,
                 "collapsed" to "false"
             ),
             sortOrder = index
@@ -262,22 +319,45 @@ class DataDogTranslator : DashboardTranslator {
         )
     }
 
-    private fun extractDisplayConfig(definition: JsonObject, ddType: String): Map<String, String> {
+    private fun extractDisplayConfig(
+        definition: JsonObject,
+        layout: DataDogLayout,
+        ddType: String,
+        support: DataDogWidgetImportSupport?
+    ): Map<String, String> {
         val config = mutableMapOf(
             "source_format" to "datadog",
-            "datadog_widget_type" to ddType
+            "source_widget_type" to ddType,
+            "source_import_strategy" to (support?.strategy ?: DD_IMPORT_STRATEGY_UNSUPPORTED),
+            SOURCE_DEFINITION_JSON_KEY to definition.toString(),
+            SOURCE_LAYOUT_JSON_KEY to layout.toJsonObject().toString()
         )
+        config["source_request_count"] = (definition["requests"]?.jsonArray?.size ?: 0).toString()
+        config["source_query_count"] = countDataDogQueries(definition).toString()
+        if (definition["requests"]?.jsonArray?.any { it.jsonObject["formulas"] is JsonArray } == true) {
+            config["source_has_formulas"] = "true"
+        }
         definition["content"]?.jsonPrimitive?.contentOrNull?.let { content ->
             config["content"] = content
         }
         definition["url"]?.jsonPrimitive?.contentOrNull?.let { url ->
-            config["content"] = "![]($url)"
+            config["content"] = if (ddType == "iframe") "[$url]($url)" else "![]($url)"
             config["image_url"] = url
+            if (ddType == "iframe") {
+                config["iframe_url"] = url
+            }
         }
         definition["legend_layout"]?.jsonPrimitive?.contentOrNull?.let { config["legendLayout"] = it }
         definition["display_type"]?.jsonPrimitive?.contentOrNull?.let { config["displayType"] = it }
         definition["background_color"]?.jsonPrimitive?.contentOrNull?.let { config["backgroundColor"] = it }
         return config
+    }
+
+    private fun DataDogLayout.toJsonObject(): JsonObject = buildJsonObject {
+        put("x", x)
+        put("y", y)
+        put("width", width)
+        put("height", height)
     }
 
     internal fun parseDataDogQuery(
@@ -293,15 +373,11 @@ class DataDogTranslator : DashboardTranslator {
         warnings: MutableList<String>,
         widgetIndex: Int
     ): List<QueryDsl> {
+        val ddType = definition["type"]?.jsonPrimitive?.contentOrNull ?: "timeseries"
         val requests = definition["requests"]?.jsonArray
 
         if (requests.isNullOrEmpty()) {
-            return listOf(
-                QueryDsl(
-                    dataSource = "events",
-                    metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count"))
-                )
-            )
+            return listOf(defaultQueryForWidget(definition, ddType, warnings, widgetIndex))
         }
 
         val parsedQueries = requests.flatMap { requestElement ->
@@ -330,26 +406,58 @@ class DataDogTranslator : DashboardTranslator {
             return listOf(parseDataDogQueryString(queryStr, warnings, widgetIndex))
         }
 
-        val formulaAliases = extractFormulaAliases(request)
         val queries = request["queries"]?.jsonArray ?: return emptyList()
-        return queries.mapNotNull { queryElement ->
+        val namedQueries = queries.mapNotNull { queryElement ->
             val queryObj = queryElement.jsonObject
-            val queryStr = queryObj["query"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            val queryStr = extractDataDogQueryString(queryObj) ?: return@mapNotNull null
             val queryName = queryObj["name"]?.jsonPrimitive?.contentOrNull
-            val alias = queryName?.let { formulaAliases[it] } ?: queryName
-            parseDataDogQueryString(queryStr, warnings, widgetIndex, alias, queryName)
+            val dataSource = queryObj["data_source"]?.jsonPrimitive?.contentOrNull
+            val parsed = parseDataDogQueryString(queryStr, warnings, widgetIndex, queryName, queryName)
+            NamedDataDogQuery(queryName, applyDataDogQuerySource(parsed, dataSource))
         }
+
+        val formulaQueries = parseFormulaQueries(request, namedQueries, warnings, widgetIndex)
+        val hasPreservedFormula = formulaQueries.any { query ->
+            query.rawQuery != null && namedQueries.none { it.dsl.rawQuery == query.rawQuery }
+        }
+        if (hasPreservedFormula) {
+            return namedQueries.map { it.dsl } + formulaQueries
+        }
+        return formulaQueries.ifEmpty { namedQueries.map { it.dsl } }
     }
 
-    private fun extractFormulaAliases(request: JsonObject): Map<String, String> {
-        val formulas = request["formulas"]?.jsonArray ?: return emptyMap()
+    private fun parseFormulaQueries(
+        request: JsonObject,
+        namedQueries: List<NamedDataDogQuery>,
+        warnings: MutableList<String>,
+        widgetIndex: Int
+    ): List<QueryDsl> {
+        val formulas = request["formulas"]?.jsonArray ?: return emptyList()
         return formulas.mapNotNull { formulaElement ->
             val formula = formulaElement.jsonObject
             val expression = formula["formula"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
-            if (!DD_SIMPLE_FORMULA_REGEX.matches(expression)) return@mapNotNull null
-            val alias = formula["alias"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
-            expression to alias
-        }.toMap()
+            val alias = formula["alias"]?.jsonPrimitive?.contentOrNull
+            if (DD_SIMPLE_FORMULA_REGEX.matches(expression)) {
+                val namedQuery = namedQueries.firstOrNull { it.name == expression }
+                if (namedQuery != null) {
+                    return@mapNotNull namedQuery.dsl.withMetricAlias(alias)
+                }
+            }
+            warnings.add(
+                "Widget $widgetIndex: Datadog formula '$expression' cannot be translated directly; " +
+                    "preserved as raw query for manual review"
+            )
+            rawFormulaQueryDsl(expression, alias)
+        }
+    }
+
+    private fun QueryDsl.withMetricAlias(alias: String?): QueryDsl {
+        if (alias.isNullOrBlank() || metrics.isEmpty()) return this
+        return copy(
+            metrics = metrics.mapIndexed { index, metric ->
+                if (index == 0) metric.copy(alias = alias) else metric
+            }
+        )
     }
 
     internal fun parseDataDogQueryString(
@@ -401,6 +509,15 @@ class DataDogTranslator : DashboardTranslator {
         )
     }
 
+    private fun rawFormulaQueryDsl(expression: String, alias: String?): QueryDsl {
+        return QueryDsl(
+            dataSource = "metrics",
+            metrics = listOf(MetricDef(AggFunction.AVG, "value", alias ?: "formula")),
+            groupBy = listOf(GroupByDef("timestamp", GroupByType.TIME, "auto")),
+            rawQuery = expression
+        )
+    }
+
     private fun parseDataDogTags(
         tagText: String?,
         dataSource: String,
@@ -412,11 +529,40 @@ class DataDogTranslator : DashboardTranslator {
         }
         if (tagText.isNullOrBlank() || tagText == "*") return filters
 
-        tagText.split(",")
+        splitDataDogTags(tagText)
             .map { it.trim() }
             .filter { it.isNotBlank() && it != "*" }
             .forEach { tag -> addDataDogTagFilter(tag, dataSource, filters) }
         return filters
+    }
+
+    private fun splitDataDogTags(tagText: String): List<String> {
+        val tags = mutableListOf<String>()
+        val current = StringBuilder()
+        var parenthesisDepth = 0
+        for (char in tagText) {
+            when (char) {
+                '(' -> {
+                    parenthesisDepth++
+                    current.append(char)
+                }
+                ')' -> {
+                    parenthesisDepth = (parenthesisDepth - 1).coerceAtLeast(0)
+                    current.append(char)
+                }
+                ',' -> {
+                    if (parenthesisDepth == 0) {
+                        tags.add(current.toString())
+                        current.clear()
+                    } else {
+                        current.append(char)
+                    }
+                }
+                else -> current.append(char)
+            }
+        }
+        tags.add(current.toString())
+        return tags
     }
 
     private fun addDataDogTagFilter(tag: String, dataSource: String, filters: MutableList<FilterDef>) {
@@ -432,15 +578,28 @@ class DataDogTranslator : DashboardTranslator {
             return FilterDef(name, FilterOp.EQ, tag)
         }
 
-        val normalized = tag.removePrefix("!")
+        DD_NOT_IN_TAG_REGEX.matchEntire(tag)?.let { match ->
+            return FilterDef(match.groupValues[1], FilterOp.NOT_IN, values = parseTagValues(match.groupValues[2]))
+        }
+        DD_IN_TAG_REGEX.matchEntire(tag)?.let { match ->
+            return FilterDef(match.groupValues[1], FilterOp.IN, values = parseTagValues(match.groupValues[2]))
+        }
+
+        val normalized = tag.removePrefix("!").removePrefix("-")
         val parts = normalized.split(":", limit = 2)
         if (parts.size != 2 || parts[1] == "*") return null
 
         return FilterDef(
             field = parts[0].trim(),
-            op = if (tag.startsWith("!")) FilterOp.NEQ else FilterOp.EQ,
+            op = if (tag.startsWith("!") || tag.startsWith("-")) FilterOp.NEQ else FilterOp.EQ,
             value = parts[1].trim()
         )
+    }
+
+    private fun parseTagValues(valueText: String): List<String> {
+        return valueText.split(",")
+            .map { it.trim().trim('\'', '"') }
+            .filter { it.isNotBlank() }
     }
 
     private fun parseDataDogGroupBy(groupByText: String?, dataSource: String): List<GroupByDef> {
@@ -488,6 +647,75 @@ class DataDogTranslator : DashboardTranslator {
         }
     }
 
+    private fun defaultQueryForWidget(
+        definition: JsonObject,
+        ddType: String,
+        warnings: MutableList<String>,
+        widgetIndex: Int
+    ): QueryDsl {
+        val dataSource = defaultDataSourceForWidget(ddType)
+        val query = extractDataDogQueryString(definition)
+        if (!query.isNullOrBlank()) {
+            warnings.add(
+                "Widget $widgetIndex: Datadog widget type '$ddType' query preserved as raw query; " +
+                    "manual review is required before it can execute"
+            )
+            return preservedRawQueryDsl(query, dataSource)
+        }
+        return QueryDsl(
+            dataSource = dataSource,
+            metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count"))
+        )
+    }
+
+    private fun defaultDataSourceForWidget(ddType: String): String = when (ddType) {
+        "log_stream", "list_stream" -> "logs"
+        "event_stream", "event_timeline" -> "events"
+        "flame_graph", "topology_map", "sankey" -> "spans"
+        "hostmap", "check_status", "manage_status", "cloud_cost_summary" -> "metrics"
+        else -> "events"
+    }
+
+    private fun extractDataDogQueryString(json: JsonObject): String? {
+        json["query"]?.jsonPrimitive?.contentOrNull?.let { return it }
+        json["q"]?.jsonPrimitive?.contentOrNull?.let { return it }
+        return json["search"]?.jsonObject?.get("query")?.jsonPrimitive?.contentOrNull
+    }
+
+    private fun applyDataDogQuerySource(dsl: QueryDsl, dataDogSource: String?): QueryDsl {
+        if (dsl.rawQuery == null || dataDogSource.isNullOrBlank()) return dsl
+        val dataSource = mapDataDogQuerySource(dataDogSource)
+        return dsl.copy(
+            dataSource = dataSource,
+            metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count"))
+        )
+    }
+
+    private fun mapDataDogQuerySource(dataDogSource: String): String = when (dataDogSource.lowercase()) {
+        "logs", "log" -> "logs"
+        "events", "event" -> "events"
+        "spans", "trace", "traces", "apm", "apm_resource_stats", "profiles" -> "spans"
+        "containers", "container" -> "containers"
+        else -> "metrics"
+    }
+
+    private fun preservedRawQueryDsl(query: String, dataSource: String): QueryDsl {
+        return QueryDsl(
+            dataSource = dataSource,
+            metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count")),
+            rawQuery = query
+        )
+    }
+
+    private fun countDataDogQueries(definition: JsonObject): Int {
+        val requests = definition["requests"]?.jsonArray ?: return 0
+        return requests.sumOf { requestElement ->
+            val request = requestElement.jsonObject
+            val directQueryCount = if (request["q"]?.jsonPrimitive?.contentOrNull != null) 1 else 0
+            directQueryCount + (request["queries"]?.jsonArray?.size ?: 0)
+        }
+    }
+
     internal fun parseDataDogVariables(json: JsonObject): List<DashboardVariable> {
         val templateVars = json["template_variables"]?.jsonArray ?: return emptyList()
 
@@ -522,7 +750,7 @@ class DataDogTranslator : DashboardTranslator {
                 put(
                     "definition",
                     buildJsonObject {
-                        put("type", reverseWidgetTypeMap[widget.widgetType] ?: "timeseries")
+                        put("type", exportDataDogWidgetType(widget))
                         widget.title?.let { put("title", it) }
                         widget.displayConfig["content"]?.let { put("content", it) }
                         put(
@@ -588,6 +816,17 @@ class DataDogTranslator : DashboardTranslator {
                 )
             }
         }
+    }
+
+    private fun exportDataDogWidgetType(widget: WidgetResponse): String {
+        val sourceType = widget.displayConfig["source_widget_type"]
+        if (widget.displayConfig["source_format"] == "datadog" &&
+            sourceType != null &&
+            widgetImportSupportByType.containsKey(sourceType)
+        ) {
+            return sourceType
+        }
+        return reverseWidgetTypeMap[widget.widgetType] ?: "timeseries"
     }
 
     internal fun buildDdQueryString(dsl: QueryDsl): String {

--- a/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DataDogTranslatorTest.kt
@@ -41,6 +41,37 @@ class DataDogTranslatorTest {
 
     private val translator = DataDogTranslator()
     private val json = Json { ignoreUnknownKeys = true }
+    private val representativeDatadogWidgetTypes = listOf(
+        "timeseries",
+        "query_value",
+        "toplist",
+        "group",
+        "note",
+        "sunburst",
+        "query_table",
+        "image",
+        "heatmap",
+        "distribution",
+        "free_text",
+        "list_stream",
+        "geomap",
+        "check_status",
+        "manage_status",
+        "bar_chart",
+        "log_stream",
+        "treemap",
+        "change",
+        "hostmap",
+        "event_stream",
+        "wildcard",
+        "event_timeline",
+        "flame_graph",
+        "cloud_cost_summary",
+        "topology_map",
+        "sankey",
+        "iframe",
+        "scatterplot"
+    )
 
     private fun loadFixture(path: String) =
         json.parseToJsonElement(
@@ -87,6 +118,20 @@ class DataDogTranslatorTest {
             }
         )
         put("layout", datadogLayout(1, 2, 4, 3))
+    }
+
+    private fun collectDatadogWidgetTypes(dashboard: kotlinx.serialization.json.JsonObject): List<String> {
+        val widgets = dashboard["widgets"]?.jsonArray ?: return emptyList()
+        return widgets.flatMap { element -> collectDatadogWidgetTypesFromWidget(element.jsonObject) }
+    }
+
+    private fun collectDatadogWidgetTypesFromWidget(widget: kotlinx.serialization.json.JsonObject): List<String> {
+        val definition = widget["definition"]?.jsonObject ?: return emptyList()
+        val type = definition["type"]?.jsonPrimitive?.content ?: return emptyList()
+        val childTypes = definition["widgets"]?.jsonArray
+            ?.flatMap { child -> collectDatadogWidgetTypesFromWidget(child.jsonObject) }
+            ?: emptyList()
+        return listOf(type) + childTypes
     }
 
     // ──── Import ────
@@ -238,7 +283,7 @@ class DataDogTranslatorTest {
         }
         val result = translator.import(json)
         assertEquals("text", result.dashboard.widgets[0].widgetType)
-        assertTrue(result.warnings.any { it.contains("unsupported type") })
+        assertTrue(result.warnings.any { it.contains("unsupported Datadog widget type") })
     }
 
     @Test
@@ -500,8 +545,63 @@ class DataDogTranslatorTest {
         assertEquals("section", result.dashboard.widgets[2].widgetType)
         assertEquals("table", result.dashboard.widgets[3].widgetType)
         assertEquals("heatmap", result.dashboard.widgets[4].widgetType)
-        assertEquals("text", result.dashboard.widgets[5].widgetType)
-        assertTrue(result.warnings.any { it.contains("unsupported type 'scatterplot'") })
+        assertEquals("scatter", result.dashboard.widgets[5].widgetType)
+        assertTrue(result.warnings.none { it.contains("Datadog widget type 'scatterplot'") })
+    }
+
+    @Test
+    fun `import supports representative Datadog widget types without fallback warnings`() {
+        val fixture = loadFixture("dashboards/datadog/datadog-import-supported-widgets.json")
+        val fixtureTypes = collectDatadogWidgetTypes(fixture)
+        val result = translator.import(fixture)
+
+        assertTrue(fixtureTypes.containsAll(representativeDatadogWidgetTypes))
+        assertTrue(result.warnings.none { it.contains("unsupported Datadog widget type") })
+        assertTrue(result.warnings.none { it.contains("imported as") })
+
+        mapOf(
+            "timeseries" to "timeseries",
+            "toplist" to "toplist",
+            "query_value" to "stat",
+            "group" to "section",
+            "note" to "text",
+            "sunburst" to "donut",
+            "query_table" to "table",
+            "image" to "text",
+            "distribution" to "bar",
+            "free_text" to "text",
+            "list_stream" to "stream",
+            "geomap" to "geo_map",
+            "check_status" to "status",
+            "manage_status" to "status",
+            "bar_chart" to "bar",
+            "log_stream" to "stream",
+            "treemap" to "treemap",
+            "change" to "change",
+            "hostmap" to "host_map",
+            "event_stream" to "stream",
+            "wildcard" to "custom",
+            "event_timeline" to "timeline",
+            "flame_graph" to "flame_graph",
+            "cloud_cost_summary" to "cost_summary",
+            "topology_map" to "topology_map",
+            "sankey" to "sankey",
+            "iframe" to "iframe",
+            "scatterplot" to "scatter"
+        ).forEach { (datadogType, moneatType) ->
+            val widget = result.dashboard.widgets.first { it.displayConfig["source_widget_type"] == datadogType }
+            assertEquals(moneatType, widget.widgetType)
+            assertEquals("native", widget.displayConfig["source_import_strategy"])
+        }
+
+        val geomap = result.dashboard.widgets.first { it.displayConfig["source_widget_type"] == "geomap" }
+        assertTrue(geomap.displayConfig["source_definition_json"]?.contains("\"type\":\"geomap\"") == true)
+        assertTrue(geomap.displayConfig["source_layout_json"]?.contains("\"width\":6") == true)
+
+        val iframe = result.dashboard.widgets.first { it.displayConfig["source_widget_type"] == "iframe" }
+        assertEquals("iframe", iframe.widgetType)
+        assertEquals("https://status.example.com", iframe.displayConfig["iframe_url"])
+        assertTrue(iframe.displayConfig["content"]?.contains("https://status.example.com") == true)
     }
 
     // ──── parseDataDogQueryString ────
@@ -541,6 +641,27 @@ class DataDogTranslatorTest {
         assertEquals(2, dsl.filters.size)
         assertTrue(dsl.filters.any { it.field == "metric_name" && it.value == "system.disk.used" })
         assertTrue(dsl.filters.any { it.field == "host" && it.value == "web01" })
+    }
+
+    @Test
+    fun `parseDataDogQueryString supports Datadog IN and NOT IN tag filters`() {
+        val warnings = mutableListOf<String>()
+        val dsl = translator.parseDataDogQueryString(
+            "avg:system.cpu.user{host IN (web01, web02),host NOT IN (web03)}",
+            warnings,
+            0
+        )
+
+        assertTrue(
+            dsl.filters.any {
+                it.field == "host" && it.op == FilterOp.IN && it.values == listOf("web01", "web02")
+            }
+        )
+        assertTrue(
+            dsl.filters.any {
+                it.field == "host" && it.op == FilterOp.NOT_IN && it.values == listOf("web03")
+            }
+        )
     }
 
     @Test
@@ -606,6 +727,60 @@ class DataDogTranslatorTest {
         assertEquals(2, queries.size)
         assertEquals("connections", queries[0].metrics[0].alias)
         assertEquals("max connections", queries[1].metrics[0].alias)
+    }
+
+    @Test
+    fun `parseDataDogQueries preserves formula expressions and source queries`() {
+        val warnings = mutableListOf<String>()
+        val definition = buildJsonObject {
+            put("type", "scatterplot")
+            put(
+                "requests",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put(
+                                "queries",
+                                buildJsonArray {
+                                    add(
+                                        buildJsonObject {
+                                            put("name", "query1")
+                                            put("query", "sum:kubernetes.cpu.usage.total{host:web01}")
+                                        }
+                                    )
+                                    add(
+                                        buildJsonObject {
+                                            put("name", "query2")
+                                            put("query", "sum:kubernetes.cpu.requests{host:web01}")
+                                        }
+                                    )
+                                }
+                            )
+                            put(
+                                "formulas",
+                                buildJsonArray {
+                                    add(
+                                        buildJsonObject {
+                                            put("formula", "query1 / query2 * 100")
+                                            put("alias", "usage percent")
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+
+        val queries = translator.parseDataDogQueries(definition, warnings, 8)
+
+        assertEquals(3, queries.size)
+        assertEquals("query1", queries[0].refId)
+        assertEquals("query2", queries[1].refId)
+        assertEquals("query1 / query2 * 100", queries[2].rawQuery)
+        assertEquals("usage percent", queries[2].metrics.single().alias)
+        assertTrue(warnings.any { it.contains("Datadog formula 'query1 / query2 * 100'") })
     }
 
     @Test
@@ -730,6 +905,16 @@ class DataDogTranslatorTest {
                     dashboardId = 1,
                     widgetType = "donut",
                     queryConfigs = listOf(QueryDsl(dataSource = "events"))
+                ),
+                WidgetResponse(
+                    id = 3,
+                    dashboardId = 1,
+                    widgetType = "scatter",
+                    queryConfigs = listOf(QueryDsl(dataSource = "metrics")),
+                    displayConfig = mapOf(
+                        "source_format" to "datadog",
+                        "source_widget_type" to "scatterplot"
+                    )
                 )
             )
         )
@@ -737,8 +922,10 @@ class DataDogTranslatorTest {
         val widgets = exported["widgets"]!!.jsonArray
         val type0 = widgets[0].jsonObject["definition"]!!.jsonObject["type"]!!.jsonPrimitive.content
         val type1 = widgets[1].jsonObject["definition"]!!.jsonObject["type"]!!.jsonPrimitive.content
+        val type2 = widgets[2].jsonObject["definition"]!!.jsonObject["type"]!!.jsonPrimitive.content
         assertEquals("query_value", type0)
         assertEquals("pie", type1)
+        assertEquals("scatterplot", type2)
     }
 
     // ──── buildDdQueryString ────

--- a/backend/src/test/resources/dashboards/datadog/datadog-import-supported-widgets.json
+++ b/backend/src/test/resources/dashboards/datadog/datadog-import-supported-widgets.json
@@ -1,0 +1,282 @@
+{
+  "title": "Datadog Import Coverage",
+  "description": "Synthetic fixture covering Datadog integration dashboard widget shapes.",
+  "layout_type": "ordered",
+  "template_variables": [
+    {
+      "name": "env",
+      "prefix": "env",
+      "default": "production",
+      "available_values": ["production", "staging"]
+    },
+    {
+      "name": "host",
+      "prefix": "host",
+      "default": "*",
+      "available_values": []
+    }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "group",
+        "title": "Core widgets",
+        "widgets": [
+          {
+            "definition": {
+              "type": "timeseries",
+              "title": "CPU",
+              "requests": [{"q": "avg:system.cpu.user{host:$host}"}]
+            },
+            "layout": {"x": 0, "y": 0, "width": 6, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "query_value",
+              "title": "Errors",
+              "requests": [{"q": "count:events{*}"}]
+            },
+            "layout": {"x": 6, "y": 0, "width": 3, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "toplist",
+              "title": "Top hosts",
+              "requests": [{"q": "sum:system.load.1{*} by {host}"}]
+            },
+            "layout": {"x": 0, "y": 3, "width": 4, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "note",
+              "content": "Review imported Datadog dashboard widgets."
+            },
+            "layout": {"x": 4, "y": 3, "width": 4, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "sunburst",
+              "title": "Services",
+              "requests": [{"q": "sum:trace.latency{*} by {service}"}]
+            },
+            "layout": {"x": 8, "y": 3, "width": 4, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "query_table",
+              "title": "Queries",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "name": "query1",
+                      "data_source": "metrics",
+                      "query": "sum:postgresql.connections{host:$host} by {host}"
+                    }
+                  ],
+                  "formulas": [{"formula": "query1", "alias": "connections"}]
+                }
+              ]
+            },
+            "layout": {"x": 0, "y": 6, "width": 6, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "image",
+              "url": "https://example.com/datadog.png"
+            },
+            "layout": {"x": 6, "y": 6, "width": 3, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "heatmap",
+              "title": "Latency heatmap",
+              "requests": [{"q": "p95:trace.latency{service:api}"}]
+            },
+            "layout": {"x": 9, "y": 6, "width": 3, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "distribution",
+              "title": "Durations",
+              "requests": [{"q": "avg:trace.latency{*}"}]
+            },
+            "layout": {"x": 0, "y": 9, "width": 4, "height": 3}
+          },
+          {
+            "definition": {
+              "type": "free_text",
+              "text": "Free text content",
+              "content": "Free text content"
+            },
+            "layout": {"x": 4, "y": 9, "width": 4, "height": 3}
+          }
+        ]
+      },
+      "layout": {"x": 0, "y": 0, "width": 12, "height": 12}
+    },
+    {
+      "definition": {
+        "type": "list_stream",
+        "title": "List stream",
+        "query": "service:api status:error"
+      },
+      "layout": {"x": 0, "y": 12, "width": 6, "height": 4}
+    },
+    {
+      "definition": {
+        "type": "geomap",
+        "title": "Regions",
+        "requests": [{"q": "avg:system.cpu.user{host IN (web01, web02)} by {host}"}]
+      },
+      "layout": {"x": 6, "y": 12, "width": 6, "height": 4}
+    },
+    {
+      "definition": {
+        "type": "check_status",
+        "title": "Checks",
+        "query": "check:postgres.can_connect"
+      },
+      "layout": {"x": 0, "y": 16, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "manage_status",
+        "title": "Monitors",
+        "query": "status:error"
+      },
+      "layout": {"x": 3, "y": 16, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "bar_chart",
+        "title": "Bars",
+        "requests": [{"q": "sum:system.load.1{*} by {host}"}]
+      },
+      "layout": {"x": 6, "y": 16, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "log_stream",
+        "title": "Logs",
+        "query": "service:api error"
+      },
+      "layout": {"x": 9, "y": 16, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "treemap",
+        "title": "Treemap",
+        "requests": [{"q": "sum:container.cpu.usage{*} by {host}"}]
+      },
+      "layout": {"x": 0, "y": 19, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "change",
+        "title": "Change",
+        "requests": [{"q": "avg:system.cpu.user{host:$host}"}]
+      },
+      "layout": {"x": 3, "y": 19, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "hostmap",
+        "title": "Host map",
+        "requests": [{"q": "avg:system.cpu.user{*} by {host}"}]
+      },
+      "layout": {"x": 6, "y": 19, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "event_stream",
+        "title": "Events",
+        "query": "source:deploy"
+      },
+      "layout": {"x": 9, "y": 19, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "wildcard",
+        "title": "Wildcard",
+        "content": "Wildcard Datadog widget"
+      },
+      "layout": {"x": 0, "y": 22, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "event_timeline",
+        "title": "Timeline",
+        "query": "source:deploy"
+      },
+      "layout": {"x": 3, "y": 22, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "flame_graph",
+        "title": "Flame graph",
+        "query": "service:api env:production"
+      },
+      "layout": {"x": 6, "y": 22, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "cloud_cost_summary",
+        "title": "Cost",
+        "requests": [{"q": "sum:aws.cost.amortized{*}"}]
+      },
+      "layout": {"x": 9, "y": 22, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "topology_map",
+        "title": "Topology",
+        "query": "service:api"
+      },
+      "layout": {"x": 0, "y": 25, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "sankey",
+        "title": "Sankey",
+        "requests": [{"q": "sum:trace.latency{*} by {service}"}]
+      },
+      "layout": {"x": 3, "y": 25, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "iframe",
+        "title": "Status iframe",
+        "url": "https://status.example.com"
+      },
+      "layout": {"x": 6, "y": 25, "width": 3, "height": 3}
+    },
+    {
+      "definition": {
+        "type": "scatterplot",
+        "title": "CPU request scatter",
+        "requests": [
+          {
+            "queries": [
+              {
+                "name": "query1",
+                "query": "sum:kubernetes.cpu.usage.total{host:$host}"
+              },
+              {
+                "name": "query2",
+                "query": "sum:kubernetes.cpu.requests{host:$host}"
+              }
+            ],
+            "formulas": [
+              {
+                "formula": "query1 / query2 * 100",
+                "alias": "usage percent"
+              }
+            ]
+          }
+        ]
+      },
+      "layout": {"x": 9, "y": 25, "width": 3, "height": 3}
+    }
+  ]
+}

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -41,6 +41,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "d3-geo": "^3.1.1",
         "date-fns": "^4.0.0",
         "lucide-react": "^0.577.0",
         "react": "^19.0.0",
@@ -55,7 +56,9 @@
         "rrweb": "^2.0.0-alpha.4",
         "rrweb-player": "^1.0.0-alpha.4",
         "tailwind-merge": "^3.0.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "topojson-client": "^3.1.0",
+        "world-atlas": "^2.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.0",
@@ -67,10 +70,12 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/d3-geo": "^3.1.0",
         "@types/node": "^24.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@types/topojson-client": "^3.1.5",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitejs/plugin-react": "^6.0.0",
@@ -4114,6 +4119,16 @@
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -4222,6 +4237,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -4322,6 +4344,27 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5397,6 +5440,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5536,6 +5585,18 @@
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -10297,6 +10358,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -11030,6 +11105,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "license": "ISC"
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -53,6 +53,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "d3-geo": "^3.1.1",
     "date-fns": "^4.0.0",
     "lucide-react": "^0.577.0",
     "react": "^19.0.0",
@@ -67,7 +68,9 @@
     "rrweb": "^2.0.0-alpha.4",
     "rrweb-player": "^1.0.0-alpha.4",
     "tailwind-merge": "^3.0.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "topojson-client": "^3.1.0",
+    "world-atlas": "^2.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
@@ -79,10 +82,12 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/d3-geo": "^3.1.0",
     "@types/node": "^24.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/topojson-client": "^3.1.5",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitejs/plugin-react": "^6.0.0",

--- a/dashboard/public/demo/widget-preview-embed.html
+++ b/dashboard/public/demo/widget-preview-embed.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Widget Preview Embed</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0f172a;
+        color: #f8fafc;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background:
+          linear-gradient(135deg, rgba(20, 184, 166, 0.18), transparent 46%),
+          linear-gradient(315deg, rgba(59, 130, 246, 0.2), transparent 48%),
+          #0f172a;
+      }
+
+      main {
+        width: min(460px, calc(100vw - 32px));
+      }
+
+      .eyebrow {
+        margin: 0 0 8px;
+        color: #67e8f9;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(22px, 6vw, 34px);
+        line-height: 1.08;
+      }
+
+      p {
+        margin: 12px 0 0;
+        color: #cbd5e1;
+        font-size: 14px;
+        line-height: 1.55;
+      }
+
+      dl {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 10px;
+        margin: 22px 0 0;
+      }
+
+      div {
+        border: 1px solid rgba(148, 163, 184, 0.26);
+        border-radius: 8px;
+        padding: 12px;
+        background: rgba(15, 23, 42, 0.62);
+      }
+
+      dt {
+        color: #94a3b8;
+        font-size: 11px;
+      }
+
+      dd {
+        margin: 5px 0 0;
+        font-size: 18px;
+        font-weight: 700;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="eyebrow">Embedded runbook</p>
+      <h1>Checkout latency response</h1>
+      <p>
+        Triage request spikes, host saturation, and recent error streams from the surrounding dashboard widgets.
+      </p>
+      <dl>
+        <div>
+          <dt>Owner</dt>
+          <dd>core</dd>
+        </div>
+        <div>
+          <dt>SLO</dt>
+          <dd>99.9%</dd>
+        </div>
+        <div>
+          <dt>Stage</dt>
+          <dd>demo</dd>
+        </div>
+      </dl>
+    </main>
+  </body>
+</html>

--- a/dashboard/src/components/dashboards/ExtendedWidgets.tsx
+++ b/dashboard/src/components/dashboards/ExtendedWidgets.tsx
@@ -598,9 +598,11 @@ function extractIframeUrl(displayConfig: DisplayConfig): string | null {
   return MARKDOWN_LINK_URL_REGEX.exec(content)?.[1] ?? null
 }
 
-function isSafeHttpUrl(value: string): boolean {
+function isSafeIframeUrl(value: string): boolean {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return true
   try {
-    const url = new URL(value)
+    const url = new URL(trimmed)
     return url.protocol === 'http:' || url.protocol === 'https:'
   } catch {
     return false
@@ -609,7 +611,7 @@ function isSafeHttpUrl(value: string): boolean {
 
 const IframeWidget = memo(function IframeWidget({widget}: {widget: DashboardWidget}) {
   const url = extractIframeUrl(widget.display_config || {})
-  if (!url || !isSafeHttpUrl(url)) return <ExtendedEmptyWidget widgetType="iframe" />
+  if (!url || !isSafeIframeUrl(url)) return <ExtendedEmptyWidget widgetType="iframe" />
 
   return (
     <ExtendedWidgetShell widgetType="iframe">

--- a/dashboard/src/components/dashboards/ExtendedWidgets.tsx
+++ b/dashboard/src/components/dashboards/ExtendedWidgets.tsx
@@ -1,0 +1,742 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {memo, type ReactNode} from 'react'
+import ReactMarkdown from 'react-markdown'
+import type {DashboardWidget} from '@/lib/api'
+import {formatValue} from './formatValue'
+import {extendedWidgetTestId} from './extendedWidgetTypes'
+
+const COLORS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+  '#8884d8',
+  '#82ca9d',
+  '#ffc658',
+  '#ff7300',
+  '#00C49F',
+]
+const TIME_KEYS = new Set(['time_bucket', 'timestamp', 'time', 'Time', 'day', 'Day'])
+const NUMBER_FORMATTER = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2})
+const MARKDOWN_LINK_URL_REGEX = /\((https?:\/\/[^)]+)\)/
+
+type DisplayConfig = Record<string, string>
+type DataRow = Record<string, unknown>
+
+interface ExtendedWidgetRendererProps {
+  widget: DashboardWidget
+  widgetType: string
+  data: DataRow[]
+  displayConfig: DisplayConfig
+}
+
+interface LabelValue {
+  label: string
+  value: number
+  secondary?: string
+}
+
+interface FlowEdge {
+  source: string
+  target: string
+  value: number
+}
+
+export const ExtendedWidgetRenderer = memo(function ExtendedWidgetRenderer({
+  widget,
+  widgetType,
+  data,
+  displayConfig,
+}: ExtendedWidgetRendererProps) {
+  switch (widgetType) {
+    case 'stream':
+      return <StreamWidget data={data} />
+    case 'timeline':
+      return <TimelineWidget data={data} />
+    case 'geo_map':
+      return <GeoMapWidget data={data} />
+    case 'host_map':
+      return <HostMapWidget data={data} />
+    case 'topology_map':
+      return <TopologyMapWidget data={data} />
+    case 'sankey':
+      return <SankeyWidget data={data} />
+    case 'treemap':
+      return <TreemapWidget data={data} />
+    case 'scatter':
+      return <ScatterWidget data={data} displayConfig={displayConfig} />
+    case 'status':
+      return <StatusWidget data={data} />
+    case 'change':
+      return <ChangeWidget data={data} widget={widget} displayConfig={displayConfig} />
+    case 'custom':
+      return <CustomWidget data={data} widget={widget} displayConfig={displayConfig} />
+    case 'flame_graph':
+      return <FlameGraphWidget data={data} />
+    case 'cost_summary':
+      return <CostSummaryWidget data={data} displayConfig={displayConfig} />
+    case 'iframe':
+      return <IframeWidget widget={widget} />
+    default:
+      return null
+  }
+})
+
+function isTimeKey(key: string): boolean {
+  return TIME_KEYS.has(key)
+}
+
+function compactNumber(value: number): string {
+  return NUMBER_FORMATTER.format(value)
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value !== 'string' || value.trim() === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function getFirstValueByKeys(row: DataRow, keys: string[]): unknown {
+  for (const key of keys) {
+    if (row[key] != null) return row[key]
+  }
+  return undefined
+}
+
+function getStringByKeys(row: DataRow, keys: string[]): string | null {
+  const value = getFirstValueByKeys(row, keys)
+  if (value == null || value === '') return null
+  return String(value)
+}
+
+function getNumberByKeys(row: DataRow, keys: string[]): number | null {
+  return toFiniteNumber(getFirstValueByKeys(row, keys))
+}
+
+function getStringEntries(row: DataRow): [string, string][] {
+  return Object.entries(row)
+    .filter(([, value]) => typeof value === 'string' && value.trim() !== '')
+    .map(([key, value]) => [key, value as string])
+}
+
+function getNumberEntries(row: DataRow): [string, number][] {
+  return Object.entries(row)
+    .map(([key, value]) => [key, toFiniteNumber(value)] as [string, number | null])
+    .filter((entry): entry is [string, number] => entry[1] != null && !isTimeKey(entry[0]))
+}
+
+function getPrimaryNumber(row: DataRow): number {
+  return getNumberEntries(row)[0]?.[1] ?? 0
+}
+
+function getRowLabel(row: DataRow, index: number): string {
+  return getStringByKeys(row, ['name', 'host', 'service', 'resource', 'title', 'message', 'path']) ??
+    getStringEntries(row)[0]?.[1] ??
+    `item ${index + 1}`
+}
+
+function getRowSecondary(row: DataRow): string | undefined {
+  const fields = [
+    getStringByKeys(row, ['service', 'env', 'environment']),
+    getStringByKeys(row, ['host', 'pod_name', 'container_name']),
+    getStringByKeys(row, ['status', 'level', 'state']),
+  ].filter((value): value is string => value != null)
+  return fields.length > 0 ? fields.join(' | ') : undefined
+}
+
+function parseUtcTimestamp(value: string): number {
+  if (value.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(value)) return Date.parse(value)
+  const iso = value.includes('T') ? value + 'Z' : value.replace(' ', 'T') + 'Z'
+  const ms = Date.parse(iso)
+  return Number.isNaN(ms) ? Date.parse(value) : ms
+}
+
+function formatTimeLabel(value: string | number): string {
+  const timestamp = typeof value === 'number' ? value : parseUtcTimestamp(value)
+  if (Number.isNaN(timestamp)) return String(value)
+  const date = new Date(timestamp)
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
+  const hours = String(date.getUTCHours()).padStart(2, '0')
+  const mins = String(date.getUTCMinutes()).padStart(2, '0')
+  return `${month}/${day} ${hours}:${mins}`
+}
+
+function getTimeLabel(row: DataRow): string | null {
+  const entry = Object.entries(row).find(([key]) => isTimeKey(key))
+  if (!entry) return null
+  if (typeof entry[1] === 'number' || typeof entry[1] === 'string') return formatTimeLabel(entry[1])
+  return String(entry[1])
+}
+
+function getTopLabelValues(data: DataRow[], limit: number): LabelValue[] {
+  return data.slice(0, limit).map((row, index) => ({
+    label: getRowLabel(row, index),
+    value: getPrimaryNumber(row),
+    secondary: getRowSecondary(row),
+  }))
+}
+
+function maxAbs(values: number[]): number {
+  let max = 0
+  for (const value of values) {
+    max = Math.max(max, Math.abs(value))
+  }
+  return max || 1
+}
+
+function ExtendedEmptyWidget({widgetType}: {widgetType: string}) {
+  return (
+    <div
+      data-testid={extendedWidgetTestId(widgetType)}
+      className="h-full flex items-center justify-center text-xs text-muted-foreground"
+    >
+      No data
+    </div>
+  )
+}
+
+function ExtendedWidgetShell({
+  widgetType,
+  children,
+  className = '',
+}: {
+  widgetType: string
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div data-testid={extendedWidgetTestId(widgetType)} className={`h-full w-full overflow-hidden ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+const StreamWidget = memo(function StreamWidget({
+  data,
+}: {
+  data: DataRow[]
+}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="stream" />
+
+  return (
+    <ExtendedWidgetShell widgetType="stream" className="overflow-auto p-2">
+      <div className="space-y-1">
+        {data.slice(0, 80).map((row, index) => {
+          const message = getStringByKeys(row, ['message', 'content', 'title', 'event', 'error', 'name']) ??
+            getRowLabel(row, index)
+          const status = getStringByKeys(row, ['level', 'status', 'severity', 'priority', 'state'])
+          const secondary = getRowSecondary(row)
+          const timeLabel = getTimeLabel(row)
+          return (
+            <div key={index} className="rounded border border-border/70 bg-background/70 px-2 py-1.5">
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                {status && <span className="rounded bg-muted px-1.5 py-0.5 font-medium uppercase">{status}</span>}
+                {timeLabel && <span className="tabular-nums">{timeLabel}</span>}
+                {secondary && <span className="min-w-0 truncate">{secondary}</span>}
+              </div>
+              <div className="mt-1 truncate text-xs font-medium">{message}</div>
+            </div>
+          )
+        })}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+const TimelineWidget = memo(function TimelineWidget({data}: {data: DataRow[]}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="timeline" />
+
+  return (
+    <ExtendedWidgetShell widgetType="timeline" className="overflow-auto p-3">
+      <div className="relative ml-2 space-y-3 border-l border-border">
+        {data.slice(0, 60).map((row, index) => {
+          const label = getRowLabel(row, index)
+          const value = getPrimaryNumber(row)
+          const timeLabel = getTimeLabel(row)
+          return (
+            <div key={index} className="relative pl-4">
+              <span className="absolute -left-[5px] top-1 h-2.5 w-2.5 rounded-full bg-primary" />
+              <div className="flex items-center justify-between gap-2 text-xs">
+                <span className="min-w-0 truncate font-medium">{label}</span>
+                {value !== 0 && <span className="shrink-0 tabular-nums">{compactNumber(value)}</span>}
+              </div>
+              {timeLabel && <div className="mt-0.5 text-[11px] text-muted-foreground">{timeLabel}</div>}
+            </div>
+          )
+        })}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+function geoPoint(row: DataRow, index: number, total: number) {
+  const lat = getNumberByKeys(row, ['lat', 'latitude', 'geo_latitude', 'location_latitude'])
+  const lon = getNumberByKeys(row, ['lon', 'lng', 'longitude', 'geo_longitude', 'location_longitude'])
+  if (lat != null && lon != null) {
+    return {
+      x: ((lon + 180) / 360) * 100,
+      y: ((90 - lat) / 180) * 100,
+    }
+  }
+  const angle = (index / Math.max(total, 1)) * Math.PI * 2
+  const radius = 34 + (index % 3) * 8
+  return {
+    x: 50 + Math.cos(angle) * radius,
+    y: 50 + Math.sin(angle) * radius * 0.55,
+  }
+}
+
+const GeoMapWidget = memo(function GeoMapWidget({data}: {data: DataRow[]}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="geo_map" />
+
+  const points = data.slice(0, 80).map((row, index) => ({
+    ...geoPoint(row, index, data.length),
+    label: getRowLabel(row, index),
+    value: getPrimaryNumber(row),
+  }))
+  const maxValue = maxAbs(points.map((point) => point.value))
+
+  return (
+    <ExtendedWidgetShell widgetType="geo_map" className="p-2">
+      <svg viewBox="0 0 100 100" className="h-full w-full rounded bg-muted/20" preserveAspectRatio="none">
+        {[20, 40, 60, 80].map((line) => (
+          <line key={line} x1={line} x2={line} y1="0" y2="100" stroke="currentColor" opacity="0.08" />
+        ))}
+        {[25, 50, 75].map((line) => (
+          <line key={line} x1="0" x2="100" y1={line} y2={line} stroke="currentColor" opacity="0.08" />
+        ))}
+        {points.map((point, index) => (
+          <circle
+            key={index}
+            cx={point.x}
+            cy={point.y}
+            r={1.8 + Math.min(7, Math.abs(point.value) / maxValue * 7)}
+            fill={COLORS[index % COLORS.length]}
+            opacity="0.78"
+          >
+            <title>{`${point.label}: ${compactNumber(point.value)}`}</title>
+          </circle>
+        ))}
+      </svg>
+    </ExtendedWidgetShell>
+  )
+})
+
+const HostMapWidget = memo(function HostMapWidget({data}: {data: DataRow[]}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="host_map" />
+  const hosts = getTopLabelValues(data, 120)
+  const maxValue = maxAbs(hosts.map((host) => host.value))
+
+  return (
+    <ExtendedWidgetShell widgetType="host_map" className="overflow-auto p-2">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-1.5">
+        {hosts.map((host, index) => (
+          <div
+            key={`${host.label}-${index}`}
+            className="min-h-14 rounded border border-border/70 p-1.5"
+            style={{
+              backgroundColor: COLORS[index % COLORS.length],
+              opacity: 0.22 + Math.min(1, Math.abs(host.value) / maxValue) * 0.68,
+            }}
+            title={`${host.label}: ${compactNumber(host.value)}`}
+          >
+            <div className="truncate text-[11px] font-medium text-foreground">{host.label}</div>
+            <div className="mt-1 text-xs font-semibold tabular-nums text-foreground">
+              {compactNumber(host.value)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+const TopologyMapWidget = memo(function TopologyMapWidget({data}: {data: DataRow[]}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="topology_map" />
+  const nodes = getTopLabelValues(data, 18)
+  const points = nodes.map((node, index) => {
+    const angle = (index / Math.max(nodes.length, 1)) * Math.PI * 2
+    return {...node, x: 50 + Math.cos(angle) * 34, y: 50 + Math.sin(angle) * 28}
+  })
+
+  return (
+    <ExtendedWidgetShell widgetType="topology_map" className="p-2">
+      <svg viewBox="0 0 100 100" className="h-full w-full">
+        {points.map((point, index) => {
+          const next = points[(index + 1) % points.length]
+          if (!next || points.length < 2) return null
+          return <line key={`${point.label}-${next.label}`} x1={point.x} y1={point.y} x2={next.x} y2={next.y} stroke="currentColor" strokeOpacity="0.18" />
+        })}
+        {points.map((point, index) => (
+          <g key={`${point.label}-${index}`}>
+            <circle cx={point.x} cy={point.y} r="7" fill={COLORS[index % COLORS.length]} opacity="0.82" />
+            <text x={point.x} y={point.y + 12} textAnchor="middle" className="fill-muted-foreground text-[4px]">
+              {point.label.slice(0, 14)}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </ExtendedWidgetShell>
+  )
+})
+
+function buildFlowEdges(data: DataRow[], limit: number): FlowEdge[] {
+  return data.slice(0, limit).map((row, index) => {
+    const stringEntries = getStringEntries(row)
+    const source = getStringByKeys(row, ['source', 'from', 'parent', 'service']) ??
+      stringEntries[0]?.[1] ??
+      `source ${index + 1}`
+    const target = getStringByKeys(row, ['target', 'to', 'child', 'resource', 'operation']) ??
+      stringEntries.find(([, value]) => value !== source)?.[1] ??
+      `target ${index + 1}`
+    return {source, target, value: getPrimaryNumber(row)}
+  })
+}
+
+const SankeyWidget = memo(function SankeyWidget({data}: {data: DataRow[]}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="sankey" />
+  const edges = buildFlowEdges(data, 40)
+  const maxValue = maxAbs(edges.map((edge) => edge.value))
+
+  return (
+    <ExtendedWidgetShell widgetType="sankey" className="overflow-auto p-2">
+      <div className="space-y-2">
+        {edges.map((edge, index) => (
+          <div key={`${edge.source}-${edge.target}-${index}`} className="grid grid-cols-[1fr_2fr_1fr] items-center gap-2">
+            <div className="truncate text-right text-[11px] text-muted-foreground">{edge.source}</div>
+            <div className="relative h-5 rounded bg-muted/30">
+              <div
+                className="h-full rounded"
+                style={{
+                  width: `${Math.max(8, Math.abs(edge.value) / maxValue * 100)}%`,
+                  backgroundColor: COLORS[index % COLORS.length],
+                }}
+              />
+              <div className="absolute inset-0 flex items-center justify-center text-[11px] font-medium tabular-nums">
+                {compactNumber(edge.value)}
+              </div>
+            </div>
+            <div className="truncate text-[11px] text-muted-foreground">{edge.target}</div>
+          </div>
+        ))}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+const TreemapWidget = memo(function TreemapWidget({data}: {data: DataRow[]}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="treemap" />
+  const items = getTopLabelValues(data, 60)
+  const total = items.reduce((sum, item) => sum + Math.abs(item.value), 0) || 1
+
+  return (
+    <ExtendedWidgetShell widgetType="treemap" className="overflow-auto p-2">
+      <div className="flex min-h-full flex-wrap content-stretch gap-1">
+        {items.map((item, index) => (
+          <div
+            key={`${item.label}-${index}`}
+            className="flex min-h-14 flex-col justify-between rounded p-2 text-primary-foreground"
+            style={{
+              flexBasis: `${Math.max(18, Math.abs(item.value) / total * 100)}%`,
+              flexGrow: Math.max(1, Math.abs(item.value)),
+              backgroundColor: COLORS[index % COLORS.length],
+            }}
+          >
+            <div className="truncate text-xs font-medium">{item.label}</div>
+            <div className="text-sm font-semibold tabular-nums">{compactNumber(item.value)}</div>
+          </div>
+        ))}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+const ScatterWidget = memo(function ScatterWidget({
+  data,
+  displayConfig,
+}: {
+  data: DataRow[]
+  displayConfig: DisplayConfig
+}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="scatter" />
+  const firstRow = data[0] ?? {}
+  const numericKeys = getNumberEntries(firstRow).map(([key]) => key)
+  const maxValue = maxAbs(data.map(getPrimaryNumber))
+
+  return (
+    <ExtendedWidgetShell widgetType="scatter" className="p-2">
+      <svg viewBox="0 0 100 100" className="h-full w-full">
+        <line x1="8" x2="8" y1="6" y2="92" stroke="currentColor" opacity="0.22" />
+        <line x1="8" x2="96" y1="92" y2="92" stroke="currentColor" opacity="0.22" />
+        {data.slice(0, 120).map((row, index) => {
+          const x = numericKeys[0] ? toFiniteNumber(row[numericKeys[0]]) ?? index : index
+          const y = numericKeys[1] ? toFiniteNumber(row[numericKeys[1]]) ?? getPrimaryNumber(row) : getPrimaryNumber(row)
+          const cx = 10 + Math.min(86, Math.abs(x) / maxValue * 86)
+          const cy = 90 - Math.min(82, Math.abs(y) / maxValue * 82)
+          return (
+            <circle key={index} cx={cx} cy={cy} r="2.5" fill={COLORS[index % COLORS.length]}>
+              <title>{`${getRowLabel(row, index)}: ${formatValue(y, displayConfig.unit, displayConfig.decimals)}`}</title>
+            </circle>
+          )
+        })}
+      </svg>
+    </ExtendedWidgetShell>
+  )
+})
+
+function statusColor(status: string | null, value: number): string {
+  const normalized = status?.toLowerCase() ?? ''
+  if (normalized.includes('ok') || normalized.includes('success') || normalized.includes('up')) return '#22c55e'
+  if (normalized.includes('warn')) return '#f59e0b'
+  if (normalized.includes('error') || normalized.includes('critical') || normalized.includes('down')) return '#ef4444'
+  if (value > 0) return '#22c55e'
+  return 'hsl(var(--muted-foreground))'
+}
+
+const StatusWidget = memo(function StatusWidget({
+  data,
+}: {
+  data: DataRow[]
+}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="status" />
+  const statuses = data.slice(0, 48).map((row, index) => {
+    const status = getStringByKeys(row, ['status', 'state', 'level'])
+    return {label: getRowLabel(row, index), value: getPrimaryNumber(row), status, secondary: getRowSecondary(row)}
+  })
+
+  return (
+    <ExtendedWidgetShell widgetType="status" className="overflow-auto p-2">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-2">
+        {statuses.map((item, index) => {
+          const color = statusColor(item.status, item.value)
+          return (
+            <div key={`${item.label}-${index}`} className="rounded border border-border/70 p-2">
+              <div className="flex items-center gap-2">
+                <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{backgroundColor: color}} />
+                <span className="min-w-0 truncate text-xs font-medium">{item.label}</span>
+              </div>
+              <div className="mt-1 flex items-center justify-between gap-2">
+                <span className="truncate text-[11px] text-muted-foreground">
+                  {item.status ?? item.secondary ?? 'status'}
+                </span>
+                <span className="shrink-0 text-xs font-semibold tabular-nums" style={{color}}>
+                  {compactNumber(item.value)}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+function getTimeSortValue(row: DataRow): number {
+  const entry = Object.entries(row).find(([key]) => isTimeKey(key))
+  if (!entry) return 0
+  if (typeof entry[1] === 'number') return entry[1]
+  if (typeof entry[1] === 'string') {
+    const parsed = parseUtcTimestamp(entry[1])
+    return Number.isNaN(parsed) ? 0 : parsed
+  }
+  return 0
+}
+
+const ChangeWidget = memo(function ChangeWidget({
+  data,
+  widget,
+  displayConfig,
+}: {
+  data: DataRow[]
+  widget: DashboardWidget
+  displayConfig: DisplayConfig
+}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="change" />
+  const sorted = [...data].sort((a, b) => getTimeSortValue(a) - getTimeSortValue(b))
+  const first = getPrimaryNumber(sorted[0] ?? {})
+  const last = getPrimaryNumber(sorted[sorted.length - 1] ?? {})
+  const delta = last - first
+  const pct = first === 0 ? null : delta / Math.abs(first) * 100
+  const formattedLast = formatValue(last, displayConfig.unit, displayConfig.decimals)
+  const formattedDelta = formatValue(delta, displayConfig.unit, displayConfig.decimals)
+
+  return (
+    <ExtendedWidgetShell widgetType="change" className="flex flex-col items-center justify-center gap-2 p-3">
+      <div className="max-w-full truncate text-xs text-muted-foreground">{widget.title ?? 'change'}</div>
+      <div className="text-3xl font-bold tabular-nums">{formattedLast}</div>
+      <div className="flex items-center gap-2 text-sm font-medium tabular-nums" style={{color: delta >= 0 ? '#22c55e' : '#ef4444'}}>
+        <span>{delta >= 0 ? '+' : ''}{formattedDelta}</span>
+        {pct != null && <span>({delta >= 0 ? '+' : ''}{pct.toFixed(1)}%)</span>}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+function extractIframeUrl(displayConfig: DisplayConfig): string | null {
+  const configuredUrl = displayConfig.iframe_url || displayConfig.image_url
+  if (configuredUrl) return configuredUrl
+  const content = displayConfig.content
+  if (!content) return null
+  return MARKDOWN_LINK_URL_REGEX.exec(content)?.[1] ?? null
+}
+
+function isSafeHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+const IframeWidget = memo(function IframeWidget({widget}: {widget: DashboardWidget}) {
+  const url = extractIframeUrl(widget.display_config || {})
+  if (!url || !isSafeHttpUrl(url)) return <ExtendedEmptyWidget widgetType="iframe" />
+
+  return (
+    <ExtendedWidgetShell widgetType="iframe">
+      <iframe
+        title={widget.title ?? 'Embedded content'}
+        src={url}
+        className="h-full w-full border-0"
+        sandbox="allow-forms allow-popups allow-same-origin allow-scripts"
+      />
+    </ExtendedWidgetShell>
+  )
+})
+
+const CustomWidget = memo(function CustomWidget({
+  data,
+  widget,
+  displayConfig,
+}: {
+  data: DataRow[]
+  widget: DashboardWidget
+  displayConfig: DisplayConfig
+}) {
+  const content = displayConfig.content || widget.title || ''
+  if (content) {
+    return (
+      <ExtendedWidgetShell widgetType="custom" className="prose prose-sm dark:prose-invert max-w-none overflow-auto p-2">
+        <ReactMarkdown>{content}</ReactMarkdown>
+      </ExtendedWidgetShell>
+    )
+  }
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="custom" />
+  return (
+    <ExtendedWidgetShell widgetType="custom">
+      <TablePreview data={data} displayConfig={displayConfig} />
+    </ExtendedWidgetShell>
+  )
+})
+
+function TablePreview({data, displayConfig}: {data: DataRow[]; displayConfig: DisplayConfig}) {
+  const columns = Object.keys(data[0] ?? {}).slice(0, 8)
+  return (
+    <div className="h-full overflow-auto">
+      <table className="w-full text-xs">
+        <thead className="sticky top-0 bg-background">
+          <tr>{columns.map((column) => <th key={column} className="px-2 py-1 text-left">{column}</th>)}</tr>
+        </thead>
+        <tbody>
+          {data.slice(0, 100).map((row, index) => (
+            <tr key={index} className="border-t border-muted/30">
+              {columns.map((column) => {
+                const value = row[column]
+                return (
+                  <td key={column} className="max-w-[240px] truncate px-2 py-1">
+                    {typeof value === 'number' ? formatValue(value, displayConfig.unit, displayConfig.decimals) : String(value ?? '')}
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const FlameGraphWidget = memo(function FlameGraphWidget({data}: {data: DataRow[]}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="flame_graph" />
+  const frames = data.slice(0, 80).map((row, index) => ({
+    label: getStringByKeys(row, ['function', 'frame', 'method', 'resource', 'name']) ?? getRowLabel(row, index),
+    value: Math.abs(getPrimaryNumber(row)) || 1,
+    depth: Math.max(0, getNumberByKeys(row, ['depth', 'level']) ?? index % 5),
+  }))
+  const maxValue = maxAbs(frames.map((frame) => frame.value))
+
+  return (
+    <ExtendedWidgetShell widgetType="flame_graph" className="overflow-auto p-2">
+      <div className="space-y-1">
+        {frames.map((frame, index) => (
+          <div key={`${frame.label}-${index}`} className="flex items-center gap-2">
+            <div style={{width: `${frame.depth * 14}px`}} className="shrink-0" />
+            <div className="relative h-5 min-w-0 flex-1 rounded bg-muted/30">
+              <div
+                className="h-full rounded"
+                style={{
+                  width: `${Math.max(6, frame.value / maxValue * 100)}%`,
+                  backgroundColor: COLORS[index % COLORS.length],
+                }}
+              />
+              <div className="absolute inset-0 truncate px-2 text-[11px] leading-5">{frame.label}</div>
+            </div>
+            <div className="w-16 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+              {compactNumber(frame.value)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})
+
+const CostSummaryWidget = memo(function CostSummaryWidget({
+  data,
+  displayConfig,
+}: {
+  data: DataRow[]
+  displayConfig: DisplayConfig
+}) {
+  if (data.length === 0) return <ExtendedEmptyWidget widgetType="cost_summary" />
+  const items = getTopLabelValues(data, 12)
+  const total = items.reduce((sum, item) => sum + item.value, 0)
+  const formatCost = (value: number) => formatValue(value, displayConfig.unit, displayConfig.decimals)
+
+  return (
+    <ExtendedWidgetShell widgetType="cost_summary" className="overflow-auto p-3">
+      <div className="mb-3">
+        <div className="text-[11px] text-muted-foreground">Total</div>
+        <div className="text-2xl font-bold tabular-nums">{formatCost(total)}</div>
+      </div>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-2">
+        {items.map((item, index) => (
+          <div key={`${item.label}-${index}`} className="rounded border border-border/70 p-2">
+            <div className="truncate text-xs font-medium">{item.label}</div>
+            <div className="mt-1 text-sm font-semibold tabular-nums">{formatCost(item.value)}</div>
+            {item.secondary && <div className="mt-1 truncate text-[11px] text-muted-foreground">{item.secondary}</div>}
+          </div>
+        ))}
+      </div>
+    </ExtendedWidgetShell>
+  )
+})

--- a/dashboard/src/components/dashboards/ExtendedWidgets.tsx
+++ b/dashboard/src/components/dashboards/ExtendedWidgets.tsx
@@ -14,8 +14,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {memo, type ReactNode} from 'react'
+import {memo, useEffect, useRef, useState, type ReactNode} from 'react'
+import {geoNaturalEarth1, geoPath, type GeoPermissibleObjects} from 'd3-geo'
 import ReactMarkdown from 'react-markdown'
+import {
+  CartesianGrid,
+  Cell,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+  type TooltipContentProps,
+} from 'recharts'
+import {feature} from 'topojson-client'
+import type {FeatureCollection, GeometryObject as GeoJsonGeometryObject} from 'geojson'
+import type {GeometryCollection, Topology} from 'topojson-specification'
+import countriesTopology from 'world-atlas/countries-110m.json'
 import type {DashboardWidget} from '@/lib/api'
 import {formatValue} from './formatValue'
 import {extendedWidgetTestId} from './extendedWidgetTypes'
@@ -35,6 +51,54 @@ const COLORS = [
 const TIME_KEYS = new Set(['time_bucket', 'timestamp', 'time', 'Time', 'day', 'Day'])
 const NUMBER_FORMATTER = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2})
 const MARKDOWN_LINK_URL_REGEX = /\((https?:\/\/[^)]+)\)/
+const GEO_VIEWBOX_HEIGHT = 56
+const GEO_POINT_PADDING = 2
+const GEO_FALLBACK_POINTS: Array<[number, number]> = [
+  [18, 22],
+  [30, 34],
+  [43, 25],
+  [54, 31],
+  [66, 23],
+  [78, 35],
+  [86, 28],
+  [58, 43],
+]
+const COUNTRY_COORDS: Record<string, [number, number]> = {
+  AR: [-34, -64],
+  AU: [-25, 134],
+  BR: [-10, -55],
+  CA: [56, -106],
+  CN: [35, 104],
+  DE: [51, 10],
+  ES: [40, -4],
+  FR: [46, 2],
+  GB: [54, -2],
+  IN: [22, 79],
+  JP: [36, 138],
+  MX: [23, -102],
+  NL: [52, 5],
+  SG: [1, 104],
+  US: [39, -98],
+}
+const WORLD_TOPOLOGY = countriesTopology as unknown as Topology<{countries: GeometryCollection}>
+const WORLD_COUNTRIES = feature(
+  WORLD_TOPOLOGY,
+  WORLD_TOPOLOGY.objects.countries,
+) as FeatureCollection<GeoJsonGeometryObject>
+const WORLD_PROJECTION = geoNaturalEarth1().fitSize(
+  [100, GEO_VIEWBOX_HEIGHT],
+  WORLD_COUNTRIES as GeoPermissibleObjects,
+)
+const WORLD_PATH = geoPath(WORLD_PROJECTION)(WORLD_COUNTRIES as GeoPermissibleObjects) ?? ''
+const CHART_MARGIN = {top: 10, right: 12, left: 16, bottom: 26}
+const TOOLTIP_STYLE = {
+  backgroundColor: 'hsl(var(--popover))',
+  border: '1px solid hsl(var(--border))',
+  borderRadius: '6px',
+  color: 'hsl(var(--popover-foreground))',
+  fontSize: '11px',
+}
+const TOOLTIP_WRAPPER_STYLE = {zIndex: 1000}
 
 type DisplayConfig = Record<string, string>
 type DataRow = Record<string, unknown>
@@ -56,6 +120,14 @@ interface FlowEdge {
   source: string
   target: string
   value: number
+}
+
+interface ScatterPoint {
+  label: string
+  x: number
+  y: number
+  z: number
+  color: string
 }
 
 export const ExtendedWidgetRenderer = memo(function ExtendedWidgetRenderer({
@@ -152,6 +224,14 @@ function getRowLabel(row: DataRow, index: number): string {
     `item ${index + 1}`
 }
 
+function getDimensionLabel(row: DataRow, index: number): string {
+  const labels = getStringEntries(row)
+    .filter(([key]) => !isTimeKey(key))
+    .map(([, value]) => value)
+    .slice(0, 3)
+  return labels.length > 0 ? labels.join(' | ') : getRowLabel(row, index)
+}
+
 function getRowSecondary(row: DataRow): string | undefined {
   const fields = [
     getStringByKeys(row, ['service', 'env', 'environment']),
@@ -202,6 +282,29 @@ function maxAbs(values: number[]): number {
   return max || 1
 }
 
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function numericDomain(values: number[]): [number, number] {
+  const finite = values.filter(Number.isFinite)
+  if (finite.length === 0) return [0, 1]
+  const isNonNegative = finite.every((value) => value >= 0)
+  let min = Math.min(...finite)
+  let max = Math.max(...finite)
+  if (min === max) {
+    const pad = Math.max(Math.abs(min) * 0.1, 1)
+    min -= pad
+    max += pad
+  } else {
+    const pad = (max - min) * 0.08
+    min -= pad
+    max += pad
+  }
+  if (isNonNegative) min = Math.max(0, min)
+  return [min, max]
+}
+
 function ExtendedEmptyWidget({widgetType}: {widgetType: string}) {
   return (
     <div
@@ -209,6 +312,36 @@ function ExtendedEmptyWidget({widgetType}: {widgetType: string}) {
       className="h-full flex items-center justify-center text-xs text-muted-foreground"
     >
       No data
+    </div>
+  )
+}
+
+function MeasuredWidgetContainer({children}: {children: (width: number, height: number) => ReactNode}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState<{width: number; height: number} | null>(null)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const measure = () => {
+      setSize({
+        width: element.clientWidth || 320,
+        height: element.clientHeight || 220,
+      })
+    }
+
+    measure()
+    if (globalThis.ResizeObserver === undefined) return
+
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref} className="h-full w-full">
+      {size != null && size.width > 0 && size.height > 0 ? children(size.width, size.height) : null}
     </div>
   )
 }
@@ -287,20 +420,45 @@ const TimelineWidget = memo(function TimelineWidget({data}: {data: DataRow[]}) {
   )
 })
 
-function geoPoint(row: DataRow, index: number, total: number) {
+function lonLatToPoint(lat: number, lon: number): {x: number; y: number} {
+  const projected = WORLD_PROJECTION([lon, lat])
+  if (projected) {
+    return {
+      x: clampNumber(projected[0], GEO_POINT_PADDING, 100 - GEO_POINT_PADDING),
+      y: clampNumber(projected[1], GEO_POINT_PADDING, GEO_VIEWBOX_HEIGHT - GEO_POINT_PADDING),
+    }
+  }
+  return {
+    x: clampNumber(((lon + 180) / 360) * 100, GEO_POINT_PADDING, 100 - GEO_POINT_PADDING),
+    y: clampNumber(
+      ((84 - lat) / 168) * GEO_VIEWBOX_HEIGHT,
+      GEO_POINT_PADDING,
+      GEO_VIEWBOX_HEIGHT - GEO_POINT_PADDING,
+    ),
+  }
+}
+
+function geoPoint(row: DataRow, index: number) {
   const lat = getNumberByKeys(row, ['lat', 'latitude', 'geo_latitude', 'location_latitude'])
   const lon = getNumberByKeys(row, ['lon', 'lng', 'longitude', 'geo_longitude', 'location_longitude'])
   if (lat != null && lon != null) {
+    return lonLatToPoint(lat, lon)
+  }
+  const country = getStringByKeys(row, ['country_code', 'country', 'countryCode'])?.toUpperCase()
+  const countryCoords = country ? COUNTRY_COORDS[country] : undefined
+  if (countryCoords) {
+    const point = lonLatToPoint(countryCoords[0], countryCoords[1])
+    const jitterX = (index % 3 - 1) * 2.4
+    const jitterY = (Math.floor(index / 3) % 3 - 1) * 1.8
     return {
-      x: ((lon + 180) / 360) * 100,
-      y: ((90 - lat) / 180) * 100,
+      x: clampNumber(point.x + jitterX, 5, 95),
+      y: clampNumber(point.y + jitterY, 5, GEO_VIEWBOX_HEIGHT - 5),
     }
   }
-  const angle = (index / Math.max(total, 1)) * Math.PI * 2
-  const radius = 34 + (index % 3) * 8
+  const fallback = GEO_FALLBACK_POINTS[index % GEO_FALLBACK_POINTS.length]
   return {
-    x: 50 + Math.cos(angle) * radius,
-    y: 50 + Math.sin(angle) * radius * 0.55,
+    x: fallback[0],
+    y: fallback[1],
   }
 }
 
@@ -308,7 +466,7 @@ const GeoMapWidget = memo(function GeoMapWidget({data}: {data: DataRow[]}) {
   if (data.length === 0) return <ExtendedEmptyWidget widgetType="geo_map" />
 
   const points = data.slice(0, 80).map((row, index) => ({
-    ...geoPoint(row, index, data.length),
+    ...geoPoint(row, index),
     label: getRowLabel(row, index),
     value: getPrimaryNumber(row),
   }))
@@ -316,21 +474,24 @@ const GeoMapWidget = memo(function GeoMapWidget({data}: {data: DataRow[]}) {
 
   return (
     <ExtendedWidgetShell widgetType="geo_map" className="p-2">
-      <svg viewBox="0 0 100 100" className="h-full w-full rounded bg-muted/20" preserveAspectRatio="none">
-        {[20, 40, 60, 80].map((line) => (
-          <line key={line} x1={line} x2={line} y1="0" y2="100" stroke="currentColor" opacity="0.08" />
-        ))}
-        {[25, 50, 75].map((line) => (
-          <line key={line} x1="0" x2="100" y1={line} y2={line} stroke="currentColor" opacity="0.08" />
-        ))}
+      <svg viewBox={`0 0 100 ${GEO_VIEWBOX_HEIGHT}`} className="h-full w-full rounded bg-muted/10">
+        <path
+          d={WORLD_PATH}
+          fill="hsl(var(--muted-foreground))"
+          opacity="0.16"
+          stroke="hsl(var(--background))"
+          strokeWidth="0.12"
+        />
         {points.map((point, index) => (
           <circle
             key={index}
             cx={point.x}
             cy={point.y}
-            r={1.8 + Math.min(7, Math.abs(point.value) / maxValue * 7)}
+            r={2.2 + Math.sqrt(Math.abs(point.value) / maxValue) * 4.8}
             fill={COLORS[index % COLORS.length]}
-            opacity="0.78"
+            opacity="0.84"
+            stroke="hsl(var(--background))"
+            strokeWidth="0.8"
           >
             <title>{`${point.label}: ${compactNumber(point.value)}`}</title>
           </circle>
@@ -351,16 +512,22 @@ const HostMapWidget = memo(function HostMapWidget({data}: {data: DataRow[]}) {
         {hosts.map((host, index) => (
           <div
             key={`${host.label}-${index}`}
-            className="min-h-14 rounded border border-border/70 p-1.5"
-            style={{
-              backgroundColor: COLORS[index % COLORS.length],
-              opacity: 0.22 + Math.min(1, Math.abs(host.value) / maxValue) * 0.68,
-            }}
+            className="min-h-14 overflow-hidden rounded border border-border/70 bg-background"
+            style={{borderColor: COLORS[index % COLORS.length]}}
             title={`${host.label}: ${compactNumber(host.value)}`}
           >
-            <div className="truncate text-[11px] font-medium text-foreground">{host.label}</div>
-            <div className="mt-1 text-xs font-semibold tabular-nums text-foreground">
-              {compactNumber(host.value)}
+            <div
+              className="h-1.5"
+              style={{
+                width: `${Math.max(18, Math.abs(host.value) / maxValue * 100)}%`,
+                backgroundColor: COLORS[index % COLORS.length],
+              }}
+            />
+            <div className="p-1.5">
+              <div className="truncate text-[11px] font-medium text-foreground">{host.label}</div>
+              <div className="mt-1 text-xs font-semibold tabular-nums text-foreground">
+                {compactNumber(host.value)}
+              </div>
             </div>
           </div>
         ))}
@@ -383,7 +550,17 @@ const TopologyMapWidget = memo(function TopologyMapWidget({data}: {data: DataRow
         {points.map((point, index) => {
           const next = points[(index + 1) % points.length]
           if (!next || points.length < 2) return null
-          return <line key={`${point.label}-${next.label}`} x1={point.x} y1={point.y} x2={next.x} y2={next.y} stroke="currentColor" strokeOpacity="0.18" />
+          return (
+            <line
+              key={`${point.label}-${next.label}`}
+              x1={point.x}
+              y1={point.y}
+              x2={next.x}
+              y2={next.y}
+              stroke="currentColor"
+              strokeOpacity="0.18"
+            />
+          )
         })}
         {points.map((point, index) => (
           <g key={`${point.label}-${index}`}>
@@ -420,18 +597,28 @@ const SankeyWidget = memo(function SankeyWidget({data}: {data: DataRow[]}) {
     <ExtendedWidgetShell widgetType="sankey" className="overflow-auto p-2">
       <div className="space-y-2">
         {edges.map((edge, index) => (
-          <div key={`${edge.source}-${edge.target}-${index}`} className="grid grid-cols-[1fr_2fr_1fr] items-center gap-2">
+          <div
+            key={`${edge.source}-${edge.target}-${index}`}
+            className="grid grid-cols-[minmax(72px,1fr)_minmax(110px,2fr)_minmax(72px,1fr)] items-center gap-2"
+          >
             <div className="truncate text-right text-[11px] text-muted-foreground">{edge.source}</div>
             <div className="relative h-5 rounded bg-muted/30">
               <div
-                className="h-full rounded"
+                className="h-full rounded shadow-sm"
                 style={{
                   width: `${Math.max(8, Math.abs(edge.value) / maxValue * 100)}%`,
                   backgroundColor: COLORS[index % COLORS.length],
                 }}
               />
-              <div className="absolute inset-0 flex items-center justify-center text-[11px] font-medium tabular-nums">
-                {compactNumber(edge.value)}
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span
+                  className={
+                    'rounded bg-background/90 px-1.5 text-[11px] font-semibold ' +
+                    'tabular-nums text-foreground shadow-sm'
+                  }
+                >
+                  {compactNumber(edge.value)}
+                </span>
               </div>
             </div>
             <div className="truncate text-[11px] text-muted-foreground">{edge.target}</div>
@@ -453,15 +640,26 @@ const TreemapWidget = memo(function TreemapWidget({data}: {data: DataRow[]}) {
         {items.map((item, index) => (
           <div
             key={`${item.label}-${index}`}
-            className="flex min-h-14 flex-col justify-between rounded p-2 text-primary-foreground"
+            className="flex min-h-14 flex-col justify-between rounded p-2"
             style={{
               flexBasis: `${Math.max(18, Math.abs(item.value) / total * 100)}%`,
               flexGrow: Math.max(1, Math.abs(item.value)),
               backgroundColor: COLORS[index % COLORS.length],
             }}
           >
-            <div className="truncate text-xs font-medium">{item.label}</div>
-            <div className="text-sm font-semibold tabular-nums">{compactNumber(item.value)}</div>
+            <div
+              className="max-w-full rounded bg-background/90 px-1.5 py-1 text-xs font-medium text-foreground shadow-sm"
+            >
+              <div className="truncate">{item.label}</div>
+            </div>
+            <div
+              className={
+                'mt-2 w-fit rounded bg-background/90 px-1.5 py-0.5 text-sm font-semibold ' +
+                'tabular-nums text-foreground shadow-sm'
+              }
+            >
+              {compactNumber(item.value)}
+            </div>
           </div>
         ))}
       </div>
@@ -479,28 +677,124 @@ const ScatterWidget = memo(function ScatterWidget({
   if (data.length === 0) return <ExtendedEmptyWidget widgetType="scatter" />
   const firstRow = data[0] ?? {}
   const numericKeys = getNumberEntries(firstRow).map(([key]) => key)
-  const maxValue = maxAbs(data.map(getPrimaryNumber))
+  const rows = data.slice(0, 120)
+  const xKey = displayConfig.x_key || numericKeys[0]
+  const yKey = displayConfig.y_key || numericKeys[1]
+  const xLabel = displayConfig.x_label || xKey || 'index'
+  const yLabel = displayConfig.y_label || yKey || 'value'
+  const xUnit = displayConfig.x_unit || displayConfig.unit
+  const yUnit = displayConfig.y_unit || displayConfig.unit
+  const points = rows.map((row, index) => ({
+    label: getDimensionLabel(row, index),
+    x: xKey ? toFiniteNumber(row[xKey]) ?? index : index,
+    y: yKey ? toFiniteNumber(row[yKey]) ?? getPrimaryNumber(row) : getPrimaryNumber(row),
+    z: 70,
+    color: COLORS[index % COLORS.length],
+  }))
+  const xDomain = numericDomain(points.map((point) => point.x))
+  const yDomain = numericDomain(points.map((point) => point.y))
+  const xTickFormatter = (value: number) => formatValue(value, xUnit, displayConfig.decimals)
+  const yTickFormatter = (value: number) => formatValue(value, yUnit, displayConfig.decimals)
 
   return (
     <ExtendedWidgetShell widgetType="scatter" className="p-2">
-      <svg viewBox="0 0 100 100" className="h-full w-full">
-        <line x1="8" x2="8" y1="6" y2="92" stroke="currentColor" opacity="0.22" />
-        <line x1="8" x2="96" y1="92" y2="92" stroke="currentColor" opacity="0.22" />
-        {data.slice(0, 120).map((row, index) => {
-          const x = numericKeys[0] ? toFiniteNumber(row[numericKeys[0]]) ?? index : index
-          const y = numericKeys[1] ? toFiniteNumber(row[numericKeys[1]]) ?? getPrimaryNumber(row) : getPrimaryNumber(row)
-          const cx = 10 + Math.min(86, Math.abs(x) / maxValue * 86)
-          const cy = 90 - Math.min(82, Math.abs(y) / maxValue * 82)
-          return (
-            <circle key={index} cx={cx} cy={cy} r="2.5" fill={COLORS[index % COLORS.length]}>
-              <title>{`${getRowLabel(row, index)}: ${formatValue(y, displayConfig.unit, displayConfig.decimals)}`}</title>
-            </circle>
-          )
-        })}
-      </svg>
+      <MeasuredWidgetContainer>
+        {(width, height) => (
+          <ScatterChart width={width} height={height} margin={CHART_MARGIN}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" opacity={0.42} />
+            <XAxis
+              dataKey="x"
+              type="number"
+              domain={xDomain}
+              allowDecimals={false}
+              tick={{fontSize: 10, fill: 'hsl(var(--muted-foreground))'}}
+              tickFormatter={xTickFormatter}
+              stroke="hsl(var(--border))"
+              label={{
+                value: xLabel,
+                position: 'insideBottom',
+                offset: -20,
+                fill: 'hsl(var(--muted-foreground))',
+                fontSize: 11,
+              }}
+            />
+            <YAxis
+              dataKey="y"
+              type="number"
+              domain={yDomain}
+              tick={{fontSize: 10, fill: 'hsl(var(--muted-foreground))'}}
+              tickFormatter={yTickFormatter}
+              stroke="hsl(var(--border))"
+              width={46}
+              label={{
+                value: yLabel,
+                angle: -90,
+                position: 'insideLeft',
+                fill: 'hsl(var(--muted-foreground))',
+                fontSize: 11,
+              }}
+            />
+            <ZAxis dataKey="z" range={[50, 50]} />
+            <Tooltip
+              content={
+                <ScatterTooltip
+                  xLabel={xLabel}
+                  xUnit={xUnit}
+                  yLabel={yLabel}
+                  yUnit={yUnit}
+                  decimals={displayConfig.decimals}
+                />
+              }
+              cursor={{stroke: 'hsl(var(--muted-foreground))', strokeDasharray: '3 3'}}
+              wrapperStyle={TOOLTIP_WRAPPER_STYLE}
+            />
+            <Scatter data={points} stroke="hsl(var(--background))" strokeWidth={1}>
+              {points.map((point, index) => (
+                <Cell key={`${point.label}-${index}`} fill={point.color} />
+              ))}
+            </Scatter>
+          </ScatterChart>
+        )}
+      </MeasuredWidgetContainer>
     </ExtendedWidgetShell>
   )
 })
+
+interface ScatterTooltipProps extends Partial<TooltipContentProps<number | string, string>> {
+  xLabel: string
+  xUnit?: string
+  yLabel: string
+  yUnit?: string
+  decimals?: string
+}
+
+function ScatterTooltip({
+  active,
+  payload,
+  xLabel,
+  xUnit,
+  yLabel,
+  yUnit,
+  decimals,
+}: ScatterTooltipProps) {
+  const point = payload?.[0]?.payload as ScatterPoint | undefined
+  if (!active || !point) return null
+
+  return (
+    <div style={TOOLTIP_STYLE} className="space-y-1 px-2 py-1.5 shadow-sm">
+      <div className="flex items-center gap-1.5 font-medium text-foreground">
+        <span className="h-2 w-2 rounded-full" style={{backgroundColor: point.color}} />
+        <span>{point.label}</span>
+      </div>
+      <div className="text-muted-foreground">
+        {xLabel}: <span className="text-foreground">{formatValue(point.x, xUnit, decimals)}</span>
+      </div>
+      <div className="text-muted-foreground">
+        {yLabel}: <span className="text-foreground">{formatValue(point.y, yUnit, decimals)}</span>
+      </div>
+    </div>
+  )
+}
 
 function statusColor(status: string | null, value: number): string {
   const normalized = status?.toLowerCase() ?? ''
@@ -690,8 +984,17 @@ const FlameGraphWidget = memo(function FlameGraphWidget({data}: {data: DataRow[]
     <ExtendedWidgetShell widgetType="flame_graph" className="overflow-auto p-2">
       <div className="space-y-1">
         {frames.map((frame, index) => (
-          <div key={`${frame.label}-${index}`} className="flex items-center gap-2">
-            <div style={{width: `${frame.depth * 14}px`}} className="shrink-0" />
+          <div
+            key={`${frame.label}-${index}`}
+            className="grid grid-cols-[minmax(0,1.35fr)_minmax(84px,2fr)_64px] items-center gap-2"
+          >
+            <div className="flex min-w-0 items-center gap-2" style={{paddingLeft: `${frame.depth * 10}px`}}>
+              <span
+                className="h-3 w-3 shrink-0 rounded-sm"
+                style={{backgroundColor: COLORS[index % COLORS.length]}}
+              />
+              <span className="truncate text-[11px] font-medium text-foreground">{frame.label}</span>
+            </div>
             <div className="relative h-5 min-w-0 flex-1 rounded bg-muted/30">
               <div
                 className="h-full rounded"
@@ -700,7 +1003,6 @@ const FlameGraphWidget = memo(function FlameGraphWidget({data}: {data: DataRow[]
                   backgroundColor: COLORS[index % COLORS.length],
                 }}
               />
-              <div className="absolute inset-0 truncate px-2 text-[11px] leading-5">{frame.label}</div>
             </div>
             <div className="w-16 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
               {compactNumber(frame.value)}

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -40,6 +40,8 @@ import {
 import {useVirtualizer} from '@tanstack/react-virtual'
 import {TopListWidget} from './TopListWidget'
 import {HeatmapWidget} from './HeatmapWidget'
+import {ExtendedWidgetRenderer} from './ExtendedWidgets'
+import {isQueryDrivenExtendedWidget, isExtendedWidgetType} from './extendedWidgetTypes'
 import ReactMarkdown from 'react-markdown'
 import type {ValueMapping} from './formatValue'
 import {formatValue} from './formatValue'
@@ -140,8 +142,10 @@ export const WidgetRenderer = memo(function WidgetRenderer({
   variables,
   alertThresholdPreview,
 }: WidgetRendererProps) {
+  const widgetType = widget.widget_type
   const queries = widget.query_configs?.length > 0 ? widget.query_configs : []
   const isBatch = queries.length > 1
+  const isExtendedWidget = isExtendedWidgetType(widgetType)
   // Include query config fingerprint so datasource/query changes trigger refetch
   const queryFingerprint = JSON.stringify(queries.map(q => ({d: q.dataSource, r: q.rawQuery || ''})))
 
@@ -191,15 +195,15 @@ export const WidgetRenderer = memo(function WidgetRenderer({
         ? api.executeWidgetQuery(dashboardId, queries[0], effectiveProjectId, timeRange, variables)
         : []
     },
-    enabled: (!!projectId || isDemo()) && widget.widget_type !== 'text' && widget.widget_type !== 'section' && queries.length > 0,
+    enabled: (!!projectId || isDemo()) && isQueryDrivenWidget(widgetType) && queries.length > 0,
     refetchInterval: autoRefresh ? 30000 : false,
   })
 
-  if (widget.widget_type === 'section') {
+  if (widgetType === 'section') {
     return null
   }
 
-  if (widget.widget_type === 'text') {
+  if (widgetType === 'text') {
     return (
       <div className="prose prose-sm dark:prose-invert max-w-none p-2 overflow-auto h-full">
         <ReactMarkdown>{widget.display_config?.content || widget.title || ''}</ReactMarkdown>
@@ -211,7 +215,7 @@ export const WidgetRenderer = memo(function WidgetRenderer({
     return <div className="h-full w-full bg-muted/20 animate-pulse rounded" />
   }
 
-  if (error || !data || data.length === 0) {
+  if (error || (!isExtendedWidget && (!data || data.length === 0))) {
     return (
       <div className="h-full flex items-center justify-center text-xs text-muted-foreground">
         {error ? 'Query error' : 'No data'}
@@ -219,11 +223,22 @@ export const WidgetRenderer = memo(function WidgetRenderer({
     )
   }
 
-  const rawData = data as Record<string, unknown>[]
+  const rawData = (data ?? []) as Record<string, unknown>[]
   const dc = widget.display_config || {}
   const chartData = applyFieldTransforms(rawData, dc)
 
-  switch (widget.widget_type) {
+  if (isExtendedWidget) {
+    return (
+      <ExtendedWidgetRenderer
+        widget={widget}
+        widgetType={widgetType}
+        data={chartData}
+        displayConfig={dc}
+      />
+    )
+  }
+
+  switch (widgetType) {
     case 'timeseries':
       return (
         <TimeseriesChart
@@ -259,7 +274,7 @@ export const WidgetRenderer = memo(function WidgetRenderer({
     default:
       return (
         <div className="h-full flex items-center justify-center text-xs text-muted-foreground">
-          Unknown widget type: {widget.widget_type}
+          Unknown widget type: {widgetType}
         </div>
       )
   }
@@ -267,6 +282,11 @@ export const WidgetRenderer = memo(function WidgetRenderer({
 
 function isTimeKey(key: string): boolean {
   return TIME_KEYS.has(key)
+}
+
+function isQueryDrivenWidget(widgetType: string): boolean {
+  if (widgetType === 'text' || widgetType === 'section') return false
+  return !isExtendedWidgetType(widgetType) || isQueryDrivenExtendedWidget(widgetType)
 }
 
 function getTimeSpanMs(timeRange: TimeRangeDef): number {

--- a/dashboard/src/components/dashboards/__tests__/ExtendedWidgets.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/ExtendedWidgets.test.tsx
@@ -1,0 +1,238 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {afterEach, describe, expect, it} from 'vitest'
+import {cleanup, render, screen} from '@testing-library/react'
+import type {DashboardWidget} from '@/lib/api'
+import {ExtendedWidgetRenderer} from '../ExtendedWidgets'
+import {extendedWidgetTestId, isQueryDrivenExtendedWidget, isExtendedWidgetType} from '../extendedWidgetTypes'
+
+const extendedWidgetTypes = [
+  'stream',
+  'timeline',
+  'geo_map',
+  'host_map',
+  'topology_map',
+  'sankey',
+  'treemap',
+  'scatter',
+  'status',
+  'change',
+  'custom',
+  'flame_graph',
+  'cost_summary',
+  'iframe',
+]
+
+const sampleRows = [
+  {
+    timestamp: '2026-05-26 12:00:00.000',
+    service: 'checkout',
+    host: 'web-1',
+    message: 'checkout latency',
+    status: 'ok',
+    source: 'checkout',
+    target: 'postgres',
+    resource: 'GET /checkout',
+    function: 'CheckoutController.render',
+    latitude: 40.71,
+    longitude: -74.01,
+    value: 42,
+    latency_ms: 18,
+    cost: 12.5,
+    depth: 1,
+  },
+  {
+    timestamp: '2026-05-26 12:05:00.000',
+    service: 'payments',
+    host: 'web-2',
+    message: 'payment queue',
+    status: 'warning',
+    source: 'payments',
+    target: 'redis',
+    resource: 'POST /pay',
+    function: 'PaymentWorker.process',
+    latitude: 37.77,
+    longitude: -122.42,
+    value: 68,
+    latency_ms: 31,
+    cost: 21.75,
+    depth: 2,
+  },
+]
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderWidget(type: string, options: {
+  data?: Record<string, unknown>[]
+  displayConfig?: Record<string, string>
+  title?: string | null
+} = {}) {
+  const displayConfig = {
+    unit: 'none',
+    iframe_url: type === 'iframe' ? 'https://status.example.com' : '',
+    ...options.displayConfig,
+  }
+  return render(
+    <ExtendedWidgetRenderer
+      widget={makeWidget(type, displayConfig, options.title)}
+      widgetType={type}
+      data={options.data ?? sampleRows}
+      displayConfig={displayConfig}
+    />
+  )
+}
+
+function makeWidget(
+  type: string,
+  displayConfig: Record<string, string>,
+  title: string | null = `Widget ${type}`
+): DashboardWidget {
+  return {
+    id: 1,
+    dashboard_id: 1,
+    title,
+    widget_type: type,
+    grid_x: 0,
+    grid_y: 0,
+    grid_w: 6,
+    grid_h: 4,
+    query_configs: [],
+    display_config: displayConfig,
+    sort_order: 0,
+  }
+}
+
+describe('extended widget rendering', () => {
+  it('recognizes every extended widget type', () => {
+    expect(extendedWidgetTypes.every(isExtendedWidgetType)).toBe(true)
+    expect(isQueryDrivenExtendedWidget('iframe')).toBe(false)
+    expect(isQueryDrivenExtendedWidget('geo_map')).toBe(true)
+  })
+
+  it('renders every extended widget type with data', () => {
+    for (const type of extendedWidgetTypes) {
+      const {unmount} = renderWidget(type)
+
+      expect(screen.getByTestId(extendedWidgetTestId(type))).toBeInTheDocument()
+      expect(screen.queryByText(/Unknown widget type/)).not.toBeInTheDocument()
+
+      unmount()
+    }
+  })
+
+  it('renders empty states for data-driven extended widgets', () => {
+    for (const type of extendedWidgetTypes.filter((widgetType) => widgetType !== 'iframe')) {
+      const {unmount} = renderWidget(type, {data: [], title: null, displayConfig: {iframe_url: ''}})
+
+      expect(screen.getByTestId(extendedWidgetTestId(type))).toBeInTheDocument()
+
+      unmount()
+    }
+  })
+
+  it('renders iframe widgets as embedded frames', () => {
+    renderWidget('iframe')
+
+    expect(screen.getByTestId('widget-iframe')).toBeInTheDocument()
+    expect(screen.getByTitle('Widget iframe')).toHaveAttribute('src', 'https://status.example.com')
+  })
+
+  it('extracts iframe URLs from markdown content and rejects unsafe iframe URLs', () => {
+    const markdown = renderWidget('iframe', {
+      displayConfig: {iframe_url: '', content: '[status](https://status.example.com/embed)'},
+    })
+    expect(screen.getByTitle('Widget iframe')).toHaveAttribute('src', 'https://status.example.com/embed')
+    markdown.unmount()
+
+    renderWidget('iframe', {displayConfig: {iframe_url: 'javascript:alert(1)'}})
+    expect(screen.getByText('No data')).toBeInTheDocument()
+  })
+
+  it('renders custom widgets as data tables when no content is configured', () => {
+    renderWidget('custom', {displayConfig: {content: ''}, title: null})
+
+    expect(screen.getByText('checkout latency')).toBeInTheDocument()
+    expect(screen.getByText('payment queue')).toBeInTheDocument()
+  })
+
+  it('covers fallback layout branches for map, status, change, and unknown widgets', () => {
+    const locationlessRows = sampleRows.map((row) => ({
+      timestamp: row.timestamp,
+      service: row.service,
+      host: row.host,
+      message: row.message,
+      status: 'critical',
+      source: row.source,
+      target: row.target,
+      resource: row.resource,
+      function: row.function,
+      value: row.value === 42 ? 90 : 10,
+      latency_ms: row.latency_ms,
+      cost: row.cost,
+      depth: row.depth,
+    }))
+    const geoMap = renderWidget('geo_map', {data: locationlessRows})
+    expect(screen.getByTestId('widget-geo_map')).toBeInTheDocument()
+    geoMap.unmount()
+
+    const status = renderWidget('status', {data: locationlessRows})
+    expect(screen.getAllByText('critical')).toHaveLength(2)
+    status.unmount()
+
+    const change = renderWidget('change', {data: locationlessRows})
+    expect(screen.getByText('-80')).toBeInTheDocument()
+    change.unmount()
+
+    const zeroChange = renderWidget('change', {
+      data: [{value: 0}, {timestamp: 123, value: 5}, {timestamp: 'not-a-date', value: 7}],
+      title: null,
+    })
+    expect(screen.getByText('+5')).toBeInTheDocument()
+    zeroChange.unmount()
+
+    const scatter = renderWidget('scatter', {data: [{name: 'alpha'}, {name: 'beta'}]})
+    expect(screen.getByTestId('widget-scatter')).toBeInTheDocument()
+    scatter.unmount()
+
+    const neutralStatus = renderWidget('status', {
+      data: [{host: 'idle', value: 0}, {host: 'upstream', status: 'up', value: 1}],
+    })
+    expect(screen.getAllByText('idle')).toHaveLength(2)
+    expect(screen.getByText('upstream')).toBeInTheDocument()
+    neutralStatus.unmount()
+
+    const unsafeIframe = renderWidget('iframe', {displayConfig: {iframe_url: 'not-a-url'}})
+    expect(screen.getByText('No data')).toBeInTheDocument()
+    unsafeIframe.unmount()
+
+    const emptyIframe = renderWidget('iframe', {displayConfig: {iframe_url: '', content: ''}})
+    expect(screen.getByText('No data')).toBeInTheDocument()
+    emptyIframe.unmount()
+
+    const unknown = render(
+      <ExtendedWidgetRenderer
+        widget={makeWidget('unknown', {})}
+        widgetType="unknown"
+        data={locationlessRows}
+        displayConfig={{}}
+      />
+    )
+    expect(unknown.container.firstChild).toBeNull()
+  })
+})

--- a/dashboard/src/components/dashboards/__tests__/ExtendedWidgets.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/ExtendedWidgets.test.tsx
@@ -153,13 +153,19 @@ describe('extended widget rendering', () => {
     expect(screen.getByTitle('Widget iframe')).toHaveAttribute('src', 'https://status.example.com')
   })
 
-  it('extracts iframe URLs from markdown content and rejects unsafe iframe URLs', () => {
+  it('extracts iframe URLs from markdown content and accepts app-relative iframe URLs', () => {
     const markdown = renderWidget('iframe', {
       displayConfig: {iframe_url: '', content: '[status](https://status.example.com/embed)'},
     })
     expect(screen.getByTitle('Widget iframe')).toHaveAttribute('src', 'https://status.example.com/embed')
     markdown.unmount()
 
+    const localEmbed = renderWidget('iframe', {displayConfig: {iframe_url: '/demo/widget-preview-embed.html'}})
+    expect(screen.getByTitle('Widget iframe')).toHaveAttribute('src', '/demo/widget-preview-embed.html')
+    localEmbed.unmount()
+  })
+
+  it('rejects unsafe iframe URLs', () => {
     renderWidget('iframe', {displayConfig: {iframe_url: 'javascript:alert(1)'}})
     expect(screen.getByText('No data')).toBeInTheDocument()
   })

--- a/dashboard/src/components/dashboards/extendedWidgetTypes.ts
+++ b/dashboard/src/components/dashboards/extendedWidgetTypes.ts
@@ -1,0 +1,44 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+export const EXTENDED_WIDGET_TYPES = new Set([
+  'stream',
+  'timeline',
+  'geo_map',
+  'host_map',
+  'topology_map',
+  'sankey',
+  'treemap',
+  'scatter',
+  'status',
+  'change',
+  'custom',
+  'flame_graph',
+  'cost_summary',
+  'iframe',
+])
+
+export function isExtendedWidgetType(widgetType: string): boolean {
+  return EXTENDED_WIDGET_TYPES.has(widgetType)
+}
+
+export function isQueryDrivenExtendedWidget(widgetType: string): boolean {
+  return widgetType !== 'iframe'
+}
+
+export function extendedWidgetTestId(widgetType: string): string {
+  return `widget-${widgetType}`
+}


### PR DESCRIPTION
## Summary

- Imports every known Datadog widget type from issue #440 without falling back to generic text/table approximations for supported shapes.
- Maps Datadog widget definitions into source-neutral Moneat widget types such as `stream`, `timeline`, `geo_map`, `host_map`, `topology_map`, `sankey`, `treemap`, `scatter`, `status`, `change`, `custom`, `flame_graph`, `cost_summary`, and `iframe`.
- Keeps the original Datadog widget type only as source metadata so Datadog export can round-trip imported dashboards accurately.
- Adds generic dashboard renderers for the new Moneat widget types rather than Datadog-specific frontend widget modules.
- Seeds a demo `Widget Gallery` dashboard so demo mode can preview the generic imported widget shapes with live demo telemetry.
- Keeps unsupported unknown Datadog widget types on the explicit unsupported fallback path with the original definition preserved for review.
- Improves Datadog query parsing for formulas, raw widget queries, stream/status widgets, and `IN` / `NOT IN` tag filters.
- Adds representative backend and frontend tests for the Datadog import path and the generic extended widget renderers.

Closes #440

## Validation

- `cd backend && ./gradlew --no-daemon :test --tests com.moneat.dashboards.DataDogTranslatorTest -Dkotlin.compiler.execution.strategy=in-process`
- `cd backend && ./gradlew --no-daemon compileKotlin -Dkotlin.compiler.execution.strategy=in-process`
- `cd backend && ./gradlew --no-daemon detekt -Dkotlin.compiler.execution.strategy=in-process`
- `cd dashboard && npm run test -- ExtendedWidgets.test.tsx`
- `cd dashboard && npm run typecheck`
- `cd dashboard && npm run lint`
- `cd dashboard && COVERAGE_GATE_PHASE=hard npm run test:coverage`
- `cd dashboard && npm run build`
- `git diff --check`
- Local preview on `http://localhost:3010`: `Widget Gallery` seeded with 15 widgets; API smoke confirmed every query-driven gallery widget returned rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for extended dashboard widgets: streams, timelines, maps, sankey diagrams, treemaps, scatter plots, status indicators, change widgets, custom widgets, flame graphs, cost summaries, and iframes
  * Enhanced Datadog dashboard import with improved query and filter parsing
  * Introduced new Widget Gallery demo dashboard

* **Tests**
  * Comprehensive test coverage for extended widget types and Datadog import validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->