### PR TITLE
chore: align telemetry ingestion setup copy

### DIFF
--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -596,7 +596,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                 <button
                   type="button"
                   className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  title="Sentry SDK Setup and Docs"
+                  title="Setup and docs"
                 >
                   <HelpCircle className="h-3.5 w-3.5" />
                 </button>
@@ -604,7 +604,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
               <DropdownMenuContent align="start" side="right" className="w-48">
                 <DropdownMenuItem onClick={() => navigate({ to: activeProjectId ? `/projects/${activeProjectId}` : '/' })}>
                   <Rocket className="h-4 w-4 mr-2" />
-                  Sentry SDK Setup
+                  Project setup
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <a href="/docs/" target="_blank" rel="noopener noreferrer">
@@ -674,7 +674,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                 <button
                   type="button"
                   className="flex w-full items-center justify-center rounded-md py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  title="Sentry SDK Setup and Docs"
+                  title="Setup and docs"
                 >
                   <HelpCircle className="h-3.5 w-3.5" />
                 </button>
@@ -682,7 +682,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
               <DropdownMenuContent align="start" side="right" className="w-48">
                 <DropdownMenuItem onClick={() => navigate({ to: activeProjectId ? `/projects/${activeProjectId}` : '/' })}>
                   <Rocket className="h-4 w-4 mr-2" />
-                  Sentry SDK Setup
+                  Project setup
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <a href="/docs/" target="_blank" rel="noopener noreferrer">

--- a/dashboard/src/components/apm/TraceList.tsx
+++ b/dashboard/src/components/apm/TraceList.tsx
@@ -199,7 +199,7 @@ export function TraceList({serviceFilter: externalService, envFilter, basePath}:
             <Clock className="h-10 w-10 mb-3 text-muted-foreground/40" />
             <p className="font-medium">No traces found</p>
             <p className="text-sm mt-1">
-              Send traces via a Datadog agent or OpenTelemetry SDK.
+              Send traces via an OpenTelemetry SDK, Collector, or compatible agent.
             </p>
           </div>
         ) : (

--- a/dashboard/src/components/profiling/ProfileList.tsx
+++ b/dashboard/src/components/profiling/ProfileList.tsx
@@ -302,8 +302,8 @@ function ProfilingEmptyState() {
         </div>
         <p className="font-semibold text-sm text-foreground">No profiles yet</p>
         <p className="text-xs text-muted-foreground mt-1 max-w-sm">
-          Set up continuous profiling with the Sentry SDK or Datadog Agent to
-          start collecting flamegraph data from your applications.
+          Set up continuous profiling in your application or compatible agent to
+          start collecting flamegraph data.
         </p>
         <a
           href="https://moneat.io/docs/sdk-setup"

--- a/dashboard/src/components/settings/AgentApiKeysTab.tsx
+++ b/dashboard/src/components/settings/AgentApiKeysTab.tsx
@@ -16,114 +16,39 @@
 
 import {Shield} from 'lucide-react'
 import {api, type DdApiKey} from '@/lib/api'
-import {backendBaseUrl} from '@/lib/backend-url'
-import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
 import {ApiKeysTabBase} from './ApiKeysTabBase'
-
-const ingestUrl = backendBaseUrl + '/dd'
 
 export function AgentApiKeysTab() {
   return (
     <ApiKeysTabBase<DdApiKey>
       cardId="agent-api-keys"
-      cardTitle="Agent Keys"
-      cardDescription="Create API keys for compatible agent and SDK ingestion. Keys are shown in full only once when created."
+      cardTitle="Datadog Agent Keys"
+      cardDescription="Create API keys for Datadog-compatible agent ingestion."
+      docsHref="/docs/datadog-agent/agent-setup"
       icon={Shield}
-      emptyTitle="No agent keys yet"
-      emptyDescription="Create a key to start ingesting data from compatible agents and SDKs."
+      emptyTitle="No Datadog Agent keys yet"
+      emptyDescription="Create a key to start ingesting data from Datadog-compatible agents."
       queryKey={['agentApiKeys']}
       queryFn={() => api.getAgentApiKeys()}
       queryEnabled={api.isAuthenticated()}
       createMutationFn={(name) => api.createAgentApiKey(name)}
       deleteMutationFn={(id) => api.deleteAgentApiKey(id)}
       createSuccessToast={{
-        title: 'Agent key created',
+        title: 'Datadog Agent key created',
         description: "Copy the key now—it won't be shown again.",
       }}
       revokeSuccessToast={{
         title: 'Key revoked',
         description: 'The agent API key has been revoked.',
       }}
-      createDialogTitle="Create Agent Key"
-      createDialogDescription='Give this key a name to identify it (e.g. "Production Agent"). The full key will be shown once and cannot be retrieved later.'
+      createDialogTitle="Create Datadog Agent Key"
+      createDialogDescription='Give this key a name to identify it (e.g. "Production Datadog Agent"). The full key will be shown once and cannot be retrieved later.'
       inputId="agent-key-name"
-      inputPlaceholder="e.g. Production Agent"
-      createdDialogTitle="Agent Key Created"
-      revokeDialogTitle="Revoke Agent Key"
+      inputPlaceholder="e.g. Production Datadog Agent"
+      createdDialogTitle="Datadog Agent Key Created"
+      revokeDialogTitle="Revoke Datadog Agent Key"
       revokeDialogDescription={(name) =>
         `Are you sure you want to revoke "${name}"? Any agents using this key will no longer be able to send data.`
-      }
-      setupInstructions={
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Agent Configuration</CardTitle>
-            <CardDescription>
-              Configure a compatible agent to send telemetry to Moneat.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <p className="text-sm font-medium mb-1">datadog.yaml</p>
-              <pre className="text-xs bg-muted px-3 py-2 rounded-md break-all whitespace-pre-wrap font-mono">
-                {`api_key: <YOUR_API_KEY>
-dd_url: ${ingestUrl}
-
-apm_config:
-  apm_dd_url: ${ingestUrl}
-  profiling_dd_url: ${ingestUrl}/dd/profiling/v1/input
-
-process_config:
-  process_dd_url: ${ingestUrl}
-
-logs_config:
-  logs_dd_url: ${ingestUrl}
-
-# Route event platform forwarder tracks to Moneat
-# (these use only the host, path is appended automatically)
-container_lifecycle:
-  dd_url: ${backendBaseUrl}
-container_image:
-  dd_url: ${backendBaseUrl}
-sbom:
-  dd_url: ${backendBaseUrl}
-synthetics:
-  forwarder:
-    dd_url: ${backendBaseUrl}
-data_streams:
-  forwarder:
-    dd_url: ${backendBaseUrl}
-event_management:
-  forwarder:
-    dd_url: ${backendBaseUrl}
-database_monitoring:
-  metrics:
-    dd_url: ${backendBaseUrl}
-  samples:
-    dd_url: ${backendBaseUrl}
-  activity:
-    dd_url: ${backendBaseUrl}`}
-              </pre>
-            </div>
-            <div>
-              <p className="text-sm font-medium mb-1">Environment variables (basic)</p>
-              <pre className="text-xs bg-muted px-3 py-2 rounded-md break-all whitespace-pre-wrap font-mono">
-                {`DD_API_KEY=<YOUR_API_KEY>
-DD_DD_URL=${ingestUrl}
-DD_APM_DD_URL=${ingestUrl}
-DD_APM_PROFILING_DD_URL=${ingestUrl}/dd/profiling/v1/input`}
-              </pre>
-              <p className="text-xs text-muted-foreground mt-2">
-                Note: EPForwarder tracks (container images, SBOM, DBM, synthetics, etc.) require the
-                full <code className="bg-muted px-1 rounded">datadog.yaml</code> above — they cannot
-                be configured via environment variables alone.
-              </p>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Replace <code className="bg-muted px-1 rounded">&lt;YOUR_API_KEY&gt;</code> with the
-              full key shown when you create a new key above.
-            </p>
-          </CardContent>
-        </Card>
       }
     />
   )

--- a/dashboard/src/components/settings/ApiKeysTabBase.tsx
+++ b/dashboard/src/components/settings/ApiKeysTabBase.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {Check, Copy, Loader2, Plus, Trash2, type LucideIcon} from 'lucide-react'
+import {BookOpen, Check, Copy, Loader2, Plus, Trash2, type LucideIcon} from 'lucide-react'
 import {type ReactNode, useState} from 'react'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {Button} from '@/components/ui/button'
@@ -45,7 +45,8 @@ export interface ApiKeyRow {
 export interface ApiKeysTabConfig<T extends ApiKeyRow> {
   readonly cardId: string
   readonly cardTitle: string
-  readonly cardDescription: string
+  readonly cardDescription: ReactNode
+  readonly docsHref: string
   readonly icon: LucideIcon
   readonly emptyTitle: string
   readonly emptyDescription: string
@@ -80,6 +81,7 @@ export function ApiKeysTabBase<T extends ApiKeyRow>(config: Readonly<ApiKeysTabC
     cardId,
     cardTitle,
     cardDescription,
+    docsHref,
     icon: Icon,
     emptyTitle,
     emptyDescription,
@@ -232,7 +234,7 @@ export function ApiKeysTabBase<T extends ApiKeyRow>(config: Readonly<ApiKeysTabC
   return (
     <>
       <Card id={cardId}>
-        <CardHeader className="flex flex-row items-start justify-between space-y-0 gap-4">
+        <CardHeader className="flex flex-col gap-4 space-y-0 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <CardTitle className="flex items-center gap-2">
               <Icon className="h-5 w-5" />
@@ -240,10 +242,18 @@ export function ApiKeysTabBase<T extends ApiKeyRow>(config: Readonly<ApiKeysTabC
             </CardTitle>
             <CardDescription>{cardDescription}</CardDescription>
           </div>
-          <Button onClick={() => setCreateOpen(true)} disabled={!!createdKey}>
-            <Plus className="h-4 w-4 mr-2" />
-            New Key
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" asChild>
+              <a href={docsHref} target="_blank" rel="noopener noreferrer">
+                <BookOpen className="h-4 w-4" />
+                Docs
+              </a>
+            </Button>
+            <Button onClick={() => setCreateOpen(true)} disabled={!!createdKey}>
+              <Plus className="h-4 w-4 mr-2" />
+              New Key
+            </Button>
+          </div>
         </CardHeader>
         <CardContent>{keysBody}</CardContent>
       </Card>

--- a/dashboard/src/components/settings/OtlpApiKeysTab.tsx
+++ b/dashboard/src/components/settings/OtlpApiKeysTab.tsx
@@ -16,8 +16,6 @@
 
 import {ScrollText} from 'lucide-react'
 import {api, type OtlpApiKey} from '@/lib/api'
-import {backendBaseUrl} from '@/lib/backend-url'
-import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
 import {ApiKeysTabBase} from './ApiKeysTabBase'
 
 export function OtlpApiKeysTab() {
@@ -25,7 +23,8 @@ export function OtlpApiKeysTab() {
     <ApiKeysTabBase<OtlpApiKey>
       cardId="otlp-api-keys"
       cardTitle="OTLP API Keys"
-      cardDescription="Create org-level API keys for OpenTelemetry ingestion (logs, traces, and metrics). Use these keys with OTLP exporters or the ingest API. Keys are shown in full only once when created."
+      cardDescription="Create org-level API keys for OpenTelemetry ingestion."
+      docsHref="/docs/logging"
       icon={ScrollText}
       emptyTitle="No OTLP API keys yet"
       emptyDescription="Create a key to send logs, traces, and metrics via OpenTelemetry."
@@ -50,41 +49,6 @@ export function OtlpApiKeysTab() {
       revokeDialogTitle="Revoke OTLP API Key"
       revokeDialogDescription={(name) =>
         `Are you sure you want to revoke "${name}"? Any clients using this key will no longer be able to send data.`
-      }
-      setupInstructions={
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Setup Instructions</CardTitle>
-            <CardDescription>
-              Configure your OpenTelemetry SDK or Collector to send telemetry data to Moneat.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <p className="text-sm font-medium mb-1">OTLP endpoints</p>
-              <code className="block text-xs bg-muted px-3 py-2 rounded-md break-all">
-                Logs: {backendBaseUrl}/v1/logs/otlp
-              </code>
-              <code className="block text-xs bg-muted px-3 py-2 rounded-md break-all mt-1">
-                Traces: {backendBaseUrl}/v1/traces/otlp
-              </code>
-              <code className="block text-xs bg-muted px-3 py-2 rounded-md break-all mt-1">
-                Metrics: {backendBaseUrl}/v1/metrics/otlp
-              </code>
-            </div>
-            <div>
-              <p className="text-sm font-medium mb-1">Authentication</p>
-              <p className="text-sm text-muted-foreground">
-                Set the <code className="bg-muted px-1 rounded">Authorization</code> header to{' '}
-                <code className="bg-muted px-1 rounded">Bearer YOUR_OTLP_API_KEY</code>
-              </p>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              For OpenTelemetry SDKs, configure the OTLP exporter with the endpoint URL and the
-              Authorization header containing your OTLP API key.
-            </p>
-          </CardContent>
-        </Card>
       }
     />
   )

--- a/dashboard/src/routes/dashboards.index.tsx
+++ b/dashboard/src/routes/dashboards.index.tsx
@@ -517,7 +517,7 @@ function EmptyState({
         <h3 className="text-2xl font-semibold mb-3">Create your first dashboard</h3>
         <p className="text-muted-foreground text-center mb-8 max-w-lg leading-relaxed">
           Visualize your data with custom charts, tables, and metrics.
-          Start from scratch, use a template, or import from Grafana and DataDog.
+          Start from scratch, use a template, or import from Grafana and Datadog.
         </p>
         <div className="flex flex-col sm:flex-row gap-3">
           <Button variant="outline" size="lg" onClick={onCreateFromTemplate}>

--- a/dashboard/src/routes/error-tracking.tsx
+++ b/dashboard/src/routes/error-tracking.tsx
@@ -21,8 +21,10 @@ import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/
 const config: FeaturePageConfig = {
   slug: 'error-tracking',
   title: 'Error Tracking',
-  tagline: 'Sentry SDK compatible',
-  description: 'Catch, group, and triage errors with smart fingerprinting. See full stack traces, breadcrumbs, and user context for every exception across all your projects. Works with your existing Sentry SDKs.',
+  tagline: 'Triage production exceptions',
+  description:
+    'Catch, group, and triage errors with smart fingerprinting. See full stack traces, breadcrumbs, and user ' +
+    'context for every exception across all your projects. Works with Sentry-compatible SDKs.',
   metaDescription: 'Error tracking with smart fingerprinting, stack traces, and breadcrumbs. Compatible with Sentry SDKs. Start free with Moneat.',
   icon: Activity,
   iconColor: 'text-sky-400',
@@ -39,7 +41,8 @@ const config: FeaturePageConfig = {
     {icon: Workflow, title: 'Issue Workflow', description: 'Mark issues as resolved, ignored, or regressed. Get notified when resolved issues recur.', iconColor: 'text-amber-400'},
     {icon: Activity, title: 'Release Tracking', description: 'Track which releases introduced new errors and which resolved them.', iconColor: 'text-green-400'},
   ],
-  compatNote: 'Compatible with Sentry SDKs for 100+ platforms. Just change your DSN and redeploy — no code changes required.',
+  compatNote:
+    'Compatible with Sentry SDKs for 100+ platforms. Just change your DSN and redeploy — no code changes required.',
 }
 
 export const Route = createFileRoute('/error-tracking')({

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -245,7 +245,7 @@ function FeedbackPage() {
               <div>
                 <h3 className="text-lg font-semibold mb-2">No projects yet</h3>
                 <p className="text-muted-foreground">
-                  Create a project and integrate the Sentry feedback widget to see user feedback here.
+                  Create a project and integrate the feedback widget to see user feedback here.
                 </p>
               </div>
             </div>
@@ -372,7 +372,7 @@ function FeedbackPage() {
                     <p className="text-sm text-muted-foreground">
                       {searchQuery
                         ? 'Try adjusting your search or changing the status filter.'
-                        : 'Use the Sentry User Feedback widget in your app to collect user feedback. It will appear here.'}
+                        : 'Use the feedback widget in your app to collect user feedback. It will appear here.'}
                     </p>
                   </div>
                 </div>

--- a/dashboard/src/routes/infrastructure-monitoring.tsx
+++ b/dashboard/src/routes/infrastructure-monitoring.tsx
@@ -21,8 +21,10 @@ import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/
 const config: FeaturePageConfig = {
   slug: 'infrastructure-monitoring',
   title: 'Infrastructure Monitoring',
-  tagline: 'Datadog Agent compatible',
-  description: 'Monitor hosts, containers, Kubernetes clusters, and databases with real-time metrics. Point your existing Datadog Agent at Moneat and get full visibility without changing a line of code.',
+  tagline: 'Infrastructure telemetry',
+  description:
+    'Monitor hosts, containers, Kubernetes clusters, and databases with real-time infrastructure telemetry. ' +
+    'Point compatible agents at Moneat and get full visibility without changing your applications.',
   metaDescription: 'Infrastructure monitoring for hosts, containers, Kubernetes, and databases. Compatible with the Datadog Agent. Start free with Moneat.',
   icon: Server,
   iconColor: 'text-orange-400',
@@ -37,9 +39,18 @@ const config: FeaturePageConfig = {
     {icon: Network, title: 'Kubernetes', description: 'Cluster, node, pod, and deployment metrics with automatic discovery and labeling.', iconColor: 'text-cyan-400'},
     {icon: Database, title: 'Database Monitoring', description: 'Track query performance, connections, and resource usage for PostgreSQL, MySQL, and more.', iconColor: 'text-violet-400'},
     {icon: HardDrive, title: 'Process Monitoring', description: 'Track individual processes, resource consumption, and detect runaway processes.', iconColor: 'text-amber-400'},
-    {icon: Server, title: 'Custom Metrics', description: 'Send custom metrics via DogStatsD or the Datadog Agent and visualize them on dashboards.', iconColor: 'text-green-400'},
+    {
+      icon: Server,
+      title: 'Custom Metrics',
+      description:
+        'Send custom metrics via OpenTelemetry, DogStatsD, or compatible agents and visualize them ' +
+        'on dashboards.',
+      iconColor: 'text-green-400',
+    },
   ],
-  compatNote: 'Works with the Datadog Agent. Just point dd_url at your Moneat instance and all infrastructure data flows through.',
+  compatNote:
+    'Works with compatible agents, including the Datadog Agent. Point the intake URL at your Moneat instance ' +
+    'and infrastructure data flows through.',
 }
 
 export const Route = createFileRoute('/infrastructure-monitoring')({

--- a/dashboard/src/routes/log-management.tsx
+++ b/dashboard/src/routes/log-management.tsx
@@ -39,7 +39,7 @@ const config: FeaturePageConfig = {
     {icon: Link2, title: 'Correlated Signals', description: 'Jump from a log line to the related error, trace, or replay in one click.', iconColor: 'text-sky-400'},
     {icon: FileText, title: 'Log-Based Alerts', description: 'Set up alerts based on log patterns, error rates, or missing heartbeat logs.', iconColor: 'text-amber-400'},
   ],
-  compatNote: 'Ingest logs from the Datadog Agent, Sentry SDKs, or any source that sends structured JSON over HTTP.',
+  compatNote: 'Ingest logs via OpenTelemetry, compatible agents, or any source that sends structured JSON over HTTP.',
 }
 
 export const Route = createFileRoute('/log-management')({

--- a/dashboard/src/routes/performance-monitoring.tsx
+++ b/dashboard/src/routes/performance-monitoring.tsx
@@ -39,7 +39,7 @@ const config: FeaturePageConfig = {
     {icon: Search, title: 'Trace Search', description: 'Search traces by duration, status, tags, or any custom attribute attached to spans.', iconColor: 'text-violet-400'},
     {icon: Zap, title: 'Apdex Scoring', description: 'Measure user satisfaction with Apdex scores based on configurable thresholds.', iconColor: 'text-green-400'},
   ],
-  compatNote: 'Compatible with Sentry SDKs and the Datadog Agent. Ingest traces from either or both simultaneously.',
+  compatNote: 'Ingest traces via OpenTelemetry SDKs, Sentry-compatible SDKs, or compatible agents simultaneously.',
 }
 
 export const Route = createFileRoute('/performance-monitoring')({

--- a/dashboard/src/routes/performance.service-map.tsx
+++ b/dashboard/src/routes/performance.service-map.tsx
@@ -8,7 +8,6 @@
 
 import {createFileRoute} from '@tanstack/react-router'
 import {ServiceMap} from '@/components/apm/ServiceMap'
-import {Badge} from '@/components/ui/badge'
 
 export const Route = createFileRoute('/performance/service-map')({
   component: PerformanceServiceMapPage,
@@ -20,10 +19,7 @@ function PerformanceServiceMapPage() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Service Map</h1>
         <p className="text-muted-foreground text-sm mt-0.5">
-          Service dependency graph from APM instrumentation
-          <Badge variant="outline" className="ml-2 text-[10px] px-1.5 py-0 font-normal">
-            Datadog
-          </Badge>
+          Service dependency graph from trace telemetry
         </p>
       </div>
       <ServiceMap />

--- a/dashboard/src/routes/performance.traces.$traceId.tsx
+++ b/dashboard/src/routes/performance.traces.$traceId.tsx
@@ -148,7 +148,7 @@ function PerformanceTraceDetailPage() {
               <span className="text-muted-foreground font-normal mx-1">.</span>
               {rootSpan?.name}
             </h1>
-            <SourceBadge source={rootSpan?.source ?? 'datadog'} />
+            <SourceBadge source={rootSpan?.source ?? ''} />
             {rootSpan?.env && (
               <Badge variant="outline" className="text-xs">
                 {rootSpan.env}

--- a/dashboard/src/routes/profiling.tsx
+++ b/dashboard/src/routes/profiling.tsx
@@ -22,7 +22,9 @@ const config: FeaturePageConfig = {
   slug: 'profiling',
   title: 'Continuous Profiling',
   tagline: 'Pinpoint hot paths in production',
-  description: 'CPU, heap, and wall-time profiles from your Datadog Agent. Identify hot functions, memory leaks, and resource bottlenecks in production without any performance overhead.',
+  description:
+    'CPU, heap, and wall-time profiles from production telemetry. Identify hot functions, memory leaks, ' +
+    'and resource bottlenecks without adding application overhead.',
   metaDescription: 'Continuous profiling with CPU, heap, and wall-time flamegraphs. Pinpoint performance bottlenecks in production. Start free with Moneat.',
   icon: Flame,
   iconColor: 'text-red-400',
@@ -36,10 +38,17 @@ const config: FeaturePageConfig = {
     {icon: Cpu, title: 'CPU Profiling', description: 'Identify hot functions and optimize the code paths that consume the most CPU cycles.', iconColor: 'text-orange-400'},
     {icon: HardDrive, title: 'Heap Profiling', description: 'Track memory allocations and find memory leaks before they cause OOM kills.', iconColor: 'text-amber-400'},
     {icon: Clock, title: 'Wall-Time Profiles', description: 'Understand where time is spent including I/O waits, locks, and external calls.', iconColor: 'text-blue-400'},
-    {icon: Layers, title: 'Multi-Language', description: 'Support for Go, Java, Python, Ruby, Node.js, .NET, and PHP via the Datadog Agent.', iconColor: 'text-violet-400'},
+    {
+      icon: Layers,
+      title: 'Multi-Language',
+      description: 'Support for Go, Java, Python, Ruby, Node.js, .NET, and PHP via compatible profiling agents.',
+      iconColor: 'text-violet-400',
+    },
     {icon: Search, title: 'Compare Profiles', description: 'Diff profiles across deployments to see exactly what changed in your performance.', iconColor: 'text-cyan-400'},
   ],
-  compatNote: 'Profiles are collected via the Datadog Agent with near-zero overhead. Enable profiling with a single config flag.',
+  compatNote:
+    'Profiles are collected through compatible profiling agents with near-zero overhead. Enable profiling with a ' +
+    'single config flag.',
 }
 
 export const Route = createFileRoute('/profiling')({

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -343,7 +343,7 @@ function ReplaysPage() {
               <div>
                 <h3 className="text-lg font-semibold mb-2">No replays yet</h3>
                 <p className="text-muted-foreground">
-                  Session replays are recorded when you enable the Sentry Replay integration in your SDK.
+                  Session replays are recorded when you enable replay capture in a compatible SDK.
                   Configure replays in your project setup to start capturing user sessions.
                 </p>
               </div>

--- a/dashboard/src/routes/security-sbom.tsx
+++ b/dashboard/src/routes/security-sbom.tsx
@@ -37,9 +37,18 @@ const config: FeaturePageConfig = {
     {icon: Search, title: 'Vulnerability Search', description: 'Search for specific CVEs or packages across your entire infrastructure instantly.', iconColor: 'text-blue-400'},
     {icon: FileText, title: 'SBOM Export', description: 'Export your software bill of materials in standard formats for compliance and auditing.', iconColor: 'text-violet-400'},
     {icon: Shield, title: 'Compliance', description: 'Meet supply-chain security requirements with automated SBOM generation and tracking.', iconColor: 'text-amber-400'},
-    {icon: ShieldCheck, title: 'Auto-Discovery', description: 'Packages are discovered automatically from your Datadog Agent — no manual configuration.', iconColor: 'text-cyan-400'},
+    {
+      icon: ShieldCheck,
+      title: 'Auto-Discovery',
+      description:
+        'Packages are discovered automatically from supported infrastructure agents with no manual ' +
+        'inventory work.',
+      iconColor: 'text-cyan-400',
+    },
   ],
-  compatNote: 'SBOM data is collected automatically via the Datadog Agent. No additional tools or scanning pipelines required.',
+  compatNote:
+    'SBOM data is collected automatically through supported infrastructure agents. No additional scanning pipeline ' +
+    'is required.',
 }
 
 export const Route = createFileRoute('/security-sbom')({

--- a/dashboard/src/routes/session-replay.tsx
+++ b/dashboard/src/routes/session-replay.tsx
@@ -39,7 +39,9 @@ const config: FeaturePageConfig = {
     {icon: Layers, title: 'Console & Network', description: 'View console logs, network requests, and JavaScript errors alongside the visual replay.', iconColor: 'text-cyan-400'},
     {icon: Play, title: 'Privacy Controls', description: 'Mask sensitive fields, exclude elements, and respect user privacy preferences automatically.', iconColor: 'text-green-400'},
   ],
-  compatNote: 'Works with Sentry SDKs. Enable session replay with a single config flag — no additional integration required.',
+  compatNote:
+    'Capture replays through compatible SDKs. Enable session replay with a single config flag — no additional ' +
+    'integration required.',
 }
 
 export const Route = createFileRoute('/session-replay')({

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -348,20 +348,20 @@ function SettingsPage() {
 function ApiKeysTab() {
   const hasDatadog = true // Datadog module is always available (OSS)
   return (
-    <Tabs defaultValue="sentry">
+    <Tabs defaultValue="logs">
       <TabsList className="mb-4">
+        <TabsTrigger value="logs">OpenTelemetry</TabsTrigger>
         <TabsTrigger value="sentry">Sentry</TabsTrigger>
         <TabsTrigger value="datadog" disabled={!hasDatadog}>Datadog Agent</TabsTrigger>
-        <TabsTrigger value="logs">OpenTelemetry</TabsTrigger>
       </TabsList>
+      <TabsContent value="logs" className="space-y-8 mt-0">
+        <OtlpApiKeysTab />
+      </TabsContent>
       <TabsContent value="sentry" className="space-y-8 mt-0">
         <AuthTokensSection />
       </TabsContent>
       <TabsContent value="datadog" className="space-y-8 mt-0">
         {hasDatadog && <AgentApiKeysTab />}
-      </TabsContent>
-      <TabsContent value="logs" className="space-y-8 mt-0">
-        <OtlpApiKeysTab />
       </TabsContent>
     </Tabs>
   )

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -53,6 +53,7 @@ import {
   AlertTriangle,
   Bell,
   BellOff,
+  BookOpen,
   Calendar,
   Check,
   CheckCircle2,
@@ -350,8 +351,8 @@ function ApiKeysTab() {
     <Tabs defaultValue="sentry">
       <TabsList className="mb-4">
         <TabsTrigger value="sentry">Sentry</TabsTrigger>
-        <TabsTrigger value="datadog" disabled={!hasDatadog}>Datadog</TabsTrigger>
-        <TabsTrigger value="logs">Logs</TabsTrigger>
+        <TabsTrigger value="datadog" disabled={!hasDatadog}>Datadog Agent</TabsTrigger>
+        <TabsTrigger value="logs">OpenTelemetry</TabsTrigger>
       </TabsList>
       <TabsContent value="sentry" className="space-y-8 mt-0">
         <AuthTokensSection />
@@ -438,20 +439,28 @@ function AuthTokensSection() {
   return (
     <>
       <Card>
-        <CardHeader className="flex flex-row items-start justify-between space-y-0 gap-4">
+        <CardHeader className="flex flex-col gap-4 space-y-0 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <CardTitle className="flex items-center gap-2">
               <Key className="h-5 w-5" />
-              Auth Tokens
+              Sentry API Tokens
             </CardTitle>
             <CardDescription>
-              For CLI tools and CI/CD: upload source maps, manage releases, read events.
+              Create tokens for sentry-cli, source maps, releases, and Sentry-compatible API access.
             </CardDescription>
           </div>
-          <Button onClick={() => setCreateOpen(true)} disabled={!!createdTokenValue}>
-            <Plus className="h-4 w-4 mr-2" />
-            New Token
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" asChild>
+              <a href="/docs/api-tokens" target="_blank" rel="noopener noreferrer">
+                <BookOpen className="h-4 w-4" />
+                Docs
+              </a>
+            </Button>
+            <Button onClick={() => setCreateOpen(true)} disabled={!!createdTokenValue}>
+              <Plus className="h-4 w-4 mr-2" />
+              New Token
+            </Button>
+          </div>
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -460,7 +469,7 @@ function AuthTokensSection() {
             <div className="border rounded-lg p-8 text-center text-muted-foreground">
               <Key className="h-10 w-10 mx-auto mb-2 opacity-50" />
               <p className="font-medium">No tokens yet</p>
-              <p className="text-sm mt-1">Create a token to use with the API or upload tools.</p>
+              <p className="text-sm mt-1">Create a Sentry API token for CLI and upload tools.</p>
               <Button variant="outline" className="mt-4" onClick={() => setCreateOpen(true)}>
                 <Plus className="h-4 w-4 mr-2" />
                 Create token


### PR DESCRIPTION
## Summary

- align dashboard product copy around Moneat telemetry workflows instead of vendor-shaped core UI
- keep vendor names where the user is configuring compatible ingestion paths, including Sentry tokens and Datadog Agent keys
- replace inline API-key setup instructions with generic Docs buttons that open documentation in a new tab

## Validation

- npm run lint -- --quiet
- npm run typecheck
- npm run build
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Simplified messaging across settings and feature pages, replacing vendor-specific references with generic language (e.g., OpenTelemetry SDK, compatible agents).
  * Updated empty-state descriptions and compatibility notes to support multiple data sources.
  * Reorganized API keys tab layout with improved header design.

* **New Features**
  * Added documentation link button to API keys configuration.

* **Bug Fixes**
  * Corrected platform name formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->