### PR TITLE
fix: preserve slack issue ids

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -625,7 +625,7 @@ class SlackService {
         issueTitle: String,
         level: String,
         culprit: String?,
-        issueId: Long,
+        issueId: String,
         baseUrl: String,
         occurrenceCount: Int = 1,
         environment: String? = null,

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -18,6 +18,8 @@ package com.moneat.notifications.services
 
 import kotlinx.serialization.SerializationException
 import java.io.IOException
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OrganizationIntegrations
@@ -43,9 +45,13 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.slf4j.LoggerFactory
 import com.moneat.utils.suspendRunCatching
-import java.util.*
+import java.util.Locale
+import java.util.UUID
 
 private const val SLACK_CHANNEL_FETCH_LIMIT = 200
+
+internal fun encodeSlackIssueIdPathSegment(value: String): String =
+    URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
 
 class SlackService {
     private val logger = LoggerFactory.getLogger(SlackService::class.java)
@@ -633,6 +639,7 @@ class SlackService {
         stackTrace: String? = null
     ): Boolean {
         val config = getSlackConfig(organizationId) ?: return false
+        val issueUrl = "$baseUrl/issues/${encodeSlackIssueIdPathSegment(issueId)}"
 
         val levelLower = level.lowercase()
         val levelEmoji =
@@ -681,7 +688,7 @@ class SlackService {
                 text =
                 SlackText(
                     type = "mrkdwn",
-                    text = "*<$baseUrl/issues/$issueId|$issueTitle>*"
+                    text = "*<$issueUrl|$issueTitle>*"
                 )
             )
         )
@@ -751,7 +758,7 @@ class SlackService {
                     SlackElement(
                         type = "button",
                         text = SlackText(type = "plain_text", text = "View Issue"),
-                        url = "$baseUrl/issues/$issueId"
+                        url = issueUrl
                     )
                 )
             )

--- a/backend/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
@@ -556,7 +556,7 @@ fun Route.adminRoutes() {
                                                 issueTitle = "NullPointerException in UserService",
                                                 level = "error",
                                                 culprit = "com.example.UserService.getUser",
-                                                issueId = 12345L,
+                                                issueId = "12345",
                                                 baseUrl = frontendUrl,
                                                 occurrenceCount = 42,
                                                 environment = "production",

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceRoutingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceRoutingTest.kt
@@ -161,6 +161,7 @@ class NotificationServiceRoutingTest {
             assertEquals(AlertStatus.FIRING, event.status)
             assertEquals(AlertSource.ERROR_ALERT, event.source)
             assertEquals("moneat-error-2001", event.deduplicationKey)
+            assertEquals("https://moneat.io/issues/2001", event.moneatUrl)
             assertEquals(orgId, event.organizationId)
         }
 

--- a/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
@@ -167,7 +167,7 @@ class SlackServiceBuildersTest {
         }
 
     @Test
-    fun `sendErrorAlert returns false when no integration configured`() =
+    fun `sendErrorAlert accepts opaque issue IDs when no integration configured`() =
         runBlocking {
             val orgId = seedOrg()
             assertFalse(
@@ -177,7 +177,7 @@ class SlackServiceBuildersTest {
                     issueTitle = "NullPointerException",
                     level = "error",
                     culprit = "com.moneat.Main",
-                    issueId = 100L,
+                    issueId = "a1b2c3d4e5f6abc0",
                     baseUrl = BASE_URL
                 )
             )
@@ -367,7 +367,7 @@ class SlackServiceBuildersTest {
                 issueTitle = "NullPointerException in UserService",
                 level = "error",
                 culprit = "com.moneat.services.UserService.getUser",
-                issueId = 500L,
+                issueId = "500",
                 baseUrl = BASE_URL,
                 occurrenceCount = 15,
                 environment = "production",
@@ -388,7 +388,7 @@ class SlackServiceBuildersTest {
                 issueTitle = "Deprecated API usage",
                 level = "warning",
                 culprit = null,
-                issueId = 501L,
+                issueId = "501",
                 baseUrl = BASE_URL
             )
             assertFalse(result)
@@ -405,7 +405,7 @@ class SlackServiceBuildersTest {
                 issueTitle = "Feature flag evaluated",
                 level = "info",
                 culprit = "flags.ts:evaluate",
-                issueId = 502L,
+                issueId = "502",
                 baseUrl = BASE_URL,
                 environment = "staging"
             )
@@ -423,7 +423,7 @@ class SlackServiceBuildersTest {
                 issueTitle = "Unrecognized event type",
                 level = "debug",
                 culprit = null,
-                issueId = 503L,
+                issueId = "503",
                 baseUrl = BASE_URL,
                 occurrenceCount = 1,
                 timestamp = "2024-06-15T12:00:00Z"
@@ -442,7 +442,7 @@ class SlackServiceBuildersTest {
                 issueTitle = "TimeoutException",
                 level = "error",
                 culprit = null,
-                issueId = 504L,
+                issueId = "504",
                 baseUrl = BASE_URL
             )
             assertFalse(result)
@@ -531,7 +531,7 @@ class SlackServiceBuildersTest {
                     issueTitle = "Error",
                     level = "error",
                     culprit = null,
-                    issueId = 1L,
+                    issueId = "1",
                     baseUrl = BASE_URL
                 )
             )

--- a/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
@@ -17,6 +17,7 @@
 package com.moneat.services
 
 import com.moneat.notifications.services.SlackService
+import com.moneat.notifications.services.encodeSlackIssueIdPathSegment
 import com.moneat.shared.models.OrganizationIntegrations
 import com.moneat.shared.models.Organizations
 import com.moneat.testsupport.TestDatabaseHelper
@@ -27,6 +28,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Clock
@@ -182,6 +184,14 @@ class SlackServiceBuildersTest {
                 )
             )
         }
+
+    @Test
+    fun `issue ID path segment encoding preserves opaque IDs in Slack URLs`() {
+        assertEquals(
+            "a%2Fb%3Fc%23d%7Ce%3Ef%20g%2Bh",
+            encodeSlackIssueIdPathSegment("a/b?c#d|e>f g+h")
+        )
+    }
 
     @Test
     fun `testConnection returns not configured when no integration`() =


### PR DESCRIPTION
## Summary
- preserve Slack issue IDs as strings when building issue links
- keep the admin Slack test payload aligned with the string issue ID contract
- add regression coverage for opaque issue IDs and notification issue URLs

## Validation
- backend: `./gradlew compileKotlin`
- backend: `./gradlew :test --tests com.moneat.services.SlackServiceBuildersTest --tests com.moneat.services.NotificationServiceRoutingTest`
- backend: `./gradlew detekt test jacocoTestReport testClasses integrationTestClasses --no-daemon`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Slack notification system to handle issue identifiers as string-based values, enabling support for more flexible ID formats.

* **Tests**
  * Expanded test coverage to validate proper processing of string-formatted issue identifiers in alert messages, formatting, and URL generation across notification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->