### PR TITLE
fix: harden clickhouse timeout hot paths

### DIFF
--- a/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceMapRollups.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceMapRollups.kt
@@ -1,0 +1,236 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.apm.services
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.suspendRunCatching
+import io.ktor.http.isSuccess
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+private const val NANOS_PER_SECOND = 1_000_000_000L
+private const val SECONDS_PER_HOUR = 3_600L
+private const val SERVICE_STATS_TABLE = "apm_service_stats_hourly"
+private const val SERVICE_EDGES_TABLE = "apm_service_edges_hourly"
+
+data class ApmServiceMapSpan(
+    val organizationId: Long,
+    val traceKey: String,
+    val spanKey: String,
+    val parentKey: String,
+    val service: String,
+    val env: String,
+    val source: String,
+    val startNanos: Long,
+    val durationNanos: Long,
+    val error: Int,
+)
+
+object ApmServiceMapRollups {
+
+    suspend fun insertForSpans(
+        clickhouseDb: String,
+        spans: List<ApmServiceMapSpan>,
+    ) {
+        val validSpans = spans.filter { it.isRollupEligible() }
+        if (validSpans.isEmpty()) return
+
+        listOfNotNull(
+            buildServiceStatsInsert(clickhouseDb, validSpans),
+            buildServiceEdgesInsert(clickhouseDb, validSpans),
+        ).forEach { statement ->
+            executeRollupInsert(statement)
+        }
+    }
+
+    internal fun buildServiceStatsInsert(
+        clickhouseDb: String,
+        spans: List<ApmServiceMapSpan>,
+    ): String? {
+        val stats = mutableMapOf<ServiceStatsKey, ServiceStatsAccumulator>()
+        spans.filter { it.isRollupEligible() }.forEach { span ->
+            val key = ServiceStatsKey(
+                organizationId = span.organizationId,
+                bucketStartSeconds = bucketStartSeconds(span.startNanos),
+                service = span.service,
+                env = span.env,
+                source = span.source,
+            )
+            stats.getOrPut(key) { ServiceStatsAccumulator() }.add(span)
+        }
+        if (stats.isEmpty()) return null
+
+        val rows = stats.entries.joinToString(",\n") { (key, value) ->
+            """(
+                ${key.organizationId},
+                toDateTime(${key.bucketStartSeconds}, 'UTC'),
+                '${escapeSql(key.service)}',
+                '${escapeSql(key.env)}',
+                '${escapeSql(key.source)}',
+                ${value.spanCount},
+                ${value.errorCount},
+                ${value.durationSum},
+                ${value.durationCount}
+            )
+            """.trimIndent()
+        }
+
+        return """
+            INSERT INTO `$clickhouseDb`.$SERVICE_STATS_TABLE (
+                organization_id, bucket_start, service, env, source,
+                span_count, error_count, duration_sum, duration_count
+            ) VALUES
+            $rows
+        """.trimIndent()
+    }
+
+    internal fun buildServiceEdgesInsert(
+        clickhouseDb: String,
+        spans: List<ApmServiceMapSpan>,
+    ): String? {
+        val spansByTraceAndId = spans
+            .filter { it.isRollupEligible() }
+            .associateBy { TraceSpanKey(it.organizationId, it.traceKey, it.spanKey) }
+        val edges = mutableMapOf<ServiceEdgeKey, ServiceEdgeAccumulator>()
+
+        spans.filter { it.isRollupEligible() && it.parentKey.isNotBlank() }.forEach { child ->
+            val parent = spansByTraceAndId[
+                TraceSpanKey(child.organizationId, child.traceKey, child.parentKey)
+            ] ?: return@forEach
+            if (parent.service == child.service) return@forEach
+
+            val key = ServiceEdgeKey(
+                organizationId = child.organizationId,
+                bucketStartSeconds = bucketStartSeconds(child.startNanos),
+                fromService = parent.service,
+                toService = child.service,
+                env = child.env,
+                source = child.source,
+            )
+            edges.getOrPut(key) { ServiceEdgeAccumulator() }.add(child)
+        }
+        if (edges.isEmpty()) return null
+
+        val rows = edges.entries.joinToString(",\n") { (key, value) ->
+            """(
+                ${key.organizationId},
+                toDateTime(${key.bucketStartSeconds}, 'UTC'),
+                '${escapeSql(key.fromService)}',
+                '${escapeSql(key.toService)}',
+                '${escapeSql(key.env)}',
+                '${escapeSql(key.source)}',
+                ${value.callCount},
+                ${value.errorCount},
+                ${value.durationSum},
+                ${value.durationCount}
+            )
+            """.trimIndent()
+        }
+
+        return """
+            INSERT INTO `$clickhouseDb`.$SERVICE_EDGES_TABLE (
+                organization_id, bucket_start, from_service, to_service, env, source,
+                call_count, error_count, duration_sum, duration_count
+            ) VALUES
+            $rows
+        """.trimIndent()
+    }
+
+    private suspend fun executeRollupInsert(statement: String) {
+        val response = suspendRunCatching { ClickHouseClient.execute(statement) }
+            .getOrElse { e ->
+                logger.warn(e) { "Failed to insert APM service-map rollup rows" }
+                return
+            }
+
+        if (!response.status.isSuccess()) {
+            logger.warn { "ClickHouse rejected APM service-map rollup insert: ${response.status}" }
+        }
+    }
+
+    private fun ApmServiceMapSpan.isRollupEligible(): Boolean =
+        organizationId > 0 &&
+            traceKey.isNotBlank() &&
+            spanKey.isNotBlank() &&
+            service.isNotBlank()
+
+    private fun bucketStartSeconds(startNanos: Long): Long {
+        val startSeconds = Math.floorDiv(startNanos, NANOS_PER_SECOND)
+        return Math.floorDiv(startSeconds, SECONDS_PER_HOUR) * SECONDS_PER_HOUR
+    }
+
+    private data class TraceSpanKey(
+        val organizationId: Long,
+        val traceKey: String,
+        val spanKey: String,
+    )
+
+    private data class ServiceStatsKey(
+        val organizationId: Long,
+        val bucketStartSeconds: Long,
+        val service: String,
+        val env: String,
+        val source: String,
+    )
+
+    private data class ServiceEdgeKey(
+        val organizationId: Long,
+        val bucketStartSeconds: Long,
+        val fromService: String,
+        val toService: String,
+        val env: String,
+        val source: String,
+    )
+
+    private class ServiceStatsAccumulator {
+        var spanCount: Long = 0
+            private set
+        var errorCount: Long = 0
+            private set
+        var durationSum: Long = 0
+            private set
+        var durationCount: Long = 0
+            private set
+
+        fun add(span: ApmServiceMapSpan) {
+            spanCount += 1
+            errorCount += span.error.toLong()
+            durationSum += span.durationNanos
+            durationCount += 1
+        }
+    }
+
+    private class ServiceEdgeAccumulator {
+        var callCount: Long = 0
+            private set
+        var errorCount: Long = 0
+            private set
+        var durationSum: Long = 0
+            private set
+        var durationCount: Long = 0
+            private set
+
+        fun add(span: ApmServiceMapSpan) {
+            callCount += 1
+            errorCount += span.error.toLong()
+            durationSum += span.durationNanos
+            durationCount += 1
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogHostRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogHostRoutes.kt
@@ -369,19 +369,19 @@ fun Route.datadogHostQueryRoutes() {
                         HttpStatusCode.BadRequest,
                         mapOf("error" to "Invalid host id")
                     )
-                val host = DatadogHostService.getHost(orgId, hostId)
+                DatadogHostService.getHost(orgId, hostId)
                     ?: return@get call.respond(
                         HttpStatusCode.NotFound,
                         mapOf("error" to "Host not found")
                     )
 
                 val db = ClickHouseClient.getDatabase()
-                // Use argMax to deduplicate: one row per container_id, taking the latest snapshot.
                 // Only show containers seen in the last 10 minutes — the DD agent reports every
                 // ~10s, so anything older is no longer running. The agent only reports running
                 // containers (stopped ones simply stop appearing).
                 val sql = """
                     SELECT
+                        argMax(host, timestamp) as host,
                         container_id,
                         argMax(name, timestamp) as name,
                         argMax(image, timestamp) as image,
@@ -393,9 +393,9 @@ fun Route.datadogHostQueryRoutes() {
                         argMax(net_tx_bytes, timestamp) as net_tx_bytes,
                         argMax(tags, timestamp) as tags,
                         formatDateTime(max(timestamp), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as ts
-                    FROM `$db`.containers
+                    FROM `$db`.containers_latest_by_host
                     WHERE ${ClickHouseQueryUtils.orgIdClause(orgId.toLong())}
-                      AND host = '${escapeSqlHost(host.hostname)}'
+                      AND host_id = $hostId
                       AND timestamp >= now64(3) - INTERVAL 10 MINUTE
                     GROUP BY container_id
                     ORDER BY max(timestamp) DESC
@@ -425,7 +425,7 @@ fun Route.datadogHostQueryRoutes() {
                         }
                         buildJsonObject {
                             put("id", containerId)
-                            put("host", host.hostname)
+                            put("host", obj["host"]?.jsonPrimitive?.content ?: "")
                             put("containerId", containerId)
                             put("name", displayName)
                             put("image", image)

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogInfraQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogInfraQueryRoutes.kt
@@ -162,27 +162,39 @@ fun Route.datadogInfraQueryRoutes() {
 
                 val countSql = """
                     SELECT count() as cnt
-                    FROM `$db`.containers
-                    WHERE $where
+                    FROM (
+                        SELECT 1
+                        FROM `$db`.containers_latest_by_host
+                        WHERE $where
+                        GROUP BY organization_id, host_id, host, container_id
+                    )
                     FORMAT JSONEachRow
                 """.trimIndent()
                 val totalCount = executeCount(countSql)
 
                 val dataSql = """
                     SELECT
-                        container_id_hash, host,
-                        container_id, name, image, state,
-                        cpu_percent, mem_usage, mem_limit,
-                        net_rx_bytes, net_tx_bytes,
-                        tags,
+                        toString(cityHash64(host, container_id)) as container_id_hash,
+                        host,
+                        container_id,
+                        argMax(name, timestamp) as name,
+                        argMax(image, timestamp) as image,
+                        argMax(state, timestamp) as state,
+                        argMax(cpu_percent, timestamp) as cpu_percent,
+                        argMax(mem_usage, timestamp) as mem_usage,
+                        argMax(mem_limit, timestamp) as mem_limit,
+                        argMax(net_rx_bytes, timestamp) as net_rx_bytes,
+                        argMax(net_tx_bytes, timestamp) as net_tx_bytes,
+                        argMax(tags, timestamp) as tags,
                         formatDateTime(
-                            timestamp,
+                            max(timestamp),
                             '%Y-%m-%dT%H:%i:%S.000Z',
                             'UTC'
                         ) as ts
-                    FROM `$db`.containers
+                    FROM `$db`.containers_latest_by_host
                     WHERE $where
-                    ORDER BY timestamp DESC
+                    GROUP BY organization_id, host_id, host, container_id
+                    ORDER BY max(timestamp) DESC
                     LIMIT $limit OFFSET $offset
                     FORMAT JSONEachRow
                 """.trimIndent()

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -19,6 +19,7 @@ package com.moneat.datadog.routes
 import com.moneat.datadog.services.DdApmQueryTimeRange
 import com.moneat.datadog.services.DdApmQueryTimeUnit
 import com.moneat.datadog.services.TraceIngestionService
+import com.moneat.plugins.getSentryTransaction
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -73,7 +74,8 @@ fun Route.traceDashboardRoutes() {
                     service,
                     limit,
                     offset,
-                    timeRange
+                    timeRange,
+                    call.getSentryTransaction(),
                 )
                 call.respond(result)
             }
@@ -108,7 +110,8 @@ fun Route.traceDashboardRoutes() {
                     env,
                     limit,
                     offset,
-                    timeRange
+                    timeRange,
+                    call.getSentryTransaction(),
                 )
                 call.respond(result)
             }
@@ -136,7 +139,8 @@ fun Route.traceDashboardRoutes() {
 
                 val result = TraceIngestionService.getTraceDetail(
                     orgId,
-                    traceId
+                    traceId,
+                    call.getSentryTransaction(),
                 )
                 if (result == null) {
                     call.respond(
@@ -158,7 +162,7 @@ fun Route.traceDashboardRoutes() {
                     HttpStatusCode.Unauthorized,
                     mapOf("error" to "Invalid token")
                 )
-            val result = TraceIngestionService.getServiceMap(orgId)
+            val result = TraceIngestionService.getServiceMap(orgId, call.getSentryTransaction())
             call.respond(result)
         }
 
@@ -189,7 +193,8 @@ fun Route.traceDashboardRoutes() {
                 service,
                 limit,
                 offset,
-                timeRange
+                timeRange,
+                call.getSentryTransaction(),
             )
             call.respond(result)
         }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogInfraService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogInfraService.kt
@@ -21,6 +21,8 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DatadogConnectionsPayload
 import com.moneat.datadog.models.DatadogContainerPayload
 import com.moneat.datadog.models.DatadogProcessPayload
+import com.moneat.monitor.services.InfraContainerRollupRow
+import com.moneat.monitor.services.InfraTelemetryRollups
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
@@ -289,6 +291,25 @@ object DatadogInfraService {
         """.trimIndent()
 
         executeInsert(insert, "DD containers")
+        InfraTelemetryRollups.insertContainerRollups(
+            batch.containers.map { container ->
+                InfraContainerRollupRow(
+                    organizationId = batch.organizationId,
+                    host = container.host,
+                    containerId = container.containerId,
+                    name = container.name,
+                    image = container.image,
+                    state = container.state,
+                    cpuPercent = container.cpuPercent,
+                    memUsage = container.memUsage,
+                    memLimit = container.memLimit,
+                    netRxBytes = container.netRxBytes,
+                    netTxBytes = container.netTxBytes,
+                    tags = container.tags,
+                    timestampMs = container.timestampMs,
+                )
+            }
+        )
     }
 
     private suspend fun insertConnections(batch: QueuedInfraBatch) {

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogInfraService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogInfraService.kt
@@ -26,6 +26,7 @@ import com.moneat.monitor.services.InfraTelemetryRollups
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -291,25 +292,7 @@ object DatadogInfraService {
         """.trimIndent()
 
         executeInsert(insert, "DD containers")
-        InfraTelemetryRollups.insertContainerRollups(
-            batch.containers.map { container ->
-                InfraContainerRollupRow(
-                    organizationId = batch.organizationId,
-                    host = container.host,
-                    containerId = container.containerId,
-                    name = container.name,
-                    image = container.image,
-                    state = container.state,
-                    cpuPercent = container.cpuPercent,
-                    memUsage = container.memUsage,
-                    memLimit = container.memLimit,
-                    netRxBytes = container.netRxBytes,
-                    netTxBytes = container.netTxBytes,
-                    tags = container.tags,
-                    timestampMs = container.timestampMs,
-                )
-            }
-        )
+        insertContainerRollupsBestEffort(batch)
     }
 
     private suspend fun insertConnections(batch: QueuedInfraBatch) {
@@ -372,5 +355,36 @@ object DatadogInfraService {
 
     fun decodeInfraBatch(encoded: String): QueuedInfraBatch {
         return json.decodeFromString(encoded)
+    }
+
+    private suspend fun insertContainerRollupsBestEffort(batch: QueuedInfraBatch) {
+        try {
+            InfraTelemetryRollups.insertContainerRollups(
+                batch.containers.map { container ->
+                    InfraContainerRollupRow(
+                        organizationId = batch.organizationId,
+                        host = container.host,
+                        containerId = container.containerId,
+                        name = container.name,
+                        image = container.image,
+                        state = container.state,
+                        cpuPercent = container.cpuPercent,
+                        memUsage = container.memUsage,
+                        memLimit = container.memLimit,
+                        netRxBytes = container.netRxBytes,
+                        netTxBytes = container.netTxBytes,
+                        tags = container.tags,
+                        timestampMs = container.timestampMs,
+                    )
+                }
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) {
+                "Failed to write Datadog container rollups for org ${batch.organizationId} " +
+                    "(${batch.containers.size} containers); raw containers were already written"
+            }
+        }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
@@ -21,14 +21,16 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DatadogMetricSeriesV1
 import com.moneat.datadog.models.DatadogMetricV1
 import com.moneat.datadog.models.DatadogSketchPayload
+import com.moneat.monitor.services.InfraMetricRollupRow
+import com.moneat.monitor.services.InfraTelemetryRollups
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
-import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 
 private val logger = KotlinLogging.logger {}
 private const val METRIC_QUEUE_KEY = "moneat:metrics:queue"
@@ -198,6 +200,20 @@ object DatadogMetricService {
                 "Failed to insert DD metrics: ${errorBody.take(ERROR_BODY_MAX_LEN)}"
             )
         }
+        InfraTelemetryRollups.insertMetricRollups(
+            batch.metrics.map { metric ->
+                InfraMetricRollupRow(
+                    organizationId = batch.organizationId,
+                    metricName = metric.name,
+                    timestampMs = metric.timestampMs,
+                    value = metric.value,
+                    host = metric.host,
+                    tags = metric.tags,
+                    unit = metric.unit,
+                    source = "datadog",
+                )
+            }
+        )
     }
 
     suspend fun insertSketchBatch(batch: QueuedSketchBatch) {

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
@@ -27,6 +27,7 @@ import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -200,20 +201,7 @@ object DatadogMetricService {
                 "Failed to insert DD metrics: ${errorBody.take(ERROR_BODY_MAX_LEN)}"
             )
         }
-        InfraTelemetryRollups.insertMetricRollups(
-            batch.metrics.map { metric ->
-                InfraMetricRollupRow(
-                    organizationId = batch.organizationId,
-                    metricName = metric.name,
-                    timestampMs = metric.timestampMs,
-                    value = metric.value,
-                    host = metric.host,
-                    tags = metric.tags,
-                    unit = metric.unit,
-                    source = "datadog",
-                )
-            }
-        )
+        insertMetricRollupsBestEffort(batch)
     }
 
     suspend fun insertSketchBatch(batch: QueuedSketchBatch) {
@@ -289,6 +277,32 @@ object DatadogMetricService {
             "rate" -> "rate"
             "count" -> "count"
             else -> "gauge"
+        }
+    }
+
+    private suspend fun insertMetricRollupsBestEffort(batch: QueuedMetricBatch) {
+        try {
+            InfraTelemetryRollups.insertMetricRollups(
+                batch.metrics.map { metric ->
+                    InfraMetricRollupRow(
+                        organizationId = batch.organizationId,
+                        metricName = metric.name,
+                        timestampMs = metric.timestampMs,
+                        value = metric.value,
+                        host = metric.host,
+                        tags = metric.tags,
+                        unit = metric.unit,
+                        source = "datadog",
+                    )
+                }
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) {
+                "Failed to write Datadog metric rollups for org ${batch.organizationId} " +
+                    "(${batch.metrics.size} metrics); raw metrics were already written"
+            }
         }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -17,6 +17,8 @@
 package com.moneat.datadog.services
 
 import com.google.protobuf.CodedInputStream
+import com.moneat.apm.services.ApmServiceMapRollups
+import com.moneat.apm.services.ApmServiceMapSpan
 import com.moneat.config.ClickHouseClient
 import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_3
 import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_4
@@ -44,6 +46,7 @@ import com.moneat.utils.ClickHouseSqlUtils.doubleMapToSqlMap
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.ClickHouseSqlUtils.mapToSqlMap
 import io.ktor.http.isSuccess
+import io.sentry.ISpan
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.double
@@ -61,6 +64,8 @@ private val logger = KotlinLogging.logger {}
 private const val APM_TRACE_SUMMARIES_TABLE = "apm_trace_summaries"
 private const val APM_ERROR_GROUPS_TABLE = "apm_error_groups_hourly"
 private const val APM_RESOURCE_STATS_TABLE = "apm_resource_stats_hourly"
+private const val APM_SERVICE_STATS_TABLE = "apm_service_stats_hourly"
+private const val APM_SERVICE_EDGES_TABLE = "apm_service_edges_hourly"
 private const val MAX_META_VALUE_LENGTH = 5000
 private const val DEFAULT_QUERY_LIMIT = 50
 private const val MAX_QUERY_LIMIT = 200
@@ -70,6 +75,7 @@ private const val PROTO_FIELD_9 = 9
 private const val PROTO_FIELD_10 = 10
 private const val PROTO_FIELD_11 = 11
 private const val PROTO_FIELD_12 = 12
+private const val DATADOG_SOURCE = "datadog"
 
 val defaultApmQueryTimeRange = DdApmQueryTimeRange(24, DdApmQueryTimeUnit.HOUR)
 
@@ -191,7 +197,7 @@ object TraceIngestionService {
                 '${java.lang.Long.toUnsignedString(span.traceId.toLong(), HEX_RADIX)}',
                 '${java.lang.Long.toUnsignedString(span.spanId.toLong(), HEX_RADIX)}',
                 '$parentIdHex',
-                'datadog'
+                '$DATADOG_SOURCE'
             )"""
         }
 
@@ -212,6 +218,10 @@ object TraceIngestionService {
                 "Failed to insert DD spans into ClickHouse"
             )
         }
+        ApmServiceMapRollups.insertForSpans(
+            clickhouseDb,
+            traces.toServiceMapSpans(organizationId, env)
+        )
 
         val totalBytes = allSpans.sumOf {
             it.name.length + it.service.length +
@@ -284,6 +294,7 @@ object TraceIngestionService {
         limit: Int,
         offset: Int,
         timeRange: DdApmQueryTimeRange = defaultApmQueryTimeRange,
+        parentSpan: ISpan? = null,
     ): DdTraceListResponse {
         val filters = mutableListOf(
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
@@ -306,9 +317,10 @@ object TraceIngestionService {
                 GROUP BY trace_id_canonical
             )
         """.trimIndent()
-        val countResult = ClickHouseClient.executeWithFormat(
+        val countResult = executeDashboardQuery(
             countQuery,
-            "TabSeparated"
+            "TabSeparated",
+            parentSpan,
         )
         val totalCount = countResult.trim().toLongOrNull() ?: 0
 
@@ -335,7 +347,7 @@ object TraceIngestionService {
             FORMAT JSONEachRow
         """.trimIndent()
 
-        val result = ClickHouseClient.executeWithFormat(query, "")
+        val result = executeDashboardQuery(query, "", parentSpan)
         val traces = if (result.isBlank()) {
             emptyList()
         } else {
@@ -374,6 +386,7 @@ object TraceIngestionService {
     suspend fun getTraceDetail(
         organizationId: Int,
         traceId: String,
+        parentSpan: ISpan? = null,
     ): DdTraceDetailResponse? {
         val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
 
@@ -396,14 +409,16 @@ object TraceIngestionService {
             FORMAT JSONEachRow
         """.trimIndent()
 
-        var result = ClickHouseClient.executeWithFormat(
+        var result = executeDashboardQuery(
             detailQuery("trace_id_hex = '${escapeSql(traceId)}'"),
             "",
+            parentSpan,
         )
         if (result.isBlank() && parseTraceId(traceId) != null) {
-            result = ClickHouseClient.executeWithFormat(
+            result = executeDashboardQuery(
                 detailQuery("trace_id = ${parseTraceId(traceId)}"),
                 "",
+                parentSpan,
             )
         }
         if (result.isBlank()) return null
@@ -444,23 +459,24 @@ object TraceIngestionService {
 
     suspend fun getServiceMap(
         organizationId: Int,
+        parentSpan: ISpan? = null,
     ): DdServiceMapResponse {
         val query = """
             SELECT
                 service,
-                count() as span_count,
-                countIf(error = 1) as error_count,
-                avg(duration) as avg_duration_ns
-            FROM `$clickhouseDb`.apm_spans
+                sum(span_count) as span_count,
+                sum(error_count) as error_count,
+                if(sum(duration_count) = 0, 0, sum(duration_sum) / sum(duration_count)) as avg_duration_ns
+            FROM `$clickhouseDb`.$APM_SERVICE_STATS_TABLE
             WHERE ${ClickHouseQueryUtils.orgIdClause(organizationId.toLong())}
-              AND start >= now() - INTERVAL 1 HOUR
+              AND bucket_start >= toStartOfHour(now() - INTERVAL 1 HOUR)
             GROUP BY service
             ORDER BY span_count DESC
             LIMIT 100
             FORMAT JSONEachRow
         """.trimIndent()
 
-        val result = ClickHouseClient.executeWithFormat(query, "")
+        val result = executeDashboardQuery(query, "", parentSpan)
         val services = if (result.isBlank()) {
             emptyList()
         } else {
@@ -485,25 +501,21 @@ object TraceIngestionService {
         // Build service relationships from parent-child spans
         val callsQuery = """
             SELECT
-                parent.service as from_service,
-                child.service as to_service
-            FROM `$clickhouseDb`.apm_spans child
-            INNER JOIN `$clickhouseDb`.apm_spans parent
-                ON child.parent_id = parent.span_id
-                AND child.parent_id_high = parent.span_id_high
-                AND child.trace_id = parent.trace_id
-                AND child.trace_id_high = parent.trace_id_high
-                AND child.organization_id = parent.organization_id
-            WHERE ${ClickHouseQueryUtils.orgIdClause(organizationId.toLong(), "child.organization_id")}
-              AND child.start >= now() - INTERVAL 1 HOUR
-              AND parent.service != child.service
-            GROUP BY parent.service, child.service
+                from_service,
+                to_service
+            FROM `$clickhouseDb`.$APM_SERVICE_EDGES_TABLE
+            WHERE ${ClickHouseQueryUtils.orgIdClause(organizationId.toLong())}
+              AND bucket_start >= toStartOfHour(now() - INTERVAL 1 HOUR)
+            GROUP BY from_service, to_service
+            HAVING sum(call_count) > 0
+            ORDER BY sum(call_count) DESC
             FORMAT JSONEachRow
         """.trimIndent()
 
-        val callsResult = ClickHouseClient.executeWithFormat(
+        val callsResult = executeDashboardQuery(
             callsQuery,
-            ""
+            "",
+            parentSpan,
         )
         val callsMap = mutableMapOf<String, MutableSet<String>>()
         if (callsResult.isNotBlank()) {
@@ -535,6 +547,7 @@ object TraceIngestionService {
         limit: Int,
         offset: Int,
         timeRange: DdApmQueryTimeRange = defaultApmQueryTimeRange,
+        parentSpan: ISpan? = null,
     ): DdApmErrorsResponse {
         val effectiveLimit = limit.coerceAtMost(MAX_QUERY_LIMIT)
         val filters = mutableListOf(
@@ -555,9 +568,10 @@ object TraceIngestionService {
                 GROUP BY service, resource, error_message, error_type
             )
         """.trimIndent()
-        val countResult = ClickHouseClient.executeWithFormat(
+        val countResult = executeDashboardQuery(
             countQuery,
-            "TabSeparated"
+            "TabSeparated",
+            parentSpan,
         )
         val totalCount = countResult.trim().toLongOrNull() ?: 0
 
@@ -578,7 +592,7 @@ object TraceIngestionService {
             FORMAT JSONEachRow
         """.trimIndent()
 
-        val result = ClickHouseClient.executeWithFormat(query, "")
+        val result = executeDashboardQuery(query, "", parentSpan)
         val errors = if (result.isBlank()) {
             emptyList()
         } else {
@@ -620,7 +634,7 @@ object TraceIngestionService {
             ORDER BY error_count DESC
             FORMAT JSONEachRow
         """.trimIndent()
-        val serviceFacetsResult = ClickHouseClient.executeWithFormat(serviceFacetsQuery, "")
+        val serviceFacetsResult = executeDashboardQuery(serviceFacetsQuery, "", parentSpan)
         val serviceFacets = if (serviceFacetsResult.isBlank()) {
             emptyList()
         } else {
@@ -650,6 +664,7 @@ object TraceIngestionService {
         limit: Int,
         offset: Int,
         timeRange: DdApmQueryTimeRange = defaultApmQueryTimeRange,
+        parentSpan: ISpan? = null,
     ): DdResourceStatsResponse {
         val effectiveLimit = limit.coerceAtMost(MAX_QUERY_LIMIT)
         val filters = mutableListOf(
@@ -668,9 +683,10 @@ object TraceIngestionService {
                 GROUP BY service, resource, name, type
             )
         """.trimIndent()
-        val countResult = ClickHouseClient.executeWithFormat(
+        val countResult = executeDashboardQuery(
             countQuery,
-            "TabSeparated"
+            "TabSeparated",
+            parentSpan,
         )
         val totalCount = countResult.trim().toLongOrNull() ?: 0
 
@@ -692,7 +708,7 @@ object TraceIngestionService {
             FORMAT JSONEachRow
         """.trimIndent()
 
-        val result = ClickHouseClient.executeWithFormat(query, "")
+        val result = executeDashboardQuery(query, "", parentSpan)
         val resources = if (result.isBlank()) {
             emptyList()
         } else {
@@ -736,8 +752,38 @@ object TraceIngestionService {
     }
 
     // --- Internal helpers ---
+    private suspend fun executeDashboardQuery(
+        query: String,
+        format: String,
+        parentSpan: ISpan?,
+    ): String =
+        if (parentSpan == null) {
+            ClickHouseClient.executeWithFormat(query, format)
+        } else {
+            ClickHouseClient.executeWithFormat(query, format, parentSpan)
+        }
+
     internal fun parseTraceId(traceId: String): ULong? =
         traceId.toULongOrNull()
+
+    private fun List<List<DdSpan>>.toServiceMapSpans(
+        organizationId: Int,
+        env: String,
+    ): List<ApmServiceMapSpan> =
+        flatten().map { span ->
+            ApmServiceMapSpan(
+                organizationId = organizationId.toLong(),
+                traceKey = span.traceId.toString(),
+                spanKey = span.spanId.toString(),
+                parentKey = if (span.parentId == 0UL) "" else span.parentId.toString(),
+                service = span.service,
+                env = span.meta["env"] ?: env,
+                source = DATADOG_SOURCE,
+                startNanos = span.start,
+                durationNanos = span.duration,
+                error = span.error,
+            )
+        }
 
     @Suppress("NestedBlockDepth")
     private fun unpackSpan(unpacker: MessageUnpacker): DdSpan {

--- a/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
@@ -140,7 +140,11 @@ class EventRepositoryImpl : EventRepository {
                 '${escapeSql(data.sdkVersion)}'
             )
         """.trimIndent()
-        return executeInsert(sql)
+        val inserted = executeInsert(sql)
+        if (inserted) {
+            insertErrorEventRollups(data)
+        }
+        return inserted
     }
 
     override suspend fun insertTransaction(data: TransactionEventInsertData): Boolean {
@@ -433,8 +437,55 @@ class EventRepositoryImpl : EventRepository {
         }
     }
 
+    private suspend fun insertErrorEventRollups(data: ErrorEventInsertData) {
+        val projectRollup = """
+            INSERT INTO `$db`.event_project_rollup_1h (
+                project_id, bucket_start, level, platform, browser_name,
+                environment, event_count
+            ) VALUES (
+                ${data.projectId},
+                toStartOfHour(fromUnixTimestamp64Milli(${data.timestampMs})),
+                '${escapeSql(data.level)}',
+                '${escapeSql(data.platform)}',
+                '',
+                '${escapeSql(data.environment)}',
+                1
+            )
+        """.trimIndent()
+        val issueRollup = """
+            INSERT INTO `$db`.event_issue_rollup_1h (
+                project_id, issue_id, bucket_start, title, event_count
+            ) VALUES (
+                ${data.projectId},
+                '${escapeSql(data.issueId)}',
+                toStartOfHour(fromUnixTimestamp64Milli(${data.timestampMs})),
+                '${escapeSql(data.message)}',
+                1
+            )
+        """.trimIndent()
+
+        executeRollupInsert(projectRollup, "project event rollup")
+        executeRollupInsert(issueRollup, "issue event rollup")
+    }
+
+    private suspend fun executeRollupInsert(sql: String, label: String) {
+        suspendRunCatching {
+            val response = ClickHouseClient.execute(sql)
+            if (!response.status.isSuccess()) {
+                val errorBody = response.bodyAsText()
+                logger.warn { "ClickHouse $label insert failed: ${errorBody.take(ERROR_BODY_PREVIEW_CHARS)}" }
+            }
+        }.getOrElse { e ->
+            logger.warn(e) { "ClickHouse $label insert failed" }
+        }
+    }
+
     private fun tagsToMap(tags: Map<String, String>?): String {
         if (tags.isNullOrEmpty()) return "{}"
         return "{${tags.entries.joinToString(",") { "'${escapeSql(it.key)}':'${escapeSql(it.value)}'" }}}"
+    }
+
+    companion object {
+        private const val ERROR_BODY_PREVIEW_CHARS = 600
     }
 }

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -16,6 +16,8 @@
 
 package com.moneat.events.services
 
+import com.moneat.apm.services.ApmServiceMapRollups
+import com.moneat.apm.services.ApmServiceMapSpan
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
 import com.moneat.events.models.EnvelopeItem
@@ -95,6 +97,7 @@ class EventService(
         private const val UUID_SEG3 = 16
         private const val UUID_SEG4 = 20
         private val OTLP_STACK_FRAME_PATTERN = Regex("""[\w.$/<>-]+\([^)]*\)""")
+        private const val SENTRY_SOURCE = "sentry"
 
         /** Keys set by the server for apm_spans; must not be overwritten by SDK tag maps. */
         private val SENTRY_APM_META_RESERVED_KEYS = setOf("sentry.transaction_id", "sentry.project_id")
@@ -1311,15 +1314,27 @@ class EventService(
         )
 
         val rows = mutableListOf<String>()
-        buildRootSpanRow(ctx, traceId, transactionOp, traceStatus, transaction)?.let { rows.add(it) }
+        val serviceMapSpans = mutableListOf<ApmServiceMapSpan>()
+        buildRootSpanRow(ctx, traceId, transactionOp, traceStatus, transaction)?.let {
+            rows.add(it.sqlRow)
+            serviceMapSpans.add(it.serviceMapSpan)
+        }
         for (span in childSpans) {
-            buildChildSpanRow(ctx, span, traceId, transaction)?.let { rows.add(it) }
+            buildChildSpanRow(ctx, span, traceId, transaction)?.let {
+                rows.add(it.sqlRow)
+                serviceMapSpans.add(it.serviceMapSpan)
+            }
         }
 
         if (rows.isNotEmpty()) {
-            executeApmSpanInsert(ctx, rows, eventId)
+            executeApmSpanInsert(ctx, rows, serviceMapSpans, eventId)
         }
     }
+
+    private data class ApmSpanInsertRow(
+        val sqlRow: String,
+        val serviceMapSpan: ApmServiceMapSpan,
+    )
 
     private fun buildRootSpanRow(
         ctx: ApmSpanContext,
@@ -1327,17 +1342,20 @@ class EventService(
         transactionOp: String,
         traceStatus: String?,
         transaction: SentryTransaction
-    ): String? {
+    ): ApmSpanInsertRow? {
         val rootSpanId = transaction.contexts?.get("trace")?.jsonObject
             ?.get("span_id")?.jsonPrimitive?.contentOrNull ?: ""
         if (rootSpanId.isBlank()) return null
 
         val startTs = transaction.startTimestamp ?: (System.currentTimeMillis() / MS_PER_SECOND)
+        val startNanos = unixSecondsToNanos(startTs)
+        val duration = durationNanos(transaction.startTimestamp, transaction.timestamp)
+        val error = sentryStatusToError(traceStatus)
         val (traceIdHigh, traceIdLow) = hexToULongPair(traceId)
         val (spanIdHigh, spanIdLow) = hexToULongPair(rootSpanId)
         val rootMetrics = extractMeasurementMetrics(transaction)
 
-        return """
+        val sqlRow = """
             (
             $spanIdLow, $spanIdHigh,
             $traceIdLow, $traceIdHigh,
@@ -1347,9 +1365,9 @@ class EventService(
             '${escapeSql(ctx.service)}',
             '${escapeSql(ctx.transactionName)}',
             '${escapeSql(transactionOp)}',
-            fromUnixTimestamp64Nano(${unixSecondsToNanos(startTs)}),
-            ${durationNanos(transaction.startTimestamp, transaction.timestamp)},
-            ${sentryStatusToError(traceStatus)},
+            fromUnixTimestamp64Nano($startNanos),
+            $duration,
+            $error,
             ${mapToSqlMap(ctx.baseMeta)},
             ${doubleMapToSqlMap(rootMetrics)},
             '${escapeSql(ctx.host)}',
@@ -1358,9 +1376,24 @@ class EventService(
             '$traceId',
             '$rootSpanId',
             '',
-            'sentry'
+            '$SENTRY_SOURCE'
             )
         """.trimIndent()
+        return ApmSpanInsertRow(
+            sqlRow = sqlRow,
+            serviceMapSpan = ApmServiceMapSpan(
+                organizationId = ctx.orgId.toLong(),
+                traceKey = traceId,
+                spanKey = rootSpanId,
+                parentKey = "",
+                service = ctx.service,
+                env = ctx.env,
+                source = SENTRY_SOURCE,
+                startNanos = startNanos,
+                durationNanos = duration,
+                error = error,
+            ),
+        )
     }
 
     private fun buildChildSpanRow(
@@ -1368,11 +1401,14 @@ class EventService(
         span: SentrySpan,
         fallbackTraceId: String,
         transaction: SentryTransaction
-    ): String? {
+    ): ApmSpanInsertRow? {
         val spanStart = span.startTimestamp ?: transaction.startTimestamp ?: return null
         val spanEnd = span.timestamp ?: transaction.timestamp ?: spanStart
         val spanId = span.spanId?.ifBlank { null } ?: UUID.randomUUID().toString().replace("-", "")
         val spanTraceId = span.traceId ?: fallbackTraceId
+        val startNanos = unixSecondsToNanos(spanStart)
+        val duration = durationNanos(spanStart, spanEnd)
+        val error = sentryStatusToError(span.status)
 
         val (traceIdHigh, traceIdLow) = hexToULongPair(spanTraceId)
         val (spanIdHigh, spanIdLow) = hexToULongPair(spanId)
@@ -1382,7 +1418,7 @@ class EventService(
         val spanMeta = extractSpanMeta(span, ctx.baseMeta)
         val spanMetrics = extractSpanMetrics(span)
 
-        return """
+        val sqlRow = """
             (
             $spanIdLow, $spanIdHigh,
             $traceIdLow, $traceIdHigh,
@@ -1392,9 +1428,9 @@ class EventService(
             '${escapeSql(ctx.service)}',
             '${escapeSql(span.description ?: "")}',
             '${escapeSql(span.op ?: "")}',
-            fromUnixTimestamp64Nano(${unixSecondsToNanos(spanStart)}),
-            ${durationNanos(spanStart, spanEnd)},
-            ${sentryStatusToError(span.status)},
+            fromUnixTimestamp64Nano($startNanos),
+            $duration,
+            $error,
             ${mapToSqlMap(spanMeta)},
             ${doubleMapToSqlMap(spanMetrics)},
             '${escapeSql(ctx.host)}',
@@ -1403,9 +1439,24 @@ class EventService(
             '${escapeSql(spanTraceId)}',
             '${escapeSql(spanId)}',
             '${escapeSql(parentHex)}',
-            'sentry'
+            '$SENTRY_SOURCE'
             )
         """.trimIndent()
+        return ApmSpanInsertRow(
+            sqlRow = sqlRow,
+            serviceMapSpan = ApmServiceMapSpan(
+                organizationId = ctx.orgId.toLong(),
+                traceKey = spanTraceId,
+                spanKey = spanId,
+                parentKey = parentHex,
+                service = ctx.service,
+                env = ctx.env,
+                source = SENTRY_SOURCE,
+                startNanos = startNanos,
+                durationNanos = duration,
+                error = error,
+            ),
+        )
     }
 
     private fun extractMeasurementMetrics(transaction: SentryTransaction): Map<String, Double> {
@@ -1462,7 +1513,12 @@ class EventService(
         return metrics
     }
 
-    private suspend fun executeApmSpanInsert(ctx: ApmSpanContext, rows: List<String>, eventId: String) {
+    private suspend fun executeApmSpanInsert(
+        ctx: ApmSpanContext,
+        rows: List<String>,
+        serviceMapSpans: List<ApmServiceMapSpan>,
+        eventId: String
+    ) {
         val insert = """
             INSERT INTO `${ctx.clickhouseDb}`.apm_spans (
                 span_id, span_id_high,
@@ -1479,6 +1535,7 @@ class EventService(
 
         val response = ClickHouseClient.execute(insert)
         if (response.status.isSuccess()) {
+            ApmServiceMapRollups.insertForSpans(ctx.clickhouseDb, serviceMapSpans)
             usageTracker.recordOrgUsage(ctx.orgId, "sentry_trace", rows.size, rows.sumOf { it.length })
         } else {
             logger.error { "Failed to insert Sentry spans into apm_spans for transaction $eventId" }

--- a/backend/src/main/kotlin/com/moneat/events/services/ProjectStatsService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ProjectStatsService.kt
@@ -90,22 +90,20 @@ class ProjectStatsService(private val queryHelper: DashboardQueryHelper) {
 
             val totalEventsQuery =
                 """
-            SELECT count() as total
-            FROM `$clickhouseDb`.events
+            SELECT sum(event_count) as total
+            FROM `$clickhouseDb`.event_project_rollup_1h
             WHERE $projectIdClause
-                AND event_type = 'error'
-                AND timestamp >= $nowSql - INTERVAL $hoursBack HOUR
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND bucket_start >= $nowSql - INTERVAL $hoursBack HOUR
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             FORMAT JSONEachRow
                 """.trimIndent()
 
             val totalIssuesQuery =
                 """
-            SELECT count(DISTINCT issue_id) as total
-            FROM `$clickhouseDb`.events
+            SELECT uniqExact(issue_id) as total
+            FROM `$clickhouseDb`.event_issue_rollup_1h
             WHERE $projectIdClause
-                AND event_type = 'error'
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             FORMAT JSONEachRow
                 """.trimIndent()
 
@@ -137,13 +135,12 @@ class ProjectStatsService(private val queryHelper: DashboardQueryHelper) {
             val eventsTimelineQuery =
                 """
             SELECT 
-                formatDateTime(toStartOfInterval(timestamp, INTERVAL $intervalMinutes MINUTE), '%Y-%m-%dT%H:%i:%SZ', 'UTC') as time,
-                count() as count
-            FROM `$clickhouseDb`.events
+                formatDateTime(toStartOfInterval(bucket_start, INTERVAL $intervalMinutes MINUTE), '%Y-%m-%dT%H:%i:%SZ', 'UTC') as time,
+                sum(event_count) as count
+            FROM `$clickhouseDb`.event_project_rollup_1h
             WHERE $projectIdClause
-                AND event_type = 'error'
-                AND timestamp >= $nowSql - INTERVAL $hoursBack HOUR
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND bucket_start >= $nowSql - INTERVAL $hoursBack HOUR
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             GROUP BY time
             ORDER BY time
             FORMAT JSONEachRow
@@ -151,25 +148,23 @@ class ProjectStatsService(private val queryHelper: DashboardQueryHelper) {
 
             val eventsByLevelQuery =
                 """
-            SELECT level, count() as count
-            FROM `$clickhouseDb`.events
+            SELECT level, sum(event_count) as count
+            FROM `$clickhouseDb`.event_project_rollup_1h
             WHERE $projectIdClause
-                AND event_type = 'error'
-                AND timestamp >= $nowSql - INTERVAL $hoursBack HOUR
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND bucket_start >= $nowSql - INTERVAL $hoursBack HOUR
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             GROUP BY level
             FORMAT JSONEachRow
                 """.trimIndent()
 
             val eventsByPlatformQuery =
                 """
-            SELECT platform, count() as count
-            FROM `$clickhouseDb`.events
+            SELECT platform, sum(event_count) as count
+            FROM `$clickhouseDb`.event_project_rollup_1h
             WHERE $projectIdClause
-                AND event_type = 'error'
-                AND timestamp >= $nowSql - INTERVAL $hoursBack HOUR
+                AND bucket_start >= $nowSql - INTERVAL $hoursBack HOUR
                 AND platform != ''
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             GROUP BY platform
             ORDER BY count DESC
             LIMIT 10
@@ -178,13 +173,12 @@ class ProjectStatsService(private val queryHelper: DashboardQueryHelper) {
 
             val eventsByBrowserQuery =
                 """
-            SELECT browser_name, count() as count
-            FROM `$clickhouseDb`.events
+            SELECT browser_name, sum(event_count) as count
+            FROM `$clickhouseDb`.event_project_rollup_1h
             WHERE $projectIdClause
-                AND event_type = 'error'
-                AND timestamp >= $nowSql - INTERVAL $hoursBack HOUR
+                AND bucket_start >= $nowSql - INTERVAL $hoursBack HOUR
                 AND browser_name != ''
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             GROUP BY browser_name
             ORDER BY count DESC
             LIMIT 10
@@ -193,13 +187,12 @@ class ProjectStatsService(private val queryHelper: DashboardQueryHelper) {
 
             val eventsByEnvironmentQuery =
                 """
-            SELECT environment, count() as count
-            FROM `$clickhouseDb`.events
+            SELECT environment, sum(event_count) as count
+            FROM `$clickhouseDb`.event_project_rollup_1h
             WHERE $projectIdClause
-                AND event_type = 'error'
-                AND timestamp >= $nowSql - INTERVAL $hoursBack HOUR
+                AND bucket_start >= $nowSql - INTERVAL $hoursBack HOUR
                 AND environment != ''
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             GROUP BY environment
             FORMAT JSONEachRow
                 """.trimIndent()
@@ -216,12 +209,11 @@ class ProjectStatsService(private val queryHelper: DashboardQueryHelper) {
 
             val topIssuesQuery =
                 """
-            SELECT issue_id, any(message) as title, count() as count
-            FROM `$clickhouseDb`.events
+            SELECT issue_id, any(title) as title, sum(event_count) as count
+            FROM `$clickhouseDb`.event_issue_rollup_1h
             WHERE $projectIdClause
-                AND timestamp >= $nowSql - INTERVAL $hoursBack HOUR
-                AND event_type = 'error'
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+                AND bucket_start >= $nowSql - INTERVAL $hoursBack HOUR
+                AND ${queryHelper.timestampRetentionClause("bucket_start", retentionDays, demoEpochMs)}
             GROUP BY issue_id
             ORDER BY count DESC
             LIMIT 10

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
@@ -456,33 +456,11 @@ class LogService(private val logRepository: LogRepository) {
                 if (hasMore) encodeCursor(row.timestampMs, row.log.logId) else null
             }
 
-        // Query total count - use full where clause (scope + filters + time + query)
-        val totalCountQuery =
-            """
-            SELECT count() as count
-            FROM `$clickhouseDb`.logs
-            WHERE $whereClause
-            FORMAT JSONEachRow
-            """.trimIndent()
-
-        val totalCountBody = logRepository.executeClickHouseQuery(totalCountQuery)
-        val totalCount =
-            if (!totalCountBody.isClickHouseError()) {
-                suspendRunCatching {
-                    val jsonElement = Json.parseToJsonElement(totalCountBody.trim())
-                    jsonElement.jsonObject["count"]?.jsonPrimitive?.longOrNull ?: 0L
-                }.getOrElse { _ ->
-                    0L
-                }
-            } else {
-                0L
-            }
-
         return LogQueryResponse(
             logs = pageRows.map { it.log },
             nextCursor = nextCursor,
             hasMore = hasMore,
-            totalCount = totalCount
+            totalCount = null
         )
     }
 

--- a/backend/src/main/kotlin/com/moneat/monitor/services/InfraTelemetryRollups.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/InfraTelemetryRollups.kt
@@ -1,0 +1,234 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.monitor.services
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import mu.KotlinLogging
+import com.moneat.utils.suspendRunCatching
+
+private val logger = KotlinLogging.logger {}
+
+data class InfraMetricRollupRow(
+    val organizationId: Long,
+    val metricName: String,
+    val timestampMs: Long,
+    val value: Double,
+    val host: String,
+    val tags: Map<String, String>,
+    val unit: String,
+    val source: String,
+)
+
+data class InfraContainerRollupRow(
+    val organizationId: Long,
+    val host: String,
+    val containerId: String,
+    val name: String,
+    val image: String,
+    val state: String,
+    val cpuPercent: Double,
+    val memUsage: Long,
+    val memLimit: Long,
+    val netRxBytes: Long,
+    val netTxBytes: Long,
+    val tags: Map<String, String>,
+    val timestampMs: Long,
+)
+
+object InfraTelemetryRollups {
+    private val infraMetricNames = setOf(
+        "system.cpu.percent",
+        "system.mem.total",
+        "system.mem.used",
+        "system.mem.available",
+        "system.disk.total",
+        "system.disk.used",
+        "system.net.recv_bytes",
+        "system.net.sent_bytes",
+        "system.load.1",
+        "system.load.5",
+        "system.load.15",
+        "system.temp.max",
+        "system.gpu.percent",
+        "system.battery.percent",
+    )
+
+    suspend fun insertMetricRollups(rows: List<InfraMetricRollupRow>) {
+        val resolvedRows = rows.mapNotNull { row ->
+            val hostId = resolveHostId(row.tags) ?: return@mapNotNull null
+            if (row.metricName !in infraMetricNames) return@mapNotNull null
+            ResolvedMetricRollupRow(row, hostId)
+        }
+        if (resolvedRows.isEmpty()) return
+
+        val db = ClickHouseClient.getDatabase()
+        val latestRows = resolvedRows.joinToString(",\n") { (row, hostId) ->
+            """(
+                ${row.organizationId},
+                $hostId,
+                '${escapeSql(row.metricName)}',
+                fromUnixTimestamp64Milli(${row.timestampMs}),
+                ${row.value},
+                '${escapeSql(row.host)}',
+                '${escapeSql(row.unit)}',
+                '${escapeSql(row.source)}',
+                ${mapToSqlMap(row.tags)}
+            )"""
+        }
+        val rollupRows = resolvedRows.joinToString(",\n") { (row, hostId) ->
+            """(
+                ${row.organizationId},
+                $hostId,
+                toStartOfMinute(fromUnixTimestamp64Milli(${row.timestampMs})),
+                '${escapeSql(row.metricName)}',
+                '${escapeSql(row.host)}',
+                '${escapeSql(row.unit)}',
+                '${escapeSql(row.source)}',
+                ${row.value},
+                1
+            )"""
+        }
+
+        executeBestEffort(
+            """
+            INSERT INTO `$db`.metrics_latest_by_host (
+                organization_id, host_id, metric_name, timestamp, value,
+                host, unit, source, tags
+            ) VALUES
+            $latestRows
+            """.trimIndent(),
+            "infra metrics latest",
+        )
+        executeBestEffort(
+            """
+            INSERT INTO `$db`.metrics_rollup_1m (
+                organization_id, host_id, bucket_start, metric_name, host,
+                unit, source, value_sum, value_count
+            ) VALUES
+            $rollupRows
+            """.trimIndent(),
+            "infra metrics 1m rollup",
+        )
+    }
+
+    suspend fun insertContainerRollups(rows: List<InfraContainerRollupRow>) {
+        val resolvedRows = rows.mapNotNull { row ->
+            val hostId = resolveHostId(row.tags) ?: return@mapNotNull null
+            ResolvedContainerRollupRow(row, hostId)
+        }
+        if (resolvedRows.isEmpty()) return
+
+        val db = ClickHouseClient.getDatabase()
+        val latestRows = resolvedRows.joinToString(",\n") { (row, hostId) ->
+            """(
+                ${row.organizationId},
+                $hostId,
+                '${escapeSql(row.host)}',
+                '${escapeSql(row.containerId)}',
+                '${escapeSql(row.name)}',
+                '${escapeSql(row.image)}',
+                '${escapeSql(row.state)}',
+                ${row.cpuPercent},
+                ${row.memUsage},
+                ${row.memLimit},
+                ${row.netRxBytes},
+                ${row.netTxBytes},
+                ${mapToSqlMap(row.tags)},
+                fromUnixTimestamp64Milli(${row.timestampMs})
+            )"""
+        }
+        val rollupRows = resolvedRows.joinToString(",\n") { (row, hostId) ->
+            """(
+                ${row.organizationId},
+                $hostId,
+                toStartOfMinute(fromUnixTimestamp64Milli(${row.timestampMs})),
+                '${escapeSql(row.host)}',
+                '${escapeSql(row.containerId)}',
+                '${escapeSql(row.name)}',
+                ${row.cpuPercent},
+                1,
+                ${row.memUsage},
+                ${row.memLimit},
+                ${row.netRxBytes},
+                ${row.netTxBytes}
+            )"""
+        }
+
+        executeBestEffort(
+            """
+            INSERT INTO `$db`.containers_latest_by_host (
+                organization_id, host_id, host, container_id, name,
+                image, state, cpu_percent, mem_usage, mem_limit,
+                net_rx_bytes, net_tx_bytes, tags, timestamp
+            ) VALUES
+            $latestRows
+            """.trimIndent(),
+            "infra containers latest",
+        )
+        executeBestEffort(
+            """
+            INSERT INTO `$db`.containers_rollup_1m (
+                organization_id, host_id, bucket_start, host, container_id,
+                name, cpu_sum, cpu_count, mem_usage_sum, mem_limit_sum,
+                net_rx_bytes_sum, net_tx_bytes_sum
+            ) VALUES
+            $rollupRows
+            """.trimIndent(),
+            "infra containers 1m rollup",
+        )
+    }
+
+    private suspend fun executeBestEffort(query: String, label: String) {
+        suspendRunCatching {
+            val response = ClickHouseClient.execute(query)
+            if (!response.status.isSuccess()) {
+                val body = response.bodyAsText()
+                logger.warn { "Failed to insert $label: ${body.take(ERROR_BODY_PREVIEW_CHARS)}" }
+            }
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to insert $label" }
+        }
+    }
+
+    private fun resolveHostId(tags: Map<String, String>): Long? =
+        (tags["host_id"] ?: tags["system_id"] ?: tags["moneat.host_id"])
+            ?.toLongOrNull()
+            ?.takeIf { it > 0L }
+
+    private fun mapToSqlMap(map: Map<String, String>): String {
+        if (map.isEmpty()) return "map()"
+        val entries = map.entries.joinToString(", ") { (key, value) ->
+            "'${escapeSql(key)}', '${escapeSql(value)}'"
+        }
+        return "map($entries)"
+    }
+
+    private data class ResolvedMetricRollupRow(
+        val row: InfraMetricRollupRow,
+        val hostId: Long,
+    )
+
+    private data class ResolvedContainerRollupRow(
+        val row: InfraContainerRollupRow,
+        val hostId: Long,
+    )
+
+    private const val ERROR_BODY_PREVIEW_CHARS = 600
+}

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -586,9 +586,9 @@ class MonitorAlertService(
         val query =
             """
             SELECT $selectExpr as value
-            FROM `$clickhouseDb`.metrics
+            FROM `$clickhouseDb`.metrics_latest_by_host
             WHERE organization_id = $organizationId
-              AND tags['host_id'] = '$hostId'
+              AND host_id = $hostId
               AND $metricFilter
               AND timestamp >= now64(3) - INTERVAL $CURRENT_METRIC_LOOKBACK_MINUTES MINUTE
             FORMAT JSONCompact
@@ -621,8 +621,8 @@ class MonitorAlertService(
      */
     private suspend fun checkSustainedCondition(alert: AlertData): Boolean {
         val baseFilter =
-            "organization_id = ${alert.organizationId} AND tags['host_id'] = '${alert.hostId}' " +
-                "AND timestamp >= now64(3) - INTERVAL ${alert.durationSeconds} SECOND"
+            "organization_id = ${alert.organizationId} AND host_id = ${alert.hostId} " +
+                "AND bucket_start >= now64(3) - INTERVAL ${alert.durationSeconds} SECOND"
 
         val (query, usesDerived) =
             when (alert.metric) {
@@ -640,11 +640,11 @@ class MonitorAlertService(
                             else -> return false
                         }
                     val pctExpr = if (availName != null) {
-                        "(1 - max(CASE WHEN metric_name='$availName' THEN value END) / " +
-                            "nullIf(max(CASE WHEN metric_name='$totalName' THEN value END), 0)) * 100"
+                        "(1 - sumIf(value_sum, metric_name='$availName') / " +
+                            "nullIf(sumIf(value_sum, metric_name='$totalName'), 0)) * 100"
                     } else {
-                        "max(CASE WHEN metric_name='$usedName' THEN value END) / " +
-                            "nullIf(max(CASE WHEN metric_name='$totalName' THEN value END), 0) * 100"
+                        "sumIf(value_sum, metric_name='$usedName') / " +
+                            "nullIf(sumIf(value_sum, metric_name='$totalName'), 0) * 100"
                     }
                     val metricFilter = if (availName != null) {
                         "metric_name IN ('$availName','$totalName')"
@@ -654,11 +654,11 @@ class MonitorAlertService(
                     val q =
                         """
                         SELECT count(*) as cnt FROM (
-                            SELECT timestamp,
+                            SELECT bucket_start,
                                 $pctExpr as pct
-                            FROM `$clickhouseDb`.metrics
+                            FROM `$clickhouseDb`.metrics_rollup_1m
                             WHERE $baseFilter AND $metricFilter
-                            GROUP BY timestamp
+                            GROUP BY bucket_start
                             HAVING $havingClause
                         )
                         FORMAT JSONCompact
@@ -689,8 +689,14 @@ class MonitorAlertService(
                     val q =
                         """
                         SELECT count(*) as cnt
-                        FROM `$clickhouseDb`.metrics
-                        WHERE $baseFilter AND metric_name = '$metricName' AND $conditionSql
+                        FROM (
+                            SELECT bucket_start,
+                                sum(value_sum) / nullIf(sum(value_count), 0) as value
+                            FROM `$clickhouseDb`.metrics_rollup_1m
+                            WHERE $baseFilter AND metric_name = '$metricName'
+                            GROUP BY bucket_start
+                            HAVING $conditionSql
+                        )
                         FORMAT JSONCompact
                         """.trimIndent()
                     q to false
@@ -718,7 +724,7 @@ class MonitorAlertService(
             val expectedDataPoints = if (alert.durationSeconds == 0) {
                 0
             } else {
-                kotlin.math.ceil(alert.durationSeconds.toDouble() / POLL_INTERVAL_SECONDS).toInt()
+                kotlin.math.ceil(alert.durationSeconds.toDouble() / SECONDS_PER_MINUTE).toInt()
             }
             count >= expectedDataPoints * MIN_DATA_POINT_RATIO
         }.getOrElse { e ->

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
@@ -220,6 +220,18 @@ class MonitorService(
         val containersDelete =
             "ALTER TABLE `$clickhouseDb`.containers DELETE WHERE organization_id = $organizationId" +
                 " AND tags['host_id'] = '$hostId'"
+        val metricsLatestDelete =
+            "ALTER TABLE `$clickhouseDb`.metrics_latest_by_host DELETE WHERE organization_id = $organizationId" +
+                " AND host_id = $hostId"
+        val metricsRollupDelete =
+            "ALTER TABLE `$clickhouseDb`.metrics_rollup_1m DELETE WHERE organization_id = $organizationId" +
+                " AND host_id = $hostId"
+        val containersLatestDelete =
+            "ALTER TABLE `$clickhouseDb`.containers_latest_by_host DELETE WHERE organization_id = $organizationId" +
+                " AND host_id = $hostId"
+        val containersRollupDelete =
+            "ALTER TABLE `$clickhouseDb`.containers_rollup_1m DELETE WHERE organization_id = $organizationId" +
+                " AND host_id = $hostId"
 
         if (!hostRepository.deleteClickHouseData(metricsDelete)) {
             logger.error { "Failed to delete ClickHouse metrics for hostId=$hostId" }
@@ -228,6 +240,22 @@ class MonitorService(
         if (!hostRepository.deleteClickHouseData(containersDelete)) {
             logger.error { "Failed to delete ClickHouse containers for hostId=$hostId" }
             throw Exception("Failed to delete host telemetry (containers)")
+        }
+        if (!hostRepository.deleteClickHouseData(metricsLatestDelete)) {
+            logger.error { "Failed to delete ClickHouse latest metrics for hostId=$hostId" }
+            throw Exception("Failed to delete host telemetry (metrics latest)")
+        }
+        if (!hostRepository.deleteClickHouseData(metricsRollupDelete)) {
+            logger.error { "Failed to delete ClickHouse metrics rollups for hostId=$hostId" }
+            throw Exception("Failed to delete host telemetry (metrics rollup)")
+        }
+        if (!hostRepository.deleteClickHouseData(containersLatestDelete)) {
+            logger.error { "Failed to delete ClickHouse latest containers for hostId=$hostId" }
+            throw Exception("Failed to delete host telemetry (containers latest)")
+        }
+        if (!hostRepository.deleteClickHouseData(containersRollupDelete)) {
+            logger.error { "Failed to delete ClickHouse container rollups for hostId=$hostId" }
+            throw Exception("Failed to delete host telemetry (containers rollup)")
         }
 
         return hostRepository.delete(hostId, organizationId)
@@ -253,9 +281,9 @@ class MonitorService(
                 argMax(CASE WHEN metric_name='system.temp.max' THEN value END, timestamp) as temp_max,
                 argMax(CASE WHEN metric_name='system.gpu.percent' THEN value END, timestamp) as gpu_percent,
                 argMax(CASE WHEN metric_name='system.battery.percent' THEN value END, timestamp) as battery_percent
-            FROM `$clickhouseDb`.metrics
+            FROM `$clickhouseDb`.metrics_latest_by_host
             WHERE organization_id = ${host.organizationId}
-              AND tags['host_id'] = '$hostId'
+              AND host_id = $hostId
               AND metric_name IN ($LATEST_METRIC_NAMES_SQL)
               AND timestamp >= now64(3) - INTERVAL $LATEST_METRICS_LOOKBACK_HOURS HOUR
             FORMAT JSONCompact
@@ -351,7 +379,7 @@ class MonitorService(
         val query =
             """
             SELECT
-                toInt32OrZero(tags['host_id']) as host_id,
+                toInt32(host_id) as host_id,
                 argMax(CASE WHEN metric_name='system.cpu.percent' THEN value END, timestamp) as cpu_percent,
                 argMax(CASE WHEN metric_name='system.mem.total' THEN value END, timestamp) as mem_total,
                 argMax(CASE WHEN metric_name='system.mem.used' THEN value END, timestamp) as mem_used,
@@ -364,9 +392,9 @@ class MonitorService(
                 argMax(CASE WHEN metric_name='system.temp.max' THEN value END, timestamp) as temp_max,
                 argMax(CASE WHEN metric_name='system.gpu.percent' THEN value END, timestamp) as gpu_percent,
                 argMax(CASE WHEN metric_name='system.battery.percent' THEN value END, timestamp) as battery_percent
-            FROM `$clickhouseDb`.metrics
+            FROM `$clickhouseDb`.metrics_latest_by_host
             WHERE organization_id = $organizationId
-              AND toInt32OrZero(tags['host_id']) IN ($hostIdList)
+              AND host_id IN ($hostIdList)
               AND metric_name IN ($LATEST_METRIC_NAMES_SQL)
               AND timestamp >= now64(3) - INTERVAL $LATEST_METRICS_LOOKBACK_HOURS HOUR
             GROUP BY host_id
@@ -474,29 +502,48 @@ class MonitorService(
                     timeRange <= ONE_WEEK_SECONDS -> INTERVAL_THIRTY_MINUTES
                     else -> INTERVAL_ONE_HOUR
                 }
+            val rollupInterval = max(calculatedInterval, INTERVAL_ONE_MINUTE)
 
             val query =
                 """
             SELECT
-                toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL $calculatedInterval second)) as ts,
-                avg(CASE WHEN metric_name='system.cpu.percent' THEN value END) as cpu,
-                (1 - avg(CASE WHEN metric_name='system.mem.available' THEN value END) /
-                    nullIf(avg(CASE WHEN metric_name='system.mem.total' THEN value END), 0)) * 100 as mem,
-                avg(CASE WHEN metric_name='system.disk.used' THEN value END) /
-                    nullIf(avg(CASE WHEN metric_name='system.disk.total' THEN value END), 0) * 100 as disk,
-                sum(CASE WHEN metric_name='system.net.recv_bytes' THEN value ELSE 0 END) as net_recv,
-                sum(CASE WHEN metric_name='system.net.sent_bytes' THEN value ELSE 0 END) as net_sent,
-                avg(CASE WHEN metric_name='system.load.1' THEN value END) as load1,
-                avg(CASE WHEN metric_name='system.load.5' THEN value END) as load5,
-                avg(CASE WHEN metric_name='system.load.15' THEN value END) as load15,
-                max(CASE WHEN metric_name='system.temp.max' THEN value END) as temp,
-                avg(CASE WHEN metric_name='system.gpu.percent' THEN value END) as gpu,
-                avg(CASE WHEN metric_name='system.battery.percent' THEN value END) as battery
-            FROM `$clickhouseDb`.metrics
+                toUnixTimestamp(toStartOfInterval(bucket_start, INTERVAL $rollupInterval second)) as ts,
+                sumIf(value_sum, metric_name='system.cpu.percent') /
+                    nullIf(sumIf(value_count, metric_name='system.cpu.percent'), 0) as cpu,
+                (1 - (
+                    sumIf(value_sum, metric_name='system.mem.available') /
+                    nullIf(sumIf(value_count, metric_name='system.mem.available'), 0)
+                ) / nullIf(
+                    sumIf(value_sum, metric_name='system.mem.total') /
+                    nullIf(sumIf(value_count, metric_name='system.mem.total'), 0),
+                    0
+                )) * 100 as mem,
+                (
+                    sumIf(value_sum, metric_name='system.disk.used') /
+                    nullIf(sumIf(value_count, metric_name='system.disk.used'), 0)
+                ) / nullIf(
+                    sumIf(value_sum, metric_name='system.disk.total') /
+                    nullIf(sumIf(value_count, metric_name='system.disk.total'), 0),
+                    0
+                ) * 100 as disk,
+                sumIf(value_sum, metric_name='system.net.recv_bytes') as net_recv,
+                sumIf(value_sum, metric_name='system.net.sent_bytes') as net_sent,
+                sumIf(value_sum, metric_name='system.load.1') /
+                    nullIf(sumIf(value_count, metric_name='system.load.1'), 0) as load1,
+                sumIf(value_sum, metric_name='system.load.5') /
+                    nullIf(sumIf(value_count, metric_name='system.load.5'), 0) as load5,
+                sumIf(value_sum, metric_name='system.load.15') /
+                    nullIf(sumIf(value_count, metric_name='system.load.15'), 0) as load15,
+                maxIf(value_sum / value_count, metric_name='system.temp.max') as temp,
+                sumIf(value_sum, metric_name='system.gpu.percent') /
+                    nullIf(sumIf(value_count, metric_name='system.gpu.percent'), 0) as gpu,
+                sumIf(value_sum, metric_name='system.battery.percent') /
+                    nullIf(sumIf(value_count, metric_name='system.battery.percent'), 0) as battery
+            FROM `$clickhouseDb`.metrics_rollup_1m
             WHERE organization_id = ${host.organizationId}
-              AND tags['host_id'] = '$hostId'
-              AND timestamp >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
-              AND timestamp <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
+              AND host_id = $hostId
+              AND bucket_start >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
+              AND bucket_start <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
             GROUP BY ts
             ORDER BY ts
             FORMAT JSONCompact
@@ -513,7 +560,7 @@ class MonitorService(
                             hostId = hostId,
                             from = effectiveFrom,
                             to = effectiveTo,
-                            intervalSeconds = calculatedInterval,
+                            intervalSeconds = rollupInterval,
                             dataPoints = emptyList()
                         )
 
@@ -554,7 +601,7 @@ class MonitorService(
                 hostId = hostId,
                 from = effectiveFrom,
                 to = effectiveTo,
-                intervalSeconds = calculatedInterval,
+                intervalSeconds = rollupInterval,
                 dataPoints = dataPoints
             )
         }
@@ -564,7 +611,6 @@ class MonitorService(
      */
     suspend fun getLatestContainers(hostId: Int): List<ContainerStats> {
         val host = getHostById(hostId) ?: return emptyList()
-        val retentionDays = retentionPolicyService.getRetentionDaysForHost(hostId) ?: PricingTier.FREE.retentionDays
         val monitorIntervalSeconds = getTierConfig(host.organizationId).monitorIntervalSeconds
         val freshnessWindowSeconds = max(
             monitorIntervalSeconds * FRESHNESS_MONITOR_MULTIPLIER,
@@ -573,16 +619,22 @@ class MonitorService(
 
         val query =
             """
-            SELECT name, container_id, image, state, cpu_percent, mem_usage, mem_limit, net_rx_bytes, net_tx_bytes
-            FROM (
-                SELECT *,
-                    ROW_NUMBER() OVER (PARTITION BY host, container_id ORDER BY timestamp DESC) as rn
-                FROM `$clickhouseDb`.containers
-                WHERE organization_id = ${host.organizationId}
-                  AND tags['host_id'] = '$hostId'
-                  AND timestamp >= now64(3) - INTERVAL $retentionDays DAY
-            ) WHERE rn = 1
+            SELECT
+                argMax(name, timestamp) as name,
+                container_id,
+                argMax(image, timestamp) as image,
+                argMax(state, timestamp) as state,
+                argMax(cpu_percent, timestamp) as cpu_percent,
+                argMax(mem_usage, timestamp) as mem_usage,
+                argMax(mem_limit, timestamp) as mem_limit,
+                argMax(net_rx_bytes, timestamp) as net_rx_bytes,
+                argMax(net_tx_bytes, timestamp) as net_tx_bytes
+            FROM `$clickhouseDb`.containers_latest_by_host
+            WHERE organization_id = ${host.organizationId}
+              AND host_id = $hostId
               AND timestamp >= now64(3) - INTERVAL $freshnessWindowSeconds SECOND
+            GROUP BY container_id
+            ORDER BY max(timestamp) DESC
             FORMAT JSONCompact
             """.trimIndent()
 
@@ -656,9 +708,7 @@ class MonitorService(
     }
 
     /**
-     * Get latest container stats per host+container_id from the containers table.
-     * Deduplicates time-series rows so each container appears once (fixes inflated
-     * counts when raw rows are returned to MCP/API consumers).
+     * Get latest container stats per host+container_id from the live latest table.
      */
     suspend fun getLatestInfraContainers(
         organizationIds: List<Int>,
@@ -671,16 +721,24 @@ class MonitorService(
         val hostClause = if (escapedHost != null) "AND host = '$escapedHost'" else ""
         val query =
             """
-            SELECT host, container_id, name, image, state, cpu_percent, mem_usage, mem_limit,
-                   net_rx_bytes, net_tx_bytes, tags, timestamp
-            FROM (
-                SELECT *,
-                    ROW_NUMBER() OVER (PARTITION BY organization_id, host, container_id ORDER BY timestamp DESC) as rn
-                FROM `$clickhouseDb`.containers
-                WHERE organization_id IN ($orgList)
-                  AND timestamp >= now64(3) - INTERVAL $INFRA_LOOKBACK_DAYS DAY
-                  $hostClause
-            ) WHERE rn = 1
+            SELECT
+                host,
+                container_id,
+                argMax(name, timestamp) as name,
+                argMax(image, timestamp) as image,
+                argMax(state, timestamp) as state,
+                argMax(cpu_percent, timestamp) as cpu_percent,
+                argMax(mem_usage, timestamp) as mem_usage,
+                argMax(mem_limit, timestamp) as mem_limit,
+                argMax(net_rx_bytes, timestamp) as net_rx_bytes,
+                argMax(net_tx_bytes, timestamp) as net_tx_bytes,
+                argMax(tags, timestamp) as tags,
+                max(timestamp) as timestamp
+            FROM `$clickhouseDb`.containers_latest_by_host
+            WHERE organization_id IN ($orgList)
+              AND timestamp >= now64(3) - INTERVAL $INFRA_LOOKBACK_DAYS DAY
+              $hostClause
+            GROUP BY organization_id, host_id, host, container_id
             ORDER BY host, name
             LIMIT $limit
             FORMAT JSONCompact
@@ -774,23 +832,24 @@ class MonitorService(
                 timeRange <= ONE_WEEK_SECONDS -> INTERVAL_THIRTY_MINUTES
                 else -> INTERVAL_ONE_HOUR
             }
+        val rollupInterval = max(calculatedInterval, INTERVAL_ONE_MINUTE)
 
         val escapedName = escapeSql(containerName)
         val query =
             """
             SELECT
-                toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL $calculatedInterval second)) as ts,
-                avg(cpu_percent) as cpu,
-                avg(mem_usage) as mem_used,
-                avg(mem_limit) as mem_limit,
-                sum(net_rx_bytes) as net_recv,
-                sum(net_tx_bytes) as net_sent
-            FROM `$clickhouseDb`.containers
+                toUnixTimestamp(toStartOfInterval(bucket_start, INTERVAL $rollupInterval second)) as ts,
+                sum(cpu_sum) / nullIf(sum(cpu_count), 0) as cpu,
+                sum(mem_usage_sum) / nullIf(sum(cpu_count), 0) as mem_used,
+                sum(mem_limit_sum) / nullIf(sum(cpu_count), 0) as mem_limit,
+                sum(net_rx_bytes_sum) as net_recv,
+                sum(net_tx_bytes_sum) as net_sent
+            FROM `$clickhouseDb`.containers_rollup_1m
             WHERE organization_id = ${host.organizationId}
-              AND tags['host_id'] = '$hostId'
+              AND host_id = $hostId
               AND name = '$escapedName'
-              AND timestamp >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
-              AND timestamp <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
+              AND bucket_start >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
+              AND bucket_start <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
             GROUP BY ts
             ORDER BY ts
             FORMAT JSONCompact
@@ -806,7 +865,7 @@ class MonitorService(
                         containerName = containerName,
                         from = effectiveFrom,
                         to = effectiveTo,
-                        intervalSeconds = calculatedInterval,
+                        intervalSeconds = rollupInterval,
                         dataPoints = emptyList()
                     )
 
@@ -850,7 +909,7 @@ class MonitorService(
             containerName = containerName,
             from = effectiveFrom,
             to = effectiveTo,
-            intervalSeconds = calculatedInterval,
+            intervalSeconds = rollupInterval,
             dataPoints = dataPoints
         )
     }

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
@@ -19,6 +19,8 @@ package com.moneat.otlp.services
 import com.google.protobuf.InvalidProtocolBufferException
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
+import com.moneat.monitor.services.InfraMetricRollupRow
+import com.moneat.monitor.services.InfraTelemetryRollups
 import com.moneat.otlp.METRIC_BILLABLE_OVERHEAD_BYTES
 import com.moneat.otlp.OtlpParsingUtils
 import com.moneat.otlp.OtlpProtobufParser
@@ -668,6 +670,21 @@ class OtlpMetricsService(
 
         val response = ClickHouseClient.execute(insert)
         check(response.status.isSuccess()) { "Failed to insert OTLP metrics into ClickHouse" }
+
+        InfraTelemetryRollups.insertMetricRollups(
+            batch.metrics.map { metric ->
+                InfraMetricRollupRow(
+                    organizationId = metric.organizationId,
+                    metricName = metric.metricName,
+                    timestampMs = metric.timestampMs,
+                    value = metric.value,
+                    host = metric.host,
+                    tags = metric.resourceAttributes + metric.tags,
+                    unit = metric.unit,
+                    source = "otlp",
+                )
+            }
+        )
 
         val totalBytes = batch.metrics.sumOf { it.metricName.length + METRIC_BILLABLE_OVERHEAD_BYTES }
         usageTracking.recordOrgUsage(

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
@@ -17,6 +17,8 @@
 package com.moneat.otlp.services
 
 import com.google.protobuf.InvalidProtocolBufferException
+import com.moneat.apm.services.ApmServiceMapRollups
+import com.moneat.apm.services.ApmServiceMapSpan
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.otlp.OtlpParsingUtils
@@ -61,6 +63,7 @@ private const val OTLP_SPAN_KIND_CLIENT = 3
 private const val OTLP_SPAN_KIND_PRODUCER = 4
 private const val OTLP_SPAN_KIND_CONSUMER = 5
 private const val ERROR_MESSAGE_PREVIEW_LENGTH = 500
+private const val OTLP_SOURCE = "otlp"
 
 @Serializable
 data class OtlpSpanInsert(
@@ -356,7 +359,7 @@ class OtlpTraceService(
                 '${escapeSql(s.traceIdHex)}',
                 '${escapeSql(s.spanIdHex)}',
                 '${escapeSql(s.parentIdHex)}',
-                'otlp',
+                '$OTLP_SOURCE',
                 '${escapeSql(s.kind)}',
                 ${s.statusCode},
                 '${escapeSql(s.statusMessage)}',
@@ -385,6 +388,7 @@ class OtlpTraceService(
 
         val response = ClickHouseClient.execute(insert)
         check(response.status.isSuccess()) { "Failed to insert OTLP spans into ClickHouse" }
+        ApmServiceMapRollups.insertForSpans(clickhouseDb, batch.spans.toServiceMapSpans())
 
         val totalBytes = batch.spans.calculateBillableBytes()
         usageTracking.recordOrgUsage(
@@ -403,6 +407,22 @@ class OtlpTraceService(
         OTLP_SPAN_KIND_CONSUMER -> "CONSUMER"
         else -> ""
     }
+
+    private fun List<OtlpSpanInsert>.toServiceMapSpans(): List<ApmServiceMapSpan> =
+        map { span ->
+            ApmServiceMapSpan(
+                organizationId = span.organizationId,
+                traceKey = span.traceIdHex,
+                spanKey = span.spanIdHex,
+                parentKey = span.parentIdHex,
+                service = span.service,
+                env = span.env,
+                source = OTLP_SOURCE,
+                startNanos = span.startNanos,
+                durationNanos = span.durationNanos,
+                error = span.error,
+            )
+        }
 
     private fun protoEventsToJson(events: List<Span.Event>): String {
         val jsonEvents =

--- a/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
@@ -51,6 +51,28 @@ private val logger = KotlinLogging.logger {}
 // Attribute key for storing Sentry transaction in call
 private val SentryTransactionKey = AttributeKey<ITransaction>("SentryTransaction")
 private val ingestPathRegex = Regex("^/api/[^/]+/(envelope|logs|store|security)/?$")
+private val datadogApiV1IntakePaths = setOf(
+    "/api/v1/container",
+    "/api/v1/discovery",
+)
+private val datadogApiV2IntakePaths = setOf(
+    "/api/v2/contimage",
+    "/api/v2/contlcycle",
+    "/api/v2/data_streams_messages",
+    "/api/v2/databasequery",
+    "/api/v2/dbmactivity",
+    "/api/v2/dbmhealth",
+    "/api/v2/dbmmetadata",
+    "/api/v2/dbmmetrics",
+    "/api/v2/events",
+    "/api/v2/ndm",
+    "/api/v2/ndmconfig",
+    "/api/v2/ndmflow",
+    "/api/v2/ndmtraps",
+    "/api/v2/netpath",
+    "/api/v2/sbom",
+    "/api/v2/synthetics",
+)
 
 private const val HTTP_CLIENT_ERROR_MIN = 400
 private const val HTTP_CLIENT_ERROR_MAX = 499
@@ -205,29 +227,37 @@ fun Application.configureMonitoring() {
     }
 }
 
-private fun shouldSkipTracing(path: String, method: String): Boolean {
-    if (path == "/health" || path == "/health/" || path.startsWith("/health/")) {
+internal fun shouldSkipTracing(path: String, method: String): Boolean {
+    val normalizedPath = path.trimEnd('/').ifEmpty { "/" }
+    val normalizedMethod = method.uppercase()
+    if (normalizedPath == "/health" || normalizedPath.startsWith("/health/")) {
         return true
     }
-    if (path == "/metrics" || path == "/metrics/") {
+    if (normalizedPath == "/metrics") {
         return true
     }
-    if (method == "POST") {
-        if (path == "/v1/logs/otlp" || path == "/v1/logs/otlp/" || path == "/v1/logs" || path == "/v1/logs/") {
-            return true
-        }
-        if (path == "/v1/traces" || path == "/v1/traces/otlp" ||
-            path == "/v1/traces/" || path == "/v1/traces/otlp/"
-        ) {
-            return true
-        }
-        if (path == "/v1/metrics" || path == "/v1/metrics/otlp" ||
-            path == "/v1/metrics/" || path == "/v1/metrics/otlp/"
-        ) {
-            return true
-        }
+    if (normalizedPath.startsWith("/dd/")) {
+        return true
     }
-    return ingestPathRegex.matches(path)
+    if (ingestPathRegex.matches(normalizedPath)) {
+        return true
+    }
+    if (normalizedMethod != "POST" && normalizedMethod != "PUT") {
+        return false
+    }
+    if (normalizedPath in datadogApiV1IntakePaths || normalizedPath in datadogApiV2IntakePaths) {
+        return true
+    }
+    return normalizedPath in setOf(
+        "/v1/logs",
+        "/v1/logs/ingest",
+        "/v1/logs/otlp",
+        "/v1/metrics",
+        "/v1/metrics/otlp",
+        "/v1/pulse",
+        "/v1/traces",
+        "/v1/traces/otlp",
+    )
 }
 
 /**

--- a/backend/src/main/resources/db/clickhouse_migration/V42__add_apm_service_map_rollups.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V42__add_apm_service_map_rollups.sql
@@ -1,0 +1,36 @@
+-- Pre-aggregated APM service-map data for read-side dependency maps.
+--
+-- The service map should not build relationships by joining raw apm_spans at
+-- request time. These rollups are populated by ingestion adapters once a trace
+-- batch has already been parsed into spans.
+
+CREATE TABLE IF NOT EXISTS apm_service_stats_hourly (
+    organization_id UInt64,
+    bucket_start DateTime('UTC'),
+    service LowCardinality(String),
+    env LowCardinality(String),
+    source LowCardinality(String),
+    span_count UInt64,
+    error_count UInt64,
+    duration_sum UInt64,
+    duration_count UInt64
+) ENGINE = SummingMergeTree((span_count, error_count, duration_sum, duration_count))
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (organization_id, bucket_start, service, env, source)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS apm_service_edges_hourly (
+    organization_id UInt64,
+    bucket_start DateTime('UTC'),
+    from_service LowCardinality(String),
+    to_service LowCardinality(String),
+    env LowCardinality(String),
+    source LowCardinality(String),
+    call_count UInt64,
+    error_count UInt64,
+    duration_sum UInt64,
+    duration_count UInt64
+) ENGINE = SummingMergeTree((call_count, error_count, duration_sum, duration_count))
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (organization_id, bucket_start, from_service, to_service, env, source)
+SETTINGS index_granularity = 8192;

--- a/backend/src/main/resources/db/clickhouse_migration/V43__add_infra_event_rollups.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V43__add_infra_event_rollups.sql
@@ -1,0 +1,108 @@
+-- Hot-path telemetry rollups populated from live ingestion. These tables are
+-- intentionally not backfilled by this migration.
+CREATE TABLE IF NOT EXISTS metrics_latest_by_host (
+    organization_id UInt64,
+    host_id UInt64,
+    metric_name LowCardinality(String),
+    timestamp DateTime64(3, 'UTC'),
+    value Float64,
+    host String DEFAULT '',
+    unit String DEFAULT '',
+    source LowCardinality(String) DEFAULT '',
+    tags Map(String, String)
+) ENGINE = ReplacingMergeTree(timestamp)
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (organization_id, host_id, metric_name)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS metrics_rollup_1m (
+    organization_id UInt64,
+    host_id UInt64,
+    bucket_start DateTime64(3, 'UTC'),
+    metric_name LowCardinality(String),
+    host String DEFAULT '',
+    unit String DEFAULT '',
+    source LowCardinality(String) DEFAULT '',
+    value_sum Float64,
+    value_count UInt64
+) ENGINE = SummingMergeTree((value_sum, value_count))
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (organization_id, host_id, bucket_start, metric_name)
+TTL toDateTime(bucket_start) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS containers_latest_by_host (
+    organization_id UInt64,
+    host_id UInt64,
+    host String,
+    container_id String,
+    name String DEFAULT '',
+    image String DEFAULT '',
+    state LowCardinality(String) DEFAULT 'running',
+    cpu_percent Float64 DEFAULT 0,
+    mem_usage UInt64 DEFAULT 0,
+    mem_limit UInt64 DEFAULT 0,
+    net_rx_bytes UInt64 DEFAULT 0,
+    net_tx_bytes UInt64 DEFAULT 0,
+    tags Map(String, String),
+    timestamp DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(timestamp)
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (organization_id, host_id, host, container_id)
+TTL toDateTime(timestamp) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS containers_rollup_1m (
+    organization_id UInt64,
+    host_id UInt64,
+    bucket_start DateTime64(3, 'UTC'),
+    host String,
+    container_id String,
+    name String DEFAULT '',
+    cpu_sum Float64,
+    cpu_count UInt64,
+    mem_usage_sum UInt64,
+    mem_limit_sum UInt64,
+    net_rx_bytes_sum UInt64,
+    net_tx_bytes_sum UInt64
+) ENGINE = SummingMergeTree((
+    cpu_sum,
+    cpu_count,
+    mem_usage_sum,
+    mem_limit_sum,
+    net_rx_bytes_sum,
+    net_tx_bytes_sum
+))
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (organization_id, host_id, bucket_start, container_id, name)
+TTL toDateTime(bucket_start) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;
+
+-- Lightweight error-event rollups for dashboard counts and timelines. These are
+-- populated only by new ingestion writes after this migration lands.
+CREATE TABLE IF NOT EXISTS event_project_rollup_1h (
+    project_id UInt64,
+    bucket_start DateTime64(3, 'UTC'),
+    level LowCardinality(String),
+    platform LowCardinality(String),
+    browser_name LowCardinality(String),
+    environment LowCardinality(String),
+    event_count UInt64
+) ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (project_id, bucket_start, level, platform, browser_name, environment)
+TTL toDateTime(bucket_start) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS event_issue_rollup_1h (
+    project_id UInt64,
+    issue_id String,
+    bucket_start DateTime64(3, 'UTC'),
+    title String,
+    event_count UInt64
+) ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (project_id, bucket_start, issue_id, title)
+TTL toDateTime(bucket_start) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogInfraServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogInfraServiceTest.kt
@@ -284,4 +284,49 @@ class DatadogInfraServiceTest {
             unmockkObject(ClickHouseClient)
         }
     }
+
+    @Test
+    fun `insertInfraBatch preserves raw container success when rollup setup fails`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        var getDatabaseCalls = 0
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } answers {
+                getDatabaseCalls += 1
+                if (getDatabaseCalls == 1) {
+                    "test_db"
+                } else {
+                    throw IllegalStateException("rollup database unavailable")
+                }
+            }
+            every { response.status } returns HttpStatusCode.OK
+            coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+            DatadogInfraService.insertInfraBatch(
+                QueuedInfraBatch(
+                    organizationId = 42L,
+                    type = "containers",
+                    containers = listOf(
+                        QueuedContainerEntry(
+                            host = "web-01",
+                            containerId = "abc123",
+                            name = "nginx",
+                            image = "nginx:latest",
+                            cpuPercent = 5.0,
+                            memUsage = 100L,
+                            memLimit = 200L,
+                            tags = mapOf("host_id" to "7"),
+                            timestampMs = 1_700_000_000_000L,
+                        )
+                    )
+                )
+            )
+
+            assertEquals(1, queries.size)
+            assertTrue(queries.single().contains("INSERT INTO `test_db`.containers "))
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogInfraServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogInfraServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.services
 
+import com.moneat.config.ClickHouseClient
 import com.moneat.datadog.models.DatadogConnection
 import com.moneat.datadog.models.DatadogConnectionsPayload
 import com.moneat.datadog.models.DatadogContainer
@@ -23,6 +24,14 @@ import com.moneat.datadog.models.DatadogContainerPayload
 import com.moneat.datadog.models.DatadogProcess
 import com.moneat.datadog.models.DatadogProcessPayload
 import com.moneat.testsupport.TestIpConstants
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -236,5 +245,43 @@ class DatadogInfraServiceTest {
         assertTrue(
             batch.processes[0].timestampMs in before..after
         )
+    }
+
+    @Test
+    fun `insertInfraBatch writes raw containers and infra rollups`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "test_db"
+            every { response.status } returns HttpStatusCode.OK
+            coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+            DatadogInfraService.insertInfraBatch(
+                QueuedInfraBatch(
+                    organizationId = 42L,
+                    type = "containers",
+                    containers = listOf(
+                        QueuedContainerEntry(
+                            host = "web-01",
+                            containerId = "abc123",
+                            name = "nginx",
+                            image = "nginx:latest",
+                            cpuPercent = 5.0,
+                            memUsage = 100L,
+                            memLimit = 200L,
+                            tags = mapOf("host_id" to "7"),
+                            timestampMs = 1_700_000_000_000L,
+                        )
+                    )
+                )
+            )
+
+            assertTrue(queries.any { it.contains("INSERT INTO `test_db`.containers ") })
+            assertTrue(queries.any { it.contains("containers_latest_by_host") })
+            assertTrue(queries.any { it.contains("containers_rollup_1m") })
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -263,4 +263,46 @@ class DatadogMetricServiceTest {
             unmockkObject(ClickHouseClient)
         }
     }
+
+    @Test
+    fun `insertMetricBatch preserves raw insert success when rollup setup fails`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        var getDatabaseCalls = 0
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } answers {
+                getDatabaseCalls += 1
+                if (getDatabaseCalls == 1) {
+                    "test_db"
+                } else {
+                    throw IllegalStateException("rollup database unavailable")
+                }
+            }
+            every { response.status } returns HttpStatusCode.OK
+            coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+            DatadogMetricService.insertMetricBatch(
+                QueuedMetricBatch(
+                    organizationId = 42L,
+                    metrics = listOf(
+                        QueuedMetricEntry(
+                            name = "system.cpu.percent",
+                            type = "gauge",
+                            timestampMs = 1_700_000_000_000L,
+                            value = 42.5,
+                            host = "web-01",
+                            tags = mapOf("host_id" to "7"),
+                            unit = "%",
+                        )
+                    )
+                )
+            )
+
+            assertEquals(1, queries.size)
+            assertTrue(queries.single().contains("INSERT INTO `test_db`.metrics "))
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -16,11 +16,20 @@
 
 package com.moneat.datadog.services
 
+import com.moneat.config.ClickHouseClient
 import com.moneat.datadog.models.DatadogMetricSeriesV1
 import com.moneat.datadog.models.DatadogMetricV1
 import com.moneat.datadog.models.DatadogSketch
 import com.moneat.datadog.models.DatadogSketchPayload
 import com.moneat.datadog.models.DatadogSketchPoint
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -218,5 +227,40 @@ class DatadogMetricServiceTest {
         assertEquals(batch.metrics.size, decoded.metrics.size)
         assertEquals(batch.metrics[0].name, decoded.metrics[0].name)
         assertEquals(batch.metrics[0].value, decoded.metrics[0].value)
+    }
+
+    @Test
+    fun `insertMetricBatch writes raw metrics and infra rollups for host metrics`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "test_db"
+            every { response.status } returns HttpStatusCode.OK
+            coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+            DatadogMetricService.insertMetricBatch(
+                QueuedMetricBatch(
+                    organizationId = 42L,
+                    metrics = listOf(
+                        QueuedMetricEntry(
+                            name = "system.cpu.percent",
+                            type = "gauge",
+                            timestampMs = 1_700_000_000_000L,
+                            value = 42.5,
+                            host = "web-01",
+                            tags = mapOf("host_id" to "7"),
+                            unit = "%",
+                        )
+                    )
+                )
+            )
+
+            assertTrue(queries.any { it.contains("INSERT INTO `test_db`.metrics ") })
+            assertTrue(queries.any { it.contains("metrics_latest_by_host") })
+            assertTrue(queries.any { it.contains("metrics_rollup_1m") })
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpMetricsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpMetricsServiceTest.kt
@@ -17,7 +17,12 @@
 package com.moneat.otlp.services
 
 import com.moneat.config.ClickHouseClient
+import com.moneat.shared.services.UsageTrackingService
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
@@ -35,6 +40,7 @@ import io.opentelemetry.proto.metrics.v1.Sum
 import io.opentelemetry.proto.metrics.v1.Summary
 import io.opentelemetry.proto.metrics.v1.SummaryDataPoint
 import io.opentelemetry.proto.resource.v1.Resource
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -594,6 +600,49 @@ class OtlpMetricsServiceTest {
         assertEquals("cpu.usage", decoded.metrics[0].metricName)
         assertEquals(DECODE_BATCH_METRIC_VALUE, decoded.metrics[0].value)
         assertEquals(TEST_ENV, decoded.metrics[0].tags["env"])
+    }
+
+    @Test
+    fun `insertBatch writes raw metrics and infra rollups for host metrics`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        every { response.status } returns HttpStatusCode.OK
+        coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+        val localService = OtlpMetricsService(mockk<UsageTrackingService>(relaxed = true))
+        localService.insertBatch(
+            QueuedOtlpMetricsBatch(
+                organizationId = 42L,
+                metrics = listOf(
+                    OtlpMetricInsert(
+                        organizationId = 42L,
+                        metricName = "system.mem.used",
+                        metricType = "gauge",
+                        description = "memory used",
+                        unit = "bytes",
+                        timestampMs = TEST_TIMESTAMP_MS_PRIMARY,
+                        value = 2048.0,
+                        isMonotonic = 0,
+                        aggregationTemporality = "",
+                        histCount = 0,
+                        histSum = null,
+                        histMin = null,
+                        histMax = null,
+                        histBucketCounts = emptyList(),
+                        histExplicitBounds = emptyList(),
+                        tags = emptyMap(),
+                        resourceAttributes = mapOf("host_id" to "7"),
+                        service = TEST_SVC,
+                        env = TEST_ENV,
+                        host = TEST_HOST,
+                    )
+                )
+            )
+        )
+
+        assertTrue(queries.any { it.contains("INSERT INTO `test_db`.metrics ") })
+        assertTrue(queries.any { it.contains("metrics_latest_by_host") })
+        assertTrue(queries.any { it.contains("metrics_rollup_1m") })
     }
 
     // ──── PROTOBUF PARSING ────

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpTraceServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpTraceServiceTest.kt
@@ -18,7 +18,12 @@ package com.moneat.otlp.services
 
 import com.google.protobuf.ByteString
 import com.moneat.config.ClickHouseClient
+import com.moneat.shared.services.UsageTrackingService
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
@@ -30,6 +35,7 @@ import io.opentelemetry.proto.trace.v1.ResourceSpans
 import io.opentelemetry.proto.trace.v1.ScopeSpans
 import io.opentelemetry.proto.trace.v1.Span
 import io.opentelemetry.proto.trace.v1.Status
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -454,6 +460,80 @@ class OtlpTraceServiceTest {
         assertEquals(MY_SVC, decoded.spans[0].service)
         assertEquals("SERVER", decoded.spans[0].kind)
         assertEquals(mapOf("key" to "value"), decoded.spans[0].meta)
+    }
+
+    @Test
+    fun `insertBatch writes service map rollups`() = runBlocking {
+        val capturedSql = mutableListOf<String>()
+        coEvery { ClickHouseClient.execute(any()) } coAnswers {
+            capturedSql.add(firstArg())
+            val response = mockk<HttpResponse>()
+            every { response.status } returns HttpStatusCode.OK
+            response
+        }
+        val usageTracking = mockk<UsageTrackingService>(relaxed = true)
+        val insertService = OtlpTraceService(usageTracking)
+
+        insertService.insertBatch(
+            QueuedOtlpTraceBatch(
+                organizationId = 42L,
+                spans = listOf(
+                    OtlpSpanInsert(
+                        traceIdHex = "0af7651916cd43dd8448eb211c80319c",
+                        spanIdHex = "0000000000000001",
+                        parentIdHex = "",
+                        organizationId = 42L,
+                        name = "GET /api/users",
+                        service = "api",
+                        resource = "GET /api/users",
+                        kind = "SERVER",
+                        startNanos = 1700000000000000000L,
+                        durationNanos = 50000000L,
+                        error = 0,
+                        statusCode = 1,
+                        statusMessage = "OK",
+                        meta = emptyMap(),
+                        resourceAttributes = emptyMap(),
+                        host = "web-01",
+                        env = "prod",
+                        version = "1.0",
+                        scopeName = TRACE_OTEL_SCOPE_NAME,
+                        scopeVersion = TRACE_OTEL_SCOPE_VERSION,
+                        events = "[]",
+                        links = "[]",
+                    ),
+                    OtlpSpanInsert(
+                        traceIdHex = "0af7651916cd43dd8448eb211c80319c",
+                        spanIdHex = "0000000000000002",
+                        parentIdHex = "0000000000000001",
+                        organizationId = 42L,
+                        name = "SELECT users",
+                        service = "postgres",
+                        resource = "SELECT users",
+                        kind = "CLIENT",
+                        startNanos = 1700000000010000000L,
+                        durationNanos = 10000000L,
+                        error = 1,
+                        statusCode = 2,
+                        statusMessage = "ERROR",
+                        meta = emptyMap(),
+                        resourceAttributes = emptyMap(),
+                        host = "web-01",
+                        env = "prod",
+                        version = "1.0",
+                        scopeName = TRACE_OTEL_SCOPE_NAME,
+                        scopeVersion = TRACE_OTEL_SCOPE_VERSION,
+                        events = "[]",
+                        links = "[]",
+                    ),
+                ),
+            )
+        )
+
+        assertTrue(capturedSql.any { it.contains("INSERT INTO `test_db`.apm_spans") })
+        assertTrue(capturedSql.any { it.contains("INSERT INTO `test_db`.apm_service_stats_hourly") })
+        assertTrue(capturedSql.any { it.contains("INSERT INTO `test_db`.apm_service_edges_hourly") })
+        assertTrue(capturedSql.any { it.contains("'api'") && it.contains("'postgres'") })
     }
 
     // ──── PROTOBUF PARSING ────

--- a/backend/src/test/kotlin/com/moneat/plugins/MonitoringTest.kt
+++ b/backend/src/test/kotlin/com/moneat/plugins/MonitoringTest.kt
@@ -21,12 +21,17 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MonitoringTest {
+
+    // ──── Health endpoints ────
+
     @Test
     fun `skips health and metrics endpoints`() {
         assertTrue(shouldSkipTracing("/health", "GET"))
         assertTrue(shouldSkipTracing("/health/ready", "GET"))
         assertTrue(shouldSkipTracing("/metrics", "GET"))
     }
+
+    // ──── Ingestion endpoints ────
 
     @Test
     fun `skips OTLP and log ingestion endpoints`() {
@@ -57,6 +62,8 @@ class MonitoringTest {
         assertTrue(shouldSkipTracing("/api/123/logs", "POST"))
         assertTrue(shouldSkipTracing("/api/123/security", "POST"))
     }
+
+    // ──── Dashboard endpoints ────
 
     @Test
     fun `does not skip dashboard reads`() {

--- a/backend/src/test/kotlin/com/moneat/plugins/MonitoringTest.kt
+++ b/backend/src/test/kotlin/com/moneat/plugins/MonitoringTest.kt
@@ -1,0 +1,68 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.plugins
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MonitoringTest {
+    @Test
+    fun `skips health and metrics endpoints`() {
+        assertTrue(shouldSkipTracing("/health", "GET"))
+        assertTrue(shouldSkipTracing("/health/ready", "GET"))
+        assertTrue(shouldSkipTracing("/metrics", "GET"))
+    }
+
+    @Test
+    fun `skips OTLP and log ingestion endpoints`() {
+        assertTrue(shouldSkipTracing("/v1/traces", "POST"))
+        assertTrue(shouldSkipTracing("/v1/traces/otlp", "POST"))
+        assertTrue(shouldSkipTracing("/v1/metrics", "POST"))
+        assertTrue(shouldSkipTracing("/v1/metrics/otlp", "POST"))
+        assertTrue(shouldSkipTracing("/v1/logs", "POST"))
+        assertTrue(shouldSkipTracing("/v1/logs/otlp", "POST"))
+        assertTrue(shouldSkipTracing("/v1/logs/ingest", "POST"))
+        assertTrue(shouldSkipTracing("/v1/pulse", "POST"))
+    }
+
+    @Test
+    fun `skips Datadog intake endpoints`() {
+        assertTrue(shouldSkipTracing("/dd/api/v1/series", "POST"))
+        assertTrue(shouldSkipTracing("/dd/v0.4/traces", "PUT"))
+        assertTrue(shouldSkipTracing("/dd/api/v2/logs", "POST"))
+        assertTrue(shouldSkipTracing("/api/v1/container", "POST"))
+        assertTrue(shouldSkipTracing("/api/v2/databasequery", "POST"))
+        assertTrue(shouldSkipTracing("/api/v2/contimage", "POST"))
+    }
+
+    @Test
+    fun `skips Sentry-compatible ingestion endpoints`() {
+        assertTrue(shouldSkipTracing("/api/123/envelope/", "POST"))
+        assertTrue(shouldSkipTracing("/api/123/store", "POST"))
+        assertTrue(shouldSkipTracing("/api/123/logs", "POST"))
+        assertTrue(shouldSkipTracing("/api/123/security", "POST"))
+    }
+
+    @Test
+    fun `does not skip dashboard reads`() {
+        assertFalse(shouldSkipTracing("/v1/traces", "GET"))
+        assertFalse(shouldSkipTracing("/v1/services/map", "GET"))
+        assertFalse(shouldSkipTracing("/v1/apm-errors", "GET"))
+        assertFalse(shouldSkipTracing("/v1/projects/1/stats", "GET"))
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/services/LogServiceExecutionTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogServiceExecutionTest.kt
@@ -81,7 +81,7 @@ class LogServiceExecutionTest {
                 assertEquals(1, result.logs.size)
                 assertTrue(result.hasMore)
                 assertNotNull(result.nextCursor)
-                assertEquals(5L, result.totalCount)
+                assertNull(result.totalCount)
 
                 val first = result.logs.first()
                 assertEquals("warn", first.level)

--- a/backend/src/test/kotlin/com/moneat/services/LogServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogServicesExtendedTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -527,7 +528,7 @@ class LogServicesExtendedTest {
 
             assertTrue(result.logs.isEmpty())
             assertFalse(result.hasMore)
-            assertEquals(0L, result.totalCount)
+            assertNull(result.totalCount)
             val allQueries = capturedQueries.joinToString("\n")
             assertTrue(allQueries.contains(SERVICE_EQ_API))
             assertTrue(allQueries.contains("environment = 'prod'"))

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -225,6 +225,8 @@ class MonitorAlertServiceCoverageTest {
             assertTrue(
                 queries.single().contains("timestamp >= now64(3) - INTERVAL 10 MINUTE")
             )
+            assertTrue(queries.single().contains("metrics_latest_by_host"))
+            assertTrue(queries.single().contains("host_id = 1"))
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
@@ -359,7 +359,10 @@ class MonitorServiceExtendedTest {
         // Host 1 has one container, Host 2 returns blank (no containers)
         coEvery {
             hostRepo.executeClickHouseQuery(
-                match { it.contains("'1'") }
+                match { query ->
+                    query.contains("containers_latest_by_host") &&
+                        query.contains("host_id = 1")
+                }
             )
         } returns """
             {
@@ -369,7 +372,14 @@ class MonitorServiceExtendedTest {
                 ]
             }
         """.trimIndent()
-        coEvery { hostRepo.executeClickHouseQuery(match { it.contains("'2'") }) } returns ""
+        coEvery {
+            hostRepo.executeClickHouseQuery(
+                match { query ->
+                    query.contains("containers_latest_by_host") &&
+                        query.contains("host_id = 2")
+                }
+            )
+        } returns ""
 
         val result = service.getLatestContainersForOrganizations(listOf(10))
         assertEquals(1, result.size)
@@ -406,7 +416,7 @@ class MonitorServiceExtendedTest {
         coEvery { retentionPolicyService.getRetentionDaysForHost(1) } returns 7
 
         val nowEpoch = Clock.System.now().epochSeconds
-        // 30-minute range => interval should be 10
+        // 30-minute range is served from the 1-minute rollup table.
         coEvery { hostRepo.executeClickHouseQuery(any()) } returns DATA_EMPTY_JSON
 
         val result = service.getHistoricalMetrics(
@@ -415,7 +425,7 @@ class MonitorServiceExtendedTest {
             nowEpoch,
             null
         )
-        assertEquals(10, result.intervalSeconds)
+        assertEquals(60, result.intervalSeconds)
         assertTrue(result.dataPoints.isEmpty())
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
@@ -189,7 +189,10 @@ class MonitorServiceTest {
         MonitorService(hostRepository, hostAlertRepository).getLatestMetrics(7)
 
         assertTrue(querySlot.captured.contains("metrics_latest_by_host"))
-        assertFalse(querySlot.captured.contains("FROM `testdb`.metrics\n"))
+        assertFalse(
+            Regex("""FROM\s+`testdb`\.metrics\b""", RegexOption.IGNORE_CASE)
+                .containsMatchIn(querySlot.captured)
+        )
         assertFalse(querySlot.captured.contains("tags['host_id']"))
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
@@ -4,7 +4,10 @@ import com.moneat.billing.models.PricingTierConfigs
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
 import com.moneat.monitor.repositories.HostAlertRepositoryImpl
+import com.moneat.monitor.repositories.HostAlertRepository
 import com.moneat.monitor.repositories.HostRepositoryImpl
+import com.moneat.monitor.repositories.HostRepository
+import com.moneat.monitor.models.HostData
 import com.moneat.monitor.services.MonitorService
 import com.moneat.shared.models.HostAlertSettings
 import com.moneat.shared.models.HostAlertTemplateStates
@@ -23,6 +26,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.core.*
@@ -42,6 +46,7 @@ class MonitorServiceTest {
         mockkObject(ClickHouseClient)
         val clickHouseOk = mockk<HttpResponse>()
         every { clickHouseOk.status } returns HttpStatusCode.OK
+        every { ClickHouseClient.getDatabase() } returns "testdb"
         coEvery { ClickHouseClient.execute(any(), any()) } returns clickHouseOk
 
         mockkObject(EnvConfig.SelfHost)
@@ -158,6 +163,34 @@ class MonitorServiceTest {
     @Test
     fun `getHostById returns null for non-existent id`() {
         assertNull(service.getHostById(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun `getLatestMetrics reads from latest metrics table`() = runBlocking {
+        val hostRepository = mockk<HostRepository>()
+        val hostAlertRepository = mockk<HostAlertRepository>(relaxed = true)
+        val querySlot = slot<String>()
+        val now = kotlin.time.Clock.System.now()
+        every { hostRepository.getById(7) } returns HostData(
+            id = 7,
+            organizationId = 42,
+            hostname = "web-01",
+            displayName = "web-01",
+            status = "online",
+            lastSeenAt = now,
+            agentVersion = null,
+            os = null,
+            arch = null,
+            firstSeenAt = now,
+            createdAt = now,
+        )
+        coEvery { hostRepository.executeClickHouseQuery(capture(querySlot)) } returns """{"data":[]}"""
+
+        MonitorService(hostRepository, hostAlertRepository).getLatestMetrics(7)
+
+        assertTrue(querySlot.captured.contains("metrics_latest_by_host"))
+        assertFalse(querySlot.captured.contains("FROM `testdb`.metrics\n"))
+        assertFalse(querySlot.captured.contains("tags['host_id']"))
     }
 
     // ──── deleteHost ────

--- a/backend/src/test/kotlin/com/moneat/services/ProjectStatsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ProjectStatsServiceTest.kt
@@ -104,10 +104,11 @@ class ProjectStatsServiceTest {
             exchange.respond(200, customResponse, TEXT_PLAIN)
         } else {
             val body = when {
-                query.contains("count() as total") && query.contains("event_type = 'error'") &&
-                    !query.contains("DISTINCT") && !query.contains("issues") ->
+                query.contains("sum(event_count) as total") &&
+                    query.contains("event_project_rollup_1h") ->
                     """{"total":$totalEvents}"""
-                query.contains("count(DISTINCT issue_id) as total") ->
+                query.contains("uniqExact(issue_id) as total") &&
+                    query.contains("event_issue_rollup_1h") ->
                     """{"total":$totalIssues}"""
                 query.contains("status = 'unresolved'") && query.contains("issues FINAL") ->
                     """{"total":$unresolvedIssues}"""
@@ -117,19 +118,19 @@ class ProjectStatsServiceTest {
                     """{"time":"2026-01-01T00:00:00Z","count":5}"""
                 query.contains("toStartOfInterval") ->
                     """{"time":"2026-01-01T00:00:00Z","count":10}"""
-                query.contains("level, count()") ->
+                query.contains("level, sum(event_count)") ->
                     """{"level":"error","count":30}
 {"level":"warning","count":12}"""
-                query.contains("platform, count()") ->
+                query.contains("platform, sum(event_count)") ->
                     """{"platform":"kotlin","count":25}"""
-                query.contains("browser_name, count()") ->
+                query.contains("browser_name, sum(event_count)") ->
                     """{"browser_name":"Chrome","count":20}"""
-                query.contains("environment, count()") ->
+                query.contains("environment, sum(event_count)") ->
                     """{"environment":"production","count":35}"""
                 query.contains("status, count()") && query.contains("GROUP BY status") ->
                     """{"status":"unresolved","count":3}
 {"status":"resolved","count":2}"""
-                query.contains("issue_id, any(message) as title") ->
+                query.contains("issue_id, any(title) as title") ->
                     """{"issue_id":"iss-1","title":"NullPointerException","count":15}"""
                 query.contains("release as version") ->
                     """{"version":"1.0.0","timestamp":"2026-01-01T12:00:00.000Z"}"""
@@ -253,9 +254,10 @@ class ProjectStatsServiceTest {
             val query = exchange.requestBodyText()
             queries += query
             val body = when {
-                query.contains("count() as total") && !query.contains("DISTINCT") && !query.contains("issues") ->
+                query.contains("sum(event_count) as total") &&
+                    query.contains("event_project_rollup_1h") ->
                     """{"total":10}"""
-                query.contains("count(DISTINCT issue_id)") ->
+                query.contains("uniqExact(issue_id)") ->
                     """{"total":2}"""
                 query.contains("status = 'unresolved'") ->
                     """{"total":1}"""

--- a/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
@@ -25,7 +25,9 @@ import com.moneat.datadog.models.DdStatsPayload
 import com.moneat.datadog.services.DdApmQueryTimeRange
 import com.moneat.datadog.services.DdApmQueryTimeUnit
 import com.moneat.datadog.services.TraceIngestionService
+import io.sentry.ISpan
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -291,6 +293,14 @@ class TraceIngestionServiceCoverageTest {
                     duration = 500000000L, error = 0,
                     meta = mapOf("env" to "prod", "http.method" to "GET"),
                     metrics = mapOf("_dd.measured" to 1.0)
+                ),
+                DdSpan(
+                    traceId = 1u, spanId = 11u, parentId = 10u,
+                    name = "db.query", service = "postgres", resource = "SELECT 1",
+                    type = "sql", start = 1700000000100000000L,
+                    duration = 250000000L, error = 1,
+                    meta = mapOf("env" to "prod"),
+                    metrics = emptyMap()
                 )
             )
         )
@@ -307,6 +317,9 @@ class TraceIngestionServiceCoverageTest {
         val sql = capturedSql.first()
         assertTrue(sql.contains("INSERT INTO"))
         assertTrue(sql.contains("apm_spans"))
+        assertTrue(capturedSql.any { it.contains("apm_service_stats_hourly") })
+        assertTrue(capturedSql.any { it.contains("apm_service_edges_hourly") })
+        assertTrue(capturedSql.any { it.contains("'api'") && it.contains("'postgres'") })
     }
 
     @Test
@@ -481,8 +494,10 @@ class TraceIngestionServiceCoverageTest {
     @Test
     fun `getServiceMap returns services with relationships`() = runBlocking {
         var callCount = 0
+        val capturedQueries = mutableListOf<String>()
         coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
             callCount++
+            capturedQueries.add(firstArg())
             if (callCount == 1) {
                 """
                 {"service":"web","span_count":100,"error_count":5,"avg_duration_ns":500000.0}
@@ -500,6 +515,22 @@ class TraceIngestionServiceCoverageTest {
         assertEquals("web", result.services[0].service)
         assertEquals(listOf("db"), result.services[0].callsTo)
         assertTrue(result.services[1].callsTo.isEmpty())
+        assertTrue(capturedQueries.any { it.contains("apm_service_stats_hourly") })
+        assertTrue(capturedQueries.any { it.contains("apm_service_edges_hourly") })
+        assertTrue(capturedQueries.none { it.contains("INNER JOIN") })
+        assertTrue(capturedQueries.none { it.contains("FROM `test_db`.apm_spans") })
+    }
+
+    @Test
+    fun `getServiceMap passes explicit Sentry span to ClickHouse queries`() = runBlocking {
+        val span = mockk<ISpan>(relaxed = true)
+        coEvery { ClickHouseClient.executeWithFormat(any(), any(), span) } returns ""
+
+        TraceIngestionService.getServiceMap(1, span)
+
+        coVerify(exactly = 2) {
+            ClickHouseClient.executeWithFormat(any(), any(), span)
+        }
     }
 
     // ===================== getApmErrors =====================


### PR DESCRIPTION
## Summary
- skip Sentry transactions for telemetry intake endpoints to avoid recursive self-monitoring
- keep ClickHouse tracing explicit and wire APM dashboard reads through request spans
- add live rollup/latest ClickHouse tables for service map, infra metrics, containers, and event summaries
- move hot dashboard and monitor queries away from raw scans while keeping raw tables and APM materialized views intact

## Notes
- no production backfill is included; new rollups warm from live ingestion
- APM trace and error materialized views remain in place
- ClickHouse migration numbering now follows develop's V41 with this branch using V42 and V43

## Validation
- ./gradlew compileKotlin compileTestKotlin detekt
- ./gradlew :test --tests com.moneat.plugins.MonitoringTest --tests com.moneat.services.TraceIngestionServiceCoverageTest --tests com.moneat.datadog.services.DatadogMetricServiceTest --tests com.moneat.datadog.services.DatadogInfraServiceTest --tests com.moneat.otlp.services.OtlpMetricsServiceTest --tests com.moneat.services.MonitorServiceTest --tests com.moneat.services.MonitorAlertServiceCoverageTest --tests com.moneat.services.LogServiceExecutionTest --tests com.moneat.services.LogServicesExtendedTest
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hourly APM service-map rollups and service-to-service edge rollups
  * Infrastructure telemetry rollups: latest-by-host and 1-minute metrics/containers; hourly event rollups

* **Improvements**
  * Dashboard, trace, and infra endpoints now read from pre-aggregated rollups for faster, host-scoped queries
  * Ingest paths emit best-effort rollups after raw inserts; trace handlers instrumented for tracing
  * Log queries no longer return total counts

* **Tests**
  * Added/expanded tests validating rollup insertion and rollup-backed queries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->