### PR TITLE
style: remove dashboard shadows

### DIFF
--- a/dashboard/src/components/AdminComponents.tsx
+++ b/dashboard/src/components/AdminComponents.tsx
@@ -200,7 +200,7 @@ export function ChartTooltipContent({ active, payload, label, formatter }: Chart
   if (!active || !payload?.length) return null
 
   return (
-    <div className="rounded-lg border bg-card px-3 py-2 shadow-lg">
+    <div className="rounded-lg border bg-card px-3 py-2">
       <p className="text-xs font-medium text-muted-foreground mb-1.5">{label}</p>
       <div className="space-y-1">
         {payload.map((entry, i) => (

--- a/dashboard/src/components/AiFloatingPanel.tsx
+++ b/dashboard/src/components/AiFloatingPanel.tsx
@@ -92,7 +92,7 @@ export function AiFloatingPanel() {
   return (
     <div
       ref={panelRef}
-      className="fixed z-50 flex flex-col rounded-xl border border-border bg-background shadow-2xl"
+      className="fixed z-50 flex flex-col rounded-xl border border-border bg-background"
       style={{
         left: pos.x,
         top: pos.y,

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -306,7 +306,7 @@ export function CommandPalette() {
         }
       }}
     >
-      <DialogContent className={cn('overflow-hidden p-0 shadow-lg', showAiMode && 'max-w-3xl')}>
+      <DialogContent className={cn('overflow-hidden p-0', showAiMode && 'max-w-3xl')}>
         <Command
           className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
           shouldFilter={false}

--- a/dashboard/src/components/MobileReplayViewer.tsx
+++ b/dashboard/src/components/MobileReplayViewer.tsx
@@ -870,7 +870,7 @@ export const MobileReplayViewer = forwardRef<MobileReplayViewerHandle, MobileRep
                           aria-label={`${marker.title} at ${formatClock(marker.globalTimeMs)}`}
                         >
                           {isHovered && (
-                            <div className="pointer-events-none absolute left-1/2 z-40 w-56 -translate-x-1/2 rounded-lg border bg-popover p-2.5 text-left shadow-lg" style={{ bottom: 'calc(100% + 10px)' }}>
+                            <div className="pointer-events-none absolute left-1/2 z-40 w-56 -translate-x-1/2 rounded-lg border bg-popover p-2.5 text-left" style={{ bottom: 'calc(100% + 10px)' }}>
                               <div className="text-xs font-semibold" style={{ color: marker.tooltipAccentColor }}>
                                 {marker.title}
                               </div>

--- a/dashboard/src/components/ReplayTimelinePanel.tsx
+++ b/dashboard/src/components/ReplayTimelinePanel.tsx
@@ -458,7 +458,7 @@ export function ReplayTimelinePanel({ items, currentOffsetMs, projectId, onSeek 
   }, [onSeek])
 
   return (
-    <div className="h-full min-h-0 rounded-lg border bg-card shadow-sm">
+    <div className="h-full min-h-0 rounded-lg border bg-card">
       <Tabs
         value={tab}
         onValueChange={(v) => setTab(v as FilterValue)}
@@ -467,22 +467,22 @@ export function ReplayTimelinePanel({ items, currentOffsetMs, projectId, onSeek 
         {/* Colored tab bar */}
         <div className="px-2 pt-2">
           <TabsList className="w-full grid grid-cols-4 h-9 gap-1 p-1 bg-muted/50">
-            <TabsTrigger value="all" className="text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm">
+            <TabsTrigger value="all" className="text-xs data-[state=active]:bg-background">
               All <span className="ml-1 text-[10px] font-mono text-muted-foreground">{items.length}</span>
             </TabsTrigger>
-            <TabsTrigger value="error" className="text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm data-[state=active]:text-red-600 dark:data-[state=active]:text-red-400">
+            <TabsTrigger value="error" className="text-xs data-[state=active]:bg-background data-[state=active]:text-red-600 dark:data-[state=active]:text-red-400">
               <span className="flex items-center gap-1">
                 <span className="h-1.5 w-1.5 rounded-full bg-red-500" />Errors
               </span>
               <span className="ml-1 text-[10px] font-mono">{errorItems.length}</span>
             </TabsTrigger>
-            <TabsTrigger value="transaction" className="text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400">
+            <TabsTrigger value="transaction" className="text-xs data-[state=active]:bg-background data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400">
               <span className="flex items-center gap-1">
                 <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />Txns
               </span>
               <span className="ml-1 text-[10px] font-mono">{transactionItems.length}</span>
             </TabsTrigger>
-            <TabsTrigger value="span" className="text-xs data-[state=active]:bg-background data-[state=active]:shadow-sm data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400">
+            <TabsTrigger value="span" className="text-xs data-[state=active]:bg-background data-[state=active]:text-emerald-600 dark:data-[state=active]:text-emerald-400">
               <span className="flex items-center gap-1">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />Spans
               </span>

--- a/dashboard/src/components/ReplayTimelineScrubber.tsx
+++ b/dashboard/src/components/ReplayTimelineScrubber.tsx
@@ -215,7 +215,7 @@ export function ReplayTimelineScrubber({
             >
               {isHovered && (
                 <div
-                  className="pointer-events-none absolute left-1/2 z-50 w-52 -translate-x-1/2 rounded-lg border bg-popover p-2 text-left shadow-lg overflow-hidden"
+                  className="pointer-events-none absolute left-1/2 z-50 w-52 -translate-x-1/2 rounded-lg border bg-popover p-2 text-left overflow-hidden"
                   style={{ bottom: 'calc(100% + 10px)' }}
                 >
                   <div className="text-xs font-semibold truncate min-w-0" style={{ color: markerColor(marker.type) }} title={marker.title}>
@@ -247,7 +247,7 @@ export function ReplayTimelineScrubber({
           className="absolute top-1/2 z-30 -translate-x-1/2 -translate-y-1/2 pointer-events-none"
           style={{ left: `${playheadPercent}%` }}
         >
-          <div className="w-3 h-3 rounded-full bg-primary border-2 border-background shadow-md" />
+          <div className="w-3 h-3 rounded-full bg-primary border-2 border-background" />
         </div>
       </div>
 

--- a/dashboard/src/components/SpanWaterfall.tsx
+++ b/dashboard/src/components/SpanWaterfall.tsx
@@ -119,7 +119,7 @@ function TimeRuler({ durationMs }: TimeRulerProps) {
 function SpanTooltip({ span, x, y }: SpanTooltipProps) {
   return (
     <div
-      className="fixed z-50 w-72 rounded-md border bg-popover px-3 py-2 text-xs shadow-lg text-popover-foreground"
+      className="fixed z-50 w-72 rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground"
       style={{ left: x, top: y }}
     >
       <div className="mb-1 font-semibold">{span.op || 'operation'}</div>

--- a/dashboard/src/components/apm/ServiceMap.tsx
+++ b/dashboard/src/components/apm/ServiceMap.tsx
@@ -199,9 +199,9 @@ const ServiceNode = memo(function ServiceNode({data}: NodeProps<Node<ServiceNode
   return (
     <div
       className={[
-        'rounded-lg border-2 bg-card text-card-foreground shadow-sm',
+        'rounded-lg border-2 bg-card text-card-foreground',
         'transition-all duration-200 cursor-pointer',
-        data.selected ? 'ring-2 ring-primary shadow-lg scale-[1.02]' : '',
+        data.selected ? 'ring-2 ring-primary scale-[1.02]' : '',
         data.dimmed ? 'opacity-25' : '',
         data.isExternal ? 'border-dashed' : '',
       ].join(' ')}
@@ -343,7 +343,7 @@ export function ServiceMap() {
 
       {/* Detail panel */}
       {selected && (
-        <div className="absolute top-3 right-3 w-60 bg-card border rounded-lg shadow-lg overflow-hidden animate-in fade-in slide-in-from-right-2 duration-200">
+        <div className="absolute top-3 right-3 w-60 bg-card border rounded-lg overflow-hidden animate-in fade-in slide-in-from-right-2 duration-200">
           <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30">
             <h3 className="font-semibold text-sm truncate">{selected.service}</h3>
             <button

--- a/dashboard/src/components/dashboards/DashboardToolbar.tsx
+++ b/dashboard/src/components/dashboards/DashboardToolbar.tsx
@@ -185,7 +185,7 @@ export function DashboardToolbar({
                 onClick={() => onTimeRangeChange({from: preset.from, to: preset.to})}
                 className={`px-3 py-1 text-xs font-medium rounded-sm transition-all ${
                   isActive
-                    ? 'bg-background text-foreground shadow-sm'
+                    ? 'bg-background text-foreground'
                     : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
                 }`}
               >
@@ -202,7 +202,7 @@ export function DashboardToolbar({
               variant={autoRefresh ? 'default' : 'outline'}
               size="icon"
               onClick={() => onAutoRefreshChange(!autoRefresh)}
-              className={`h-8 w-8 ${autoRefresh ? '' : 'shadow-none border-transparent hover:bg-muted'}`}
+              className={`h-8 w-8 ${autoRefresh ? '' : 'border-transparent hover:bg-muted'}`}
             >
               <RefreshCw className={`h-3.5 w-3.5 ${autoRefresh ? 'animate-spin' : ''}`} />
             </Button>
@@ -240,7 +240,7 @@ export function DashboardToolbar({
               </TooltipTrigger>
               <TooltipContent>Export dashboard</TooltipContent>
             </Tooltip>
-            <Button variant="outline" size="sm" onClick={onToggleEdit} className="h-8 text-xs shadow-none border-transparent hover:bg-muted">
+            <Button variant="outline" size="sm" onClick={onToggleEdit} className="h-8 text-xs border-transparent hover:bg-muted">
               <Pencil className="h-3.5 w-3.5" />
             </Button>
           </div>

--- a/dashboard/src/components/dashboards/DataSourceMapperModal.tsx
+++ b/dashboard/src/components/dashboards/DataSourceMapperModal.tsx
@@ -98,7 +98,7 @@ export function DataSourceMapperModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-background w-full max-w-md rounded-lg border p-6 shadow-lg">
+      <div className="bg-background w-full max-w-md rounded-lg border p-6">
         <div className="mb-4 flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-500/10">
             <AlertTriangle className="h-5 w-5 text-yellow-500" />

--- a/dashboard/src/components/dashboards/ExtendedWidgets.tsx
+++ b/dashboard/src/components/dashboards/ExtendedWidgets.tsx
@@ -604,7 +604,7 @@ const SankeyWidget = memo(function SankeyWidget({data}: {data: DataRow[]}) {
             <div className="truncate text-right text-[11px] text-muted-foreground">{edge.source}</div>
             <div className="relative h-5 rounded bg-muted/30">
               <div
-                className="h-full rounded shadow-sm"
+                className="h-full rounded"
                 style={{
                   width: `${Math.max(8, Math.abs(edge.value) / maxValue * 100)}%`,
                   backgroundColor: COLORS[index % COLORS.length],
@@ -613,8 +613,7 @@ const SankeyWidget = memo(function SankeyWidget({data}: {data: DataRow[]}) {
               <div className="absolute inset-0 flex items-center justify-center">
                 <span
                   className={
-                    'rounded bg-background/90 px-1.5 text-[11px] font-semibold ' +
-                    'tabular-nums text-foreground shadow-sm'
+                    'rounded bg-background/90 px-1.5 text-[11px] font-semibold tabular-nums text-foreground'
                   }
                 >
                   {compactNumber(edge.value)}
@@ -648,14 +647,13 @@ const TreemapWidget = memo(function TreemapWidget({data}: {data: DataRow[]}) {
             }}
           >
             <div
-              className="max-w-full rounded bg-background/90 px-1.5 py-1 text-xs font-medium text-foreground shadow-sm"
+              className="max-w-full rounded bg-background/90 px-1.5 py-1 text-xs font-medium text-foreground"
             >
               <div className="truncate">{item.label}</div>
             </div>
             <div
               className={
-                'mt-2 w-fit rounded bg-background/90 px-1.5 py-0.5 text-sm font-semibold ' +
-                'tabular-nums text-foreground shadow-sm'
+                'mt-2 w-fit rounded bg-background/90 px-1.5 py-0.5 text-sm font-semibold tabular-nums text-foreground'
               }
             >
               {compactNumber(item.value)}
@@ -781,7 +779,7 @@ function ScatterTooltip({
   if (!active || !point) return null
 
   return (
-    <div style={TOOLTIP_STYLE} className="space-y-1 px-2 py-1.5 shadow-sm">
+    <div style={TOOLTIP_STYLE} className="space-y-1 px-2 py-1.5">
       <div className="flex items-center gap-1.5 font-medium text-foreground">
         <span className="h-2 w-2 rounded-full" style={{backgroundColor: point.color}} />
         <span>{point.label}</span>

--- a/dashboard/src/components/dashboards/ImportExportModal.tsx
+++ b/dashboard/src/components/dashboards/ImportExportModal.tsx
@@ -203,14 +203,14 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
       for (const ds of foundDataSources) {
         // Check if it's a built-in source - these don't need mapping
         if (builtInSources.has(ds)) {
-          console.log(`  ${ds} -> matched built-in, no mapping needed`)
+          console.log(`${ds} -> matched built-in, no mapping needed`)
           continue
         }
         
         // Everything else is external and needs to be mapped to a custom datasource
         // Even if we have a matching source_type, we can't assume which specific
         // custom datasource the user wants (they might have multiple Prometheus sources)
-        console.log(`  ${ds} -> external datasource, needs mapping`)
+        console.log(`${ds} -> external datasource, needs mapping`)
         unmapped.push(ds)
       }
       
@@ -370,7 +370,7 @@ export function ImportExportModal({open, onOpenChange, mode, dashboardId}: Impor
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="fixed inset-0 bg-black/50" onClick={() => onOpenChange(false)} />
-      <div className="relative bg-background border rounded-lg shadow-xl w-[520px] max-h-[80vh] flex flex-col">
+      <div className="relative bg-background border rounded-lg w-[520px] max-h-[80vh] flex flex-col">
         {/* Header */}
         <div className="px-5 py-4 border-b">
           <h2 className="text-lg font-semibold flex items-center gap-2">

--- a/dashboard/src/components/dashboards/WidgetConfigPanel.tsx
+++ b/dashboard/src/components/dashboards/WidgetConfigPanel.tsx
@@ -95,7 +95,7 @@ export function WidgetConfigPanel({
   }
 
   return (
-    <div className="fixed inset-y-0 right-0 w-[880px] bg-background border-l shadow-xl z-50 flex flex-col">
+    <div className="fixed inset-y-0 right-0 w-[880px] bg-background border-l z-50 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b">
         <h3 className="font-medium text-sm">Configure Widget</h3>

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -1517,7 +1517,7 @@ const TableWidget = memo(function TableWidget({data, displayConfig: dc}: {data: 
   return (
     <div ref={parentRef} className="h-full overflow-auto">
       <table className="w-full text-xs">
-        <thead className="sticky top-0 bg-muted/90 z-10 shadow-sm">
+        <thead className="sticky top-0 bg-muted/90 z-10">
           <tr>
             {columns.map((col) => (
               <th key={col} className="text-left px-2 py-1.5 font-medium whitespace-nowrap bg-background/95 backdrop-blur">

--- a/dashboard/src/components/dashboards/__tests__/DashboardToolbar-extended.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DashboardToolbar-extended.test.tsx
@@ -198,8 +198,10 @@ describe('DashboardToolbar – extended branch coverage', () => {
     it('does not highlight non-active time range presets', () => {
       renderToolbar({timeRange: {from: 'now-7d', to: 'now'}})
       const btn1h = screen.getByText('1h')
+      const classTokens = btn1h.className.split(/\s+/)
       expect(btn1h.className).toContain('text-muted-foreground')
-      expect(btn1h.className).not.toContain('bg-background text-foreground')
+      expect(classTokens).not.toContain('bg-background')
+      expect(classTokens).not.toContain('text-foreground')
     })
 
     it('applies inactive style to custom time range (no preset match)', () => {
@@ -208,7 +210,9 @@ describe('DashboardToolbar – extended branch coverage', () => {
       const allPresets = ['15m', '1h', '4h', '24h', '7d', '30d']
       for (const preset of allPresets) {
         const btn = screen.getByText(preset)
-        expect(btn.className).not.toContain('bg-background text-foreground')
+        const classTokens = btn.className.split(/\s+/)
+        expect(classTokens).not.toContain('bg-background')
+        expect(classTokens).not.toContain('text-foreground')
       }
     })
   })

--- a/dashboard/src/components/dashboards/__tests__/DashboardToolbar-extended.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DashboardToolbar-extended.test.tsx
@@ -192,14 +192,14 @@ describe('DashboardToolbar – extended branch coverage', () => {
       renderToolbar({timeRange: {from: 'now-7d', to: 'now'}})
       const btn7d = screen.getByText('7d')
       expect(btn7d.className).toContain('bg-background')
-      expect(btn7d.className).toContain('shadow-sm')
+      expect(btn7d.className).toContain('text-foreground')
     })
 
     it('does not highlight non-active time range presets', () => {
       renderToolbar({timeRange: {from: 'now-7d', to: 'now'}})
       const btn1h = screen.getByText('1h')
       expect(btn1h.className).toContain('text-muted-foreground')
-      expect(btn1h.className).not.toContain('shadow-sm')
+      expect(btn1h.className).not.toContain('bg-background text-foreground')
     })
 
     it('applies inactive style to custom time range (no preset match)', () => {
@@ -208,7 +208,7 @@ describe('DashboardToolbar – extended branch coverage', () => {
       const allPresets = ['15m', '1h', '4h', '24h', '7d', '30d']
       for (const preset of allPresets) {
         const btn = screen.getByText(preset)
-        expect(btn.className).not.toContain('shadow-sm')
+        expect(btn.className).not.toContain('bg-background text-foreground')
       }
     })
   })

--- a/dashboard/src/components/logs/LogSearchBar.tsx
+++ b/dashboard/src/components/logs/LogSearchBar.tsx
@@ -458,7 +458,7 @@ export function LogSearchBar({
           {showSuggestions && suggestions.length > 0 && (
             <div
               ref={suggestionsRef}
-              className="absolute left-0 right-0 top-full z-50 mt-1 rounded-lg border bg-popover p-1 shadow-lg"
+              className="absolute left-0 right-0 top-full z-50 mt-1 rounded-lg border bg-popover p-1"
             >
               {suggestions.map((suggestion, index) => (
                 <button
@@ -511,7 +511,7 @@ export function LogSearchBar({
           </Button>
 
           {showLevelDropdown && (
-            <div className="absolute right-0 top-full z-50 mt-1 w-[200px] rounded-lg border bg-popover p-1 shadow-lg">
+            <div className="absolute right-0 top-full z-50 mt-1 w-[200px] rounded-lg border bg-popover p-1">
               {LEVEL_OPTIONS.map((level) => {
                 const active = levels.includes(level)
                 return (
@@ -562,7 +562,7 @@ export function LogSearchBar({
             </Button>
 
           {showTimeDropdown && (
-            <div className="absolute right-0 top-full z-50 mt-1 w-[260px] rounded-lg border bg-popover p-1 shadow-lg">
+            <div className="absolute right-0 top-full z-50 mt-1 w-[260px] rounded-lg border bg-popover p-1">
               {TIME_PRESETS.map((preset) => (
                 <button
                   key={preset.value}

--- a/dashboard/src/components/logs/LogSetupGuide.tsx
+++ b/dashboard/src/components/logs/LogSetupGuide.tsx
@@ -269,7 +269,7 @@ export function LogSetupGuide({sdkVersions}: LogSetupGuideProps) {
                   key={platform.id}
                   value={platform.id}
                   className={cn(
-                    'gap-2 rounded-lg border px-4 py-2.5 text-sm data-[state=active]:shadow-sm',
+                    'gap-2 rounded-lg border px-4 py-2.5 text-sm',
                     'data-[state=active]:border-border data-[state=active]:bg-card',
                     'data-[state=inactive]:border-transparent data-[state=inactive]:bg-transparent'
                   )}

--- a/dashboard/src/components/logs/LogVizTabs.tsx
+++ b/dashboard/src/components/logs/LogVizTabs.tsx
@@ -42,7 +42,7 @@ export function LogVizTabs({mode, onModeChange}: LogVizTabsProps) {
           className={cn(
             'flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium transition-colors',
             mode === value
-              ? 'bg-background text-foreground shadow-sm'
+              ? 'bg-background text-foreground'
               : 'text-muted-foreground hover:text-foreground'
           )}
         >

--- a/dashboard/src/components/monitoring/ContainerList.tsx
+++ b/dashboard/src/components/monitoring/ContainerList.tsx
@@ -238,7 +238,7 @@ export function ContainerList() {
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                 stateFilter === f
-                  ? 'bg-secondary text-secondary-foreground shadow-sm'
+                  ? 'bg-secondary text-secondary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
               )}
             >
@@ -289,7 +289,7 @@ export function ContainerList() {
           <p className="text-sm mt-1">Try adjusting your search or state filter.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table className="min-w-[980px]">
               <TableHeader>

--- a/dashboard/src/components/monitoring/EventStream.tsx
+++ b/dashboard/src/components/monitoring/EventStream.tsx
@@ -208,7 +208,7 @@ export function EventStream() {
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                 alertTypeFilter === f
-                  ? 'bg-secondary text-secondary-foreground shadow-sm'
+                  ? 'bg-secondary text-secondary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
               )}
             >
@@ -245,7 +245,7 @@ export function EventStream() {
           <p className="text-sm mt-1">Try adjusting your search or alert type filter.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table className="min-w-[800px]">
               <TableHeader>

--- a/dashboard/src/components/monitoring/HostList.tsx
+++ b/dashboard/src/components/monitoring/HostList.tsx
@@ -174,7 +174,7 @@ export function HostList() {
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                 statusFilter === f.key
-                  ? 'bg-secondary text-secondary-foreground shadow-sm'
+                  ? 'bg-secondary text-secondary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
               )}
             >
@@ -211,7 +211,7 @@ export function HostList() {
           <p className="text-sm mt-1">Try adjusting your search or status filter.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table className="min-w-[900px]">
               <TableHeader>

--- a/dashboard/src/components/monitoring/NetworkConnections.tsx
+++ b/dashboard/src/components/monitoring/NetworkConnections.tsx
@@ -182,7 +182,7 @@ export function NetworkConnections() {
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                 protocolFilter === f
-                  ? 'bg-secondary text-secondary-foreground shadow-sm'
+                  ? 'bg-secondary text-secondary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
               )}
             >
@@ -205,7 +205,7 @@ export function NetworkConnections() {
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                 directionFilter === f
-                  ? 'bg-secondary text-secondary-foreground shadow-sm'
+                  ? 'bg-secondary text-secondary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
               )}
             >
@@ -246,7 +246,7 @@ export function NetworkConnections() {
           <p className="text-sm mt-1">Try adjusting your search, protocol, or direction filter.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table className="min-w-[950px]">
               <TableHeader>

--- a/dashboard/src/components/monitoring/ProcessExplorer.tsx
+++ b/dashboard/src/components/monitoring/ProcessExplorer.tsx
@@ -283,7 +283,7 @@ export function ProcessExplorer() {
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                 stateFilter === f.key
-                  ? 'bg-secondary text-secondary-foreground shadow-sm'
+                  ? 'bg-secondary text-secondary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
               )}
             >
@@ -320,7 +320,7 @@ export function ProcessExplorer() {
           <p className="text-sm mt-1">Try adjusting your search or state filter.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table className="min-w-[950px]">
               <TableHeader>

--- a/dashboard/src/components/monitoring/ServiceCheckList.tsx
+++ b/dashboard/src/components/monitoring/ServiceCheckList.tsx
@@ -194,7 +194,7 @@ export function ServiceCheckList() {
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                 statusFilter === f
-                  ? 'bg-secondary text-secondary-foreground shadow-sm'
+                  ? 'bg-secondary text-secondary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
               )}
             >
@@ -231,7 +231,7 @@ export function ServiceCheckList() {
           <p className="text-sm mt-1">Try adjusting your search or status filter.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table className="min-w-[750px]">
               <TableHeader>

--- a/dashboard/src/components/profiling/Flamegraph.tsx
+++ b/dashboard/src/components/profiling/Flamegraph.tsx
@@ -427,7 +427,7 @@ export function Flamegraph({frames, emptyMessage}: Props) {
             top: -9999,
           }}
         >
-          <div className="bg-popover border rounded-lg px-3 py-2 shadow-lg text-xs space-y-1.5">
+          <div className="bg-popover border rounded-lg px-3 py-2 text-xs space-y-1.5">
             <p className="font-semibold text-popover-foreground break-all leading-snug">
               {hoveredFrame.frame.name}
             </p>

--- a/dashboard/src/components/projects/ProjectSetupForm.tsx
+++ b/dashboard/src/components/projects/ProjectSetupForm.tsx
@@ -195,7 +195,7 @@ export function ProjectSetupForm({
                   className={cn(
                     'relative flex flex-col items-center gap-1.5 rounded-lg border-2 p-3 transition-all',
                     isSelected
-                      ? 'border-primary bg-primary/5 shadow-md'
+                      ? 'border-primary bg-primary/5'
                       : 'border-border hover:border-primary/50 hover:bg-accent'
                   )}
                   aria-pressed={isSelected}

--- a/dashboard/src/components/replay-containers/BrowserWindowContainer.tsx
+++ b/dashboard/src/components/replay-containers/BrowserWindowContainer.tsx
@@ -35,7 +35,7 @@ export function BrowserWindowContainer({
     displayUrl.length > 80 ? displayUrl.slice(0, 77) + '...' : displayUrl
 
   return (
-    <div className={cn('rounded-xl border bg-card shadow-sm overflow-hidden', className)}>
+    <div className={cn('rounded-xl border bg-card overflow-hidden', className)}>
       {/* Browser chrome / title bar */}
       <div className="flex items-center gap-2 px-3 py-2 border-b bg-muted/50">
         {/* Traffic light dots */}

--- a/dashboard/src/components/replay-containers/MobileDeviceContainer.tsx
+++ b/dashboard/src/components/replay-containers/MobileDeviceContainer.tsx
@@ -139,7 +139,7 @@ export function MobileDeviceContainer({
       {/* Phone bezel - dimensions swap for landscape, smooth transition */}
       <div
         className={cn(
-          'relative bg-[#1a1a1e] shadow-2xl shadow-black/50 border border-white/[0.08] overflow-hidden flex transition-all duration-300 ease-in-out',
+          'relative bg-[#1a1a1e] border border-white/[0.08] overflow-hidden flex transition-all duration-300 ease-in-out',
           isIOS ? 'rounded-[2.5rem]' : 'rounded-[1.5rem]',
           isLandscape ? 'flex-row' : 'flex-col'
         )}

--- a/dashboard/src/components/ui/alert-dialog.tsx
+++ b/dashboard/src/components/ui/alert-dialog.tsx
@@ -32,7 +32,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -50,7 +50,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/dashboard/src/components/ui/command.tsx
+++ b/dashboard/src/components/ui/command.tsx
@@ -42,7 +42,7 @@ type CommandDialogProps = DialogProps
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="overflow-hidden p-0">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -52,7 +52,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 flex max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg overflow-hidden",
+        "fixed left-[50%] top-[50%] z-50 flex max-h-[90vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col border bg-background duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg overflow-hidden",
         className
       )}
       {...props}

--- a/dashboard/src/components/ui/sheet.tsx
+++ b/dashboard/src/components/ui/sheet.tsx
@@ -35,7 +35,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -45,7 +45,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 bg-background p-6 transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {

--- a/dashboard/src/components/ui/toast.tsx
+++ b/dashboard/src/components/ui/toast.tsx
@@ -39,7 +39,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {

--- a/dashboard/src/components/uptime/MonitorCompactTable.tsx
+++ b/dashboard/src/components/uptime/MonitorCompactTable.tsx
@@ -211,7 +211,7 @@ function MonitorRow({monitor}: {readonly monitor: UptimeMonitor}) {
 
 export default function MonitorCompactTable({monitors}: MonitorCompactTableProps) {
   return (
-    <Card className="overflow-hidden border-border/60 shadow-sm">
+    <Card className="overflow-hidden border-border/60">
       <CardContent className="p-0">
         <Table className="min-w-[800px]">
           <TableHeader>

--- a/dashboard/src/components/uptime/MonitorListItem.tsx
+++ b/dashboard/src/components/uptime/MonitorListItem.tsx
@@ -98,7 +98,7 @@ export default function MonitorListItem({monitor}: MonitorListItemProps) {
   }[monitor.status] || 'border-l-gray-300'
 
   return (
-    <Card className={cn("hover:shadow-md transition-shadow overflow-hidden border-l-4", statusColor)}>
+    <Card className={cn("overflow-hidden border-l-4", statusColor)}>
       <CardContent className="p-3">
         <div className="flex flex-col gap-3">
           {/* Header Row */}

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -223,7 +223,7 @@ function NotFoundPage() {
       <div className="flex items-center gap-4">
         <Link
           to="/"
-          className="px-5 py-2.5 text-sm font-medium text-white bg-sky-500 hover:bg-sky-600 rounded-lg shadow-md shadow-sky-500/25 transition-colors"
+          className="px-5 py-2.5 text-sm font-medium text-white bg-sky-500 hover:bg-sky-600 rounded-lg transition-colors"
         >
           Go to overview
         </Link>

--- a/dashboard/src/routes/admin.billing.tsx
+++ b/dashboard/src/routes/admin.billing.tsx
@@ -1564,7 +1564,7 @@ function AdminBillingPage() {
                     onClick={() => setPreviewInterval('monthly')}
                     className={`relative rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
                       previewInterval === 'monthly'
-                        ? 'bg-background text-foreground shadow-sm'
+                        ? 'bg-background text-foreground'
                         : 'text-muted-foreground hover:text-foreground'
                     }`}
                     type="button"
@@ -1575,7 +1575,7 @@ function AdminBillingPage() {
                     onClick={() => setPreviewInterval('yearly')}
                     className={`relative rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
                       previewInterval === 'yearly'
-                        ? 'bg-background text-foreground shadow-sm'
+                        ? 'bg-background text-foreground'
                         : 'text-muted-foreground hover:text-foreground'
                     }`}
                     type="button"
@@ -2349,7 +2349,7 @@ function PricingPreviewGrid({
       {cards.map((tier) => (
         <Card
           key={tier.tierName}
-          className={tier.highlight ? 'relative border-sky-500/50 shadow-md shadow-sky-500/10' : 'border-border/60'}
+          className={tier.highlight ? 'relative border-sky-500/50' : 'border-border/60'}
         >
           {tier.highlight && (
             <div className="absolute -top-3 left-1/2 -translate-x-1/2">
@@ -2384,7 +2384,7 @@ function PricingPreviewGrid({
             </ul>
             <div className="pt-2 text-center">
               <Button
-                className={`w-full ${tier.highlight ? 'bg-sky-500 hover:bg-sky-400 text-white shadow-md shadow-sky-500/25' : ''}`}
+                className={`w-full ${tier.highlight ? 'bg-sky-500 hover:bg-sky-400 text-white' : ''}`}
                 variant={tier.highlight ? 'default' : 'outline'}
                 size="sm"
                 disabled

--- a/dashboard/src/routes/admin.emails.tsx
+++ b/dashboard/src/routes/admin.emails.tsx
@@ -177,7 +177,7 @@ function AdminEmailsPage() {
                   content={({ active, payload }) => {
                     if (!active || !payload?.[0]) return null
                     return (
-                      <div className="bg-background border rounded-lg shadow-lg p-3">
+                      <div className="bg-background border rounded-lg p-3">
                         <p className="text-sm font-semibold">{payload[0].payload.type}</p>
                         <p className="text-sm text-muted-foreground">
                           {formatNumber(payload[0].value as number)} emails

--- a/dashboard/src/routes/admin.tsx
+++ b/dashboard/src/routes/admin.tsx
@@ -103,7 +103,7 @@ function AdminLayout() {
       {/* Mobile Menu Button */}
       <button
         onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-        className="lg:hidden fixed top-4 left-4 z-50 p-2 rounded-lg bg-background border shadow-lg"
+        className="lg:hidden fixed top-4 left-4 z-50 p-2 rounded-lg bg-background border"
         aria-label="Toggle admin menu"
       >
         {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -159,7 +159,7 @@ function AdminLayout() {
                       className={cn(
                         'flex items-center gap-3 px-3 py-2 rounded-lg text-[13px] font-medium transition-all',
                         isActive
-                          ? 'bg-primary text-primary-foreground shadow-sm'
+                          ? 'bg-primary text-primary-foreground'
                           : 'text-muted-foreground hover:text-foreground hover:bg-accent'
                       )}
                     >

--- a/dashboard/src/routes/dashboards.datasources.tsx
+++ b/dashboard/src/routes/dashboards.datasources.tsx
@@ -303,14 +303,14 @@ function DataSourcesPage() {
                 <div className="bg-muted inline-flex rounded-md p-0.5">
                   <button
                     type="button"
-                    className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${connectionMode === 'fields' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+                    className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${connectionMode === 'fields' ? 'bg-background' : 'text-muted-foreground hover:text-foreground'}`}
                     onClick={() => setConnectionMode('fields')}
                   >
                     Fields
                   </button>
                   <button
                     type="button"
-                    className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${connectionMode === 'url' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+                    className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${connectionMode === 'url' ? 'bg-background' : 'text-muted-foreground hover:text-foreground'}`}
                     onClick={() => setConnectionMode('url')}
                   >
                     <Link2 className="mr-1 inline h-3 w-3" />

--- a/dashboard/src/routes/dashboards.index.tsx
+++ b/dashboard/src/routes/dashboards.index.tsx
@@ -675,7 +675,7 @@ const DashboardCard = memo(function DashboardCard({
     <Link
       to="/dashboards/$dashboardId"
       params={{dashboardId: String(dashboard.id)}}
-      className="group relative block rounded-lg border bg-card overflow-hidden hover:shadow-lg hover:border-primary/40 transition-all duration-200"
+      className="group relative block rounded-lg border bg-card overflow-hidden hover:border-primary/40 transition-all duration-200"
     >
       <div className={`h-1.5 w-full bg-gradient-to-r ${accent}`} />
       <div className="p-4">

--- a/dashboard/src/routes/feature-flags.tsx
+++ b/dashboard/src/routes/feature-flags.tsx
@@ -79,7 +79,7 @@ const defaultSegmentConditions = JSON.stringify({all: []}, null, 2)
 const tabTriggerClass = [
   'border border-transparent',
   'data-[state=active]:border-foreground data-[state=active]:bg-background',
-  'data-[state=active]:shadow-sm data-[state=active]:ring-1 data-[state=active]:ring-foreground/20',
+  'data-[state=active]:ring-1 data-[state=active]:ring-foreground/20',
 ].join(' ')
 const tooltipText = {
   environment: 'Choose which environment you are editing and evaluating flags for.',
@@ -809,7 +809,7 @@ function CompactMetric({
   return (
     <div
       aria-label={`${label}: ${value}`}
-      className="flex h-8 items-center gap-2 rounded-md border bg-card px-2.5 text-left text-sm shadow-sm"
+      className="flex h-8 items-center gap-2 rounded-md border bg-card px-2.5 text-left text-sm"
     >
       <Icon className="h-3.5 w-3.5 text-muted-foreground" />
       <span className="flex items-center gap-1.5">

--- a/dashboard/src/routes/feedback.$feedbackId.tsx
+++ b/dashboard/src/routes/feedback.$feedbackId.tsx
@@ -247,7 +247,7 @@ function FeedbackDetailPage() {
                   {feedback.status !== 'resolved' && (
                     <Button
                       size="sm"
-                      className="bg-emerald-600 hover:bg-emerald-700 shadow-sm"
+                      className="bg-emerald-600 hover:bg-emerald-700"
                       onClick={() => updateMutation.mutate('resolved')}
                       disabled={updateMutation.isPending}
                     >

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -257,9 +257,9 @@ function FeedbackPage() {
               <div className="grid grid-cols-2 md:grid-cols-4 gap-1.5 mb-3">
                 <button
                   onClick={() => setStatusFilter('all')}
-                  className={`rounded-lg border p-2 text-left transition-all hover:shadow-md ${
+                  className={`rounded-lg border p-2 text-left transition-all ${
                     statusFilter === 'all'
-                      ? 'border-violet-500/40 bg-violet-500/10 shadow-sm ring-1 ring-violet-500/20'
+                      ? 'border-violet-500/40 bg-violet-500/10 ring-1 ring-violet-500/20'
                       : 'border-border/60 bg-card hover:border-violet-500/20'
                   }`}
                 >
@@ -271,9 +271,9 @@ function FeedbackPage() {
                 </button>
                 <button
                   onClick={() => setStatusFilter('unresolved')}
-                  className={`rounded-lg border p-2 text-left transition-all hover:shadow-md ${
+                  className={`rounded-lg border p-2 text-left transition-all ${
                     statusFilter === 'unresolved'
-                      ? 'border-amber-500/40 bg-amber-500/10 shadow-sm ring-1 ring-amber-500/20'
+                      ? 'border-amber-500/40 bg-amber-500/10 ring-1 ring-amber-500/20'
                       : 'border-border/60 bg-card hover:border-amber-500/20'
                   }`}
                 >
@@ -285,9 +285,9 @@ function FeedbackPage() {
                 </button>
                 <button
                   onClick={() => setStatusFilter('resolved')}
-                  className={`rounded-lg border p-2 text-left transition-all hover:shadow-md ${
+                  className={`rounded-lg border p-2 text-left transition-all ${
                     statusFilter === 'resolved'
-                      ? 'border-emerald-500/40 bg-emerald-500/10 shadow-sm ring-1 ring-emerald-500/20'
+                      ? 'border-emerald-500/40 bg-emerald-500/10 ring-1 ring-emerald-500/20'
                       : 'border-border/60 bg-card hover:border-emerald-500/20'
                   }`}
                 >
@@ -299,9 +299,9 @@ function FeedbackPage() {
                 </button>
                 <button
                   onClick={() => setStatusFilter('archived')}
-                  className={`rounded-lg border p-2 text-left transition-all hover:shadow-md ${
+                  className={`rounded-lg border p-2 text-left transition-all ${
                     statusFilter === 'archived'
-                      ? 'border-slate-500/40 bg-slate-500/10 shadow-sm ring-1 ring-slate-500/20'
+                      ? 'border-slate-500/40 bg-slate-500/10 ring-1 ring-slate-500/20'
                       : 'border-border/60 bg-card hover:border-slate-500/20'
                   }`}
                 >
@@ -390,7 +390,7 @@ function FeedbackPage() {
                       <div
                         key={f.feedbackId}
                         onClick={() => navigate({ to: '/feedback/$feedbackId', params: { feedbackId: f.feedbackId } })}
-                        className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all hover:shadow-md border-l-[3px] ${config.border}`}
+                        className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
                       >
                         <div className="flex items-start gap-2 p-2">
                           {/* Checkbox */}

--- a/dashboard/src/routes/issues.$issueId.tsx
+++ b/dashboard/src/routes/issues.$issueId.tsx
@@ -969,7 +969,7 @@ function ContextSection({ name, data, depth = 0, defaultOpen = true }: { name: s
     : [['value', data]]
 
   return (
-    <div className={`rounded-lg border border-border bg-card shadow-sm ${isNested ? 'ml-4 mt-2 mb-3 border-l-2 border-l-primary/20 first:mt-0' : ''}`}>
+    <div className={`rounded-lg border border-border bg-card ${isNested ? 'ml-4 mt-2 mb-3 border-l-2 border-l-primary/20 first:mt-0' : ''}`}>
       <button
         type="button"
         onClick={() => setOpen(!open)}

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -870,7 +870,7 @@ function ApmErrorsTab({ isActive }: { isActive: boolean }) {
                 value={overflowSelected ? selectedService : ''}
                 onValueChange={(val) => handleServiceChange(val)}
               >
-                <SelectTrigger className="h-8 text-sm border-0 shadow-none px-2 gap-1 text-muted-foreground hover:text-foreground focus:ring-0 w-auto">
+                <SelectTrigger className="h-8 text-sm border-0 px-2 gap-1 text-muted-foreground hover:text-foreground focus:ring-0 w-auto">
                   <SelectValue placeholder={`+${overflowServices.length} more`} />
                 </SelectTrigger>
                 <SelectContent>

--- a/dashboard/src/routes/monitoring.databases.tsx
+++ b/dashboard/src/routes/monitoring.databases.tsx
@@ -98,7 +98,7 @@ function DatabaseMonitoring() {
               <p className="text-sm mt-1">Try adjusting your search query.</p>
             </div>
           ) : (
-            <Card className="overflow-hidden border-border/60 shadow-sm">
+            <Card className="overflow-hidden border-border/60">
               <CardContent className="p-0">
                 <Table>
                   <TableHeader>

--- a/dashboard/src/routes/monitoring.debugger.tsx
+++ b/dashboard/src/routes/monitoring.debugger.tsx
@@ -139,7 +139,7 @@ function DebuggerDashboard() {
         </div>
 
         <div className="grid gap-4 lg:grid-cols-2">
-          <Card className="overflow-hidden border-border/60 shadow-sm">
+          <Card className="overflow-hidden border-border/60">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <Activity className="h-4 w-4 text-purple-500" />
@@ -195,7 +195,7 @@ function DebuggerDashboard() {
             </CardContent>
           </Card>
 
-          <Card className="overflow-hidden border-border/60 shadow-sm">
+          <Card className="overflow-hidden border-border/60">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <Bug className="h-4 w-4 text-pink-500" />

--- a/dashboard/src/routes/monitoring.hosts.$hostId.tsx
+++ b/dashboard/src/routes/monitoring.hosts.$hostId.tsx
@@ -210,7 +210,7 @@ function ChartTooltip({
   if (!active || !payload?.length) return null
 
   return (
-    <div className="bg-popover/95 backdrop-blur-sm border rounded-lg px-3 py-2 shadow-xl">
+    <div className="bg-popover/95 backdrop-blur-sm border rounded-lg px-3 py-2">
       <p className="text-xs text-muted-foreground mb-1">{label}</p>
       {payload.map((entry, idx: number) => (
         <div key={idx} className="flex items-center gap-2 text-sm">
@@ -1038,13 +1038,12 @@ function HostDetailPage() {
                 <CardContent className="py-12">
                   <div className="mx-auto max-w-2xl text-center">
                     <div
-                      className={
+                      className={[
+                        'mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl',
                         hostMonitoringLimitState
-                          ? 'mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl ' +
-                            'bg-amber-500/10 border border-amber-500/20'
-                          : 'mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl ' +
-                            'bg-cyan-500/10 border border-cyan-500/20'
-                      }
+                          ? 'bg-amber-500/10 border border-amber-500/20'
+                          : 'bg-cyan-500/10 border border-cyan-500/20',
+                      ].join(' ')}
                     >
                       {hostMonitoringLimitState ? (
                         <AlertTriangle className="h-8 w-8 text-amber-600 dark:text-amber-400" />

--- a/dashboard/src/routes/monitoring.index.tsx
+++ b/dashboard/src/routes/monitoring.index.tsx
@@ -727,7 +727,7 @@ function HostCard({host, onDelete}: {host: DdHostResponse; onDelete: (id: number
       params={{hostId: String(host.id)}}
       className="block group"
     >
-      <Card className="relative overflow-hidden transition-all duration-200 hover:shadow-lg hover:shadow-primary/5 hover:border-primary/20 group-hover:-translate-y-0.5">
+      <Card className="relative overflow-hidden transition-all duration-200 hover:border-primary/20 group-hover:-translate-y-0.5">
         {/* Top color accent bar */}
         <div
           className={cn(
@@ -1063,7 +1063,7 @@ function MonitoringHostsPage() {
                     className={cn(
                       'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
                       statusFilter === f.key
-                        ? 'bg-secondary text-secondary-foreground shadow-sm'
+                        ? 'bg-secondary text-secondary-foreground'
                         : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                     )}
                   >
@@ -1079,7 +1079,7 @@ function MonitoringHostsPage() {
                   className={cn(
                     'p-1.5 rounded-md transition-colors',
                     viewMode === 'grid'
-                      ? 'bg-secondary text-secondary-foreground shadow-sm'
+                      ? 'bg-secondary text-secondary-foreground'
                       : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                   )}
                 >
@@ -1090,7 +1090,7 @@ function MonitoringHostsPage() {
                   className={cn(
                     'p-1.5 rounded-md transition-colors',
                     viewMode === 'list'
-                      ? 'bg-secondary text-secondary-foreground shadow-sm'
+                      ? 'bg-secondary text-secondary-foreground'
                       : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                   )}
                 >
@@ -1134,7 +1134,7 @@ function MonitoringHostsPage() {
             ))}
           </div>
         ) : (
-          <Card className="overflow-hidden border-border/60 shadow-sm">
+          <Card className="overflow-hidden border-border/60">
             <CardContent className="p-0">
               <Table className="min-w-[900px]">
                 <TableHeader>

--- a/dashboard/src/routes/monitoring.kubernetes.$resourceType.tsx
+++ b/dashboard/src/routes/monitoring.kubernetes.$resourceType.tsx
@@ -118,7 +118,7 @@ function KubernetesResourceList() {
           <p className="text-sm mt-1">Try adjusting your search query.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table>
               <TableHeader>

--- a/dashboard/src/routes/monitoring.kubernetes.index.tsx
+++ b/dashboard/src/routes/monitoring.kubernetes.index.tsx
@@ -102,7 +102,7 @@ function KubernetesPods() {
           <p className="text-sm mt-1">Try adjusting your search query.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table>
               <TableHeader>

--- a/dashboard/src/routes/monitoring.network-devices.flows.tsx
+++ b/dashboard/src/routes/monitoring.network-devices.flows.tsx
@@ -106,7 +106,7 @@ function NdmFlows() {
           <p className="text-sm mt-1">Try adjusting your search query.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table>
               <TableHeader>

--- a/dashboard/src/routes/monitoring.network-devices.paths.tsx
+++ b/dashboard/src/routes/monitoring.network-devices.paths.tsx
@@ -100,7 +100,7 @@ function NdmPaths() {
           <p className="text-sm mt-1">Try adjusting your search query.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table>
               <TableHeader>

--- a/dashboard/src/routes/monitoring.network-devices.traps.tsx
+++ b/dashboard/src/routes/monitoring.network-devices.traps.tsx
@@ -111,7 +111,7 @@ function NdmTraps() {
           <p className="text-sm mt-1">Try adjusting your search query.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden border-border/60 shadow-sm">
+        <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
             <Table>
               <TableHeader>

--- a/dashboard/src/routes/monitoring.network-devices.tsx
+++ b/dashboard/src/routes/monitoring.network-devices.tsx
@@ -136,7 +136,7 @@ function NetworkDevicesLayout() {
                 <p className="text-sm mt-1">Try adjusting your search query.</p>
               </div>
             ) : (
-              <Card className="overflow-hidden border-border/60 shadow-sm">
+              <Card className="overflow-hidden border-border/60">
                 <CardContent className="p-0">
                   <Table>
                     <TableHeader>

--- a/dashboard/src/routes/monitoring.sbom.tsx
+++ b/dashboard/src/routes/monitoring.sbom.tsx
@@ -113,7 +113,7 @@ function SbomDashboard() {
               <p className="text-sm mt-1">Try adjusting your search query.</p>
             </div>
           ) : (
-            <Card className="overflow-hidden border-border/60 shadow-sm">
+            <Card className="overflow-hidden border-border/60">
               <CardContent className="p-0">
                 <Table>
                   <TableHeader>

--- a/dashboard/src/routes/on-call.declared-incidents.tsx
+++ b/dashboard/src/routes/on-call.declared-incidents.tsx
@@ -101,7 +101,7 @@ function DeclaredIncidents() {
             className={cn(
               'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-all',
               statusFilter === 'OPEN'
-                ? 'bg-red-500/15 border-red-500/40 text-red-400 shadow-sm shadow-red-500/10'
+                ? 'bg-red-500/15 border-red-500/40 text-red-400'
                 : 'hover:bg-muted/60'
             )}
           >
@@ -113,7 +113,7 @@ function DeclaredIncidents() {
             className={cn(
               'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-all',
               statusFilter === 'RESOLVED'
-                ? 'bg-green-500/15 border-green-500/40 text-green-400 shadow-sm shadow-green-500/10'
+                ? 'bg-green-500/15 border-green-500/40 text-green-400'
                 : 'hover:bg-muted/60'
             )}
           >
@@ -186,7 +186,7 @@ function DeclaredIncidents() {
                 className="block group"
               >
                 <Card className={cn(
-                  'transition-all hover:shadow-md border-l-4',
+                  'transition-all border-l-4',
                   incident.status === 'OPEN' && 'border-l-red-500 hover:border-red-500/40',
                   incident.status === 'RESOLVED' && 'border-l-transparent hover:border-muted-foreground/20',
                 )}>

--- a/dashboard/src/routes/on-call.incidents.tsx
+++ b/dashboard/src/routes/on-call.incidents.tsx
@@ -115,7 +115,7 @@ function Incidents() {
             className={cn(
               'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-all',
               statusFilter === 'TRIGGERED'
-                ? 'bg-red-500/15 border-red-500/40 text-red-400 shadow-sm shadow-red-500/10'
+                ? 'bg-red-500/15 border-red-500/40 text-red-400'
                 : 'hover:bg-muted/60'
             )}
           >
@@ -127,7 +127,7 @@ function Incidents() {
             className={cn(
               'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-all',
               statusFilter === 'ACKNOWLEDGED'
-                ? 'bg-amber-500/15 border-amber-500/40 text-amber-400 shadow-sm shadow-amber-500/10'
+                ? 'bg-amber-500/15 border-amber-500/40 text-amber-400'
                 : 'hover:bg-muted/60'
             )}
           >
@@ -139,7 +139,7 @@ function Incidents() {
             className={cn(
               'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-all',
               statusFilter === 'RESOLVED'
-                ? 'bg-green-500/15 border-green-500/40 text-green-400 shadow-sm shadow-green-500/10'
+                ? 'bg-green-500/15 border-green-500/40 text-green-400'
                 : 'hover:bg-muted/60'
             )}
           >
@@ -214,7 +214,7 @@ function Incidents() {
                 className="block group"
               >
                 <Card className={cn(
-                  'transition-all hover:shadow-md border-l-4',
+                  'transition-all border-l-4',
                   incident.status === 'TRIGGERED' && 'border-l-red-500 hover:border-red-500/40',
                   incident.status === 'ACKNOWLEDGED' && 'border-l-amber-500 hover:border-amber-500/40',
                   incident.status === 'RESOLVED' && 'border-l-transparent hover:border-muted-foreground/20',

--- a/dashboard/src/routes/on-call.index.tsx
+++ b/dashboard/src/routes/on-call.index.tsx
@@ -134,7 +134,7 @@ function OnCallOverview() {
       <div className="grid gap-3 md:grid-cols-3">
         <Card className={cn(
           'relative overflow-hidden transition-all',
-          hasActiveIncidents && 'border-red-500/25 shadow-md shadow-red-500/5'
+          hasActiveIncidents && 'border-red-500/25'
         )}>
           {hasActiveIncidents && (
             <div className="absolute inset-0 bg-gradient-to-br from-red-500/[0.03] to-transparent pointer-events-none" />

--- a/dashboard/src/routes/on-call.tsx
+++ b/dashboard/src/routes/on-call.tsx
@@ -37,7 +37,7 @@ function OnCallLayout() {
   return (
     <div className="p-4 space-y-4">
       <div className="flex items-center gap-2.5">
-        <div className="flex items-center justify-center h-8 w-8 rounded-lg bg-gradient-to-br from-blue-500/80 to-violet-500/80 shadow-md shadow-blue-500/10 shrink-0">
+        <div className="flex items-center justify-center h-8 w-8 rounded-lg bg-gradient-to-br from-blue-500/80 to-violet-500/80 shrink-0">
           <Shield className="h-4 w-4 text-white" />
         </div>
         <div className="min-w-0">

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -246,21 +246,21 @@ function ReplaysPage() {
         {/* Stats Cards */}
         {replays.length > 0 && (
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
-            <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-2.5 transition-all hover:shadow-md hover:border-blue-500/30">
+            <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-2.5 transition-all hover:border-blue-500/30">
               <div className="flex items-center gap-1.5 mb-1">
                 <Play className="h-3 w-3 text-blue-500" />
                 <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Sessions</span>
               </div>
               <div className="text-xl font-bold text-blue-600 dark:text-blue-400">{stats.total}</div>
             </div>
-            <div className="rounded-lg border border-rose-500/20 bg-rose-500/5 p-2.5 transition-all hover:shadow-md hover:border-rose-500/30">
+            <div className="rounded-lg border border-rose-500/20 bg-rose-500/5 p-2.5 transition-all hover:border-rose-500/30">
               <div className="flex items-center gap-1.5 mb-1">
                 <AlertCircle className="h-3 w-3 text-rose-500" />
                 <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Errors</span>
               </div>
               <div className="text-xl font-bold text-rose-600 dark:text-rose-400">{stats.totalErrors}</div>
             </div>
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-2.5 transition-all hover:shadow-md hover:border-emerald-500/30">
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-2.5 transition-all hover:border-emerald-500/30">
               <div className="flex items-center gap-1.5 mb-1">
                 <Timer className="h-3 w-3 text-emerald-500" />
                 <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Avg Duration</span>
@@ -269,7 +269,7 @@ function ReplaysPage() {
                 {formatDuration(stats.avgDuration)}
               </div>
             </div>
-            <div className="rounded-lg border border-violet-500/20 bg-violet-500/5 p-2.5 transition-all hover:shadow-md hover:border-violet-500/30">
+            <div className="rounded-lg border border-violet-500/20 bg-violet-500/5 p-2.5 transition-all hover:border-violet-500/30">
               <div className="flex items-center gap-1.5 mb-1">
                 <User className="h-3 w-3 text-violet-500" />
                 <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Unique Users</span>
@@ -380,7 +380,7 @@ function ReplaysPage() {
                   <div
                     key={replay.replayId}
                     onClick={() => navigate({ to: '/replays/$replayId', params: { replayId: replay.replayId } })}
-                    className={`cursor-pointer rounded-xl border bg-card hover:bg-accent/50 transition-all hover:shadow-md border-l-[3px] ${
+                    className={`cursor-pointer rounded-xl border bg-card hover:bg-accent/50 transition-all border-l-[3px] ${
                       hasErrors
                         ? 'border-l-rose-500 border-border/60 hover:border-rose-500/30'
                         : 'border-l-blue-500/40 border-border/60 hover:border-blue-500/30'

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -201,14 +201,14 @@ function SettingsPage() {
               </div>
               <TabsTrigger 
                 value="general" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <SlidersHorizontal className="h-4 w-4 mr-2" />
                 General
               </TabsTrigger>
               <TabsTrigger 
                 value="api-keys" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <Key className="h-4 w-4 mr-2" />
                 API Keys
@@ -219,28 +219,28 @@ function SettingsPage() {
               </div>
               <TabsTrigger 
                 value="integrations" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <Plug className="h-4 w-4 mr-2" />
                 Integrations
               </TabsTrigger>
               <TabsTrigger 
                 value="notifications" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <Bell className="h-4 w-4 mr-2" />
                 Notifications
               </TabsTrigger>
               <TabsTrigger 
                 value="silence" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <BellOff className="h-4 w-4 mr-2" />
                 Silence Periods
               </TabsTrigger>
               <TabsTrigger 
                 value="log-indexes" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <Database className="h-4 w-4 mr-2" />
                 Log Indexes
@@ -253,7 +253,7 @@ function SettingsPage() {
               {canManageTeam && (
                 <TabsTrigger 
                   value="team" 
-                  className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
                 >
                   <Users className="h-4 w-4 mr-2" />
                   Team
@@ -262,7 +262,7 @@ function SettingsPage() {
               {!isSelfHosted && (
               <TabsTrigger 
                 value="billing" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <CreditCard className="h-4 w-4 mr-2" />
                 Billing
@@ -270,7 +270,7 @@ function SettingsPage() {
               )}
               <TabsTrigger 
                 value="usage" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <Layers className="h-4 w-4 mr-2" />
                 Usage
@@ -278,7 +278,7 @@ function SettingsPage() {
               {canViewSsoTab && (
                 <TabsTrigger 
                   value="sso" 
-                  className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
                 >
                   <Shield className="h-4 w-4 mr-2" />
                   SSO
@@ -290,7 +290,7 @@ function SettingsPage() {
               </div>
               <TabsTrigger 
                 value="account" 
-                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                className="w-full justify-start px-3 py-2 h-9 text-sm font-medium rounded-md hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground"
               >
                 <Trash2 className="h-4 w-4 mr-2" />
                 Account
@@ -1630,7 +1630,7 @@ function BillingTab() {
                 onClick={() => setBillingInterval('monthly')}
                 className={`relative rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
                   billingInterval === 'monthly'
-                    ? 'bg-background text-foreground shadow-sm'
+                    ? 'bg-background text-foreground'
                     : 'text-muted-foreground hover:text-foreground'
                 }`}
               >
@@ -1640,7 +1640,7 @@ function BillingTab() {
                 onClick={() => setBillingInterval('yearly')}
                 className={`relative rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
                   billingInterval === 'yearly'
-                    ? 'bg-background text-foreground shadow-sm'
+                    ? 'bg-background text-foreground'
                     : 'text-muted-foreground hover:text-foreground'
                 }`}
               >
@@ -1673,7 +1673,7 @@ function BillingTab() {
                     key={plan.tier.id}
                     className={`flex flex-col rounded-xl border-2 p-6 transition-all ${
                       isCurrentPlan
-                        ? 'border-primary bg-primary/5 shadow-md relative'
+                        ? 'border-primary bg-primary/5 relative'
                         : 'border-muted hover:border-primary/50'
                     }`}
                   >
@@ -2099,7 +2099,7 @@ function IntegrationsTab() {
         <CardHeader className="bg-muted/10 pb-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="h-12 w-12 rounded-xl bg-white shadow-sm border flex items-center justify-center p-2">
+              <div className="h-12 w-12 rounded-xl bg-white border flex items-center justify-center p-2">
                 <SlackLogo className="h-full w-full" />
               </div>
               <div>
@@ -2246,7 +2246,7 @@ function IntegrationsTab() {
         <CardHeader className="bg-muted/10 pb-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className="h-12 w-12 rounded-xl bg-white shadow-sm border flex items-center justify-center p-2">
+              <div className="h-12 w-12 rounded-xl bg-white border flex items-center justify-center p-2">
                 <DiscordLogo className="h-full w-full" />
               </div>
               <div>

--- a/dashboard/src/routes/status-pages.$pageId.tsx
+++ b/dashboard/src/routes/status-pages.$pageId.tsx
@@ -617,7 +617,7 @@ function OverviewTab({statusPage, onUpdate, isSaving, showPreview}: {statusPage:
           </Card>
 
           {/* Save Button */}
-          <div className={`flex items-center justify-between sticky bottom-4 p-3 border rounded-lg shadow-sm transition-colors ${hasChanges ? 'bg-primary/5 border-primary/20' : 'bg-background/80 backdrop-blur-sm'}`}>
+          <div className={`flex items-center justify-between sticky bottom-4 p-3 border rounded-lg transition-colors ${hasChanges ? 'bg-primary/5 border-primary/20' : 'bg-background/80 backdrop-blur-sm'}`}>
             {hasChanges && (
               <p className="text-sm text-muted-foreground flex items-center gap-2">
                 <CircleDot className="h-3.5 w-3.5 text-primary" />
@@ -848,7 +848,7 @@ function MonitorsTab({pageId, statusPage}: {pageId: string; statusPage: StatusPa
                   <div
                     key={monitor.id}
                     className={`flex items-center justify-between p-3.5 border rounded-lg transition-all ${
-                      isSelected ? 'border-primary bg-primary/5 shadow-sm' : ''
+                      isSelected ? 'border-primary bg-primary/5' : ''
                     } ${isAlreadyAdded ? 'opacity-50' : 'cursor-pointer hover:border-primary/40'}`}
                     onClick={() => {
                       if (!isAlreadyAdded) {

--- a/dashboard/src/routes/status-pages.index.tsx
+++ b/dashboard/src/routes/status-pages.index.tsx
@@ -196,7 +196,7 @@ function StatusPagesListPage() {
             {statusPages.map((page) => (
               <Card
                 key={page.id}
-                className="group hover:shadow-lg transition-all duration-200 cursor-pointer overflow-hidden"
+                className="group transition-all duration-200 cursor-pointer overflow-hidden"
                 onClick={() => navigate({to: '/status-pages/$pageId', params: {pageId: page.id}})}
               >
                 {/* Color Bar */}

--- a/dashboard/src/routes/traces.tsx
+++ b/dashboard/src/routes/traces.tsx
@@ -105,7 +105,7 @@ function Traces() {
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-center gap-3">
-          <div className="flex items-center justify-center h-10 w-10 rounded-lg bg-gradient-to-br from-violet-500 to-indigo-600 shadow-lg shadow-violet-500/20">
+          <div className="flex items-center justify-center h-10 w-10 rounded-lg bg-gradient-to-br from-violet-500 to-indigo-600">
             <Activity className="h-5 w-5 text-white" />
           </div>
           <div>

--- a/dashboard/src/routes/workflows.tsx
+++ b/dashboard/src/routes/workflows.tsx
@@ -791,7 +791,7 @@ function TriggerNode({
         }
       }}
       className={cn(
-        'w-full rounded-lg border bg-background p-4 text-left shadow-sm transition-colors hover:bg-muted/30',
+        'w-full rounded-lg border bg-background p-4 text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -926,7 +926,7 @@ function DelayNode({
         }
       }}
       className={cn(
-        'flex w-full items-center justify-between gap-3 rounded-lg border bg-background px-4 py-3 text-left shadow-sm transition-colors hover:bg-muted/30',
+        'flex w-full items-center justify-between gap-3 rounded-lg border bg-background px-4 py-3 text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -970,7 +970,7 @@ function ConditionNode({
         }
       }}
       className={cn(
-        'overflow-hidden rounded-lg border bg-background text-left shadow-sm transition-colors hover:bg-muted/30',
+        'overflow-hidden rounded-lg border bg-background text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -1124,7 +1124,7 @@ function StepEditor({
         ))}
       </div>
       <div className="flex justify-center">
-        <Button type="button" variant="outline" size="sm" onClick={onAddStep} className="gap-1.5 rounded-lg shadow-sm">
+        <Button type="button" variant="outline" size="sm" onClick={onAddStep} className="gap-1.5 rounded-lg">
           <Plus className="h-3.5 w-3.5" />
           Add step
         </Button>
@@ -1162,7 +1162,7 @@ function StepNode({
         }
       }}
       className={cn(
-        'overflow-hidden rounded-lg border bg-background text-left shadow-sm transition-colors hover:bg-muted/30',
+        'overflow-hidden rounded-lg border bg-background text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -1292,7 +1292,7 @@ function WorkflowInspector({
   const selectedStep = selectedStepIndex !== null ? form.steps[selectedStepIndex] : undefined
 
   return (
-    <div className="rounded-lg border bg-muted/20 p-3 shadow-sm">
+    <div className="rounded-lg border bg-muted/20 p-3">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
           <h3 className="text-sm font-semibold">{inspectorTitle(panel)}</h3>


### PR DESCRIPTION
## Summary
- remove Tailwind shadow classes from dashboard primitives and dashboard product screens
- keep landing/marketing shadows and theme-specific CSS box-shadows intact
- update the dashboard toolbar test expectation for the active state

## Tests
- npm run test -- src/components/dashboards/__tests__/DashboardToolbar-extended.test.tsx
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated visual styling across dashboard components by removing shadow effects from tooltips, cards, buttons, dialogs, modals, and panels to create a cleaner, flatter design aesthetic throughout the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->