### PR TITLE
feat: add product analytics tab

### DIFF
--- a/backend/src/main/kotlin/com/moneat/analytics/AnalyticsModule.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/AnalyticsModule.kt
@@ -18,6 +18,7 @@ package com.moneat.analytics
 
 import com.moneat.analytics.routes.analyticsIngestRoutes
 import com.moneat.analytics.routes.analyticsRoutes
+import com.moneat.analytics.routes.analyticsServerIngestRoutes
 import com.moneat.analytics.services.AnalyticsIngestionWorker
 import com.moneat.enterprise.EnterpriseModule
 import io.ktor.server.application.Application
@@ -38,6 +39,7 @@ class AnalyticsModule : EnterpriseModule {
     override fun registerRoutes(route: Route) {
         route.apply {
             analyticsIngestRoutes()
+            analyticsServerIngestRoutes()
             analyticsRoutes()
         }
     }

--- a/backend/src/main/kotlin/com/moneat/analytics/models/AnalyticsModels.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/models/AnalyticsModels.kt
@@ -17,6 +17,7 @@
 package com.moneat.analytics.models
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /** Inbound payload from the tracking script. */
 @Serializable
@@ -34,7 +35,9 @@ data class AnalyticsEventPayload(
 data class EnrichedAnalyticsEvent(
     val projectId: Long,
     val sessionId: String,
+    val userId: String = "",
     val eventName: String,
+    val source: String = "web",
     val hostname: String,
     val pathname: String,
     val referrer: String,
@@ -55,6 +58,22 @@ data class EnrichedAnalyticsEvent(
     val screenWidth: Int,
     val props: Map<String, String>,
     val timestamp: Long,
+)
+
+@Serializable
+data class ServerAnalyticsEventPayload(
+    val events: List<ServerAnalyticsEvent> = emptyList(),
+)
+
+@Serializable
+data class ServerAnalyticsEvent(
+    val name: String = "",
+    @SerialName("user_id")
+    val userId: String = "",
+    @SerialName("session_id")
+    val sessionId: String = "",
+    val props: Map<String, String> = emptyMap(),
+    val timestamp: Long? = null,
 )
 
 // --- Dashboard API response models ---
@@ -104,11 +123,34 @@ data class FunnelStep(
     val name: String,
     val visitors: Long,
     val dropoff: Double,
+    val conversionRate: Double,
 )
 
 @Serializable
 data class FunnelResponse(
     val steps: List<FunnelStep>,
+    val overallConversion: Double,
+)
+
+@Serializable
+data class RetentionPeriod(
+    val days: Int,
+    val retainedUsers: Long,
+    val retentionRate: Double,
+)
+
+@Serializable
+data class RetentionCohort(
+    val cohortWeek: String,
+    val users: Long,
+    val periods: List<RetentionPeriod>,
+)
+
+@Serializable
+data class RetentionResponse(
+    val startEvent: String,
+    val returnEvent: String,
+    val cohorts: List<RetentionCohort>,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/analytics/models/AnalyticsModels.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/models/AnalyticsModels.kt
@@ -136,6 +136,7 @@ data class FunnelResponse(
 data class RetentionPeriod(
     val days: Int,
     val retainedUsers: Long,
+    val eligibleUsers: Long,
     val retentionRate: Double,
 )
 

--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
@@ -40,6 +40,8 @@ private const val PERIOD_30D_OFFSET_DAYS = 29L
 private const val PERIOD_6MO_MONTHS = 6L
 private const val PERIOD_12MO_MONTHS = 12L
 private const val FILTER_PARTS_COUNT = 3
+private const val MAX_RETENTION_PERIOD_DAYS = 365
+private val DEFAULT_RETENTION_PERIODS = listOf(1, 7, 14, 30)
 
 /**
  * Authenticated dashboard API routes for product analytics.
@@ -197,8 +199,10 @@ fun Route.analyticsRoutes(
                 }
                 val filters = parseFilters(call)
                 val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
+                val groupBy = call.request.queryParameters["group_by"] ?: "session_id"
+                val source = call.request.queryParameters["source"]
 
-                val result = analyticsService.getEvents(projectId, dateFrom, dateTo, filters, limit)
+                val result = analyticsService.getEvents(projectId, dateFrom, dateTo, filters, limit, groupBy, source)
                 call.respond(result)
             }
 
@@ -214,13 +218,41 @@ fun Route.analyticsRoutes(
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
                     return@get
                 }
-                val steps = call.request.queryParameters.getAll("steps") ?: emptyList()
+                val steps = call.request.queryParameters.getAll("steps")
+                    ?: call.request.queryParameters.getAll("steps[]")
+                    ?: emptyList()
                 if (steps.size < 2) {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse("At least 2 funnel steps required"))
                     return@get
                 }
+                val groupBy = call.request.queryParameters["group_by"] ?: "session_id"
+                val source = call.request.queryParameters["source"]
 
-                val result = analyticsService.getFunnel(projectId, dateFrom, dateTo, steps)
+                val result = analyticsService.getFunnel(projectId, dateFrom, dateTo, steps, groupBy, source)
+                call.respond(result)
+            }
+
+            get("/retention") {
+                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    return@get
+                }
+                val startEvent = call.request.queryParameters["start_event"]
+                val returnEvent = call.request.queryParameters["return_event"]
+                if (startEvent.isNullOrBlank() || returnEvent.isNullOrBlank()) {
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("start_event and return_event are required"))
+                    return@get
+                }
+
+                val result = analyticsService.getRetention(
+                    projectId,
+                    dateFrom,
+                    dateTo,
+                    startEvent,
+                    returnEvent,
+                    parseRetentionPeriods(call),
+                )
                 call.respond(result)
             }
         }
@@ -312,4 +344,17 @@ private fun parseFilters(call: io.ktor.server.application.ApplicationCall): List
             null
         }
     }
+}
+
+private fun parseRetentionPeriods(call: io.ktor.server.application.ApplicationCall): List<Int> {
+    val values = call.request.queryParameters.getAll("periods")
+        ?: call.request.queryParameters.getAll("periods[]")
+        ?: return DEFAULT_RETENTION_PERIODS
+
+    return values
+        .mapNotNull(String::toIntOrNull)
+        .filter { it in 1..MAX_RETENTION_PERIOD_DAYS }
+        .distinct()
+        .sorted()
+        .ifEmpty { DEFAULT_RETENTION_PERIODS }
 }

--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
@@ -41,6 +41,7 @@ private const val PERIOD_6MO_MONTHS = 6L
 private const val PERIOD_12MO_MONTHS = 12L
 private const val FILTER_PARTS_COUNT = 3
 private const val MAX_RETENTION_PERIOD_DAYS = 365
+private const val INVALID_DATE_RANGE = "Invalid date range"
 private val DEFAULT_RETENTION_PERIODS = listOf(1, 7, 14, 30)
 
 /**
@@ -56,7 +57,7 @@ fun Route.analyticsRoutes(
             get("/overview") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -69,7 +70,7 @@ fun Route.analyticsRoutes(
             get("/timeseries") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -81,7 +82,7 @@ fun Route.analyticsRoutes(
             get("/pages") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -94,7 +95,7 @@ fun Route.analyticsRoutes(
             get("/entry-pages") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -107,7 +108,7 @@ fun Route.analyticsRoutes(
             get("/exit-pages") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -120,7 +121,7 @@ fun Route.analyticsRoutes(
             get("/sources") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -140,7 +141,7 @@ fun Route.analyticsRoutes(
             get("/utm/{param}") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -155,7 +156,7 @@ fun Route.analyticsRoutes(
             get("/locations") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -175,7 +176,7 @@ fun Route.analyticsRoutes(
             get("/devices") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -194,7 +195,7 @@ fun Route.analyticsRoutes(
             get("/events") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val filters = parseFilters(call)
@@ -215,7 +216,7 @@ fun Route.analyticsRoutes(
             get("/funnel") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val steps = call.request.queryParameters.getAll("steps")
@@ -235,7 +236,7 @@ fun Route.analyticsRoutes(
             get("/retention") {
                 val (projectId, _) = extractContext(call, dashboardService) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date range"))
+                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
                 }
                 val startEvent = call.request.queryParameters["start_event"]

--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsServerIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsServerIngestRoutes.kt
@@ -48,8 +48,10 @@ private const val MAX_SERVER_ANALYTICS_EVENTS = 500
 
 fun Route.analyticsServerIngestRoutes(
     otlpApiKeyService: OtlpApiKeyService = GlobalContext.get().get(),
-    enqueueEvent: (String) -> Unit = { message ->
-        RedisConfig.sync().lpush(AnalyticsIngestionWorker.QUEUE_KEY, message)
+    enqueueEvents: (List<String>) -> Unit = { messages ->
+        if (messages.isNotEmpty()) {
+            RedisConfig.sync().lpush(AnalyticsIngestionWorker.QUEUE_KEY, *messages.toTypedArray())
+        }
     },
 ) {
     route("/v1/analytics/{projectId}") {
@@ -65,10 +67,10 @@ fun Route.analyticsServerIngestRoutes(
             val events = validateServerAnalyticsEvents(call, payload.events) ?: return@post
 
             try {
-                events
+                val messages = events
                     .map { event -> createServerAnalyticsEvent(projectId, event) }
                     .map { event -> serverIngestJson.encodeToString(event) }
-                    .forEach(enqueueEvent)
+                enqueueEvents(messages)
             } catch (e: RuntimeException) {
                 serverIngestLogger.error(e) {
                     "Failed to enqueue server analytics events for project $projectId organization $organizationId"

--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsServerIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsServerIngestRoutes.kt
@@ -1,0 +1,180 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.analytics.routes
+
+import com.moneat.analytics.models.EnrichedAnalyticsEvent
+import com.moneat.analytics.models.ServerAnalyticsEvent
+import com.moneat.analytics.models.ServerAnalyticsEventPayload
+import com.moneat.analytics.services.AnalyticsIngestionWorker
+import com.moneat.config.RedisConfig
+import com.moneat.otlp.OtlpAuth
+import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.shared.models.Projects
+import com.moneat.utils.suspendRunCatching
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.header
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.koin.core.context.GlobalContext
+
+private val serverIngestLogger = KotlinLogging.logger {}
+private val serverIngestJson = Json { ignoreUnknownKeys = true }
+
+private const val MAX_SERVER_ANALYTICS_EVENTS = 500
+
+fun Route.analyticsServerIngestRoutes(
+    otlpApiKeyService: OtlpApiKeyService = GlobalContext.get().get(),
+    enqueueEvent: (String) -> Unit = { message ->
+        RedisConfig.sync().lpush(AnalyticsIngestionWorker.QUEUE_KEY, message)
+    },
+) {
+    route("/v1/analytics/{projectId}") {
+        post("/events") {
+            val projectId = call.parameters["projectId"]?.toLongOrNull()
+            if (projectId == null) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
+                return@post
+            }
+
+            val organizationId = authorizeServerAnalyticsIngest(call, projectId, otlpApiKeyService) ?: return@post
+            val payload = receiveServerAnalyticsPayload(call) ?: return@post
+            val events = validateServerAnalyticsEvents(call, payload.events) ?: return@post
+
+            try {
+                events
+                    .map { event -> createServerAnalyticsEvent(projectId, event) }
+                    .map { event -> serverIngestJson.encodeToString(event) }
+                    .forEach(enqueueEvent)
+            } catch (e: RuntimeException) {
+                serverIngestLogger.error(e) {
+                    "Failed to enqueue server analytics events for project $projectId organization $organizationId"
+                }
+                call.respond(HttpStatusCode.InternalServerError, "Failed to enqueue events")
+                return@post
+            }
+
+            call.respond(HttpStatusCode.Accepted, "ok")
+        }
+    }
+}
+
+private suspend fun authorizeServerAnalyticsIngest(
+    call: ApplicationCall,
+    projectId: Long,
+    otlpApiKeyService: OtlpApiKeyService,
+): Int? {
+    val token = OtlpAuth.extractBearerToken(call.request.header(HttpHeaders.Authorization))
+    if (token == null) {
+        call.respond(HttpStatusCode.Unauthorized, "Missing Bearer token")
+        return null
+    }
+
+    val organizationId = otlpApiKeyService.validateKey(token)
+    if (organizationId == null) {
+        call.respond(HttpStatusCode.Unauthorized, "Invalid API key")
+        return null
+    }
+
+    val projectOrganizationId = getProjectOrganizationId(projectId)
+    if (projectOrganizationId == null || projectOrganizationId != organizationId) {
+        call.respond(HttpStatusCode.Forbidden, "Project is not available for this API key")
+        return null
+    }
+
+    return organizationId
+}
+
+private suspend fun receiveServerAnalyticsPayload(
+    call: ApplicationCall,
+): ServerAnalyticsEventPayload? {
+    return suspendRunCatching {
+        call.receive<ServerAnalyticsEventPayload>()
+    }.onFailure { e ->
+        serverIngestLogger.debug { "Invalid server analytics payload: ${e.message}" }
+        call.respond(HttpStatusCode.BadRequest, "Invalid payload")
+    }.getOrNull()
+}
+
+private suspend fun validateServerAnalyticsEvents(
+    call: ApplicationCall,
+    events: List<ServerAnalyticsEvent>,
+): List<ServerAnalyticsEvent>? {
+    if (events.isEmpty()) {
+        call.respond(HttpStatusCode.BadRequest, "At least one event is required")
+        return null
+    }
+    if (events.size > MAX_SERVER_ANALYTICS_EVENTS) {
+        call.respond(HttpStatusCode.BadRequest, "Too many events")
+        return null
+    }
+    if (events.any { it.name.isBlank() || it.userId.isBlank() }) {
+        call.respond(HttpStatusCode.BadRequest, "Event name and user_id are required")
+        return null
+    }
+    return events
+}
+
+private fun createServerAnalyticsEvent(
+    projectId: Long,
+    event: ServerAnalyticsEvent,
+): EnrichedAnalyticsEvent =
+    EnrichedAnalyticsEvent(
+        projectId = projectId,
+        sessionId = event.sessionId.ifBlank { event.userId },
+        userId = event.userId,
+        eventName = event.name,
+        source = "server",
+        hostname = "",
+        pathname = "",
+        referrer = "",
+        referrerSource = "",
+        utmSource = "",
+        utmMedium = "",
+        utmCampaign = "",
+        utmTerm = "",
+        utmContent = "",
+        countryCode = "",
+        subdivision = "",
+        city = "",
+        browser = "",
+        browserVersion = "",
+        os = "",
+        osVersion = "",
+        deviceType = "",
+        screenWidth = 0,
+        props = event.props,
+        timestamp = event.timestamp ?: System.currentTimeMillis(),
+    )
+
+private fun getProjectOrganizationId(projectId: Long): Int? =
+    transaction {
+        Projects
+            .selectAll()
+            .where { Projects.id eq projectId }
+            .firstOrNull()
+            ?.get(Projects.organization_id)
+    }

--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
@@ -129,7 +129,7 @@ class AnalyticsIngestionWorker(
 
         val sql = """
             INSERT INTO analytics_events (
-                project_id, session_id, event_name, hostname, pathname,
+                project_id, session_id, user_id, event_name, source, hostname, pathname,
                 referrer, referrer_source,
                 utm_source, utm_medium, utm_campaign, utm_term, utm_content,
                 country_code, subdivision, city,
@@ -138,7 +138,9 @@ class AnalyticsIngestionWorker(
             ) VALUES (
                 ${event.projectId},
                 '${escapeCH(event.sessionId)}',
+                '${escapeCH(event.userId)}',
                 '${escapeCH(event.eventName)}',
+                '${escapeCH(event.source)}',
                 '${escapeCH(event.hostname)}',
                 '${escapeCH(event.pathname)}',
                 '${escapeCH(event.referrer)}',

--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsService.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsService.kt
@@ -327,8 +327,11 @@ class AnalyticsService {
         val escapedStartEvent = AnalyticsIngestionWorker.escapeCH(startEvent)
         val escapedReturnEvent = AnalyticsIngestionWorker.escapeCH(returnEvent)
         val maxPeriod = periods.maxOrNull() ?: 0
-        val retainedColumns = periods.joinToString(",\n") { period ->
-            "                uniqExactIf(c.user_id, e.timestamp > c.first_seen " +
+        val retentionColumns = periods.joinToString(",\n") { period ->
+            val cohortIsMature = "c.first_seen + INTERVAL $period DAY <= now()"
+            "                uniqExactIf(c.user_id, $cohortIsMature) AS eligible_$period,\n" +
+                "                uniqExactIf(c.user_id, $cohortIsMature " +
+                "AND e.timestamp > c.first_seen " +
                 "AND e.timestamp <= c.first_seen + INTERVAL $period DAY) AS retained_$period"
         }
 
@@ -349,7 +352,7 @@ class AnalyticsService {
             SELECT
                 toString(c.cohort_week) AS cohort_week,
                 uniqExact(c.user_id) AS users,
-$retainedColumns
+$retentionColumns
             FROM cohorts AS c
             LEFT JOIN analytics_events AS e
                 ON e.project_id = ${asClickHouseProjectId(projectId)}
@@ -369,11 +372,13 @@ $retainedColumns
                 cohortWeek = row.stringValue("cohort_week"),
                 users = users,
                 periods = periods.map { period ->
+                    val eligibleUsers = row.longValue("eligible_$period")
                     val retainedUsers = row.longValue("retained_$period")
                     RetentionPeriod(
                         days = period,
                         retainedUsers = retainedUsers,
-                        retentionRate = percentage(retainedUsers, users),
+                        eligibleUsers = eligibleUsers,
+                        retentionRate = percentage(retainedUsers, eligibleUsers),
                     )
                 },
             )

--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsService.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsService.kt
@@ -23,6 +23,9 @@ import com.moneat.analytics.models.BreakdownRow
 import com.moneat.analytics.models.FunnelResponse
 import com.moneat.analytics.models.FunnelStep
 import com.moneat.analytics.models.RealtimeResponse
+import com.moneat.analytics.models.RetentionCohort
+import com.moneat.analytics.models.RetentionPeriod
+import com.moneat.analytics.models.RetentionResponse
 import com.moneat.analytics.models.TimeseriesPoint
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
@@ -42,6 +45,7 @@ private val jsonParser = Json { ignoreUnknownKeys = true }
 private const val ERROR_TRUNCATE_LENGTH = 500
 private const val PERCENTAGE_MULTIPLIER = 100
 private const val DEFAULT_LIMIT = 100
+private const val FUNNEL_WINDOW_SECONDS = 86400
 
 /**
  * Query builder for analytics dashboard endpoints.
@@ -239,9 +243,14 @@ class AnalyticsService {
         dateFrom: LocalDate,
         dateTo: LocalDate,
         steps: List<String>,
+        groupBy: String = "session_id",
+        source: String? = null,
     ): FunnelResponse {
-        if (steps.size < 2) return FunnelResponse(emptyList())
+        if (steps.size < 2) return FunnelResponse(emptyList(), 0.0)
         val dateWhere = dateRange(dateFrom, dateTo)
+        val groupByColumn = resolveGroupByColumn(groupBy)
+        val sourceClause = sourceWhere(source)
+        val nonEmptyGroupClause = if (groupByColumn == "user_id") "AND user_id != ''" else ""
 
         // Build a windowFunnel query
         val events = steps.joinToString(", ") { "event_name = '${AnalyticsIngestionWorker.escapeCH(it)}'" }
@@ -251,11 +260,14 @@ class AnalyticsService {
                 count() AS cnt
             FROM (
                 SELECT
-                    session_id,
-                    windowFunnel(86400)(timestamp, $events) AS level
+                    $groupByColumn,
+                    windowFunnel($FUNNEL_WINDOW_SECONDS)(toDateTime(timestamp), $events) AS level
                 FROM analytics_events
-                WHERE project_id = ${asClickHouseProjectId(projectId)} AND $dateWhere
-                GROUP BY session_id
+                WHERE project_id = ${asClickHouseProjectId(projectId)}
+                  AND $dateWhere
+                  $sourceClause
+                  $nonEmptyGroupClause
+                GROUP BY $groupByColumn
             )
             WHERE level > 0
             GROUP BY level
@@ -279,20 +291,94 @@ class AnalyticsService {
                 name = name,
                 visitors = visitors,
                 dropoff = 0.0,
+                conversionRate = 0.0,
             )
         }
 
-        // Calculate dropoff rates
-        val withDropoff = funnelSteps.mapIndexed { i, step ->
+        // Calculate dropoff and conversion rates
+        val firstStepVisitors = funnelSteps.firstOrNull()?.visitors ?: 0
+        val withMetrics = funnelSteps.mapIndexed { i, step ->
+            val conversionRate = percentage(step.visitors, firstStepVisitors)
             if (i == 0) {
-                step
+                step.copy(conversionRate = conversionRate)
             } else {
                 val prev = funnelSteps[i - 1].visitors
-                val dropoff = if (prev > 0) ((prev - step.visitors).toDouble() / prev * PERCENTAGE_MULTIPLIER) else 0.0
-                step.copy(dropoff = dropoff)
+                val dropoff = percentage(prev - step.visitors, prev)
+                step.copy(dropoff = dropoff, conversionRate = conversionRate)
             }
         }
-        return FunnelResponse(withDropoff)
+        val overallConversion = percentage(funnelSteps.lastOrNull()?.visitors ?: 0, firstStepVisitors)
+        return FunnelResponse(withMetrics, overallConversion)
+    }
+
+    suspend fun getRetention(
+        projectId: Long,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        startEvent: String,
+        returnEvent: String,
+        periods: List<Int>,
+    ): RetentionResponse {
+        if (startEvent.isBlank() || returnEvent.isBlank() || periods.isEmpty()) {
+            return RetentionResponse(startEvent, returnEvent, emptyList())
+        }
+
+        val dateWhere = dateRange(dateFrom, dateTo, "e", "timestamp")
+        val escapedStartEvent = AnalyticsIngestionWorker.escapeCH(startEvent)
+        val escapedReturnEvent = AnalyticsIngestionWorker.escapeCH(returnEvent)
+        val maxPeriod = periods.maxOrNull() ?: 0
+        val retainedColumns = periods.joinToString(",\n") { period ->
+            "                uniqExactIf(c.user_id, e.timestamp > c.first_seen " +
+                "AND e.timestamp <= c.first_seen + INTERVAL $period DAY) AS retained_$period"
+        }
+
+        val sql = """
+            WITH cohorts AS (
+                SELECT
+                    user_id,
+                    min(timestamp) AS first_seen,
+                    toStartOfWeek(min(timestamp)) AS cohort_week
+                FROM analytics_events AS e
+                WHERE e.project_id = ${asClickHouseProjectId(projectId)}
+                  AND e.source = 'server'
+                  AND e.event_name = '$escapedStartEvent'
+                  AND e.user_id != ''
+                  AND $dateWhere
+                GROUP BY user_id
+            )
+            SELECT
+                toString(c.cohort_week) AS cohort_week,
+                uniqExact(c.user_id) AS users,
+$retainedColumns
+            FROM cohorts AS c
+            LEFT JOIN analytics_events AS e
+                ON e.project_id = ${asClickHouseProjectId(projectId)}
+                AND e.source = 'server'
+                AND e.user_id = c.user_id
+                AND e.event_name = '$escapedReturnEvent'
+                AND e.timestamp > c.first_seen
+                AND e.timestamp <= c.first_seen + INTERVAL $maxPeriod DAY
+            GROUP BY c.cohort_week
+            ORDER BY c.cohort_week
+            FORMAT JSONEachRow
+        """.trimIndent()
+
+        val cohorts = parseRows(ClickHouseClient.executeWithFormat(sql, "JSONEachRow")) { row ->
+            val users = row.longValue("users")
+            RetentionCohort(
+                cohortWeek = row.stringValue("cohort_week"),
+                users = users,
+                periods = periods.map { period ->
+                    val retainedUsers = row.longValue("retained_$period")
+                    RetentionPeriod(
+                        days = period,
+                        retainedUsers = retainedUsers,
+                        retentionRate = percentage(retainedUsers, users),
+                    )
+                },
+            )
+        }
+        return RetentionResponse(startEvent, returnEvent, cohorts)
     }
 
     // --- Events breakdown (custom events) ---
@@ -303,15 +389,23 @@ class AnalyticsService {
         dateTo: LocalDate,
         filters: List<AnalyticsFilter>,
         limit: Int = DEFAULT_LIMIT,
+        groupBy: String = "session_id",
+        source: String? = null,
     ): BreakdownResponse {
         val where = buildWhere(projectId, dateFrom, dateTo, filters, "e", "timestamp")
+        val groupByColumn = resolveGroupByColumn(groupBy)
+        val sourceClause = sourceWhere(source, "e")
+        val nonEmptyGroupClause = if (groupByColumn == "user_id") "AND e.user_id != ''" else ""
         val sql = """
             SELECT
                 e.event_name AS name,
-                uniq(e.session_id) AS visitors,
+                uniq(e.$groupByColumn) AS visitors,
                 count() AS pageviews
             FROM analytics_events AS e
-            WHERE $where AND e.event_name != 'pageview'
+            WHERE $where
+              AND e.event_name != 'pageview'
+              $sourceClause
+              $nonEmptyGroupClause
             GROUP BY name
             ORDER BY visitors DESC
             LIMIT $limit
@@ -374,6 +468,28 @@ class AnalyticsService {
             "event", "event_name" -> if (alias == "e") "event_name" else null
             else -> null
         }
+    }
+
+    private fun resolveGroupByColumn(groupBy: String): String =
+        when (groupBy) {
+            "user_id" -> "user_id"
+            else -> "session_id"
+        }
+
+    private fun percentage(
+        numerator: Long,
+        denominator: Long,
+    ): Double =
+        if (denominator > 0) numerator.toDouble() / denominator * PERCENTAGE_MULTIPLIER else 0.0
+
+    private fun sourceWhere(
+        source: String?,
+        alias: String = "",
+    ): String {
+        if (source.isNullOrBlank()) return ""
+        val prefix = if (alias.isNotEmpty()) "$alias." else ""
+        val escapedSource = AnalyticsIngestionWorker.escapeCH(source)
+        return "AND ${prefix}source = '$escapedSource'"
     }
 
     private fun asClickHouseProjectId(projectId: Long): String {

--- a/backend/src/main/resources/db/clickhouse_migration/V44__add_product_analytics_columns.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V44__add_product_analytics_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE moneat.analytics_events
+    ADD COLUMN IF NOT EXISTS user_id String DEFAULT '';
+
+ALTER TABLE moneat.analytics_events
+    ADD COLUMN IF NOT EXISTS source LowCardinality(String) DEFAULT 'web';

--- a/backend/src/test/kotlin/com/moneat/analytics/AnalyticsIngestionWorkerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/analytics/AnalyticsIngestionWorkerTest.kt
@@ -16,8 +16,13 @@
 
 package com.moneat.analytics
 
+import com.moneat.analytics.models.EnrichedAnalyticsEvent
 import com.moneat.analytics.services.AnalyticsIngestionWorker
+import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
+import com.moneat.testsupport.requestBodyText
+import com.moneat.testsupport.respond
+import com.moneat.testsupport.withClickHouseMockServer
 import com.moneat.utils.ClickHouseSqlUtils
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.every
@@ -25,6 +30,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -45,6 +51,7 @@ class AnalyticsIngestionWorkerTest {
     @AfterTest
     fun teardown() {
         unmockkObject(RedisConfig)
+        ClickHouseClient.close()
     }
 
     @Test
@@ -79,6 +86,51 @@ class AnalyticsIngestionWorkerTest {
         val worker = AnalyticsIngestionWorker(workerCount = 0)
         runBlocking {
             worker.processMessage(2, "")
+        }
+    }
+
+    @Test
+    fun `processMessage inserts product analytics user and source columns`() = runBlocking {
+        val queries = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            queries.add(exchange.requestBodyText())
+            exchange.respond(200, "", contentType = "text/plain")
+        }) { _ ->
+            val worker = AnalyticsIngestionWorker(workerCount = 0)
+            val message = Json.encodeToString(
+                EnrichedAnalyticsEvent(
+                    projectId = 42L,
+                    sessionId = "sess-1",
+                    userId = "user-1",
+                    eventName = "recording.started",
+                    source = "server",
+                    hostname = "",
+                    pathname = "",
+                    referrer = "",
+                    referrerSource = "",
+                    utmSource = "",
+                    utmMedium = "",
+                    utmCampaign = "",
+                    utmTerm = "",
+                    utmContent = "",
+                    countryCode = "",
+                    subdivision = "",
+                    city = "",
+                    browser = "",
+                    browserVersion = "",
+                    os = "",
+                    osVersion = "",
+                    deviceType = "",
+                    screenWidth = 0,
+                    props = mapOf("platform" to "ios"),
+                    timestamp = 1_716_825_600_000,
+                )
+            )
+
+            worker.processMessage(1, message)
+
+            assertTrue(queries.any { it.contains("session_id, user_id, event_name, source") })
+            assertTrue(queries.any { it.contains("'user-1'") && it.contains("'server'") })
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/analytics/AnalyticsIngestionWorkerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/analytics/AnalyticsIngestionWorkerTest.kt
@@ -38,6 +38,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class AnalyticsIngestionWorkerTest {
+    // ──── Mocks & Setup ────
 
     private val mockRedis = mockk<RedisCommands<String, String>>(relaxed = true)
 
@@ -53,6 +54,8 @@ class AnalyticsIngestionWorkerTest {
         unmockkObject(RedisConfig)
         ClickHouseClient.close()
     }
+
+    // ──── Companion Metadata ────
 
     @Test
     fun `companion exposes queue and dlq keys`() {
@@ -72,6 +75,8 @@ class AnalyticsIngestionWorkerTest {
         val raw = "a'b\\c\n"
         assertEquals(ClickHouseSqlUtils.escapeSql(raw), AnalyticsIngestionWorker.escapeCH(raw))
     }
+
+    // ──── Message Processing ────
 
     @Test
     fun `processMessage with invalid JSON does not throw`() {
@@ -133,6 +138,8 @@ class AnalyticsIngestionWorkerTest {
             assertTrue(queries.any { it.contains("'user-1'") && it.contains("'server'") })
         }
     }
+
+    // ──── Lifecycle ────
 
     @Test
     fun `stop without start does not throw`() {

--- a/backend/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
@@ -1,0 +1,198 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.analytics
+
+import com.moneat.analytics.routes.analyticsServerIngestRoutes
+import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
+import com.moneat.testsupport.TestDatabaseHelper
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockk
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AnalyticsServerIngestRoutesTest {
+    companion object {
+        private const val API_KEY = "motlp_valid_server_key"
+        private var db: Database? = null
+    }
+
+    private val otlpApiKeyService = mockk<OtlpApiKeyService>()
+
+    @BeforeTest
+    fun setupDatabase() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_server_analytics_routes;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.resetSchema(Organizations, Projects)
+    }
+
+    @Test
+    fun `POST server analytics event enqueues canonical product event`() = testApplication {
+        val (organizationId, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
+        val queuedMessages = mutableListOf<String>()
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvent = queuedMessages::add,
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody(
+                """
+                {
+                  "events": [{
+                    "name": "recording.started",
+                    "user_id": "sha256-user",
+                    "session_id": "sess-abc",
+                    "props": {"platform": "ios", "app_version": "1.2.3"},
+                    "timestamp": 1716825600000
+                  }]
+                }
+                """.trimIndent()
+            )
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status, response.bodyAsText())
+        assertEquals(1, queuedMessages.size)
+        val message = queuedMessages.first()
+        assertTrue(message.contains("\"projectId\":$projectId"))
+        assertTrue(message.contains("\"sessionId\":\"sess-abc\""))
+        assertTrue(message.contains("\"userId\":\"sha256-user\""))
+        assertTrue(message.contains("\"eventName\":\"recording.started\""))
+        assertTrue(message.contains("\"source\":\"server\""))
+        assertTrue(message.contains("\"platform\":\"ios\""))
+    }
+
+    @Test
+    fun `POST server analytics event requires bearer token`() = testApplication {
+        val (_, projectId) = seedProject()
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvent = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"events":[]}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `POST server analytics event rejects API key from another organization`() = testApplication {
+        val (_, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns 999
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvent = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody("""{"events":[{"name":"recording.started","user_id":"user"}]}""")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `POST server analytics event validates payload events`() = testApplication {
+        val (organizationId, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvent = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody("""{"events":[{"name":"","user_id":""}]}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    private fun seedProject(): Pair<Int, Long> {
+        return transaction {
+            val organizationId = Organizations.insert {
+                it[name] = "Server Analytics Org"
+                it[slug] = "server-analytics-org"
+            } get Organizations.id
+            val projectId = Projects.insert {
+                it[organization_id] = organizationId
+                it[name] = "Server Analytics Project"
+                it[slug] = "server-analytics-project"
+                it[framework] = "mobile"
+            } get Projects.id
+            organizationId to projectId
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
@@ -17,10 +17,13 @@
 package com.moneat.analytics
 
 import com.moneat.analytics.routes.analyticsServerIngestRoutes
+import com.moneat.analytics.services.AnalyticsIngestionWorker
+import com.moneat.config.RedisConfig
 import com.moneat.otlp.services.OtlpApiKeyService
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
 import com.moneat.testsupport.TestDatabaseHelper
+import io.lettuce.core.api.sync.RedisCommands
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -36,20 +39,29 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class AnalyticsServerIngestRoutesTest {
+    // ──── Companion ────
+
     companion object {
         private const val API_KEY = "motlp_valid_server_key"
+        private const val TOO_MANY_EVENTS_COUNT = 501
         private var db: Database? = null
     }
+
+    // ──── Mocks & Setup ────
 
     private val otlpApiKeyService = mockk<OtlpApiKeyService>()
 
@@ -64,6 +76,13 @@ class AnalyticsServerIngestRoutesTest {
         TransactionManager.defaultDatabase = db
         TestDatabaseHelper.resetSchema(Organizations, Projects)
     }
+
+    @AfterTest
+    fun teardown() {
+        unmockkObject(RedisConfig)
+    }
+
+    // ──── Tests ────
 
     @Test
     fun `POST server analytics event enqueues canonical product event`() = testApplication {
@@ -125,6 +144,66 @@ class AnalyticsServerIngestRoutesTest {
     }
 
     @Test
+    fun `POST server analytics event uses default Redis queue`() = testApplication {
+        val (organizationId, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
+        val mockRedis = mockk<RedisCommands<String, String>>()
+        mockkObject(RedisConfig)
+        every {
+            mockRedis.lpush(AnalyticsIngestionWorker.QUEUE_KEY, *anyVararg())
+        } returns 2L
+        every { RedisConfig.sync() } returns mockRedis
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(otlpApiKeyService = otlpApiKeyService)
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody(
+                """
+                {
+                  "events": [
+                    {"name": "recording.started", "user_id": "user-a"},
+                    {"name": "export.completed", "user_id": "user-a"}
+                  ]
+                }
+                """.trimIndent()
+            )
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status, response.bodyAsText())
+        verify(exactly = 1) {
+            mockRedis.lpush(AnalyticsIngestionWorker.QUEUE_KEY, *anyVararg())
+        }
+    }
+
+    @Test
+    fun `POST server analytics event rejects invalid project ID`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvents = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/not-a-number/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody("""{"events":[{"name":"recording.started","user_id":"user"}]}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
     fun `POST server analytics event requires bearer token`() = testApplication {
         val (_, projectId) = seedProject()
 
@@ -141,6 +220,30 @@ class AnalyticsServerIngestRoutesTest {
         val response = client.post("/v1/analytics/$projectId/events") {
             contentType(ContentType.Application.Json)
             setBody("""{"events":[]}""")
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `POST server analytics event rejects invalid API key`() = testApplication {
+        val (_, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns null
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvents = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody("""{"events":[{"name":"recording.started","user_id":"user"}]}""")
         }
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
@@ -171,6 +274,81 @@ class AnalyticsServerIngestRoutesTest {
     }
 
     @Test
+    fun `POST server analytics event rejects malformed payload`() = testApplication {
+        val (organizationId, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvents = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody("{not-json")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST server analytics event rejects empty event list`() = testApplication {
+        val (organizationId, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvents = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody("""{"events":[]}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST server analytics event rejects oversized event list`() = testApplication {
+        val (organizationId, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
+        val events = List(TOO_MANY_EVENTS_COUNT) { index ->
+            """{"name":"recording.started","user_id":"user-$index"}"""
+        }.joinToString(prefix = """{"events":[""", separator = ",", postfix = "]}")
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvents = { },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody(events)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
     fun `POST server analytics event validates payload events`() = testApplication {
         val (organizationId, projectId) = seedProject()
         every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
@@ -193,6 +371,32 @@ class AnalyticsServerIngestRoutesTest {
 
         assertEquals(HttpStatusCode.BadRequest, response.status)
     }
+
+    @Test
+    fun `POST server analytics event returns 500 when enqueue fails`() = testApplication {
+        val (organizationId, projectId) = seedProject()
+        every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
+
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                analyticsServerIngestRoutes(
+                    otlpApiKeyService = otlpApiKeyService,
+                    enqueueEvents = { throw RuntimeException("queue unavailable") },
+                )
+            }
+        }
+
+        val response = client.post("/v1/analytics/$projectId/events") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $API_KEY")
+            setBody("""{"events":[{"name":"recording.started","user_id":"user"}]}""")
+        }
+
+        assertEquals(HttpStatusCode.InternalServerError, response.status)
+    }
+
+    // ──── Helpers ────
 
     private fun seedProject(): Pair<Int, Long> {
         return transaction {

--- a/backend/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
@@ -70,13 +70,17 @@ class AnalyticsServerIngestRoutesTest {
         val (organizationId, projectId) = seedProject()
         every { otlpApiKeyService.validateKey(API_KEY) } returns organizationId
         val queuedMessages = mutableListOf<String>()
+        var enqueueCalls = 0
 
         application {
             install(ContentNegotiation) { json() }
             routing {
                 analyticsServerIngestRoutes(
                     otlpApiKeyService = otlpApiKeyService,
-                    enqueueEvent = queuedMessages::add,
+                    enqueueEvents = { messages ->
+                        enqueueCalls += 1
+                        queuedMessages.addAll(messages)
+                    },
                 )
             }
         }
@@ -87,20 +91,30 @@ class AnalyticsServerIngestRoutesTest {
             setBody(
                 """
                 {
-                  "events": [{
-                    "name": "recording.started",
-                    "user_id": "sha256-user",
-                    "session_id": "sess-abc",
-                    "props": {"platform": "ios", "app_version": "1.2.3"},
-                    "timestamp": 1716825600000
-                  }]
+                  "events": [
+                    {
+                      "name": "recording.started",
+                      "user_id": "sha256-user",
+                      "session_id": "sess-abc",
+                      "props": {"platform": "ios", "app_version": "1.2.3"},
+                      "timestamp": 1716825600000
+                    },
+                    {
+                      "name": "export.completed",
+                      "user_id": "sha256-user",
+                      "session_id": "sess-abc",
+                      "props": {"platform": "ios"},
+                      "timestamp": 1716825601000
+                    }
+                  ]
                 }
                 """.trimIndent()
             )
         }
 
         assertEquals(HttpStatusCode.Accepted, response.status, response.bodyAsText())
-        assertEquals(1, queuedMessages.size)
+        assertEquals(1, enqueueCalls)
+        assertEquals(2, queuedMessages.size)
         val message = queuedMessages.first()
         assertTrue(message.contains("\"projectId\":$projectId"))
         assertTrue(message.contains("\"sessionId\":\"sess-abc\""))
@@ -119,7 +133,7 @@ class AnalyticsServerIngestRoutesTest {
             routing {
                 analyticsServerIngestRoutes(
                     otlpApiKeyService = otlpApiKeyService,
-                    enqueueEvent = { },
+                    enqueueEvents = { },
                 )
             }
         }
@@ -142,7 +156,7 @@ class AnalyticsServerIngestRoutesTest {
             routing {
                 analyticsServerIngestRoutes(
                     otlpApiKeyService = otlpApiKeyService,
-                    enqueueEvent = { },
+                    enqueueEvents = { },
                 )
             }
         }
@@ -166,7 +180,7 @@ class AnalyticsServerIngestRoutesTest {
             routing {
                 analyticsServerIngestRoutes(
                     otlpApiKeyService = otlpApiKeyService,
-                    enqueueEvent = { },
+                    enqueueEvents = { },
                 )
             }
         }

--- a/backend/src/test/kotlin/com/moneat/routes/AnalyticsRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/AnalyticsRoutesTest.kt
@@ -24,6 +24,7 @@ import com.moneat.analytics.models.BreakdownRow
 import com.moneat.analytics.models.FunnelResponse
 import com.moneat.analytics.models.FunnelStep
 import com.moneat.analytics.models.RealtimeResponse
+import com.moneat.analytics.models.RetentionResponse
 import com.moneat.analytics.models.TimeseriesPoint
 import com.moneat.analytics.routes.analyticsRoutes
 import com.moneat.analytics.services.AnalyticsService
@@ -144,9 +145,16 @@ class AnalyticsRoutesTest {
 
     private val funnelResponse = FunnelResponse(
         steps = listOf(
-            FunnelStep(name = "/home", visitors = 100, dropoff = 0.0),
-            FunnelStep(name = "/signup", visitors = 40, dropoff = 60.0),
-        )
+            FunnelStep(name = "/home", visitors = 100, dropoff = 0.0, conversionRate = 100.0),
+            FunnelStep(name = "/signup", visitors = 40, dropoff = 60.0, conversionRate = 40.0),
+        ),
+        overallConversion = 40.0,
+    )
+
+    private val retentionResponse = RetentionResponse(
+        startEvent = "signup.completed",
+        returnEvent = "recording.started",
+        cohorts = emptyList(),
     )
 
     // ──── Auth ────
@@ -572,7 +580,7 @@ class AnalyticsRoutesTest {
         val userId = seedUser()
         stubAccess(userId)
         coEvery {
-            mockAnalyticsService.getEvents(PROJECT_ID, any(), any(), any(), any())
+            mockAnalyticsService.getEvents(PROJECT_ID, any(), any(), any(), any(), any(), any())
         } returns breakdownResponse
         application { installRoutes(this) }
         val r = client.get(authedGet("/events?period=30d")) {
@@ -603,7 +611,7 @@ class AnalyticsRoutesTest {
         val userId = seedUser()
         stubAccess(userId)
         coEvery {
-            mockAnalyticsService.getFunnel(PROJECT_ID, any(), any(), any())
+            mockAnalyticsService.getFunnel(PROJECT_ID, any(), any(), any(), any(), any())
         } returns funnelResponse
         application { installRoutes(this) }
         val r = client.get(authedGet("/funnel?period=30d&steps=/home&steps=/signup")) {
@@ -612,6 +620,76 @@ class AnalyticsRoutesTest {
         assertEquals(HttpStatusCode.OK, r.status)
         val body = r.bodyAsText()
         assertTrue(body.contains("\"steps\""))
+    }
+
+    @Test
+    fun `GET funnel forwards product grouping params`() = testApplication {
+        val userId = seedUser()
+        stubAccess(userId)
+        coEvery {
+            mockAnalyticsService.getFunnel(
+                PROJECT_ID,
+                any(),
+                any(),
+                any(),
+                "user_id",
+                "server"
+            )
+        } returns funnelResponse
+        application { installRoutes(this) }
+        val path = "/funnel?period=30d&steps[]=signup.completed" +
+            "&steps[]=recording.started&group_by=user_id&source=server"
+        val r = client.get(authedGet(path)) {
+            withAuth(token(userId))
+        }
+        assertEquals(HttpStatusCode.OK, r.status)
+        coVerify(exactly = 1) {
+            mockAnalyticsService.getFunnel(
+                PROJECT_ID,
+                any(),
+                any(),
+                listOf("signup.completed", "recording.started"),
+                "user_id",
+                "server"
+            )
+        }
+    }
+
+    @Test
+    fun `GET retention returns 200`() = testApplication {
+        val userId = seedUser()
+        stubAccess(userId)
+        coEvery {
+            mockAnalyticsService.getRetention(
+                PROJECT_ID,
+                any(),
+                any(),
+                "signup.completed",
+                "recording.started",
+                listOf(1, 7, 30),
+            )
+        } returns retentionResponse
+        application { installRoutes(this) }
+        val path = "/retention?period=30d&start_event=signup.completed" +
+            "&return_event=recording.started&periods[]=1&periods[]=7&periods[]=30"
+        val r = client.get(
+            authedGet(path)
+        ) {
+            withAuth(token(userId))
+        }
+        assertEquals(HttpStatusCode.OK, r.status)
+        assertTrue(r.bodyAsText().contains("\"cohorts\""))
+    }
+
+    @Test
+    fun `GET retention returns 400 without events`() = testApplication {
+        val userId = seedUser()
+        stubAccess(userId)
+        application { installRoutes(this) }
+        val r = client.get(authedGet("/retention?period=30d")) {
+            withAuth(token(userId))
+        }
+        assertEquals(HttpStatusCode.BadRequest, r.status)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/routes/AnalyticsRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/AnalyticsRoutesTest.kt
@@ -576,17 +576,20 @@ class AnalyticsRoutesTest {
     // ──── Events ────
 
     @Test
-    fun `GET events returns 200`() = testApplication {
+    fun `GET events forwards product grouping params`() = testApplication {
         val userId = seedUser()
         stubAccess(userId)
         coEvery {
-            mockAnalyticsService.getEvents(PROJECT_ID, any(), any(), any(), any(), any(), any())
+            mockAnalyticsService.getEvents(PROJECT_ID, any(), any(), any(), 25, "user_id", "server")
         } returns breakdownResponse
         application { installRoutes(this) }
-        val r = client.get(authedGet("/events?period=30d")) {
+        val r = client.get(authedGet("/events?period=30d&limit=25&group_by=user_id&source=server")) {
             withAuth(token(userId))
         }
         assertEquals(HttpStatusCode.OK, r.status)
+        coVerify(exactly = 1) {
+            mockAnalyticsService.getEvents(PROJECT_ID, any(), any(), any(), 25, "user_id", "server")
+        }
     }
 
     // ──── Realtime ────

--- a/backend/src/test/kotlin/com/moneat/services/AnalyticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/AnalyticsServiceTest.kt
@@ -371,17 +371,22 @@ class AnalyticsServiceTest {
             assertEquals("page_load", result.steps[0].name)
             assertEquals(90L, result.steps[0].visitors)
             assertEquals(0.0, result.steps[0].dropoff)
+            assertEquals(100.0, result.steps[0].conversionRate)
             // Step 2: level>=2 => 30+10 = 40
             assertEquals("signup_click", result.steps[1].name)
             assertEquals(40L, result.steps[1].visitors)
             // dropoff = (90-40)/90*100 ≈ 55.56
             assertTrue(result.steps[1].dropoff > 55.0)
             assertTrue(result.steps[1].dropoff < 56.0)
+            assertTrue(result.steps[1].conversionRate > 44.0)
+            assertTrue(result.steps[1].conversionRate < 45.0)
             // Step 3: level>=3 => 10
             assertEquals("signup_complete", result.steps[2].name)
             assertEquals(10L, result.steps[2].visitors)
             // dropoff = (40-10)/40*100 = 75.0
             assertEquals(75.0, result.steps[2].dropoff)
+            assertTrue(result.overallConversion > 11.0)
+            assertTrue(result.overallConversion < 12.0)
         }
     }
 
@@ -398,6 +403,62 @@ class AnalyticsServiceTest {
             assertEquals(2, result.steps.size)
             assertEquals(0L, result.steps[0].visitors)
             assertEquals(0L, result.steps[1].visitors)
+            assertEquals(0.0, result.overallConversion)
+        }
+    }
+
+    @Test
+    fun `getFunnel can group product events by user id and source`() = runBlocking {
+        val queries = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            queries.add(exchange.requestBodyText())
+            exchange.respond(200, "", contentType = CONTENT_TYPE_TEXT_PLAIN)
+        }) { _ ->
+
+            service.getFunnel(
+                projectId,
+                dateFrom,
+                dateTo,
+                listOf("signup.completed", "recording.started"),
+                groupBy = "user_id",
+                source = "server"
+            )
+
+            assertTrue(queries.any { it.contains("GROUP BY user_id") })
+            assertTrue(queries.any { it.contains("source = 'server'") })
+            assertTrue(queries.any { it.contains("user_id != ''") })
+        }
+    }
+
+    @Test
+    fun `getRetention returns weekly cohorts`() = runBlocking {
+        val queries = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            queries.add(exchange.requestBodyText())
+            exchange.respond(
+                200,
+                """{"cohort_week":"2026-01-05 00:00:00","users":10,"retained_1":4,"retained_7":6}""",
+                contentType = CONTENT_TYPE_TEXT_PLAIN
+            )
+        }) { _ ->
+
+            val result = service.getRetention(
+                projectId,
+                dateFrom,
+                dateTo,
+                "signup.completed",
+                "recording.started",
+                listOf(1, 7),
+            )
+
+            assertEquals("signup.completed", result.startEvent)
+            assertEquals("recording.started", result.returnEvent)
+            assertEquals(1, result.cohorts.size)
+            assertEquals(10L, result.cohorts[0].users)
+            assertEquals(40.0, result.cohorts[0].periods[0].retentionRate)
+            assertEquals(60.0, result.cohorts[0].periods[1].retentionRate)
+            assertTrue(queries.any { it.contains("e.source = 'server'") })
+            assertTrue(queries.any { it.contains("retained_7") })
         }
     }
 
@@ -435,6 +496,29 @@ class AnalyticsServiceTest {
             service.getEvents(projectId, dateFrom, dateTo, emptyList())
 
             assertTrue(queries.any { it.contains("event_name != 'pageview'") })
+        }
+    }
+
+    @Test
+    fun `getEvents can count product events by user id and source`() = runBlocking {
+        val queries = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            queries.add(exchange.requestBodyText())
+            exchange.respond(200, "", contentType = CONTENT_TYPE_TEXT_PLAIN)
+        }) { _ ->
+
+            service.getEvents(
+                projectId,
+                dateFrom,
+                dateTo,
+                emptyList(),
+                groupBy = "user_id",
+                source = "server",
+            )
+
+            assertTrue(queries.any { it.contains("uniq(e.user_id)") })
+            assertTrue(queries.any { it.contains("e.source = 'server'") })
+            assertTrue(queries.any { it.contains("e.user_id != ''") })
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/AnalyticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/AnalyticsServiceTest.kt
@@ -435,9 +435,17 @@ class AnalyticsServiceTest {
         val queries = mutableListOf<String>()
         withClickHouseMockServer({ exchange ->
             queries.add(exchange.requestBodyText())
+            val retentionRow = listOf(
+                """"cohort_week":"2026-01-05 00:00:00"""",
+                """"users":10""",
+                """"eligible_1":10""",
+                """"retained_1":4""",
+                """"eligible_7":8""",
+                """"retained_7":6""",
+            ).joinToString(prefix = "{", postfix = "}")
             exchange.respond(
                 200,
-                """{"cohort_week":"2026-01-05 00:00:00","users":10,"retained_1":4,"retained_7":6}""",
+                retentionRow,
                 contentType = CONTENT_TYPE_TEXT_PLAIN
             )
         }) { _ ->
@@ -455,9 +463,12 @@ class AnalyticsServiceTest {
             assertEquals("recording.started", result.returnEvent)
             assertEquals(1, result.cohorts.size)
             assertEquals(10L, result.cohorts[0].users)
+            assertEquals(10L, result.cohorts[0].periods[0].eligibleUsers)
             assertEquals(40.0, result.cohorts[0].periods[0].retentionRate)
-            assertEquals(60.0, result.cohorts[0].periods[1].retentionRate)
+            assertEquals(8L, result.cohorts[0].periods[1].eligibleUsers)
+            assertEquals(75.0, result.cohorts[0].periods[1].retentionRate)
             assertTrue(queries.any { it.contains("e.source = 'server'") })
+            assertTrue(queries.any { it.contains("eligible_7") })
             assertTrue(queries.any { it.contains("retained_7") })
         }
     }

--- a/dashboard/src/components/analytics/AnalyticsRetentionTable.tsx
+++ b/dashboard/src/components/analytics/AnalyticsRetentionTable.tsx
@@ -25,8 +25,13 @@ function retentionTone(rate: number): string {
   return 'bg-muted text-muted-foreground'
 }
 
+function retentionPeriods(data: AnalyticsRetentionResponse): number[] {
+  const periods = data.cohorts.flatMap(cohort => cohort.periods.map(period => period.days))
+  return [...new Set(periods)].sort((a, b) => a - b)
+}
+
 export function AnalyticsRetentionTable({data, isLoading}: AnalyticsRetentionTableProps) {
-  const periods = data?.cohorts[0]?.periods.map(period => period.days) ?? [1, 7, 14, 30]
+  const periods = data ? retentionPeriods(data) : [1, 7, 14, 30]
 
   if (isLoading) {
     return (
@@ -88,11 +93,12 @@ export function AnalyticsRetentionTable({data, isLoading}: AnalyticsRetentionTab
                 </TableCell>
                 {periods.map(period => {
                   const periodData = cohort.periods.find(item => item.days === period)
+                  const isEligible = periodData !== undefined && (periodData.eligibleUsers ?? cohort.users) > 0
                   const rate = periodData?.retentionRate ?? 0
                   return (
                     <TableCell key={period} className="p-1 text-right">
                       <span className={cn('inline-flex min-w-14 justify-end rounded px-2 py-1 text-xs', retentionTone(rate))}>
-                        {formatPercent(rate)}
+                        {isEligible ? formatPercent(rate) : '-'}
                       </span>
                     </TableCell>
                   )

--- a/dashboard/src/components/analytics/AnalyticsRetentionTable.tsx
+++ b/dashboard/src/components/analytics/AnalyticsRetentionTable.tsx
@@ -1,0 +1,107 @@
+import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
+import {cn} from '@/lib/utils'
+import {CalendarDays} from 'lucide-react'
+import type {AnalyticsRetentionResponse} from '@/lib/api'
+
+interface AnalyticsRetentionTableProps {
+  data?: AnalyticsRetentionResponse
+  isLoading?: boolean
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(1)}%`
+}
+
+function formatCohortWeek(value: string): string {
+  return value.split(' ')[0] || value
+}
+
+function retentionTone(rate: number): string {
+  if (rate >= 60) return 'bg-emerald-500/25 text-emerald-950 dark:text-emerald-100'
+  if (rate >= 40) return 'bg-cyan-500/20 text-cyan-950 dark:text-cyan-100'
+  if (rate >= 20) return 'bg-amber-500/20 text-amber-950 dark:text-amber-100'
+  if (rate > 0) return 'bg-rose-500/15 text-rose-950 dark:text-rose-100'
+  return 'bg-muted text-muted-foreground'
+}
+
+export function AnalyticsRetentionTable({data, isLoading}: AnalyticsRetentionTableProps) {
+  const periods = data?.cohorts[0]?.periods.map(period => period.days) ?? [1, 7, 14, 30]
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-xs font-medium flex items-center gap-1.5">
+            <CalendarDays className="h-3.5 w-3.5 text-cyan-500" />
+            Retention Cohorts
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[180px] w-full animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!data || data.cohorts.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-xs font-medium flex items-center gap-1.5">
+            <CalendarDays className="h-3.5 w-3.5 text-cyan-500" />
+            Retention Cohorts
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground text-center py-8">No retention data</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-1">
+        <CardTitle className="text-xs font-medium flex items-center gap-1.5">
+          <CalendarDays className="h-3.5 w-3.5 text-cyan-500" />
+          Retention Cohorts
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="text-xs">Cohort</TableHead>
+              <TableHead className="text-right text-xs">Users</TableHead>
+              {periods.map(period => (
+                <TableHead key={period} className="text-right text-xs">D{period}</TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.cohorts.map(cohort => (
+              <TableRow key={cohort.cohortWeek}>
+                <TableCell className="text-xs font-medium">{formatCohortWeek(cohort.cohortWeek)}</TableCell>
+                <TableCell className="text-right text-xs text-muted-foreground">
+                  {cohort.users.toLocaleString()}
+                </TableCell>
+                {periods.map(period => {
+                  const periodData = cohort.periods.find(item => item.days === period)
+                  const rate = periodData?.retentionRate ?? 0
+                  return (
+                    <TableCell key={period} className="p-1 text-right">
+                      <span className={cn('inline-flex min-w-14 justify-end rounded px-2 py-1 text-xs', retentionTone(rate))}>
+                        {formatPercent(rate)}
+                      </span>
+                    </TableCell>
+                  )
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/dashboard/src/lib/api/modules/__tests__/analytics.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/analytics.test.ts
@@ -347,9 +347,10 @@ describe('Analytics API', () => {
     it('fetches funnel data with steps', async () => {
       const mockFunnel = {
         steps: [
-          { name: '/home', visitors: 100, dropoff: 0 },
-          { name: '/signup', visitors: 60, dropoff: 40 },
+          { name: '/home', visitors: 100, dropoff: 0, conversionRate: 100 },
+          { name: '/signup', visitors: 60, dropoff: 40, conversionRate: 60 },
         ],
+        overallConversion: 60,
       }
 
       server.use(
@@ -363,6 +364,59 @@ describe('Analytics API', () => {
 
       const result = await api.getAnalyticsFunnel(1, ['/home', '/signup'])
       expect(result.steps).toHaveLength(2)
+    })
+
+    it('passes product funnel options', async () => {
+      server.use(
+        http.get(`${API_BASE}/v1/analytics/1/funnel`, ({ request }) => {
+          const url = new URL(request.url)
+          expect(url.searchParams.get('source')).toBe('server')
+          expect(url.searchParams.get('group_by')).toBe('user_id')
+          expect(url.searchParams.getAll('steps[]')).toEqual(['signup.completed', 'recording.started'])
+          return HttpResponse.json({ steps: [], overallConversion: 0 })
+        })
+      )
+
+      await api.getAnalyticsFunnel(
+        1,
+        ['signup.completed', 'recording.started'],
+        { period: '30d' },
+        { source: 'server', groupBy: 'user_id' }
+      )
+    })
+  })
+
+  // ──── getAnalyticsRetention ────
+
+  describe('getAnalyticsRetention', () => {
+    it('fetches retention cohorts', async () => {
+      server.use(
+        http.get(`${API_BASE}/v1/analytics/1/retention`, ({ request }) => {
+          const url = new URL(request.url)
+          expect(url.searchParams.get('start_event')).toBe('signup.completed')
+          expect(url.searchParams.get('return_event')).toBe('recording.started')
+          expect(url.searchParams.getAll('periods[]')).toEqual(['1', '7', '30'])
+          return HttpResponse.json({
+            startEvent: 'signup.completed',
+            returnEvent: 'recording.started',
+            cohorts: [
+              {
+                cohortWeek: '2026-01-05 00:00:00',
+                users: 10,
+                periods: [{ days: 7, retainedUsers: 4, retentionRate: 40 }],
+              },
+            ],
+          })
+        })
+      )
+
+      const result = await api.getAnalyticsRetention(1, {
+        period: '30d',
+        startEvent: 'signup.completed',
+        returnEvent: 'recording.started',
+        periods: [1, 7, 30],
+      })
+      expect(result.cohorts[0].periods[0].retentionRate).toBe(40)
     })
   })
 })

--- a/dashboard/src/lib/api/modules/analytics.ts
+++ b/dashboard/src/lib/api/modules/analytics.ts
@@ -22,14 +22,16 @@ import type {
   AnalyticsBreakdownItem,
   AnalyticsRealtimeResponse,
   AnalyticsFunnelResponse,
+  AnalyticsEventQueryOptions,
   AnalyticsOverviewApiResponse,
   AnalyticsTimeseriesApiPoint,
   AnalyticsBreakdownApiResponse,
   AnalyticsRealtimeApiResponse,
+  AnalyticsRetentionQuery,
+  AnalyticsRetentionResponse,
 } from '../types'
 
-function buildAnalyticsQuery(params?: AnalyticsParams): string {
-  const qs = new URLSearchParams()
+function appendAnalyticsParams(qs: URLSearchParams, params?: AnalyticsParams) {
   if (params?.period) qs.append('period', params.period)
   if (params?.from) qs.append('date_from', params.from)
   if (params?.to) qs.append('date_to', params.to)
@@ -41,8 +43,39 @@ function buildAnalyticsQuery(params?: AnalyticsParams): string {
       qs.append('filters[]', `${f.property}:${f.operator}:${f.value}`)
     }
   }
+}
+
+function appendEventQueryOptions(
+  qs: URLSearchParams,
+  options?: AnalyticsEventQueryOptions
+) {
+  if (options?.source) qs.append('source', options.source)
+  if (options?.groupBy) qs.append('group_by', options.groupBy)
+  if (options?.limit != null) qs.append('limit', String(options.limit))
+}
+
+function toQueryString(qs: URLSearchParams): string {
   const s = qs.toString()
   return s ? `?${s}` : ''
+}
+
+function buildAnalyticsQuery(
+  params?: AnalyticsParams,
+  options?: AnalyticsEventQueryOptions
+): string {
+  const qs = new URLSearchParams()
+  appendAnalyticsParams(qs, params)
+  appendEventQueryOptions(qs, options)
+  return toQueryString(qs)
+}
+
+function buildRetentionQuery(params: AnalyticsRetentionQuery): string {
+  const qs = new URLSearchParams()
+  appendAnalyticsParams(qs, params)
+  qs.append('start_event', params.startEvent)
+  qs.append('return_event', params.returnEvent)
+  params.periods?.forEach((period) => qs.append('periods[]', String(period)))
+  return toQueryString(qs)
 }
 
 function normalizeAnalyticsOverview(
@@ -173,9 +206,13 @@ export function analyticsMethods(core: ApiClientCore) {
       )
     },
 
-    getAnalyticsEvents: (projectId: number, params?: AnalyticsParams) =>
+    getAnalyticsEvents: (
+      projectId: number,
+      params?: AnalyticsParams,
+      options?: AnalyticsEventQueryOptions
+    ) =>
       fetchAnalyticsBreakdown(
-        `${base}/analytics/${projectId}/events${buildAnalyticsQuery(params)}`
+        `${base}/analytics/${projectId}/events${buildAnalyticsQuery(params, options)}`
       ),
 
     getAnalyticsRealtime: async (projectId: number) => {
@@ -190,9 +227,10 @@ export function analyticsMethods(core: ApiClientCore) {
     getAnalyticsFunnel: (
       projectId: number,
       steps: string[],
-      params?: AnalyticsParams
+      params?: AnalyticsParams,
+      options?: AnalyticsEventQueryOptions
     ) => {
-      const qs = buildAnalyticsQuery(params)
+      const qs = buildAnalyticsQuery(params, options)
       const sep = qs ? '&' : '?'
       const stepsParam = steps
         .map((s) => `steps[]=${encodeURIComponent(s)}`)
@@ -201,5 +239,13 @@ export function analyticsMethods(core: ApiClientCore) {
         `${base}/analytics/${projectId}/funnel${qs}${sep}${stepsParam}`
       )
     },
+
+    getAnalyticsRetention: (
+      projectId: number,
+      params: AnalyticsRetentionQuery
+    ) =>
+      core.request<AnalyticsRetentionResponse>(
+        `${base}/analytics/${projectId}/retention${buildRetentionQuery(params)}`
+      ),
   }
 }

--- a/dashboard/src/lib/api/types/analytics.ts
+++ b/dashboard/src/lib/api/types/analytics.ts
@@ -41,6 +41,21 @@ export interface AnalyticsParams {
   comparison?: AnalyticsComparison
 }
 
+export type AnalyticsEventSource = 'web' | 'server'
+export type AnalyticsGroupBy = 'session_id' | 'user_id'
+
+export interface AnalyticsEventQueryOptions {
+  source?: AnalyticsEventSource
+  groupBy?: AnalyticsGroupBy
+  limit?: number
+}
+
+export interface AnalyticsRetentionQuery extends AnalyticsParams {
+  startEvent: string
+  returnEvent: string
+  periods?: number[]
+}
+
 export interface AnalyticsOverview {
   uniqueVisitors: number
   totalPageviews: number
@@ -85,6 +100,24 @@ export interface AnalyticsFunnelStep {
 export interface AnalyticsFunnelResponse {
   steps: AnalyticsFunnelStep[]
   overallConversion: number
+}
+
+export interface AnalyticsRetentionPeriod {
+  days: number
+  retainedUsers: number
+  retentionRate: number
+}
+
+export interface AnalyticsRetentionCohort {
+  cohortWeek: string
+  users: number
+  periods: AnalyticsRetentionPeriod[]
+}
+
+export interface AnalyticsRetentionResponse {
+  startEvent: string
+  returnEvent: string
+  cohorts: AnalyticsRetentionCohort[]
 }
 
 export interface AnalyticsOverviewApiResponse {

--- a/dashboard/src/lib/api/types/analytics.ts
+++ b/dashboard/src/lib/api/types/analytics.ts
@@ -105,6 +105,7 @@ export interface AnalyticsFunnelResponse {
 export interface AnalyticsRetentionPeriod {
   days: number
   retainedUsers: number
+  eligibleUsers?: number
   retentionRate: number
 }
 

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -8,23 +8,34 @@ import {AnalyticsFilterBar} from '@/components/analytics/AnalyticsFilterBar'
 import {AnalyticsKpiCards, AnalyticsKpiCardsSkeleton} from '@/components/analytics/AnalyticsKpiCards'
 import {AnalyticsChart} from '@/components/analytics/AnalyticsChart'
 import {AnalyticsBreakdownTable} from '@/components/analytics/AnalyticsBreakdownTable'
+import {AnalyticsRetentionTable} from '@/components/analytics/AnalyticsRetentionTable'
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
 import {Card, CardContent} from '@/components/ui/card'
 import {CopyBlock} from '@/components/ui/copy-block'
+import {Button} from '@/components/ui/button'
+import {Input} from '@/components/ui/input'
 import {
-  ArrowRight, BarChart3, BookOpen, FileText, Globe, Laptop, LogIn, LogOut, MapPin, Megaphone, MousePointerClick, Share2,
+  ArrowRight, BarChart3, BookOpen, FileText, Globe, Laptop, LogIn, LogOut, MapPin, Megaphone,
+  MousePointerClick, Plus, Share2, Target, Trash2,
 } from 'lucide-react'
-import type {AnalyticsFilter, AnalyticsParams, AnalyticsBreakdownItem} from '@/lib/api'
+import type {AnalyticsFilter, AnalyticsParams, AnalyticsBreakdownItem, AnalyticsFunnelResponse} from '@/lib/api'
 
 export const Route = createFileRoute('/analytics/')({
   component: AnalyticsOverview,
 })
+
+const PRODUCT_PRESENCE_PARAMS: AnalyticsParams = {period: '12mo'}
+const DEFAULT_PRODUCT_FUNNEL_STEPS = ['signup.completed', 'recording.started', 'export.completed']
+const PRODUCT_RETENTION_PERIODS = [1, 7, 14, 30]
+const PRODUCT_RETENTION_START_EVENT = 'signup.completed'
+const PRODUCT_RETENTION_RETURN_EVENT = 'recording.started'
 
 function AnalyticsOverview() {
   const {selectedProjectId} = useProject()
   const {period, customFrom, customTo} = useAnalyticsParams()
   const [filters, setFilters] = useState<AnalyticsFilter[]>([])
   const [breakdownTab, setBreakdownTab] = useState('pages')
+  const [analyticsTab, setAnalyticsTab] = useState('web')
 
   const {data: projects} = useQuery({
     queryKey: ['projects'],
@@ -35,14 +46,19 @@ function AnalyticsOverview() {
   const projectId = (hasSelectedProject ? selectedProjectId : null) || projects?.[0]?.id
   const project = projects?.find(p => p.id === projectId)
 
-  const buildParams = useCallback((): AnalyticsParams => ({
+  const buildDateParams = useCallback((): AnalyticsParams => ({
     period,
     ...(period === 'custom' && customFrom && customTo ? {from: customFrom, to: customTo} : {}),
+  }), [period, customFrom, customTo])
+
+  const buildParams = useCallback((): AnalyticsParams => ({
+    ...buildDateParams(),
     filters: filters.length > 0 ? filters : undefined,
     comparison: 'previous_period',
-  }), [period, customFrom, customTo, filters])
+  }), [buildDateParams, filters])
 
   const params = buildParams()
+  const productParams = buildDateParams()
 
   const {data: overview, isLoading: overviewLoading} = useQuery({
     queryKey: ['analytics-overview', projectId, params],
@@ -116,6 +132,19 @@ function AnalyticsOverview() {
     enabled: !!projectId && breakdownTab === 'events',
   })
 
+  const {data: productEventsPreview, isLoading: productPresenceLoading} = useQuery({
+    queryKey: ['analytics-product-events-preview', projectId],
+    queryFn: () => api.getAnalyticsEvents(projectId!, PRODUCT_PRESENCE_PARAMS, {
+      source: 'server',
+      groupBy: 'user_id',
+      limit: 1,
+    }),
+    enabled: !!projectId,
+  })
+
+  const hasProductEvents = (productEventsPreview?.length ?? 0) > 0
+  const activeAnalyticsTab = hasProductEvents ? analyticsTab : 'web'
+
   const addFilterFromRow = (property: string) => (item: AnalyticsBreakdownItem) => {
     if (filters.some(f => f.property === property && f.value === item.name)) return
     setFilters([...filters, {property, operator: 'is', value: item.name}])
@@ -129,7 +158,12 @@ function AnalyticsOverview() {
     )
   }
 
-  if (!overviewLoading && (!overview || (overview.uniqueVisitors === 0 && overview.totalPageviews === 0))) {
+  if (
+    !overviewLoading &&
+    !productPresenceLoading &&
+    !hasProductEvents &&
+    (!overview || (overview.uniqueVisitors === 0 && overview.totalPageviews === 0))
+  ) {
     let scriptHost = 'https://your-moneat-instance.com'
     let publicKey = 'your-project-public-key'
     if (project?.dsn) {
@@ -191,155 +225,327 @@ function AnalyticsOverview() {
 
   return (
     <div className="space-y-2">
-      {/* Filters */}
-      <AnalyticsFilterBar filters={filters} onFiltersChange={setFilters} />
-
-      {/* KPI Cards */}
-      {overviewLoading ? (
-        <AnalyticsKpiCardsSkeleton />
-      ) : (
-        <AnalyticsKpiCards data={overview} isLoading={overviewLoading} />
-      )}
-
-      {/* Timeseries Chart */}
-      <AnalyticsChart data={timeseries} isLoading={timeseriesLoading} />
-
-      {/* Breakdown Tables with Tabs */}
-      <Tabs value={breakdownTab} onValueChange={setBreakdownTab}>
+      <Tabs value={activeAnalyticsTab} onValueChange={setAnalyticsTab}>
         <TabsList className="h-7">
-          <TabsTrigger value="pages" className="gap-1.5 text-xs">
-            <FileText className="h-3.5 w-3.5" /> Pages
+          <TabsTrigger value="web" className="gap-1.5 text-xs">
+            <Globe className="h-3.5 w-3.5" /> Web
           </TabsTrigger>
-          <TabsTrigger value="entry-pages" className="gap-1.5 text-xs">
-            <LogIn className="h-3.5 w-3.5" /> Entry Pages
-          </TabsTrigger>
-          <TabsTrigger value="exit-pages" className="gap-1.5 text-xs">
-            <LogOut className="h-3.5 w-3.5" /> Exit Pages
-          </TabsTrigger>
-          <TabsTrigger value="sources" className="gap-1.5 text-xs">
-            <Share2 className="h-3.5 w-3.5" /> Sources
-          </TabsTrigger>
-          <TabsTrigger value="locations" className="gap-1.5 text-xs">
-            <MapPin className="h-3.5 w-3.5" /> Locations
-          </TabsTrigger>
-          <TabsTrigger value="devices" className="gap-1.5 text-xs">
-            <Laptop className="h-3.5 w-3.5" /> Devices
-          </TabsTrigger>
-          <TabsTrigger value="utm" className="gap-1.5 text-xs">
-            <Megaphone className="h-3.5 w-3.5" /> UTM
-          </TabsTrigger>
-          <TabsTrigger value="events" className="gap-1.5 text-xs">
-            <MousePointerClick className="h-3.5 w-3.5" /> Events
-          </TabsTrigger>
+          {hasProductEvents && (
+            <TabsTrigger value="product" className="gap-1.5 text-xs">
+              <Target className="h-3.5 w-3.5" /> Product
+            </TabsTrigger>
+          )}
         </TabsList>
 
-        <TabsContent value="pages" className="mt-2">
-          <AnalyticsBreakdownTable
-            title="Top Pages"
-            icon={FileText}
-            iconColor="text-blue-500"
-            data={pages}
-            isLoading={pagesLoading}
-            showBounceRate
-            showDuration
-            onRowClick={addFilterFromRow('pathname')}
-          />
+        <TabsContent value="web" className="mt-2 space-y-2">
+          <AnalyticsFilterBar filters={filters} onFiltersChange={setFilters} />
+
+          {overviewLoading ? (
+            <AnalyticsKpiCardsSkeleton />
+          ) : (
+            <AnalyticsKpiCards data={overview} isLoading={overviewLoading} />
+          )}
+
+          <AnalyticsChart data={timeseries} isLoading={timeseriesLoading} />
+
+          <Tabs value={breakdownTab} onValueChange={setBreakdownTab}>
+            <TabsList className="h-7">
+              <TabsTrigger value="pages" className="gap-1.5 text-xs">
+                <FileText className="h-3.5 w-3.5" /> Pages
+              </TabsTrigger>
+              <TabsTrigger value="entry-pages" className="gap-1.5 text-xs">
+                <LogIn className="h-3.5 w-3.5" /> Entry Pages
+              </TabsTrigger>
+              <TabsTrigger value="exit-pages" className="gap-1.5 text-xs">
+                <LogOut className="h-3.5 w-3.5" /> Exit Pages
+              </TabsTrigger>
+              <TabsTrigger value="sources" className="gap-1.5 text-xs">
+                <Share2 className="h-3.5 w-3.5" /> Sources
+              </TabsTrigger>
+              <TabsTrigger value="locations" className="gap-1.5 text-xs">
+                <MapPin className="h-3.5 w-3.5" /> Locations
+              </TabsTrigger>
+              <TabsTrigger value="devices" className="gap-1.5 text-xs">
+                <Laptop className="h-3.5 w-3.5" /> Devices
+              </TabsTrigger>
+              <TabsTrigger value="utm" className="gap-1.5 text-xs">
+                <Megaphone className="h-3.5 w-3.5" /> UTM
+              </TabsTrigger>
+              <TabsTrigger value="events" className="gap-1.5 text-xs">
+                <MousePointerClick className="h-3.5 w-3.5" /> Events
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="pages" className="mt-2">
+              <AnalyticsBreakdownTable
+                title="Top Pages"
+                icon={FileText}
+                iconColor="text-blue-500"
+                data={pages}
+                isLoading={pagesLoading}
+                showBounceRate
+                showDuration
+                onRowClick={addFilterFromRow('pathname')}
+              />
+            </TabsContent>
+
+            <TabsContent value="entry-pages" className="mt-2">
+              <AnalyticsBreakdownTable
+                title="Entry Pages"
+                icon={LogIn}
+                iconColor="text-emerald-500"
+                data={entryPages}
+                isLoading={entryPagesLoading}
+                showBounceRate
+                onRowClick={addFilterFromRow('entry_page')}
+              />
+            </TabsContent>
+
+            <TabsContent value="exit-pages" className="mt-2">
+              <AnalyticsBreakdownTable
+                title="Exit Pages"
+                icon={LogOut}
+                iconColor="text-rose-500"
+                data={exitPages}
+                isLoading={exitPagesLoading}
+                onRowClick={addFilterFromRow('exit_page')}
+              />
+            </TabsContent>
+
+            <TabsContent value="sources" className="mt-2">
+              <AnalyticsBreakdownTable
+                title="Top Sources"
+                icon={Share2}
+                iconColor="text-violet-500"
+                data={sources}
+                isLoading={sourcesLoading}
+                onRowClick={addFilterFromRow('referrer_source')}
+              />
+            </TabsContent>
+
+            <TabsContent value="locations" className="mt-2">
+              <AnalyticsBreakdownTable
+                title="Countries"
+                icon={MapPin}
+                iconColor="text-amber-500"
+                data={locations}
+                isLoading={locationsLoading}
+                onRowClick={addFilterFromRow('country_code')}
+              />
+            </TabsContent>
+
+            <TabsContent value="devices" className="mt-2">
+              <div className="grid gap-2 lg:grid-cols-3">
+                <AnalyticsBreakdownTable
+                  title="Browsers"
+                  icon={Globe}
+                  iconColor="text-blue-500"
+                  data={browsers}
+                  isLoading={browsersLoading}
+                  onRowClick={addFilterFromRow('browser')}
+                />
+                <AnalyticsBreakdownTable
+                  title="Operating Systems"
+                  icon={Laptop}
+                  iconColor="text-emerald-500"
+                  data={operatingSystems}
+                  isLoading={osLoading}
+                  onRowClick={addFilterFromRow('os')}
+                />
+                <AnalyticsBreakdownTable
+                  title="Device Types"
+                  icon={Laptop}
+                  iconColor="text-violet-500"
+                  data={deviceTypes}
+                  isLoading={deviceTypesLoading}
+                  onRowClick={addFilterFromRow('device_type')}
+                />
+              </div>
+            </TabsContent>
+
+            <TabsContent value="utm" className="mt-2">
+              <AnalyticsBreakdownTable
+                title="UTM Sources"
+                icon={Megaphone}
+                iconColor="text-cyan-500"
+                data={utmSources}
+                isLoading={utmSourcesLoading}
+              />
+            </TabsContent>
+
+            <TabsContent value="events" className="mt-2">
+              <AnalyticsBreakdownTable
+                title="Custom Events"
+                icon={MousePointerClick}
+                iconColor="text-orange-500"
+                data={customEvents}
+                isLoading={customEventsLoading}
+              />
+            </TabsContent>
+          </Tabs>
         </TabsContent>
 
-        <TabsContent value="entry-pages" className="mt-2">
-          <AnalyticsBreakdownTable
-            title="Entry Pages"
-            icon={LogIn}
-            iconColor="text-emerald-500"
-            data={entryPages}
-            isLoading={entryPagesLoading}
-            showBounceRate
-            onRowClick={addFilterFromRow('entry_page')}
-          />
-        </TabsContent>
-
-        <TabsContent value="exit-pages" className="mt-2">
-          <AnalyticsBreakdownTable
-            title="Exit Pages"
-            icon={LogOut}
-            iconColor="text-rose-500"
-            data={exitPages}
-            isLoading={exitPagesLoading}
-            onRowClick={addFilterFromRow('exit_page')}
-          />
-        </TabsContent>
-
-        <TabsContent value="sources" className="mt-2">
-          <AnalyticsBreakdownTable
-            title="Top Sources"
-            icon={Share2}
-            iconColor="text-violet-500"
-            data={sources}
-            isLoading={sourcesLoading}
-            onRowClick={addFilterFromRow('referrer_source')}
-          />
-        </TabsContent>
-
-        <TabsContent value="locations" className="mt-2">
-          <AnalyticsBreakdownTable
-            title="Countries"
-            icon={MapPin}
-            iconColor="text-amber-500"
-            data={locations}
-            isLoading={locationsLoading}
-            onRowClick={addFilterFromRow('country_code')}
-          />
-        </TabsContent>
-
-        <TabsContent value="devices" className="mt-2">
-          <div className="grid gap-2 lg:grid-cols-3">
-            <AnalyticsBreakdownTable
-              title="Browsers"
-              icon={Globe}
-              iconColor="text-blue-500"
-              data={browsers}
-              isLoading={browsersLoading}
-              onRowClick={addFilterFromRow('browser')}
-            />
-            <AnalyticsBreakdownTable
-              title="Operating Systems"
-              icon={Laptop}
-              iconColor="text-emerald-500"
-              data={operatingSystems}
-              isLoading={osLoading}
-              onRowClick={addFilterFromRow('os')}
-            />
-            <AnalyticsBreakdownTable
-              title="Device Types"
-              icon={Laptop}
-              iconColor="text-violet-500"
-              data={deviceTypes}
-              isLoading={deviceTypesLoading}
-              onRowClick={addFilterFromRow('device_type')}
-            />
-          </div>
-        </TabsContent>
-
-        <TabsContent value="utm" className="mt-2">
-          <AnalyticsBreakdownTable
-            title="UTM Sources"
-            icon={Megaphone}
-            iconColor="text-cyan-500"
-            data={utmSources}
-            isLoading={utmSourcesLoading}
-          />
-        </TabsContent>
-
-        <TabsContent value="events" className="mt-2">
-          <AnalyticsBreakdownTable
-            title="Custom Events"
-            icon={MousePointerClick}
-            iconColor="text-orange-500"
-            data={customEvents}
-            isLoading={customEventsLoading}
-          />
-        </TabsContent>
+        {hasProductEvents && (
+          <TabsContent value="product" className="mt-2">
+            <ProductAnalyticsTab projectId={projectId} params={productParams} />
+          </TabsContent>
+        )}
       </Tabs>
+    </div>
+  )
+}
+
+function ProductAnalyticsTab({projectId, params}: {projectId: number; params: AnalyticsParams}) {
+  const {data: productEvents, isLoading: productEventsLoading} = useQuery({
+    queryKey: ['analytics-product-events', projectId, params],
+    queryFn: () => api.getAnalyticsEvents(projectId, params, {
+      source: 'server',
+      groupBy: 'user_id',
+    }),
+  })
+
+  const {data: retention, isLoading: retentionLoading} = useQuery({
+    queryKey: ['analytics-product-retention', projectId, params],
+    queryFn: () => api.getAnalyticsRetention(projectId, {
+      ...params,
+      startEvent: PRODUCT_RETENTION_START_EVENT,
+      returnEvent: PRODUCT_RETENTION_RETURN_EVENT,
+      periods: PRODUCT_RETENTION_PERIODS,
+    }),
+  })
+
+  return (
+    <div className="space-y-2">
+      <div className="grid gap-2 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <AnalyticsBreakdownTable
+          title="Product Events"
+          icon={MousePointerClick}
+          iconColor="text-orange-500"
+          data={productEvents}
+          isLoading={productEventsLoading}
+        />
+        <ProductFunnelPanel projectId={projectId} params={params} />
+      </div>
+      <AnalyticsRetentionTable data={retention} isLoading={retentionLoading} />
+    </div>
+  )
+}
+
+function ProductFunnelPanel({projectId, params}: {projectId: number; params: AnalyticsParams}) {
+  const [steps, setSteps] = useState(DEFAULT_PRODUCT_FUNNEL_STEPS)
+  const validSteps = steps.map(step => step.trim()).filter(Boolean)
+  const {data: funnel, isLoading} = useQuery({
+    queryKey: ['analytics-product-funnel', projectId, params, validSteps],
+    queryFn: () => api.getAnalyticsFunnel(projectId, validSteps, params, {
+      source: 'server',
+      groupBy: 'user_id',
+    }),
+    enabled: validSteps.length >= 2,
+  })
+
+  const updateStep = (index: number, value: string) => {
+    setSteps(current => current.map((step, stepIndex) => (stepIndex === index ? value : step)))
+  }
+
+  const removeStep = (index: number) => {
+    setSteps(current => current.filter((_, stepIndex) => stepIndex !== index))
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-3 space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5 text-xs font-medium">
+            <Target className="h-3.5 w-3.5 text-emerald-500" />
+            Activation Funnel
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setSteps(current => [...current, ''])}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Step
+          </Button>
+        </div>
+
+        <div className="space-y-1.5">
+          {steps.map((step, index) => (
+            <div key={index} className="flex items-center gap-1.5">
+              <Input
+                value={step}
+                onChange={(event) => updateStep(index, event.target.value)}
+                className="h-7 text-xs"
+                placeholder="event.name"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                aria-label="Remove funnel step"
+                disabled={steps.length <= 2}
+                onClick={() => removeStep(index)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <ProductFunnelResults data={funnel} isLoading={isLoading} hasEnoughSteps={validSteps.length >= 2} />
+      </CardContent>
+    </Card>
+  )
+}
+
+function ProductFunnelResults({
+  data,
+  isLoading,
+  hasEnoughSteps,
+}: {
+  data?: AnalyticsFunnelResponse
+  isLoading: boolean
+  hasEnoughSteps: boolean
+}) {
+  if (!hasEnoughSteps) {
+    return <p className="text-xs text-muted-foreground text-center py-4">Add at least two steps</p>
+  }
+
+  if (isLoading) {
+    return <div className="h-[140px] w-full animate-pulse rounded bg-muted" />
+  }
+
+  if (!data || data.steps.length === 0) {
+    return <p className="text-xs text-muted-foreground text-center py-4">No funnel data</p>
+  }
+
+  const maxVisitors = Math.max(data.steps[0]?.visitors ?? 0, 1)
+
+  return (
+    <div className="space-y-2">
+      <div className="text-xs text-muted-foreground">
+        Overall conversion <span className="font-medium text-foreground">{data.overallConversion.toFixed(1)}%</span>
+      </div>
+      <div className="space-y-1.5">
+        {data.steps.map(step => (
+          <div key={step.name} className="space-y-1">
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="truncate font-medium">{step.name}</span>
+              <span className="text-muted-foreground">
+                {step.visitors.toLocaleString()} / {step.conversionRate.toFixed(1)}%
+              </span>
+            </div>
+            <div className="h-2 rounded bg-muted">
+              <div
+                className="h-2 rounded bg-emerald-500"
+                style={{width: `${Math.max((step.visitors / maxVisitors) * 100, step.visitors > 0 ? 2 : 0)}%`}}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- route server-side product events into `analytics_events` with `user_id` and `source`
- add retention cohorts plus user-level product funnel metrics
- add the analytics Product tab with event breakdown, activation funnel, and retention heatmap

## Validation
- `cd backend && ./gradlew compileKotlin`
- `cd backend && ./gradlew :test --tests com.moneat.services.AnalyticsServiceTest --tests com.moneat.routes.AnalyticsRoutesTest --tests com.moneat.analytics.AnalyticsIngestionWorkerTest --tests com.moneat.analytics.AnalyticsServerIngestRoutesTest`
- `cd dashboard && npm run lint`
- `cd dashboard && npm run typecheck`
- `cd dashboard && npm run test -- src/lib/api/modules/__tests__/analytics.test.ts src/lib/api/modules/__tests__/analytics-branches.test.ts`
- `cd backend && ./gradlew detekt test jacocoTestReport testClasses integrationTestClasses --no-daemon`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secure server-side event ingestion (API-key protected) with batching and validation.
  * Retention analytics: cohort tables with period-level retention rates.
  * Enhanced funnel analysis: configurable grouping and event-source filters plus overall conversion metrics.
  * Product analytics dashboard: retention table component and configurable activation funnel; UI now toggles between Web and Product analytics when product events exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->