### PR TITLE
feat: add rich workflow notification previews

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -68,6 +68,12 @@ private val logger = KotlinLogging.logger {}
 private const val ALERT_CHANNEL_EMAIL_REFERENCE = "alert.channels.email"
 private const val ALERT_CHANNEL_SLACK_REFERENCE = "alert.channels.slack"
 private const val ALERT_CHANNEL_DISCORD_REFERENCE = "alert.channels.discord"
+private const val ALERT_DISPLAY_TITLE_REFERENCE = "alert.display_title"
+private const val ALERT_DASHBOARD_TITLE_REFERENCE = "alert.dashboard.title"
+private const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
+private const val ALERT_CONDITION_REFERENCE = "alert.condition"
+private const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
+private const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
 
 private enum class DashboardAlertLevel(val label: String) {
     WARNING("Warning"),
@@ -383,9 +389,14 @@ class DashboardAlertService(
             DashboardAlertLevel.WARNING -> AlertSeverity.LOW
             DashboardAlertLevel.ERROR -> AlertSeverity.HIGH
         }
+        val formattedValue = "%.2f".format(currentValue)
+        val recoveredThreshold = when (previousLevel) {
+            DashboardAlertLevel.WARNING -> alert.warningThreshold ?: alert.threshold
+            DashboardAlertLevel.ERROR -> alert.threshold
+        }
         val title = "Dashboard Alert Resolved: ${alert.name}"
         val description = "${alert.widgetTitle} on ${alert.dashboardTitle} recovered. " +
-            "Current value: ${"%.2f".format(currentValue)}"
+            "Current value: $formattedValue"
         val moneatUrl = "$baseUrl/dashboards/${alert.dashboardId}"
         val event =
             AlertLifecycleEvent(
@@ -396,7 +407,9 @@ class DashboardAlertService(
                 source = AlertSource.DASHBOARD_ALERT,
                 deduplicationKey = "moneat-dashboard-alert-${alert.alertId}",
                 organizationId = alert.orgId.toInt(),
-                metadata = alert.notificationChannels.workflowScopeMetadata(),
+                metadata = alert.notificationChannels.workflowScopeMetadata(
+                    alert.workflowScopeMetadata(formattedValue, "%.2f".format(recoveredThreshold))
+                ),
                 moneatUrl = moneatUrl
             )
         suspendRunCatching {
@@ -700,7 +713,9 @@ class DashboardAlertService(
                 source = AlertSource.DASHBOARD_ALERT,
                 deduplicationKey = "moneat-dashboard-alert-${alert.alertId}",
                 organizationId = orgId,
-                metadata = alert.notificationChannels.workflowScopeMetadata(),
+                metadata = alert.notificationChannels.workflowScopeMetadata(
+                    alert.workflowScopeMetadata(formattedValue, formattedThreshold)
+                ),
                 moneatUrl = "$baseUrl/dashboards/${alert.dashboardId}"
             )
 
@@ -740,11 +755,26 @@ class DashboardAlertService(
         }
     }
 
-    private fun NotificationChannels.workflowScopeMetadata(): Map<String, JsonElement> =
+    private fun NotificationChannels.workflowScopeMetadata(
+        alertMetadata: Map<String, JsonElement>
+    ): Map<String, JsonElement> =
         mapOf(
             ALERT_CHANNEL_EMAIL_REFERENCE to JsonPrimitive(email),
             ALERT_CHANNEL_SLACK_REFERENCE to JsonPrimitive(slack),
             ALERT_CHANNEL_DISCORD_REFERENCE to JsonPrimitive(discord)
+        ) + alertMetadata
+
+    private fun AlertContext.workflowScopeMetadata(
+        formattedCurrentValue: String,
+        formattedThreshold: String
+    ): Map<String, JsonElement> =
+        mapOf(
+            ALERT_DISPLAY_TITLE_REFERENCE to JsonPrimitive(name),
+            ALERT_DASHBOARD_TITLE_REFERENCE to JsonPrimitive(dashboardTitle),
+            ALERT_WIDGET_TITLE_REFERENCE to JsonPrimitive(widgetTitle),
+            ALERT_CONDITION_REFERENCE to JsonPrimitive(condition),
+            ALERT_THRESHOLD_REFERENCE to JsonPrimitive(formattedThreshold),
+            ALERT_CURRENT_VALUE_REFERENCE to JsonPrimitive(formattedCurrentValue)
         )
 
     private fun toResponse(row: ResultRow): DashboardAlertResponse {

--- a/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
@@ -556,7 +556,7 @@ class DiscordService(
                 channelId = config.channelId,
                 embed = embed,
                 fallbackText = "$title: $message"
-        )
+            )
         return success
     }
 
@@ -582,7 +582,7 @@ class DiscordService(
                 channelId = config.channelId,
                 embed = embed,
                 fallbackText = preview.fallbackText
-        )
+            )
         return success
     }
 

--- a/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
@@ -18,6 +18,7 @@ package com.moneat.notifications.services
 
 import com.moneat.config.EnvConfig
 import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.workflows.models.WorkflowStepPreview
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
@@ -555,9 +556,71 @@ class DiscordService(
                 channelId = config.channelId,
                 embed = embed,
                 fallbackText = "$title: $message"
-            )
+        )
         return success
     }
+
+    suspend fun sendWorkflowAlertMessage(
+        organizationId: Int,
+        preview: WorkflowStepPreview,
+        skipIfUnconfigured: Boolean = false
+    ): Boolean {
+        val config = getDiscordConfig(organizationId) ?: return skipIfUnconfigured
+        val embed =
+            DiscordEmbed(
+                title = discordWorkflowAlertHeaderText(preview),
+                description = discordWorkflowAlertDescription(preview),
+                color = parseHexColor(preview.color),
+                fields = preview.fields.map { field ->
+                    DiscordField(field.label, field.value, inline = true)
+                },
+                footer = DiscordFooter("Added by Moneat"),
+                timestamp = Clock.System.now().toString()
+            )
+        val (success, _) =
+            sendMessage(
+                channelId = config.channelId,
+                embed = embed,
+                fallbackText = preview.fallbackText
+        )
+        return success
+    }
+
+    private fun discordWorkflowAlertDescription(preview: WorkflowStepPreview): String =
+        buildString {
+            if (preview.body.isNotBlank()) {
+                appendLine(preview.body)
+            }
+            if (!preview.ctaUrl.isNullOrBlank()) {
+                appendLine()
+                append("[")
+                append(preview.ctaLabel ?: "View")
+                append("](")
+                append(preview.ctaUrl)
+                append(")")
+            }
+        }.trim()
+
+    private fun discordWorkflowAlertHeaderText(preview: WorkflowStepPreview): String {
+        val emoji =
+            when {
+                discordWorkflowAlertFieldValue(preview, "Status").equals("Resolved", ignoreCase = true) -> "✅"
+                parseHexColor(preview.color) == DISCORD_COLOR_RED -> "🔴"
+                else -> "⚠️"
+            }
+        return listOf(emoji, preview.title)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+    }
+
+    private fun discordWorkflowAlertFieldValue(
+        preview: WorkflowStepPreview,
+        label: String
+    ): String =
+        preview.fields
+            .firstOrNull { it.label.equals(label, ignoreCase = true) }
+            ?.value
+            .orEmpty()
 
     suspend fun testConnection(
         organizationId: Int,
@@ -626,3 +689,10 @@ class DiscordService(
         }
     }
 }
+
+private fun parseHexColor(color: String): Int? {
+    val normalized = color.removePrefix("#")
+    return normalized.toIntOrNull(HEX_RADIX)
+}
+
+private const val HEX_RADIX = 16

--- a/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/DiscordService.kt
@@ -604,7 +604,7 @@ class DiscordService(
     private fun discordWorkflowAlertHeaderText(preview: WorkflowStepPreview): String {
         val emoji =
             when {
-                discordWorkflowAlertFieldValue(preview, "Status").equals("Resolved", ignoreCase = true) -> "✅"
+                discordWorkflowAlertFieldValue(preview, "Status") == "Resolved" -> "✅"
                 parseHexColor(preview.color) == DISCORD_COLOR_RED -> "🔴"
                 else -> "⚠️"
             }

--- a/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
@@ -656,7 +656,7 @@ class EmailService {
                     <p><strong>Status:</strong> $safeLastSeenText</p>
                     <p>The monitoring agent has stopped reporting metrics. Please check if the host is online and the agent is running.</p>
                     <div style="margin: 30px 0;">
-                        <a href="$safeHostUrl" style="display: inline-block; background-color: #dc2626; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View Host</a>
+                        <a href="$safeHostUrl" style="display: inline-block; background-color: #dc2626; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View</a>
                     </div>
                     <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
                     <p style="color: #999; font-size: 12px;">Moneat Server Monitoring</p>
@@ -674,7 +674,7 @@ class EmailService {
             
             The monitoring agent has stopped reporting metrics. Please check if the host is online and the agent is running.
             
-            View host: $hostUrl
+            View: $hostUrl
             
             ---
             Moneat Server Monitoring
@@ -713,7 +713,7 @@ class EmailService {
                     <p><strong>Status:</strong> ${status.uppercase()}</p>
                     ${if (message.isNotBlank()) "<p><strong>Message:</strong> $message</p>" else ""}
                     <div style="margin: 30px 0;">
-                        <a href="$monitorUrl" style="display: inline-block; background-color: $buttonColor; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View Monitor</a>
+                        <a href="$monitorUrl" style="display: inline-block; background-color: $buttonColor; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View</a>
                     </div>
                     <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
                     <p style="color: #999; font-size: 12px;">Moneat Uptime Monitoring</p>
@@ -728,7 +728,7 @@ class EmailService {
             Status: ${status.uppercase()}
             ${if (message.isNotBlank()) "Message: $message" else ""}
             
-            View monitor: $monitorUrl
+            View: $monitorUrl
             """.trimIndent()
 
         sendEmail(to, subject, htmlBody, textBody, "uptime_alert")
@@ -756,7 +756,7 @@ class EmailService {
                     <p><strong>Host:</strong> $safeHostName</p>
                     <p>The host is now reporting metrics again.</p>
                     <div style="margin: 30px 0;">
-                        <a href="$safeHostUrl" style="display: inline-block; background-color: #16a34a; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View Host</a>
+                        <a href="$safeHostUrl" style="display: inline-block; background-color: #16a34a; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View</a>
                     </div>
                     <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
                     <p style="color: #999; font-size: 12px;">Moneat Server Monitoring</p>
@@ -773,7 +773,7 @@ class EmailService {
             
             The host is now reporting metrics again.
             
-            View host: $hostUrl
+            View: $hostUrl
             
             ---
             Moneat Server Monitoring

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -50,6 +50,9 @@ import java.util.Locale
 import java.util.UUID
 
 private const val SLACK_CHANNEL_FETCH_LIMIT = 200
+private const val SLACK_COLOR_RED = "#E01E5A"
+private const val SLACK_COLOR_GREEN = "#2EB67D"
+private const val SLACK_COLOR_YELLOW = "#ECB22E"
 
 internal fun encodeSlackIssueIdPathSegment(value: String): String =
     URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
@@ -312,7 +315,7 @@ class SlackService {
         val attachments =
             listOf(
                 SlackAttachment(
-                    color = "#ECB22E", // Warning yellow
+                    color = SLACK_COLOR_YELLOW,
                     blocks = attachmentBlocks,
                     fallback = "⚠️ Host Alert: $hostName"
                 )
@@ -425,8 +428,8 @@ class SlackService {
     private fun workflowAlertHeaderText(preview: WorkflowStepPreview): String {
         val emoji =
             when {
-                workflowAlertFieldValue(preview, "Status").equals("Resolved", ignoreCase = true) -> "✅"
-                preview.color.equals("#E01E5A", ignoreCase = true) -> "🔴"
+                workflowAlertFieldValue(preview, "Status") == "Resolved" -> "✅"
+                preview.color == SLACK_COLOR_RED -> "🔴"
                 else -> "⚠️"
             }
         return listOf(emoji, preview.title)
@@ -491,7 +494,7 @@ class SlackService {
         val attachments =
             listOf(
                 SlackAttachment(
-                    color = "#E01E5A", // Error red
+                    color = SLACK_COLOR_RED,
                     blocks = attachmentBlocks,
                     fallback = "🔴 Host Down: $hostName"
                 )
@@ -555,7 +558,7 @@ class SlackService {
         val attachments =
             listOf(
                 SlackAttachment(
-                    color = "#2EB67D", // Success green
+                    color = SLACK_COLOR_GREEN,
                     blocks = attachmentBlocks,
                     fallback = "🟢 Host Recovered: $hostName"
                 )
@@ -586,7 +589,7 @@ class SlackService {
         val isDown = newStatus.equals("down", ignoreCase = true)
         val emoji = if (isDown) "🔴" else "🟢"
         val headerText = if (isDown) "Monitor Down" else "Monitor Recovered"
-        val color = if (isDown) "#E01E5A" else "#2EB67D"
+        val color = if (isDown) SLACK_COLOR_RED else SLACK_COLOR_GREEN
 
         val mainBlocks =
             listOf(
@@ -661,10 +664,10 @@ class SlackService {
 
         val emoji = if (severity == "CRITICAL" || severity == "HIGH") "🔴" else "⚠️"
         val color = when (severity) {
-            "CRITICAL" -> "#E01E5A"
-            "HIGH" -> "#E01E5A"
-            "MEDIUM" -> "#ECB22E"
-            else -> "#ECB22E"
+            "CRITICAL" -> SLACK_COLOR_RED
+            "HIGH" -> SLACK_COLOR_RED
+            "MEDIUM" -> SLACK_COLOR_YELLOW
+            else -> SLACK_COLOR_YELLOW
         }
 
         val mainBlocks = listOf(
@@ -741,16 +744,10 @@ class SlackService {
 
         val color =
             when (levelLower) {
-                "error" -> "#E01E5A"
-
-                // Slack red
-                "warning" -> "#ECB22E"
-
-                // Slack warning yellow
-                "info" -> "#2EB67D"
-
-                // Slack green
-                else -> "#ECB22E"
+                "error" -> SLACK_COLOR_RED
+                "warning" -> SLACK_COLOR_YELLOW
+                "info" -> SLACK_COLOR_GREEN
+                else -> SLACK_COLOR_YELLOW
             }
 
         // Header block

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -351,7 +351,7 @@ class SlackService {
                 channel = config.channelId,
                 blocks = blocks,
                 fallbackText = message
-        )
+            )
         return success
     }
 

--- a/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/SlackService.kt
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets
 
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OrganizationIntegrations
+import com.moneat.workflows.models.WorkflowStepPreview
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
@@ -301,7 +302,7 @@ class SlackService {
                     listOf(
                         SlackElement(
                             type = "button",
-                            text = SlackText(type = "plain_text", text = "View Host"),
+                            text = SlackText(type = "plain_text", text = "View"),
                             url = "$baseUrl/monitoring/hosts/$hostId"
                         )
                     )
@@ -350,9 +351,97 @@ class SlackService {
                 channel = config.channelId,
                 blocks = blocks,
                 fallbackText = message
+        )
+        return success
+    }
+
+    suspend fun sendWorkflowAlertMessage(
+        organizationId: Int,
+        preview: WorkflowStepPreview,
+        skipIfUnconfigured: Boolean = false
+    ): Boolean {
+        val config = getSlackConfig(organizationId) ?: return skipIfUnconfigured
+        val blocks =
+            listOf(
+                SlackBlock(
+                    type = "header",
+                    text = SlackText(type = "plain_text", text = workflowAlertHeaderText(preview), emoji = true)
+                )
+            )
+        val attachmentBlocks = buildWorkflowAlertSlackBlocks(preview)
+        val attachments =
+            listOf(
+                SlackAttachment(
+                    color = preview.color,
+                    blocks = attachmentBlocks,
+                    fallback = preview.fallbackText
+                )
+            )
+        val (success, _) =
+            sendMessage(
+                accessToken = config.accessToken,
+                channel = config.channelId,
+                blocks = blocks,
+                attachments = attachments,
+                fallbackText = preview.fallbackText
             )
         return success
     }
+
+    private fun buildWorkflowAlertSlackBlocks(preview: WorkflowStepPreview): List<SlackBlock> {
+        val blocks = mutableListOf<SlackBlock>()
+        if (preview.body.isNotBlank()) {
+            blocks += SlackBlock(
+                type = "section",
+                text = SlackText(type = "mrkdwn", text = preview.body)
+            )
+        }
+        if (preview.fields.isNotEmpty()) {
+            blocks += SlackBlock(
+                type = "section",
+                fields = preview.fields.map { field ->
+                    SlackText(type = "mrkdwn", text = "*${field.label}:*\n${field.value}")
+                }
+            )
+        }
+        val ctaUrl = preview.ctaUrl
+        val ctaLabel = preview.ctaLabel
+        if (!ctaUrl.isNullOrBlank() && !ctaLabel.isNullOrBlank()) {
+            blocks += SlackBlock(
+                type = "actions",
+                elements =
+                listOf(
+                    SlackElement(
+                        type = "button",
+                        text = SlackText(type = "plain_text", text = ctaLabel),
+                        url = ctaUrl
+                    )
+                )
+            )
+        }
+        return blocks
+    }
+
+    private fun workflowAlertHeaderText(preview: WorkflowStepPreview): String {
+        val emoji =
+            when {
+                workflowAlertFieldValue(preview, "Status").equals("Resolved", ignoreCase = true) -> "✅"
+                preview.color.equals("#E01E5A", ignoreCase = true) -> "🔴"
+                else -> "⚠️"
+            }
+        return listOf(emoji, preview.title)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+    }
+
+    private fun workflowAlertFieldValue(
+        preview: WorkflowStepPreview,
+        label: String
+    ): String =
+        preview.fields
+            .firstOrNull { it.label.equals(label, ignoreCase = true) }
+            ?.value
+            .orEmpty()
 
     suspend fun sendHostDown(
         organizationId: Int,
@@ -392,7 +481,7 @@ class SlackService {
                     listOf(
                         SlackElement(
                             type = "button",
-                            text = SlackText(type = "plain_text", text = "View Host"),
+                            text = SlackText(type = "plain_text", text = "View"),
                             url = "$baseUrl/monitoring/hosts/$hostId"
                         )
                     )
@@ -456,7 +545,7 @@ class SlackService {
                     listOf(
                         SlackElement(
                             type = "button",
-                            text = SlackText(type = "plain_text", text = "View Host"),
+                            text = SlackText(type = "plain_text", text = "View"),
                             url = "$baseUrl/monitoring/hosts/$hostId"
                         )
                     )
@@ -529,7 +618,7 @@ class SlackService {
                     listOf(
                         SlackElement(
                             type = "button",
-                            text = SlackText(type = "plain_text", text = "View Monitor"),
+                            text = SlackText(type = "plain_text", text = "View"),
                             url = "$baseUrl/uptime?monitor=$monitorId"
                         )
                     )
@@ -600,7 +689,7 @@ class SlackService {
                 elements = listOf(
                     SlackElement(
                         type = "button",
-                        text = SlackText(type = "plain_text", text = "View Dashboard"),
+                        text = SlackText(type = "plain_text", text = "View"),
                         url = "$baseUrl/dashboards/$dashboardId"
                     )
                 )
@@ -757,7 +846,7 @@ class SlackService {
                 listOf(
                     SlackElement(
                         type = "button",
-                        text = SlackText(type = "plain_text", text = "View Issue"),
+                        text = SlackText(type = "plain_text", text = "View"),
                         url = issueUrl
                     )
                 )

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -26,6 +26,13 @@ private const val ALERT_DEDUPLICATION_KEY_REFERENCE = "alert.deduplication_key"
 private const val ALERT_CHANNEL_EMAIL_REFERENCE = "alert.channels.email"
 private const val ALERT_CHANNEL_SLACK_REFERENCE = "alert.channels.slack"
 private const val ALERT_CHANNEL_DISCORD_REFERENCE = "alert.channels.discord"
+private const val ALERT_DISPLAY_TITLE_REFERENCE = "alert.display_title"
+private const val ALERT_PRIORITY_REFERENCE = "alert.priority"
+private const val ALERT_DASHBOARD_TITLE_REFERENCE = "alert.dashboard.title"
+private const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
+private const val ALERT_CONDITION_REFERENCE = "alert.condition"
+private const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
+private const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
 
 @Serializable
 data class WorkflowFieldConfig(
@@ -170,12 +177,19 @@ object WorkflowCatalog {
 
     private val alertScope = listOf(
         WorkflowScopeReferenceDefinition("alert.title", "Alert title", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_DISPLAY_TITLE_REFERENCE, "Display title", "String"),
         WorkflowScopeReferenceDefinition("alert.description", "Alert description", "Text"),
         WorkflowScopeReferenceDefinition("alert.severity", "Severity", "AlertSeverity"),
+        WorkflowScopeReferenceDefinition(ALERT_PRIORITY_REFERENCE, "Priority", "String"),
         WorkflowScopeReferenceDefinition(ALERT_STATUS_REFERENCE, "Status", "AlertStatus"),
         WorkflowScopeReferenceDefinition("alert.source", "Source", "AlertSource"),
         WorkflowScopeReferenceDefinition(ALERT_DEDUPLICATION_KEY_REFERENCE, "Deduplication key", "String"),
         WorkflowScopeReferenceDefinition("alert.url", "Moneat URL", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_DASHBOARD_TITLE_REFERENCE, "Dashboard title", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_WIDGET_TITLE_REFERENCE, "Widget title", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_CONDITION_REFERENCE, "Condition", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_THRESHOLD_REFERENCE, "Threshold", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_CURRENT_VALUE_REFERENCE, "Current value", "String"),
         WorkflowScopeReferenceDefinition(ALERT_CHANNEL_EMAIL_REFERENCE, "Email channel", "Boolean"),
         WorkflowScopeReferenceDefinition(ALERT_CHANNEL_SLACK_REFERENCE, "Slack channel", "Boolean"),
         WorkflowScopeReferenceDefinition(ALERT_CHANNEL_DISCORD_REFERENCE, "Discord channel", "Boolean"),

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
@@ -74,6 +74,56 @@ data class WorkflowStepConfig(
 )
 
 @Serializable
+data class WorkflowPreviewRequest(
+    @SerialName("trigger_name") val triggerName: String,
+    val steps: List<WorkflowStepConfig>,
+    val scope: Map<String, String> = emptyMap()
+)
+
+@Serializable
+data class WorkflowPreviewResponse(
+    val scope: Map<String, String>,
+    val previews: List<WorkflowStepPreview>
+)
+
+@Serializable
+data class WorkflowTestMessageResponse(
+    val scope: Map<String, String>,
+    val results: List<WorkflowTestMessageResult>
+)
+
+@Serializable
+data class WorkflowTestMessageResult(
+    val step: String,
+    val channel: String,
+    val status: String,
+    @SerialName("error_message") val errorMessage: String? = null
+)
+
+@Serializable
+data class WorkflowStepPreview(
+    val step: String,
+    val channel: String,
+    val title: String,
+    val subject: String? = null,
+    val body: String,
+    @SerialName("html_body") val htmlBody: String? = null,
+    @SerialName("text_body") val textBody: String,
+    val fields: List<WorkflowPreviewField> = emptyList(),
+    val color: String,
+    @SerialName("cta_label") val ctaLabel: String? = null,
+    @SerialName("cta_url") val ctaUrl: String? = null,
+    val footer: String? = null,
+    @SerialName("fallback_text") val fallbackText: String
+)
+
+@Serializable
+data class WorkflowPreviewField(
+    val label: String,
+    val value: String
+)
+
+@Serializable
 data class WorkflowRunStepProgress(
     val step: String,
     val status: String,

--- a/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
@@ -20,6 +20,7 @@ import com.moneat.utils.ErrorResponse
 import com.moneat.utils.suspendRunCatching
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
+import com.moneat.workflows.models.WorkflowPreviewRequest
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
@@ -64,6 +65,28 @@ fun Route.workflowRoutes() {
                     workflowService.createWorkflow(organizationId, request)
                 }.fold(
                     onSuccess = { workflow -> call.respond(HttpStatusCode.Created, workflow) },
+                    onFailure = { error -> respondWorkflowError(error) }
+                )
+            }
+
+            post("/preview") {
+                currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
+                val request = call.receive<WorkflowPreviewRequest>()
+                suspendRunCatching {
+                    workflowService.previewWorkflow(request)
+                }.fold(
+                    onSuccess = { preview -> call.respond(preview) },
+                    onFailure = { error -> respondWorkflowError(error) }
+                )
+            }
+
+            post("/test-message") {
+                val organizationId = currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
+                val request = call.receive<WorkflowPreviewRequest>()
+                suspendRunCatching {
+                    workflowService.testWorkflowMessage(organizationId, request)
+                }.fold(
+                    onSuccess = { result -> call.respond(result) },
                     onFailure = { error -> respondWorkflowError(error) }
                 )
             }

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -103,6 +103,9 @@ private const val FORMAT_PARAM = "format"
 private const val ALERT_LIFECYCLE_FORMAT = "alert_lifecycle"
 private const val ALERT_SOURCE_TEMPLATE_LINE = "Source: {{alert.source}}\n"
 private const val ALERT_URL_TEMPLATE = "{{alert.url}}"
+private const val ALERT_PRIORITY_TEMPLATE_LINE = "Priority: {{alert.priority}}\n"
+private const val ALERT_DESCRIPTION_TEMPLATE_BLOCK = "{{alert.description}}\n\n"
+private const val DEFAULT_WORKFLOW_TITLE = "Moneat workflow"
 private const val DEFAULT_WORKFLOW_READ_ONLY_MESSAGE = "Default workflows cannot be modified"
 private const val ALERT_DISPLAY_TITLE_REFERENCE = "alert.display_title"
 private const val ALERT_DASHBOARD_TITLE_REFERENCE = "alert.dashboard.title"
@@ -570,7 +573,7 @@ class WorkflowService(
                             skipIfUnconfigured
                         )
                     } else {
-                        val title = interpolate(step.params["title"] ?: "Moneat workflow", scope)
+                        val title = interpolate(step.params["title"] ?: DEFAULT_WORKFLOW_TITLE, scope)
                         val message = interpolate(step.params["message"].orEmpty(), scope)
                         discordService.sendWorkflowMessage(organizationId, title, message, skipIfUnconfigured)
                     }
@@ -666,7 +669,7 @@ class WorkflowService(
         } else {
             discordService.sendWorkflowMessage(
                 organizationId,
-                interpolate(step.params["title"] ?: "Moneat workflow", scope),
+                interpolate(step.params["title"] ?: DEFAULT_WORKFLOW_TITLE, scope),
                 interpolate(step.params["message"].orEmpty(), scope),
                 skipIfUnconfigured = false
             )
@@ -756,7 +759,7 @@ class WorkflowService(
                 WorkflowStepPreview(
                     step = step.name,
                     channel = SLACK_CHANNEL,
-                    title = "Moneat workflow",
+                    title = DEFAULT_WORKFLOW_TITLE,
                     body = body,
                     textBody = body,
                     color = ALERT_COLOR_PURPLE,
@@ -764,7 +767,7 @@ class WorkflowService(
                 )
             }
             DISCORD_STEP -> {
-                val title = interpolate(step.params["title"] ?: "Moneat workflow", scope)
+                val title = interpolate(step.params["title"] ?: DEFAULT_WORKFLOW_TITLE, scope)
                 val body = interpolate(step.params["message"].orEmpty(), scope)
                 WorkflowStepPreview(
                     step = step.name,
@@ -773,7 +776,7 @@ class WorkflowService(
                     body = body,
                     textBody = body,
                     color = ALERT_COLOR_PURPLE,
-                    footer = "Moneat workflow",
+                    footer = DEFAULT_WORKFLOW_TITLE,
                     fallbackText = "$title: $body"
                 )
             }
@@ -948,8 +951,8 @@ class WorkflowService(
 
     private fun alertEmailEmoji(preview: WorkflowStepPreview): String {
         val status = previewFieldValue(preview, "Status")
-        if (status.equals("Resolved", ignoreCase = true)) return "✅"
-        return if (preview.color.equals(ALERT_COLOR_RED, ignoreCase = true)) "🔴" else "⚠️"
+        if (status == "Resolved") return "✅"
+        return if (preview.color == ALERT_COLOR_RED) "🔴" else "⚠️"
     }
 
     private fun previewFieldValue(
@@ -1419,8 +1422,8 @@ class WorkflowService(
                             params = mapOf(
                                 FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
                                 "subject" to "[Moneat] {{alert.priority}} {{alert.display_title}}",
-                                "body" to "{{alert.display_title}}\n\n{{alert.description}}\n\n" +
-                                    "Priority: {{alert.priority}}\n" +
+                                "body" to "{{alert.display_title}}\n\n" + ALERT_DESCRIPTION_TEMPLATE_BLOCK +
+                                    ALERT_PRIORITY_TEMPLATE_LINE +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n\n" +
                                     "View: {{alert.url}}"
@@ -1443,8 +1446,8 @@ class WorkflowService(
                             params = mapOf(
                                 FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
                                 "title" to "{{alert.priority}} {{alert.display_title}}",
-                                "message" to "{{alert.description}}\n\n" +
-                                    "Priority: {{alert.priority}}\n" +
+                                "message" to ALERT_DESCRIPTION_TEMPLATE_BLOCK +
+                                    ALERT_PRIORITY_TEMPLATE_LINE +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n" +
                                     ALERT_URL_TEMPLATE,
@@ -1464,8 +1467,8 @@ class WorkflowService(
                             params = mapOf(
                                 FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
                                 "subject" to "[Moneat] {{alert.priority}} Resolved: {{alert.display_title}}",
-                                "body" to "{{alert.display_title}}\n\n{{alert.description}}\n\n" +
-                                    "Priority: {{alert.priority}}\n" +
+                                "body" to "{{alert.display_title}}\n\n" + ALERT_DESCRIPTION_TEMPLATE_BLOCK +
+                                    ALERT_PRIORITY_TEMPLATE_LINE +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n\n" +
                                     "View: {{alert.url}}"
@@ -1476,7 +1479,7 @@ class WorkflowService(
                             params = mapOf(
                                 FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
                                 "message" to "*{{alert.priority}} Resolved: {{alert.display_title}}*\n" +
-                                    "{{alert.description}}\n\n" +
+                                    ALERT_DESCRIPTION_TEMPLATE_BLOCK +
                                     "*Priority:* {{alert.priority}}\n" +
                                     "*Source:* {{alert.source}}\n" +
                                     "*Status:* {{alert.status}}\n" +
@@ -1489,8 +1492,8 @@ class WorkflowService(
                             params = mapOf(
                                 FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
                                 "title" to "{{alert.priority}} Resolved: {{alert.display_title}}",
-                                "message" to "{{alert.description}}\n\n" +
-                                    "Priority: {{alert.priority}}\n" +
+                                "message" to ALERT_DESCRIPTION_TEMPLATE_BLOCK +
+                                    ALERT_PRIORITY_TEMPLATE_LINE +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n" +
                                     ALERT_URL_TEMPLATE,

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.workflows.services
 
+import com.moneat.config.EnvConfig
 import com.moneat.config.RedisConfig
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSeverity
@@ -31,12 +32,18 @@ import com.moneat.workflows.engine.WorkflowCatalog
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowPreviewField
+import com.moneat.workflows.models.WorkflowPreviewRequest
+import com.moneat.workflows.models.WorkflowPreviewResponse
 import com.moneat.workflows.models.WorkflowResponse
 import com.moneat.workflows.models.WorkflowRunQueuedMessage
 import com.moneat.workflows.models.WorkflowRunResponse
 import com.moneat.workflows.models.WorkflowRunStepProgress
+import com.moneat.workflows.models.WorkflowStepPreview
 import com.moneat.workflows.models.WorkflowRuns
 import com.moneat.workflows.models.WorkflowStepConfig
+import com.moneat.workflows.models.WorkflowTestMessageResponse
+import com.moneat.workflows.models.WorkflowTestMessageResult
 import com.moneat.workflows.models.WorkflowTriggerEvent
 import com.moneat.workflows.models.WorkflowVersions
 import com.moneat.workflows.models.Workflows
@@ -76,6 +83,7 @@ private const val SEVERITY_UNKNOWN_RANK = 0
 private const val ALERT_TITLE_REFERENCE = "alert.title"
 private const val ALERT_DESCRIPTION_REFERENCE = "alert.description"
 private const val ALERT_SEVERITY_REFERENCE = "alert.severity"
+private const val ALERT_PRIORITY_REFERENCE = "alert.priority"
 private const val ALERT_STATUS_REFERENCE = "alert.status"
 private const val ALERT_SOURCE_REFERENCE = "alert.source"
 private const val ALERT_DEDUPLICATION_KEY_REFERENCE = "alert.deduplication_key"
@@ -87,12 +95,38 @@ private const val ORGANIZATION_ID_REFERENCE = "organization.id"
 private const val EMAIL_ORG_STEP = "notification.email_org"
 private const val SLACK_STEP = "notification.slack"
 private const val DISCORD_STEP = "notification.discord"
+private const val EMAIL_CHANNEL = "email"
+private const val SLACK_CHANNEL = "slack"
+private const val DISCORD_CHANNEL = "discord"
 private const val SKIP_IF_UNCONFIGURED_PARAM = "skip_if_unconfigured"
+private const val FORMAT_PARAM = "format"
+private const val ALERT_LIFECYCLE_FORMAT = "alert_lifecycle"
 private const val ALERT_SOURCE_TEMPLATE_LINE = "Source: {{alert.source}}\n"
 private const val ALERT_URL_TEMPLATE = "{{alert.url}}"
 private const val DEFAULT_WORKFLOW_READ_ONLY_MESSAGE = "Default workflows cannot be modified"
+private const val ALERT_DISPLAY_TITLE_REFERENCE = "alert.display_title"
+private const val ALERT_DASHBOARD_TITLE_REFERENCE = "alert.dashboard.title"
+private const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
+private const val ALERT_CONDITION_REFERENCE = "alert.condition"
+private const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
+private const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
+private const val ALERT_COLOR_RED = "#E01E5A"
+private const val ALERT_COLOR_GREEN = "#2EB67D"
+private const val ALERT_COLOR_YELLOW = "#ECB22E"
+private const val ALERT_COLOR_PURPLE = "#6366F1"
+private const val VIEW_CTA_LABEL = "View"
 private val ALERT_CHANNEL_REFERENCES =
     setOf(ALERT_CHANNEL_EMAIL_REFERENCE, ALERT_CHANNEL_SLACK_REFERENCE, ALERT_CHANNEL_DISCORD_REFERENCE)
+private val ALERT_METADATA_REFERENCES =
+    ALERT_CHANNEL_REFERENCES + setOf(
+        ALERT_PRIORITY_REFERENCE,
+        ALERT_DISPLAY_TITLE_REFERENCE,
+        ALERT_DASHBOARD_TITLE_REFERENCE,
+        ALERT_WIDGET_TITLE_REFERENCE,
+        ALERT_CONDITION_REFERENCE,
+        ALERT_THRESHOLD_REFERENCE,
+        ALERT_CURRENT_VALUE_REFERENCE
+    )
 
 class WorkflowService(
     private val emailService: EmailService = EmailService(),
@@ -102,6 +136,34 @@ class WorkflowService(
     private val json = Json { ignoreUnknownKeys = true }
 
     fun catalog() = WorkflowCatalog.response()
+
+    fun previewWorkflow(request: WorkflowPreviewRequest): WorkflowPreviewResponse {
+        val scope = previewScopeForRequest(request)
+        return WorkflowPreviewResponse(
+            scope = scope,
+            previews = request.steps.map { step -> renderStepPreview(step, scope) }
+        )
+    }
+
+    suspend fun testWorkflowMessage(
+        organizationId: Int,
+        request: WorkflowPreviewRequest
+    ): WorkflowTestMessageResponse {
+        val scope = previewScopeForRequest(request)
+        return WorkflowTestMessageResponse(
+            scope = scope,
+            results = request.steps.map { step -> sendTestMessageStep(organizationId, step, scope) }
+        )
+    }
+
+    private fun previewScopeForRequest(request: WorkflowPreviewRequest): Map<String, String> {
+        val trigger = WorkflowCatalog.trigger(request.triggerName)
+            ?: throw IllegalArgumentException("Unknown workflow trigger ${request.triggerName}")
+        request.steps.forEach { step ->
+            WorkflowCatalog.step(step.name) ?: throw IllegalArgumentException("Unknown workflow step ${step.name}")
+        }
+        return sampleScopeForTrigger(trigger.name) + request.scope
+    }
 
     fun ensureDefaultWorkflowsForOrganization(organizationId: Int) {
         val now = Clock.System.now()
@@ -334,6 +396,7 @@ class WorkflowService(
                     ALERT_TITLE_REFERENCE to title,
                     ALERT_DESCRIPTION_REFERENCE to description,
                     ALERT_SEVERITY_REFERENCE to severity?.name.orEmpty(),
+                    ALERT_PRIORITY_REFERENCE to priorityLabelForSeverity(severity?.name),
                     ALERT_STATUS_REFERENCE to AlertStatus.RESOLVED.name,
                     ALERT_SOURCE_REFERENCE to source,
                     ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
@@ -481,23 +544,133 @@ class WorkflowService(
         when (step.name) {
             EMAIL_ORG_STEP -> sendOrganizationEmail(organizationId, step.params, scope)
             SLACK_STEP -> {
-                val message = interpolate(step.params["message"].orEmpty(), scope)
                 val skipIfUnconfigured = step.params[SKIP_IF_UNCONFIGURED_PARAM]?.toBoolean() ?: true
-                check(slackService.sendWorkflowMessage(organizationId, message, skipIfUnconfigured)) {
+                val sent =
+                    if (step.usesAlertLifecycleFormat()) {
+                        slackService.sendWorkflowAlertMessage(
+                            organizationId,
+                            renderStepPreview(step, scope),
+                            skipIfUnconfigured
+                        )
+                    } else {
+                        val message = interpolate(step.params["message"].orEmpty(), scope)
+                        slackService.sendWorkflowMessage(organizationId, message, skipIfUnconfigured)
+                    }
+                check(sent) {
                     "Slack workflow message was not sent"
                 }
             }
             DISCORD_STEP -> {
-                val title = interpolate(step.params["title"] ?: "Moneat workflow", scope)
-                val message = interpolate(step.params["message"].orEmpty(), scope)
                 val skipIfUnconfigured = step.params[SKIP_IF_UNCONFIGURED_PARAM]?.toBoolean() ?: true
-                check(discordService.sendWorkflowMessage(organizationId, title, message, skipIfUnconfigured)) {
+                val sent =
+                    if (step.usesAlertLifecycleFormat()) {
+                        discordService.sendWorkflowAlertMessage(
+                            organizationId,
+                            renderStepPreview(step, scope),
+                            skipIfUnconfigured
+                        )
+                    } else {
+                        val title = interpolate(step.params["title"] ?: "Moneat workflow", scope)
+                        val message = interpolate(step.params["message"].orEmpty(), scope)
+                        discordService.sendWorkflowMessage(organizationId, title, message, skipIfUnconfigured)
+                    }
+                check(sent) {
                     "Discord workflow message was not sent"
                 }
             }
             else -> throw IllegalArgumentException("Unknown workflow step ${step.name}")
         }
     }
+
+    private suspend fun sendTestMessageStep(
+        organizationId: Int,
+        step: WorkflowStepConfig,
+        scope: Map<String, String>
+    ): WorkflowTestMessageResult {
+        val channel = channelForStep(step.name)
+        if (!notificationStepEnabled(step.name, scope)) {
+            return WorkflowTestMessageResult(
+                step = step.name,
+                channel = channel,
+                status = "skipped",
+                errorMessage = "Notification channel is disabled for this sample"
+            )
+        }
+        return suspendRunCatching {
+            sendTestMessageStepOrThrow(organizationId, step, scope)
+        }.fold(
+            onSuccess = { WorkflowTestMessageResult(step.name, channel, "sent") },
+            onFailure = { error ->
+                WorkflowTestMessageResult(
+                    step = step.name,
+                    channel = channel,
+                    status = "failed",
+                    errorMessage = error.message ?: "Test message was not sent"
+                )
+            }
+        )
+    }
+
+    private suspend fun sendTestMessageStepOrThrow(
+        organizationId: Int,
+        step: WorkflowStepConfig,
+        scope: Map<String, String>
+    ) {
+        when (step.name) {
+            EMAIL_ORG_STEP -> {
+                val recipientCount = sendOrganizationEmail(organizationId, step.params, scope)
+                check(recipientCount > 0) {
+                    "No verified organization email recipients"
+                }
+            }
+            SLACK_STEP -> check(sendSlackTestMessage(organizationId, step, scope)) {
+                "Slack test message was not sent"
+            }
+            DISCORD_STEP -> check(sendDiscordTestMessage(organizationId, step, scope)) {
+                "Discord test message was not sent"
+            }
+            else -> throw IllegalArgumentException("Unknown workflow step ${step.name}")
+        }
+    }
+
+    private suspend fun sendSlackTestMessage(
+        organizationId: Int,
+        step: WorkflowStepConfig,
+        scope: Map<String, String>
+    ): Boolean =
+        if (step.usesAlertLifecycleFormat()) {
+            slackService.sendWorkflowAlertMessage(
+                organizationId,
+                renderStepPreview(step, scope),
+                skipIfUnconfigured = false
+            )
+        } else {
+            slackService.sendWorkflowMessage(
+                organizationId,
+                interpolate(step.params["message"].orEmpty(), scope),
+                skipIfUnconfigured = false
+            )
+        }
+
+    private suspend fun sendDiscordTestMessage(
+        organizationId: Int,
+        step: WorkflowStepConfig,
+        scope: Map<String, String>
+    ): Boolean =
+        if (step.usesAlertLifecycleFormat()) {
+            discordService.sendWorkflowAlertMessage(
+                organizationId,
+                renderStepPreview(step, scope),
+                skipIfUnconfigured = false
+            )
+        } else {
+            discordService.sendWorkflowMessage(
+                organizationId,
+                interpolate(step.params["title"] ?: "Moneat workflow", scope),
+                interpolate(step.params["message"].orEmpty(), scope),
+                skipIfUnconfigured = false
+            )
+        }
 
     private fun notificationStepEnabled(
         stepName: String,
@@ -520,7 +693,7 @@ class WorkflowService(
         organizationId: Int,
         params: Map<String, String>,
         scope: Map<String, String>
-    ) {
+    ): Int {
         val recipients =
             transaction {
                 Memberships
@@ -533,12 +706,381 @@ class WorkflowService(
             }
         val subject = interpolate(params["subject"] ?: "Moneat workflow: {{alert.title}}", scope)
         val body = interpolate(params["body"].orEmpty(), scope)
-        val htmlBody = "<pre style=\"font-family:system-ui,sans-serif;white-space:pre-wrap\">" +
-            body.escapeHtml() +
-            "</pre>"
+        val preview =
+            if (params[FORMAT_PARAM] == ALERT_LIFECYCLE_FORMAT) {
+                renderStepPreview(WorkflowStepConfig(EMAIL_ORG_STEP, params), scope)
+            } else {
+                null
+            }
+        val htmlBody = preview?.htmlBody ?: body.preformattedHtml()
+        val textBody = preview?.textBody ?: body
+        val emailSubject = preview?.subject ?: subject
         recipients.forEach { email ->
-            emailService.sendEmail(email, subject, htmlBody, body, "workflow")
+            emailService.sendEmail(email, emailSubject, htmlBody, textBody, "workflow")
         }
+        return recipients.size
+    }
+
+    private fun renderStepPreview(
+        step: WorkflowStepConfig,
+        scope: Map<String, String>
+    ): WorkflowStepPreview =
+        if (step.usesAlertLifecycleFormat()) {
+            renderAlertLifecyclePreview(step, scope)
+        } else {
+            renderFreeformStepPreview(step, scope)
+        }
+
+    private fun renderFreeformStepPreview(
+        step: WorkflowStepConfig,
+        scope: Map<String, String>
+    ): WorkflowStepPreview =
+        when (step.name) {
+            EMAIL_ORG_STEP -> {
+                val subject = interpolate(step.params["subject"] ?: "Moneat workflow: {{alert.title}}", scope)
+                val body = interpolate(step.params["body"].orEmpty(), scope)
+                WorkflowStepPreview(
+                    step = step.name,
+                    channel = EMAIL_CHANNEL,
+                    title = subject,
+                    subject = subject,
+                    body = body,
+                    htmlBody = body.preformattedHtml(),
+                    textBody = body,
+                    color = ALERT_COLOR_PURPLE,
+                    fallbackText = "$subject: $body"
+                )
+            }
+            SLACK_STEP -> {
+                val body = interpolate(step.params["message"].orEmpty(), scope)
+                WorkflowStepPreview(
+                    step = step.name,
+                    channel = SLACK_CHANNEL,
+                    title = "Moneat workflow",
+                    body = body,
+                    textBody = body,
+                    color = ALERT_COLOR_PURPLE,
+                    fallbackText = body
+                )
+            }
+            DISCORD_STEP -> {
+                val title = interpolate(step.params["title"] ?: "Moneat workflow", scope)
+                val body = interpolate(step.params["message"].orEmpty(), scope)
+                WorkflowStepPreview(
+                    step = step.name,
+                    channel = DISCORD_CHANNEL,
+                    title = title,
+                    body = body,
+                    textBody = body,
+                    color = ALERT_COLOR_PURPLE,
+                    footer = "Moneat workflow",
+                    fallbackText = "$title: $body"
+                )
+            }
+            else -> throw IllegalArgumentException("Unknown workflow step ${step.name}")
+        }
+
+    private fun renderAlertLifecyclePreview(
+        step: WorkflowStepConfig,
+        scope: Map<String, String>
+    ): WorkflowStepPreview {
+        val channel = channelForStep(step.name)
+        val displayTitle = alertDisplayTitle(scope)
+        val title = alertLifecycleTitle(displayTitle, scope)
+        val body = scope[ALERT_DESCRIPTION_REFERENCE]?.ifBlank { null } ?: "Moneat detected an alert lifecycle event."
+        val fields = alertLifecycleFields(scope)
+        val color = alertLifecycleColor(scope)
+        val ctaUrl = scope[ALERT_URL_REFERENCE]?.takeIf { it.isNotBlank() }
+        val ctaLabel = ctaUrl?.let { VIEW_CTA_LABEL }
+        val sourceLabel = sourceLabel(scope[ALERT_SOURCE_REFERENCE])
+        val textBody = buildAlertText(title, body, fields, ctaLabel, ctaUrl)
+        val preview =
+            WorkflowStepPreview(
+                step = step.name,
+                channel = channel,
+                title = title,
+                subject = if (channel == EMAIL_CHANNEL) "[Moneat] $title" else null,
+                body = body,
+                textBody = textBody,
+                fields = fields,
+                color = color,
+                ctaLabel = ctaLabel,
+                ctaUrl = ctaUrl,
+                footer = sourceLabel,
+                fallbackText = "$title: $body"
+            )
+        return if (channel == EMAIL_CHANNEL) {
+            preview.copy(htmlBody = buildAlertLifecycleHtml(preview))
+        } else {
+            preview
+        }
+    }
+
+    private fun channelForStep(stepName: String): String =
+        when (stepName) {
+            EMAIL_ORG_STEP -> EMAIL_CHANNEL
+            SLACK_STEP -> SLACK_CHANNEL
+            DISCORD_STEP -> DISCORD_CHANNEL
+            else -> throw IllegalArgumentException("Unknown workflow step $stepName")
+        }
+
+    private fun alertDisplayTitle(scope: Map<String, String>): String =
+        scope[ALERT_DISPLAY_TITLE_REFERENCE]?.takeIf { it.isNotBlank() }
+            ?: cleanAlertTitle(scope[ALERT_TITLE_REFERENCE], scope[ALERT_STATUS_REFERENCE])
+
+    private fun alertLifecycleTitle(
+        displayTitle: String,
+        scope: Map<String, String>
+    ): String {
+        val priority = priorityLabel(scope)
+        if (scope[ALERT_STATUS_REFERENCE] == AlertStatus.RESOLVED.name) {
+            val prefix = listOf(priority, "Resolved").filter { it.isNotBlank() }.joinToString(" ")
+            return if (prefix.isBlank()) displayTitle else "$prefix: $displayTitle"
+        }
+        return listOf(priority, displayTitle).filter { it.isNotBlank() }.joinToString(" ")
+    }
+
+    private fun cleanAlertTitle(
+        title: String?,
+        status: String?
+    ): String {
+        val prefixes =
+            if (status == AlertStatus.RESOLVED.name) {
+                listOf("Resolved: ", "Dashboard Alert Resolved: ")
+            } else {
+                listOf("Dashboard Critical: ", "Dashboard Error: ", "Dashboard Warning: ", "Dashboard Alert: ")
+            }
+        return prefixes.fold(title.orEmpty()) { current, prefix ->
+            current.removePrefix(prefix)
+        }.ifBlank { "Moneat alert" }
+    }
+
+    private fun alertLifecycleFields(scope: Map<String, String>): List<WorkflowPreviewField> {
+        val fields = mutableListOf<WorkflowPreviewField>()
+        addField(fields, "Status", humanizeEnum(scope[ALERT_STATUS_REFERENCE]))
+        addField(fields, "Priority", priorityLabel(scope))
+        addField(fields, "Source", sourceLabel(scope[ALERT_SOURCE_REFERENCE]))
+        addField(fields, "Dashboard", scope[ALERT_DASHBOARD_TITLE_REFERENCE])
+        addField(fields, "Widget", scope[ALERT_WIDGET_TITLE_REFERENCE])
+        addField(fields, "Current value", scope[ALERT_CURRENT_VALUE_REFERENCE])
+        addField(fields, "Threshold", thresholdText(scope))
+        return fields
+    }
+
+    private fun addField(
+        fields: MutableList<WorkflowPreviewField>,
+        label: String,
+        value: String?
+    ) {
+        if (!value.isNullOrBlank()) {
+            fields += WorkflowPreviewField(label, value)
+        }
+    }
+
+    private fun thresholdText(scope: Map<String, String>): String? {
+        val condition = scope[ALERT_CONDITION_REFERENCE]?.takeIf { it.isNotBlank() }
+        val threshold = scope[ALERT_THRESHOLD_REFERENCE]?.takeIf { it.isNotBlank() }
+        return when {
+            condition != null && threshold != null -> "$condition $threshold"
+            threshold != null -> threshold
+            else -> null
+        }
+    }
+
+    private fun alertLifecycleColor(scope: Map<String, String>): String {
+        if (scope[ALERT_STATUS_REFERENCE] == AlertStatus.RESOLVED.name) return ALERT_COLOR_GREEN
+        return when (scope[ALERT_SEVERITY_REFERENCE]) {
+            AlertSeverity.CRITICAL.name, AlertSeverity.HIGH.name -> ALERT_COLOR_RED
+            else -> ALERT_COLOR_YELLOW
+        }
+    }
+
+    private fun priorityLabel(scope: Map<String, String>): String =
+        scope[ALERT_PRIORITY_REFERENCE]?.takeIf { it.isNotBlank() }
+            ?: priorityLabelForSeverity(scope[ALERT_SEVERITY_REFERENCE])
+
+    private fun priorityLabelForSeverity(severity: String?): String =
+        when (severity?.uppercase()) {
+            AlertSeverity.CRITICAL.name -> "[P0]"
+            AlertSeverity.HIGH.name -> "[P1]"
+            AlertSeverity.MEDIUM.name -> "[P2]"
+            AlertSeverity.LOW.name -> "[P3]"
+            else -> ""
+        }
+
+    private fun sourceLabel(source: String?): String =
+        when (source) {
+            "DASHBOARD_ALERT" -> "Dashboard alert"
+            "HOST_ALERT" -> "Host metric alert"
+            "HOST_DOWN" -> "Host down"
+            "UPTIME_MONITOR" -> "Uptime monitor"
+            "SYNTHETIC_TEST" -> "Synthetic test"
+            "ERROR_ALERT" -> "Error issue"
+            else -> humanizeEnum(source).ifBlank { "Moneat alert" }
+        }
+
+    private fun buildAlertText(
+        title: String,
+        body: String,
+        fields: List<WorkflowPreviewField>,
+        ctaLabel: String?,
+        ctaUrl: String?
+    ): String =
+        buildString {
+            appendLine(title)
+            appendLine()
+            appendLine(body)
+            if (fields.isNotEmpty()) {
+                appendLine()
+                fields.forEach { field -> appendLine("${field.label}: ${field.value}") }
+            }
+            if (!ctaUrl.isNullOrBlank()) {
+                appendLine()
+                appendLine("${ctaLabel ?: VIEW_CTA_LABEL}: $ctaUrl")
+            }
+        }.trim()
+
+    private fun alertEmailHeaderText(preview: WorkflowStepPreview): String {
+        return listOf(alertEmailEmoji(preview), preview.title)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+    }
+
+    private fun alertEmailEmoji(preview: WorkflowStepPreview): String {
+        val status = previewFieldValue(preview, "Status")
+        if (status.equals("Resolved", ignoreCase = true)) return "✅"
+        return if (preview.color.equals(ALERT_COLOR_RED, ignoreCase = true)) "🔴" else "⚠️"
+    }
+
+    private fun previewFieldValue(
+        preview: WorkflowStepPreview,
+        label: String
+    ): String =
+        preview.fields
+            .firstOrNull { it.label.equals(label, ignoreCase = true) }
+            ?.value
+            .orEmpty()
+
+    private fun buildAlertLifecycleHtml(preview: WorkflowStepPreview): String {
+        val fieldRows = preview.fields.chunked(2).joinToString("") { row ->
+            val cells =
+                row.joinToString("") { field ->
+                    """
+                    <td style="width:50%;padding:0 20px 16px 0;vertical-align:top;">
+                        <div style="font-size:14px;line-height:20px;font-weight:700;color:#334155;">
+                            ${field.label.escapeHtml()}:
+                        </div>
+                        <div style="font-size:14px;line-height:20px;color:#475569;word-break:break-word;">
+                            ${field.value.escapeHtml()}
+                        </div>
+                    </td>
+                    """.trimIndent()
+                }
+            val filler =
+                if (row.size == 1) {
+                    """<td style="width:50%;padding:0 20px 16px 0;vertical-align:top;"></td>"""
+                } else {
+                    ""
+                }
+            "<tr>$cells$filler</tr>"
+        }
+        val ctaHtml =
+            if (!preview.ctaUrl.isNullOrBlank() && !preview.ctaLabel.isNullOrBlank()) {
+                """
+                <div style="margin-top:20px;">
+                    <a href="${preview.ctaUrl.escapeHtml()}" style="display:inline-block;background:#111827;
+                        color:#f8fafc;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:700;
+                        font-size:14px;line-height:20px;">
+                        ${preview.ctaLabel.escapeHtml()}
+                    </a>
+                </div>
+                """.trimIndent()
+            } else {
+                ""
+            }
+        val appHeader = alertEmailHeaderText(preview).escapeHtml()
+        val accentColor = preview.color.escapeHtml()
+        val logoUrl = moneatFaviconUrl().escapeHtml()
+        return """
+            <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f8fafc;
+                padding:24px;">
+                <div style="max-width:640px;margin:0 auto;border:1px solid #e2e8f0;border-radius:12px;
+                    background:#ffffff;color:#0f172a;padding:24px;">
+                    <table role="presentation" style="width:100%;border-collapse:collapse;margin:0;">
+                        <tr>
+                            <td style="width:48px;padding:0 12px 0 0;vertical-align:top;">
+                                <div style="width:40px;height:40px;border-radius:10px;background:#ffffff;
+                                    border:1px solid #e2e8f0;text-align:center;">
+                                    <img src="$logoUrl" width="40" height="40" alt="Moneat" style="display:block;
+                                        width:40px;height:40px;border-radius:10px;">
+                                </div>
+                            </td>
+                            <td style="padding:0;vertical-align:top;">
+                                <div style="font-size:14px;line-height:20px;font-weight:700;color:#0f172a;">Moneat</div>
+                                <div style="margin-top:10px;font-size:18px;line-height:26px;font-weight:700;
+                                    color:#0f172a;">
+                                    $appHeader
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <div style="margin-top:20px;border-top:4px solid $accentColor;padding-top:18px;">
+                        <div style="margin:0 0 18px;color:#334155;font-size:14px;line-height:21px;">
+                            ${preview.body.toHtmlLines()}
+                        </div>
+                        <table role="presentation" style="width:100%;border-collapse:collapse;margin:0;">
+                            $fieldRows
+                        </table>
+                        $ctaHtml
+                        <div style="margin-top:18px;color:#64748b;font-size:12px;line-height:18px;">
+                            Added by Moneat
+                        </div>
+                    </div>
+                </div>
+            </div>
+        """.trimIndent()
+    }
+
+    private fun moneatFaviconUrl(): String {
+        val frontendUrl = EnvConfig.get("FRONTEND_URL", "https://moneat.io").trimEnd('/')
+        return "$frontendUrl/favicon.svg"
+    }
+
+    private fun sampleScopeForTrigger(triggerName: String): Map<String, String> {
+        val resolved = triggerName == ALERT_RESOLVED_TRIGGER
+        val status = if (resolved) AlertStatus.RESOLVED.name else AlertStatus.FIRING.name
+        val severity = if (resolved) AlertSeverity.LOW.name else AlertSeverity.HIGH.name
+        val title = if (resolved) {
+            "Dashboard Alert Resolved: Worker failures detected"
+        } else {
+            "Dashboard Error: Worker failures detected"
+        }
+        val description = if (resolved) {
+            "Worker failures [1h] on Moneat Backend System Health recovered. Current value: 0.00"
+        } else {
+            "Worker failures [1h] on Moneat Backend System Health crossed > 5.00. Current value: 12.00"
+        }
+        val currentValue = if (resolved) "0.00" else "12.00"
+        return mapOf(
+            ALERT_TITLE_REFERENCE to title,
+            ALERT_DISPLAY_TITLE_REFERENCE to "Worker failures detected",
+            ALERT_DESCRIPTION_REFERENCE to description,
+            ALERT_SEVERITY_REFERENCE to severity,
+            ALERT_PRIORITY_REFERENCE to priorityLabelForSeverity(severity),
+            ALERT_STATUS_REFERENCE to status,
+            ALERT_SOURCE_REFERENCE to "DASHBOARD_ALERT",
+            ALERT_DEDUPLICATION_KEY_REFERENCE to "moneat-dashboard-alert-preview",
+            ALERT_URL_REFERENCE to "https://moneat.io/dashboards/13",
+            ALERT_DASHBOARD_TITLE_REFERENCE to "Moneat Backend System Health",
+            ALERT_WIDGET_TITLE_REFERENCE to "Worker failures [1h]",
+            ALERT_CONDITION_REFERENCE to ">",
+            ALERT_THRESHOLD_REFERENCE to "5.00",
+            ALERT_CURRENT_VALUE_REFERENCE to currentValue,
+            ALERT_CHANNEL_EMAIL_REFERENCE to "true",
+            ALERT_CHANNEL_SLACK_REFERENCE to "true",
+            ALERT_CHANNEL_DISCORD_REFERENCE to "true",
+            ORGANIZATION_ID_REFERENCE to "1"
+        )
     }
 
     private fun latestVersion(workflowId: Int): WorkflowVersionRecord? =
@@ -839,6 +1381,7 @@ class WorkflowService(
             ALERT_TITLE_REFERENCE to event.title,
             ALERT_DESCRIPTION_REFERENCE to event.description,
             ALERT_SEVERITY_REFERENCE to event.severity.name,
+            ALERT_PRIORITY_REFERENCE to priorityLabelForSeverity(event.severity.name),
             ALERT_STATUS_REFERENCE to event.status.name,
             ALERT_SOURCE_REFERENCE to event.source.name,
             ALERT_DEDUPLICATION_KEY_REFERENCE to event.deduplicationKey,
@@ -849,7 +1392,7 @@ class WorkflowService(
     private fun alertMetadataScope(metadata: Map<String, JsonElement>): Map<String, String> =
         metadata
             .mapNotNull { (reference, value) ->
-                if (reference !in ALERT_CHANNEL_REFERENCES) return@mapNotNull null
+                if (reference !in ALERT_METADATA_REFERENCES) return@mapNotNull null
                 value.workflowScopeValue()?.let { reference to it }
             }.toMap()
 
@@ -874,19 +1417,21 @@ class WorkflowService(
                         WorkflowStepConfig(
                             name = EMAIL_ORG_STEP,
                             params = mapOf(
-                                "subject" to "[Moneat] {{alert.title}}",
-                                "body" to "{{alert.title}}\n\n{{alert.description}}\n\n" +
-                                    "Severity: {{alert.severity}}\n" +
+                                FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
+                                "subject" to "[Moneat] {{alert.priority}} {{alert.display_title}}",
+                                "body" to "{{alert.display_title}}\n\n{{alert.description}}\n\n" +
+                                    "Priority: {{alert.priority}}\n" +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n\n" +
-                                    "View in Moneat: {{alert.url}}"
+                                    "View: {{alert.url}}"
                             )
                         ),
                         WorkflowStepConfig(
                             name = SLACK_STEP,
                             params = mapOf(
-                                "message" to "*{{alert.title}}*\n{{alert.description}}\n\n" +
-                                    "*Severity:* {{alert.severity}}\n" +
+                                FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
+                                "message" to "*{{alert.priority}} {{alert.display_title}}*\n{{alert.description}}\n\n" +
+                                    "*Priority:* {{alert.priority}}\n" +
                                     "*Source:* {{alert.source}}\n" +
                                     "*Status:* {{alert.status}}\n" +
                                     ALERT_URL_TEMPLATE,
@@ -896,9 +1441,10 @@ class WorkflowService(
                         WorkflowStepConfig(
                             name = DISCORD_STEP,
                             params = mapOf(
-                                "title" to "{{alert.title}}",
+                                FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
+                                "title" to "{{alert.priority}} {{alert.display_title}}",
                                 "message" to "{{alert.description}}\n\n" +
-                                    "Severity: {{alert.severity}}\n" +
+                                    "Priority: {{alert.priority}}\n" +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n" +
                                     ALERT_URL_TEMPLATE,
@@ -916,17 +1462,22 @@ class WorkflowService(
                         WorkflowStepConfig(
                             name = EMAIL_ORG_STEP,
                             params = mapOf(
-                                "subject" to "[Moneat] Resolved: {{alert.title}}",
-                                "body" to "{{alert.title}}\n\n{{alert.description}}\n\n" +
+                                FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
+                                "subject" to "[Moneat] {{alert.priority}} Resolved: {{alert.display_title}}",
+                                "body" to "{{alert.display_title}}\n\n{{alert.description}}\n\n" +
+                                    "Priority: {{alert.priority}}\n" +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n\n" +
-                                    "View in Moneat: {{alert.url}}"
+                                    "View: {{alert.url}}"
                             )
                         ),
                         WorkflowStepConfig(
                             name = SLACK_STEP,
                             params = mapOf(
-                                "message" to "*Resolved: {{alert.title}}*\n{{alert.description}}\n\n" +
+                                FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
+                                "message" to "*{{alert.priority}} Resolved: {{alert.display_title}}*\n" +
+                                    "{{alert.description}}\n\n" +
+                                    "*Priority:* {{alert.priority}}\n" +
                                     "*Source:* {{alert.source}}\n" +
                                     "*Status:* {{alert.status}}\n" +
                                     ALERT_URL_TEMPLATE,
@@ -936,8 +1487,10 @@ class WorkflowService(
                         WorkflowStepConfig(
                             name = DISCORD_STEP,
                             params = mapOf(
-                                "title" to "Resolved: {{alert.title}}",
+                                FORMAT_PARAM to ALERT_LIFECYCLE_FORMAT,
+                                "title" to "{{alert.priority}} Resolved: {{alert.display_title}}",
                                 "message" to "{{alert.description}}\n\n" +
+                                    "Priority: {{alert.priority}}\n" +
                                     ALERT_SOURCE_TEMPLATE_LINE +
                                     "Status: {{alert.status}}\n" +
                                     ALERT_URL_TEMPLATE,
@@ -997,6 +1550,25 @@ private fun interpolate(
     scope.entries.fold(template) { text, (reference, value) ->
         text.replace("{{$reference}}", value)
     }
+
+private fun WorkflowStepConfig.usesAlertLifecycleFormat(): Boolean =
+    params[FORMAT_PARAM] == ALERT_LIFECYCLE_FORMAT
+
+private fun humanizeEnum(value: String?): String =
+    value
+        ?.takeIf { it.isNotBlank() }
+        ?.lowercase()
+        ?.split("_")
+        ?.joinToString(" ") { part -> part.replaceFirstChar { it.uppercase() } }
+        .orEmpty()
+
+private fun String.preformattedHtml(): String =
+    "<pre style=\"font-family:system-ui,sans-serif;white-space:pre-wrap\">" +
+        escapeHtml() +
+        "</pre>"
+
+private fun String.toHtmlLines(): String =
+    escapeHtml().replace("\n", "<br>")
 
 private fun String.escapeHtml(): String =
     replace("&", "&amp;")

--- a/backend/src/main/resources/db/migration/V110__refresh_default_workflow_notification_format.sql
+++ b/backend/src/main/resources/db/migration/V110__refresh_default_workflow_notification_format.sql
@@ -1,0 +1,130 @@
+WITH target_workflows AS (
+    SELECT
+        w.id AS workflow_id,
+        w.system_key,
+        COALESCE(MAX(wv.version), 0) + 1 AS next_version
+    FROM workflows w
+    LEFT JOIN workflow_versions wv ON wv.workflow_id = w.id
+    WHERE w.system_key IN ('default_alert_notifications', 'default_recovery_notifications')
+    GROUP BY w.id, w.system_key
+)
+UPDATE workflow_versions wv
+SET most_recent = FALSE
+FROM target_workflows tw
+WHERE wv.workflow_id = tw.workflow_id
+    AND wv.most_recent = TRUE;
+
+WITH target_workflows AS (
+    SELECT
+        w.id AS workflow_id,
+        w.system_key,
+        COALESCE(MAX(wv.version), 0) + 1 AS next_version
+    FROM workflows w
+    LEFT JOIN workflow_versions wv ON wv.workflow_id = w.id
+    WHERE w.system_key IN ('default_alert_notifications', 'default_recovery_notifications')
+    GROUP BY w.id, w.system_key
+)
+INSERT INTO workflow_versions (
+    workflow_id,
+    version,
+    conditions,
+    steps,
+    once_for_template,
+    engine_config,
+    most_recent,
+    created_at
+)
+SELECT
+    workflow_id,
+    next_version,
+    '[]'::JSONB,
+    CASE system_key
+        WHEN 'default_alert_notifications' THEN
+            $json$
+            [
+              {
+                "name": "notification.email_org",
+                "params": {
+                  "format": "alert_lifecycle",
+                  "subject": "[Moneat] {{alert.priority}} {{alert.display_title}}",
+                  "body": "{{alert.display_title}}\n\n{{alert.description}}\n\nPriority: {{alert.priority}}\nSource: {{alert.source}}\nStatus: {{alert.status}}\n\nView: {{alert.url}}"
+                }
+              },
+              {
+                "name": "notification.slack",
+                "params": {
+                  "format": "alert_lifecycle",
+                  "message": "*{{alert.priority}} {{alert.display_title}}*\n{{alert.description}}\n\n*Priority:* {{alert.priority}}\n*Source:* {{alert.source}}\n*Status:* {{alert.status}}\n{{alert.url}}",
+                  "skip_if_unconfigured": "true"
+                }
+              },
+              {
+                "name": "notification.discord",
+                "params": {
+                  "format": "alert_lifecycle",
+                  "title": "{{alert.priority}} {{alert.display_title}}",
+                  "message": "{{alert.description}}\n\nPriority: {{alert.priority}}\nSource: {{alert.source}}\nStatus: {{alert.status}}\n{{alert.url}}",
+                  "skip_if_unconfigured": "true"
+                }
+              }
+            ]
+            $json$::JSONB
+        ELSE
+            $json$
+            [
+              {
+                "name": "notification.email_org",
+                "params": {
+                  "format": "alert_lifecycle",
+                  "subject": "[Moneat] {{alert.priority}} Resolved: {{alert.display_title}}",
+                  "body": "{{alert.display_title}}\n\n{{alert.description}}\n\nPriority: {{alert.priority}}\nSource: {{alert.source}}\nStatus: {{alert.status}}\n\nView: {{alert.url}}"
+                }
+              },
+              {
+                "name": "notification.slack",
+                "params": {
+                  "format": "alert_lifecycle",
+                  "message": "*{{alert.priority}} Resolved: {{alert.display_title}}*\n{{alert.description}}\n\n*Priority:* {{alert.priority}}\n*Source:* {{alert.source}}\n*Status:* {{alert.status}}\n{{alert.url}}",
+                  "skip_if_unconfigured": "true"
+                }
+              },
+              {
+                "name": "notification.discord",
+                "params": {
+                  "format": "alert_lifecycle",
+                  "title": "{{alert.priority}} Resolved: {{alert.display_title}}",
+                  "message": "{{alert.description}}\n\nPriority: {{alert.priority}}\nSource: {{alert.source}}\nStatus: {{alert.status}}\n{{alert.url}}",
+                  "skip_if_unconfigured": "true"
+                }
+              }
+            ]
+            $json$::JSONB
+    END,
+    CASE system_key
+        WHEN 'default_alert_notifications' THEN '["alert.deduplication_key"]'::JSONB
+        ELSE '["alert.deduplication_key", "alert.status"]'::JSONB
+    END,
+    $json$
+    [
+      "alert.display_title",
+      "alert.description",
+      "alert.severity",
+      "alert.priority",
+      "alert.source",
+      "alert.status",
+      "alert.url",
+      "alert.deduplication_key",
+      "alert.dashboard.title",
+      "alert.widget.title",
+      "alert.condition",
+      "alert.threshold",
+      "alert.current_value"
+    ]
+    $json$::JSONB,
+    TRUE,
+    NOW()
+FROM target_workflows;
+
+UPDATE workflows
+SET updated_at = NOW()
+WHERE system_key IN ('default_alert_notifications', 'default_recovery_notifications');

--- a/backend/src/main/resources/docs/api/workflows.md
+++ b/backend/src/main/resources/docs/api/workflows.md
@@ -37,6 +37,36 @@ Create a workflow.
 | steps | array | no | Step configuration |
 | once_for_template | array | no | Scope references used to build the idempotency key |
 
+### POST /v1/workflows/preview
+
+Render workflow notification messages without sending them.
+
+**Body:**
+
+| name | type | required | description |
+|------|------|----------|-------------|
+| trigger_name | string | yes | Trigger name from the catalog |
+| steps | array | yes | Step configuration to preview |
+| scope | object | no | Scope values that override the representative sample alert |
+
+The response includes the sample scope and one preview item per notification step. Preview items include
+channel, title or subject, text body, optional HTML body, fields, status color, CTA label, and CTA URL.
+
+### POST /v1/workflows/test-message
+
+Send representative workflow notification messages to the configured integrations without creating a workflow run.
+
+**Body:**
+
+| name | type | required | description |
+|------|------|----------|-------------|
+| trigger_name | string | yes | Trigger name from the catalog |
+| steps | array | yes | Step configuration to send |
+| scope | object | no | Scope values that override the representative sample alert |
+
+The response includes the sample scope and one send result per notification step. Result statuses are
+`sent`, `failed`, or `skipped`.
+
 ### GET /v1/workflows/{workflowId}
 
 Get a workflow by ID.
@@ -84,9 +114,17 @@ Step parameters support double-brace interpolation with trigger scope references
 
 ```text
 {{alert.title}}
+{{alert.display_title}}
 {{alert.severity}}
+{{alert.priority}}
 {{alert.url}}
 ```
+
+`alert.severity` keeps the internal enum value (`CRITICAL`, `HIGH`, `MEDIUM`, or `LOW`).
+`alert.priority` renders the alerting label (`[P0]` through `[P3]`) used in notification titles.
+
+Dashboard alert events also expose dashboard-specific fields such as `alert.dashboard.title`,
+`alert.widget.title`, `alert.condition`, `alert.threshold`, and `alert.current_value`.
 
 ## Run identity
 

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -849,7 +849,9 @@ class DashboardAlertServiceTest {
                         it.status.name == "RESOLVED" &&
                             it.metadata["alert.channels.email"]?.jsonPrimitive?.content == "false" &&
                             it.metadata["alert.channels.slack"]?.jsonPrimitive?.content == "true" &&
-                            it.metadata["alert.channels.discord"]?.jsonPrimitive?.content == "false"
+                            it.metadata["alert.channels.discord"]?.jsonPrimitive?.content == "false" &&
+                            it.metadata["alert.display_title"]?.jsonPrimitive?.content == "High Error Rate" &&
+                            it.metadata["alert.current_value"]?.jsonPrimitive?.content == "50.00"
                     }
                 )
             }
@@ -910,7 +912,9 @@ class DashboardAlertServiceTest {
                     match {
                         it.severity == AlertSeverity.LOW &&
                             it.title == "Dashboard Warning: High Error Rate" &&
-                            it.source == AlertSource.DASHBOARD_ALERT
+                            it.source == AlertSource.DASHBOARD_ALERT &&
+                            it.metadata["alert.display_title"]?.jsonPrimitive?.content == "High Error Rate" &&
+                            it.metadata["alert.dashboard.title"]?.jsonPrimitive?.content == "Test Dashboard"
                     }
                 )
             }

--- a/backend/src/test/kotlin/com/moneat/services/DiscordServiceBuildersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/DiscordServiceBuildersTest.kt
@@ -23,6 +23,7 @@ import com.moneat.shared.models.Organizations
 import com.moneat.testsupport.MockHttpServer
 import com.moneat.testsupport.TestDatabaseHelper
 import com.moneat.testsupport.respond
+import com.moneat.workflows.models.WorkflowStepPreview
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
@@ -84,6 +85,19 @@ class DiscordServiceBuildersTest {
             } get Organizations.id
         }
 
+    private fun workflowPreview(): WorkflowStepPreview =
+        WorkflowStepPreview(
+            step = "notification.discord",
+            channel = "discord",
+            title = "[P1] Worker failures detected",
+            body = "Worker failures crossed the threshold",
+            textBody = "[P1] Worker failures detected",
+            color = "#E01E5A",
+            ctaLabel = "View",
+            ctaUrl = "$BASE_URL_APP/dashboards/13",
+            fallbackText = "[P1] Worker failures detected"
+        )
+
     // ── No-config path tests ────────────────────────────────────────────
 
     @Test
@@ -117,6 +131,13 @@ class DiscordServiceBuildersTest {
                     baseUrl = BASE_URL_APP
                 )
             )
+        }
+
+    @Test
+    fun `sendWorkflowAlertMessage returns false when no integration configured`() =
+        runBlocking {
+            val orgId = seedOrg()
+            assertFalse(discordService.sendWorkflowAlertMessage(orgId, workflowPreview()))
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/DiscordServiceBuildersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/DiscordServiceBuildersTest.kt
@@ -23,6 +23,7 @@ import com.moneat.shared.models.Organizations
 import com.moneat.testsupport.MockHttpServer
 import com.moneat.testsupport.TestDatabaseHelper
 import com.moneat.testsupport.respond
+import com.moneat.workflows.models.WorkflowPreviewField
 import com.moneat.workflows.models.WorkflowStepPreview
 import io.mockk.every
 import io.mockk.mockkObject
@@ -93,10 +94,29 @@ class DiscordServiceBuildersTest {
             body = "Worker failures crossed the threshold",
             textBody = "[P1] Worker failures detected",
             color = "#E01E5A",
+            fields = listOf(
+                WorkflowPreviewField("Status", "Firing"),
+                WorkflowPreviewField("Priority", "[P1]"),
+                WorkflowPreviewField("Dashboard", "Moneat Backend System Health")
+            ),
             ctaLabel = "View",
             ctaUrl = "$BASE_URL_APP/dashboards/13",
             fallbackText = "[P1] Worker failures detected"
         )
+
+    private fun seedDiscordIntegration(orgId: Int) {
+        transaction {
+            OrganizationIntegrations.insert {
+                it[organization_id] = orgId
+                it[integration_type] = "discord"
+                it[team_id] = "123"
+                it[channel_id] = "456"
+                it[enabled] = true
+                it[created_at] = Clock.System.now()
+                it[updated_at] = Clock.System.now()
+            }
+        }
+    }
 
     // ── No-config path tests ────────────────────────────────────────────
 
@@ -138,6 +158,17 @@ class DiscordServiceBuildersTest {
         runBlocking {
             val orgId = seedOrg()
             assertFalse(discordService.sendWorkflowAlertMessage(orgId, workflowPreview()))
+        }
+
+    @Test
+    fun `sendWorkflowAlertMessage builds rich alert embed with configured integration`() =
+        runBlocking {
+            val orgId = seedOrg("Workflow Discord Org")
+            seedDiscordIntegration(orgId)
+
+            val result = discordService.sendWorkflowAlertMessage(orgId, workflowPreview())
+
+            assertFalse(result)
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationFormattingTest.kt
@@ -475,7 +475,7 @@ class NotificationFormattingTest {
                 elements = listOf(
                     SlackService.SlackElement(
                         type = "button",
-                        text = SlackService.SlackText(type = "plain_text", text = "View Host"),
+                        text = SlackService.SlackText(type = "plain_text", text = "View"),
                         url = "https://app.moneat.io/monitoring/hosts/1"
                     )
                 )

--- a/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
@@ -21,6 +21,7 @@ import com.moneat.notifications.services.encodeSlackIssueIdPathSegment
 import com.moneat.shared.models.OrganizationIntegrations
 import com.moneat.shared.models.Organizations
 import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.workflows.models.WorkflowStepPreview
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -82,6 +83,19 @@ class SlackServiceBuildersTest {
         }
     }
 
+    private fun workflowPreview(): WorkflowStepPreview =
+        WorkflowStepPreview(
+            step = "notification.slack",
+            channel = "slack",
+            title = "[P1] Worker failures detected",
+            body = "Worker failures crossed the threshold",
+            textBody = "[P1] Worker failures detected",
+            color = "#E01E5A",
+            ctaLabel = "View",
+            ctaUrl = "$BASE_URL/dashboards/13",
+            fallbackText = "[P1] Worker failures detected"
+        )
+
     // ── No-config path tests ────────────────────────────────────────────
 
     @Test
@@ -115,6 +129,13 @@ class SlackServiceBuildersTest {
                     baseUrl = BASE_URL
                 )
             )
+        }
+
+    @Test
+    fun `sendWorkflowAlertMessage returns false when no integration configured`() =
+        runBlocking {
+            val orgId = seedOrg()
+            assertFalse(slackService.sendWorkflowAlertMessage(orgId, workflowPreview()))
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SlackServiceBuildersTest.kt
@@ -21,6 +21,7 @@ import com.moneat.notifications.services.encodeSlackIssueIdPathSegment
 import com.moneat.shared.models.OrganizationIntegrations
 import com.moneat.shared.models.Organizations
 import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.workflows.models.WorkflowPreviewField
 import com.moneat.workflows.models.WorkflowStepPreview
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -91,6 +92,11 @@ class SlackServiceBuildersTest {
             body = "Worker failures crossed the threshold",
             textBody = "[P1] Worker failures detected",
             color = "#E01E5A",
+            fields = listOf(
+                WorkflowPreviewField("Status", "Firing"),
+                WorkflowPreviewField("Priority", "[P1]"),
+                WorkflowPreviewField("Dashboard", "Moneat Backend System Health")
+            ),
             ctaLabel = "View",
             ctaUrl = "$BASE_URL/dashboards/13",
             fallbackText = "[P1] Worker failures detected"
@@ -136,6 +142,17 @@ class SlackServiceBuildersTest {
         runBlocking {
             val orgId = seedOrg()
             assertFalse(slackService.sendWorkflowAlertMessage(orgId, workflowPreview()))
+        }
+
+    @Test
+    fun `sendWorkflowAlertMessage builds rich alert blocks with configured integration`() =
+        runBlocking {
+            val orgId = seedOrg("Alert Org Workflow")
+            seedSlackIntegration(orgId)
+
+            val result = slackService.sendWorkflowAlertMessage(orgId, workflowPreview())
+
+            assertFalse(result)
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -283,6 +283,44 @@ class WorkflowServiceTest {
     }
 
     @Test
+    fun `workflow preview renders freeform notification messages`() {
+        val response =
+            service.previewWorkflow(
+                WorkflowPreviewRequest(
+                    triggerName = "alert.triggered",
+                    steps = listOf(emailStep(), slackStep(), discordStep())
+                )
+            )
+
+        assertEquals(3, response.previews.size)
+        val emailPreview = response.previews.first { it.channel == "email" }
+        assertEquals("Workflow Dashboard Error: Worker failures detected", emailPreview.subject)
+        assertTrue(emailPreview.htmlBody.orEmpty().contains("Worker failures [1h]"))
+        assertTrue(emailPreview.fallbackText.contains("DASHBOARD_ALERT"))
+
+        val slackPreview = response.previews.first { it.channel == "slack" }
+        assertEquals("Moneat workflow", slackPreview.title)
+        assertTrue(slackPreview.body.contains("https://moneat.io/dashboards/13"))
+
+        val discordPreview = response.previews.first { it.channel == "discord" }
+        assertEquals("Dashboard Error: Worker failures detected", discordPreview.title)
+        assertEquals("Moneat workflow", discordPreview.footer)
+        assertTrue(discordPreview.fallbackText.contains("DASHBOARD_ALERT"))
+    }
+
+    @Test
+    fun `workflow preview rejects unknown triggers`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.previewWorkflow(
+                WorkflowPreviewRequest(
+                    triggerName = "alert.missing",
+                    steps = listOf(slackStep())
+                )
+            )
+        }
+    }
+
+    @Test
     fun `testWorkflowMessage sends representative alert messages without creating a run`() =
         runBlocking {
             val request =
@@ -331,6 +369,85 @@ class WorkflowServiceTest {
                 discordService.sendWorkflowAlertMessage(
                     orgId,
                     match { it.ctaLabel == "View" && it.title.contains("[P1]") },
+                    false
+                )
+            }
+        }
+
+    @Test
+    fun `testWorkflowMessage sends freeform Slack and Discord messages`() =
+        runBlocking {
+            val response =
+                service.testWorkflowMessage(
+                    orgId,
+                    WorkflowPreviewRequest(
+                        triggerName = "alert.triggered",
+                        steps = listOf(slackStep(), discordStep())
+                    )
+                )
+
+            assertEquals(listOf("sent", "sent"), response.results.map { it.status })
+            coVerify(exactly = 1) {
+                slackService.sendWorkflowMessage(
+                    orgId,
+                    match { it.contains("Worker failures detected") && it.contains("https://moneat.io/dashboards/13") },
+                    false
+                )
+            }
+            coVerify(exactly = 1) {
+                discordService.sendWorkflowMessage(
+                    orgId,
+                    "Dashboard Error: Worker failures detected",
+                    match { it.contains("DASHBOARD_ALERT") && it.contains("FIRING") },
+                    false
+                )
+            }
+        }
+
+    @Test
+    fun `testWorkflowMessage reports skipped and failed notification steps`() =
+        runBlocking {
+            coEvery { discordService.sendWorkflowAlertMessage(any(), any(), any()) } returns false
+
+            val response =
+                service.testWorkflowMessage(
+                    orgId,
+                    WorkflowPreviewRequest(
+                        triggerName = "alert.triggered",
+                        steps = listOf(
+                            WorkflowStepConfig(
+                                name = "notification.slack",
+                                params = mapOf(
+                                    "format" to "alert_lifecycle",
+                                    "message" to "{{alert.description}}"
+                                )
+                            ),
+                            WorkflowStepConfig(
+                                name = "notification.discord",
+                                params = mapOf(
+                                    "format" to "alert_lifecycle",
+                                    "title" to "{{alert.title}}",
+                                    "message" to "{{alert.description}}"
+                                )
+                            )
+                        ),
+                        scope = mapOf("alert.channels.slack" to "false")
+                    )
+                )
+
+            val resultsByChannel = response.results.associateBy { it.channel }
+            assertEquals("skipped", resultsByChannel["slack"]?.status)
+            assertEquals(
+                "Notification channel is disabled for this sample",
+                resultsByChannel["slack"]?.errorMessage
+            )
+            assertEquals("failed", resultsByChannel["discord"]?.status)
+            assertEquals("Discord test message was not sent", resultsByChannel["discord"]?.errorMessage)
+            coVerify(exactly = 0) { slackService.sendWorkflowAlertMessage(any(), any(), any()) }
+            coVerify(exactly = 1) {
+                discordService.sendWorkflowAlertMessage(
+                    orgId,
+                    match { it.title.contains("[P1]") },
                     false
                 )
             }
@@ -435,6 +552,62 @@ class WorkflowServiceTest {
             )
         }
     }
+
+    @Test
+    fun `executing alert lifecycle workflows sends rich previews`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Rich alert lifecycle",
+                        triggerName = "alert.triggered",
+                        steps = listOf(
+                            WorkflowStepConfig(
+                                name = "notification.slack",
+                                params = mapOf(
+                                    "format" to "alert_lifecycle",
+                                    "message" to "{{alert.description}}"
+                                )
+                            ),
+                            WorkflowStepConfig(
+                                name = "notification.discord",
+                                params = mapOf(
+                                    "format" to "alert_lifecycle",
+                                    "title" to "{{alert.title}}",
+                                    "message" to "{{alert.description}}"
+                                )
+                            )
+                        ),
+                        onceForTemplate = listOf("alert.deduplication_key")
+                    )
+                )
+
+            service.publishAlertTriggered(alertEvent())
+            val queuedRun = service.listRuns(orgId, workflow.id).single()
+
+            service.executeRun(queuedRun.id)
+
+            val completedRun = service.listRuns(orgId, workflow.id).single()
+            assertEquals("complete", completedRun.status)
+            coVerify(exactly = 1) {
+                slackService.sendWorkflowAlertMessage(
+                    orgId,
+                    match { it.title == "[P0] CPU saturation" && it.ctaLabel == "View" },
+                    true
+                )
+            }
+            coVerify(exactly = 1) {
+                discordService.sendWorkflowAlertMessage(
+                    orgId,
+                    match { preview ->
+                        preview.footer == "Host metric alert" &&
+                            preview.fields.any { field -> field.label == "Priority" }
+                    },
+                    true
+                )
+            }
+        }
 
     @Test
     fun `publishing and executing alert workflows records successful runs`() =

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -32,6 +32,7 @@ import com.moneat.workflows.engine.WorkflowCatalog
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowPreviewRequest
 import com.moneat.workflows.models.WorkflowRuns
 import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowVersions
@@ -96,7 +97,9 @@ class WorkflowServiceTest {
         every { redis.lpush(any(), any<String>()) } returns 1L
         every { emailService.sendEmail(any(), any(), any(), any(), any()) } just runs
         coEvery { slackService.sendWorkflowMessage(any(), any(), any()) } returns true
+        coEvery { slackService.sendWorkflowAlertMessage(any(), any(), any()) } returns true
         coEvery { discordService.sendWorkflowMessage(any(), any(), any(), any()) } returns true
+        coEvery { discordService.sendWorkflowAlertMessage(any(), any(), any()) } returns true
         service = WorkflowService(emailService, slackService, discordService)
         orgId = seedOrganizationWithMembers()
     }
@@ -202,6 +205,7 @@ class WorkflowServiceTest {
         )
         assertEquals("Email organization members", WorkflowCatalog.step("notification.email_org")?.label)
         assertEquals("AlertSeverity", WorkflowCatalog.scopeType("alert.triggered", "alert.severity"))
+        assertEquals("String", WorkflowCatalog.scopeType("alert.triggered", "alert.priority"))
         assertEquals("Boolean", WorkflowCatalog.scopeType("alert.triggered", "alert.channels.email"))
         assertNull(WorkflowCatalog.trigger("missing.trigger"))
         assertNull(WorkflowCatalog.step("notification.unknown"))
@@ -230,7 +234,9 @@ class WorkflowServiceTest {
             setOf("default_alert_notifications", "default_recovery_notifications"),
             firstOrgWorkflows.mapNotNull { it.systemKey }.toSet()
         )
-        assertEquals(3, firstOrgWorkflows.first { it.triggerName == "alert.triggered" }.steps.size)
+        val defaultAlertWorkflow = firstOrgWorkflows.first { it.triggerName == "alert.triggered" }
+        assertEquals(3, defaultAlertWorkflow.steps.size)
+        assertTrue(defaultAlertWorkflow.steps.all { it.params["format"] == "alert_lifecycle" })
         assertFailsWith<IllegalArgumentException> {
             service.updateWorkflow(orgId, firstOrgWorkflows.first().id, UpdateWorkflowRequest(name = "Edited default"))
         }
@@ -239,6 +245,96 @@ class WorkflowServiceTest {
         }
         assertEquals(2L, transaction { Workflows.selectAll().where { Workflows.organizationId eq orgId }.count() })
     }
+
+    @Test
+    fun `workflow preview renders rich alert lifecycle messages`() {
+        val response =
+            service.previewWorkflow(
+                WorkflowPreviewRequest(
+                    triggerName = "alert.resolved",
+                    steps = listOf(
+                        WorkflowStepConfig(
+                            name = "notification.email_org",
+                            params = mapOf("format" to "alert_lifecycle")
+                        ),
+                        WorkflowStepConfig(
+                            name = "notification.slack",
+                            params = mapOf("format" to "alert_lifecycle")
+                        )
+                    )
+                )
+            )
+
+        assertEquals("RESOLVED", response.scope["alert.status"])
+        assertEquals("[P3]", response.scope["alert.priority"])
+        assertEquals(2, response.previews.size)
+        val emailPreview = response.previews.first { it.channel == "email" }
+        assertEquals("[Moneat] [P3] Resolved: Worker failures detected", emailPreview.subject)
+        assertEquals("#2EB67D", emailPreview.color)
+        assertTrue(emailPreview.htmlBody.orEmpty().contains("View"))
+        assertTrue(emailPreview.htmlBody.orEmpty().contains("/favicon.svg"))
+        assertFalse(emailPreview.htmlBody.orEmpty().contains(">APP</span>"))
+        assertTrue(emailPreview.fields.any { it.label == "Dashboard" })
+        assertTrue(emailPreview.fields.any { it.label == "Priority" && it.value == "[P3]" })
+        val slackPreview = response.previews.first { it.channel == "slack" }
+        assertEquals("[P3] Resolved: Worker failures detected", slackPreview.title)
+        assertEquals("View", slackPreview.ctaLabel)
+        assertTrue(slackPreview.textBody.contains("Status: Resolved"))
+    }
+
+    @Test
+    fun `testWorkflowMessage sends representative alert messages without creating a run`() =
+        runBlocking {
+            val request =
+                WorkflowPreviewRequest(
+                    triggerName = "alert.triggered",
+                    steps = listOf(
+                        WorkflowStepConfig(
+                            name = "notification.email_org",
+                            params = mapOf("format" to "alert_lifecycle")
+                        ),
+                        WorkflowStepConfig(
+                            name = "notification.slack",
+                            params = mapOf("format" to "alert_lifecycle")
+                        ),
+                        WorkflowStepConfig(
+                            name = "notification.discord",
+                            params = mapOf("format" to "alert_lifecycle")
+                        )
+                    )
+                )
+
+            val response = service.testWorkflowMessage(orgId, request)
+
+            assertEquals(listOf("sent", "sent", "sent"), response.results.map { it.status })
+            assertEquals(emptyList(), service.listRuns(orgId, workflowId = 1))
+            verify(exactly = 1) {
+                emailService.sendEmail(
+                    "verified@moneat.io",
+                    "[Moneat] [P1] Worker failures detected",
+                    match { it.contains("Added by Moneat") && it.contains("/favicon.svg") },
+                    match { it.contains("View: https://moneat.io/dashboards/13") },
+                    "workflow"
+                )
+            }
+            verify(exactly = 0) {
+                emailService.sendEmail("unverified@moneat.io", any(), any(), any(), any())
+            }
+            coVerify(exactly = 1) {
+                slackService.sendWorkflowAlertMessage(
+                    orgId,
+                    match { it.ctaLabel == "View" && it.title.contains("[P1]") },
+                    false
+                )
+            }
+            coVerify(exactly = 1) {
+                discordService.sendWorkflowAlertMessage(
+                    orgId,
+                    match { it.ctaLabel == "View" && it.title.contains("[P1]") },
+                    false
+                )
+            }
+        }
 
     @Test
     fun `create update list get and delete workflow validates the catalog contract`() {

--- a/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
@@ -28,9 +28,14 @@ import com.moneat.workflows.engine.WorkflowCatalog
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowPreviewRequest
+import com.moneat.workflows.models.WorkflowPreviewResponse
 import com.moneat.workflows.models.WorkflowResponse
 import com.moneat.workflows.models.WorkflowRunResponse
 import com.moneat.workflows.models.WorkflowStepConfig
+import com.moneat.workflows.models.WorkflowStepPreview
+import com.moneat.workflows.models.WorkflowTestMessageResponse
+import com.moneat.workflows.models.WorkflowTestMessageResult
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
@@ -44,6 +49,8 @@ import io.ktor.http.contentType
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -191,6 +198,78 @@ class WorkflowRoutesTest {
             assertTrue(created.bodyAsText().contains("Route workflow"))
             assertEquals(HttpStatusCode.BadRequest, invalid.status)
             assertTrue(invalid.bodyAsText().contains("Workflow name is required"))
+        }
+
+    @Test
+    fun `preview route returns rendered workflow messages`() =
+        testApplication {
+            setupApp()
+            val request =
+                WorkflowPreviewRequest(
+                    triggerName = "alert.triggered",
+                    steps = listOf(WorkflowStepConfig("notification.slack"))
+                )
+            val preview =
+                WorkflowPreviewResponse(
+                    scope = mapOf("alert.status" to "FIRING"),
+                    previews = listOf(
+                        WorkflowStepPreview(
+                            step = "notification.slack",
+                            channel = "slack",
+                            title = "[P1] Worker failures detected",
+                            body = "Worker failures crossed the threshold",
+                            textBody = "[P1] Worker failures detected",
+                            color = "#E01E5A",
+                            ctaLabel = "View",
+                            ctaUrl = "https://moneat.io/dashboards/13",
+                            fallbackText = "[P1] Worker failures detected"
+                        )
+                    )
+                )
+            every { workflowService.previewWorkflow(request) } returns preview
+
+            val response = client.post("/v1/workflows/preview") {
+                withAuth(token())
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(request))
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"cta_label\":\"View\""))
+            verify { workflowService.previewWorkflow(request) }
+        }
+
+    @Test
+    fun `test message route sends rendered workflow messages`() =
+        testApplication {
+            setupApp()
+            val request =
+                WorkflowPreviewRequest(
+                    triggerName = "alert.triggered",
+                    steps = listOf(WorkflowStepConfig("notification.slack"))
+                )
+            val result =
+                WorkflowTestMessageResponse(
+                    scope = mapOf("alert.status" to "FIRING"),
+                    results = listOf(
+                        WorkflowTestMessageResult(
+                            step = "notification.slack",
+                            channel = "slack",
+                            status = "sent"
+                        )
+                    )
+                )
+            coEvery { workflowService.testWorkflowMessage(organizationId, request) } returns result
+
+            val response = client.post("/v1/workflows/test-message") {
+                withAuth(token())
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(request))
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"status\":\"sent\""))
+            coVerify { workflowService.testWorkflowMessage(organizationId, request) }
         }
 
     @Test

--- a/dashboard/src/docs/pages/workflows.mdx
+++ b/dashboard/src/docs/pages/workflows.mdx
@@ -117,12 +117,20 @@ Workflow step fields support interpolation with double braces. Use references fr
 
 ```text
 {{alert.title}}
-Severity: {{alert.severity}}
+{{alert.display_title}}
+Priority: {{alert.priority}}
 Source: {{alert.source}}
 View: {{alert.url}}
 ```
 
 When a workflow runs, Moneat replaces each variable with the matching alert value.
+`alert.severity` keeps the internal enum value, while `alert.priority` renders `[P0]` through `[P3]`.
+Dashboard alerts also expose `alert.dashboard.title`, `alert.widget.title`, `alert.condition`,
+`alert.threshold`, and `alert.current_value`.
+
+Use **Preview** in the workflow editor to render representative Slack, Discord, and email messages
+without sending them. Use the test action on an individual step to send that step's representative
+sample to its configured destination without creating a workflow run.
 
 ## Viewing runs
 
@@ -141,5 +149,4 @@ Use run history to confirm that a workflow matched the alerts you expected and t
 - Workflows run immediately after the trigger and conditions match.
 - Delay configuration is visible in the builder but not available yet.
 - Conditions are currently combined with **and** logic only.
-- Workflow testing from the UI is not available yet; use run history after matching alert events fire.
 - Native on-call escalation and external incident-provider routing are not workflow steps yet.

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -333,7 +333,6 @@
   box-shadow: 2px 2px 0px 0px hsl(var(--foreground));
 }
 
-
 /* Gamer theme neon glow effects */
 .theme-gamer *:focus-visible {
   box-shadow: 0 0 8px hsl(var(--ring) / 0.5);
@@ -541,4 +540,10 @@
 
 .service-map .react-flow__edge-path {
   stroke-linecap: round;
+}
+
+.workflows-page :is(.shadow, .shadow-sm, .shadow-md, .shadow-lg),
+.workflow-editor-dialog:is(.shadow, .shadow-sm, .shadow-md, .shadow-lg),
+.workflow-editor-dialog :is(.shadow, .shadow-sm, .shadow-md, .shadow-lg) {
+  box-shadow: none;
 }

--- a/dashboard/src/lib/api/modules/workflows.ts
+++ b/dashboard/src/lib/api/modules/workflows.ts
@@ -17,9 +17,12 @@
 import type {ApiClientCore} from '../client'
 import type {
   WorkflowCatalogResponse,
+  WorkflowPreviewRequest,
+  WorkflowPreviewResponse,
   WorkflowRequest,
   WorkflowResponse,
   WorkflowRunResponse,
+  WorkflowTestMessageResponse,
   WorkflowUpdateRequest,
 } from '../types'
 
@@ -35,6 +38,18 @@ export function workflowsMethods(core: ApiClientCore) {
 
     createWorkflow: (request: WorkflowRequest) =>
       core.request<WorkflowResponse>(`${base}/workflows`, {
+        method: 'POST',
+        body: JSON.stringify(request),
+      }),
+
+    previewWorkflow: (request: WorkflowPreviewRequest) =>
+      core.request<WorkflowPreviewResponse>(`${base}/workflows/preview`, {
+        method: 'POST',
+        body: JSON.stringify(request),
+      }),
+
+    testWorkflowMessage: (request: WorkflowPreviewRequest) =>
+      core.request<WorkflowTestMessageResponse>(`${base}/workflows/test-message`, {
         method: 'POST',
         body: JSON.stringify(request),
       }),

--- a/dashboard/src/lib/api/types/workflows.ts
+++ b/dashboard/src/lib/api/types/workflows.ts
@@ -25,6 +25,50 @@ export interface WorkflowStepConfig {
   params: Record<string, string>
 }
 
+export interface WorkflowPreviewRequest {
+  trigger_name: string
+  steps: WorkflowStepConfig[]
+  scope?: Record<string, string>
+}
+
+export interface WorkflowPreviewField {
+  label: string
+  value: string
+}
+
+export interface WorkflowStepPreview {
+  step: string
+  channel: string
+  title: string
+  subject?: string | null
+  body: string
+  html_body?: string | null
+  text_body: string
+  fields: WorkflowPreviewField[]
+  color: string
+  cta_label?: string | null
+  cta_url?: string | null
+  footer?: string | null
+  fallback_text: string
+}
+
+export interface WorkflowPreviewResponse {
+  scope: Record<string, string>
+  previews: WorkflowStepPreview[]
+}
+
+export interface WorkflowTestMessageResult {
+  step: string
+  channel: string
+  status: string
+  error_message?: string | null
+}
+
+export interface WorkflowTestMessageResponse {
+  scope: Record<string, string>
+  results: WorkflowTestMessageResult[]
+}
+
 export interface WorkflowRequest {
   name: string
   trigger_name: string

--- a/dashboard/src/routes/workflows.tsx
+++ b/dashboard/src/routes/workflows.tsx
@@ -26,11 +26,13 @@ import {
   Filter,
   GitBranch,
   Hash,
+  Eye,
   Loader2,
   Mail,
   MessageSquare,
   Plus,
   Save,
+  Send,
   Trash2,
   Workflow,
   X,
@@ -40,12 +42,15 @@ import type {
   WorkflowCatalogResponse,
   WorkflowConditionConfig,
   WorkflowOperationDefinition,
+  WorkflowPreviewResponse,
   WorkflowRequest,
   WorkflowResponse,
   WorkflowRunResponse,
   WorkflowScopeReferenceDefinition,
   WorkflowStepConfig,
   WorkflowStepDefinition,
+  WorkflowStepPreview,
+  WorkflowTestMessageResponse,
   WorkflowTriggerDefinition,
 } from '@/lib/api'
 import {Badge} from '@/components/ui/badge'
@@ -62,6 +67,7 @@ import {Input} from '@/components/ui/input'
 import {Label} from '@/components/ui/label'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
 import {Switch} from '@/components/ui/switch'
+import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
 import {Textarea} from '@/components/ui/textarea'
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip'
 import {useToast} from '@/hooks/useToast'
@@ -94,7 +100,7 @@ function isDefaultWorkflow(workflow: WorkflowResponse): boolean {
 const defaultMessage = [
   '{{alert.title}}',
   '',
-  'Severity: {{alert.severity}}',
+  'Priority: {{alert.priority}}',
   'Source: {{alert.source}}',
   'View: {{alert.url}}',
 ].join('\n')
@@ -132,6 +138,34 @@ function formToRequest(form: WorkflowFormState): WorkflowRequest {
     steps: form.steps,
     once_for_template: splitReferences(form.onceForTemplate),
   }
+}
+
+function formToPreviewRequest(form: WorkflowFormState) {
+  return {
+    trigger_name: form.triggerName,
+    steps: form.steps,
+  }
+}
+
+function formToStepPreviewRequest(form: WorkflowFormState, step: WorkflowStepConfig) {
+  return {
+    trigger_name: form.triggerName,
+    steps: [step],
+  }
+}
+
+function workflowTestMessageSummary(response: WorkflowTestMessageResponse): string {
+  const sentCount = response.results.filter((result) => result.status === 'sent').length
+  const skippedCount = response.results.filter((result) => result.status === 'skipped').length
+  const failed = response.results.filter((result) => result.status === 'failed')
+  if (failed.length > 0) {
+    return failed
+      .map((result) => `${previewChannelLabel(result.channel)}: ${result.error_message ?? 'not sent'}`)
+      .join('; ')
+  }
+  const parts = [`${sentCount} sent`]
+  if (skippedCount > 0) parts.push(`${skippedCount} skipped`)
+  return parts.join(', ')
 }
 
 function splitReferences(value: string): string[] {
@@ -329,7 +363,7 @@ function WorkflowsPage() {
   const isLoading = catalogLoading || workflowsLoading
 
   return (
-    <div>
+    <div className="workflows-page">
       <div className="border-b bg-card/50">
         <div className="px-4 py-3 lg:px-6">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -524,11 +558,11 @@ function WorkflowDetail({
             </div>
             <p className="mt-1 text-sm text-muted-foreground">{trigger?.description ?? workflow.trigger_name}</p>
           </div>
-          {!defaultWorkflow && (
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={() => onEdit(workflow)}>
-                Edit
-              </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => onEdit(workflow)}>
+              Edit
+            </Button>
+            {!defaultWorkflow && (
               <Button
                 variant="outline"
                 size="sm"
@@ -539,8 +573,8 @@ function WorkflowDetail({
                 <Trash2 className="h-3.5 w-3.5" />
                 Delete
               </Button>
-            </div>
-          )}
+            )}
+          </div>
         </div>
 
         <div className="grid gap-4 p-4 lg:grid-cols-2">
@@ -669,17 +703,55 @@ function WorkflowDialog({
   onFormChange: (form: WorkflowFormState) => void
   onSubmit: () => void
 }) {
+  const {toast} = useToast()
   const [selectedPanel, setSelectedPanel] = useState<WorkflowEditorPanel>('trigger')
+  const [preview, setPreview] = useState<WorkflowPreviewResponse | null>(null)
   const selectedStepIndex = selectedPanel.startsWith('step:') ? Number(selectedPanel.slice(5)) : null
   const activePanel: WorkflowEditorPanel = selectedStepIndex !== null && !form.steps[selectedStepIndex]
     ? 'trigger'
     : selectedPanel
+  const previewMutation = useMutation({
+    mutationFn: () => api.previewWorkflow(formToPreviewRequest(form)),
+    onSuccess: (response) => {
+      setPreview(response)
+    },
+    onError: (error: Error) => {
+      toast({title: 'Failed to preview workflow', description: error.message, variant: 'destructive'})
+    },
+  })
+  const testMessageMutation = useMutation({
+    mutationFn: ({step}: {step: WorkflowStepConfig; index: number}) =>
+      api.testWorkflowMessage(formToStepPreviewRequest(form, step)),
+    onSuccess: (response) => {
+      const failedCount = response.results.filter((result) => result.status === 'failed').length
+      toast({
+        title: failedCount > 0 ? 'Test message failed' : 'Test message sent',
+        description: workflowTestMessageSummary(response),
+        variant: failedCount > 0 ? 'destructive' : undefined,
+      })
+    },
+    onError: (error: Error) => {
+      toast({title: 'Failed to send test message', description: error.message, variant: 'destructive'})
+    },
+  })
+
+  const handleFormChange = (nextForm: WorkflowFormState) => {
+    setPreview(null)
+    onFormChange(nextForm)
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setPreview(null)
+    }
+    onOpenChange(nextOpen)
+  }
 
   const addCondition = () => {
     const firstReference = activeTrigger?.scope[0]
     const operation = operationsForReference(catalog, firstReference)[0]
     if (!firstReference || !operation) return
-    onFormChange({
+    handleFormChange({
       ...form,
       conditions: [...form.conditions, {reference: firstReference.name, operation: operation.name, value: ''}],
     })
@@ -689,7 +761,7 @@ function WorkflowDialog({
   const addStep = () => {
     const step = catalog?.steps[0]
     if (!step) return
-    onFormChange({
+    handleFormChange({
       ...form,
       steps: [...form.steps, {name: step.name, params: defaultStepParams(step)}],
     })
@@ -697,14 +769,15 @@ function WorkflowDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[92vh] max-w-6xl overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{editingWorkflow ? 'Edit Workflow' : 'New Workflow'}</DialogTitle>
-          <DialogDescription className="sr-only">
-            Configure trigger conditions, idempotency, and notification steps for alert automation.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="workflow-editor-dialog max-h-[92vh] max-w-6xl overflow-y-auto shadow-none">
+          <DialogHeader>
+            <DialogTitle>{editingWorkflow ? 'Edit Workflow' : 'New Workflow'}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Configure trigger conditions, idempotency, and notification steps for alert automation.
+            </DialogDescription>
+          </DialogHeader>
 
         <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
           <div className="mx-auto w-full max-w-3xl">
@@ -730,10 +803,14 @@ function WorkflowDialog({
               catalog={catalog}
               steps={form.steps}
               selectedStepIndex={activePanel.startsWith('step:') ? Number(activePanel.slice(5)) : null}
+              testMessageStepIndex={testMessageMutation.variables?.index ?? null}
+              testMessagePending={testMessageMutation.isPending}
+              testMessageDisabled={testMessageMutation.isPending}
               onSelectStep={(index) => setSelectedPanel(`step:${index}`)}
+              onTestStep={(step, index) => testMessageMutation.mutate({step, index})}
               onAddStep={addStep}
               onRemoveStep={(index) => {
-                onFormChange({...form, steps: form.steps.filter((_, itemIndex) => itemIndex !== index)})
+                handleFormChange({...form, steps: form.steps.filter((_, itemIndex) => itemIndex !== index)})
                 setSelectedPanel('trigger')
               }}
             />
@@ -746,15 +823,21 @@ function WorkflowDialog({
               trigger={activeTrigger}
               form={form}
               editingWorkflow={editingWorkflow}
-              onFormChange={onFormChange}
+              onFormChange={handleFormChange}
               onSelectPanel={setSelectedPanel}
+            />
+            <WorkflowPreviewPanel
+              preview={preview}
+              pending={previewMutation.isPending}
+              canPreview={form.steps.length > 0}
+              onPreview={() => previewMutation.mutate()}
             />
             <CatalogPanel catalog={catalog} trigger={activeTrigger} />
           </div>
         </div>
 
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+        <DialogFooter className="mt-2 gap-2 sm:space-x-0">
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
             <X className="mr-1.5 h-3.5 w-3.5" />
             Cancel
           </Button>
@@ -763,8 +846,9 @@ function WorkflowDialog({
             Save Workflow
           </Button>
         </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 
@@ -791,7 +875,7 @@ function TriggerNode({
         }
       }}
       className={cn(
-        'w-full rounded-lg border bg-background p-4 text-left shadow-sm transition-colors hover:bg-muted/30',
+        'w-full rounded-lg border bg-background p-4 text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -926,7 +1010,7 @@ function DelayNode({
         }
       }}
       className={cn(
-        'flex w-full items-center justify-between gap-3 rounded-lg border bg-background px-4 py-3 text-left shadow-sm transition-colors hover:bg-muted/30',
+        'flex w-full items-center justify-between gap-3 rounded-lg border bg-background px-4 py-3 text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -970,7 +1054,7 @@ function ConditionNode({
         }
       }}
       className={cn(
-        'overflow-hidden rounded-lg border bg-background text-left shadow-sm transition-colors hover:bg-muted/30',
+        'overflow-hidden rounded-lg border bg-background text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -1095,14 +1179,22 @@ function StepEditor({
   catalog,
   steps,
   selectedStepIndex,
+  testMessageStepIndex,
+  testMessagePending,
+  testMessageDisabled,
   onSelectStep,
+  onTestStep,
   onAddStep,
   onRemoveStep,
 }: {
   catalog?: WorkflowCatalogResponse
   steps: WorkflowStepConfig[]
   selectedStepIndex: number | null
+  testMessageStepIndex: number | null
+  testMessagePending: boolean
+  testMessageDisabled: boolean
   onSelectStep: (index: number) => void
+  onTestStep: (step: WorkflowStepConfig, index: number) => void
   onAddStep: () => void
   onRemoveStep: (index: number) => void
 }) {
@@ -1116,7 +1208,10 @@ function StepEditor({
               step={step}
               index={index}
               selected={selectedStepIndex === index}
+              testMessagePending={testMessagePending && testMessageStepIndex === index}
+              testMessageDisabled={testMessageDisabled}
               onSelect={() => onSelectStep(index)}
+              onTest={() => onTestStep(step, index)}
               onRemove={() => onRemoveStep(index)}
             />
             <FlowConnector />
@@ -1124,7 +1219,7 @@ function StepEditor({
         ))}
       </div>
       <div className="flex justify-center">
-        <Button type="button" variant="outline" size="sm" onClick={onAddStep} className="gap-1.5 rounded-lg shadow-sm">
+        <Button type="button" variant="outline" size="sm" onClick={onAddStep} className="gap-1.5 rounded-lg">
           <Plus className="h-3.5 w-3.5" />
           Add step
         </Button>
@@ -1138,14 +1233,20 @@ function StepNode({
   step,
   index,
   selected,
+  testMessagePending,
+  testMessageDisabled,
   onSelect,
+  onTest,
   onRemove,
 }: {
   definition?: WorkflowStepDefinition
   step: WorkflowStepConfig
   index: number
   selected: boolean
+  testMessagePending: boolean
+  testMessageDisabled: boolean
   onSelect: () => void
+  onTest: () => void
   onRemove: () => void
 }) {
   const firstParam = definition?.params[0]
@@ -1162,7 +1263,7 @@ function StepNode({
         }
       }}
       className={cn(
-        'overflow-hidden rounded-lg border bg-background text-left shadow-sm transition-colors hover:bg-muted/30',
+        'overflow-hidden rounded-lg border bg-background text-left transition-colors hover:bg-muted/30',
         selected && 'border-primary/60 ring-2 ring-primary/15'
       )}
     >
@@ -1175,17 +1276,42 @@ function StepNode({
           <p className="truncate text-sm font-semibold">{definition?.label ?? step.name}</p>
           {firstValue && <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{firstValue}</p>}
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          onClick={(event) => {
-            event.stopPropagation()
-            onRemove()
-          }}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+        <div className="flex shrink-0 items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Send test message for ${definition?.label ?? step.name}`}
+                disabled={testMessageDisabled}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onTest()
+                }}
+                className="h-8 w-8"
+              >
+                {testMessagePending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Send className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Send test message</TooltipContent>
+          </Tooltip>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={(event) => {
+              event.stopPropagation()
+              onRemove()
+            }}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
     </div>
   )
@@ -1292,7 +1418,7 @@ function WorkflowInspector({
   const selectedStep = selectedStepIndex !== null ? form.steps[selectedStepIndex] : undefined
 
   return (
-    <div className="rounded-lg border bg-muted/20 p-3 shadow-sm">
+    <div className="rounded-lg border bg-muted/20 p-3">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
           <h3 className="text-sm font-semibold">{inspectorTitle(panel)}</h3>
@@ -1382,6 +1508,226 @@ function inspectorSubtitle(panel: WorkflowEditorPanel): string {
   if (panel === 'conditions') return 'Filter when this workflow should apply.'
   if (panel === 'delay') return 'Timing for execution after a match.'
   return 'Choose the action and fill in its parameters.'
+}
+
+function WorkflowPreviewPanel({
+  preview,
+  pending,
+  canPreview,
+  onPreview,
+}: {
+  preview: WorkflowPreviewResponse | null
+  pending: boolean
+  canPreview: boolean
+  onPreview: () => void
+}) {
+  const previewItems = preview?.previews ?? []
+  const hasPreview = previewItems.length > 0
+  const firstTab = hasPreview ? previewTabValue(previewItems[0], 0) : ''
+  return (
+    <div className="rounded-lg border bg-muted/20 p-3">
+      <div className="mb-3 flex flex-col gap-3">
+        <div>
+          <h3 className="text-sm font-semibold">Message preview</h3>
+          <p className="text-xs text-muted-foreground">Representative alert sample</p>
+        </div>
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onPreview}
+            disabled={!canPreview || pending}
+            className="h-8 justify-center gap-1.5"
+          >
+            {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Eye className="h-3.5 w-3.5" />}
+            Preview
+          </Button>
+        </div>
+      </div>
+
+      {pending ? (
+        <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Rendering preview
+        </div>
+      ) : hasPreview ? (
+        <Tabs defaultValue={firstTab} className="w-full">
+          <TabsList className="grid h-auto w-full auto-cols-fr grid-flow-col">
+            {previewItems.map((item, index) => (
+              <TabsTrigger key={previewTabValue(item, index)} value={previewTabValue(item, index)}>
+                {previewChannelLabel(item.channel)}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {previewItems.map((item, index) => (
+            <TabsContent key={previewTabValue(item, index)} value={previewTabValue(item, index)} className="mt-3">
+              <WorkflowPreviewCard item={item} />
+            </TabsContent>
+          ))}
+        </Tabs>
+      ) : (
+        <div className="rounded-md border border-dashed bg-background px-3 py-4 text-sm text-muted-foreground">
+          Not rendered yet.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function WorkflowPreviewCard({item}: {item: WorkflowStepPreview}) {
+  if (item.channel === 'email') return <EmailPreview item={item} />
+  if (item.channel === 'discord') return <DiscordPreview item={item} />
+  return <SlackPreview item={item} />
+}
+
+function EmailPreview({item}: {item: WorkflowStepPreview}) {
+  return (
+    <div className="overflow-hidden rounded-md border bg-background">
+      <div className="border-b px-3 py-2 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">Subject:</span> {item.subject ?? item.title}
+      </div>
+      <div className="bg-muted/20 p-4">
+        <div className="rounded-md border bg-card p-4 text-card-foreground">
+          <div className="flex items-start gap-3">
+            <MoneatMessageAvatar />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold">Moneat</p>
+              <h4 className="mt-3 flex items-start gap-2 text-base font-semibold leading-snug">
+                <span aria-hidden="true">{previewStatusEmoji(item)}</span>
+                <span>{previewHeaderText(item)}</span>
+              </h4>
+              <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">{item.body}</p>
+              <EmailFieldGrid fields={item.fields} />
+              <PreviewCta item={item} />
+              {item.footer && <p className="mt-4 text-xs text-muted-foreground">Added by Moneat</p>}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SlackPreview({item}: {item: WorkflowStepPreview}) {
+  return <AlertMessagePreview item={item} />
+}
+
+function DiscordPreview({item}: {item: WorkflowStepPreview}) {
+  return <AlertMessagePreview item={item} />
+}
+
+function AlertMessagePreview({item}: {item: WorkflowStepPreview}) {
+  return (
+    <div className="rounded-md border bg-[#1f2227] p-3 text-[#d1d2d3]">
+      <div className="flex items-start gap-3">
+        <MoneatMessageAvatar />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5 text-sm leading-none">
+            <span className="font-bold text-[#f2f3f5]">Moneat</span>
+            <span className="rounded bg-[#34373c] px-1 py-0.5 text-[10px] font-bold text-[#c9cbd0]">APP</span>
+            <span className="text-[#a5a7aa]">now</span>
+          </div>
+          <div className="mt-3 flex items-center gap-2 text-sm font-bold text-[#f2f3f5]">
+            <span>{previewStatusEmoji(item)}</span>
+            <span>{previewHeaderText(item)}</span>
+          </div>
+          <div className="mt-3 border-l-4 py-1 pl-4" style={{borderLeftColor: item.color}}>
+            <p className="mb-3 whitespace-pre-wrap text-sm text-[#d1d2d3]">{item.body}</p>
+            <AlertFieldGrid fields={item.fields} />
+            <PreviewCta item={item} dark />
+            {item.footer && <p className="mt-3 text-xs text-[#a5a7aa]">Added by Moneat</p>}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MoneatMessageAvatar() {
+  return (
+    <div
+      aria-hidden="true"
+      className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white"
+    >
+      <img src="/favicon.svg" alt="" className="h-8 w-8" />
+    </div>
+  )
+}
+
+function EmailFieldGrid({fields}: {fields: WorkflowStepPreview['fields']}) {
+  if (fields.length === 0) return null
+  return (
+    <div className="mt-4 grid gap-x-6 gap-y-3 sm:grid-cols-2">
+      {fields.map((field) => (
+        <div key={field.label} className="min-w-0">
+          <p className="text-sm font-semibold text-foreground">{field.label}:</p>
+          <p className="break-words text-sm text-muted-foreground">{field.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function AlertFieldGrid({fields}: {fields: WorkflowStepPreview['fields']}) {
+  if (fields.length === 0) return null
+  return (
+    <div className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+      {fields.map((field) => (
+        <div key={field.label} className="min-w-0">
+          <p className="text-sm font-bold text-[#d1d2d3]">{field.label}:</p>
+          <p className="break-words text-sm text-[#d1d2d3]">{field.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PreviewCta({
+  item,
+  dark = false,
+}: {
+  item: WorkflowStepPreview
+  dark?: boolean
+}) {
+  if (!item.cta_label || !item.cta_url) return null
+  return (
+    <div className="mt-3">
+      <Button type="button" variant={dark ? 'secondary' : 'outline'} size="sm" className="h-8 px-3">
+        {item.cta_label}
+      </Button>
+    </div>
+  )
+}
+
+function previewStatusEmoji(item: WorkflowStepPreview): string {
+  const status = previewFieldValue(item, 'Status')
+  if (status.toLowerCase() === 'resolved') return '✅'
+  return item.color.toLowerCase() === '#e01e5a' ? '🔴' : '⚠️'
+}
+
+function previewHeaderText(item: WorkflowStepPreview): string {
+  return item.title
+}
+
+function previewFieldValue(
+  item: WorkflowStepPreview,
+  label: string
+): string {
+  return item.fields.find((field) => field.label.toLowerCase() === label.toLowerCase())?.value ?? ''
+}
+
+function previewTabValue(
+  item: WorkflowStepPreview,
+  index: number
+): string {
+  return item.channel + '-' + index
+}
+
+function previewChannelLabel(channel: string): string {
+  if (channel === 'email') return 'Email'
+  if (channel === 'discord') return 'Discord'
+  if (channel === 'slack') return 'Slack'
+  return channel
 }
 
 function CatalogPanel({


### PR DESCRIPTION
## Summary
- add rich alert lifecycle workflow rendering for Slack, Discord, and email
- add workflow preview and per-step test message support in the dashboard
- refresh default alert/recovery workflow notification format while preserving custom workflows

## Validation
- cd dashboard && npm ci
- cd dashboard && npm run lint && npm run typecheck
- cd backend && ./gradlew compileKotlin --no-daemon
- cd backend && GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.workflows.WorkflowServiceTest --tests com.moneat.workflows.routes.WorkflowRoutesTest --tests com.moneat.dashboards.DashboardAlertServiceTest --tests com.moneat.services.SlackServiceBuildersTest --tests com.moneat.services.DiscordServiceBuildersTest --tests com.moneat.services.EmailServiceTest --tests com.moneat.services.NotificationFormattingTest -Dkotlin.compiler.execution.strategy=in-process
- cd backend && ./gradlew detekt --no-daemon
- git diff --check
