### PR TITLE
feat: use project resource IDs publicly

### DIFF
--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsIngestRoutes.kt
@@ -31,6 +31,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.events.services.EventService
 import com.moneat.shared.models.ProjectKeys
 import com.moneat.shared.models.Projects
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
@@ -75,6 +76,7 @@ fun Route.analyticsIngestRoutes(
     eventService: EventService = GlobalContext.get().get(),
     quotaService: BillingQuotaService = GlobalContext.get().get(),
     pricingTierService: PricingTierService = GlobalContext.get().get(),
+    projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
     enqueueEvent: (String) -> Unit = { message ->
         RedisConfig.sync().lpush(AnalyticsIngestionWorker.QUEUE_KEY, message)
     },
@@ -116,7 +118,7 @@ fun Route.analyticsIngestRoutes(
     // Project-ID route for API clients
     route("/api/{projectId}/analytics") {
         post("/event") {
-            val projectId = call.parameters["projectId"]?.toLongOrNull()
+            val projectId = call.parameters["projectId"]?.let(projectIdResolver::resolve)
             if (projectId == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                 return@post

--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
@@ -19,6 +19,7 @@ package com.moneat.analytics.routes
 import com.moneat.analytics.models.AnalyticsFilter
 import com.moneat.analytics.services.AnalyticsService
 import com.moneat.events.services.DashboardService
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
@@ -51,11 +52,12 @@ private val DEFAULT_RETENTION_PERIODS = listOf(1, 7, 14, 30)
 fun Route.analyticsRoutes(
     analyticsService: AnalyticsService = GlobalContext.get().get(),
     dashboardService: DashboardService = GlobalContext.get().get(),
+    projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
 ) {
     route("/v1/analytics/{projectId}") {
         authenticate("auth-jwt") {
             get("/overview") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -68,7 +70,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/timeseries") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -80,7 +82,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/pages") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -93,7 +95,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/entry-pages") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -106,7 +108,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/exit-pages") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -119,7 +121,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/sources") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -139,7 +141,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/utm/{param}") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -154,7 +156,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/locations") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -174,7 +176,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/devices") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -193,7 +195,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/events") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -208,13 +210,13 @@ fun Route.analyticsRoutes(
             }
 
             get("/realtime") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val result = analyticsService.getRealtime(projectId)
                 call.respond(result)
             }
 
             get("/funnel") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -234,7 +236,7 @@ fun Route.analyticsRoutes(
             }
 
             get("/retention") {
-                val (projectId, _) = extractContext(call, dashboardService) ?: return@get
+                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
                 val (dateFrom, dateTo) = parseDateRange(call) ?: run {
                     call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
                     return@get
@@ -267,6 +269,7 @@ private const val DEFAULT_LIMIT = 100
 private suspend fun extractContext(
     call: io.ktor.server.application.ApplicationCall,
     dashboardService: DashboardService,
+    projectIdResolver: ProjectIdResolver,
 ): Pair<Long, Int>? {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal?.payload?.getClaim("userId")?.asInt()
@@ -274,7 +277,7 @@ private suspend fun extractContext(
         call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
         return null
     }
-    val projectId = call.parameters["projectId"]?.toLongOrNull()
+    val projectId = call.parameters["projectId"]?.let(projectIdResolver::resolve)
     if (projectId == null) {
         call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid project ID"))
         return null

--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsServerIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsServerIngestRoutes.kt
@@ -24,6 +24,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.otlp.OtlpAuth
 import com.moneat.otlp.services.OtlpApiKeyService
 import com.moneat.shared.models.Projects
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -48,6 +49,7 @@ private const val MAX_SERVER_ANALYTICS_EVENTS = 500
 
 fun Route.analyticsServerIngestRoutes(
     otlpApiKeyService: OtlpApiKeyService = GlobalContext.get().get(),
+    projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
     enqueueEvents: (List<String>) -> Unit = { messages ->
         if (messages.isNotEmpty()) {
             RedisConfig.sync().lpush(AnalyticsIngestionWorker.QUEUE_KEY, *messages.toTypedArray())
@@ -56,7 +58,7 @@ fun Route.analyticsServerIngestRoutes(
 ) {
     route("/v1/analytics/{projectId}") {
         post("/events") {
-            val projectId = call.parameters["projectId"]?.toLongOrNull()
+            val projectId = call.parameters["projectId"]?.let(projectIdResolver::resolve)
             if (projectId == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                 return@post

--- a/backend/src/main/kotlin/com/moneat/dashboards/models/DashboardModels.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/models/DashboardModels.kt
@@ -209,6 +209,7 @@ data class SearchResponse(
 @Serializable
 data class SearchProjectResponse(
     val id: Long,
+    val resourceId: String = id.toString(),
     val name: String
 )
 

--- a/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
@@ -48,6 +48,7 @@ import com.moneat.dashboards.translation.GrafanaTranslator
 import com.moneat.plugins.getDemoEpochMs
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Projects
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.utils.ErrorResponse
 import com.moneat.utils.suspendRunCatching
@@ -149,12 +150,13 @@ private fun resolvePrometheusDataSource(
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleListDashboards(
     dashboardService: CustomDashboardService,
+    projectIdResolver: ProjectIdResolver,
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
     val orgId = getOrgIdForUser(userId)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
-    val projectId = call.request.queryParameters["projectId"]?.toLongOrNull()
+    val projectId = call.request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
     val dashboards = dashboardService.listDashboards(orgId, projectId, userId)
     call.respond(dashboards)
 }
@@ -305,6 +307,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDashboardQuery(
     retentionPolicyService: RetentionPolicyService,
     dataSourceService: CustomDataSourceService,
     dataSourceExecutor: CustomDataSourceExecutor,
+    projectIdResolver: ProjectIdResolver,
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
@@ -323,7 +326,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDashboardQuery(
     val projectId: Long = if (isDemoUser) {
         -1L // Queries against all 3 demo projects via ClickHouseQueryUtils.projectIdClause
     } else {
-        call.request.queryParameters["projectId"]?.toLongOrNull()
+        call.request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
             ?: return call.respond(
                 HttpStatusCode.BadRequest, ErrorResponse("projectId query parameter required")
             )
@@ -417,6 +420,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleBatchDashboardQu
     retentionPolicyService: RetentionPolicyService,
     dataSourceService: CustomDataSourceService,
     dataSourceExecutor: CustomDataSourceExecutor,
+    projectIdResolver: ProjectIdResolver,
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
@@ -434,7 +438,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleBatchDashboardQu
     val projectId: Long = if (isDemoUser) {
         -1L
     } else {
-        call.request.queryParameters["projectId"]?.toLongOrNull()
+        call.request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
             ?: return call.respond(
                 HttpStatusCode.BadRequest, ErrorResponse("projectId query parameter required")
             )
@@ -903,6 +907,7 @@ fun Route.customDashboardRoutes(
     dashboardService: CustomDashboardService = GlobalContext.get().get(),
     queryEngine: DashboardQueryEngine = GlobalContext.get().get(),
     retentionPolicyService: RetentionPolicyService = GlobalContext.get().get(),
+    projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
     translators: DashboardTranslators = DashboardTranslators(),
     dataSourceService: CustomDataSourceService = GlobalContext.get().get(),
     dataSourceExecutor: CustomDataSourceExecutor = GlobalContext.get().get(),
@@ -910,7 +915,7 @@ fun Route.customDashboardRoutes(
 ) {
     route("/v1/dashboards") {
         authenticate(AUTH_JWT) {
-            get { handleListDashboards(dashboardService) }
+            get { handleListDashboards(dashboardService, projectIdResolver) }
             post { handleCreateDashboard(dashboardService) }
             route("/folders") {
                 get { handleListFolders(dashboardService) }
@@ -924,10 +929,22 @@ fun Route.customDashboardRoutes(
             put("/{id}") { handleUpdateDashboard(dashboardService) }
             delete("/{id}") { handleDeleteDashboard(dashboardService) }
             post("/{id}/query") {
-                handleDashboardQuery(queryEngine, retentionPolicyService, dataSourceService, dataSourceExecutor)
+                handleDashboardQuery(
+                    queryEngine,
+                    retentionPolicyService,
+                    dataSourceService,
+                    dataSourceExecutor,
+                    projectIdResolver
+                )
             }
             post("/{id}/query/batch") {
-                handleBatchDashboardQuery(queryEngine, retentionPolicyService, dataSourceService, dataSourceExecutor)
+                handleBatchDashboardQuery(
+                    queryEngine,
+                    retentionPolicyService,
+                    dataSourceService,
+                    dataSourceExecutor,
+                    projectIdResolver
+                )
             }
             post("/{id}/variables/resolve") {
                 handleVariablesResolve(dashboardService, dataSourceService, dataSourceExecutor)

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/CustomDashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/CustomDashboardService.kt
@@ -227,7 +227,7 @@ class CustomDashboardService(
             mapToResponse(d, loadWidgets(d.id))
         }
         val projects = projectRepository.searchProjectsByName(orgId.toInt(), pattern, limit = 10).map { row ->
-            SearchProjectResponse(id = row.projectId, name = row.name)
+            SearchProjectResponse(id = row.projectId, resourceId = row.resourceId, name = row.name)
         }
         return SearchResponse(dashboards = dashboards, projects = projects)
     }

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -93,6 +93,7 @@ import com.moneat.shared.repositories.OrganizationRepository
 import com.moneat.shared.repositories.OrganizationRepositoryImpl
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.AttributionAnalyticsService
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.shared.services.RetentionBackgroundService
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.statuspage.services.StatusPageService
@@ -123,6 +124,7 @@ val sharedModule = module {
     single { EntitlementService(get()) }
     single { RetentionPolicyService(get()) }
     single { RetentionBackgroundService(get()) }
+    single { ProjectIdResolver() }
 
     single { AttributionAnalyticsService() }
 }

--- a/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
@@ -70,6 +70,7 @@ data class ProjectKeyResponse(
 @Serializable
 data class ProjectResponse(
     val id: Long,
+    val resourceId: String = id.toString(),
     val name: String,
     val slug: String,
     val framework: String?,
@@ -82,6 +83,7 @@ data class ProjectResponse(
 data class IssueResponse(
     val id: String,
     val projectId: Long,
+    val projectResourceId: String = projectId.toString(),
     val title: String,
     val culprit: String,
     val level: String,
@@ -99,6 +101,7 @@ data class IssueResponse(
 data class IssueDetailResponse(
     val id: String,
     val projectId: Long,
+    val projectResourceId: String = projectId.toString(),
     val projectName: String,
     val title: String,
     val culprit: String,
@@ -232,6 +235,7 @@ data class TransactionWithSpansResponse(
 data class TraceDetailResponse(
     val traceId: String,
     val projectId: Long,
+    val projectResourceId: String = projectId.toString(),
     val spans: List<SpanResponse>,
     val startTimestamp: Double,
     val endTimestamp: Double,
@@ -243,6 +247,7 @@ data class EventTraceResponse(
     val eventId: String?,
     val eventType: String?,
     val projectId: Long,
+    val projectResourceId: String = projectId.toString(),
     val traceId: String,
     val transaction: TransactionDetailResponse? = null,
     val spans: List<SpanResponse> = emptyList()
@@ -455,6 +460,7 @@ data class ReleaseMarker(
 data class ReplayListItem(
     val replayId: String,
     val projectId: Long,
+    val projectResourceId: String = projectId.toString(),
     val startedAt: String,
     val finishedAt: String,
     val durationMs: Double,
@@ -472,6 +478,7 @@ data class ReplayListItem(
 data class ReplayDetailResponse(
     val replayId: String,
     val projectId: Long,
+    val projectResourceId: String = projectId.toString(),
     val startedAt: String,
     val finishedAt: String,
     val durationMs: Double,
@@ -607,6 +614,7 @@ data class NotificationPreferencesData(
 @Serializable
 data class ProjectNotificationPreferences(
     val projectId: Long,
+    val projectResourceId: String = projectId.toString(),
     val projectName: String,
     val issueAlerts: Boolean,
     val errorAlerts: Boolean,

--- a/backend/src/main/kotlin/com/moneat/events/repositories/ProjectRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/ProjectRepositoryImpl.kt
@@ -197,6 +197,7 @@ class ProjectRepositoryImpl(
                 .map { row ->
                     ProjectRow(
                         projectId = row[Projects.id],
+                        resourceId = row[Projects.resource_id].toString(),
                         name = row[Projects.name],
                         slug = row[Projects.slug],
                         framework = row[Projects.framework],
@@ -267,6 +268,7 @@ class ProjectRepositoryImpl(
         val firstDsn = keys.firstOrNull { it.platformTarget == null }?.dsn ?: keys.firstOrNull()?.dsn ?: ""
         return ProjectRow(
             projectId = row[Projects.id],
+            resourceId = row[Projects.resource_id].toString(),
             name = row[Projects.name],
             slug = row[Projects.slug],
             framework = row[Projects.framework],

--- a/backend/src/main/kotlin/com/moneat/events/repositories/models/ProjectRow.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/models/ProjectRow.kt
@@ -27,5 +27,6 @@ data class ProjectRow(
     val slug: String,
     val framework: String?,
     val keys: List<ProjectKeyResponse>,
-    val dsn: String
+    val dsn: String,
+    val resourceId: String = projectId.toString(),
 )

--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -49,10 +49,12 @@ import com.moneat.shared.models.OnCallPhoneConsentEvents
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Users
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.shared.services.SdkVersionService
 import com.moneat.shared.services.SidebarPreferenceService
 import com.moneat.utils.DetailedErrorResponse
 import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
@@ -80,7 +82,6 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.koin.core.context.GlobalContext
 import kotlin.time.Clock
-import com.moneat.utils.suspendRunCatching
 
 private const val DEFAULT_PAGE_LIMIT = 25
 private const val DEFAULT_EVENTS_LIMIT = 50
@@ -93,6 +94,7 @@ private const val ERROR_NO_ORGANIZATION_ACCESS = "No organization access"
 fun Route.apiRoutes() {
     val koin = GlobalContext.get()
     val dashboardService = koin.get<DashboardService>()
+    val projectIdResolver = koin.get<ProjectIdResolver>()
 
     // Public routes (no auth required)
     route("/v1") {
@@ -481,7 +483,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                         return@get
@@ -504,7 +506,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                         return@post
@@ -528,7 +530,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                         return@put
@@ -548,7 +550,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                         return@delete
@@ -570,7 +572,7 @@ fun Route.apiRoutes() {
                     val isDemo = call.isDemoUser()
                     val demoEpochMs = call.getDemoEpochMs()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest)
                         return@get
@@ -601,7 +603,7 @@ fun Route.apiRoutes() {
                         return@get
                     }
 
-                    val projectId = call.request.queryParameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectQueryId(projectIdResolver)
 
                     if (!isDemo) {
                         if (projectId != null) {
@@ -631,7 +633,7 @@ fun Route.apiRoutes() {
 
                     val issueId = call.parameters["issueId"]
                     val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_EVENTS_LIMIT
-                    val projectId = call.request.queryParameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectQueryId(projectIdResolver)
 
                     if (issueId == null) {
                         call.respond(HttpStatusCode.BadRequest)
@@ -662,7 +664,7 @@ fun Route.apiRoutes() {
 
                     val issueId = call.parameters["issueId"]
                     val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_TRANSACTIONS_LIMIT
-                    val projectId = call.request.queryParameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectQueryId(projectIdResolver)
 
                     if (issueId == null) {
                         call.respond(HttpStatusCode.BadRequest)
@@ -695,7 +697,7 @@ fun Route.apiRoutes() {
                         return@patch
                     }
 
-                    val projectId = call.request.queryParameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectQueryId(projectIdResolver)
                     val hasAccess = if (projectId != null) {
                         dashboardService.hasProjectAccess(userId, projectId)
                     } else {
@@ -718,7 +720,7 @@ fun Route.apiRoutes() {
                     val isDemo = call.isDemoUser()
                     val demoEpochMs = call.getDemoEpochMs()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest)
                         return@get
@@ -746,7 +748,7 @@ fun Route.apiRoutes() {
                     val isDemo = call.isDemoUser()
                     val demoEpochMs = call.getDemoEpochMs()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest)
                         return@get
@@ -777,7 +779,7 @@ fun Route.apiRoutes() {
                     val isDemo = call.isDemoUser()
                     val demoEpochMs = call.getDemoEpochMs()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest)
                         return@get
@@ -873,7 +875,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     val traceId = call.parameters["traceId"]
 
                     if (projectId == null || traceId == null) {
@@ -899,7 +901,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     val spanId = call.parameters["spanId"]
 
                     if (projectId == null || spanId == null) {
@@ -927,7 +929,7 @@ fun Route.apiRoutes() {
                     val isDemo = call.isDemoUser()
                     val demoEpochMs = call.getDemoEpochMs()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest)
                         return@get
@@ -1023,7 +1025,7 @@ fun Route.apiRoutes() {
                     val isDemo = call.isDemoUser()
                     val demoEpochMs = call.getDemoEpochMs()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest)
                         return@get
@@ -1120,7 +1122,7 @@ fun Route.apiRoutes() {
                         return@get
                     }
 
-                    val projectId = call.request.queryParameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectQueryId(projectIdResolver)
                     val hasAccess = if (projectId != null) {
                         dashboardService.hasProjectAccess(userId, projectId)
                     } else {
@@ -1142,7 +1144,7 @@ fun Route.apiRoutes() {
                     val userId = principal!!.payload.getClaim("userId").asInt()
                     val isDemo = call.isDemoUser()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest)
                         return@get
@@ -1161,7 +1163,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     val version = call.parameters["version"]
                     if (projectId == null || version == null) {
                         call.respond(HttpStatusCode.BadRequest)
@@ -1223,15 +1225,18 @@ fun Route.apiRoutes() {
                                             (NotificationPreferences.project_id.isNotNull())
                                     }.map { pref ->
                                         val projectId = pref[NotificationPreferences.project_id]!!
-                                        val projectName =
+                                        val projectRow =
                                             Projects
                                                 .selectAll()
                                                 .where { Projects.id eq projectId }
                                                 .firstOrNull()
-                                                ?.get(Projects.name) ?: "Unknown"
+                                        val projectName = projectRow?.get(Projects.name) ?: "Unknown"
+                                        val projectResourceId =
+                                            projectRow?.get(Projects.resource_id)?.toString() ?: projectId.toString()
 
                                         ProjectNotificationPreferences(
                                             projectId = projectId,
+                                            projectResourceId = projectResourceId,
                                             projectName = projectName,
                                             issueAlerts = pref[NotificationPreferences.issue_alerts],
                                             errorAlerts = pref[NotificationPreferences.error_alerts],
@@ -1311,7 +1316,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                         return@put
@@ -1455,7 +1460,7 @@ fun Route.apiRoutes() {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
 
-                    val projectId = call.parameters["projectId"]?.toLongOrNull()
+                    val projectId = call.resolveProjectPathId(projectIdResolver)
                     if (projectId == null) {
                         call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                         return@delete
@@ -1487,6 +1492,12 @@ fun Route.apiRoutes() {
         integrationCallbackRoutes()
     }
 }
+
+private fun ApplicationCall.resolveProjectPathId(projectIdResolver: ProjectIdResolver): Long? =
+    parameters["projectId"]?.let(projectIdResolver::resolve)
+
+private fun ApplicationCall.resolveProjectQueryId(projectIdResolver: ProjectIdResolver): Long? =
+    request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
 
 private suspend fun ApplicationCall.resolveSubscriptionOrganizationId(userId: Int): Int? {
     val orgId = principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()

--- a/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
@@ -27,6 +27,7 @@ import com.moneat.events.services.EventService
 import com.moneat.events.services.IngestionWorker
 import com.moneat.logs.models.LogIngestEntry
 import com.moneat.logs.services.LogService
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.DetailedErrorResponse
 import com.moneat.utils.ErrorResponse
 import com.moneat.utils.suspendRunCatching
@@ -58,6 +59,7 @@ fun Route.ingestRoutes(
     eventService: EventService = GlobalContext.get().get(),
     quotaService: BillingQuotaService = GlobalContext.get().get(),
     logService: LogService = GlobalContext.get().get(),
+    projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
     enqueueEnvelope: (queueKey: String, message: String) -> Unit = { queueKey, message ->
         RedisConfig.sync().lpush(queueKey, message)
     },
@@ -76,7 +78,7 @@ fun Route.ingestRoutes(
                 call.application.environment.config
                     .property("ingest.queueKey")
                     .getString()
-            val projectId = call.parameters["projectId"]?.toLongOrNull()
+            val projectId = call.parameters["projectId"]?.let(projectIdResolver::resolve)
             if (projectId == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                 return@post
@@ -162,7 +164,7 @@ fun Route.ingestRoutes(
 
         // Structured logs endpoint
         post("/logs/") {
-            val projectId = call.parameters["projectId"]?.toLongOrNull()
+            val projectId = call.parameters["projectId"]?.let(projectIdResolver::resolve)
             if (projectId == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                 return@post
@@ -240,7 +242,7 @@ fun Route.ingestRoutes(
 
         // Legacy store endpoint
         post("/store/") {
-            val projectId = call.parameters["projectId"]?.toLongOrNull()
+            val projectId = call.parameters["projectId"]?.let(projectIdResolver::resolve)
             if (projectId == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                 return@post
@@ -318,7 +320,7 @@ fun extractPublicKey(
 fun extractPublicKeyFromDsn(dsnLikeHeader: String?): String? {
     if (dsnLikeHeader.isNullOrBlank()) return null
     val cleaned = dsnLikeHeader.removePrefix("DSN ").trim()
-    val regex = "https?://([a-zA-Z0-9_-]+)@[^/]+/[0-9]+".toRegex(RegexOption.IGNORE_CASE)
+    val regex = "https?://([a-zA-Z0-9_-]+)@[^/]+/([0-9]+|[0-9a-f-]{36})".toRegex(RegexOption.IGNORE_CASE)
     return regex.find(cleaned)?.groupValues?.getOrNull(1)
 }
 

--- a/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/IngestRoutes.kt
@@ -49,6 +49,8 @@ import java.security.MessageDigest
 private val logger = KotlinLogging.logger {}
 private val json = Json { ignoreUnknownKeys = true }
 private const val SHA256_HEX_PREFIX_CHARS = 16
+private const val PROJECT_ID_DSN_SEGMENT_PATTERN =
+    "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9]+)"
 
 private fun sha256HexPrefix(bytes: ByteArray, maxHexChars: Int): String {
     val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
@@ -320,7 +322,8 @@ fun extractPublicKey(
 fun extractPublicKeyFromDsn(dsnLikeHeader: String?): String? {
     if (dsnLikeHeader.isNullOrBlank()) return null
     val cleaned = dsnLikeHeader.removePrefix("DSN ").trim()
-    val regex = "https?://([a-zA-Z0-9_-]+)@[^/]+/([0-9]+|[0-9a-f-]{36})".toRegex(RegexOption.IGNORE_CASE)
+    val regex = "https?://([a-zA-Z0-9_-]+)@[^/]+/$PROJECT_ID_DSN_SEGMENT_PATTERN(?:[/?#]|$)"
+        .toRegex(RegexOption.IGNORE_CASE)
     return regex.find(cleaned)?.groupValues?.getOrNull(1)
 }
 

--- a/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
@@ -22,18 +22,19 @@ import com.moneat.events.models.IssueResponse
 import com.moneat.events.models.IssueTransactionResponse
 import com.moneat.events.models.IssueUpdateRequest
 import com.moneat.events.repositories.IssueRepository
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.suspendRunCatching
 import io.ktor.server.plugins.BadRequestException
 import mu.KotlinLogging
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
 class IssueService(
     private val issueRepository: IssueRepository,
-    private val queryHelper: DashboardQueryHelper
+    private val queryHelper: DashboardQueryHelper,
+    private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
 ) {
-
     companion object {
         private const val ISSUE_OVERFETCH_MULTIPLIER = 5
     }
@@ -55,6 +56,7 @@ class IssueService(
             queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)
 
         val pgOverrides = issueRepository.getIssueStatusOverrides(projectId)
+        val projectResourceId = projectResourceId(projectId)
 
         val overfetch = if (status != null) (limit + offset) * ISSUE_OVERFETCH_MULTIPLIER else limit + offset
         val rows = issueRepository.getIssuesRaw(
@@ -82,6 +84,7 @@ class IssueService(
                     IssueResponse(
                         id = row.issueId,
                         projectId = row.projectId,
+                        projectResourceId = projectResourceId,
                         title = row.title,
                         culprit = row.culprit,
                         level = row.level,
@@ -126,12 +129,14 @@ class IssueService(
         val pgStatus = issueRepository.getIssueStatus(issueId, projectId)
         val projectName = issueRepository.getProjectName(projectId)
         val effectiveStatus = pgStatus ?: obj.status
+        val projectResourceId = projectResourceId(projectId)
 
         val latestEvent = getIssueEvents(issueId, 1, demoEpochMs, projectId).firstOrNull()
 
         return IssueDetailResponse(
             id = obj.issueId,
             projectId = obj.projectId,
+            projectResourceId = projectResourceId,
             projectName = projectName ?: "Unknown",
             title = obj.title,
             culprit = obj.culprit,
@@ -169,6 +174,9 @@ class IssueService(
             projectIdClause = projectIdClause
         )
     }
+
+    private fun projectResourceId(projectId: Long): String =
+        projectIdResolver.resourceIdFor(projectId) ?: projectId.toString()
 
     suspend fun getIssueTransactions(
         issueId: String,

--- a/backend/src/main/kotlin/com/moneat/events/services/ProjectService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ProjectService.kt
@@ -47,19 +47,20 @@ class ProjectService(
 
         val projects = projectRepository.getProjectsForOrganizations(orgIds)
 
-        return projects.map { (projectId, name, slug, framework, keys, dsn) ->
+        return projects.map { row ->
             val issueCount = projectRepository.getIssueCountForProject(
-                projectId,
-                queryHelper.getProjectRetentionDays(projectId),
+                row.projectId,
+                queryHelper.getProjectRetentionDays(row.projectId),
                 demoEpochMs
             )
             ProjectResponse(
-                id = projectId,
-                name = name,
-                slug = slug,
-                framework = framework,
-                keys = keys,
-                dsn = dsn,
+                id = row.projectId,
+                resourceId = row.resourceId,
+                name = row.name,
+                slug = row.slug,
+                framework = row.framework,
+                keys = row.keys,
+                dsn = row.dsn,
                 issueCount = issueCount
             )
         }
@@ -74,6 +75,7 @@ class ProjectService(
         )
         return ProjectResponse(
             id = row.projectId,
+            resourceId = row.resourceId,
             name = row.name,
             slug = row.slug,
             framework = row.framework,

--- a/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
@@ -23,8 +23,10 @@ import com.moneat.events.models.ReplayRecordingResponse
 import com.moneat.events.models.ReplayTimelineItem
 import com.moneat.events.models.ReplayTimelineResponse
 import com.moneat.shared.models.Projects
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.HttpConstants.HTTP_SUCCESS_RANGE
 import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.json.JsonArray
@@ -46,12 +48,12 @@ import org.msgpack.core.MessageUnpacker
 import org.msgpack.value.ValueType
 import java.time.Instant
 import java.util.Base64
-import com.moneat.utils.HttpConstants.HTTP_SUCCESS_RANGE
 
 private val logger = KotlinLogging.logger {}
 
 class ReplayService(
-    private val queryHelper: DashboardQueryHelper
+    private val queryHelper: DashboardQueryHelper,
+    private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
 ) {
     private val clickhouseDb: String get() = queryHelper.clickhouseDb
     private val json get() = queryHelper.json
@@ -92,15 +94,20 @@ class ReplayService(
         return arr.mapNotNull { it.jsonPrimitive.contentOrNull }
     }
 
+    private fun projectResourceId(projectId: Long): String =
+        projectIdResolver.resourceIdFor(projectId) ?: projectId.toString()
+
     private fun buildReplayListItemFromJson(
         obj: JsonObject,
         projectId: Long,
         errorCount: Int
     ): ReplayListItem? {
         val replayId = obj["replay_id"]?.jsonPrimitive?.content ?: return null
+        val objProjectId = obj["project_id"]?.jsonPrimitive?.long ?: projectId
         return ReplayListItem(
             replayId = replayId,
-            projectId = obj["project_id"]?.jsonPrimitive?.long ?: projectId,
+            projectId = objProjectId,
+            projectResourceId = projectResourceId(objProjectId),
             startedAt = obj["started_at"]?.jsonPrimitive?.content ?: "",
             finishedAt = obj["finished_at"]?.jsonPrimitive?.content ?: "",
             durationMs = obj["duration_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: 0.0,
@@ -579,6 +586,7 @@ class ReplayService(
         return ReplayDetailResponse(
             replayId = replayId,
             projectId = objProjectId,
+            projectResourceId = projectResourceId(objProjectId),
             startedAt = obj["started_at"]?.jsonPrimitive?.content ?: "",
             finishedAt = obj["finished_at"]?.jsonPrimitive?.content ?: "",
             durationMs = obj["duration_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: 0.0,

--- a/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
@@ -27,8 +27,11 @@ import com.moneat.events.models.TransactionDetailResponse
 import com.moneat.events.models.TransactionSummaryResponse
 import com.moneat.events.models.TransactionWithSpansResponse
 import com.moneat.shared.models.Projects
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.HttpConstants.HTTP_SUCCESS_RANGE
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -40,12 +43,13 @@ import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import com.moneat.utils.suspendRunCatching
-import com.moneat.utils.HttpConstants.HTTP_SUCCESS_RANGE
 
 private val logger = KotlinLogging.logger {}
 
-class TransactionService(private val queryHelper: DashboardQueryHelper) {
+class TransactionService(
+    private val queryHelper: DashboardQueryHelper,
+    private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
+) {
     private val clickhouseDb: String get() = queryHelper.clickhouseDb
     private val json get() = queryHelper.json
 
@@ -71,6 +75,9 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
                 .firstOrNull()
                 ?.get(Projects.organization_id)
         }
+
+    private fun projectResourceId(projectId: Long): String =
+        projectIdResolver.resourceIdFor(projectId) ?: projectId.toString()
 
     private fun mapSpanRowFromApm(obj: JsonObject): SpanResponse {
         val startNs = obj["start_ns"]?.jsonPrimitive?.contentOrNull?.toLongOrNull() ?: 0L
@@ -403,6 +410,7 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
                 eventId = lookup.eventId,
                 eventType = lookup.eventType,
                 projectId = lookup.projectId,
+                projectResourceId = projectResourceId(lookup.projectId),
                 traceId = "",
                 transaction = null,
                 spans = emptyList()
@@ -420,6 +428,7 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
             eventId = lookup.eventId,
             eventType = lookup.eventType,
             projectId = lookup.projectId,
+            projectResourceId = projectResourceId(lookup.projectId),
             traceId = lookup.traceId,
             transaction = transactionWithSpans?.transaction,
             spans = transactionWithSpans?.spans?.takeIf { it.isNotEmpty() } ?: traceSpans
@@ -432,6 +441,7 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
             eventId = null,
             eventType = null,
             projectId = projectId,
+            projectResourceId = projectResourceId(projectId),
             traceId = traceId,
             transaction = null,
             spans = trace.spans
@@ -477,6 +487,7 @@ class TransactionService(private val queryHelper: DashboardQueryHelper) {
             TraceDetailResponse(
                 traceId = traceId,
                 projectId = projectId,
+                projectResourceId = projectResourceId(projectId),
                 spans = spans,
                 startTimestamp = startTs,
                 endTimestamp = endTs,

--- a/backend/src/main/kotlin/com/moneat/llm/routes/LlmIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/routes/LlmIngestRoutes.kt
@@ -24,6 +24,8 @@ import com.moneat.events.services.EventService
 import com.moneat.llm.models.LlmIngestPayload
 import com.moneat.llm.services.LlmIngestionWorker
 import com.moneat.utils.ErrorResponse
+import com.moneat.shared.services.ProjectIdResolver
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.header
 import io.ktor.server.request.receive
@@ -34,7 +36,6 @@ import io.ktor.server.routing.route
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
 import org.koin.core.context.GlobalContext
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 private val json = Json { ignoreUnknownKeys = true }
@@ -42,6 +43,7 @@ private val json = Json { ignoreUnknownKeys = true }
 fun Route.llmIngestRoutes() {
     val eventService = GlobalContext.get().get<EventService>()
     val quotaService = GlobalContext.get().get<BillingQuotaService>()
+    val projectIdResolver = GlobalContext.get().get<ProjectIdResolver>()
 
     route("/api/{projectId}") {
         post("/llm/") {
@@ -50,7 +52,7 @@ fun Route.llmIngestRoutes() {
                     .propertyOrNull("llm.queueKey")
                     ?.getString()
                     ?: "moneat:llm:queue"
-            val projectId = call.parameters["projectId"]?.toLongOrNull()
+            val projectId = call.parameters["projectId"]?.let(projectIdResolver::resolve)
             if (projectId == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid project ID")
                 return@post

--- a/backend/src/main/kotlin/com/moneat/llm/routes/LlmRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/routes/LlmRoutes.kt
@@ -20,6 +20,7 @@ import com.moneat.events.services.DashboardService
 import com.moneat.llm.services.LlmDashboardService
 import com.moneat.plugins.getDemoEpochMs
 import com.moneat.plugins.isDemoUser
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
@@ -38,16 +39,17 @@ private const val DEFAULT_PAGE_SIZE = 25
 fun Route.llmRoutes(
     dashboardService: DashboardService = GlobalContext.get().get(),
     llmService: LlmDashboardService = GlobalContext.get().get(),
+    projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
 ) {
     authenticate("auth-jwt") {
         rateLimit(RateLimitName("api")) {
             route("/v1/llm") {
-                get("/overview") { handleLlmOverview(dashboardService, llmService) }
-                get("/generations") { handleLlmGenerations(dashboardService, llmService) }
-                get("/generations/{id}") { handleLlmGenerationDetail(dashboardService, llmService) }
-                get("/traces/{traceId}") { handleLlmTrace(dashboardService, llmService) }
-                get("/models") { handleLlmModels(dashboardService, llmService) }
-                get("/costs") { handleLlmCosts(dashboardService, llmService) }
+                get("/overview") { handleLlmOverview(dashboardService, llmService, projectIdResolver) }
+                get("/generations") { handleLlmGenerations(dashboardService, llmService, projectIdResolver) }
+                get("/generations/{id}") { handleLlmGenerationDetail(dashboardService, llmService, projectIdResolver) }
+                get("/traces/{traceId}") { handleLlmTrace(dashboardService, llmService, projectIdResolver) }
+                get("/models") { handleLlmModels(dashboardService, llmService, projectIdResolver) }
+                get("/costs") { handleLlmCosts(dashboardService, llmService, projectIdResolver) }
             }
         }
     }
@@ -55,11 +57,12 @@ fun Route.llmRoutes(
 
 private suspend fun io.ktor.server.routing.RoutingContext.requireLlmProjectAccess(
     dashboardService: DashboardService,
+    projectIdResolver: ProjectIdResolver,
 ): Long? {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
     val isDemo = call.isDemoUser()
-    val projectId = call.request.queryParameters["projectId"]?.toLongOrNull()
+    val projectId = call.request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
     if (projectId == null) {
         call.respond(HttpStatusCode.BadRequest, ErrorResponse("projectId is required"))
         return null
@@ -74,8 +77,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.requireLlmProjectAcces
 private suspend fun io.ktor.server.routing.RoutingContext.handleLlmOverview(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
+    projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService) ?: return
+    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val demoEpochMs = call.getDemoEpochMs()
     call.respond(llmService.getOverview(projectId, range, demoEpochMs))
@@ -84,8 +88,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmOverview(
 private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerations(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
+    projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService) ?: return
+    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val model = call.request.queryParameters["model"]
     val provider = call.request.queryParameters["provider"]
@@ -102,8 +107,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerations(
 private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerationDetail(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
+    projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService) ?: return
+    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
     val generationId =
         call.parameters["id"] ?: run {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse("generation id is required"))
@@ -120,8 +126,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerationDet
 private suspend fun io.ktor.server.routing.RoutingContext.handleLlmTrace(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
+    projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService) ?: return
+    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
     val traceId =
         call.parameters["traceId"] ?: run {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse("traceId is required"))
@@ -138,8 +145,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmTrace(
 private suspend fun io.ktor.server.routing.RoutingContext.handleLlmModels(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
+    projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService) ?: return
+    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val demoEpochMs = call.getDemoEpochMs()
     call.respond(llmService.getModels(projectId, range, demoEpochMs))
@@ -148,8 +156,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmModels(
 private suspend fun io.ktor.server.routing.RoutingContext.handleLlmCosts(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
+    projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService) ?: return
+    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val demoEpochMs = call.getDemoEpochMs()
     call.respond(llmService.getCosts(projectId, range, demoEpochMs))

--- a/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
@@ -41,7 +41,9 @@ import com.moneat.otlp.services.OtlpServiceRoutingService
 import com.moneat.otlp.services.OtlpSignalType
 import com.moneat.plugins.getDemoEpochMs
 import com.moneat.plugins.isDemoUser
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -69,7 +71,6 @@ import org.koin.core.context.GlobalContext
 import java.time.Instant
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 private val json = Json { ignoreUnknownKeys = true }
@@ -603,6 +604,7 @@ fun Route.logIngestRoutes(
     otlpApiKeyService: OtlpApiKeyService = GlobalContext.get().get(),
     eventService: EventService = GlobalContext.get().get(),
     otlpServiceRoutingService: OtlpServiceRoutingService = GlobalContext.get().get(),
+    projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
 ) {
     route("/v1") {
         // Standard OTLP/HTTP path alias
@@ -613,7 +615,8 @@ fun Route.logIngestRoutes(
                 quotaService,
                 otlpApiKeyService,
                 eventService,
-                otlpServiceRoutingService
+                otlpServiceRoutingService,
+                projectIdResolver
             )
         }
         // Moneat convention path
@@ -624,7 +627,8 @@ fun Route.logIngestRoutes(
                 quotaService,
                 otlpApiKeyService,
                 eventService,
-                otlpServiceRoutingService
+                otlpServiceRoutingService,
+                projectIdResolver
             )
         }
 
@@ -696,6 +700,7 @@ private suspend fun handleOtlpLogIngest(
     otlpApiKeyService: OtlpApiKeyService,
     eventService: EventService,
     otlpServiceRoutingService: OtlpServiceRoutingService,
+    projectIdResolver: ProjectIdResolver,
 ) {
     val contentType = call.request.header(HttpHeaders.ContentType) ?: ""
     val isJson = contentType.contains("application/json", ignoreCase = true)
@@ -711,7 +716,7 @@ private suspend fun handleOtlpLogIngest(
     }
 
     val organizationId: Int? =
-        OtlpAuth.resolveOtlpIngestOrganizationId(call, otlpApiKeyService, eventService)
+        OtlpAuth.resolveOtlpIngestOrganizationId(call, otlpApiKeyService, eventService, projectIdResolver)
 
     if (organizationId == null) {
         call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Missing or invalid OTLP API key or DSN"))

--- a/backend/src/main/kotlin/com/moneat/mcp/auth/McpAuthorization.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/auth/McpAuthorization.kt
@@ -25,6 +25,7 @@ import com.moneat.events.services.TransactionService
 import com.moneat.mcp.models.McpContext
 import com.moneat.shared.models.Hosts
 import com.moneat.shared.models.Projects
+import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.statuspage.models.StatusPages
 import com.moneat.uptime.models.UptimeMonitors
 import kotlinx.serialization.json.JsonObject
@@ -45,6 +46,7 @@ object McpAuthorization {
     private val queryHelper = DashboardQueryHelper()
     private val issueService = IssueService(IssueRepositoryImpl(queryHelper), queryHelper)
     private val transactionService = TransactionService(queryHelper)
+    private val projectIdResolver = ProjectIdResolver()
 
     fun requireScopes(context: McpContext, requiredScopes: Set<String>) {
         val missingScopes = requiredScopes.filterNot { it in context.scopes }
@@ -55,7 +57,7 @@ object McpAuthorization {
     }
 
     suspend fun requireObjectAccess(args: JsonObject, context: McpContext) {
-        args.longValue("project_id")?.let { requireProjectAccess(it, context) }
+        args.projectIdValue("project_id")?.let { requireProjectAccess(it, context) }
         args.stringValue("issue_id")?.let { requireIssueAccess(it, context) }
         args.stringValue("event_id")?.let { requireTransactionAccess(it, context) }
         args.stringValue("host_id")?.toIntOrNull()?.let { requireHostAccess(it, context) }
@@ -78,6 +80,8 @@ object McpAuthorization {
         }
         ensureAuthorized(hasAccess, "$AUTHORIZATION_ERROR: project not found")
     }
+
+    fun resolveProjectId(value: String): Long? = projectIdResolver.resolve(value)
 
     private suspend fun requireIssueAccess(issueId: String, context: McpContext) {
         val projectId = issueService.getProjectIdForIssue(issueId)
@@ -171,6 +175,9 @@ private fun JsonObject.longValue(name: String): Long? {
         else -> null
     }
 }
+
+private fun JsonObject.projectIdValue(name: String): Long? =
+    stringValue(name)?.let(McpAuthorization::resolveProjectId)
 
 private fun JsonObject.uuidValue(name: String): UUID? =
     stringValue(name)?.let { runCatching { UUID.fromString(it) }.getOrNull() }

--- a/backend/src/main/kotlin/com/moneat/mcp/services/NotificationPreferencesService.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/services/NotificationPreferencesService.kt
@@ -22,6 +22,7 @@ import com.moneat.events.models.ProjectNotificationPreferences
 import com.moneat.shared.models.NotificationPreferences
 import com.moneat.shared.models.Projects
 import kotlin.time.Clock
+import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
@@ -77,8 +78,8 @@ class NotificationPreferencesService {
             Projects
                 .selectAll()
                 .where { Projects.id inList projectIds }
-                .associate {
-                    it[Projects.id] to (it[Projects.name] to it[Projects.resource_id].toString())
+                .associate { row ->
+                    row[Projects.id] to (row[Projects.name] to projectResourceId(row))
                 }
         }
 
@@ -97,6 +98,11 @@ class NotificationPreferencesService {
         }
 
         NotificationPreferencesResponse(global = globalPrefs, projects = projects)
+    }
+
+    private fun projectResourceId(row: ResultRow): String {
+        val resourceId = row[Projects.resource_id].toString()
+        return resourceId.takeUnless { it == "null" } ?: row[Projects.id].toString()
     }
 
     fun updatePreferences(

--- a/backend/src/main/kotlin/com/moneat/mcp/services/NotificationPreferencesService.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/services/NotificationPreferencesService.kt
@@ -71,20 +71,24 @@ class NotificationPreferencesService {
             }.toList()
 
         val projectIds = projectPrefs.map { it[NotificationPreferences.project_id]!! }
-        val projectNames: Map<Long, String> = if (projectIds.isEmpty()) {
+        val projectRows = if (projectIds.isEmpty()) {
             emptyMap()
         } else {
             Projects
                 .selectAll()
                 .where { Projects.id inList projectIds }
-                .associate { it[Projects.id] to it[Projects.name] }
+                .associate {
+                    it[Projects.id] to (it[Projects.name] to it[Projects.resource_id].toString())
+                }
         }
 
         val projects = projectPrefs.map { pref ->
             val projectId = pref[NotificationPreferences.project_id]!!
+            val projectRow = projectRows[projectId]
             ProjectNotificationPreferences(
                 projectId = projectId,
-                projectName = projectNames[projectId] ?: "Unknown",
+                projectResourceId = projectRow?.second ?: projectId.toString(),
+                projectName = projectRow?.first ?: "Unknown",
                 issueAlerts = pref[NotificationPreferences.issue_alerts],
                 errorAlerts = pref[NotificationPreferences.error_alerts],
                 weeklySummary = pref[NotificationPreferences.weekly_summary],

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ApmDeepTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ApmDeepTool.kt
@@ -52,9 +52,7 @@ class GetTransactionStatsTool : McpTool {
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val period = args["period"]?.jsonPrimitive?.content
             ?: "24h"
         val environment = args["environment"]
@@ -68,7 +66,7 @@ class GetTransactionStatsTool : McpTool {
             environment,
             operation
         )
-        return jsonResult(stats)
+        jsonResult(stats)
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ApmDeepTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ApmDeepTool.kt
@@ -24,7 +24,6 @@ import com.moneat.events.services.DashboardService
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
 
 private val apmDeepService = DashboardService.create()
 
@@ -38,7 +37,7 @@ class GetTransactionStatsTool : McpTool {
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "project_id" to schemaNumber("Project ID"),
+                "project_id" to schemaProjectId(),
                 "period" to schemaEnum(
                     "Time period",
                     listOf("1h", "6h", "24h", "7d", "30d")
@@ -54,7 +53,7 @@ class GetTransactionStatsTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive?.long
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val period = args["period"]?.jsonPrimitive?.content
             ?: "24h"

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ApmTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ApmTool.kt
@@ -49,9 +49,7 @@ class ListTransactionsTool : McpTool {
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val period = args["period"]?.jsonPrimitive?.content ?: "7d"
         val env = args["environment"]?.jsonPrimitive?.content
         val op = args["operation"]?.jsonPrimitive?.content
@@ -61,7 +59,7 @@ class ListTransactionsTool : McpTool {
             env,
             op
         )
-        return jsonResult(txns)
+        jsonResult(txns)
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ApmTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ApmTool.kt
@@ -24,8 +24,6 @@ import com.moneat.events.services.DashboardService
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
-import kotlinx.serialization.json.longOrNull
 
 private val dashboardService = DashboardService.create()
 
@@ -36,7 +34,7 @@ class ListTransactionsTool : McpTool {
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "project_id" to schemaNumber("Project ID"),
+                "project_id" to schemaProjectId(),
                 "period" to schemaEnum(
                     "Time period",
                     listOf("1h", "6h", "24h", "7d", "30d")
@@ -52,7 +50,7 @@ class ListTransactionsTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive?.long
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val period = args["period"]?.jsonPrimitive?.content ?: "7d"
         val env = args["environment"]?.jsonPrimitive?.content
@@ -76,7 +74,7 @@ class GetTraceTool : McpTool {
             mapOf(
                 "event_id" to schemaString("Transaction or error event ID"),
                 "trace_id" to schemaString("Trace ID"),
-                "project_id" to schemaNumber("Project ID for trace_id lookups")
+                "project_id" to schemaProjectId("Project resource ID for trace_id lookups")
             )
         )
     )
@@ -87,7 +85,7 @@ class GetTraceTool : McpTool {
     ): ToolCallResult {
         val eventId = args["event_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
         val traceId = args["trace_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
-        val projectId = args["project_id"]?.jsonPrimitive?.longOrNull
+        val projectId = args.projectIdArg()
 
         if (eventId == null && traceId == null) {
             return errorResult("event_id or trace_id is required")

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/CorrelatedTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/CorrelatedTool.kt
@@ -83,9 +83,7 @@ class ListFeedbackTool : McpTool {
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val limit = (
             args["limit"]?.jsonPrimitive?.intOrNull
                 ?: DEFAULT_FEEDBACK_LIMIT
@@ -94,6 +92,6 @@ class ListFeedbackTool : McpTool {
             projectId = projectId,
             limit = limit
         )
-        return jsonResult(feedback)
+        jsonResult(feedback)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/CorrelatedTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/CorrelatedTool.kt
@@ -71,7 +71,7 @@ class ListFeedbackTool : McpTool {
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "project_id" to schemaNumber("Project ID"),
+                "project_id" to schemaProjectId(),
                 "limit" to schemaNumber(
                     "Max results (default 50)"
                 )
@@ -84,10 +84,8 @@ class ListFeedbackTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectIdStr = args["project_id"]?.jsonPrimitive?.content
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
-        val projectId = projectIdStr.toLongOrNull()
-            ?: return errorResult("project_id must be a numeric id")
         val limit = (
             args["limit"]?.jsonPrimitive?.intOrNull
                 ?: DEFAULT_FEEDBACK_LIMIT

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardTemplateTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardTemplateTool.kt
@@ -153,7 +153,7 @@ class ExecuteDashboardQueryTool : McpTool {
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "project_id" to schemaNumber("Project ID"),
+                "project_id" to schemaProjectId(),
                 "query_config" to schemaObject(
                     "Query DSL config (QueryDsl JSON)"
                 ),
@@ -170,8 +170,7 @@ class ExecuteDashboardQueryTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive
-            ?.content?.toLongOrNull()
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val queryConfigJson = args["query_config"] as? JsonObject
             ?: return errorResult("query_config must be an object")

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardTemplateTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardTemplateTool.kt
@@ -169,11 +169,9 @@ class ExecuteDashboardQueryTool : McpTool {
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val queryConfigJson = args["query_config"] as? JsonObject
-            ?: return errorResult("query_config must be an object")
+            ?: return@withRequiredProjectId errorResult("query_config must be an object")
         val retentionDays = args["retention_days"]?.jsonPrimitive
             ?.content?.toIntOrNull() ?: DEFAULT_RETENTION_DAYS
 
@@ -183,12 +181,12 @@ class ExecuteDashboardQueryTool : McpTool {
                 queryConfigJson
             )
         } catch (e: Exception) {
-            return errorResult(
+            return@withRequiredProjectId errorResult(
                 "Invalid query_config: ${e.message}"
             )
         }
 
-        return try {
+        try {
             val results = dashQueryEngine.executeQuery(
                 dsl = dsl,
                 projectId = projectId,

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardTool.kt
@@ -41,7 +41,7 @@ class ListDashboardsTool : McpTool {
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "project_id" to schemaNumber("Optional project ID filter")
+                "project_id" to schemaProjectId("Optional project resource ID filter")
             )
         )
     )
@@ -50,8 +50,7 @@ class ListDashboardsTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive
-            ?.content?.toLongOrNull()
+        val projectId = args.projectIdArg()
         val dashboards = dashboardService.listDashboards(
             orgId = context.organizationId.toLong(),
             projectId = projectId,

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
@@ -430,7 +430,7 @@ class PreviewDashboardWidgetQueryTool : McpTool {
         properties = schemaProperties(
             dashboardIdProperty(),
             "query_config" to schemaObject("QueryDsl config"),
-            "project_id" to schemaNumber("Project ID"),
+            "project_id" to schemaProjectId("Project resource ID or legacy numeric project ID"),
             "variables" to schemaObject("Variable values"),
             "time_range" to schemaObject("Time range override")
         ),
@@ -445,7 +445,7 @@ class PreviewDashboardWidgetQueryTool : McpTool {
         val queryConfig = args.requiredQueryConfig()
         val timeRange = args.optionalTimeRange()
         val variables = args.optionalVariables()
-        val requestedProjectId = args.longArg("project_id")
+        val requestedProjectId = args.projectIdArg("project_id")
         val orgId = context.organizationId.toLong()
         val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
             ?: return errorResult("Dashboard not found: $dashboardId")

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/IssueTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/IssueTool.kt
@@ -27,7 +27,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
 
 private val dashboardService = DashboardService.create()
 
@@ -51,7 +50,7 @@ class ListIssuesTool : McpTool {
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "project_id" to schemaNumber("Project ID"),
+                "project_id" to schemaProjectId(),
                 "status" to schemaEnum(
                     "Filter by status",
                     ALLOWED_ISSUE_STATUSES
@@ -67,7 +66,7 @@ class ListIssuesTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive?.long
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val status = args["status"]?.jsonPrimitive?.content
         val page = args["page"]?.jsonPrimitive?.intOrNull ?: DEFAULT_PAGE

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/IssueTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/IssueTool.kt
@@ -65,15 +65,13 @@ class ListIssuesTool : McpTool {
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val status = args["status"]?.jsonPrimitive?.content
         val page = args["page"]?.jsonPrimitive?.intOrNull ?: DEFAULT_PAGE
         val limit = (args["limit"]?.jsonPrimitive?.intOrNull ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
 
         val issues = dashboardService.getIssues(projectId, page, limit, status)
-        return jsonResult(issues)
+        jsonResult(issues)
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ProjectTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ProjectTool.kt
@@ -84,22 +84,15 @@ class GetProjectTool : McpTool {
     override val name = "get_project"
     override val description =
         "Get project details including DSN and settings"
-    override val inputSchema = InputSchema(
-        properties = JsonObject(
-            mapOf("project_id" to schemaProjectId())
-        ),
-        required = listOf("project_id")
-    )
+    override val inputSchema = projectIdInputSchema()
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val project = projectDashboardService.getProject(projectId)
-            ?: return errorResult("Project not found: $projectId")
-        return jsonResult(project)
+            ?: return@withRequiredProjectId errorResult("Project not found: $projectId")
+        jsonResult(project)
     }
 }
 
@@ -123,14 +116,12 @@ class GetProjectStatsTool : McpTool {
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val period = args["period"]?.jsonPrimitive?.content ?: "7d"
         val stats = projectDashboardService.getProjectStats(
             projectId,
             period
         )
-        return jsonResult(stats)
+        jsonResult(stats)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ProjectTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ProjectTool.kt
@@ -24,7 +24,6 @@ import com.moneat.events.models.CreateProjectRequest
 import com.moneat.events.services.DashboardService
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
 
 private val projectDashboardService = DashboardService.create()
 
@@ -87,7 +86,7 @@ class GetProjectTool : McpTool {
         "Get project details including DSN and settings"
     override val inputSchema = InputSchema(
         properties = JsonObject(
-            mapOf("project_id" to schemaNumber("Project ID"))
+            mapOf("project_id" to schemaProjectId())
         ),
         required = listOf("project_id")
     )
@@ -96,7 +95,7 @@ class GetProjectTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive?.long
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val project = projectDashboardService.getProject(projectId)
             ?: return errorResult("Project not found: $projectId")
@@ -111,7 +110,7 @@ class GetProjectStatsTool : McpTool {
     override val inputSchema = InputSchema(
         properties = JsonObject(
             mapOf(
-                "project_id" to schemaNumber("Project ID"),
+                "project_id" to schemaProjectId(),
                 "period" to schemaEnum(
                     "Time period",
                     listOf("24h", "7d", "30d")
@@ -125,7 +124,7 @@ class GetProjectStatsTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive?.long
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val period = args["period"]?.jsonPrimitive?.content ?: "7d"
         val stats = projectDashboardService.getProjectStats(

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ReleaseTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ReleaseTool.kt
@@ -23,8 +23,6 @@ import com.moneat.mcp.protocol.ToolCallResult
 import com.moneat.events.services.DashboardService
 import com.moneat.events.services.ReleaseService
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
 
 private val releaseService = ReleaseService()
 private val dashboardService = DashboardService.create()
@@ -34,7 +32,7 @@ class ListReleasesTool : McpTool {
     override val description = "List releases for a project"
     override val inputSchema = InputSchema(
         properties = JsonObject(
-            mapOf("project_id" to schemaNumber("Project ID"))
+            mapOf("project_id" to schemaProjectId())
         ),
         required = listOf("project_id")
     )
@@ -43,7 +41,7 @@ class ListReleasesTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive?.long
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val releases = releaseService.listReleases(projectId)
         return jsonResult(releases)
@@ -56,7 +54,7 @@ class GetReleaseStatsTool : McpTool {
         "Get release list with error/performance stats"
     override val inputSchema = InputSchema(
         properties = JsonObject(
-            mapOf("project_id" to schemaNumber("Project ID"))
+            mapOf("project_id" to schemaProjectId())
         ),
         required = listOf("project_id")
     )
@@ -65,7 +63,7 @@ class GetReleaseStatsTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val projectId = args["project_id"]?.jsonPrimitive?.long
+        val projectId = args.projectIdArg()
             ?: return errorResult("project_id is required")
         val releases = dashboardService.getReleases(projectId)
         return jsonResult(releases)

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ReleaseTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ReleaseTool.kt
@@ -17,7 +17,6 @@
 package com.moneat.mcp.tools
 
 import com.moneat.mcp.models.McpContext
-import com.moneat.mcp.protocol.InputSchema
 import com.moneat.mcp.protocol.McpTool
 import com.moneat.mcp.protocol.ToolCallResult
 import com.moneat.events.services.DashboardService
@@ -30,21 +29,14 @@ private val dashboardService = DashboardService.create()
 class ListReleasesTool : McpTool {
     override val name = "list_releases"
     override val description = "List releases for a project"
-    override val inputSchema = InputSchema(
-        properties = JsonObject(
-            mapOf("project_id" to schemaProjectId())
-        ),
-        required = listOf("project_id")
-    )
+    override val inputSchema = projectIdInputSchema()
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val releases = releaseService.listReleases(projectId)
-        return jsonResult(releases)
+        jsonResult(releases)
     }
 }
 
@@ -52,20 +44,13 @@ class GetReleaseStatsTool : McpTool {
     override val name = "get_release_stats"
     override val description =
         "Get release list with error/performance stats"
-    override val inputSchema = InputSchema(
-        properties = JsonObject(
-            mapOf("project_id" to schemaProjectId())
-        ),
-        required = listOf("project_id")
-    )
+    override val inputSchema = projectIdInputSchema()
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
-    ): ToolCallResult {
-        val projectId = args.projectIdArg()
-            ?: return errorResult("project_id is required")
+    ): ToolCallResult = withRequiredProjectId(args) { projectId ->
         val releases = dashboardService.getReleases(projectId)
-        return jsonResult(releases)
+        jsonResult(releases)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ToolUtils.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ToolUtils.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.mcp.tools
 
+import com.moneat.mcp.protocol.InputSchema
 import com.moneat.mcp.protocol.ToolCallResult
 import com.moneat.mcp.protocol.ToolContent
 import com.moneat.shared.services.ProjectIdResolver
@@ -53,9 +54,25 @@ inline fun <reified T> jsonResult(data: T): ToolCallResult {
 fun JsonObject.projectIdArg(name: String = "project_id"): Long? =
     this[name]?.jsonPrimitive?.contentOrNull?.let(projectIdResolver::resolve)
 
+suspend fun withRequiredProjectId(
+    args: JsonObject,
+    block: suspend (Long) -> ToolCallResult,
+): ToolCallResult {
+    val projectId = args.projectIdArg() ?: return errorResult("project_id is required")
+    return block(projectId)
+}
+
 fun schemaProjectId(description: String = "Project resource ID or legacy numeric project ID"): JsonObject = JsonObject(
     mapOf(
         "type" to JsonPrimitive("string"),
         "description" to JsonPrimitive(description)
     )
 )
+
+fun projectIdInputSchema(description: String = "Project resource ID or legacy numeric project ID"): InputSchema =
+    InputSchema(
+        properties = JsonObject(
+            mapOf("project_id" to schemaProjectId(description))
+        ),
+        required = listOf("project_id")
+    )

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ToolUtils.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ToolUtils.kt
@@ -18,14 +18,21 @@ package com.moneat.mcp.tools
 
 import com.moneat.mcp.protocol.ToolCallResult
 import com.moneat.mcp.protocol.ToolContent
+import com.moneat.shared.services.ProjectIdResolver
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 val toolJson = Json {
     encodeDefaults = true
     ignoreUnknownKeys = true
     prettyPrint = true
 }
+
+private val projectIdResolver = ProjectIdResolver()
 
 fun textResult(text: String): ToolCallResult {
     return ToolCallResult(content = listOf(ToolContent(text = text)))
@@ -42,3 +49,13 @@ inline fun <reified T> jsonResult(data: T): ToolCallResult {
     val text = toolJson.encodeToString(data)
     return ToolCallResult(content = listOf(ToolContent(text = text)))
 }
+
+fun JsonObject.projectIdArg(name: String = "project_id"): Long? =
+    this[name]?.jsonPrimitive?.contentOrNull?.let(projectIdResolver::resolve)
+
+fun schemaProjectId(description: String = "Project resource ID or legacy numeric project ID"): JsonObject = JsonObject(
+    mapOf(
+        "type" to JsonPrimitive("string"),
+        "description" to JsonPrimitive(description)
+    )
+)

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ToolUtils.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ToolUtils.kt
@@ -22,6 +22,7 @@ import com.moneat.mcp.protocol.ToolContent
 import com.moneat.shared.services.ProjectIdResolver
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -64,7 +65,7 @@ suspend fun withRequiredProjectId(
 
 fun schemaProjectId(description: String = "Project resource ID or legacy numeric project ID"): JsonObject = JsonObject(
     mapOf(
-        "type" to JsonPrimitive("string"),
+        "type" to JsonArray(listOf(JsonPrimitive("string"), JsonPrimitive("number"))),
         "description" to JsonPrimitive(description)
     )
 )

--- a/backend/src/main/kotlin/com/moneat/otlp/OtlpAuth.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/OtlpAuth.kt
@@ -20,6 +20,7 @@ import com.moneat.events.routes.extractPublicKey
 import com.moneat.events.routes.extractPublicKeyFromDsn
 import com.moneat.events.services.EventService
 import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.shared.services.ProjectIdResolver
 import io.ktor.http.HttpHeaders
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.header
@@ -32,7 +33,7 @@ object OtlpAuth {
     private const val BEARER_PREFIX = "Bearer "
 
     private val projectIdFromDsnRegex =
-        "https?://[^@]+@[^/]+/([0-9]+)".toRegex(RegexOption.IGNORE_CASE)
+        "https?://[^@]+@[^/]+/([0-9]+|[0-9a-f-]{36})".toRegex(RegexOption.IGNORE_CASE)
 
     fun extractBearerToken(authorizationHeader: String?): String? {
         if (authorizationHeader == null) return null
@@ -55,20 +56,22 @@ object OtlpAuth {
         call: ApplicationCall,
         otlpApiKeyService: OtlpApiKeyService,
         eventService: EventService,
+        projectIdResolver: ProjectIdResolver,
     ): Int? =
         extractOrgId(call, otlpApiKeyService)
-            ?: extractOrgIdFromLegacyDsn(call, eventService)
+            ?: extractOrgIdFromLegacyDsn(call, eventService, projectIdResolver)
 
     private fun extractOrgIdFromLegacyDsn(
         call: ApplicationCall,
         eventService: EventService,
+        projectIdResolver: ProjectIdResolver,
     ): Int? {
         val dsnLikeHeader =
             call.request.header("x-moneat-dsn")
                 ?: call.request.header(HttpHeaders.Authorization)
         val projectId =
-            extractProjectIdFromDsn(dsnLikeHeader)
-                ?: call.request.queryParameters["projectId"]?.toLongOrNull()
+            extractProjectIdFromDsn(dsnLikeHeader, projectIdResolver)
+                ?: call.request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
                 ?: return null
         val publicKey =
             extractPublicKey(
@@ -82,9 +85,13 @@ object OtlpAuth {
         return eventService.getOrganizationIdForProject(projectId)
     }
 
-    private fun extractProjectIdFromDsn(dsnLike: String?): Long? {
+    private fun extractProjectIdFromDsn(dsnLike: String?, projectIdResolver: ProjectIdResolver): Long? {
         if (dsnLike.isNullOrBlank()) return null
         val cleaned = dsnLike.removePrefix("DSN ").trim()
-        return projectIdFromDsnRegex.find(cleaned)?.groupValues?.getOrNull(1)?.toLongOrNull()
+        return projectIdFromDsnRegex
+            .find(cleaned)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.let(projectIdResolver::resolve)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/otlp/OtlpAuth.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/OtlpAuth.kt
@@ -31,9 +31,12 @@ import io.ktor.server.request.header
  */
 object OtlpAuth {
     private const val BEARER_PREFIX = "Bearer "
+    private const val PROJECT_ID_SEGMENT_PATTERN =
+        "([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9]+)"
 
     private val projectIdFromDsnRegex =
-        "https?://[^@]+@[^/]+/([0-9]+|[0-9a-f-]{36})".toRegex(RegexOption.IGNORE_CASE)
+        "https?://[^@]+@[^/]+/$PROJECT_ID_SEGMENT_PATTERN(?:[/?#]|$)"
+            .toRegex(RegexOption.IGNORE_CASE)
 
     fun extractBearerToken(authorizationHeader: String?): String? {
         if (authorizationHeader == null) return null

--- a/backend/src/main/kotlin/com/moneat/otlp/models/OtlpServiceRoutingModels.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/models/OtlpServiceRoutingModels.kt
@@ -33,7 +33,7 @@ data class OtlpServiceMappingResponse(
     @SerialName("service_namespace") val serviceNamespace: String,
     @SerialName("service_name") val serviceName: String,
     @SerialName("project_id") val projectId: Long,
-    @SerialName("project_resource_id") val projectResourceId: String = projectId.toString(),
+    @SerialName("project_resource_id") val projectResourceId: String,
     @SerialName("project_name") val projectName: String,
     @SerialName("updated_at") val updatedAt: String,
 )
@@ -45,7 +45,7 @@ data class OtlpObservedServiceResponse(
     @SerialName("service_namespace") val serviceNamespace: String,
     @SerialName("service_name") val serviceName: String,
     @SerialName("project_id") val projectId: Long? = null,
-    @SerialName("project_resource_id") val projectResourceId: String? = projectId?.toString(),
+    @SerialName("project_resource_id") val projectResourceId: String? = null,
     @SerialName("project_name") val projectName: String? = null,
     @SerialName("seen_logs") val seenLogs: Boolean,
     @SerialName("seen_traces") val seenTraces: Boolean,

--- a/backend/src/main/kotlin/com/moneat/otlp/models/OtlpServiceRoutingModels.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/models/OtlpServiceRoutingModels.kt
@@ -23,7 +23,8 @@ import kotlinx.serialization.Serializable
 data class CreateOtlpServiceMappingRequest(
     @SerialName("service_namespace") val serviceNamespace: String? = null,
     @SerialName("service_name") val serviceName: String,
-    @SerialName("project_id") val projectId: Long,
+    @SerialName("project_id") val projectId: Long? = null,
+    @SerialName("project_resource_id") val projectResourceId: String? = null,
 )
 
 @Serializable
@@ -32,6 +33,7 @@ data class OtlpServiceMappingResponse(
     @SerialName("service_namespace") val serviceNamespace: String,
     @SerialName("service_name") val serviceName: String,
     @SerialName("project_id") val projectId: Long,
+    @SerialName("project_resource_id") val projectResourceId: String = projectId.toString(),
     @SerialName("project_name") val projectName: String,
     @SerialName("updated_at") val updatedAt: String,
 )
@@ -43,6 +45,7 @@ data class OtlpObservedServiceResponse(
     @SerialName("service_namespace") val serviceNamespace: String,
     @SerialName("service_name") val serviceName: String,
     @SerialName("project_id") val projectId: Long? = null,
+    @SerialName("project_resource_id") val projectResourceId: String? = projectId?.toString(),
     @SerialName("project_name") val projectName: String? = null,
     @SerialName("seen_logs") val seenLogs: Boolean,
     @SerialName("seen_traces") val seenTraces: Boolean,

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpServiceRoutingService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpServiceRoutingService.kt
@@ -23,6 +23,7 @@ import com.moneat.shared.models.OtelObservedServices
 import com.moneat.shared.models.OtelServiceProjectMappings
 import com.moneat.shared.models.Projects
 import com.moneat.shared.services.ProjectIdResolver
+import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -83,7 +84,7 @@ class OtlpServiceRoutingService {
             val projectsById = Projects
                 .selectAll()
                 .where { Projects.organization_id eq organizationId }
-                .associate { row -> row[Projects.id] to (row[Projects.name] to row[Projects.resource_id].toString()) }
+                .associate { row -> row[Projects.id] to (row[Projects.name] to projectResourceId(row)) }
 
             OtelObservedServices
                 .selectAll()
@@ -130,7 +131,7 @@ class OtlpServiceRoutingService {
                 .firstOrNull()
                 ?: return@transaction null
             val projectName = projectRow[Projects.name]
-            val projectResourceId = projectRow[Projects.resource_id].toString()
+            val projectResourceId = projectResourceId(projectRow)
 
             OtelServiceProjectMappings.insertIgnore {
                 it[OtelServiceProjectMappings.organization_id] = organizationId
@@ -252,6 +253,11 @@ class OtlpServiceRoutingService {
                     projectId = row[OtelServiceProjectMappings.project_id],
                 )
             }
+
+    private fun projectResourceId(row: ResultRow): String {
+        val resourceId = row[Projects.resource_id].toString()
+        return resourceId.takeUnless { it == "null" } ?: row[Projects.id].toString()
+    }
 
     private data class MappingRow(
         val id: Int,

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpServiceRoutingService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpServiceRoutingService.kt
@@ -22,6 +22,7 @@ import com.moneat.otlp.models.OtlpServiceMappingResponse
 import com.moneat.shared.models.OtelObservedServices
 import com.moneat.shared.models.OtelServiceProjectMappings
 import com.moneat.shared.models.Projects
+import com.moneat.shared.services.ProjectIdResolver
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -52,6 +53,7 @@ enum class OtlpSignalType {
 }
 
 class OtlpServiceRoutingService {
+    private val projectIdResolver = ProjectIdResolver()
 
     fun resolveProjectIds(
         organizationId: Int,
@@ -81,7 +83,7 @@ class OtlpServiceRoutingService {
             val projectsById = Projects
                 .selectAll()
                 .where { Projects.organization_id eq organizationId }
-                .associate { row -> row[Projects.id] to row[Projects.name] }
+                .associate { row -> row[Projects.id] to (row[Projects.name] to row[Projects.resource_id].toString()) }
 
             OtelObservedServices
                 .selectAll()
@@ -99,7 +101,8 @@ class OtlpServiceRoutingService {
                         serviceNamespace = identity.serviceNamespace,
                         serviceName = identity.serviceName,
                         projectId = mapping?.projectId,
-                        projectName = mapping?.projectId?.let { projectsById[it] },
+                        projectResourceId = mapping?.projectId?.let { projectsById[it]?.second },
+                        projectName = mapping?.projectId?.let { projectsById[it]?.first },
                         seenLogs = row[OtelObservedServices.seen_logs],
                         seenTraces = row[OtelObservedServices.seen_traces],
                         seenMetrics = row[OtelObservedServices.seen_metrics],
@@ -116,22 +119,24 @@ class OtlpServiceRoutingService {
     ): OtlpServiceMappingResponse? {
         val identity = normalizeIdentity(request.serviceNamespace, request.serviceName) ?: return null
         val now = Clock.System.now()
+        val projectId = request.projectResourceId?.let(projectIdResolver::resolve) ?: request.projectId ?: return null
         return transaction {
-            val projectName = Projects
+            val projectRow = Projects
                 .selectAll()
                 .where {
-                    (Projects.id eq request.projectId) and
+                    (Projects.id eq projectId) and
                         (Projects.organization_id eq organizationId)
                 }
                 .firstOrNull()
-                ?.get(Projects.name)
                 ?: return@transaction null
+            val projectName = projectRow[Projects.name]
+            val projectResourceId = projectRow[Projects.resource_id].toString()
 
             OtelServiceProjectMappings.insertIgnore {
                 it[OtelServiceProjectMappings.organization_id] = organizationId
                 it[OtelServiceProjectMappings.service_namespace] = identity.serviceNamespace
                 it[OtelServiceProjectMappings.service_name] = identity.serviceName
-                it[OtelServiceProjectMappings.project_id] = request.projectId
+                it[OtelServiceProjectMappings.project_id] = projectId
                 it[OtelServiceProjectMappings.created_at] = now
                 it[OtelServiceProjectMappings.updated_at] = now
             }
@@ -140,7 +145,7 @@ class OtlpServiceRoutingService {
                     (OtelServiceProjectMappings.service_namespace eq identity.serviceNamespace) and
                     (OtelServiceProjectMappings.service_name eq identity.serviceName)
             }) {
-                it[OtelServiceProjectMappings.project_id] = request.projectId
+                it[OtelServiceProjectMappings.project_id] = projectId
                 it[OtelServiceProjectMappings.updated_at] = now
             }
             val id = OtelServiceProjectMappings
@@ -156,7 +161,8 @@ class OtlpServiceRoutingService {
                 id = id,
                 serviceNamespace = identity.serviceNamespace,
                 serviceName = identity.serviceName,
-                projectId = request.projectId,
+                projectId = projectId,
+                projectResourceId = projectResourceId,
                 projectName = projectName,
                 updatedAt = now.toString(),
             )

--- a/backend/src/main/kotlin/com/moneat/plugins/RateLimiting.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/RateLimiting.kt
@@ -22,6 +22,8 @@ import com.moneat.events.routes.extractPublicKey
 import com.moneat.events.services.EventService
 import com.moneat.otlp.OtlpAuth
 import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.shared.services.ProjectIdResolver
+import com.moneat.utils.suspendRunCatching
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -34,7 +36,6 @@ import org.koin.core.context.GlobalContext
 import java.net.InetAddress
 import java.security.MessageDigest
 import kotlin.time.Duration.Companion.seconds
-import com.moneat.utils.suspendRunCatching
 
 /**
  * Trusted upstream proxies consulted before accepting forwarded-IP headers.
@@ -128,8 +129,10 @@ private fun bearerToken(header: String?): String? {
 fun Application.configureRateLimiting() {
     install(RateLimit) {
         register(RateLimitName("ingestion")) {
+            val projectIdResolver = GlobalContext.get().get<ProjectIdResolver>()
             requestKey { call ->
-                val projectId = call.parameters["projectId"] ?: "unknown"
+                val rawProjectId = call.parameters["projectId"]
+                val projectId = rawProjectId?.let(projectIdResolver::resolve)?.toString() ?: rawProjectId ?: "unknown"
                 val auth = call.request.headers.get("X-Sentry-Auth")
                 val sentryKey = call.request.queryParameters["sentry_key"]
                 val key = extractPublicKey(auth, sentryKey) ?: "anon"
@@ -187,10 +190,16 @@ fun Application.configureRateLimiting() {
             } else {
                 null
             }
+            val projectIdResolver = GlobalContext.get().get<ProjectIdResolver>()
             register(RateLimitName(name)) {
                 requestKey { call ->
                     val organizationId = if (allowLegacyDsn && eventService != null) {
-                        OtlpAuth.resolveOtlpIngestOrganizationId(call, otlpApiKeyService, eventService)
+                        OtlpAuth.resolveOtlpIngestOrganizationId(
+                            call,
+                            otlpApiKeyService,
+                            eventService,
+                            projectIdResolver
+                        )
                     } else {
                         OtlpAuth.extractOrgId(call, otlpApiKeyService)
                     }

--- a/backend/src/main/kotlin/com/moneat/plugins/RateLimiting.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/RateLimiting.kt
@@ -132,7 +132,9 @@ fun Application.configureRateLimiting() {
             val projectIdResolver = GlobalContext.get().get<ProjectIdResolver>()
             requestKey { call ->
                 val rawProjectId = call.parameters["projectId"]
-                val projectId = rawProjectId?.let(projectIdResolver::resolve)?.toString() ?: rawProjectId ?: "unknown"
+                val projectId = rawProjectId
+                    ?.let { projectIdResolver.resolve(it)?.toString() ?: it }
+                    ?: "unknown"
                 val auth = call.request.headers.get("X-Sentry-Auth")
                 val sentryKey = call.request.queryParameters["sentry_key"]
                 val key = extractPublicKey(auth, sentryKey) ?: "anon"

--- a/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
@@ -23,6 +23,7 @@ import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.datetime.date
 import org.jetbrains.exposed.v1.datetime.timestamp
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import kotlin.uuid.Uuid
 
 class JsonbColumnType : ColumnType<String>() {
     private fun isH2(): Boolean =
@@ -193,6 +194,7 @@ object SidebarPreferenceEvents : Table("sidebar_preference_events") {
 
 object Projects : Table("projects") {
     val id = long("id").autoIncrement()
+    val resource_id = uuid("resource_id").clientDefault { Uuid.random() }
     val organization_id = integer("organization_id")
     val name = varchar("name", 255)
     val slug = varchar("slug", 255)

--- a/backend/src/main/kotlin/com/moneat/shared/services/ProjectIdResolver.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/ProjectIdResolver.kt
@@ -1,0 +1,91 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.shared.services
+
+import com.moneat.shared.models.Projects
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.uuid.Uuid
+
+class ProjectIdResolver(
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+    private val lookupProjectIdByResourceId: (Uuid) -> Long? = ::lookupProjectIdByResourceId,
+    private val lookupResourceIdByProjectId: (Long) -> Uuid? = ::lookupResourceIdByProjectId,
+) {
+    private data class CachedEntry<T : Any>(val value: T, val expiresAt: Long)
+
+    private val projectIdByResourceId = ConcurrentHashMap<Uuid, CachedEntry<Long>>()
+    private val resourceIdByProjectId = ConcurrentHashMap<Long, CachedEntry<Uuid>>()
+
+    fun resolve(param: String): Long? {
+        val normalized = param.trim().takeIf { it.isNotBlank() } ?: return null
+        normalized.toLongOrNull()?.let { return it }
+
+        val resourceId = parseUuid(normalized) ?: return null
+        val now = nowMs()
+        projectIdByResourceId[resourceId]?.let { entry ->
+            if (entry.expiresAt > now) return entry.value
+        }
+
+        val projectId = lookupProjectIdByResourceId(resourceId) ?: return null
+        projectIdByResourceId[resourceId] = CachedEntry(projectId, now + CACHE_TTL_MS)
+        resourceIdByProjectId[projectId] = CachedEntry(resourceId, now + CACHE_TTL_MS)
+        return projectId
+    }
+
+    fun resourceIdFor(projectId: Long): String? {
+        val now = nowMs()
+        resourceIdByProjectId[projectId]?.let { entry ->
+            if (entry.expiresAt > now) return entry.value.toString()
+        }
+
+        val resourceId = lookupResourceIdByProjectId(projectId) ?: return null
+        resourceIdByProjectId[projectId] = CachedEntry(resourceId, now + CACHE_TTL_MS)
+        projectIdByResourceId[resourceId] = CachedEntry(projectId, now + CACHE_TTL_MS)
+        return resourceId.toString()
+    }
+
+    private fun parseUuid(value: String): Uuid? =
+        runCatching { Uuid.parse(value) }.getOrNull()
+
+    companion object {
+        private const val MINUTES_PER_HALF_HOUR = 30
+        private const val SECONDS_PER_MINUTE = 60
+        private const val MILLIS_PER_SECOND = 1_000L
+        private const val CACHE_TTL_MS = MINUTES_PER_HALF_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND
+    }
+}
+
+private fun lookupProjectIdByResourceId(resourceId: Uuid): Long? =
+    transaction {
+        Projects
+            .selectAll()
+            .where { Projects.resource_id eq resourceId }
+            .firstOrNull()
+            ?.get(Projects.id)
+    }
+
+private fun lookupResourceIdByProjectId(projectId: Long): Uuid? =
+    transaction {
+        Projects
+            .selectAll()
+            .where { Projects.id eq projectId }
+            .firstOrNull()
+            ?.get(Projects.resource_id)
+    }

--- a/backend/src/main/resources/db/migration/V112__add_project_resource_id.sql
+++ b/backend/src/main/resources/db/migration/V112__add_project_resource_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE projects ADD COLUMN resource_id UUID NOT NULL DEFAULT gen_random_uuid();
+
+CREATE UNIQUE INDEX idx_projects_resource_id ON projects(resource_id);

--- a/backend/src/test/kotlin/com/moneat/dashboards/CustomDashboardServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/CustomDashboardServiceTest.kt
@@ -653,6 +653,7 @@ class CustomDashboardServiceTest {
         } returns listOf(
             mockk {
                 every { projectId } returns 42L
+                every { resourceId } returns "018f4ce4-3f2a-7a67-a32b-0c1848f62b9d"
                 every { name } returns "error-tracker"
             }
         )
@@ -663,6 +664,7 @@ class CustomDashboardServiceTest {
         assertEquals("Error Dashboard", result.dashboards[0].title)
         assertEquals(1, result.projects.size)
         assertEquals(42L, result.projects[0].id)
+        assertEquals("018f4ce4-3f2a-7a67-a32b-0c1848f62b9d", result.projects[0].resourceId)
         assertEquals("error-tracker", result.projects[0].name)
     }
 

--- a/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
@@ -681,8 +681,12 @@ class LogRoutesExtendedTest {
             }
 
             assertEquals(HttpStatusCode.OK, response.status)
-            assertTrue(response.bodyAsText().contains("checkout"))
-            assertTrue(response.bodyAsText().contains("Backend"))
+            val responseBody = response.bodyAsText()
+            assertTrue(responseBody.contains("checkout"))
+            assertTrue(responseBody.contains("Backend"))
+            assertTrue(
+                responseBody.contains(""""project_resource_id":"11111111-1111-1111-1111-111111111111"""")
+            )
         }
 
     @Test
@@ -717,7 +721,11 @@ class LogRoutesExtendedTest {
             }
 
             assertEquals(HttpStatusCode.OK, response.status)
-            assertTrue(response.bodyAsText().contains("Backend"))
+            val responseBody = response.bodyAsText()
+            assertTrue(responseBody.contains("Backend"))
+            assertTrue(
+                responseBody.contains(""""project_resource_id":"11111111-1111-1111-1111-111111111111"""")
+            )
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
@@ -653,6 +653,7 @@ class LogRoutesExtendedTest {
                     serviceNamespace = "checkout",
                     serviceName = "api",
                     projectId = 30,
+                    projectResourceId = "11111111-1111-1111-1111-111111111111",
                     projectName = "Backend",
                     seenLogs = true,
                     seenTraces = false,
@@ -692,6 +693,7 @@ class LogRoutesExtendedTest {
                 serviceNamespace = "checkout",
                 serviceName = "api",
                 projectId = 30,
+                projectResourceId = "11111111-1111-1111-1111-111111111111",
                 projectName = "Backend",
                 updatedAt = "2026-01-01T00:00:00Z"
             )

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
@@ -564,6 +564,20 @@ class DashboardCrudToolTest {
     }
 
     @Test
+    fun `preview dashboard widget query schema accepts resource IDs and legacy numeric IDs`() {
+        val projectIdSchema = PreviewDashboardWidgetQueryTool()
+            .inputSchema
+            .properties["project_id"]!!
+            .jsonObject
+        val typeValues = projectIdSchema["type"] as JsonArray
+
+        assertEquals(
+            listOf("string", "number"),
+            typeValues.jsonArray.map { it.jsonPrimitive.content }
+        )
+    }
+
+    @Test
     fun `preview dashboard widget query requires project id for unscoped dashboards`() = runBlocking {
         val dashboardId = seedDashboard(projectId = null)
 

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -29,14 +29,18 @@ import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -158,6 +162,17 @@ class McpToolValidationTest {
             assertFalse(result.isError)
             assertTrue(result.content.first().text.orEmpty().contains(TRACE_ID))
         }
+    }
+
+    @Test
+    fun `project id schemas accept resource IDs and legacy numeric IDs`() {
+        val projectIdSchema = projectIdInputSchema().properties["project_id"] as JsonObject
+        val typeValues = projectIdSchema["type"] as JsonArray
+
+        assertEquals(
+            listOf("string", "number"),
+            typeValues.jsonArray.map { it.jsonPrimitive.content }
+        )
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -366,6 +366,7 @@ class McpToolValidationTest {
             ),
             case("create_uptime_name", CreateUptimeMonitorTool(), obj(), "name is required"),
             case("create_uptime_url", CreateUptimeMonitorTool(), obj("name" to "API"), "url is required"),
+            case("list_transactions_project_id", ListTransactionsTool(), obj(), "project_id is required"),
             case("get_trace_lookup", GetTraceTool(), obj(), "event_id or trace_id is required"),
             case(
                 "get_trace_project_id",
@@ -373,6 +374,14 @@ class McpToolValidationTest {
                 obj("trace_id" to TRACE_ID),
                 "project_id is required when trace_id is used without event_id",
             ),
+            case("transaction_stats_project_id", GetTransactionStatsTool(), obj(), "project_id is required"),
+            case("list_issues_project_id", ListIssuesTool(), obj(), "project_id is required"),
+            case("list_releases_project_id", ListReleasesTool(), obj(), "project_id is required"),
+            case("release_stats_project_id", GetReleaseStatsTool(), obj(), "project_id is required"),
+            case("get_project_project_id", GetProjectTool(), obj(), "project_id is required"),
+            case("get_project_stats_project_id", GetProjectStatsTool(), obj(), "project_id is required"),
+            case("list_feedback_project_id", ListFeedbackTool(), obj(), "project_id is required"),
+            case("execute_dashboard_query_project_id", ExecuteDashboardQueryTool(), obj(), "project_id is required"),
             case("create_datasource_name", CreateDataSourceTool(), obj(), "name is required"),
             case(
                 "create_datasource_type",

--- a/backend/src/test/kotlin/com/moneat/otlp/OtlpAuthTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/OtlpAuthTest.kt
@@ -1,0 +1,149 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.otlp
+
+import com.moneat.events.repositories.models.ProjectKeyVerification
+import com.moneat.events.services.EventService
+import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.shared.services.ProjectIdResolver
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class OtlpAuthTest {
+
+    @Test
+    fun `resolveOtlpIngestOrganizationId returns org from bearer API key`() = testApplication {
+        val apiKeyService = mockk<OtlpApiKeyService>()
+        val eventService = mockk<EventService>(relaxed = true)
+
+        every { apiKeyService.validateKey("valid-otlp-key") } returns ORG_ID
+
+        installAuthRoute(apiKeyService, eventService, ProjectIdResolver())
+
+        val response = client.get("/auth") {
+            header(HttpHeaders.Authorization, "Bearer valid-otlp-key")
+        }
+
+        assertEquals(ORG_ID.toString(), response.bodyAsText())
+        verify(exactly = 0) { eventService.verifyProjectKey(any(), any()) }
+    }
+
+    @Test
+    fun `resolveOtlpIngestOrganizationId accepts UUID project DSN header`() = testApplication {
+        val resourceId = Uuid.parse("818f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        val apiKeyService = mockk<OtlpApiKeyService>()
+        val eventService = verifiedProjectKeyService()
+        val resolver = resourceIdResolver(resourceId)
+
+        every { apiKeyService.validateKey(any()) } returns null
+
+        installAuthRoute(apiKeyService, eventService, resolver)
+
+        val response = client.get("/auth") {
+            header("x-moneat-dsn", "https://$PUBLIC_KEY@example.test/$resourceId")
+            header("X-Sentry-Auth", "Sentry sentry_key=$PUBLIC_KEY, sentry_version=7")
+        }
+
+        assertEquals(ORG_ID.toString(), response.bodyAsText())
+        verify { eventService.verifyProjectKey(PROJECT_ID, PUBLIC_KEY) }
+    }
+
+    @Test
+    fun `resolveOtlpIngestOrganizationId accepts UUID project query parameter`() = testApplication {
+        val resourceId = Uuid.parse("918f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        val apiKeyService = mockk<OtlpApiKeyService>()
+        val eventService = verifiedProjectKeyService()
+        val resolver = resourceIdResolver(resourceId)
+
+        every { apiKeyService.validateKey(any()) } returns null
+
+        installAuthRoute(apiKeyService, eventService, resolver)
+
+        val response = client.get("/auth?projectId=$resourceId&sentry_key=$PUBLIC_KEY")
+
+        assertEquals(ORG_ID.toString(), response.bodyAsText())
+        verify { eventService.verifyProjectKey(PROJECT_ID, PUBLIC_KEY) }
+    }
+
+    @Test
+    fun `resolveOtlpIngestOrganizationId accepts DSN authorization header`() = testApplication {
+        val apiKeyService = mockk<OtlpApiKeyService>()
+        val eventService = verifiedProjectKeyService()
+
+        installAuthRoute(apiKeyService, eventService, ProjectIdResolver())
+
+        val response = client.get("/auth") {
+            header(HttpHeaders.Authorization, "DSN https://$PUBLIC_KEY@example.test/$PROJECT_ID")
+        }
+
+        assertEquals(ORG_ID.toString(), response.bodyAsText())
+        verify { eventService.verifyProjectKey(PROJECT_ID, PUBLIC_KEY) }
+    }
+
+    private fun ApplicationTestBuilder.installAuthRoute(
+        apiKeyService: OtlpApiKeyService,
+        eventService: EventService,
+        projectIdResolver: ProjectIdResolver,
+    ) {
+        application {
+            routing {
+                get("/auth") {
+                    val orgId = OtlpAuth.resolveOtlpIngestOrganizationId(
+                        call,
+                        apiKeyService,
+                        eventService,
+                        projectIdResolver,
+                    )
+                    call.respondText(orgId?.toString() ?: "none")
+                }
+            }
+        }
+    }
+
+    private fun verifiedProjectKeyService(): EventService {
+        val eventService = mockk<EventService>()
+        every { eventService.verifyProjectKey(PROJECT_ID, PUBLIC_KEY) } returns ProjectKeyVerification(true, "jvm")
+        every { eventService.getOrganizationIdForProject(PROJECT_ID) } returns ORG_ID
+        return eventService
+    }
+
+    private fun resourceIdResolver(resourceId: Uuid): ProjectIdResolver =
+        ProjectIdResolver(
+            lookupProjectIdByResourceId = { candidate ->
+                if (candidate == resourceId) PROJECT_ID else null
+            }
+        )
+
+    private companion object {
+        private const val ORG_ID = 7
+        private const val PROJECT_ID = 42L
+        private const val PUBLIC_KEY = "pubkey"
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpServiceRoutingServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpServiceRoutingServiceTest.kt
@@ -22,8 +22,10 @@ import com.moneat.shared.models.OtelObservedServices
 import com.moneat.shared.models.OtelServiceProjectMappings
 import com.moneat.shared.models.Projects
 import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.test.BeforeTest
@@ -212,6 +214,38 @@ class OtlpServiceRoutingServiceTest {
     }
 
     @Test
+    fun `upsertMapping accepts project resource ID`() {
+        val resourceId = projectResourceId(orgOne.projects.first())
+        val mapping = service.upsertMapping(
+            organizationId = orgOne.id,
+            request = CreateOtlpServiceMappingRequest(
+                serviceName = "checkout-api",
+                serviceNamespace = "checkout",
+                projectResourceId = resourceId
+            )
+        )
+
+        assertNotNull(mapping)
+        assertEquals(orgOne.projects.first(), mapping.projectId)
+        assertEquals(resourceId, mapping.projectResourceId)
+
+        service.resolveProjectIds(
+            organizationId = orgOne.id,
+            services = listOf(
+                OtlpServiceDescriptor(
+                    serviceNamespace = "checkout",
+                    serviceName = "checkout-api",
+                    environment = "production"
+                )
+            ),
+            signalType = OtlpSignalType.TRACES
+        )
+
+        val observed = service.listObservedServices(orgOne.id).single()
+        assertEquals(resourceId, observed.projectResourceId)
+    }
+
+    @Test
     fun `deleteMapping removes only mappings in the organization`() {
         val mapping = service.upsertMapping(
             organizationId = orgOne.id,
@@ -246,6 +280,14 @@ class OtlpServiceRoutingServiceTest {
             } get Projects.id
         }
         OrgProjects(orgId, projects)
+    }
+
+    private fun projectResourceId(projectId: Long): String = transaction {
+        Projects
+            .selectAll()
+            .where { Projects.id eq projectId }
+            .first()[Projects.resource_id]
+            .toString()
     }
 
     private data class OrgProjects(

--- a/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
@@ -74,8 +74,10 @@ import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.loadKoinModules
@@ -187,6 +189,14 @@ class EventRoutesExtendedTest {
             } get Projects.id
         }
         return Pair(userId, projectId)
+    }
+
+    private fun projectResourceId(projectId: Long): String = transaction {
+        Projects
+            .selectAll()
+            .where { Projects.id eq projectId }
+            .first()[Projects.resource_id]
+            .toString()
     }
 
     // ──── GET /v1/projects ────
@@ -907,6 +917,29 @@ class EventRoutesExtendedTest {
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("issueAlerts"))
+    }
+
+    @Test
+    fun `GET notification-preferences returns project resource IDs`() = testApplication {
+        val (userId, projectId) = seedUserWithProject()
+        val resourceId = projectResourceId(projectId)
+        transaction {
+            NotificationPreferences.insert {
+                it[user_id] = userId
+                it[project_id] = projectId
+                it[issue_alerts] = false
+            }
+        }
+
+        application { installTestApp() }
+        val response = client.get("/v1/notification-preferences") {
+            withAuth(token(userId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains(resourceId))
+        assertTrue(body.contains("Ext Test Project"))
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
@@ -29,6 +29,7 @@ import com.moneat.events.services.DashboardQueryHelper
 import com.moneat.events.services.FeedbackService
 import com.moneat.events.services.IngestionWorker
 import com.moneat.events.services.IssueService
+import com.moneat.shared.services.ProjectIdResolver
 import io.ktor.server.plugins.BadRequestException
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -83,7 +84,11 @@ class EventServicesExtendedTest {
         } returns "timestamp >= now() - INTERVAL 30 DAY"
         every { queryHelper.demoNowClause(any()) } returns "now()"
 
-        issueService = IssueService(issueRepository, queryHelper)
+        issueService = IssueService(
+            issueRepository,
+            queryHelper,
+            ProjectIdResolver(lookupResourceIdByProjectId = { null })
+        )
     }
 
     // ================================================================

--- a/backend/src/test/kotlin/com/moneat/shared/services/ProjectIdResolverTest.kt
+++ b/backend/src/test/kotlin/com/moneat/shared/services/ProjectIdResolverTest.kt
@@ -1,0 +1,80 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.shared.services
+
+import kotlin.uuid.Uuid
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ProjectIdResolverTest {
+    @Test
+    fun `resolve returns legacy numeric project IDs without lookup`() {
+        var lookupCalls = 0
+        val resolver = ProjectIdResolver(
+            lookupProjectIdByResourceId = {
+                lookupCalls++
+                10L
+            }
+        )
+
+        assertEquals(42L, resolver.resolve("42"))
+        assertEquals(0, lookupCalls)
+    }
+
+    @Test
+    fun `resolve looks up UUID resource IDs and caches results`() {
+        val resourceId = Uuid.parse("018f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        var lookupCalls = 0
+        val resolver = ProjectIdResolver(
+            lookupProjectIdByResourceId = {
+                lookupCalls++
+                if (it == resourceId) 99L else null
+            }
+        )
+
+        assertEquals(99L, resolver.resolve(resourceId.toString()))
+        assertEquals(99L, resolver.resolve(resourceId.toString()))
+        assertEquals(1, lookupCalls)
+    }
+
+    @Test
+    fun `resolve returns null for invalid identifiers`() {
+        val resolver = ProjectIdResolver(
+            lookupProjectIdByResourceId = { error("lookup should not be called") }
+        )
+
+        assertNull(resolver.resolve(""))
+        assertNull(resolver.resolve("not-a-project-id"))
+    }
+
+    @Test
+    fun `resourceIdFor looks up and caches project resource IDs`() {
+        val resourceId = Uuid.parse("118f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        var lookupCalls = 0
+        val resolver = ProjectIdResolver(
+            lookupResourceIdByProjectId = {
+                lookupCalls++
+                if (it == 17L) resourceId else null
+            }
+        )
+
+        assertEquals(resourceId.toString(), resolver.resourceIdFor(17L))
+        assertEquals(resourceId.toString(), resolver.resourceIdFor(17L))
+        assertEquals(1, lookupCalls)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/shared/services/ProjectIdResolverTest.kt
+++ b/backend/src/test/kotlin/com/moneat/shared/services/ProjectIdResolverTest.kt
@@ -16,6 +16,13 @@
 
 package com.moneat.shared.services
 
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
+import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -59,7 +66,39 @@ class ProjectIdResolverTest {
         )
 
         assertNull(resolver.resolve(""))
+        assertNull(resolver.resolve("   "))
         assertNull(resolver.resolve("not-a-project-id"))
+    }
+
+    @Test
+    fun `resolve returns null when UUID resource ID is unknown`() {
+        val resolver = ProjectIdResolver(
+            lookupProjectIdByResourceId = { null }
+        )
+
+        assertNull(resolver.resolve("218f4ce4-3f2a-7a67-a32b-0c1848f62b9d"))
+    }
+
+    @Test
+    fun `resolve refreshes expired cache entries`() {
+        val resourceId = Uuid.parse("318f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        var now = 0L
+        var projectId = 10L
+        var lookupCalls = 0
+        val resolver = ProjectIdResolver(
+            nowMs = { now },
+            lookupProjectIdByResourceId = {
+                lookupCalls++
+                projectId
+            }
+        )
+
+        assertEquals(10L, resolver.resolve(resourceId.toString()))
+        projectId = 11L
+        now = CACHE_TTL_MS_FOR_TEST + 1
+
+        assertEquals(11L, resolver.resolve(resourceId.toString()))
+        assertEquals(2, lookupCalls)
     }
 
     @Test
@@ -76,5 +115,85 @@ class ProjectIdResolverTest {
         assertEquals(resourceId.toString(), resolver.resourceIdFor(17L))
         assertEquals(resourceId.toString(), resolver.resourceIdFor(17L))
         assertEquals(1, lookupCalls)
+    }
+
+    @Test
+    fun `resourceIdFor returns null when project ID is unknown`() {
+        val resolver = ProjectIdResolver(
+            lookupResourceIdByProjectId = { null }
+        )
+
+        assertNull(resolver.resourceIdFor(404L))
+    }
+
+    @Test
+    fun `resourceIdFor refreshes expired cache entries`() {
+        val firstResourceId = Uuid.parse("418f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        val secondResourceId = Uuid.parse("518f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        var now = 0L
+        var resourceId = firstResourceId
+        var lookupCalls = 0
+        val resolver = ProjectIdResolver(
+            nowMs = { now },
+            lookupResourceIdByProjectId = {
+                lookupCalls++
+                resourceId
+            }
+        )
+
+        assertEquals(firstResourceId.toString(), resolver.resourceIdFor(17L))
+        resourceId = secondResourceId
+        now = CACHE_TTL_MS_FOR_TEST + 1
+
+        assertEquals(secondResourceId.toString(), resolver.resourceIdFor(17L))
+        assertEquals(2, lookupCalls)
+    }
+
+    @Test
+    fun `resolve uses the default database lookup when no lookup is injected`() {
+        resetProjectTables()
+        val resourceId = Uuid.parse("618f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        val projectId = seedProject(resourceId)
+
+        assertEquals(projectId, ProjectIdResolver().resolve(resourceId.toString()))
+    }
+
+    @Test
+    fun `resourceIdFor uses the default database lookup when no lookup is injected`() {
+        resetProjectTables()
+        val resourceId = Uuid.parse("718f4ce4-3f2a-7a67-a32b-0c1848f62b9d")
+        val projectId = seedProject(resourceId)
+
+        assertEquals(resourceId.toString(), ProjectIdResolver().resourceIdFor(projectId))
+    }
+
+    private fun resetProjectTables() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_project_id_resolver;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.resetSchema(Organizations, Projects)
+    }
+
+    private fun seedProject(resourceId: Uuid): Long = transaction {
+        val organizationId = Organizations.insert {
+            it[name] = "Resolver Org"
+            it[slug] = "resolver-org"
+        } get Organizations.id
+        Projects.insert {
+            it[organization_id] = organizationId
+            it[Projects.resource_id] = resourceId
+            it[name] = "Resolver Project"
+            it[slug] = "resolver-project"
+            it[framework] = "otel"
+        } get Projects.id
+    }
+
+    private companion object {
+        private const val CACHE_TTL_MS_FOR_TEST = 30 * 60 * 1_000L
+        private var db: Database? = null
     }
 }

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -420,7 +420,7 @@ export function CommandPalette() {
                       onSelect={() => {
                         setIsOpen(false)
                         setSearch('')
-                        navigate({to: '/projects/$projectId', params: {projectId: String(p.id)}})
+                        navigate({to: '/projects/$projectId', params: {projectId: p.resourceId}})
                       }}
                     >
                       <Folder className="mr-2 h-4 w-4" />

--- a/dashboard/src/components/ReplayTimelinePanel.tsx
+++ b/dashboard/src/components/ReplayTimelinePanel.tsx
@@ -49,7 +49,7 @@ export type TimelineItem = BaseTimelineItem & {
 export interface ReplayTimelinePanelProps {
   readonly items: TimelineItem[]
   readonly currentOffsetMs: number
-  readonly projectId?: number
+  readonly projectId?: string | number
   readonly onSeek: (offsetMs: number) => void
 }
 
@@ -295,7 +295,7 @@ function WaterfallPanel({
   projectId,
 }: {
   readonly item: TimelineItem
-  readonly projectId?: number
+  readonly projectId?: string | number
 }) {
   const colors = typeColorClasses(item.type)
 
@@ -398,7 +398,7 @@ function ExpandedItemPanel({
   projectId,
 }: {
   readonly item: TimelineItem
-  readonly projectId?: number
+  readonly projectId?: string | number
 }) {
   if (canFetchSpans(item)) {
     return <WaterfallPanel item={item} projectId={projectId} />
@@ -542,7 +542,7 @@ interface TimelineListProps {
   readonly items: TimelineItem[]
   readonly activeIndex: number
   readonly expandedId: string | null
-  readonly projectId?: number
+  readonly projectId?: string | number
   readonly onItemClick: (item: TimelineItem) => void
 }
 

--- a/dashboard/src/components/ReplayTimelinePanel.tsx
+++ b/dashboard/src/components/ReplayTimelinePanel.tsx
@@ -49,6 +49,7 @@ export type TimelineItem = BaseTimelineItem & {
 export interface ReplayTimelinePanelProps {
   readonly items: TimelineItem[]
   readonly currentOffsetMs: number
+  /** Project resource ID for replay links; legacy numeric IDs are accepted during migration. */
   readonly projectId?: string | number
   readonly onSeek: (offsetMs: number) => void
 }

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -127,24 +127,32 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
     enabled: api.isAuthenticated(),
   })
 
-  const activeProject = projects?.find((project) => project.id === selectedProjectId) ?? projects?.[0] ?? null
-  const activeProjectId = activeProject?.id ?? null
+  const activeProject = projects?.find((project) =>
+    project.resourceId === selectedProjectId || String(project.id) === selectedProjectId
+  ) ?? projects?.[0] ?? null
+  const activeProjectId = activeProject?.resourceId ?? null
+
+  useEffect(() => {
+    if (activeProject && selectedProjectId !== activeProject.resourceId) {
+      setSelectedProjectId(activeProject.resourceId)
+    }
+  }, [activeProject, selectedProjectId, setSelectedProjectId])
 
   const createProjectMutation = useMutation({
     mutationFn: (data: ProjectSetupSubmission) =>
       api.createProject(data.name, data.framework, data.targets),
     onSuccess: (project, submission) => {
-      storeTelemetrySourceIdsForProject(project.id, submission.sourceIds)
+      storeTelemetrySourceIdsForProject(project.resourceId, submission.sourceIds)
       trackEvent('Project Create', {
         framework: project.framework || 'none',
         sources: serializeTelemetrySourceIds(submission.sourceIds),
       })
       queryClient.invalidateQueries({ queryKey: ['projects'] })
-      setSelectedProjectId(project.id)
+      setSelectedProjectId(project.resourceId)
       resetCreateForm()
       navigate({
         to: '/projects/$projectId',
-        params: { projectId: String(project.id) },
+        params: { projectId: project.resourceId },
         search: { sources: serializeTelemetrySourceIds(submission.sourceIds) },
       })
     },
@@ -377,7 +385,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                   return (
                     <DropdownMenuItem
                       key={project.id}
-                      onClick={() => setSelectedProjectId(project.id)}
+                      onClick={() => setSelectedProjectId(project.resourceId)}
                       className={cn(
                         'flex items-center gap-2',
                         project.id === activeProject?.id && 'bg-accent'
@@ -427,7 +435,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                   return (
                     <DropdownMenuItem
                       key={project.id}
-                      onClick={() => setSelectedProjectId(project.id)}
+                      onClick={() => setSelectedProjectId(project.resourceId)}
                       className={cn(
                         'flex items-center gap-2',
                         project.id === activeProject?.id && 'bg-accent'

--- a/dashboard/src/components/analytics/AnalyticsRealtimeBadge.tsx
+++ b/dashboard/src/components/analytics/AnalyticsRealtimeBadge.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 
-export function AnalyticsRealtimeBadge({projectId}: {projectId: number}) {
+export function AnalyticsRealtimeBadge({projectId}: {projectId: string | number}) {
   const {data} = useQuery({
     queryKey: ['analytics-realtime', projectId],
     queryFn: () => api.getAnalyticsRealtime(projectId),

--- a/dashboard/src/components/dashboards/DashboardGrid.tsx
+++ b/dashboard/src/components/dashboards/DashboardGrid.tsx
@@ -32,7 +32,7 @@ interface DashboardGridProps {
   widgets: DashboardWidget[]
   isEditing: boolean
   dashboardId: number
-  projectId?: number
+  projectId?: string | number
   timeRange: TimeRangeDef
   autoRefresh: boolean
   variableValues?: Record<string, string>
@@ -333,7 +333,7 @@ function WidgetCard({
   widget: DashboardWidget
   isEditing: boolean
   dashboardId: number
-  projectId?: number
+  projectId?: string | number
   timeRange: TimeRangeDef
   autoRefresh: boolean
   variableValues?: Record<string, string>

--- a/dashboard/src/components/dashboards/WidgetConfigPanel.tsx
+++ b/dashboard/src/components/dashboards/WidgetConfigPanel.tsx
@@ -55,7 +55,7 @@ interface WidgetConfigPanelProps {
   onSave: (widget: DashboardWidget) => void
   onClose: () => void
   dashboardId: number
-  projectId?: number
+  projectId?: string | number
 }
 
 export function WidgetConfigPanel({

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -126,7 +126,7 @@ function DebouncedChartContainer({children, debounceMs = 150}: {
 interface WidgetRendererProps {
   widget: DashboardWidget
   dashboardId: number
-  projectId?: number
+  projectId?: string | number
   timeRange: TimeRangeDef
   autoRefresh: boolean
   variables?: Record<string, string>

--- a/dashboard/src/components/logs/EmbeddedLogs.tsx
+++ b/dashboard/src/components/logs/EmbeddedLogs.tsx
@@ -28,7 +28,7 @@ import {ChevronLeft, ChevronRight, Loader2, TerminalSquare} from 'lucide-react'
 
 interface EmbeddedLogsProps {
   systemId?: string
-  /** Optional project ID for trace/span links in log detail (e.g. when embedded in issue view) */
+  /** Optional project resource ID for trace/span links; legacy numeric IDs are accepted during migration. */
   projectId?: string | number
   /**
    * Filter logs by time range around a specific timestamp

--- a/dashboard/src/components/logs/EmbeddedLogs.tsx
+++ b/dashboard/src/components/logs/EmbeddedLogs.tsx
@@ -29,7 +29,7 @@ import {ChevronLeft, ChevronRight, Loader2, TerminalSquare} from 'lucide-react'
 interface EmbeddedLogsProps {
   systemId?: string
   /** Optional project ID for trace/span links in log detail (e.g. when embedded in issue view) */
-  projectId?: number
+  projectId?: string | number
   /**
    * Filter logs by time range around a specific timestamp
    * Shows logs from [centerTimestamp - contextMinutes] to [centerTimestamp + contextMinutes]

--- a/dashboard/src/components/logs/LogDetail.tsx
+++ b/dashboard/src/components/logs/LogDetail.tsx
@@ -31,7 +31,7 @@ interface LogDetailProps {
   open: boolean
   onClose: () => void
   onViewInContext?: (log: LogEntry) => void
-  /** Optional project ID for trace/span links (traces are project-scoped) */
+  /** Optional project resource ID for trace/span links; legacy numeric IDs are accepted during migration. */
   projectId?: string | number
 }
 
@@ -269,7 +269,10 @@ export function LogDetail({log, open, onClose, onViewInContext, projectId}: LogD
                   <LinkableField
                     label="Span ID"
                     value={log.spanId}
-                    to={`/projects/${projectId}/spans/${log.spanId}`}
+                    to={
+                      `/projects/${encodeURIComponent(String(projectId))}` +
+                      `/spans/${encodeURIComponent(log.spanId)}`
+                    }
                   />
                 )}
               </div>

--- a/dashboard/src/components/logs/LogDetail.tsx
+++ b/dashboard/src/components/logs/LogDetail.tsx
@@ -32,7 +32,7 @@ interface LogDetailProps {
   onClose: () => void
   onViewInContext?: (log: LogEntry) => void
   /** Optional project ID for trace/span links (traces are project-scoped) */
-  projectId?: number
+  projectId?: string | number
 }
 
 const levelStyles: Record<string, string> = {

--- a/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
+++ b/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
@@ -773,9 +773,18 @@ export function ProjectTelemetrySetupHub({
   const [createdAgentKey, setCreatedAgentKey] = useState<string | null>(null)
 
   const copyResourceId = async () => {
-    await navigator.clipboard.writeText(project.resourceId)
-    setCopiedResourceId(true)
-    setTimeout(() => setCopiedResourceId(false), COPY_RESET_MS)
+    try {
+      await navigator.clipboard.writeText(project.resourceId)
+      setCopiedResourceId(true)
+      setTimeout(() => setCopiedResourceId(false), COPY_RESET_MS)
+    } catch (error) {
+      console.error('Failed to copy project resource ID:', error)
+      toast({
+        title: 'Could not copy resource ID',
+        description: 'Check browser clipboard permissions and try again.',
+        variant: 'destructive',
+      })
+    }
   }
 
   useEffect(() => {

--- a/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
+++ b/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
@@ -67,6 +67,7 @@ const sourceIcons: Record<TelemetrySourceId, ComponentType<{className?: string}>
 
 const DATADOG_AGENT_CONFIG_PATH = '/etc/datadog-agent/datadog.yaml'
 const DATADOG_AGENT_SETUP_DOCS_HREF = '/docs/datadog-agent/agent-setup'
+const COPY_RESET_MS = 2000
 
 const datadogSetupSteps = [
   {
@@ -112,7 +113,7 @@ function statusVariant(state: TelemetrySourceStatusState): 'default' | 'secondar
   return 'outline'
 }
 
-function getInitialSourceIds(projectId: number, selectedSourcesParam?: string): TelemetrySourceId[] {
+function getInitialSourceIds(projectId: string | number, selectedSourcesParam?: string): TelemetrySourceId[] {
   const sourceIdsFromSearch = parseTelemetrySourceIds(selectedSourcesParam)
   if (sourceIdsFromSearch.length > 0) return sourceIdsFromSearch
 
@@ -281,7 +282,7 @@ function TargetPlatformSection({
   const [showAddPlatform, setShowAddPlatform] = useState(false)
 
   const addTargetMutation = useMutation({
-    mutationFn: (target: string) => api.addProjectTarget(project.id, target),
+    mutationFn: (target: string) => api.addProjectTarget(project.resourceId, target),
     onSuccess: (_key, target) => {
       queryClient.invalidateQueries({queryKey: ['projects']})
       router.invalidate()
@@ -396,7 +397,7 @@ function DsnSection({
   const handleCopyDsn = async (dsn: string, target: string) => {
     await navigator.clipboard.writeText(dsn)
     setCopiedTarget(target)
-    setTimeout(() => setCopiedTarget(null), 2000)
+    setTimeout(() => setCopiedTarget(null), COPY_RESET_MS)
   }
 
   if (project.keys.length > 1) {
@@ -757,7 +758,7 @@ export function ProjectTelemetrySetupHub({
     [selectedSourcesParam]
   )
   const [storedSourceIds, setStoredSourceIds] = useState<TelemetrySourceId[]>(
-    () => getInitialSourceIds(project.id)
+    () => getInitialSourceIds(project.resourceId)
   )
   const selectedSourceIds = sourceIdsFromSearch.length > 0 ? sourceIdsFromSearch : storedSourceIds
   const [requestedActiveSourceId, setRequestedActiveSourceId] = useState<TelemetrySourceId>(selectedSourceIds[0])
@@ -767,12 +768,19 @@ export function ProjectTelemetrySetupHub({
   const [selectedTarget, setSelectedTarget] = useState<string | null>(
     () => project.keys[0]?.platformTarget ?? 'default'
   )
+  const [copiedResourceId, setCopiedResourceId] = useState(false)
   const [createdOtlpKey, setCreatedOtlpKey] = useState<string | null>(null)
   const [createdAgentKey, setCreatedAgentKey] = useState<string | null>(null)
 
+  const copyResourceId = async () => {
+    await navigator.clipboard.writeText(project.resourceId)
+    setCopiedResourceId(true)
+    setTimeout(() => setCopiedResourceId(false), COPY_RESET_MS)
+  }
+
   useEffect(() => {
-    storeTelemetrySourceIdsForProject(project.id, selectedSourceIds)
-  }, [project.id, selectedSourceIds])
+    storeTelemetrySourceIdsForProject(project.resourceId, selectedSourceIds)
+  }, [project.resourceId, selectedSourceIds])
 
   const {data: sdkVersionsResponse} = useQuery({
     queryKey: ['sdk-versions'],
@@ -785,8 +793,8 @@ export function ProjectTelemetrySetupHub({
     staleTime: 30 * 60 * 1000,
   })
   const {data: projectStats} = useQuery({
-    queryKey: ['projectStats', project.id, '24h'],
-    queryFn: () => api.getProjectStats(project.id, '24h'),
+    queryKey: ['projectStats', project.resourceId, '24h'],
+    queryFn: () => api.getProjectStats(project.resourceId, '24h'),
   })
   const {data: otlpKeyResponse} = useQuery({
     queryKey: ['otlpApiKeys'],
@@ -846,7 +854,7 @@ export function ProjectTelemetrySetupHub({
 
   const updateSelectedSources = (sourceIds: TelemetrySourceId[]) => {
     setStoredSourceIds(sourceIds)
-    storeTelemetrySourceIdsForProject(project.id, sourceIds)
+    storeTelemetrySourceIdsForProject(project.resourceId, sourceIds)
     navigate({
       search: (previous) => ({
         ...previous,
@@ -880,10 +888,25 @@ export function ProjectTelemetrySetupHub({
               <Badge variant={statusVariant(activeStatus.state)}>{activeStatus.label}</Badge>
             </div>
             <h1 className="text-3xl font-bold">{project.name}</h1>
-            <p className="mt-1 text-muted-foreground">Telemetry source setup</p>
+            <div className="mt-1 flex max-w-full items-center gap-2 text-xs text-muted-foreground">
+              <span>Project ID</span>
+              <code className="max-w-[min(28rem,70vw)] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-foreground">
+                {project.resourceId}
+              </code>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0"
+                aria-label="Copy project ID"
+                onClick={copyResourceId}
+              >
+                {copiedResourceId ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              </Button>
+            </div>
           </div>
           <Button asChild variant="outline" size="icon" aria-label="Project settings">
-            <Link to="/projects/$projectId/settings" params={{projectId: String(project.id)}}>
+            <Link to="/projects/$projectId/settings" params={{projectId: project.resourceId}}>
               <Settings className="h-4 w-4" />
             </Link>
           </Button>

--- a/dashboard/src/components/settings/OtlpApiKeysTab.tsx
+++ b/dashboard/src/components/settings/OtlpApiKeysTab.tsx
@@ -101,7 +101,7 @@ function OtlpServiceRoutingPanel() {
   })
 
   const upsertMapping = useMutation({
-    mutationFn: (input: {service: OtlpObservedService; projectId: number}) =>
+    mutationFn: (input: {service: OtlpObservedService; projectId: string | number}) =>
       api.upsertOtlpServiceMapping(
         input.service.serviceName,
         input.projectId,
@@ -185,12 +185,12 @@ function OtlpServiceRoutingPanel() {
 function OtlpServiceRoutingRow(props: {
   readonly service: OtlpObservedService
   readonly projects: Project[]
-  readonly upsertMapping: (projectId: number) => void
+  readonly upsertMapping: (projectId: string | number) => void
   readonly deleteMapping: () => void
   readonly isPending: boolean
 }) {
   const {service, projects, upsertMapping, deleteMapping, isPending} = props
-  const selectedProject = service.projectId == null ? UNMAPPED_PROJECT_VALUE : String(service.projectId)
+  const selectedProject = service.projectResourceId ?? UNMAPPED_PROJECT_VALUE
 
   return (
     <TableRow>
@@ -225,7 +225,7 @@ function OtlpServiceRoutingRow(props: {
               if (service.mappingId != null) deleteMapping()
               return
             }
-            upsertMapping(Number(value))
+            upsertMapping(value)
           }}
         >
           <SelectTrigger>
@@ -235,7 +235,7 @@ function OtlpServiceRoutingRow(props: {
             <SelectGroup>
               <SelectItem value={UNMAPPED_PROJECT_VALUE}>Unmapped</SelectItem>
               {projects.map((project) => (
-                <SelectItem key={project.id} value={String(project.id)}>
+                <SelectItem key={project.id} value={project.resourceId}>
                   {project.name}
                 </SelectItem>
               ))}

--- a/dashboard/src/components/settings/__tests__/OtlpApiKeysTab.test.tsx
+++ b/dashboard/src/components/settings/__tests__/OtlpApiKeysTab.test.tsx
@@ -23,6 +23,8 @@ import {clearAuthStorage, renderWithQueryClient} from '@/test/utils'
 import {OtlpApiKeysTab} from '../OtlpApiKeysTab'
 
 const API_BASE = 'http://localhost:8080'
+const WEB_APP_RESOURCE_ID = '123e4567-e89b-12d3-a456-426614174030'
+const WORKER_RESOURCE_ID = '123e4567-e89b-12d3-a456-426614174031'
 
 function mockBaseResponses() {
   server.use(
@@ -50,8 +52,24 @@ function mockBaseResponses() {
     }),
     http.get(`${API_BASE}/v1/projects`, () => {
       return HttpResponse.json([
-        {id: 30, name: 'Web App', slug: 'web-app', framework: 'react', keys: [], dsn: ''},
-        {id: 31, name: 'Worker', slug: 'worker', framework: 'kotlin', keys: [], dsn: ''},
+        {
+          id: 30,
+          resourceId: WEB_APP_RESOURCE_ID,
+          name: 'Web App',
+          slug: 'web-app',
+          framework: 'react',
+          keys: [],
+          dsn: '',
+        },
+        {
+          id: 31,
+          resourceId: WORKER_RESOURCE_ID,
+          name: 'Worker',
+          slug: 'worker',
+          framework: 'kotlin',
+          keys: [],
+          dsn: '',
+        },
       ])
     }),
     http.get(`${API_BASE}/v1/otlp/services`, () => {
@@ -63,6 +81,7 @@ function mockBaseResponses() {
             service_namespace: 'checkout',
             service_name: 'api',
             project_id: 30,
+            project_resource_id: WEB_APP_RESOURCE_ID,
             project_name: 'Web App',
             seen_logs: true,
             seen_traces: true,
@@ -181,7 +200,7 @@ describe('OtlpApiKeysTab', () => {
       expect(capturedBody).toEqual({
         service_name: 'worker',
         service_namespace: '',
-        project_id: 31,
+        project_resource_id: WORKER_RESOURCE_ID,
       })
     })
   })

--- a/dashboard/src/contexts/ProjectContext.tsx
+++ b/dashboard/src/contexts/ProjectContext.tsx
@@ -17,23 +17,23 @@
 import {createContext, ReactNode, useContext, useEffect, useMemo, useState} from 'react'
 
 interface ProjectContextType {
-  readonly selectedProjectId: number | null
-  readonly setSelectedProjectId: (id: number | null) => void
+  readonly selectedProjectId: string | null
+  readonly setSelectedProjectId: (id: string | null) => void
 }
 
 const ProjectContext = createContext<ProjectContextType | undefined>(undefined)
 
 export function ProjectProvider({ children }: { readonly children: ReactNode }) {
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(() => {
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(() => {
     const saved = localStorage.getItem('selectedProjectId')
-    return saved ? Number(saved) : null
+    return saved || null
   })
 
   useEffect(() => {
     if (selectedProjectId === null) {
       localStorage.removeItem('selectedProjectId')
     } else {
-      localStorage.setItem('selectedProjectId', selectedProjectId.toString())
+      localStorage.setItem('selectedProjectId', selectedProjectId)
     }
   }, [selectedProjectId])
 

--- a/dashboard/src/contexts/__tests__/ProjectContext.test.tsx
+++ b/dashboard/src/contexts/__tests__/ProjectContext.test.tsx
@@ -19,7 +19,7 @@ describe('ProjectProvider', () => {
     const { result } = renderHook(() => useProject(), {
       wrapper: ProjectProvider,
     })
-    expect(result.current.selectedProjectId).toBe(42)
+    expect(result.current.selectedProjectId).toBe('42')
   })
 
   it('updates selectedProjectId', () => {
@@ -28,10 +28,10 @@ describe('ProjectProvider', () => {
     })
 
     act(() => {
-      result.current.setSelectedProjectId(5)
+      result.current.setSelectedProjectId('5')
     })
 
-    expect(result.current.selectedProjectId).toBe(5)
+    expect(result.current.selectedProjectId).toBe('5')
   })
 
   it('persists to localStorage when project selected', () => {
@@ -40,7 +40,7 @@ describe('ProjectProvider', () => {
     })
 
     act(() => {
-      result.current.setSelectedProjectId(10)
+      result.current.setSelectedProjectId('10')
     })
 
     expect(localStorage.getItem('selectedProjectId')).toBe('10')

--- a/dashboard/src/docs/pages/mcp-server/tools-reference.md
+++ b/dashboard/src/docs/pages/mcp-server/tools-reference.md
@@ -336,7 +336,7 @@ Preview a widget query with dashboard variable substitution and datasource resol
 |-----------|------|----------|-------------|
 | `dashboard_id` | number | Yes | Dashboard ID |
 | `query_config` | object | Yes | QueryDsl config |
-| `project_id` | number | No | Project ID when the dashboard is not project-scoped |
+| `project_id` | string or number | No | Project resource ID or legacy numeric project ID when unscoped |
 | `variables` | object | No | Variable values |
 | `time_range` | object | No | Time range override |
 

--- a/dashboard/src/lib/api/modules/analytics.ts
+++ b/dashboard/src/lib/api/modules/analytics.ts
@@ -142,7 +142,7 @@ export function analyticsMethods(core: ApiClientCore) {
 
   return {
     getAnalyticsOverview: async (
-      projectId: number,
+      projectId: string | number,
       params?: AnalyticsParams
     ) => {
       const response = await core.request<AnalyticsOverviewApiResponse>(
@@ -152,7 +152,7 @@ export function analyticsMethods(core: ApiClientCore) {
     },
 
     getAnalyticsTimeseries: async (
-      projectId: number,
+      projectId: string | number,
       params?: AnalyticsParams
     ) => {
       const response = await core.request<AnalyticsTimeseriesApiPoint[]>(
@@ -161,28 +161,28 @@ export function analyticsMethods(core: ApiClientCore) {
       return normalizeAnalyticsTimeseries(response)
     },
 
-    getAnalyticsPages: (projectId: number, params?: AnalyticsParams) =>
+    getAnalyticsPages: (projectId: string | number, params?: AnalyticsParams) =>
       fetchAnalyticsBreakdown(
         `${base}/analytics/${projectId}/pages${buildAnalyticsQuery(params)}`
       ),
 
-    getAnalyticsEntryPages: (projectId: number, params?: AnalyticsParams) =>
+    getAnalyticsEntryPages: (projectId: string | number, params?: AnalyticsParams) =>
       fetchAnalyticsBreakdown(
         `${base}/analytics/${projectId}/entry-pages${buildAnalyticsQuery(params)}`
       ),
 
-    getAnalyticsExitPages: (projectId: number, params?: AnalyticsParams) =>
+    getAnalyticsExitPages: (projectId: string | number, params?: AnalyticsParams) =>
       fetchAnalyticsBreakdown(
         `${base}/analytics/${projectId}/exit-pages${buildAnalyticsQuery(params)}`
       ),
 
-    getAnalyticsSources: (projectId: number, params?: AnalyticsParams) =>
+    getAnalyticsSources: (projectId: string | number, params?: AnalyticsParams) =>
       fetchAnalyticsBreakdown(
         `${base}/analytics/${projectId}/sources${buildAnalyticsQuery(params)}`
       ),
 
     getAnalyticsUtm: (
-      projectId: number,
+      projectId: string | number,
       utmParam: string,
       params?: AnalyticsParams
     ) =>
@@ -190,13 +190,13 @@ export function analyticsMethods(core: ApiClientCore) {
         `${base}/analytics/${projectId}/utm/${encodeURIComponent(utmParam)}${buildAnalyticsQuery(params)}`
       ),
 
-    getAnalyticsLocations: (projectId: number, params?: AnalyticsParams) =>
+    getAnalyticsLocations: (projectId: string | number, params?: AnalyticsParams) =>
       fetchAnalyticsBreakdown(
         `${base}/analytics/${projectId}/locations${buildAnalyticsQuery(params)}`
       ),
 
     getAnalyticsDevices: (
-      projectId: number,
+      projectId: string | number,
       type: 'browser' | 'os' | 'device',
       params?: AnalyticsParams
     ) => {
@@ -207,7 +207,7 @@ export function analyticsMethods(core: ApiClientCore) {
     },
 
     getAnalyticsEvents: (
-      projectId: number,
+      projectId: string | number,
       params?: AnalyticsParams,
       options?: AnalyticsEventQueryOptions
     ) =>
@@ -215,7 +215,7 @@ export function analyticsMethods(core: ApiClientCore) {
         `${base}/analytics/${projectId}/events${buildAnalyticsQuery(params, options)}`
       ),
 
-    getAnalyticsRealtime: async (projectId: number) => {
+    getAnalyticsRealtime: async (projectId: string | number) => {
       const response = await core.request<AnalyticsRealtimeApiResponse>(
         `${base}/analytics/${projectId}/realtime`
       )
@@ -225,7 +225,7 @@ export function analyticsMethods(core: ApiClientCore) {
     },
 
     getAnalyticsFunnel: (
-      projectId: number,
+      projectId: string | number,
       steps: string[],
       params?: AnalyticsParams,
       options?: AnalyticsEventQueryOptions
@@ -241,7 +241,7 @@ export function analyticsMethods(core: ApiClientCore) {
     },
 
     getAnalyticsRetention: (
-      projectId: number,
+      projectId: string | number,
       params: AnalyticsRetentionQuery
     ) =>
       core.request<AnalyticsRetentionResponse>(

--- a/dashboard/src/lib/api/modules/dashboards.ts
+++ b/dashboard/src/lib/api/modules/dashboards.ts
@@ -44,7 +44,7 @@ export function dashboardsMethods(core: ApiClientCore) {
   const base = core.API_BASE
 
   return {
-    getDashboards: (projectId?: number) => {
+    getDashboards: (projectId?: string | number) => {
       const qs = projectId ? `?projectId=${projectId}` : ''
       return core.request<CustomDashboard[]>(`${base}/dashboards${qs}`)
     },
@@ -113,7 +113,7 @@ export function dashboardsMethods(core: ApiClientCore) {
     executeWidgetQuery: (
       dashboardId: number,
       queryConfig: QueryDsl,
-      projectId: number,
+      projectId: string | number,
       timeRange?: TimeRangeDef,
       variables?: Record<string, string>
     ) =>
@@ -133,7 +133,7 @@ export function dashboardsMethods(core: ApiClientCore) {
     executeBatchQuery: (
       dashboardId: number,
       queries: QueryDsl[],
-      projectId: number,
+      projectId: string | number,
       timeRange?: TimeRangeDef,
       variables?: Record<string, string>
     ) =>

--- a/dashboard/src/lib/api/modules/feedback.ts
+++ b/dashboard/src/lib/api/modules/feedback.ts
@@ -22,7 +22,7 @@ export function feedbackMethods(core: ApiClientCore) {
 
   return {
     getFeedback: (
-      projectId: number,
+      projectId: string | number,
       options: { page?: number; limit?: number; status?: string } = {}
     ) => {
       const params = new URLSearchParams()

--- a/dashboard/src/lib/api/modules/issues.ts
+++ b/dashboard/src/lib/api/modules/issues.ts
@@ -21,6 +21,7 @@ import type {
   IssueDetail,
   IssueTransaction,
 } from '../types'
+import { urlWithQuery } from '../utils'
 
 export function issuesMethods(core: ApiClientCore) {
   const base = core.API_BASE
@@ -37,14 +38,17 @@ export function issuesMethods(core: ApiClientCore) {
         limit: String(limit),
       })
       if (status) params.set('status', status)
+      const path = `${base}/projects/${encodeURIComponent(String(projectId))}/issues`
       return core.request<Issue[]>(
-        `${base}/projects/${projectId}/issues?${params.toString()}`
+        urlWithQuery(path, params.toString())
       )
     },
 
     getIssue: (issueId: string, projectId?: string | number | null) => {
-      const params = projectId == null ? '' : `?projectId=${projectId}`
-      return core.request<IssueDetail>(`${base}/issues/${encodeURIComponent(issueId)}${params}`)
+      const params = new URLSearchParams()
+      if (projectId != null) params.set('projectId', String(projectId))
+      const path = `${base}/issues/${encodeURIComponent(issueId)}`
+      return core.request<IssueDetail>(urlWithQuery(path, params.toString()))
     },
 
     getIssueEvents: (issueId: string, limit = 50, projectId?: string | number | null) => {
@@ -72,8 +76,10 @@ export function issuesMethods(core: ApiClientCore) {
       },
       projectId?: string | number | null
     ) => {
-      const params = projectId == null ? '' : `?projectId=${projectId}`
-      return core.request(`${base}/issues/${encodeURIComponent(issueId)}${params}`, {
+      const params = new URLSearchParams()
+      if (projectId != null) params.set('projectId', String(projectId))
+      const path = `${base}/issues/${encodeURIComponent(issueId)}`
+      return core.request(urlWithQuery(path, params.toString()), {
         method: 'PATCH',
         body: JSON.stringify(updates),
       })

--- a/dashboard/src/lib/api/modules/issues.ts
+++ b/dashboard/src/lib/api/modules/issues.ts
@@ -27,7 +27,7 @@ export function issuesMethods(core: ApiClientCore) {
 
   return {
     getIssues: (
-      projectId: number,
+      projectId: string | number,
       page = 1,
       limit = 25,
       status?: string
@@ -42,12 +42,12 @@ export function issuesMethods(core: ApiClientCore) {
       )
     },
 
-    getIssue: (issueId: string, projectId?: number | null) => {
+    getIssue: (issueId: string, projectId?: string | number | null) => {
       const params = projectId == null ? '' : `?projectId=${projectId}`
       return core.request<IssueDetail>(`${base}/issues/${encodeURIComponent(issueId)}${params}`)
     },
 
-    getIssueEvents: (issueId: string, limit = 50, projectId?: number | null) => {
+    getIssueEvents: (issueId: string, limit = 50, projectId?: string | number | null) => {
       const params = new URLSearchParams({ limit: String(limit) })
       if (projectId != null) params.set('projectId', String(projectId))
       return core.request<Event[]>(
@@ -55,7 +55,7 @@ export function issuesMethods(core: ApiClientCore) {
       )
     },
 
-    getIssueTransactions: (issueId: string, limit = 20, projectId?: number | null) => {
+    getIssueTransactions: (issueId: string, limit = 20, projectId?: string | number | null) => {
       const params = new URLSearchParams({ limit: String(limit) })
       if (projectId != null) params.set('projectId', String(projectId))
       return core.request<IssueTransaction[]>(
@@ -70,7 +70,7 @@ export function issuesMethods(core: ApiClientCore) {
         substatus?: string
         statusDetail?: Record<string, string>
       },
-      projectId?: number | null
+      projectId?: string | number | null
     ) => {
       const params = projectId == null ? '' : `?projectId=${projectId}`
       return core.request(`${base}/issues/${encodeURIComponent(issueId)}${params}`, {

--- a/dashboard/src/lib/api/modules/llm.ts
+++ b/dashboard/src/lib/api/modules/llm.ts
@@ -28,13 +28,13 @@ export function llmMethods(core: ApiClientCore) {
   const base = core.API_BASE
 
   return {
-    getLlmOverview: (projectId: number, range = '24h') =>
+    getLlmOverview: (projectId: string | number, range = '24h') =>
       core.request<LlmOverviewResponse>(
         `${base}/llm/overview?projectId=${projectId}&range=${encodeURIComponent(range)}`
       ),
 
     getLlmGenerations: (
-      projectId: number,
+      projectId: string | number,
       params: {
         range?: string
         model?: string
@@ -58,22 +58,22 @@ export function llmMethods(core: ApiClientCore) {
       )
     },
 
-    getLlmGenerationDetail: (projectId: number, generationId: string) =>
+    getLlmGenerationDetail: (projectId: string | number, generationId: string) =>
       core.request<LlmGenerationDetail>(
         `${base}/llm/generations/${encodeURIComponent(generationId)}?projectId=${projectId}`
       ),
 
-    getLlmTrace: (projectId: number, traceId: string) =>
+    getLlmTrace: (projectId: string | number, traceId: string) =>
       core.request<LlmTraceResponse>(
         `${base}/llm/traces/${encodeURIComponent(traceId)}?projectId=${projectId}`
       ),
 
-    getLlmModels: (projectId: number, range = '24h') =>
+    getLlmModels: (projectId: string | number, range = '24h') =>
       core.request<LlmModelStats[]>(
         `${base}/llm/models?projectId=${projectId}&range=${encodeURIComponent(range)}`
       ),
 
-    getLlmCosts: (projectId: number, range = '24h') =>
+    getLlmCosts: (projectId: string | number, range = '24h') =>
       core.request<LlmCostsResponse>(
         `${base}/llm/costs?projectId=${projectId}&range=${encodeURIComponent(range)}`
       ),

--- a/dashboard/src/lib/api/modules/llm.ts
+++ b/dashboard/src/lib/api/modules/llm.ts
@@ -23,6 +23,12 @@ import type {
   LlmModelStats,
   LlmCostsResponse,
 } from '../types'
+import { urlWithQuery } from '../utils'
+
+function projectQuery(projectId: string | number, params: Record<string, string> = {}): string {
+  const searchParams = new URLSearchParams({projectId: String(projectId), ...params})
+  return searchParams.toString()
+}
 
 export function llmMethods(core: ApiClientCore) {
   const base = core.API_BASE
@@ -30,7 +36,7 @@ export function llmMethods(core: ApiClientCore) {
   return {
     getLlmOverview: (projectId: string | number, range = '24h') =>
       core.request<LlmOverviewResponse>(
-        `${base}/llm/overview?projectId=${projectId}&range=${encodeURIComponent(range)}`
+        urlWithQuery(`${base}/llm/overview`, projectQuery(projectId, {range}))
       ),
 
     getLlmGenerations: (
@@ -60,22 +66,22 @@ export function llmMethods(core: ApiClientCore) {
 
     getLlmGenerationDetail: (projectId: string | number, generationId: string) =>
       core.request<LlmGenerationDetail>(
-        `${base}/llm/generations/${encodeURIComponent(generationId)}?projectId=${projectId}`
+        urlWithQuery(`${base}/llm/generations/${encodeURIComponent(generationId)}`, projectQuery(projectId))
       ),
 
     getLlmTrace: (projectId: string | number, traceId: string) =>
       core.request<LlmTraceResponse>(
-        `${base}/llm/traces/${encodeURIComponent(traceId)}?projectId=${projectId}`
+        urlWithQuery(`${base}/llm/traces/${encodeURIComponent(traceId)}`, projectQuery(projectId))
       ),
 
     getLlmModels: (projectId: string | number, range = '24h') =>
       core.request<LlmModelStats[]>(
-        `${base}/llm/models?projectId=${projectId}&range=${encodeURIComponent(range)}`
+        urlWithQuery(`${base}/llm/models`, projectQuery(projectId, {range}))
       ),
 
     getLlmCosts: (projectId: string | number, range = '24h') =>
       core.request<LlmCostsResponse>(
-        `${base}/llm/costs?projectId=${projectId}&range=${encodeURIComponent(range)}`
+        urlWithQuery(`${base}/llm/costs`, projectQuery(projectId, {range}))
       ),
   }
 }

--- a/dashboard/src/lib/api/modules/logs.ts
+++ b/dashboard/src/lib/api/modules/logs.ts
@@ -94,6 +94,14 @@ function mapOtlpServiceMapping(mapping: Record<string, unknown>): OtlpServiceMap
   }
 }
 
+function projectMappingField(projectId: string | number): {project_id: number} | {project_resource_id: string} {
+  const projectIdValue = String(projectId)
+  if (typeof projectId === 'number' || /^\d+$/.test(projectIdValue)) {
+    return {project_id: Number(projectIdValue)}
+  }
+  return {project_resource_id: projectIdValue}
+}
+
 function buildLogFilterParams(options: {
   query?: string
   levels?: string[]
@@ -256,10 +264,7 @@ export function logsMethods(core: ApiClientCore) {
       projectId: string | number,
       serviceNamespace = ''
     ): Promise<OtlpServiceMapping> => {
-      const projectField =
-        typeof projectId === 'number'
-          ? { project_id: projectId }
-          : { project_resource_id: projectId }
+      const projectField = projectMappingField(projectId)
       const response = await core.request<Record<string, unknown>>(`${base}/otlp/service-mappings`, {
         method: 'POST',
         body: JSON.stringify({

--- a/dashboard/src/lib/api/modules/logs.ts
+++ b/dashboard/src/lib/api/modules/logs.ts
@@ -71,6 +71,7 @@ function mapOtlpObservedService(service: Record<string, unknown>): OtlpObservedS
     serviceNamespace: (service.serviceNamespace ?? service.service_namespace ?? '') as string,
     serviceName: (service.serviceName ?? service.service_name ?? '') as string,
     projectId: (service.projectId ?? service.project_id) as number | null | undefined,
+    projectResourceId: (service.projectResourceId ?? service.project_resource_id) as string | null | undefined,
     projectName: (service.projectName ?? service.project_name) as string | null | undefined,
     seenLogs: (service.seenLogs ?? service.seen_logs ?? false) as boolean,
     seenTraces: (service.seenTraces ?? service.seen_traces ?? false) as boolean,
@@ -87,6 +88,7 @@ function mapOtlpServiceMapping(mapping: Record<string, unknown>): OtlpServiceMap
     serviceNamespace: (mapping.serviceNamespace ?? mapping.service_namespace ?? '') as string,
     serviceName: (mapping.serviceName ?? mapping.service_name ?? '') as string,
     projectId: (mapping.projectId ?? mapping.project_id) as number,
+    projectResourceId: (mapping.projectResourceId ?? mapping.project_resource_id) as string,
     projectName: (mapping.projectName ?? mapping.project_name ?? '') as string,
     updatedAt: (mapping.updatedAt ?? mapping.updated_at) as string,
   }
@@ -251,15 +253,19 @@ export function logsMethods(core: ApiClientCore) {
 
     upsertOtlpServiceMapping: async (
       serviceName: string,
-      projectId: number,
+      projectId: string | number,
       serviceNamespace = ''
     ): Promise<OtlpServiceMapping> => {
+      const projectField =
+        typeof projectId === 'number'
+          ? { project_id: projectId }
+          : { project_resource_id: projectId }
       const response = await core.request<Record<string, unknown>>(`${base}/otlp/service-mappings`, {
         method: 'POST',
         body: JSON.stringify({
           service_name: serviceName,
           service_namespace: serviceNamespace,
-          project_id: projectId,
+          ...projectField,
         }),
       })
       return mapOtlpServiceMapping(response)

--- a/dashboard/src/lib/api/modules/notifications.ts
+++ b/dashboard/src/lib/api/modules/notifications.ts
@@ -39,7 +39,7 @@ export function notificationsMethods(core: ApiClientCore) {
       }),
 
     updateProjectNotificationPreferences: (
-      projectId: number,
+      projectId: string | number,
       preferences: Partial<NotificationPreference>
     ) =>
       core.request<void>(`${base}/notification-preferences/${projectId}`, {
@@ -47,7 +47,7 @@ export function notificationsMethods(core: ApiClientCore) {
         body: JSON.stringify(preferences),
       }),
 
-    deleteProjectNotificationPreferences: (projectId: number) =>
+    deleteProjectNotificationPreferences: (projectId: string | number) =>
       core.request<void>(`${base}/notification-preferences/${projectId}`, {
         method: 'DELETE',
       }),

--- a/dashboard/src/lib/api/modules/performance.ts
+++ b/dashboard/src/lib/api/modules/performance.ts
@@ -30,7 +30,7 @@ export function performanceMethods(core: ApiClientCore) {
 
   return {
     getTransactions: async (
-      projectId: number,
+      projectId: string | number,
       options: { period?: '24h' | '7d' | '30d' | '90d'; environment?: string; operation?: string } = {}
     ) => {
       const params = new URLSearchParams()
@@ -48,7 +48,7 @@ export function performanceMethods(core: ApiClientCore) {
     },
 
     getPerformanceStats: (
-      projectId: number,
+      projectId: string | number,
       options: { period?: '24h' | '7d' | '30d' | '90d'; environment?: string; operation?: string } = {}
     ) => {
       const params = new URLSearchParams()
@@ -68,12 +68,12 @@ export function performanceMethods(core: ApiClientCore) {
         `${base}/transactions/${encodeURIComponent(eventId)}/spans`
       ),
 
-    getTraceDetails: (projectId: number, traceId: string) =>
+    getTraceDetails: (projectId: string | number, traceId: string) =>
       core.request<TraceDetail>(
         `${base}/projects/${projectId}/traces/${encodeURIComponent(traceId)}`
       ),
 
-    getSpanDetails: (projectId: number, spanId: string) =>
+    getSpanDetails: (projectId: string | number, spanId: string) =>
       core.request<SpanDetail>(
         `${base}/projects/${projectId}/spans/${encodeURIComponent(spanId)}`
       ),

--- a/dashboard/src/lib/api/modules/projects.ts
+++ b/dashboard/src/lib/api/modules/projects.ts
@@ -28,7 +28,7 @@ export function projectsMethods(core: ApiClientCore) {
   return {
     getProjects: () => core.request<Project[]>(`${base}/projects`),
 
-    getProject: (projectId: number) =>
+    getProject: (projectId: string | number) =>
       core.request<Project>(`${base}/projects/${projectId}`),
 
     getSdkVersions: () =>
@@ -44,14 +44,14 @@ export function projectsMethods(core: ApiClientCore) {
         body: JSON.stringify({ name, framework, targets }),
       }),
 
-    addProjectTarget: (projectId: number, target: string) =>
+    addProjectTarget: (projectId: string | number, target: string) =>
       core.request<ProjectKey>(`${base}/projects/${projectId}/targets`, {
         method: 'POST',
         body: JSON.stringify({ target }),
       }),
 
     updateProject: (
-      projectId: number,
+      projectId: string | number,
       updates: { name?: string; framework?: string }
     ) =>
       core.request(`${base}/projects/${projectId}`, {
@@ -59,11 +59,11 @@ export function projectsMethods(core: ApiClientCore) {
         body: JSON.stringify(updates),
       }),
 
-    deleteProject: (projectId: number) =>
+    deleteProject: (projectId: string | number) =>
       core.request(`${base}/projects/${projectId}`, { method: 'DELETE' }),
 
     getProjectStats: (
-      projectId: number,
+      projectId: string | number,
       period: '24h' | '7d' | '30d' | '90d' = '7d'
     ) =>
       core.request<ProjectStats>(

--- a/dashboard/src/lib/api/modules/releases.ts
+++ b/dashboard/src/lib/api/modules/releases.ts
@@ -21,10 +21,10 @@ export function releasesMethods(core: ApiClientCore) {
   const base = core.API_BASE
 
   return {
-    getReleases: (projectId: number) =>
+    getReleases: (projectId: string | number) =>
       core.request<Release[]>(`${base}/projects/${projectId}/releases`),
 
-    getReleaseStats: (projectId: number, version: string) =>
+    getReleaseStats: (projectId: string | number, version: string) =>
       core.request<ReleaseStats>(
         `${base}/projects/${projectId}/releases/${encodeURIComponent(version)}/stats`
       ),

--- a/dashboard/src/lib/api/modules/replays.ts
+++ b/dashboard/src/lib/api/modules/replays.ts
@@ -27,7 +27,7 @@ export function replaysMethods(core: ApiClientCore) {
 
   return {
     getReplays: (
-      projectId: number,
+      projectId: string | number,
       options: {
         page?: number
         limit?: number
@@ -67,7 +67,7 @@ export function replaysMethods(core: ApiClientCore) {
       }
     },
 
-    getReplaysForIssue: (issueId: string, limit = 10, projectId?: number | null) => {
+    getReplaysForIssue: (issueId: string, limit = 10, projectId?: string | number | null) => {
       const params = new URLSearchParams({ limit: String(limit) })
       if (projectId != null) params.set('projectId', String(projectId))
       return core.request<Replay[]>(

--- a/dashboard/src/lib/api/types/dashboards.ts
+++ b/dashboard/src/lib/api/types/dashboards.ts
@@ -220,6 +220,7 @@ export interface SearchResponse {
 
 export interface SearchProjectResponse {
   id: number
+  resourceId: string
   name: string
 }
 

--- a/dashboard/src/lib/api/types/issues.ts
+++ b/dashboard/src/lib/api/types/issues.ts
@@ -36,6 +36,7 @@ export interface Event {
 export interface Issue {
   id: string
   projectId: number
+  projectResourceId: string
   title: string
   culprit: string
   level: string

--- a/dashboard/src/lib/api/types/logs.ts
+++ b/dashboard/src/lib/api/types/logs.ts
@@ -107,6 +107,7 @@ export interface OtlpObservedService {
   serviceNamespace: string
   serviceName: string
   projectId?: number | null
+  projectResourceId?: string | null
   projectName?: string | null
   seenLogs: boolean
   seenTraces: boolean
@@ -121,6 +122,7 @@ export interface OtlpServiceMapping {
   serviceNamespace: string
   serviceName: string
   projectId: number
+  projectResourceId: string
   projectName: string
   updatedAt: string
 }

--- a/dashboard/src/lib/api/types/notifications.ts
+++ b/dashboard/src/lib/api/types/notifications.ts
@@ -23,6 +23,7 @@ export interface NotificationPreference {
 
 export interface ProjectNotificationPreference extends NotificationPreference {
   projectId: number
+  projectResourceId: string
   projectName: string
 }
 

--- a/dashboard/src/lib/api/types/performance.ts
+++ b/dashboard/src/lib/api/types/performance.ts
@@ -78,6 +78,7 @@ export interface TransactionWithSpans {
 export interface TraceDetail {
   traceId: string
   projectId: number
+  projectResourceId: string
   spans: Span[]
   startTimestamp: number
   endTimestamp: number

--- a/dashboard/src/lib/api/types/projects.ts
+++ b/dashboard/src/lib/api/types/projects.ts
@@ -19,8 +19,11 @@ export interface ProjectKey {
   dsn: string
 }
 
+export type ProjectIdentifier = string
+
 export interface Project {
   id: number
+  resourceId: ProjectIdentifier
   name: string
   slug: string
   framework?: string

--- a/dashboard/src/lib/api/types/replays.ts
+++ b/dashboard/src/lib/api/types/replays.ts
@@ -17,6 +17,7 @@
 export interface Replay {
   replayId: string
   projectId: number
+  projectResourceId: string
   startedAt: string
   finishedAt: string
   durationMs: number

--- a/dashboard/src/lib/mcp-chat.ts
+++ b/dashboard/src/lib/mcp-chat.ts
@@ -75,7 +75,7 @@ export async function streamAiAssistant(
   conversationId: string | null,
   onEvent: (event: AssistantStreamEvent) => void,
   signal?: AbortSignal,
-  projectId?: number | null,
+  projectId?: string | number | null,
 ): Promise<void> {
   const impersonateToken = sessionStorage.getItem('impersonate_token')
   const authHeaders: Record<string, string> = impersonateToken

--- a/dashboard/src/lib/telemetry-sources.ts
+++ b/dashboard/src/lib/telemetry-sources.ts
@@ -141,17 +141,17 @@ export function toggleTelemetrySourceId(
   return [...selectedSourceIds, sourceId]
 }
 
-export function telemetrySourcesStorageKey(projectId: number): string {
+export function telemetrySourcesStorageKey(projectId: string | number): string {
   return `moneat:project:${projectId}:telemetry-sources`
 }
 
-export function loadTelemetrySourceIdsForProject(projectId: number): TelemetrySourceId[] {
+export function loadTelemetrySourceIdsForProject(projectId: string | number): TelemetrySourceId[] {
   const rawValue = globalThis.localStorage?.getItem(telemetrySourcesStorageKey(projectId))
   return parseTelemetrySourceIds(rawValue)
 }
 
 export function storeTelemetrySourceIdsForProject(
-  projectId: number,
+  projectId: string | number,
   sourceIds: TelemetrySourceId[]
 ): void {
   globalThis.localStorage?.setItem(telemetrySourcesStorageKey(projectId), serializeTelemetrySourceIds(sourceIds))

--- a/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
@@ -47,7 +47,8 @@ vi.mock('@tanstack/react-router', () => ({
 import { Route as IssuesIndexRoute } from '../issues.index'
 
 const mockProject = {
-  id: 'proj-1',
+  id: 1,
+  resourceId: 'proj-1',
   name: 'Test Project',
   slug: 'test-project',
   platform: 'javascript',

--- a/dashboard/src/routes/ai.traces.$traceId.tsx
+++ b/dashboard/src/routes/ai.traces.$traceId.tsx
@@ -28,15 +28,8 @@ import { cn } from '@/lib/utils'
 export const Route = createFileRoute('/ai/traces/$traceId')({
   validateSearch: (search: Record<string, unknown>) => {
     const rawProjectId = search.projectId
-    const parsedProjectId =
-      typeof rawProjectId === 'number'
-        ? rawProjectId
-        : typeof rawProjectId === 'string'
-          ? Number(rawProjectId)
-          : undefined
-
     return {
-      projectId: Number.isFinite(parsedProjectId) ? parsedProjectId : undefined,
+      projectId: typeof rawProjectId === 'string' && rawProjectId.length > 0 ? rawProjectId : undefined,
     }
   },
   component: TraceDetailPage,

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -42,9 +42,9 @@ function AnalyticsOverview() {
     queryFn: () => api.getProjects(),
   })
 
-  const hasSelectedProject = selectedProjectId != null && projects?.some(p => p.id === selectedProjectId)
-  const projectId = (hasSelectedProject ? selectedProjectId : null) || projects?.[0]?.id
-  const project = projects?.find(p => p.id === projectId)
+  const hasSelectedProject = selectedProjectId != null && projects?.some(p => p.resourceId === selectedProjectId)
+  const projectId = (hasSelectedProject ? selectedProjectId : null) || projects?.[0]?.resourceId
+  const project = projects?.find(p => p.resourceId === projectId)
 
   const buildDateParams = useCallback((): AnalyticsParams => ({
     period,
@@ -395,7 +395,7 @@ function AnalyticsOverview() {
   )
 }
 
-function ProductAnalyticsTab({projectId, params}: {projectId: number; params: AnalyticsParams}) {
+function ProductAnalyticsTab({projectId, params}: {projectId: string; params: AnalyticsParams}) {
   const {data: productEvents, isLoading: productEventsLoading} = useQuery({
     queryKey: ['analytics-product-events', projectId, params],
     queryFn: () => api.getAnalyticsEvents(projectId, params, {
@@ -431,7 +431,7 @@ function ProductAnalyticsTab({projectId, params}: {projectId: number; params: An
   )
 }
 
-function ProductFunnelPanel({projectId, params}: {projectId: number; params: AnalyticsParams}) {
+function ProductFunnelPanel({projectId, params}: {projectId: string; params: AnalyticsParams}) {
   const [steps, setSteps] = useState(DEFAULT_PRODUCT_FUNNEL_STEPS)
   const validSteps = steps.map(step => step.trim()).filter(Boolean)
   const {data: funnel, isLoading} = useQuery({

--- a/dashboard/src/routes/analytics.tsx
+++ b/dashboard/src/routes/analytics.tsx
@@ -21,9 +21,9 @@ function AnalyticsLayoutInner() {
     queryFn: () => api.getProjects(),
   })
 
-  const hasSelectedProject = selectedProjectId != null && projects?.some(p => p.id === selectedProjectId)
-  const projectId = (hasSelectedProject ? selectedProjectId : null) || projects?.[0]?.id
-  const project = projects?.find(p => p.id === projectId)
+  const hasSelectedProject = selectedProjectId != null && projects?.some(p => p.resourceId === selectedProjectId)
+  const projectId = (hasSelectedProject ? selectedProjectId : null) || projects?.[0]?.resourceId
+  const project = projects?.find(p => p.resourceId === projectId)
 
   return (
     <div className="p-3 space-y-2">

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -40,7 +40,7 @@ import {
   Search,
   Video,
 } from 'lucide-react'
-import {useMemo, useState} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import {useToast} from '@/hooks/useToast'
 
 export const Route = createFileRoute('/feedback')({
@@ -132,9 +132,11 @@ function FeedbackPage() {
 
   const projectId = selectedProjectId || projects?.[0]?.resourceId
 
-  if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.resourceId) {
-    setSelectedProjectId(projects[0].resourceId)
-  }
+  useEffect(() => {
+    if (!selectedProjectId && projects?.[0]?.resourceId) {
+      setSelectedProjectId(projects[0].resourceId)
+    }
+  }, [selectedProjectId, projects, setSelectedProjectId])
 
   // Fetch all feedback for stats (unfiltered)
   const { data: allFeedback = [] } = useQuery({

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -130,10 +130,10 @@ function FeedbackPage() {
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.id
+  const projectId = selectedProjectId || projects?.[0]?.resourceId
 
-  if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.id) {
-    setSelectedProjectId(projects[0].id)
+  if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.resourceId) {
+    setSelectedProjectId(projects[0].resourceId)
   }
 
   // Fetch all feedback for stats (unfiltered)

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -353,9 +353,11 @@ function DashboardPage() {
 
   const projectId = selectedProjectId || projects?.[0]?.resourceId
 
-  if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.resourceId) {
-    setSelectedProjectId(projects[0].resourceId)
-  }
+  useEffect(() => {
+    if (!selectedProjectId && projects?.[0]?.resourceId) {
+      setSelectedProjectId(projects[0].resourceId)
+    }
+  }, [selectedProjectId, projects, setSelectedProjectId])
 
   const {data: stats, isLoading: isLoadingStats} = useQuery({
     queryKey: ['stats', projectId],

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -351,10 +351,10 @@ function DashboardPage() {
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.id
+  const projectId = selectedProjectId || projects?.[0]?.resourceId
 
-  if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.id) {
-    setSelectedProjectId(projects[0].id)
+  if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.resourceId) {
+    setSelectedProjectId(projects[0].resourceId)
   }
 
   const {data: stats, isLoading: isLoadingStats} = useQuery({

--- a/dashboard/src/routes/issues.$issueId.tsx
+++ b/dashboard/src/routes/issues.$issueId.tsx
@@ -392,7 +392,7 @@ function IssueDetailPage() {
                   </CardHeader>
                   <CardContent className="px-0 pb-0">
                     <EmbeddedLogs
-                      projectId={issue.projectId}
+                      projectId={issue.projectResourceId}
                       centerTimestamp={latestEvent.timestamp}
                       contextMinutes={5}
                       environment={latestEvent.environment}

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -260,13 +260,13 @@ function DashboardPage() {
   })
   const hasProjects = (projects?.length ?? 0) > 0
 
-  const projectId = selectedProjectId || projects?.[0]?.id
-  const currentProject = projects?.find(p => p.id === projectId)
+  const projectId = selectedProjectId || projects?.[0]?.resourceId
+  const currentProject = projects?.find(p => p.resourceId === projectId)
 
   // Auto-select first project after data load without mutating state during render.
   useEffect(() => {
-    if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.id) {
-      setSelectedProjectId(projects[0].id)
+    if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.resourceId) {
+      setSelectedProjectId(projects[0].resourceId)
     }
   }, [selectedProjectId, projects, setSelectedProjectId])
 

--- a/dashboard/src/routes/onboarding.tsx
+++ b/dashboard/src/routes/onboarding.tsx
@@ -216,16 +216,16 @@ function OnboardingPage() {
     mutationFn: (data: ProjectSetupSubmission) =>
       api.createProject(data.name, data.framework, data.targets),
     onSuccess: (project, submission) => {
-      storeTelemetrySourceIdsForProject(project.id, submission.sourceIds)
+      storeTelemetrySourceIdsForProject(project.resourceId, submission.sourceIds)
       trackEvent('Onboarding Project Create', {
         framework: project.framework || 'none',
         sources: serializeTelemetrySourceIds(submission.sourceIds),
       })
       queryClient.invalidateQueries({ queryKey: ['projects'] })
-      setSelectedProjectId(project.id)
+      setSelectedProjectId(project.resourceId)
       navigate({
         to: '/projects/$projectId',
-        params: { projectId: String(project.id) },
+        params: { projectId: project.resourceId },
         search: { sources: serializeTelemetrySourceIds(submission.sourceIds) },
       })
     },

--- a/dashboard/src/routes/projects.$projectId.settings.tsx
+++ b/dashboard/src/routes/projects.$projectId.settings.tsx
@@ -61,7 +61,7 @@ export const Route = createFileRoute('/projects/$projectId/settings')({
     }
   },
   loader: async ({ params }) => {
-    const project = await api.getProject(Number(params.projectId))
+    const project = await api.getProject(params.projectId)
     return { project }
   },
   component: ProjectSettingsPage,
@@ -126,11 +126,11 @@ project=${project.slug}` : null
   }, [platformFilter])
 
   const updateProjectMutation = useMutation({
-    mutationFn: (updates: { name?: string; framework?: string }) => api.updateProject(project.id, updates),
+    mutationFn: (updates: { name?: string; framework?: string }) => api.updateProject(project.resourceId, updates),
     onSuccess: async () => {
       trackEvent('Project Update')
       await queryClient.invalidateQueries({ queryKey: ['projects'] })
-      await queryClient.invalidateQueries({ queryKey: ['project', project.id] })
+      await queryClient.invalidateQueries({ queryKey: ['project', project.resourceId] })
       await router.invalidate()
       toast({
         title: 'Project updated',
@@ -147,11 +147,11 @@ project=${project.slug}` : null
   })
 
   const deleteProjectMutation = useMutation({
-    mutationFn: () => api.deleteProject(project.id),
+    mutationFn: () => api.deleteProject(project.resourceId),
     onSuccess: async () => {
       trackEvent('Project Delete')
       await queryClient.invalidateQueries({ queryKey: ['projects'] })
-      if (selectedProjectId === project.id) {
+      if (selectedProjectId === project.resourceId) {
         setSelectedProjectId(null)
       }
       toast({
@@ -170,7 +170,7 @@ project=${project.slug}` : null
   })
 
   const addTargetMutation = useMutation({
-    mutationFn: (target: string) => api.addProjectTarget(project.id, target),
+    mutationFn: (target: string) => api.addProjectTarget(project.resourceId, target),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['projects'] })
       await router.invalidate()
@@ -227,7 +227,7 @@ project=${project.slug}` : null
           <div className="space-y-2">
             <Link
               to="/projects/$projectId"
-              params={{ projectId: String(project.id) }}
+              params={{ projectId: project.resourceId }}
               className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
             >
               <ArrowLeft className="h-4 w-4" />

--- a/dashboard/src/routes/projects.$projectId.spans.$spanId.tsx
+++ b/dashboard/src/routes/projects.$projectId.spans.$spanId.tsx
@@ -32,7 +32,7 @@ function SpanDetailPage() {
   
   const { data: spanDetail, isLoading, error } = useQuery({
     queryKey: ['span', projectId, spanId],
-    queryFn: () => api.getSpanDetails(parseInt(projectId), spanId),
+    queryFn: () => api.getSpanDetails(projectId, spanId),
   })
 
   if (isLoading) {

--- a/dashboard/src/routes/projects.$projectId.tsx
+++ b/dashboard/src/routes/projects.$projectId.tsx
@@ -28,7 +28,7 @@ export const Route = createFileRoute('/projects/$projectId')({
     }
   },
   loader: async ({ params }) => {
-    const project = await api.getProject(Number(params.projectId))
+    const project = await api.getProject(params.projectId)
     return { project }
   },
   component: SetupPage,

--- a/dashboard/src/routes/releases.$version.tsx
+++ b/dashboard/src/routes/releases.$version.tsx
@@ -43,7 +43,7 @@ function ReleaseDetailPage() {
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.id
+  const projectId = selectedProjectId || projects?.[0]?.resourceId
 
   const { data: stats, isLoading } = useQuery({
     queryKey: ['releaseStats', projectId, releaseVersion],

--- a/dashboard/src/routes/releases.tsx
+++ b/dashboard/src/routes/releases.tsx
@@ -58,7 +58,7 @@ function ReleasesPage() {
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.id
+  const projectId = selectedProjectId || projects?.[0]?.resourceId
 
   const { data: releases, isLoading, error } = useQuery({
     queryKey: ['releases', projectId],

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -665,7 +665,7 @@ function ReplayDetailPage() {
               <ReplayTimelinePanel
                 items={timelineItems}
                 currentOffsetMs={currentOffsetMs}
-                projectId={replay.projectResourceId}
+                projectId={replay.projectResourceId ?? replay.projectId}
                 onSeek={handleSeek}
               />
             ) : (

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -665,7 +665,7 @@ function ReplayDetailPage() {
               <ReplayTimelinePanel
                 items={timelineItems}
                 currentOffsetMs={currentOffsetMs}
-                projectId={replay.projectId}
+                projectId={replay.projectResourceId}
                 onSeek={handleSeek}
               />
             ) : (

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -139,7 +139,7 @@ function ReplaysPage() {
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.id
+  const projectId = selectedProjectId || projects?.[0]?.resourceId
   const { data: billingUsage } = useQuery({
     queryKey: ['billing-usage'],
     queryFn: () => api.getBillingUsage(),

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -2497,7 +2497,7 @@ function NotificationsTab() {
 
   const updateProjectMutation = useMutation({
     mutationFn: ({ projectId, prefs }: {
-      projectId: number
+      projectId: string
       prefs: Partial<{
         issueAlerts: boolean
         errorAlerts: boolean
@@ -2519,7 +2519,7 @@ function NotificationsTab() {
   })
 
   const deleteProjectMutation = useMutation({
-    mutationFn: (projectId: number) => api.deleteProjectNotificationPreferences(projectId),
+    mutationFn: (projectId: string) => api.deleteProjectNotificationPreferences(projectId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['notificationPreferences'] })
       toast({ title: 'Project override removed', description: 'Using global preferences for this project.' })
@@ -2701,14 +2701,14 @@ function NotificationsTab() {
               </TableHeader>
               <TableBody>
                 {projects.map((project) => (
-                  <TableRow key={project.projectId}>
+                  <TableRow key={project.projectResourceId}>
                     <TableCell className="font-medium">{project.projectName}</TableCell>
                     <TableCell className="text-center">
                       <Checkbox
                         checked={project.issueAlerts}
                         onCheckedChange={(checked) =>
                           updateProjectMutation.mutate({
-                            projectId: project.projectId,
+                            projectId: project.projectResourceId,
                             prefs: { issueAlerts: checked === true },
                           })
                         }
@@ -2719,7 +2719,7 @@ function NotificationsTab() {
                         checked={project.errorAlerts}
                         onCheckedChange={(checked) =>
                           updateProjectMutation.mutate({
-                            projectId: project.projectId,
+                            projectId: project.projectResourceId,
                             prefs: { errorAlerts: checked === true },
                           })
                         }
@@ -2730,7 +2730,7 @@ function NotificationsTab() {
                         checked={project.weeklySummary}
                         onCheckedChange={(checked) =>
                           updateProjectMutation.mutate({
-                            projectId: project.projectId,
+                            projectId: project.projectResourceId,
                             prefs: { weeklySummary: checked === true },
                           })
                         }
@@ -2745,7 +2745,7 @@ function NotificationsTab() {
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => deleteProjectMutation.mutate(project.projectId)}
+                        onClick={() => deleteProjectMutation.mutate(project.projectResourceId)}
                       >
                         Reset
                       </Button>


### PR DESCRIPTION
## Summary
- add immutable project `resource_id` UUIDs and a cached resolver for public project identifiers
- accept both legacy numeric project IDs and UUID resource IDs across backend API, ingest, MCP, OTLP routing, and dashboard flows
- expose transitional `resourceId` / `projectResourceId` fields and move dashboard routes/API calls to resource IDs while keeping integer DSNs compatible

## Verification
- `backend ./gradlew compileKotlin detekt test`
- `dashboard npm run build`
- `git diff --check origin/develop...HEAD`

Closes #458
Closes #459
Closes #460
Closes #461
Closes #462
Refs #463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable string-based project resource IDs introduced across APIs and UI; endpoints and clients now accept string or numeric project identifiers.
  * OTLP/service mapping and project search results include project resource IDs.

* **Bug Fixes & Improvements**
  * Routes, ingestion, tools, and services now reliably resolve project identifiers (legacy numeric or resource ID) and handle DSNs more robustly.
  * Frontend selection, routing, telemetry, and APIs updated to use resource IDs where applicable.

* **Tests**
  * Added and updated tests to cover resource-ID resolution, caching, and OTLP behavior.

* **Documentation**
  * Tool docs updated to reflect project_id accepts string or number.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->