### PR TITLE
feat: add dashboard widget mcp tools

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/repositories/DashboardWidgetRepository.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/repositories/DashboardWidgetRepository.kt
@@ -27,6 +27,7 @@ interface DashboardWidgetRepository {
     fun listByDashboardId(dashboardId: Long): List<WidgetData>
     fun bulkUpsert(dashboardId: Long, widgets: List<UpdateWidgetRequest>, now: Instant): Set<Long>
     fun deleteNotIn(dashboardId: Long, keepIds: Set<Long>)
+    fun deleteById(dashboardId: Long, widgetId: Long): Boolean
     fun insert(dashboardId: Long, widget: CreateWidgetRequest, sortOrder: Int, now: Instant): Long
 }
 

--- a/backend/src/main/kotlin/com/moneat/dashboards/repositories/DashboardWidgetRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/repositories/DashboardWidgetRepositoryImpl.kt
@@ -155,6 +155,14 @@ class DashboardWidgetRepositoryImpl : DashboardWidgetRepository {
         }
     }
 
+    override fun deleteById(dashboardId: Long, widgetId: Long): Boolean =
+        transaction {
+            DashboardWidgets.deleteWhere {
+                (DashboardWidgets.dashboardId eq dashboardId) and
+                    (DashboardWidgets.id eq widgetId)
+            } > 0
+        }
+
     override fun insert(dashboardId: Long, widget: CreateWidgetRequest, sortOrder: Int, now: Instant): Long =
         transaction {
             DashboardWidgets.insert {

--- a/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
@@ -78,7 +78,6 @@ import org.koin.core.context.GlobalContext
 private val logger = KotlinLogging.logger {}
 private val json = Json { ignoreUnknownKeys = true }
 
-private const val QUERY_PREVIEW_LENGTH = 80
 private const val DEFAULT_RETENTION_DAYS = 90
 private const val MAX_QUERIES_PER_REQUEST = 10
 
@@ -123,28 +122,6 @@ private fun getDashboardScope(dashboardId: Long, orgId: Long): DashboardScope? {
                 )
             }
     }
-}
-
-private fun resolvePrometheusDataSource(
-    dsl: QueryDsl,
-    orgId: Long,
-    dataSourceService: CustomDataSourceService,
-): QueryDsl {
-    if (dsl.dataSource != "__prometheus") return dsl
-    val sources = dataSourceService.listDataSources(orgId)
-    val promSource = sources.firstOrNull { it.sourceType.equals("prometheus", ignoreCase = true) }
-    if (promSource == null) {
-        logger.warn {
-            val sourcesList = sources.map { "${it.id}:${it.sourceType}" }
-            val shortQuery = dsl.rawQuery?.take(QUERY_PREVIEW_LENGTH) ?: ""
-            "No Prometheus datasource found for org $orgId (${sources.size} sources: $sourcesList), " +
-                "cannot resolve __prometheus for rawQuery=$shortQuery"
-        }
-        return dsl
-    }
-    val rawQueryPreview = dsl.rawQuery?.take(QUERY_PREVIEW_LENGTH)
-    logger.debug { "Resolved __prometheus -> custom:${promSource.id} for rawQuery=$rawQueryPreview" }
-    return dsl.copy(dataSource = "custom:${promSource.id}")
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleListDashboards(
@@ -348,7 +325,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDashboardQuery(
     } else {
         request.queryConfig
     }
-    val effectiveQuery = resolvePrometheusDataSource(
+    val effectiveQuery = queryEngine.resolvePrometheusDataSource(
         queryEngine.applyVariables(withTimeRange, request.variables),
         orgId,
         dataSourceService
@@ -468,7 +445,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleBatchDashboardQu
         } else {
             query
         }
-        val effectiveQuery = resolvePrometheusDataSource(
+        val effectiveQuery = queryEngine.resolvePrometheusDataSource(
             queryEngine.applyVariables(withTimeRange, request.variables),
             orgId,
             dataSourceService

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
@@ -89,6 +89,7 @@ class DashboardQueryEngine {
         private const val MAX_QUERY_RESULT_LIMIT = 10000
         private const val EPOCH_MS_TO_SECONDS_DIVISOR = 1000.0
         private const val DATETIME64_MILLIS_PRECISION = 3
+        private const val QUERY_PREVIEW_LENGTH = 80
 
         fun resolveTimeInterval(from: String, to: String): String {
             val rangeMs = parseRelativeTime(to) - parseRelativeTime(from)
@@ -161,6 +162,28 @@ class DashboardQueryEngine {
             },
             rawQuery = substituteVars(dsl.rawQuery)
         )
+    }
+
+    fun resolvePrometheusDataSource(
+        dsl: QueryDsl,
+        orgId: Long,
+        dataSourceService: CustomDataSourceService,
+    ): QueryDsl {
+        if (dsl.dataSource != "__prometheus") return dsl
+        val sources = dataSourceService.listDataSources(orgId)
+        val promSource = sources.firstOrNull { it.sourceType.equals("prometheus", ignoreCase = true) }
+        if (promSource == null) {
+            logger.warn {
+                val sourcesList = sources.map { "${it.id}:${it.sourceType}" }
+                val shortQuery = dsl.rawQuery?.take(QUERY_PREVIEW_LENGTH) ?: ""
+                "No Prometheus datasource found for org $orgId (${sources.size} sources: $sourcesList), " +
+                    "cannot resolve __prometheus for rawQuery=$shortQuery"
+            }
+            return dsl
+        }
+        val rawQueryPreview = dsl.rawQuery?.take(QUERY_PREVIEW_LENGTH)
+        logger.debug { "Resolved __prometheus -> custom:${promSource.id} for rawQuery=$rawQueryPreview" }
+        return dsl.copy(dataSource = "custom:${promSource.id}")
     }
 
     fun buildQuery(

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
@@ -171,12 +171,14 @@ class DashboardQueryEngine {
     ): QueryDsl {
         if (dsl.dataSource != "__prometheus") return dsl
         val sources = dataSourceService.listDataSources(orgId)
-        val promSource = sources.firstOrNull { it.sourceType.equals("prometheus", ignoreCase = true) }
+        val promSource = sources.firstOrNull {
+            it.enabled && it.sourceType.equals("prometheus", ignoreCase = true)
+        }
         if (promSource == null) {
             logger.warn {
                 val sourcesList = sources.map { "${it.id}:${it.sourceType}" }
                 val shortQuery = dsl.rawQuery?.take(QUERY_PREVIEW_LENGTH) ?: ""
-                "No Prometheus datasource found for org $orgId (${sources.size} sources: $sourcesList), " +
+                "No enabled Prometheus datasource found for org $orgId (${sources.size} sources: $sourcesList), " +
                     "cannot resolve __prometheus for rawQuery=$shortQuery"
             }
             return dsl

--- a/backend/src/main/kotlin/com/moneat/mcp/McpToolRegistrar.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/McpToolRegistrar.kt
@@ -22,6 +22,7 @@ import com.moneat.mcp.tools.AggregateLogsTool
 import com.moneat.mcp.tools.CreateAlertTool
 import com.moneat.mcp.tools.CreateDashboardAlertTool
 import com.moneat.mcp.tools.CreateDashboardTool
+import com.moneat.mcp.tools.CreateDashboardWidgetTool
 import com.moneat.mcp.tools.CreateDataSourceTool
 import com.moneat.mcp.tools.CreateFeatureFlagTool
 import com.moneat.mcp.tools.CreateAgentKeyTool
@@ -33,6 +34,7 @@ import com.moneat.mcp.tools.CreateUptimeMonitorTool
 import com.moneat.mcp.tools.DeleteAlertTool
 import com.moneat.mcp.tools.DeleteDashboardAlertTool
 import com.moneat.mcp.tools.DeleteDashboardTool
+import com.moneat.mcp.tools.DeleteDashboardWidgetTool
 import com.moneat.mcp.tools.DeleteHostTool
 import com.moneat.mcp.tools.DeleteSilencePeriodTool
 import com.moneat.mcp.tools.DeleteUptimeMonitorTool
@@ -89,12 +91,15 @@ import com.moneat.mcp.tools.ListTransactionsTool
 import com.moneat.mcp.tools.ListUptimeMonitorsTool
 import com.moneat.mcp.tools.PauseUptimeMonitorTool
 import com.moneat.mcp.tools.PostIncidentUpdateTool
+import com.moneat.mcp.tools.PreviewDashboardWidgetQueryTool
 import com.moneat.mcp.tools.QueryLogsTool
+import com.moneat.mcp.tools.ReplaceDashboardWidgetsTool
 import com.moneat.mcp.tools.ResumeUptimeMonitorTool
 import com.moneat.mcp.tools.UpdateAlertNotificationChannelsTool
 import com.moneat.mcp.tools.UpdateAlertTool
 import com.moneat.mcp.tools.UpdateDashboardAlertTool
 import com.moneat.mcp.tools.UpdateDashboardTool
+import com.moneat.mcp.tools.UpdateDashboardWidgetTool
 import com.moneat.mcp.tools.UpdateIssueStatusTool
 import com.moneat.mcp.tools.UpdateNotificationPreferencesTool
 import com.moneat.mcp.tools.UpdateStatusPageIncidentTool
@@ -130,6 +135,11 @@ object McpToolRegistrar {
         toolRegistry.register(CreateDashboardTool())
         toolRegistry.register(UpdateDashboardTool())
         toolRegistry.register(DeleteDashboardTool())
+        toolRegistry.register(CreateDashboardWidgetTool())
+        toolRegistry.register(UpdateDashboardWidgetTool())
+        toolRegistry.register(DeleteDashboardWidgetTool())
+        toolRegistry.register(PreviewDashboardWidgetQueryTool())
+        toolRegistry.register(ReplaceDashboardWidgetsTool())
 
         // Alert tools
         toolRegistry.register(ListAlertsTool())

--- a/backend/src/main/kotlin/com/moneat/mcp/auth/McpScopes.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/auth/McpScopes.kt
@@ -73,6 +73,7 @@ object McpScopes {
         "list_silence_periods",
         "list_status_pages",
         "list_uptime_monitors",
+        "preview_dashboard_widget_query",
     ).associateWith { setOf(PROJECT_READ) }
 
     private val releaseReadTools = listOf(
@@ -97,6 +98,7 @@ object McpScopes {
         "create_alert",
         "create_dashboard",
         "create_dashboard_alert",
+        "create_dashboard_widget",
         "create_datasource",
         "create_feature_flag",
         "create_project",
@@ -107,6 +109,7 @@ object McpScopes {
         "delete_alert",
         "delete_dashboard",
         "delete_dashboard_alert",
+        "delete_dashboard_widget",
         "delete_host",
         "delete_silence_period",
         "delete_uptime_monitor",
@@ -120,11 +123,13 @@ object McpScopes {
         "update_alert_notification_channels",
         "update_dashboard",
         "update_dashboard_alert",
+        "update_dashboard_widget",
         "update_issue_status",
         "update_notification_preferences",
         "update_status_page",
         "update_status_page_incident",
         "update_uptime_monitor",
+        "replace_dashboard_widgets",
     ).associateWith { setOf(PROJECT_WRITE) }
 
     private val readScopesByTool = telemetryReadTools + projectReadTools + releaseReadTools + orgReadTools

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardCrudTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardCrudTool.kt
@@ -71,7 +71,7 @@ private fun dashboardAlertSeverity(input: String?): String? {
 class UpdateDashboardTool : McpTool {
     override val name = "update_dashboard"
     override val description =
-        "Update a dashboard (title, description, widgets)"
+        "Update a dashboard's title and description"
     override val readOnly = false
     override val inputSchema = InputSchema(
         properties = JsonObject(

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
@@ -71,6 +71,12 @@ private val queryDslListSerializer = ListSerializer(QueryDsl.serializer())
 private val updateWidgetListSerializer = ListSerializer(UpdateWidgetRequest.serializer())
 private val displayConfigSerializer = MapSerializer(String.serializer(), String.serializer())
 
+private const val DASHBOARD_ID_ARG = "dashboard_id"
+private const val DASHBOARD_ID_LABEL = "Dashboard ID"
+private const val WIDGET_ID_ARG = "widget_id"
+private const val WIDGET_ID_LABEL = "Widget ID"
+private const val INVALID_WIDGET_REQUEST_MESSAGE = "Invalid dashboard widget request"
+private const val INVALID_QUERY_REQUEST_MESSAGE = "Invalid dashboard query request"
 private const val DEFAULT_WIDGET_X = 0
 private const val DEFAULT_WIDGET_WIDTH = 6
 private const val DEFAULT_WIDGET_HEIGHT = 4
@@ -147,9 +153,7 @@ private fun JsonObject.requiredWidgetType(): String {
 }
 
 private fun validateWidgetType(widgetType: String) {
-    if (widgetType !in dashboardWidgetTypeSet) {
-        throw IllegalArgumentException("Unknown widget_type: $widgetType")
-    }
+    require(widgetType in dashboardWidgetTypeSet) { "Unknown widget_type: $widgetType" }
 }
 
 private fun JsonObject.optionalQueryConfigs(): List<QueryDsl>? {
@@ -266,31 +270,51 @@ private fun hasWidgetUpdateFields(args: JsonObject): Boolean =
 private fun schemaProperties(vararg pairs: Pair<String, JsonObject>): JsonObject =
     JsonObject(mapOf(*pairs))
 
+private fun dashboardIdProperty(): Pair<String, JsonObject> =
+    DASHBOARD_ID_ARG to schemaNumber(DASHBOARD_ID_LABEL)
+
+private fun widgetIdProperty(): Pair<String, JsonObject> =
+    WIDGET_ID_ARG to schemaNumber(WIDGET_ID_LABEL)
+
+private fun widgetMutationProperties(includeWidgetId: Boolean): JsonObject {
+    val properties = mutableListOf(dashboardIdProperty())
+    if (includeWidgetId) {
+        properties += widgetIdProperty()
+    }
+    properties += listOf(
+        "title" to schemaString("Widget title"),
+        "widget_type" to schemaEnum("Widget type", dashboardWidgetTypes),
+        "grid_x" to schemaInteger("Grid x position"),
+        "grid_y" to schemaInteger("Grid y position"),
+        "grid_w" to schemaInteger("Grid width"),
+        "grid_h" to schemaInteger("Grid height"),
+        "query_configs" to schemaArray("QueryDsl array"),
+        "display_config" to schemaObject("Display config"),
+        "sort_order" to schemaInteger("Sort order")
+    )
+    return schemaProperties(*properties.toTypedArray())
+}
+
+private fun widgetTargetProperties(): JsonObject =
+    schemaProperties(dashboardIdProperty(), widgetIdProperty())
+
+private fun invalidWidgetRequestResult(e: IllegalArgumentException): ToolCallResult =
+    errorResult(e.message ?: INVALID_WIDGET_REQUEST_MESSAGE)
+
 class CreateDashboardWidgetTool : McpTool {
     override val name = "create_dashboard_widget"
     override val description = "Create a dashboard widget"
     override val readOnly = false
     override val inputSchema = InputSchema(
-        properties = schemaProperties(
-            "dashboard_id" to schemaNumber("Dashboard ID"),
-            "title" to schemaString("Widget title"),
-            "widget_type" to schemaEnum("Widget type", dashboardWidgetTypes),
-            "grid_x" to schemaInteger("Grid x position"),
-            "grid_y" to schemaInteger("Grid y position"),
-            "grid_w" to schemaInteger("Grid width"),
-            "grid_h" to schemaInteger("Grid height"),
-            "query_configs" to schemaArray("QueryDsl array"),
-            "display_config" to schemaObject("Display config"),
-            "sort_order" to schemaInteger("Sort order")
-        ),
-        required = listOf("dashboard_id", "widget_type")
+        properties = widgetMutationProperties(includeWidgetId = false),
+        required = listOf(DASHBOARD_ID_ARG, "widget_type")
     )
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
     ): ToolCallResult = try {
-        val dashboardId = args.requiredLongArg("dashboard_id")
+        val dashboardId = args.requiredLongArg(DASHBOARD_ID_ARG)
         val widgetType = args.requiredWidgetType()
         val title = args.optionalStringArg("title")
         val gridX = args.optionalIntArg("grid_x")
@@ -321,7 +345,7 @@ class CreateDashboardWidgetTool : McpTool {
             ?: return errorResult("Dashboard not found: $dashboardId")
         jsonResult(dashboard)
     } catch (e: IllegalArgumentException) {
-        errorResult(e.message ?: "Invalid dashboard widget request")
+        invalidWidgetRequestResult(e)
     }
 }
 
@@ -330,28 +354,16 @@ class UpdateDashboardWidgetTool : McpTool {
     override val description = "Update a dashboard widget"
     override val readOnly = false
     override val inputSchema = InputSchema(
-        properties = schemaProperties(
-            "dashboard_id" to schemaNumber("Dashboard ID"),
-            "widget_id" to schemaNumber("Widget ID"),
-            "title" to schemaString("Widget title"),
-            "widget_type" to schemaEnum("Widget type", dashboardWidgetTypes),
-            "grid_x" to schemaInteger("Grid x position"),
-            "grid_y" to schemaInteger("Grid y position"),
-            "grid_w" to schemaInteger("Grid width"),
-            "grid_h" to schemaInteger("Grid height"),
-            "query_configs" to schemaArray("QueryDsl array"),
-            "display_config" to schemaObject("Display config"),
-            "sort_order" to schemaInteger("Sort order")
-        ),
-        required = listOf("dashboard_id", "widget_id")
+        properties = widgetMutationProperties(includeWidgetId = true),
+        required = listOf(DASHBOARD_ID_ARG, WIDGET_ID_ARG)
     )
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
     ): ToolCallResult = try {
-        val dashboardId = args.requiredLongArg("dashboard_id")
-        val widgetId = args.requiredLongArg("widget_id")
+        val dashboardId = args.requiredLongArg(DASHBOARD_ID_ARG)
+        val widgetId = args.requiredLongArg(WIDGET_ID_ARG)
         if (!hasWidgetUpdateFields(args)) {
             return errorResult("At least one widget field must be provided to update")
         }
@@ -373,7 +385,7 @@ class UpdateDashboardWidgetTool : McpTool {
         ) ?: return errorResult("Dashboard not found: $dashboardId")
         jsonResult(updated)
     } catch (e: IllegalArgumentException) {
-        errorResult(e.message ?: "Invalid dashboard widget request")
+        invalidWidgetRequestResult(e)
     }
 }
 
@@ -382,19 +394,16 @@ class DeleteDashboardWidgetTool : McpTool {
     override val description = "Delete a dashboard widget"
     override val readOnly = false
     override val inputSchema = InputSchema(
-        properties = schemaProperties(
-            "dashboard_id" to schemaNumber("Dashboard ID"),
-            "widget_id" to schemaNumber("Widget ID")
-        ),
-        required = listOf("dashboard_id", "widget_id")
+        properties = widgetTargetProperties(),
+        required = listOf(DASHBOARD_ID_ARG, WIDGET_ID_ARG)
     )
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
     ): ToolCallResult = try {
-        val dashboardId = args.requiredLongArg("dashboard_id")
-        val widgetId = args.requiredLongArg("widget_id")
+        val dashboardId = args.requiredLongArg(DASHBOARD_ID_ARG)
+        val widgetId = args.requiredLongArg(WIDGET_ID_ARG)
         val orgId = context.organizationId.toLong()
         val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
             ?: return errorResult("Dashboard not found: $dashboardId")
@@ -408,7 +417,7 @@ class DeleteDashboardWidgetTool : McpTool {
             ?: return errorResult("Dashboard not found: $dashboardId")
         jsonResult(updated)
     } catch (e: IllegalArgumentException) {
-        errorResult(e.message ?: "Invalid dashboard widget request")
+        invalidWidgetRequestResult(e)
     }
 }
 
@@ -417,20 +426,20 @@ class PreviewDashboardWidgetQueryTool : McpTool {
     override val description = "Preview a dashboard widget query using dashboard resolution rules"
     override val inputSchema = InputSchema(
         properties = schemaProperties(
-            "dashboard_id" to schemaNumber("Dashboard ID"),
+            dashboardIdProperty(),
             "query_config" to schemaObject("QueryDsl config"),
             "project_id" to schemaNumber("Project ID"),
             "variables" to schemaObject("Variable values"),
             "time_range" to schemaObject("Time range override")
         ),
-        required = listOf("dashboard_id", "query_config")
+        required = listOf(DASHBOARD_ID_ARG, "query_config")
     )
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
     ): ToolCallResult = try {
-        val dashboardId = args.requiredLongArg("dashboard_id")
+        val dashboardId = args.requiredLongArg(DASHBOARD_ID_ARG)
         val queryConfig = args.requiredQueryConfig()
         val timeRange = args.optionalTimeRange()
         val variables = args.optionalVariables()
@@ -455,7 +464,7 @@ class PreviewDashboardWidgetQueryTool : McpTool {
     } catch (e: CancellationException) {
         throw e
     } catch (e: IllegalArgumentException) {
-        errorResult(e.message ?: "Invalid dashboard query request")
+        errorResult(e.message ?: INVALID_QUERY_REQUEST_MESSAGE)
     }
 
     private suspend fun executePreviewQuery(
@@ -464,8 +473,12 @@ class PreviewDashboardWidgetQueryTool : McpTool {
         projectId: Long,
     ): List<Map<String, JsonElement>> {
         if (!dashboardWidgetQueryEngine.isCustomDataSource(effectiveQuery.dataSource)) {
-            val retentionDays = dashboardWidgetRetentionPolicyService.getRetentionDaysForProject(projectId)
-                ?: DASHBOARD_WIDGET_DEFAULT_RETENTION_DAYS
+            val retentionDays = if (effectiveQuery.rawQuery == null) {
+                dashboardWidgetRetentionPolicyService.getRetentionDaysForProject(projectId)
+                    ?: DASHBOARD_WIDGET_DEFAULT_RETENTION_DAYS
+            } else {
+                DASHBOARD_WIDGET_DEFAULT_RETENTION_DAYS
+            }
             return dashboardWidgetQueryEngine.executeQuery(
                 dsl = effectiveQuery,
                 projectId = projectId,
@@ -503,18 +516,18 @@ class ReplaceDashboardWidgetsTool : McpTool {
     override val readOnly = false
     override val inputSchema = InputSchema(
         properties = schemaProperties(
-            "dashboard_id" to schemaNumber("Dashboard ID"),
+            dashboardIdProperty(),
             "widgets" to schemaArray("Replacement dashboard widget objects"),
             "expected_widget_count" to schemaInteger("Current widget count expected by caller")
         ),
-        required = listOf("dashboard_id", "widgets", "expected_widget_count")
+        required = listOf(DASHBOARD_ID_ARG, "widgets", "expected_widget_count")
     )
 
     override suspend fun execute(
         args: JsonObject,
         context: McpContext
     ): ToolCallResult = try {
-        val dashboardId = args.requiredLongArg("dashboard_id")
+        val dashboardId = args.requiredLongArg(DASHBOARD_ID_ARG)
         val expectedWidgetCount = args.requiredIntArg("expected_widget_count")
         val orgId = context.organizationId.toLong()
         val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
@@ -534,6 +547,6 @@ class ReplaceDashboardWidgetsTool : McpTool {
         ) ?: return errorResult("Dashboard not found: $dashboardId")
         jsonResult(updated)
     } catch (e: IllegalArgumentException) {
-        errorResult(e.message ?: "Invalid dashboard widget request")
+        invalidWidgetRequestResult(e)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
@@ -1,0 +1,539 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.mcp.tools
+
+import com.moneat.dashboards.models.CreateWidgetRequest
+import com.moneat.dashboards.models.CustomDataSourceType
+import com.moneat.dashboards.models.QueryDsl
+import com.moneat.dashboards.models.TimeRangeDef
+import com.moneat.dashboards.models.UpdateDashboardRequest
+import com.moneat.dashboards.models.UpdateWidgetRequest
+import com.moneat.dashboards.models.WidgetResponse
+import com.moneat.dashboards.repositories.DashboardFolderRepositoryImpl
+import com.moneat.dashboards.repositories.DashboardRepositoryImpl
+import com.moneat.dashboards.repositories.DashboardWidgetRepositoryImpl
+import com.moneat.dashboards.repositories.WidgetData
+import com.moneat.dashboards.services.CustomDashboardService
+import com.moneat.dashboards.services.CustomDataSourceExecutor
+import com.moneat.dashboards.services.CustomDataSourceService
+import com.moneat.dashboards.services.DashboardQueryEngine
+import com.moneat.events.repositories.ProjectRepositoryImpl
+import com.moneat.mcp.models.McpContext
+import com.moneat.mcp.protocol.InputSchema
+import com.moneat.mcp.protocol.McpTool
+import com.moneat.mcp.protocol.ToolCallResult
+import com.moneat.shared.services.RetentionPolicyService
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
+import kotlin.time.Clock
+
+private val dashboardWidgetRepo = DashboardWidgetRepositoryImpl()
+private val dashboardWidgetCrudService = CustomDashboardService(
+    DashboardFolderRepositoryImpl(),
+    DashboardRepositoryImpl(),
+    dashboardWidgetRepo,
+    ProjectRepositoryImpl { col, _, _ -> col },
+)
+private val dashboardWidgetQueryEngine = DashboardQueryEngine()
+private val dashboardWidgetDataSourceService = CustomDataSourceService()
+private val dashboardWidgetDataSourceExecutor = CustomDataSourceExecutor()
+private val dashboardWidgetRetentionPolicyService = RetentionPolicyService()
+private val dashboardWidgetJson = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+}
+private val queryDslListSerializer = ListSerializer(QueryDsl.serializer())
+private val updateWidgetListSerializer = ListSerializer(UpdateWidgetRequest.serializer())
+private val displayConfigSerializer = MapSerializer(String.serializer(), String.serializer())
+
+private const val DEFAULT_WIDGET_X = 0
+private const val DEFAULT_WIDGET_WIDTH = 6
+private const val DEFAULT_WIDGET_HEIGHT = 4
+private const val DASHBOARD_WIDGET_DEFAULT_RETENTION_DAYS = 90
+
+private val dashboardWidgetTypes = listOf(
+    "timeseries",
+    "bar",
+    "donut",
+    "stat",
+    "gauge",
+    "bargauge",
+    "table",
+    "toplist",
+    "heatmap",
+    "text",
+    "section",
+    "stream",
+    "timeline",
+    "geo_map",
+    "host_map",
+    "topology_map",
+    "sankey",
+    "treemap",
+    "scatter",
+    "status",
+    "change",
+    "custom",
+    "flame_graph",
+    "cost_summary",
+    "iframe",
+)
+private val dashboardWidgetTypeSet = dashboardWidgetTypes.toSet()
+
+private fun schemaArray(description: String): JsonObject = JsonObject(
+    mapOf(
+        "type" to JsonPrimitive("array"),
+        "description" to JsonPrimitive(description),
+        "items" to schemaObject("Array item")
+    )
+)
+
+private fun JsonObject.longArg(name: String): Long? {
+    val value = this[name] as? JsonPrimitive ?: return null
+    return value.longOrNull ?: value.content.toLongOrNull()
+}
+
+private fun JsonObject.requiredLongArg(name: String): Long =
+    longArg(name) ?: throw IllegalArgumentException("$name is required")
+
+private fun JsonObject.optionalIntArg(name: String): Int? {
+    if (!containsKey(name)) return null
+    val value = this[name] as? JsonPrimitive
+        ?: throw IllegalArgumentException("$name must be a valid integer")
+    return value.intOrNull ?: value.content.toIntOrNull()
+        ?: throw IllegalArgumentException("$name must be a valid integer")
+}
+
+private fun JsonObject.requiredIntArg(name: String): Int =
+    optionalIntArg(name) ?: throw IllegalArgumentException("$name is required")
+
+private fun JsonObject.optionalStringArg(name: String): String? {
+    if (!containsKey(name)) return null
+    val value = this[name] as? JsonPrimitive
+        ?: throw IllegalArgumentException("$name must be a string")
+    return value.content
+}
+
+private fun JsonObject.requiredWidgetType(): String {
+    val widgetType = optionalStringArg("widget_type")
+        ?: throw IllegalArgumentException("widget_type is required")
+    validateWidgetType(widgetType)
+    return widgetType
+}
+
+private fun validateWidgetType(widgetType: String) {
+    if (widgetType !in dashboardWidgetTypeSet) {
+        throw IllegalArgumentException("Unknown widget_type: $widgetType")
+    }
+}
+
+private fun JsonObject.optionalQueryConfigs(): List<QueryDsl>? {
+    if (!containsKey("query_configs")) return null
+    val value = this["query_configs"] as? JsonArray
+        ?: throw IllegalArgumentException("query_configs must be an array")
+    return decodeArg("query_configs") {
+        dashboardWidgetJson.decodeFromJsonElement(queryDslListSerializer, value)
+    }
+}
+
+private fun JsonObject.optionalDisplayConfig(): Map<String, String>? {
+    if (!containsKey("display_config")) return null
+    val value = this["display_config"] as? JsonObject
+        ?: throw IllegalArgumentException("display_config must be an object")
+    return decodeArg("display_config") {
+        dashboardWidgetJson.decodeFromJsonElement(displayConfigSerializer, value)
+    }
+}
+
+private fun JsonObject.optionalVariables(): Map<String, String> {
+    if (!containsKey("variables")) return emptyMap()
+    val value = this["variables"] as? JsonObject
+        ?: throw IllegalArgumentException("variables must be an object")
+    return value.mapValues { (name, entry) ->
+        val primitive = entry as? JsonPrimitive
+            ?: throw IllegalArgumentException("variables.$name must be a string")
+        primitive.content
+    }
+}
+
+private fun JsonObject.optionalTimeRange(): TimeRangeDef? {
+    if (!containsKey("time_range")) return null
+    val value = this["time_range"] as? JsonObject
+        ?: throw IllegalArgumentException("time_range must be an object")
+    return decodeArg("time_range") {
+        dashboardWidgetJson.decodeFromJsonElement(TimeRangeDef.serializer(), value)
+    }
+}
+
+private fun JsonObject.requiredQueryConfig(): QueryDsl {
+    val value = this["query_config"] as? JsonObject
+        ?: throw IllegalArgumentException("query_config must be an object")
+    return decodeArg("query_config") {
+        dashboardWidgetJson.decodeFromJsonElement(QueryDsl.serializer(), value)
+    }
+}
+
+private fun JsonObject.requiredReplacementWidgets(): List<UpdateWidgetRequest> {
+    val value = this["widgets"] as? JsonArray
+        ?: throw IllegalArgumentException("widgets must be an array")
+    val widgets = decodeArg("widgets") {
+        dashboardWidgetJson.decodeFromJsonElement(updateWidgetListSerializer, value)
+    }
+    widgets.mapNotNull { it.widgetType }.forEach(::validateWidgetType)
+    return widgets
+}
+
+private fun <T> decodeArg(name: String, block: () -> T): T =
+    try {
+        block()
+    } catch (e: SerializationException) {
+        throw IllegalArgumentException("Invalid $name: ${e.message}", e)
+    }
+
+private fun appendBottomY(widgets: List<WidgetData>): Int =
+    widgets.maxOfOrNull { it.gridY + it.gridH } ?: 0
+
+private fun nextSortOrder(widgets: List<WidgetData>): Int =
+    (widgets.maxOfOrNull { it.sortOrder } ?: -1) + 1
+
+private fun toUpdateWidgetRequest(widget: WidgetResponse): UpdateWidgetRequest =
+    UpdateWidgetRequest(
+        id = widget.id,
+        title = widget.title,
+        widgetType = widget.widgetType,
+        gridX = widget.gridX,
+        gridY = widget.gridY,
+        gridW = widget.gridW,
+        gridH = widget.gridH,
+        queryConfigs = widget.queryConfigs,
+        displayConfig = widget.displayConfig,
+        sortOrder = widget.sortOrder
+    )
+
+private fun patchWidget(base: UpdateWidgetRequest, args: JsonObject): UpdateWidgetRequest {
+    val widgetType = args.optionalStringArg("widget_type")?.also(::validateWidgetType)
+    return base.copy(
+        title = if (args.containsKey("title")) args.optionalStringArg("title") else base.title,
+        widgetType = widgetType ?: base.widgetType,
+        gridX = args.optionalIntArg("grid_x") ?: base.gridX,
+        gridY = args.optionalIntArg("grid_y") ?: base.gridY,
+        gridW = args.optionalIntArg("grid_w") ?: base.gridW,
+        gridH = args.optionalIntArg("grid_h") ?: base.gridH,
+        queryConfigs = args.optionalQueryConfigs() ?: base.queryConfigs,
+        displayConfig = args.optionalDisplayConfig() ?: base.displayConfig,
+        sortOrder = args.optionalIntArg("sort_order") ?: base.sortOrder
+    )
+}
+
+private fun hasWidgetUpdateFields(args: JsonObject): Boolean =
+    listOf(
+        "title",
+        "widget_type",
+        "grid_x",
+        "grid_y",
+        "grid_w",
+        "grid_h",
+        "query_configs",
+        "display_config",
+        "sort_order",
+    ).any(args::containsKey)
+
+private fun schemaProperties(vararg pairs: Pair<String, JsonObject>): JsonObject =
+    JsonObject(mapOf(*pairs))
+
+class CreateDashboardWidgetTool : McpTool {
+    override val name = "create_dashboard_widget"
+    override val description = "Create a dashboard widget"
+    override val readOnly = false
+    override val inputSchema = InputSchema(
+        properties = schemaProperties(
+            "dashboard_id" to schemaNumber("Dashboard ID"),
+            "title" to schemaString("Widget title"),
+            "widget_type" to schemaEnum("Widget type", dashboardWidgetTypes),
+            "grid_x" to schemaInteger("Grid x position"),
+            "grid_y" to schemaInteger("Grid y position"),
+            "grid_w" to schemaInteger("Grid width"),
+            "grid_h" to schemaInteger("Grid height"),
+            "query_configs" to schemaArray("QueryDsl array"),
+            "display_config" to schemaObject("Display config"),
+            "sort_order" to schemaInteger("Sort order")
+        ),
+        required = listOf("dashboard_id", "widget_type")
+    )
+
+    override suspend fun execute(
+        args: JsonObject,
+        context: McpContext
+    ): ToolCallResult = try {
+        val dashboardId = args.requiredLongArg("dashboard_id")
+        val widgetType = args.requiredWidgetType()
+        val title = args.optionalStringArg("title")
+        val gridX = args.optionalIntArg("grid_x")
+        val gridY = args.optionalIntArg("grid_y")
+        val gridW = args.optionalIntArg("grid_w")
+        val gridH = args.optionalIntArg("grid_h")
+        val queryConfigs = args.optionalQueryConfigs()
+        val displayConfig = args.optionalDisplayConfig()
+        val orgId = context.organizationId.toLong()
+        dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
+            ?: return errorResult("Dashboard not found: $dashboardId")
+
+        val existingWidgets = dashboardWidgetRepo.listByDashboardId(dashboardId)
+        val sortOrder = args.optionalIntArg("sort_order") ?: nextSortOrder(existingWidgets)
+        val widget = CreateWidgetRequest(
+            title = title,
+            widgetType = widgetType,
+            gridX = gridX ?: DEFAULT_WIDGET_X,
+            gridY = gridY ?: appendBottomY(existingWidgets),
+            gridW = gridW ?: DEFAULT_WIDGET_WIDTH,
+            gridH = gridH ?: DEFAULT_WIDGET_HEIGHT,
+            queryConfigs = queryConfigs ?: emptyList(),
+            displayConfig = displayConfig ?: emptyMap(),
+            sortOrder = sortOrder
+        )
+        dashboardWidgetRepo.insert(dashboardId, widget, sortOrder, Clock.System.now())
+        val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
+            ?: return errorResult("Dashboard not found: $dashboardId")
+        jsonResult(dashboard)
+    } catch (e: IllegalArgumentException) {
+        errorResult(e.message ?: "Invalid dashboard widget request")
+    }
+}
+
+class UpdateDashboardWidgetTool : McpTool {
+    override val name = "update_dashboard_widget"
+    override val description = "Update a dashboard widget"
+    override val readOnly = false
+    override val inputSchema = InputSchema(
+        properties = schemaProperties(
+            "dashboard_id" to schemaNumber("Dashboard ID"),
+            "widget_id" to schemaNumber("Widget ID"),
+            "title" to schemaString("Widget title"),
+            "widget_type" to schemaEnum("Widget type", dashboardWidgetTypes),
+            "grid_x" to schemaInteger("Grid x position"),
+            "grid_y" to schemaInteger("Grid y position"),
+            "grid_w" to schemaInteger("Grid width"),
+            "grid_h" to schemaInteger("Grid height"),
+            "query_configs" to schemaArray("QueryDsl array"),
+            "display_config" to schemaObject("Display config"),
+            "sort_order" to schemaInteger("Sort order")
+        ),
+        required = listOf("dashboard_id", "widget_id")
+    )
+
+    override suspend fun execute(
+        args: JsonObject,
+        context: McpContext
+    ): ToolCallResult = try {
+        val dashboardId = args.requiredLongArg("dashboard_id")
+        val widgetId = args.requiredLongArg("widget_id")
+        if (!hasWidgetUpdateFields(args)) {
+            return errorResult("At least one widget field must be provided to update")
+        }
+        val orgId = context.organizationId.toLong()
+        val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
+            ?: return errorResult("Dashboard not found: $dashboardId")
+        if (dashboard.widgets.none { it.id == widgetId }) {
+            return errorResult("Widget not found on dashboard: $widgetId")
+        }
+
+        val widgets = dashboard.widgets.map { widget ->
+            val request = toUpdateWidgetRequest(widget)
+            if (widget.id == widgetId) patchWidget(request, args) else request
+        }
+        val updated = dashboardWidgetCrudService.updateDashboard(
+            id = dashboardId,
+            orgId = orgId,
+            request = UpdateDashboardRequest(widgets = widgets)
+        ) ?: return errorResult("Dashboard not found: $dashboardId")
+        jsonResult(updated)
+    } catch (e: IllegalArgumentException) {
+        errorResult(e.message ?: "Invalid dashboard widget request")
+    }
+}
+
+class DeleteDashboardWidgetTool : McpTool {
+    override val name = "delete_dashboard_widget"
+    override val description = "Delete a dashboard widget"
+    override val readOnly = false
+    override val inputSchema = InputSchema(
+        properties = schemaProperties(
+            "dashboard_id" to schemaNumber("Dashboard ID"),
+            "widget_id" to schemaNumber("Widget ID")
+        ),
+        required = listOf("dashboard_id", "widget_id")
+    )
+
+    override suspend fun execute(
+        args: JsonObject,
+        context: McpContext
+    ): ToolCallResult = try {
+        val dashboardId = args.requiredLongArg("dashboard_id")
+        val widgetId = args.requiredLongArg("widget_id")
+        val orgId = context.organizationId.toLong()
+        val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
+            ?: return errorResult("Dashboard not found: $dashboardId")
+        if (dashboard.widgets.none { it.id == widgetId }) {
+            return errorResult("Widget not found on dashboard: $widgetId")
+        }
+        if (!dashboardWidgetRepo.deleteById(dashboardId, widgetId)) {
+            return errorResult("Widget not found on dashboard: $widgetId")
+        }
+        val updated = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
+            ?: return errorResult("Dashboard not found: $dashboardId")
+        jsonResult(updated)
+    } catch (e: IllegalArgumentException) {
+        errorResult(e.message ?: "Invalid dashboard widget request")
+    }
+}
+
+class PreviewDashboardWidgetQueryTool : McpTool {
+    override val name = "preview_dashboard_widget_query"
+    override val description = "Preview a dashboard widget query using dashboard resolution rules"
+    override val inputSchema = InputSchema(
+        properties = schemaProperties(
+            "dashboard_id" to schemaNumber("Dashboard ID"),
+            "query_config" to schemaObject("QueryDsl config"),
+            "project_id" to schemaNumber("Project ID"),
+            "variables" to schemaObject("Variable values"),
+            "time_range" to schemaObject("Time range override")
+        ),
+        required = listOf("dashboard_id", "query_config")
+    )
+
+    override suspend fun execute(
+        args: JsonObject,
+        context: McpContext
+    ): ToolCallResult = try {
+        val dashboardId = args.requiredLongArg("dashboard_id")
+        val queryConfig = args.requiredQueryConfig()
+        val timeRange = args.optionalTimeRange()
+        val variables = args.optionalVariables()
+        val requestedProjectId = args.longArg("project_id")
+        val orgId = context.organizationId.toLong()
+        val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
+            ?: return errorResult("Dashboard not found: $dashboardId")
+        if (dashboard.projectId != null && requestedProjectId != null && dashboard.projectId != requestedProjectId) {
+            return errorResult("Dashboard is scoped to project ${dashboard.projectId}")
+        }
+        val projectId = dashboard.projectId ?: requestedProjectId
+            ?: return errorResult("project_id is required when dashboard is not scoped to a project")
+
+        val withTimeRange = timeRange?.let { queryConfig.copy(timeRange = it) } ?: queryConfig
+        val effectiveQuery = dashboardWidgetQueryEngine.resolvePrometheusDataSource(
+            dashboardWidgetQueryEngine.applyVariables(withTimeRange, variables),
+            orgId,
+            dashboardWidgetDataSourceService
+        )
+        val results = executePreviewQuery(effectiveQuery, orgId, projectId)
+        jsonResult(results)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: IllegalArgumentException) {
+        errorResult(e.message ?: "Invalid dashboard query request")
+    }
+
+    private suspend fun executePreviewQuery(
+        effectiveQuery: QueryDsl,
+        orgId: Long,
+        projectId: Long,
+    ): List<Map<String, JsonElement>> {
+        if (!dashboardWidgetQueryEngine.isCustomDataSource(effectiveQuery.dataSource)) {
+            val retentionDays = dashboardWidgetRetentionPolicyService.getRetentionDaysForProject(projectId)
+                ?: DASHBOARD_WIDGET_DEFAULT_RETENTION_DAYS
+            return dashboardWidgetQueryEngine.executeQuery(
+                dsl = effectiveQuery,
+                projectId = projectId,
+                retentionDays = retentionDays
+            )
+        }
+
+        val sourceId = dashboardWidgetQueryEngine.parseCustomDataSourceId(effectiveQuery.dataSource)
+            ?: throw IllegalArgumentException("Invalid custom data source ID")
+        val source = dashboardWidgetDataSourceService.getDataSource(sourceId, orgId)
+            ?: throw IllegalArgumentException("Data source not found")
+        val credentials = dashboardWidgetDataSourceService.getDecryptedCredentials(sourceId, orgId)
+            ?: throw IllegalArgumentException("Failed to decrypt credentials")
+        val sourceType = CustomDataSourceType.fromString(source.sourceType)
+            ?: throw IllegalArgumentException("Unknown source type")
+        val rawQuery = effectiveQuery.rawQuery
+            ?: throw IllegalArgumentException("Custom data source queries require a rawQuery")
+        return dashboardWidgetDataSourceExecutor.executeQuery(
+            sourceId = sourceId,
+            sourceType = sourceType,
+            host = source.host,
+            port = source.port,
+            databaseName = source.databaseName,
+            credentials = credentials,
+            query = rawQuery,
+            limit = effectiveQuery.limit,
+            timeRange = effectiveQuery.timeRange
+        )
+    }
+}
+
+class ReplaceDashboardWidgetsTool : McpTool {
+    override val name = "replace_dashboard_widgets"
+    override val description = "Replace all widgets on a dashboard with an expected-count safety check"
+    override val readOnly = false
+    override val inputSchema = InputSchema(
+        properties = schemaProperties(
+            "dashboard_id" to schemaNumber("Dashboard ID"),
+            "widgets" to schemaArray("Replacement dashboard widget objects"),
+            "expected_widget_count" to schemaInteger("Current widget count expected by caller")
+        ),
+        required = listOf("dashboard_id", "widgets", "expected_widget_count")
+    )
+
+    override suspend fun execute(
+        args: JsonObject,
+        context: McpContext
+    ): ToolCallResult = try {
+        val dashboardId = args.requiredLongArg("dashboard_id")
+        val expectedWidgetCount = args.requiredIntArg("expected_widget_count")
+        val orgId = context.organizationId.toLong()
+        val dashboard = dashboardWidgetCrudService.getDashboard(dashboardId, orgId, context.userId)
+            ?: return errorResult("Dashboard not found: $dashboardId")
+        val currentCount = dashboard.widgets.size
+        if (currentCount != expectedWidgetCount) {
+            return errorResult(
+                "Dashboard has $currentCount widgets but expected_widget_count is $expectedWidgetCount. " +
+                    "Read the dashboard first to get current state."
+            )
+        }
+        val replacementWidgets = args.requiredReplacementWidgets()
+        val updated = dashboardWidgetCrudService.updateDashboard(
+            id = dashboardId,
+            orgId = orgId,
+            request = UpdateDashboardRequest(widgets = replacementWidgets)
+        ) ?: return errorResult("Dashboard not found: $dashboardId")
+        jsonResult(updated)
+    } catch (e: IllegalArgumentException) {
+        errorResult(e.message ?: "Invalid dashboard widget request")
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
@@ -142,6 +142,7 @@ private fun JsonObject.optionalStringArg(name: String): String? {
     if (!containsKey(name)) return null
     val value = this[name] as? JsonPrimitive
         ?: throw IllegalArgumentException("$name must be a string")
+    if (!value.isString) throw IllegalArgumentException("$name must be a string")
     return value.content
 }
 
@@ -181,6 +182,7 @@ private fun JsonObject.optionalVariables(): Map<String, String> {
     return value.mapValues { (name, entry) ->
         val primitive = entry as? JsonPrimitive
             ?: throw IllegalArgumentException("variables.$name must be a string")
+        if (!primitive.isString) throw IllegalArgumentException("variables.$name must be a string")
         primitive.content
     }
 }

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
@@ -142,7 +142,7 @@ private fun JsonObject.optionalStringArg(name: String): String? {
     if (!containsKey(name)) return null
     val value = this[name] as? JsonPrimitive
         ?: throw IllegalArgumentException("$name must be a string")
-    if (!value.isString) throw IllegalArgumentException("$name must be a string")
+    require(value.isString) { "$name must be a string" }
     return value.content
 }
 
@@ -182,7 +182,7 @@ private fun JsonObject.optionalVariables(): Map<String, String> {
     return value.mapValues { (name, entry) ->
         val primitive = entry as? JsonPrimitive
             ?: throw IllegalArgumentException("variables.$name must be a string")
-        if (!primitive.isString) throw IllegalArgumentException("variables.$name must be a string")
+        require(primitive.isString) { "variables.$name must be a string" }
         primitive.content
     }
 }

--- a/backend/src/test/kotlin/com/moneat/mcp/protocol/McpToolRegistryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/protocol/McpToolRegistryTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-private const val EXPECTED_CORE_MCP_TOOL_COUNT = 83
+private const val EXPECTED_CORE_MCP_TOOL_COUNT = 88
 
 class McpToolRegistryTest {
 
@@ -334,8 +334,12 @@ class McpToolRegistryTest {
             "pause_uptime_monitor",
             "resume_uptime_monitor",
             "create_dashboard",
+            "create_dashboard_widget",
             "update_dashboard",
+            "update_dashboard_widget",
             "delete_dashboard",
+            "delete_dashboard_widget",
+            "replace_dashboard_widgets",
             "import_dashboard",
             "execute_dashboard_query",
             "create_dashboard_alert",

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
@@ -21,6 +21,7 @@ import com.moneat.dashboards.models.DashboardResponse
 import com.moneat.dashboards.models.DashboardWidgetAlerts
 import com.moneat.dashboards.models.DashboardWidgets
 import com.moneat.mcp.models.McpContext
+import com.moneat.mcp.protocol.McpTool
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -69,6 +70,7 @@ class DashboardCrudToolTest {
             exec("DROP TABLE IF EXISTS dashboard_widget_alerts")
             exec("DROP TABLE IF EXISTS dashboard_widgets")
             exec("DROP TABLE IF EXISTS dashboard_favorites")
+            exec("DROP TABLE IF EXISTS custom_data_sources")
             exec("DROP TABLE IF EXISTS dashboards")
             patchJsonbForH2(DashboardWidgets, DashboardWidgetAlerts)
             exec(
@@ -96,6 +98,26 @@ class DashboardCrudToolTest {
                     dashboard_id BIGINT NOT NULL,
                     created_at TIMESTAMP NOT NULL,
                     PRIMARY KEY (user_id, dashboard_id)
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE custom_data_sources (
+                    id BIGSERIAL PRIMARY KEY,
+                    org_id BIGINT NOT NULL,
+                    name VARCHAR(255) NOT NULL,
+                    description TEXT,
+                    source_type VARCHAR(50) NOT NULL,
+                    host VARCHAR(512) NOT NULL,
+                    port INT,
+                    database_name VARCHAR(255),
+                    encrypted_credentials TEXT NOT NULL,
+                    extra_config TEXT NOT NULL,
+                    enabled BOOLEAN DEFAULT TRUE NOT NULL,
+                    created_by BIGINT NOT NULL,
+                    created_at TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP NOT NULL
                 )
                 """.trimIndent()
             )
@@ -478,15 +500,346 @@ class DashboardCrudToolTest {
         )
     }
 
+    @Test
+    fun `replace dashboard widgets swaps all widgets when expected count matches`() = runBlocking {
+        val dashboardId = seedDashboard()
+        seedWidget(dashboardId, title = "CPU")
+
+        val result = ReplaceDashboardWidgetsTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "expected_widget_count" to JsonPrimitive(1),
+                    "widgets" to JsonArray(
+                        listOf(
+                            JsonObject(
+                                mapOf(
+                                    "title" to JsonPrimitive("Requests"),
+                                    "widget_type" to JsonPrimitive("bar"),
+                                    "grid_x" to JsonPrimitive(1),
+                                    "grid_y" to JsonPrimitive(2),
+                                    "grid_w" to JsonPrimitive(8),
+                                    "grid_h" to JsonPrimitive(3),
+                                    "query_configs" to JsonArray(listOf(queryDslJson("logs"))),
+                                    "display_config" to JsonObject(mapOf("unit" to JsonPrimitive("count"))),
+                                    "sort_order" to JsonPrimitive(7),
+                                )
+                            )
+                        )
+                    ),
+                )
+            ),
+            context
+        )
+
+        val dashboard = decodeDashboard(result.content.first().text!!)
+        val replacement = dashboard.widgets.single()
+        assertFalse(result.isError)
+        assertEquals("Requests", replacement.title)
+        assertEquals("bar", replacement.widgetType)
+        assertEquals(2, replacement.gridY)
+        assertEquals(8, replacement.gridW)
+        assertEquals(7, replacement.sortOrder)
+        assertEquals("logs", replacement.queryConfigs.single().dataSource)
+        assertEquals("count", replacement.displayConfig["unit"])
+    }
+
+    @Test
+    fun `preview dashboard widget query rejects mismatched project scope`() = runBlocking {
+        val dashboardId = seedDashboard()
+
+        val result = PreviewDashboardWidgetQueryTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "project_id" to JsonPrimitive(PROJECT_ID + 1),
+                    "query_config" to queryDslJson("metrics"),
+                )
+            ),
+            context
+        )
+
+        assertTrue(result.isError)
+        assertEquals("Dashboard is scoped to project $PROJECT_ID", result.content.first().text)
+    }
+
+    @Test
+    fun `preview dashboard widget query requires project id for unscoped dashboards`() = runBlocking {
+        val dashboardId = seedDashboard(projectId = null)
+
+        val result = PreviewDashboardWidgetQueryTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "query_config" to queryDslJson("metrics"),
+                )
+            ),
+            context
+        )
+
+        assertTrue(result.isError)
+        assertEquals("project_id is required when dashboard is not scoped to a project", result.content.first().text)
+    }
+
+    @Test
+    fun `preview dashboard widget query validates custom data source id after substitutions`() = runBlocking {
+        val dashboardId = seedDashboard()
+
+        val result = PreviewDashboardWidgetQueryTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "query_config" to queryDslJson("custom:bad", rawQuery = "up{service=\"\$service\"}"),
+                    "variables" to JsonObject(mapOf("service" to JsonPrimitive("api"))),
+                    "time_range" to JsonObject(
+                        mapOf(
+                            "from" to JsonPrimitive("now-1h"),
+                            "to" to JsonPrimitive("now"),
+                        )
+                    ),
+                )
+            ),
+            context
+        )
+
+        assertTrue(result.isError)
+        assertEquals("Invalid custom data source ID", result.content.first().text)
+    }
+
+    @Test
+    fun `preview dashboard widget query reports missing custom data source`() = runBlocking {
+        val dashboardId = seedDashboard()
+
+        val result = PreviewDashboardWidgetQueryTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "query_config" to queryDslJson("custom:123", rawQuery = "up"),
+                )
+            ),
+            context
+        )
+
+        assertTrue(result.isError)
+        assertEquals("Data source not found", result.content.first().text)
+    }
+
+    @Test
+    fun `preview dashboard widget query resolves prometheus alias`() = runBlocking {
+        val dashboardId = seedDashboard()
+        seedCustomDataSource(sourceType = "prometheus")
+
+        val result = PreviewDashboardWidgetQueryTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "query_config" to queryDslJson("__prometheus", rawQuery = "up"),
+                )
+            ),
+            context
+        )
+
+        assertTrue(result.isError)
+        assertEquals("Failed to decrypt credentials", result.content.first().text)
+    }
+
+    @Test
+    fun `preview dashboard widget query skips built in raw query execution`() = runBlocking {
+        val dashboardId = seedDashboard()
+
+        val result = PreviewDashboardWidgetQueryTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "query_config" to queryDslJson("metrics", rawQuery = "SELECT 1"),
+                )
+            ),
+            context
+        )
+
+        assertFalse(result.isError)
+        assertEquals("[]", result.content.first().text)
+    }
+
+    @Test
+    fun `dashboard widget tools report missing dashboards and widgets`() = runBlocking {
+        val dashboardId = seedDashboard()
+
+        assertToolError(
+            UpdateDashboardWidgetTool(),
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "widget_id" to JsonPrimitive(WIDGET_ID),
+                    "title" to JsonPrimitive("CPU"),
+                )
+            ),
+            "Widget not found on dashboard: $WIDGET_ID"
+        )
+        assertToolError(
+            DeleteDashboardWidgetTool(),
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "widget_id" to JsonPrimitive(WIDGET_ID),
+                )
+            ),
+            "Widget not found on dashboard: $WIDGET_ID"
+        )
+        assertToolError(
+            ReplaceDashboardWidgetsTool(),
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(DASHBOARD_ID + 1),
+                    "expected_widget_count" to JsonPrimitive(0),
+                    "widgets" to JsonArray(emptyList()),
+                )
+            ),
+            "Dashboard not found: ${DASHBOARD_ID + 1}"
+        )
+        assertToolError(
+            PreviewDashboardWidgetQueryTool(),
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(DASHBOARD_ID + 1),
+                    "query_config" to queryDslJson("metrics"),
+                )
+            ),
+            "Dashboard not found: ${DASHBOARD_ID + 1}"
+        )
+    }
+
+    @Test
+    fun `dashboard widget tools reject malformed argument types`() = runBlocking {
+        val dashboardId = seedDashboard()
+        seedWidget(dashboardId)
+
+        val baseCreateArgs = mapOf(
+            "dashboard_id" to JsonPrimitive(dashboardId),
+            "widget_type" to JsonPrimitive("stat"),
+        )
+
+        val cases = listOf(
+            ToolCase(
+                CreateDashboardWidgetTool(),
+                JsonObject(baseCreateArgs + ("grid_x" to JsonObject(emptyMap()))),
+                "grid_x must be a valid integer",
+            ),
+            ToolCase(
+                CreateDashboardWidgetTool(),
+                JsonObject(baseCreateArgs + ("title" to JsonObject(emptyMap()))),
+                "title must be a string",
+            ),
+            ToolCase(
+                CreateDashboardWidgetTool(),
+                JsonObject(baseCreateArgs + ("query_configs" to JsonObject(emptyMap()))),
+                "query_configs must be an array",
+            ),
+            ToolCase(
+                CreateDashboardWidgetTool(),
+                JsonObject(baseCreateArgs + ("display_config" to JsonArray(emptyList()))),
+                "display_config must be an object",
+            ),
+            ToolCase(
+                PreviewDashboardWidgetQueryTool(),
+                JsonObject(
+                    mapOf(
+                        "dashboard_id" to JsonPrimitive(dashboardId),
+                        "query_config" to JsonObject(emptyMap()),
+                    )
+                ),
+                "Invalid query_config:",
+            ),
+            ToolCase(
+                PreviewDashboardWidgetQueryTool(),
+                JsonObject(
+                    mapOf(
+                        "dashboard_id" to JsonPrimitive(dashboardId),
+                        "query_config" to queryDslJson("metrics"),
+                        "variables" to JsonArray(emptyList()),
+                    )
+                ),
+                "variables must be an object",
+            ),
+            ToolCase(
+                PreviewDashboardWidgetQueryTool(),
+                JsonObject(
+                    mapOf(
+                        "dashboard_id" to JsonPrimitive(dashboardId),
+                        "query_config" to queryDslJson("metrics"),
+                        "variables" to JsonObject(mapOf("service" to JsonObject(emptyMap()))),
+                    )
+                ),
+                "variables.service must be a string",
+            ),
+            ToolCase(
+                PreviewDashboardWidgetQueryTool(),
+                JsonObject(
+                    mapOf(
+                        "dashboard_id" to JsonPrimitive(dashboardId),
+                        "query_config" to queryDslJson("metrics"),
+                        "time_range" to JsonArray(emptyList()),
+                    )
+                ),
+                "time_range must be an object",
+            ),
+            ToolCase(
+                ReplaceDashboardWidgetsTool(),
+                JsonObject(
+                    mapOf(
+                        "dashboard_id" to JsonPrimitive(dashboardId),
+                        "expected_widget_count" to JsonPrimitive(1),
+                        "widgets" to JsonObject(emptyMap()),
+                    )
+                ),
+                "widgets must be an array",
+            ),
+            ToolCase(
+                ReplaceDashboardWidgetsTool(),
+                JsonObject(
+                    mapOf(
+                        "dashboard_id" to JsonPrimitive(dashboardId),
+                        "expected_widget_count" to JsonPrimitive(1),
+                        "widgets" to JsonArray(
+                            listOf(JsonObject(mapOf("widget_type" to JsonPrimitive("bad"))))
+                        ),
+                    )
+                ),
+                "Unknown widget_type: bad",
+            ),
+        )
+
+        cases.forEach { case ->
+            assertToolError(case.tool, case.args, case.expectedMessage)
+        }
+    }
+
     // ──── Helpers ────
 
-    private fun seedDashboard(): Long = transaction {
+    private data class ToolCase(
+        val tool: McpTool,
+        val args: JsonObject,
+        val expectedMessage: String,
+    )
+
+    private suspend fun assertToolError(tool: McpTool, args: JsonObject, expectedMessage: String) {
+        val result = tool.execute(args, context)
+
+        assertTrue(result.isError)
+        assertTrue(
+            result.content.first().text!!.startsWith(expectedMessage),
+            "Expected '${result.content.first().text}' to start with '$expectedMessage'",
+        )
+    }
+
+    private fun seedDashboard(projectId: Long? = PROJECT_ID): Long = transaction {
+        val projectValue = projectId?.toString() ?: "NULL"
         exec(
             """
             INSERT INTO dashboards (
                 id, org_id, project_id, title, created_by, created_at, updated_at
             ) VALUES (
-                $DASHBOARD_ID, $ORG_ID, $PROJECT_ID, 'MCP Test Dashboard',
+                $DASHBOARD_ID, $ORG_ID, $projectValue, 'MCP Test Dashboard',
                 $CREATED_BY, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
             )
             """.trimIndent()
@@ -518,14 +871,37 @@ class DashboardCrudToolTest {
         widgetId
     }
 
+    private fun seedCustomDataSource(
+        sourceId: Long = DATA_SOURCE_ID,
+        sourceType: String,
+    ): Long = transaction {
+        exec(
+            """
+            INSERT INTO custom_data_sources (
+                id, org_id, name, source_type, host, encrypted_credentials, extra_config,
+                enabled, created_by, created_at, updated_at
+            ) VALUES (
+                $sourceId, $ORG_ID, 'Prometheus', '$sourceType', 'prometheus.local',
+                'not-encrypted', '{}', TRUE, $CREATED_BY, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            """.trimIndent()
+        )
+        sourceId
+    }
+
     private fun decodeAlert(text: String): DashboardAlertResponse =
         json.decodeFromString<DashboardAlertResponse>(text)
 
     private fun decodeDashboard(text: String): DashboardResponse =
         json.decodeFromString<DashboardResponse>(text)
 
-    private fun queryDslJson(dataSource: String): JsonObject =
-        JsonObject(mapOf("dataSource" to JsonPrimitive(dataSource)))
+    private fun queryDslJson(dataSource: String, rawQuery: String? = null): JsonObject {
+        val fields = mutableMapOf<String, JsonElement>("dataSource" to JsonPrimitive(dataSource))
+        if (rawQuery != null) {
+            fields["rawQuery"] = JsonPrimitive(rawQuery)
+        }
+        return JsonObject(fields)
+    }
 
     private fun enumValues(properties: JsonObject, property: String): List<String> {
         val values = properties[property]!!.jsonObject["enum"] as JsonArray
@@ -562,6 +938,7 @@ class DashboardCrudToolTest {
         private const val PROJECT_ID = 200L
         private const val DASHBOARD_ID = 10L
         private const val WIDGET_ID = 20L
+        private const val DATA_SOURCE_ID = 30L
         private const val DASHBOARD_JSONB_TYPE = "com.moneat.dashboards.models.JsonbColumnType"
     }
 }

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
@@ -17,6 +17,7 @@
 package com.moneat.mcp.tools
 
 import com.moneat.dashboards.models.DashboardAlertResponse
+import com.moneat.dashboards.models.DashboardResponse
 import com.moneat.dashboards.models.DashboardWidgetAlerts
 import com.moneat.dashboards.models.DashboardWidgets
 import com.moneat.mcp.models.McpContext
@@ -67,6 +68,7 @@ class DashboardCrudToolTest {
         transaction {
             exec("DROP TABLE IF EXISTS dashboard_widget_alerts")
             exec("DROP TABLE IF EXISTS dashboard_widgets")
+            exec("DROP TABLE IF EXISTS dashboard_favorites")
             exec("DROP TABLE IF EXISTS dashboards")
             patchJsonbForH2(DashboardWidgets, DashboardWidgetAlerts)
             exec(
@@ -84,6 +86,16 @@ class DashboardCrudToolTest {
                     created_by BIGINT NOT NULL,
                     created_at TIMESTAMP NOT NULL,
                     updated_at TIMESTAMP NOT NULL
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE dashboard_favorites (
+                    user_id INT NOT NULL,
+                    dashboard_id BIGINT NOT NULL,
+                    created_at TIMESTAMP NOT NULL,
+                    PRIMARY KEY (user_id, dashboard_id)
                 )
                 """.trimIndent()
             )
@@ -360,6 +372,112 @@ class DashboardCrudToolTest {
         }
     }
 
+    @Test
+    fun `create dashboard widget appends below existing widgets`() = runBlocking {
+        val dashboardId = seedDashboard()
+        seedWidget(dashboardId)
+
+        val result = CreateDashboardWidgetTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "title" to JsonPrimitive("Memory"),
+                    "widget_type" to JsonPrimitive("stat"),
+                    "query_configs" to JsonArray(listOf(queryDslJson("metrics"))),
+                    "display_config" to JsonObject(mapOf("unit" to JsonPrimitive("bytes"))),
+                )
+            ),
+            context
+        )
+
+        val dashboard = decodeDashboard(result.content.first().text!!)
+        val created = dashboard.widgets.single { it.title == "Memory" }
+        assertFalse(result.isError)
+        assertEquals(2, dashboard.widgets.size)
+        assertEquals("stat", created.widgetType)
+        assertEquals(4, created.gridY)
+        assertEquals("bytes", created.displayConfig["unit"])
+        assertEquals("metrics", created.queryConfigs.single().dataSource)
+    }
+
+    @Test
+    fun `update dashboard widget patches target and preserves sibling widgets`() = runBlocking {
+        val dashboardId = seedDashboard()
+        val firstWidgetId = seedWidget(dashboardId, title = "CPU")
+        val secondWidgetId = seedWidget(dashboardId, widgetId = WIDGET_ID + 1, title = "Latency", sortOrder = 1)
+
+        val result = UpdateDashboardWidgetTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "widget_id" to JsonPrimitive(firstWidgetId),
+                    "title" to JsonPrimitive("CPU load"),
+                    "widget_type" to JsonPrimitive("gauge"),
+                    "grid_w" to JsonPrimitive(3),
+                    "query_configs" to JsonArray(listOf(queryDslJson("spans"))),
+                )
+            ),
+            context
+        )
+
+        val dashboard = decodeDashboard(result.content.first().text!!)
+        val updated = dashboard.widgets.single { it.id == firstWidgetId }
+        val untouched = dashboard.widgets.single { it.id == secondWidgetId }
+        assertFalse(result.isError)
+        assertEquals("CPU load", updated.title)
+        assertEquals("gauge", updated.widgetType)
+        assertEquals(3, updated.gridW)
+        assertEquals("spans", updated.queryConfigs.single().dataSource)
+        assertEquals("Latency", untouched.title)
+        assertEquals("timeseries", untouched.widgetType)
+    }
+
+    @Test
+    fun `delete dashboard widget removes only the target widget`() = runBlocking {
+        val dashboardId = seedDashboard()
+        val firstWidgetId = seedWidget(dashboardId, title = "CPU")
+        val secondWidgetId = seedWidget(dashboardId, widgetId = WIDGET_ID + 1, title = "Latency", sortOrder = 1)
+
+        val result = DeleteDashboardWidgetTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "widget_id" to JsonPrimitive(firstWidgetId),
+                )
+            ),
+            context
+        )
+
+        val dashboard = decodeDashboard(result.content.first().text!!)
+        assertFalse(result.isError)
+        assertEquals(listOf(secondWidgetId), dashboard.widgets.map { it.id })
+        assertEquals("Latency", dashboard.widgets.single().title)
+    }
+
+    @Test
+    fun `replace dashboard widgets rejects stale expected widget count`() = runBlocking {
+        val dashboardId = seedDashboard()
+        seedWidget(dashboardId)
+
+        val result = ReplaceDashboardWidgetsTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "expected_widget_count" to JsonPrimitive(2),
+                    "widgets" to JsonArray(emptyList()),
+                )
+            ),
+            context
+        )
+
+        assertTrue(result.isError)
+        assertEquals(
+            "Dashboard has 1 widgets but expected_widget_count is 2. " +
+                "Read the dashboard first to get current state.",
+            result.content.first().text,
+        )
+    }
+
     // ──── Helpers ────
 
     private fun seedDashboard(): Long = transaction {
@@ -376,23 +494,38 @@ class DashboardCrudToolTest {
         DASHBOARD_ID
     }
 
-    private fun seedWidget(dashboardId: Long): Long = transaction {
+    private fun seedWidget(
+        dashboardId: Long,
+        widgetId: Long = WIDGET_ID,
+        title: String = "Test Widget",
+        widgetType: String = "timeseries",
+        gridY: Int = 0,
+        gridH: Int = 4,
+        sortOrder: Int = 0,
+    ): Long = transaction {
         exec(
             """
             INSERT INTO dashboard_widgets (
                 id, dashboard_id, title, widget_type, query_config, query_configs, display_config,
-                created_at, updated_at
+                grid_y, grid_h, sort_order, created_at, updated_at
             ) VALUES (
-                $WIDGET_ID, $dashboardId, 'Test Widget', 'timeseries', '{}', '[]', '{}',
+                $widgetId, $dashboardId, '$title', '$widgetType', '{}', '[]', '{}',
+                $gridY, $gridH, $sortOrder,
                 CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
             )
             """.trimIndent()
         )
-        WIDGET_ID
+        widgetId
     }
 
     private fun decodeAlert(text: String): DashboardAlertResponse =
         json.decodeFromString<DashboardAlertResponse>(text)
+
+    private fun decodeDashboard(text: String): DashboardResponse =
+        json.decodeFromString<DashboardResponse>(text)
+
+    private fun queryDslJson(dataSource: String): JsonObject =
+        JsonObject(mapOf("dataSource" to JsonPrimitive(dataSource)))
 
     private fun enumValues(properties: JsonObject, property: String): List<String> {
         val values = properties[property]!!.jsonObject["enum"] as JsonArray

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
@@ -644,6 +644,25 @@ class DashboardCrudToolTest {
     }
 
     @Test
+    fun `preview dashboard widget query ignores disabled prometheus alias target`() = runBlocking {
+        val dashboardId = seedDashboard()
+        seedCustomDataSource(sourceType = "prometheus", enabled = false)
+
+        val result = PreviewDashboardWidgetQueryTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardId),
+                    "query_config" to queryDslJson("__prometheus", rawQuery = "up"),
+                )
+            ),
+            context
+        )
+
+        assertFalse(result.isError)
+        assertEquals("[]", result.content.first().text)
+    }
+
+    @Test
     fun `preview dashboard widget query skips built in raw query execution`() = runBlocking {
         val dashboardId = seedDashboard()
 
@@ -732,6 +751,11 @@ class DashboardCrudToolTest {
             ),
             ToolCase(
                 CreateDashboardWidgetTool(),
+                JsonObject(baseCreateArgs + ("title" to JsonPrimitive(123))),
+                "title must be a string",
+            ),
+            ToolCase(
+                CreateDashboardWidgetTool(),
                 JsonObject(baseCreateArgs + ("query_configs" to JsonObject(emptyMap()))),
                 "query_configs must be an array",
             ),
@@ -768,6 +792,17 @@ class DashboardCrudToolTest {
                         "dashboard_id" to JsonPrimitive(dashboardId),
                         "query_config" to queryDslJson("metrics"),
                         "variables" to JsonObject(mapOf("service" to JsonObject(emptyMap()))),
+                    )
+                ),
+                "variables.service must be a string",
+            ),
+            ToolCase(
+                PreviewDashboardWidgetQueryTool(),
+                JsonObject(
+                    mapOf(
+                        "dashboard_id" to JsonPrimitive(dashboardId),
+                        "query_config" to queryDslJson("metrics"),
+                        "variables" to JsonObject(mapOf("service" to JsonPrimitive(123))),
                     )
                 ),
                 "variables.service must be a string",
@@ -874,7 +909,9 @@ class DashboardCrudToolTest {
     private fun seedCustomDataSource(
         sourceId: Long = DATA_SOURCE_ID,
         sourceType: String,
+        enabled: Boolean = true,
     ): Long = transaction {
+        val enabledValue = if (enabled) "TRUE" else "FALSE"
         exec(
             """
             INSERT INTO custom_data_sources (
@@ -882,7 +919,7 @@ class DashboardCrudToolTest {
                 enabled, created_by, created_at, updated_at
             ) VALUES (
                 $sourceId, $ORG_ID, 'Prometheus', '$sourceType', 'prometheus.local',
-                'not-encrypted', '{}', TRUE, $CREATED_BY, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                'not-encrypted', '{}', $enabledValue, $CREATED_BY, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
             )
             """.trimIndent()
         )

--- a/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -259,6 +259,48 @@ class McpToolValidationTest {
             case("update_dashboard_fields", UpdateDashboardTool(), obj("dashboard_id" to 1), "At least one"),
             case("delete_dashboard_id", DeleteDashboardTool(), obj(), "dashboard_id is required"),
             case(
+                "create_dashboard_widget_type",
+                CreateDashboardWidgetTool(),
+                obj("dashboard_id" to 1),
+                "widget_type is required",
+            ),
+            case(
+                "create_dashboard_widget_unknown_type",
+                CreateDashboardWidgetTool(),
+                obj("dashboard_id" to 1, "widget_type" to "bad"),
+                "Unknown widget_type",
+            ),
+            case(
+                "update_dashboard_widget_id",
+                UpdateDashboardWidgetTool(),
+                obj("dashboard_id" to 1),
+                "widget_id is required",
+            ),
+            case(
+                "update_dashboard_widget_fields",
+                UpdateDashboardWidgetTool(),
+                obj("dashboard_id" to 1, "widget_id" to 2),
+                "At least one widget field",
+            ),
+            case(
+                "delete_dashboard_widget_id",
+                DeleteDashboardWidgetTool(),
+                obj("dashboard_id" to 1),
+                "widget_id is required",
+            ),
+            case(
+                "preview_dashboard_widget_query_config",
+                PreviewDashboardWidgetQueryTool(),
+                obj("dashboard_id" to 1),
+                "query_config must be an object",
+            ),
+            case(
+                "replace_dashboard_widgets_expected",
+                ReplaceDashboardWidgetsTool(),
+                obj("dashboard_id" to 1, "widgets" to emptyList<String>()),
+                "expected_widget_count is required",
+            ),
+            case(
                 "create_dashboard_alert_widget",
                 CreateDashboardAlertTool(),
                 obj("dashboard_id" to 1),

--- a/dashboard/src/docs/pages/mcp-server/tools-reference.md
+++ b/dashboard/src/docs/pages/mcp-server/tools-reference.md
@@ -280,7 +280,7 @@ Create a new dashboard.
 | `description` | string | No | Description |
 
 ### ✏️ `update_dashboard`
-Update a dashboard (title, description, widgets).
+Update a dashboard's title and description.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -294,6 +294,60 @@ Delete a dashboard.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `dashboard_id` | number | Yes | Dashboard ID |
+
+### ✏️ `create_dashboard_widget`
+Create a widget on a dashboard and append it to the bottom of the grid when `grid_y` is omitted.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dashboard_id` | number | Yes | Dashboard ID |
+| `widget_type` | string | Yes | Widget type |
+| `title` | string | No | Widget title |
+| `grid_x`, `grid_y`, `grid_w`, `grid_h` | integer | No | Grid position and size |
+| `query_configs` | array | No | QueryDsl array |
+| `display_config` | object | No | Display config |
+| `sort_order` | integer | No | Sort order |
+
+### ✏️ `update_dashboard_widget`
+Update one widget while preserving the rest of the dashboard.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dashboard_id` | number | Yes | Dashboard ID |
+| `widget_id` | number | Yes | Widget ID |
+| `title`, `widget_type` | string | No | Widget title or type |
+| `grid_x`, `grid_y`, `grid_w`, `grid_h` | integer | No | Grid position and size |
+| `query_configs` | array | No | QueryDsl array |
+| `display_config` | object | No | Display config |
+| `sort_order` | integer | No | Sort order |
+
+### ✏️ `delete_dashboard_widget`
+Delete one widget from a dashboard.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dashboard_id` | number | Yes | Dashboard ID |
+| `widget_id` | number | Yes | Widget ID |
+
+### `preview_dashboard_widget_query`
+Preview a widget query with dashboard variable substitution and datasource resolution.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dashboard_id` | number | Yes | Dashboard ID |
+| `query_config` | object | Yes | QueryDsl config |
+| `project_id` | number | No | Project ID when the dashboard is not project-scoped |
+| `variables` | object | No | Variable values |
+| `time_range` | object | No | Time range override |
+
+### ✏️ `replace_dashboard_widgets`
+Replace every widget on a dashboard after verifying the current widget count.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `dashboard_id` | number | Yes | Dashboard ID |
+| `widgets` | array | Yes | Replacement widget objects |
+| `expected_widget_count` | integer | Yes | Current widget count expected by caller |
 
 ### ✏️ `create_dashboard_alert`
 Create an alert on a dashboard widget.


### PR DESCRIPTION
## Summary
- add MCP tools to create, update, delete, preview, and replace dashboard widgets
- share dashboard query datasource resolution with the UI query path
- update MCP scope registration, tests, and tool reference docs

## Validation
- backend/gradlew compileKotlin :ee:compileKotlin
- backend/gradlew :test --tests com.moneat.mcp.tools.DashboardCrudToolTest --tests com.moneat.mcp.tools.McpToolValidationTest --tests com.moneat.mcp.protocol.McpToolRegistryTest
- backend/gradlew detekt
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard widget management: create, update, delete, replace widgets (single & bulk)
  * Widget query preview to validate queries/config before applying
  * Improved Prometheus datasource resolution for dashboard queries

* **Documentation**
  * Expanded MCP tool reference for all dashboard widget operations; clarified that update_dashboard updates only title and description

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->