### PR TITLE
fix: keep analytics product tab discoverable

### DIFF
--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -18,7 +18,13 @@ import {
   ArrowRight, BarChart3, BookOpen, FileText, Globe, Laptop, LogIn, LogOut, MapPin, Megaphone,
   MousePointerClick, Plus, Share2, Target, Trash2,
 } from 'lucide-react'
-import type {AnalyticsFilter, AnalyticsParams, AnalyticsBreakdownItem, AnalyticsFunnelResponse} from '@/lib/api'
+import type {
+  AnalyticsBreakdownItem,
+  AnalyticsFilter,
+  AnalyticsFunnelResponse,
+  AnalyticsParams,
+  Project,
+} from '@/lib/api'
 
 export const Route = createFileRoute('/analytics/')({
   component: AnalyticsOverview,
@@ -143,7 +149,8 @@ function AnalyticsOverview() {
   })
 
   const hasProductEvents = (productEventsPreview?.length ?? 0) > 0
-  const activeAnalyticsTab = hasProductEvents ? analyticsTab : 'web'
+  const hasWebAnalytics = (overview?.uniqueVisitors ?? 0) > 0 || (overview?.totalPageviews ?? 0) > 0
+  const activeAnalyticsTab = analyticsTab
 
   const addFilterFromRow = (property: string) => (item: AnalyticsBreakdownItem) => {
     if (filters.some(f => f.property === property && f.value === item.name)) return
@@ -158,71 +165,6 @@ function AnalyticsOverview() {
     )
   }
 
-  if (
-    !overviewLoading &&
-    !productPresenceLoading &&
-    !hasProductEvents &&
-    (!overview || (overview.uniqueVisitors === 0 && overview.totalPageviews === 0))
-  ) {
-    let scriptHost = 'https://your-moneat-instance.com'
-    let publicKey = 'your-project-public-key'
-    if (project?.dsn) {
-      try {
-        const url = new URL(project.dsn)
-        scriptHost = `${url.protocol}//${url.host}`
-        publicKey = url.username || publicKey
-      } catch { /* ignore parse errors */ }
-    }
-
-    const scriptCode = `<script
-  defer
-  data-domain="yoursite.com"
-  data-key="${publicKey}"
-  src="${scriptHost}/js/m.js"
-></script>`
-
-    return (
-      <div className="flex flex-col items-center justify-center py-6">
-        <div className="max-w-2xl w-full space-y-4">
-          <div className="text-center">
-            <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-500/10 mb-3">
-              <BarChart3 className="h-6 w-6 text-blue-500" />
-            </div>
-            <h2 className="text-lg font-semibold mb-1.5">Get Started with Analytics</h2>
-            <p className="text-muted-foreground text-sm max-w-md mx-auto">
-              Add privacy-focused, cookie-free web analytics to your site. No cookies, no personal data stored.
-            </p>
-          </div>
-
-          <Card>
-            <CardContent className="p-4 space-y-3">
-              <div>
-                <h3 className="text-xs font-medium mb-1.5">1. Add the tracking script to your site</h3>
-                <CopyBlock code={scriptCode} language="html" />
-              </div>
-
-              <div>
-                <h3 className="text-xs font-medium mb-1.5">2. Or use the NPM package for SPAs</h3>
-                <CopyBlock code="npm install @moneat/analytics" language="bash" />
-              </div>
-            </CardContent>
-          </Card>
-
-          <div className="text-center">
-            <a
-              href="/docs/product-analytics"
-              className="inline-flex items-center gap-1.5 bg-primary text-primary-foreground px-3 py-1.5 rounded text-xs font-medium hover:bg-primary/90 transition-colors"
-            >
-              <BookOpen className="h-3 w-3" />
-              View Full Documentation
-              <ArrowRight className="h-3 w-3" />
-            </a>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div className="space-y-2">
       <Tabs value={activeAnalyticsTab} onValueChange={setAnalyticsTab}>
@@ -230,169 +172,240 @@ function AnalyticsOverview() {
           <TabsTrigger value="web" className="gap-1.5 text-xs">
             <Globe className="h-3.5 w-3.5" /> Web
           </TabsTrigger>
-          {hasProductEvents && (
-            <TabsTrigger value="product" className="gap-1.5 text-xs">
-              <Target className="h-3.5 w-3.5" /> Product
-            </TabsTrigger>
-          )}
+          <TabsTrigger value="product" className="gap-1.5 text-xs">
+            <Target className="h-3.5 w-3.5" /> Product
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="web" className="mt-2 space-y-2">
-          <AnalyticsFilterBar filters={filters} onFiltersChange={setFilters} />
-
-          {overviewLoading ? (
-            <AnalyticsKpiCardsSkeleton />
+          {!overviewLoading && !hasWebAnalytics ? (
+            <WebAnalyticsEmptyState project={project} />
           ) : (
-            <AnalyticsKpiCards data={overview} isLoading={overviewLoading} />
+            <>
+              <AnalyticsFilterBar filters={filters} onFiltersChange={setFilters} />
+
+              {overviewLoading ? (
+                <AnalyticsKpiCardsSkeleton />
+              ) : (
+                <AnalyticsKpiCards data={overview} isLoading={overviewLoading} />
+              )}
+
+              <AnalyticsChart data={timeseries} isLoading={timeseriesLoading} />
+
+              <Tabs value={breakdownTab} onValueChange={setBreakdownTab}>
+                <TabsList className="h-7">
+                  <TabsTrigger value="pages" className="gap-1.5 text-xs">
+                    <FileText className="h-3.5 w-3.5" /> Pages
+                  </TabsTrigger>
+                  <TabsTrigger value="entry-pages" className="gap-1.5 text-xs">
+                    <LogIn className="h-3.5 w-3.5" /> Entry Pages
+                  </TabsTrigger>
+                  <TabsTrigger value="exit-pages" className="gap-1.5 text-xs">
+                    <LogOut className="h-3.5 w-3.5" /> Exit Pages
+                  </TabsTrigger>
+                  <TabsTrigger value="sources" className="gap-1.5 text-xs">
+                    <Share2 className="h-3.5 w-3.5" /> Sources
+                  </TabsTrigger>
+                  <TabsTrigger value="locations" className="gap-1.5 text-xs">
+                    <MapPin className="h-3.5 w-3.5" /> Locations
+                  </TabsTrigger>
+                  <TabsTrigger value="devices" className="gap-1.5 text-xs">
+                    <Laptop className="h-3.5 w-3.5" /> Devices
+                  </TabsTrigger>
+                  <TabsTrigger value="utm" className="gap-1.5 text-xs">
+                    <Megaphone className="h-3.5 w-3.5" /> UTM
+                  </TabsTrigger>
+                  <TabsTrigger value="events" className="gap-1.5 text-xs">
+                    <MousePointerClick className="h-3.5 w-3.5" /> Events
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="pages" className="mt-2">
+                  <AnalyticsBreakdownTable
+                    title="Top Pages"
+                    icon={FileText}
+                    iconColor="text-blue-500"
+                    data={pages}
+                    isLoading={pagesLoading}
+                    showBounceRate
+                    showDuration
+                    onRowClick={addFilterFromRow('pathname')}
+                  />
+                </TabsContent>
+
+                <TabsContent value="entry-pages" className="mt-2">
+                  <AnalyticsBreakdownTable
+                    title="Entry Pages"
+                    icon={LogIn}
+                    iconColor="text-emerald-500"
+                    data={entryPages}
+                    isLoading={entryPagesLoading}
+                    showBounceRate
+                    onRowClick={addFilterFromRow('entry_page')}
+                  />
+                </TabsContent>
+
+                <TabsContent value="exit-pages" className="mt-2">
+                  <AnalyticsBreakdownTable
+                    title="Exit Pages"
+                    icon={LogOut}
+                    iconColor="text-rose-500"
+                    data={exitPages}
+                    isLoading={exitPagesLoading}
+                    onRowClick={addFilterFromRow('exit_page')}
+                  />
+                </TabsContent>
+
+                <TabsContent value="sources" className="mt-2">
+                  <AnalyticsBreakdownTable
+                    title="Top Sources"
+                    icon={Share2}
+                    iconColor="text-violet-500"
+                    data={sources}
+                    isLoading={sourcesLoading}
+                    onRowClick={addFilterFromRow('referrer_source')}
+                  />
+                </TabsContent>
+
+                <TabsContent value="locations" className="mt-2">
+                  <AnalyticsBreakdownTable
+                    title="Countries"
+                    icon={MapPin}
+                    iconColor="text-amber-500"
+                    data={locations}
+                    isLoading={locationsLoading}
+                    onRowClick={addFilterFromRow('country_code')}
+                  />
+                </TabsContent>
+
+                <TabsContent value="devices" className="mt-2">
+                  <div className="grid gap-2 lg:grid-cols-3">
+                    <AnalyticsBreakdownTable
+                      title="Browsers"
+                      icon={Globe}
+                      iconColor="text-blue-500"
+                      data={browsers}
+                      isLoading={browsersLoading}
+                      onRowClick={addFilterFromRow('browser')}
+                    />
+                    <AnalyticsBreakdownTable
+                      title="Operating Systems"
+                      icon={Laptop}
+                      iconColor="text-emerald-500"
+                      data={operatingSystems}
+                      isLoading={osLoading}
+                      onRowClick={addFilterFromRow('os')}
+                    />
+                    <AnalyticsBreakdownTable
+                      title="Device Types"
+                      icon={Laptop}
+                      iconColor="text-violet-500"
+                      data={deviceTypes}
+                      isLoading={deviceTypesLoading}
+                      onRowClick={addFilterFromRow('device_type')}
+                    />
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="utm" className="mt-2">
+                  <AnalyticsBreakdownTable
+                    title="UTM Sources"
+                    icon={Megaphone}
+                    iconColor="text-cyan-500"
+                    data={utmSources}
+                    isLoading={utmSourcesLoading}
+                  />
+                </TabsContent>
+
+                <TabsContent value="events" className="mt-2">
+                  <AnalyticsBreakdownTable
+                    title="Custom Events"
+                    icon={MousePointerClick}
+                    iconColor="text-orange-500"
+                    data={customEvents}
+                    isLoading={customEventsLoading}
+                  />
+                </TabsContent>
+              </Tabs>
+            </>
           )}
-
-          <AnalyticsChart data={timeseries} isLoading={timeseriesLoading} />
-
-          <Tabs value={breakdownTab} onValueChange={setBreakdownTab}>
-            <TabsList className="h-7">
-              <TabsTrigger value="pages" className="gap-1.5 text-xs">
-                <FileText className="h-3.5 w-3.5" /> Pages
-              </TabsTrigger>
-              <TabsTrigger value="entry-pages" className="gap-1.5 text-xs">
-                <LogIn className="h-3.5 w-3.5" /> Entry Pages
-              </TabsTrigger>
-              <TabsTrigger value="exit-pages" className="gap-1.5 text-xs">
-                <LogOut className="h-3.5 w-3.5" /> Exit Pages
-              </TabsTrigger>
-              <TabsTrigger value="sources" className="gap-1.5 text-xs">
-                <Share2 className="h-3.5 w-3.5" /> Sources
-              </TabsTrigger>
-              <TabsTrigger value="locations" className="gap-1.5 text-xs">
-                <MapPin className="h-3.5 w-3.5" /> Locations
-              </TabsTrigger>
-              <TabsTrigger value="devices" className="gap-1.5 text-xs">
-                <Laptop className="h-3.5 w-3.5" /> Devices
-              </TabsTrigger>
-              <TabsTrigger value="utm" className="gap-1.5 text-xs">
-                <Megaphone className="h-3.5 w-3.5" /> UTM
-              </TabsTrigger>
-              <TabsTrigger value="events" className="gap-1.5 text-xs">
-                <MousePointerClick className="h-3.5 w-3.5" /> Events
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="pages" className="mt-2">
-              <AnalyticsBreakdownTable
-                title="Top Pages"
-                icon={FileText}
-                iconColor="text-blue-500"
-                data={pages}
-                isLoading={pagesLoading}
-                showBounceRate
-                showDuration
-                onRowClick={addFilterFromRow('pathname')}
-              />
-            </TabsContent>
-
-            <TabsContent value="entry-pages" className="mt-2">
-              <AnalyticsBreakdownTable
-                title="Entry Pages"
-                icon={LogIn}
-                iconColor="text-emerald-500"
-                data={entryPages}
-                isLoading={entryPagesLoading}
-                showBounceRate
-                onRowClick={addFilterFromRow('entry_page')}
-              />
-            </TabsContent>
-
-            <TabsContent value="exit-pages" className="mt-2">
-              <AnalyticsBreakdownTable
-                title="Exit Pages"
-                icon={LogOut}
-                iconColor="text-rose-500"
-                data={exitPages}
-                isLoading={exitPagesLoading}
-                onRowClick={addFilterFromRow('exit_page')}
-              />
-            </TabsContent>
-
-            <TabsContent value="sources" className="mt-2">
-              <AnalyticsBreakdownTable
-                title="Top Sources"
-                icon={Share2}
-                iconColor="text-violet-500"
-                data={sources}
-                isLoading={sourcesLoading}
-                onRowClick={addFilterFromRow('referrer_source')}
-              />
-            </TabsContent>
-
-            <TabsContent value="locations" className="mt-2">
-              <AnalyticsBreakdownTable
-                title="Countries"
-                icon={MapPin}
-                iconColor="text-amber-500"
-                data={locations}
-                isLoading={locationsLoading}
-                onRowClick={addFilterFromRow('country_code')}
-              />
-            </TabsContent>
-
-            <TabsContent value="devices" className="mt-2">
-              <div className="grid gap-2 lg:grid-cols-3">
-                <AnalyticsBreakdownTable
-                  title="Browsers"
-                  icon={Globe}
-                  iconColor="text-blue-500"
-                  data={browsers}
-                  isLoading={browsersLoading}
-                  onRowClick={addFilterFromRow('browser')}
-                />
-                <AnalyticsBreakdownTable
-                  title="Operating Systems"
-                  icon={Laptop}
-                  iconColor="text-emerald-500"
-                  data={operatingSystems}
-                  isLoading={osLoading}
-                  onRowClick={addFilterFromRow('os')}
-                />
-                <AnalyticsBreakdownTable
-                  title="Device Types"
-                  icon={Laptop}
-                  iconColor="text-violet-500"
-                  data={deviceTypes}
-                  isLoading={deviceTypesLoading}
-                  onRowClick={addFilterFromRow('device_type')}
-                />
-              </div>
-            </TabsContent>
-
-            <TabsContent value="utm" className="mt-2">
-              <AnalyticsBreakdownTable
-                title="UTM Sources"
-                icon={Megaphone}
-                iconColor="text-cyan-500"
-                data={utmSources}
-                isLoading={utmSourcesLoading}
-              />
-            </TabsContent>
-
-            <TabsContent value="events" className="mt-2">
-              <AnalyticsBreakdownTable
-                title="Custom Events"
-                icon={MousePointerClick}
-                iconColor="text-orange-500"
-                data={customEvents}
-                isLoading={customEventsLoading}
-              />
-            </TabsContent>
-          </Tabs>
         </TabsContent>
 
-        {hasProductEvents && (
-          <TabsContent value="product" className="mt-2">
+        <TabsContent value="product" className="mt-2">
+          {productPresenceLoading ? (
+            <div className="h-[220px] w-full animate-pulse rounded bg-muted" />
+          ) : hasProductEvents ? (
             <ProductAnalyticsTab projectId={projectId} params={productParams} />
-          </TabsContent>
-        )}
+          ) : (
+            <ProductAnalyticsEmptyState project={project} projectId={projectId} />
+          )}
+        </TabsContent>
       </Tabs>
     </div>
   )
+}
+
+function WebAnalyticsEmptyState({project}: {project?: Project}) {
+  const scriptHost = getProjectApiHost(project)
+  const publicKey = getProjectPublicKey(project)
+  const scriptCode = `<script
+  defer
+  data-domain="yoursite.com"
+  data-key="${publicKey}"
+  src="${scriptHost}/js/m.js"
+></script>`
+
+  return (
+    <div className="flex flex-col items-center justify-center py-6">
+      <div className="max-w-2xl w-full space-y-4">
+        <div className="text-center">
+          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-500/10 mb-3">
+            <BarChart3 className="h-6 w-6 text-blue-500" />
+          </div>
+          <h2 className="text-lg font-semibold mb-1.5">Get Started with Analytics</h2>
+          <p className="text-muted-foreground text-sm max-w-md mx-auto">
+            Add privacy-focused, cookie-free web analytics to your site. No cookies, no personal data stored.
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="p-4 space-y-3">
+            <div>
+              <h3 className="text-xs font-medium mb-1.5">1. Add the tracking script to your site</h3>
+              <CopyBlock code={scriptCode} language="html" />
+            </div>
+
+            <div>
+              <h3 className="text-xs font-medium mb-1.5">2. Or use the NPM package for SPAs</h3>
+              <CopyBlock code="npm install @moneat/analytics" language="bash" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="text-center">
+          <a
+            href="/docs/product-analytics"
+            className="inline-flex items-center gap-1.5 bg-primary text-primary-foreground px-3 py-1.5 rounded text-xs font-medium hover:bg-primary/90 transition-colors"
+          >
+            <BookOpen className="h-3 w-3" />
+            View Full Documentation
+            <ArrowRight className="h-3 w-3" />
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function getProjectPublicKey(project?: Project): string {
+  if (!project?.dsn) return 'your-project-public-key'
+
+  try {
+    const url = new URL(project.dsn)
+    return url.username || 'your-project-public-key'
+  } catch {
+    return 'your-project-public-key'
+  }
 }
 
 function ProductAnalyticsTab({projectId, params}: {projectId: number; params: AnalyticsParams}) {
@@ -548,4 +561,92 @@ function ProductFunnelResults({
       </div>
     </div>
   )
+}
+
+function ProductAnalyticsEmptyState({project, projectId}: {project?: Project; projectId: number}) {
+  const apiHost = getProjectApiHost(project)
+  const endpoint = `${apiHost}/v1/analytics/${projectId}/events`
+  const nodeCode = `await fetch('${endpoint}', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer <YOUR_OTLP_API_KEY>',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    events: [{
+      name: 'signup.completed',
+      user_id: 'user_123',
+      props: { plan: 'pro' },
+    }],
+  }),
+})`
+  const curlCode = `curl -X POST '${endpoint}' \\
+  -H 'Authorization: Bearer <YOUR_OTLP_API_KEY>' \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "events": [{
+      "name": "signup.completed",
+      "user_id": "user_123",
+      "props": { "plan": "pro" }
+    }]
+  }'`
+
+  return (
+    <div className="flex flex-col items-center justify-center py-6">
+      <div className="max-w-3xl w-full space-y-4">
+        <div className="text-center">
+          <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-blue-500/10 mb-3">
+            <Target className="h-6 w-6 text-blue-500" />
+          </div>
+          <h2 className="text-lg font-semibold mb-1.5">Get Started with Product Analytics</h2>
+          <p className="text-muted-foreground text-sm max-w-md mx-auto">
+            Track server-side, user-level events to understand activation, retention, funnels, and product usage.
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="p-4 space-y-4">
+            <div>
+              <h3 className="text-xs font-medium mb-1.5">1. Send events from your server</h3>
+              <CopyBlock code={nodeCode} language="typescript" />
+            </div>
+
+            <div>
+              <h3 className="text-xs font-medium mb-1.5">2. Or use cURL for quick testing</h3>
+              <CopyBlock code={curlCode} language="bash" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <p className="text-xs text-muted-foreground text-center">
+          Server-side product events require an OTLP API key. Create one in{' '}
+          <a href="/settings?tab=api-keys" className="text-primary hover:underline">
+            Settings &gt; API Keys
+          </a>
+          .
+        </p>
+
+        <div className="text-center">
+          <Button asChild size="sm">
+            <a href="/docs/product-analytics">
+              <BookOpen className="h-3 w-3" />
+              View Full Documentation
+              <ArrowRight className="h-3 w-3" />
+            </a>
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function getProjectApiHost(project?: Project): string {
+  if (!project?.dsn) return 'https://your-moneat-instance.com'
+
+  try {
+    const url = new URL(project.dsn)
+    return `${url.protocol}//${url.host}`
+  } catch {
+    return 'https://your-moneat-instance.com'
+  }
 }


### PR DESCRIPTION
## Summary

- Keep the Analytics Product tab visible for empty and web-only projects.
- Move web analytics setup into the Web tab empty state and add a Product tab onboarding state.
- Use the selected project's DSN host and project ID in the setup snippets.

## Testing

- `git diff --check`
- `npm run build`