### PR TITLE
fix: optimize trace dashboard queries

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/services/CustomDashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/CustomDashboardService.kt
@@ -318,7 +318,7 @@ class CustomDashboardService(
                     QueryDsl(
                         dataSource = "events",
                         metrics = listOf(MetricDef(AggFunction.COUNT, alias = "count")),
-                        groupBy = listOf(GroupByDef("transaction", GroupByType.FIELD)),
+                        groupBy = listOf(GroupByDef("transaction_name", GroupByType.FIELD)),
                         filters = listOf(FilterDef("level", FilterOp.EQ, "error")),
                         orderBy = OrderByDef("count", "desc"),
                         limit = 10

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -63,6 +63,8 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import mu.KotlinLogging
 import org.msgpack.core.MessagePack
 import org.msgpack.core.MessageUnpacker
@@ -401,14 +403,8 @@ object TraceIngestionService {
             SELECT count()
             FROM ($subquery)
         """.trimIndent()
-        val countResult = executeDashboardQuery(
-            countQuery,
-            "TabSeparated",
-            parentSpan,
-        )
-        val totalCount = countResult.trim().toLongOrNull() ?: 0
 
-        val query = """
+        val dataQuery = """
             SELECT
                 trace_id_canonical,
                 root_service,
@@ -425,40 +421,48 @@ object TraceIngestionService {
             FORMAT JSONEachRow
         """.trimIndent()
 
-        val result = executeDashboardQuery(query, "", parentSpan)
-        val traces = if (result.isBlank()) {
-            emptyList()
-        } else {
-            result.trim().lines()
-                .filter { it.isNotBlank() }
-                .map { line ->
-                    val obj = json.parseToJsonElement(line).jsonObject
-                    DdTraceListItem(
-                        traceId = obj["trace_id_canonical"]!!
-                            .jsonPrimitive.content,
-                        rootService = obj["root_service"]!!
-                            .jsonPrimitive.content,
-                        rootResource = obj["root_resource"]!!
-                            .jsonPrimitive.content,
-                        rootName = obj["root_name"]!!
-                            .jsonPrimitive.content,
-                        spanCount = obj["span_count"]!!
-                            .jsonPrimitive.int,
-                        durationNs = obj["duration_ns"]!!
-                            .jsonPrimitive.long,
-                        startNs = obj["start_ns"]?.jsonPrimitive?.long
-                            ?: 0,
-                        hasError = (
-                            obj["has_error"]
-                                ?.jsonPrimitive?.int ?: 0
-                            ) > 0,
-                        source = obj["source"]
-                            ?.jsonPrimitive?.content ?: "datadog",
-                    )
+        return coroutineScope {
+            val countDeferred = async {
+                val countResult = executeDashboardQuery(countQuery, "TabSeparated", parentSpan)
+                countResult.trim().toLongOrNull() ?: 0
+            }
+            val dataDeferred = async {
+                val result = executeDashboardQuery(dataQuery, "", parentSpan)
+                if (result.isBlank()) {
+                    emptyList()
+                } else {
+                    result.trim().lines()
+                        .filter { it.isNotBlank() }
+                        .map { line ->
+                            val obj = json.parseToJsonElement(line).jsonObject
+                            DdTraceListItem(
+                                traceId = obj["trace_id_canonical"]!!
+                                    .jsonPrimitive.content,
+                                rootService = obj["root_service"]!!
+                                    .jsonPrimitive.content,
+                                rootResource = obj["root_resource"]!!
+                                    .jsonPrimitive.content,
+                                rootName = obj["root_name"]!!
+                                    .jsonPrimitive.content,
+                                spanCount = obj["span_count"]!!
+                                    .jsonPrimitive.int,
+                                durationNs = obj["duration_ns"]!!
+                                    .jsonPrimitive.long,
+                                startNs = obj["start_ns"]?.jsonPrimitive?.long
+                                    ?: 0,
+                                hasError = (
+                                    obj["has_error"]
+                                        ?.jsonPrimitive?.int ?: 0
+                                    ) > 0,
+                                source = obj["source"]
+                                    ?.jsonPrimitive?.content ?: "datadog",
+                            )
+                        }
                 }
-        }
+            }
 
-        return DdTraceListResponse(traces = traces, totalCount = totalCount)
+            DdTraceListResponse(traces = dataDeferred.await(), totalCount = countDeferred.await())
+        }
     }
 
     suspend fun getApmOverview(
@@ -475,16 +479,26 @@ object TraceIngestionService {
             query = query,
             previousWindow = true,
         )
-        val previousStats = getOverviewPreviousStats(previousSubquery, parentSpan)
 
-        return DdApmOverviewResponse(
-            stats = getOverviewStats(currentSubquery, previousStats, parentSpan),
-            latencySeries = getLatencySeries(currentSubquery, parentSpan),
-            serviceHealth = getServiceHealth(currentSubquery, parentSpan),
-            resourceHotspots = getResourceHotspots(currentSubquery, parentSpan),
-            errors = getOverviewErrors(currentSubquery, parentSpan),
-            facets = getOverviewFacets(currentSubquery, parentSpan),
-        )
+        return coroutineScope {
+            val previousStatsDeferred = async { getOverviewPreviousStats(previousSubquery, parentSpan) }
+            val statsDeferred = async { getOverviewStats(currentSubquery, emptyOverviewPreviousStats(), parentSpan) }
+            val latencyDeferred = async { getLatencySeries(currentSubquery, parentSpan) }
+            val serviceHealthDeferred = async { getServiceHealth(currentSubquery, parentSpan) }
+            val resourceHotspotsDeferred = async { getResourceHotspots(currentSubquery, parentSpan) }
+            val errorsDeferred = async { getOverviewErrors(currentSubquery, parentSpan) }
+            val facetsDeferred = async { getOverviewFacetsCombined(currentSubquery, parentSpan) }
+
+            val stats = statsDeferred.await()
+            DdApmOverviewResponse(
+                stats = stats.copy(previous = previousStatsDeferred.await()),
+                latencySeries = latencyDeferred.await(),
+                serviceHealth = serviceHealthDeferred.await(),
+                resourceHotspots = resourceHotspotsDeferred.await(),
+                errors = errorsDeferred.await(),
+                facets = facetsDeferred.await(),
+            )
+        }
     }
 
     private suspend fun getOverviewStats(
@@ -676,39 +690,45 @@ object TraceIngestionService {
         }
     }
 
-    private suspend fun getOverviewFacets(
+    private suspend fun getOverviewFacetsCombined(
         subquery: String,
         parentSpan: ISpan?,
-    ): DdApmOverviewFacets =
-        DdApmOverviewFacets(
-            services = getFacetItems(subquery, "root_service", parentSpan),
-            sources = getFacetItems(subquery, "source", parentSpan),
-            environments = getFacetItems(subquery, "env", parentSpan),
-        )
-
-    private suspend fun getFacetItems(
-        subquery: String,
-        field: String,
-        parentSpan: ISpan?,
-    ): List<DdApmFacetItem> {
+    ): DdApmOverviewFacets {
         val query = """
-            SELECT
-                $field as value,
-                count() as count
-            FROM ($subquery)
-            WHERE $field != ''
-            GROUP BY value
-            ORDER BY count DESC, value ASC
-            LIMIT $MAX_FILTER_FACETS
+            SELECT 'service' as facet_type, root_service as value, count() as count
+            FROM ($subquery) WHERE root_service != ''
+            GROUP BY root_service ORDER BY count DESC, value ASC LIMIT $MAX_FILTER_FACETS
+            UNION ALL
+            SELECT 'source' as facet_type, source as value, count() as count
+            FROM ($subquery) WHERE source != ''
+            GROUP BY source ORDER BY count DESC, value ASC LIMIT $MAX_FILTER_FACETS
+            UNION ALL
+            SELECT 'env' as facet_type, env as value, count() as count
+            FROM ($subquery) WHERE env != ''
+            GROUP BY env ORDER BY count DESC, value ASC LIMIT $MAX_FILTER_FACETS
             FORMAT JSONEachRow
         """.trimIndent()
 
-        return jsonRows(query, parentSpan).map { obj ->
-            DdApmFacetItem(
+        val rows = jsonRows(query, parentSpan)
+        val services = mutableListOf<DdApmFacetItem>()
+        val sources = mutableListOf<DdApmFacetItem>()
+        val environments = mutableListOf<DdApmFacetItem>()
+        for (obj in rows) {
+            val item = DdApmFacetItem(
                 value = obj.stringValue("value"),
                 count = obj.longValue("count"),
             )
+            when (obj.stringValue("facet_type")) {
+                "service" -> services.add(item)
+                "source" -> sources.add(item)
+                "env" -> environments.add(item)
+            }
         }
+        return DdApmOverviewFacets(
+            services = services,
+            sources = sources,
+            environments = environments,
+        )
     }
 
     private suspend fun firstJsonRow(

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
@@ -1624,12 +1624,12 @@ class LogService(private val logRepository: LogRepository) {
 
     private fun buildSimpleSearchCondition(term: String): String {
         val escaped = ClickHouseSqlUtils.escapeLikePattern(term)
-        val hasSeparators = term.any { it == '-' || it == '.' || it == '/' || it == ':' || it == ' ' }
-        return if (hasSeparators) {
-            "(message ILIKE '%$escaped%' OR body ILIKE '%$escaped%')"
-        } else {
+        val isSimpleToken = term.all { it.isLetterOrDigit() }
+        return if (isSimpleToken) {
             val tokenEscaped = ClickHouseSqlUtils.escapeSql(term)
             "(hasTokenCaseInsensitive(message, '$tokenEscaped') OR hasTokenCaseInsensitive(body, '$tokenEscaped'))"
+        } else {
+            "(message ILIKE '%$escaped%' OR body ILIKE '%$escaped%')"
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/summary/services/SummaryService.kt
+++ b/backend/src/main/kotlin/com/moneat/summary/services/SummaryService.kt
@@ -683,7 +683,7 @@ class SummaryService(
         if (projectIds.isEmpty()) return emptyList()
         val projectClause = projectIdClause(projectIds)
         val query = """
-            SELECT transaction as name,
+            SELECT transaction_name as name,
                    quantile(0.95)(duration) as p95,
                    count() as cnt
             FROM `$clickhouseDb`.events

--- a/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
@@ -205,7 +205,7 @@ class TraceIngestionServiceTest {
     @Test
     fun `getApmOverview aggregates filtered trace summaries`() = runBlocking {
         mockkObject(ClickHouseClient)
-        val queries = mutableListOf<String>()
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
             coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
@@ -233,22 +233,20 @@ class TraceIngestionServiceTest {
                             "\"service\":\"checkout-service\",\"resource\":\"POST /checkout\"," +
                             "\"source\":\"otlp\",\"trace_count\":1234,\"error_count\":154," +
                             "\"error_rate\":0.1248,\"p95_duration_ns\":612000000}"
-                    "GROUP BY root_service" in query ->
+                    "GROUP BY root_service" in query && "UNION ALL" !in query ->
                         "{" +
                             "\"service\":\"checkout-service\",\"source\":\"otlp\",\"trace_count\":5642," +
                             "\"error_count\":326,\"error_rate\":0.0578,\"p95_duration_ns\":612000000," +
                             "\"avg_spans_per_trace\":22.4}"
-                    "avg_spans_per_trace" in query ->
+                    "avg_spans_per_trace" in query && "service_count" !in query ->
                         "{" +
                             "\"total_traces\":10,\"error_rate\":0.10,\"p50_duration_ns\":50000000," +
                             "\"p95_duration_ns\":400000000,\"p99_duration_ns\":900000000," +
                             "\"avg_spans_per_trace\":15.2}"
-                    "GROUP BY value" in query && "root_service as value" in query ->
-                        "{\"value\":\"checkout-service\",\"count\":5642}"
-                    "GROUP BY value" in query && "source as value" in query ->
-                        "{\"value\":\"otlp\",\"count\":5000}"
-                    "GROUP BY value" in query && "env as value" in query ->
-                        "{\"value\":\"production\",\"count\":5000}"
+                    "UNION ALL" in query && "facet_type" in query ->
+                        "{\"facet_type\":\"service\",\"value\":\"checkout-service\",\"count\":5642}\n" +
+                            "{\"facet_type\":\"source\",\"value\":\"otlp\",\"count\":5000}\n" +
+                            "{\"facet_type\":\"env\",\"value\":\"production\",\"count\":5000}"
                     else -> ""
                 }
             }


### PR DESCRIPTION
## Summary
- run trace list count and data queries concurrently
- parallelize APM overview dashboard queries and combine facet lookup
- switch transaction queries to transaction_name and tighten simple log token search

## Validation
- ./gradlew compileKotlin
- ./gradlew detekt
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.datadog.services.TraceIngestionServiceTest -Dkotlin.compiler.execution.strategy=in-process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Trace listing and APM overview endpoints now execute multiple database queries concurrently for faster response times.

* **Improvements**
  * Enhanced log search term classification for more accurate results.
  * Updated transaction identification in error message dashboards and latency summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->