### PR TITLE
fix: harden clickhouse query failures

### DIFF
--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -31,9 +31,18 @@ import io.ktor.server.application.*
 import io.sentry.ISpan
 import io.sentry.Sentry
 import kotlinx.coroutines.CancellationException
+import mu.KotlinLogging
 import java.util.Locale
 
 private val CLICKHOUSE_ERROR_CODE = Regex("""^Code:\s*(\d+)""")
+private val logger = KotlinLogging.logger {}
+
+class ClickHouseQueryException(
+    val isTimeout: Boolean,
+    internalDetail: String,
+) : RuntimeException(if (isTimeout) "Query timed out" else "Query failed") {
+    val detail: String = internalDetail
+}
 
 object ClickHouseClient {
     private const val MIGRATION_TIMEOUT_MS = 600_000L
@@ -42,10 +51,11 @@ object ClickHouseClient {
     private const val CONNECT_TIMEOUT_MS = 10_000L
     private const val SOCKET_TIMEOUT_MS = 30_000L
     private const val MIGRATION_MAX_CONNECTIONS = 4
-    private const val QUERY_LOG_MAX_LEN = 200
+    private const val QUERY_LOG_MAX_LEN = 8192
     private const val ERROR_BODY_MAX_LEN = 500
     private const val NANOS_PER_SECOND = 1_000_000_000.0
     private const val READ_QUERY_MAX_EXECUTION_SECONDS = 10
+    private const val SLOW_QUERY_THRESHOLD_SECONDS = 3.0
 
     @Volatile
     private var httpClient: HttpClient? = null
@@ -135,8 +145,14 @@ object ClickHouseClient {
                 contentType(ContentType.Text.Plain)
                 setBody(query)
             }
+            val elapsed = elapsedSeconds(startedAt)
             val status = if (response.status.isSuccess()) "success" else "http_${response.status.value}"
-            OperationalMetrics.recordClickHouseRequest(operation, status, elapsedSeconds(startedAt))
+            OperationalMetrics.recordClickHouseRequest(operation, status, elapsed)
+            if (elapsed >= SLOW_QUERY_THRESHOLD_SECONDS) {
+                val elapsedText = String.format("%.1f", elapsed)
+                val truncatedQuery = query.take(QUERY_LOG_MAX_LEN)
+                logger.warn { "Slow ClickHouse query (${elapsedText}s): $truncatedQuery" }
+            }
             return response
         } catch (e: HttpRequestTimeoutException) {
             OperationalMetrics.recordClickHouseRequestFailure(operation, e, elapsedSeconds(startedAt))
@@ -177,10 +193,14 @@ object ClickHouseClient {
         val body = response.bodyAsText()
         val isError = response.isClickHouseError(body)
         if (isError) {
-            OperationalMetrics.recordClickHouseQueryError("execute", clickHouseErrorCode(body))
-        }
-        check(!isError) {
-            "ClickHouse query failed (${response.status.value}): ${body.take(ERROR_BODY_MAX_LEN)}"
+            val errorCode = clickHouseErrorCode(body)
+            OperationalMetrics.recordClickHouseQueryError("execute", errorCode)
+            val detail = "ClickHouse query failed (${response.status.value}): ${body.take(ERROR_BODY_MAX_LEN)}"
+            logger.error { "$detail | query: ${query.take(QUERY_LOG_MAX_LEN)}" }
+            throw ClickHouseQueryException(
+                isTimeout = "TIMEOUT_EXCEEDED" in body || errorCode == "159",
+                internalDetail = detail,
+            )
         }
         return body
     }

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -56,6 +56,9 @@ object ClickHouseClient {
     private const val NANOS_PER_SECOND = 1_000_000_000.0
     private const val READ_QUERY_MAX_EXECUTION_SECONDS = 10
     private const val SLOW_QUERY_THRESHOLD_SECONDS = 3.0
+    private const val CLICKHOUSE_TIMEOUT_ERROR_CODE = "159"
+    private const val CLICKHOUSE_TIMEOUT_ERROR_NAME = "TIMEOUT_EXCEEDED"
+    private const val CLICKHOUSE_TIMEOUT_MESSAGE = "timeout exceeded"
 
     @Volatile
     private var httpClient: HttpClient? = null
@@ -198,11 +201,17 @@ object ClickHouseClient {
             val detail = "ClickHouse query failed (${response.status.value}): ${body.take(ERROR_BODY_MAX_LEN)}"
             logger.error { "$detail | query: ${query.take(QUERY_LOG_MAX_LEN)}" }
             throw ClickHouseQueryException(
-                isTimeout = "TIMEOUT_EXCEEDED" in body || errorCode == "159",
+                isTimeout = isClickHouseTimeout(body, errorCode),
                 internalDetail = detail,
             )
         }
         return body
+    }
+
+    private fun isClickHouseTimeout(body: String, errorCode: String): Boolean {
+        return errorCode == CLICKHOUSE_TIMEOUT_ERROR_CODE ||
+            body.contains(CLICKHOUSE_TIMEOUT_ERROR_NAME, ignoreCase = true) ||
+            body.contains(CLICKHOUSE_TIMEOUT_MESSAGE, ignoreCase = true)
     }
 
     /**

--- a/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
@@ -19,6 +19,7 @@ package com.moneat.plugins
 import kotlinx.serialization.SerializationException
 import java.io.IOException
 
+import com.moneat.config.ClickHouseQueryException
 import com.moneat.config.SentryConfig
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.ErrorResponse
@@ -174,6 +175,22 @@ fun Application.configureMonitoring() {
                 )
             }
         }
+        exception<ClickHouseQueryException> { call, cause ->
+            logger.error { "ClickHouse query error on ${call.request.path()}: ${cause.detail}" }
+            if (SentryConfig.isEnabled()) {
+                Sentry.captureException(cause) { scope ->
+                    scope.setTag("http.method", call.request.httpMethod.value)
+                    scope.setTag("http.path", call.request.path())
+                    scope.setTag("clickhouse.timeout", cause.isTimeout.toString())
+                    scope.setExtra("clickhouse.detail", cause.detail)
+                }
+            }
+            if (!call.response.isCommitted) {
+                val status = if (cause.isTimeout) HttpStatusCode.GatewayTimeout else HttpStatusCode.InternalServerError
+                val message = if (cause.isTimeout) "Query timed out" else "Data unavailable"
+                call.respond(status, mapOf("error" to message))
+            }
+        }
         exception<Throwable> { call, cause ->
             logger.error(cause) { "Unhandled exception: ${cause.message}" }
 
@@ -205,7 +222,7 @@ fun Application.configureMonitoring() {
             if (!call.response.isCommitted) {
                 call.respond(
                     HttpStatusCode.InternalServerError,
-                    mapOf("error" to "Internal server error", "message" to (cause.message ?: "Unknown error"))
+                    mapOf("error" to "Internal server error")
                 )
             } else {
                 logger.debug {

--- a/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
@@ -16,9 +16,6 @@
 
 package com.moneat.plugins
 
-import kotlinx.serialization.SerializationException
-import java.io.IOException
-
 import com.moneat.config.ClickHouseQueryException
 import com.moneat.config.SentryConfig
 import com.moneat.monitoring.OperationalMetrics
@@ -79,6 +76,11 @@ private const val HTTP_CLIENT_ERROR_MIN = 400
 private const val HTTP_CLIENT_ERROR_MAX = 499
 private const val HTTP_SERVER_ERROR_MIN = 500
 private const val HTTP_SERVER_ERROR_MAX = 599
+private const val HTTP_METHOD_TAG = "http.method"
+private const val HTTP_PATH_TAG = "http.path"
+private const val HTTP_STATUS_CODE_TAG = "http.status_code"
+private const val HTTP_SERVER_OPERATION = "http.server"
+private const val SENTRY_INTERNAL_ERROR_STATUS = "500"
 
 fun Application.configureMonitoring() {
     OperationalMetrics.bindSystemMetrics()
@@ -86,86 +88,88 @@ fun Application.configureMonitoring() {
         registry = OperationalMetrics.registry
     }
 
+    installSentryTracing()
+    installErrorHandling()
+    installRequestLogging()
+}
+
+private fun Application.installSentryTracing() {
     // Sentry transaction interceptor for non-ingestion, non-health requests
     intercept(ApplicationCallPipeline.Setup) {
-        if (SentryConfig.isEnabled()) {
-            val method = call.request.httpMethod.value
-            val path = call.request.path()
-
-            if (shouldSkipTracing(path, method)) {
-                proceed()
-                return@intercept
-            }
-
-            // Create transaction for this HTTP request
-            val transaction = Sentry.startTransaction("$method $path", "http.server")
-            transaction.setData("http.method", method)
-            transaction.setData("http.url", path)
-            transaction.setData("http.query", call.request.queryString())
-
-            // Store transaction in call attributes
-            call.attributes.put(SentryTransactionKey, transaction)
-
-            // Add breadcrumb for request
-            SentryUtils.breadcrumb(
-                "http.request",
-                "HTTP $method $path",
-                mapOf(
-                    "method" to method,
-                    "path" to path,
-                    "query" to (call.request.queryString().takeIf { it.isNotEmpty() } ?: "")
-                )
-            )
-
-            try {
-                proceed()
-
-                // Set response status
-                val status = call.response.status()
-                transaction.setData("http.status_code", status?.value ?: 0)
-
-                // Determine transaction status based on HTTP status code
-                transaction.status =
-                    when (status?.value) {
-                        in HTTP_SUCCESS_MIN..HTTP_SUCCESS_MAX -> SpanStatus.OK
-                        in HTTP_CLIENT_ERROR_MIN..HTTP_CLIENT_ERROR_MAX -> SpanStatus.INVALID_ARGUMENT
-                        in HTTP_SERVER_ERROR_MIN..HTTP_SERVER_ERROR_MAX -> SpanStatus.INTERNAL_ERROR
-                        else -> SpanStatus.UNKNOWN_ERROR
-                    }
-
-                // Add breadcrumb for response
-                SentryUtils.breadcrumb(
-                    "http.response",
-                    "HTTP ${status?.value ?: 0}",
-                    mapOf(
-                        "status" to (status?.value ?: 0),
-                        "description" to (status?.description ?: "")
-                    )
-                )
-            } catch (e: SerializationException) {
-                transaction.status = SpanStatus.INTERNAL_ERROR
-                transaction.throwable = e
-                throw e
-            } catch (e: IOException) {
-                transaction.status = SpanStatus.INTERNAL_ERROR
-                transaction.throwable = e
-                throw e
-            } catch (e: IllegalStateException) {
-                transaction.status = SpanStatus.INTERNAL_ERROR
-                transaction.throwable = e
-                throw e
-            } catch (e: IllegalArgumentException) {
-                transaction.status = SpanStatus.INTERNAL_ERROR
-                transaction.throwable = e
-                throw e
-            } finally {
-                transaction.finish()
-            }
-        } else {
+        if (!SentryConfig.isEnabled()) {
             proceed()
+            return@intercept
+        }
+
+        val method = call.request.httpMethod.value
+        val path = call.request.path()
+        if (shouldSkipTracing(path, method)) {
+            proceed()
+            return@intercept
+        }
+
+        val queryString = call.request.queryString()
+        val transaction = Sentry.startTransaction("$method $path", HTTP_SERVER_OPERATION)
+        transaction.setRequestData(method, path, queryString)
+        call.attributes.put(SentryTransactionKey, transaction)
+        addRequestBreadcrumb(method, path, queryString)
+
+        try {
+            proceed()
+            recordTransactionResponse(call, transaction)
+        } catch (e: Exception) {
+            transaction.status = SpanStatus.INTERNAL_ERROR
+            transaction.throwable = e
+            throw e
+        } finally {
+            transaction.finish()
         }
     }
+}
 
+private fun ITransaction.setRequestData(method: String, path: String, queryString: String) {
+    setData(HTTP_METHOD_TAG, method)
+    setData("http.url", path)
+    setData("http.query", queryString)
+}
+
+private fun addRequestBreadcrumb(method: String, path: String, queryString: String) {
+    SentryUtils.breadcrumb(
+        "http.request",
+        "HTTP $method $path",
+        mapOf(
+            "method" to method,
+            "path" to path,
+            "query" to (queryString.takeIf { it.isNotEmpty() } ?: "")
+        )
+    )
+}
+
+private fun recordTransactionResponse(call: ApplicationCall, transaction: ITransaction) {
+    val status = call.response.status()
+    val statusCode = status?.value ?: 0
+    transaction.setData(HTTP_STATUS_CODE_TAG, statusCode)
+    transaction.status = spanStatusFor(statusCode)
+    SentryUtils.breadcrumb(
+        "http.response",
+        "HTTP $statusCode",
+        mapOf(
+            "status" to statusCode,
+            "description" to (status?.description ?: "")
+        )
+    )
+}
+
+private fun spanStatusFor(statusCode: Int): SpanStatus {
+    return when (statusCode) {
+        in HTTP_SUCCESS_MIN..HTTP_SUCCESS_MAX -> SpanStatus.OK
+        in HTTP_CLIENT_ERROR_MIN..HTTP_CLIENT_ERROR_MAX -> SpanStatus.INVALID_ARGUMENT
+        in HTTP_SERVER_ERROR_MIN..HTTP_SERVER_ERROR_MAX -> SpanStatus.INTERNAL_ERROR
+        else -> SpanStatus.UNKNOWN_ERROR
+    }
+}
+
+private fun Application.installErrorHandling() {
     install(StatusPages) {
         exception<BadRequestException> { call, cause ->
             if (!call.response.isCommitted) {
@@ -179,8 +183,8 @@ fun Application.configureMonitoring() {
             logger.error { "ClickHouse query error on ${call.request.path()}: ${cause.detail}" }
             if (SentryConfig.isEnabled()) {
                 Sentry.captureException(cause) { scope ->
-                    scope.setTag("http.method", call.request.httpMethod.value)
-                    scope.setTag("http.path", call.request.path())
+                    scope.setTag(HTTP_METHOD_TAG, call.request.httpMethod.value)
+                    scope.setTag(HTTP_PATH_TAG, call.request.path())
                     scope.setTag("clickhouse.timeout", cause.isTimeout.toString())
                     scope.setExtra("clickhouse.detail", cause.detail)
                 }
@@ -197,9 +201,9 @@ fun Application.configureMonitoring() {
             // Send to Sentry if enabled
             if (SentryConfig.isEnabled()) {
                 Sentry.captureException(cause) { scope ->
-                    scope.setTag("http.method", call.request.httpMethod.value)
-                    scope.setTag("http.path", call.request.path())
-                    scope.setTag("http.status_code", "500")
+                    scope.setTag(HTTP_METHOD_TAG, call.request.httpMethod.value)
+                    scope.setTag(HTTP_PATH_TAG, call.request.path())
+                    scope.setTag(HTTP_STATUS_CODE_TAG, SENTRY_INTERNAL_ERROR_STATUS)
 
                     val userAgent = call.request.headers["User-Agent"] ?: "unknown"
                     scope.setExtra("user_agent", userAgent)
@@ -231,7 +235,9 @@ fun Application.configureMonitoring() {
             }
         }
     }
+}
 
+private fun Application.installRequestLogging() {
     install(CallLogging) {
         level = Level.TRACE
         filter { call -> call.request.path().startsWith("/") }

--- a/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Monitoring.kt
@@ -172,69 +172,86 @@ private fun spanStatusFor(statusCode: Int): SpanStatus {
 private fun Application.installErrorHandling() {
     install(StatusPages) {
         exception<BadRequestException> { call, cause ->
-            if (!call.response.isCommitted) {
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    ErrorResponse(cause.message ?: "Bad request"),
-                )
-            }
+            handleBadRequest(call, cause)
         }
         exception<ClickHouseQueryException> { call, cause ->
-            logger.error { "ClickHouse query error on ${call.request.path()}: ${cause.detail}" }
-            if (SentryConfig.isEnabled()) {
-                Sentry.captureException(cause) { scope ->
-                    scope.setTag(HTTP_METHOD_TAG, call.request.httpMethod.value)
-                    scope.setTag(HTTP_PATH_TAG, call.request.path())
-                    scope.setTag("clickhouse.timeout", cause.isTimeout.toString())
-                    scope.setExtra("clickhouse.detail", cause.detail)
-                }
-            }
-            if (!call.response.isCommitted) {
-                val status = if (cause.isTimeout) HttpStatusCode.GatewayTimeout else HttpStatusCode.InternalServerError
-                val message = if (cause.isTimeout) "Query timed out" else "Data unavailable"
-                call.respond(status, mapOf("error" to message))
-            }
+            handleClickHouseQueryException(call, cause)
         }
         exception<Throwable> { call, cause ->
-            logger.error(cause) { "Unhandled exception: ${cause.message}" }
-
-            // Send to Sentry if enabled
-            if (SentryConfig.isEnabled()) {
-                Sentry.captureException(cause) { scope ->
-                    scope.setTag(HTTP_METHOD_TAG, call.request.httpMethod.value)
-                    scope.setTag(HTTP_PATH_TAG, call.request.path())
-                    scope.setTag(HTTP_STATUS_CODE_TAG, SENTRY_INTERNAL_ERROR_STATUS)
-
-                    val userAgent = call.request.headers["User-Agent"] ?: "unknown"
-                    scope.setExtra("user_agent", userAgent)
-                    scope.setExtra("remote_host", call.request.local.remoteHost)
-                    scope.setExtra("query_string", call.request.queryString())
-
-                    // Add request headers as extra context (excluding sensitive ones)
-                    val safeHeaders =
-                        call.request.headers
-                            .entries()
-                            .filter { (key, _) ->
-                                !key.equals("Authorization", ignoreCase = true) &&
-                                    !key.equals("Cookie", ignoreCase = true)
-                            }.associate { (key, values) -> key to values.joinToString(", ") }
-                    scope.setExtra("request_headers", safeHeaders.toString())
-                }
-            }
-
-            cause.printStackTrace()
-            if (!call.response.isCommitted) {
-                call.respond(
-                    HttpStatusCode.InternalServerError,
-                    mapOf("error" to "Internal server error")
-                )
-            } else {
-                logger.debug {
-                    "Skipping error response because response is already committed for ${call.request.path()}"
-                }
-            }
+            handleUnhandledException(call, cause)
         }
     }
+}
+
+private suspend fun handleBadRequest(call: ApplicationCall, cause: BadRequestException) {
+    if (!call.response.isCommitted) {
+        call.respond(
+            HttpStatusCode.BadRequest,
+            ErrorResponse(cause.message ?: "Bad request"),
+        )
+    }
+}
+
+private suspend fun handleClickHouseQueryException(call: ApplicationCall, cause: ClickHouseQueryException) {
+    logger.error { "ClickHouse query error on ${call.request.path()}: ${cause.detail}" }
+    captureClickHouseQueryException(call, cause)
+    if (!call.response.isCommitted) {
+        val status = if (cause.isTimeout) HttpStatusCode.GatewayTimeout else HttpStatusCode.InternalServerError
+        val message = if (cause.isTimeout) "Query timed out" else "Data unavailable"
+        call.respond(status, mapOf("error" to message))
+    }
+}
+
+private fun captureClickHouseQueryException(call: ApplicationCall, cause: ClickHouseQueryException) {
+    if (!SentryConfig.isEnabled()) {
+        return
+    }
+    Sentry.captureException(cause) { scope ->
+        scope.setTag(HTTP_METHOD_TAG, call.request.httpMethod.value)
+        scope.setTag(HTTP_PATH_TAG, call.request.path())
+        scope.setTag("clickhouse.timeout", cause.isTimeout.toString())
+        scope.setExtra("clickhouse.detail", cause.detail)
+    }
+}
+
+private suspend fun handleUnhandledException(call: ApplicationCall, cause: Throwable) {
+    logger.error(cause) { "Unhandled exception: ${cause.message}" }
+    captureUnhandledException(call, cause)
+    cause.printStackTrace()
+    if (!call.response.isCommitted) {
+        call.respond(
+            HttpStatusCode.InternalServerError,
+            mapOf("error" to "Internal server error")
+        )
+    } else {
+        logger.debug {
+            "Skipping error response because response is already committed for ${call.request.path()}"
+        }
+    }
+}
+
+private fun captureUnhandledException(call: ApplicationCall, cause: Throwable) {
+    if (!SentryConfig.isEnabled()) {
+        return
+    }
+    Sentry.captureException(cause) { scope ->
+        scope.setTag(HTTP_METHOD_TAG, call.request.httpMethod.value)
+        scope.setTag(HTTP_PATH_TAG, call.request.path())
+        scope.setTag(HTTP_STATUS_CODE_TAG, SENTRY_INTERNAL_ERROR_STATUS)
+        scope.setExtra("user_agent", call.request.headers["User-Agent"] ?: "unknown")
+        scope.setExtra("remote_host", call.request.local.remoteHost)
+        scope.setExtra("query_string", call.request.queryString())
+        scope.setExtra("request_headers", call.safeRequestHeaders().toString())
+    }
+}
+
+private fun ApplicationCall.safeRequestHeaders(): Map<String, String> {
+    return request.headers
+        .entries()
+        .filter { (key, _) ->
+            !key.equals("Authorization", ignoreCase = true) &&
+                !key.equals("Cookie", ignoreCase = true)
+        }.associate { (key, values) -> key to values.joinToString(", ") }
 }
 
 private fun Application.installRequestLogging() {

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
@@ -107,9 +107,11 @@ class ClickHouseClientTest {
                 "text/plain"
             )
         }) {
-            assertFailsWith<IllegalStateException> {
+            val ex = assertFailsWith<ClickHouseQueryException> {
                 ClickHouseClient.executeWithFormat("SELECT 1", "TabSeparated")
             }
+            assertEquals(true, ex.isTimeout)
+            assertEquals("Query timed out", ex.message)
         }
 
         val rendered = OperationalMetrics.scrape()

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
@@ -120,6 +120,23 @@ class ClickHouseClientTest {
         assertContains(rendered, "code=\"159\"")
     }
 
+    @Test
+    fun `executeWithFormat detects timeout messages case insensitively`() = runBlocking {
+        withClickHouseMockServer({ exchange ->
+            exchange.respond(
+                200,
+                "Code: 999. DB::Exception: Timeout exceeded while reading",
+                "text/plain"
+            )
+        }) {
+            val ex = assertFailsWith<ClickHouseQueryException> {
+                ClickHouseClient.executeWithFormat("SELECT 1", "TabSeparated")
+            }
+            assertEquals(true, ex.isTimeout)
+            assertEquals("Query timed out", ex.message)
+        }
+    }
+
     private fun parseQueryParams(rawQuery: String?): Map<String, String> {
         if (rawQuery.isNullOrBlank()) return emptyMap()
         return rawQuery.split("&").associate { part ->


### PR DESCRIPTION
## Summary
- add a typed ClickHouse query exception that keeps internal details out of API responses
- log slow and failed ClickHouse queries with bounded query text for diagnosis
- map ClickHouse timeouts to 504 responses and generic query failures to 500 responses
- update ClickHouse client timeout/error coverage

## Validation
- ./gradlew compileKotlin
- ./gradlew detekt
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.config.ClickHouseClientTest -Dkotlin.compiler.execution.strategy=in-process
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of database query timeouts, with timeouts surfaced correctly as gateway timeouts.
  * Improved and consistent error responses when database errors occur.

* **Improvements**
  * Automatic slow-query detection and warning logs for long-running queries.
  * Enhanced observability and error tracking for faster diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->