### PR TITLE
fix: omit null fields from MCP responses

### DIFF
--- a/backend/src/main/kotlin/com/moneat/mcp/routes/McpRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/routes/McpRoutes.kt
@@ -23,12 +23,17 @@ import com.moneat.mcp.models.McpContext
 import com.moneat.mcp.protocol.InputSchema
 import com.moneat.mcp.protocol.McpResourceRegistry
 import com.moneat.mcp.protocol.McpToolRegistry
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.call
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.request.header
+import io.ktor.server.request.path
+import io.ktor.server.response.ApplicationSendPipeline
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
@@ -40,9 +45,12 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransport
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult as SdkCallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceResult as SdkReadResourceResult
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
-import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent as SdkTextContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
@@ -50,15 +58,22 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import mu.KotlinLogging
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 private val logger = KotlinLogging.logger {}
 
 private const val MCP_SERVER_NAME = "moneat-mcp-server"
 private const val MCP_SERVER_VERSION = "1.0.0"
+private const val MCP_ROUTE_PATH = "/v1/mcp"
 private const val MCP_SESSION_ID_HEADER = "mcp-session-id"
 
 private val sessions = ConcurrentHashMap<String, McpStreamableSession>()
@@ -69,7 +84,9 @@ fun Route.mcpRoutes(
     resourceRegistry: McpResourceRegistry,
 ) {
     rateLimit(RateLimitName("mcp")) {
-        route("/v1/mcp") {
+        route(MCP_ROUTE_PATH) {
+            installMcpJsonResponseTransform()
+
             post {
                 val session = resolveOrCreateSession(call, toolRegistry, resourceRegistry)
                     ?: return@post
@@ -207,7 +224,7 @@ private fun createMcpServer(
             )
             SdkCallToolResult(
                 content = result.content.map { content ->
-                    TextContent(text = content.text ?: "")
+                    SdkTextContent(text = content.text ?: "")
                 },
                 isError = result.isError,
             )
@@ -239,6 +256,72 @@ private fun createMcpServer(
 
     logger.debug { "Created MCP server" }
     return server
+}
+
+private fun Route.installMcpJsonResponseTransform() {
+    (this as ApplicationCallPipeline).sendPipeline.intercept(ApplicationSendPipeline.Before) {
+        if (call.request.path() != MCP_ROUTE_PATH) return@intercept
+        val responseText = encodeMcpJsonRpcResponse(subject) ?: return@intercept
+        proceedWith(
+            TextContent(
+                text = responseText,
+                contentType = ContentType.Application.Json,
+                status = call.response.status(),
+            )
+        )
+    }
+}
+
+private fun encodeMcpJsonRpcResponse(body: Any): String? =
+    when (body) {
+        is JSONRPCMessage -> encodeMcpJsonRpcMessage(body)
+        is List<*> -> encodeMcpJsonRpcBatchResponse(body)
+        else -> null
+    }
+
+private fun encodeMcpJsonRpcMessage(message: JSONRPCMessage): String =
+    McpJson
+        .parseToJsonElement(McpJson.encodeToString(message))
+        .withoutNullFields()
+        .withJsonRpcNullErrorId(message)
+        .toString()
+
+private fun encodeMcpJsonRpcBatchResponse(body: List<*>): String? {
+    val encodedMessages = body.map { item ->
+        val message = item as? JSONRPCMessage ?: return null
+        encodeMcpJsonRpcMessage(message)
+    }
+    return encodedMessages.joinToString(prefix = "[", postfix = "]")
+}
+
+private fun JsonElement.withoutNullFields(): JsonElement =
+    when (this) {
+        is JsonObject -> buildJsonObject {
+            for ((key, value) in this@withoutNullFields) {
+                if (value !is JsonNull || shouldKeepNullJsonField(key, this@withoutNullFields)) {
+                    put(key, value.withoutNullFields())
+                }
+            }
+        }
+        is JsonArray -> buildJsonArray {
+            for (value in this@withoutNullFields) {
+                add(value.withoutNullFields())
+            }
+        }
+        else -> this
+    }
+
+private fun shouldKeepNullJsonField(key: String, parent: JsonObject): Boolean =
+    key == "id" && "error" in parent
+
+private fun JsonElement.withJsonRpcNullErrorId(message: JSONRPCMessage): JsonElement {
+    if (message !is JSONRPCError || message.id != null || this !is JsonObject) return this
+    return buildJsonObject {
+        put("id", JsonNull)
+        for ((key, value) in this@withJsonRpcNullErrorId) {
+            put(key, value)
+        }
+    }
 }
 
 private class McpStreamableSession(

--- a/backend/src/main/kotlin/com/moneat/mcp/routes/McpRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/routes/McpRoutes.kt
@@ -298,7 +298,7 @@ private fun JsonElement.withoutNullFields(): JsonElement =
     when (this) {
         is JsonObject -> buildJsonObject {
             for ((key, value) in this@withoutNullFields) {
-                if (value !is JsonNull || shouldKeepNullJsonField(key, this@withoutNullFields)) {
+                if (value !is JsonNull) {
                     put(key, value.withoutNullFields())
                 }
             }
@@ -310,9 +310,6 @@ private fun JsonElement.withoutNullFields(): JsonElement =
         }
         else -> this
     }
-
-private fun shouldKeepNullJsonField(key: String, parent: JsonObject): Boolean =
-    key == "id" && "error" in parent
 
 private fun JsonElement.withJsonRpcNullErrorId(message: JSONRPCMessage): JsonElement {
     if (message !is JSONRPCError || message.id != null || this !is JsonObject) return this

--- a/backend/src/test/kotlin/com/moneat/mcp/routes/McpRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/routes/McpRoutesTest.kt
@@ -56,8 +56,10 @@ import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -147,6 +149,31 @@ class McpRoutesTest {
         assertEquals(HttpStatusCode.OK, response.status)
         val body = response.bodyAsText()
         assertTrue(body.contains("authorized_read"), body)
+    }
+
+    @Test
+    fun `POST v1 mcp handles batched json rpc requests`() = testApplication {
+        setupApp()
+        val sessionId = initializeSession()
+
+        val response = client.post("/v1/mcp") {
+            mcpHeaders()
+            header("mcp-session-id", sessionId)
+            setBody(
+                """
+                [
+                  {"jsonrpc":"2.0","id":2,"method":"tools/list"},
+                  {"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"moneat://test-resource"}}
+                ]
+                """.trimIndent()
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonArray
+        assertEquals(2, body.size)
+        assertTrue(body.anyJsonObjectContains("authorized_read"))
+        assertTrue(body.anyJsonObjectContains("resource ok"))
     }
 
     @Test
@@ -396,6 +423,9 @@ class McpRoutesTest {
             .token ?: error("Generated token was missing")
     }
 }
+
+private fun JsonArray.anyJsonObjectContains(value: String): Boolean =
+    any { element -> element.toString().contains(value) }
 
 private class AuthorizedReadTool : McpTool {
     override val name: String = "authorized_read"

--- a/backend/src/test/kotlin/com/moneat/mcp/routes/McpRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/routes/McpRoutesTest.kt
@@ -55,7 +55,10 @@ import io.ktor.server.plugins.ratelimit.RateLimit
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
@@ -63,6 +66,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
@@ -99,6 +103,34 @@ class McpRoutesTest {
         val body = response.bodyAsText()
         assertTrue(body.contains("moneat-mcp-server"), body)
         assertTrue(response.headers["mcp-session-id"]?.isNotBlank() == true)
+    }
+
+    @Test
+    fun `POST v1 mcp initialize response omits optional null fields`() = testApplication {
+        setupApp()
+
+        val response = client.post("/v1/mcp") {
+            mcpHeaders()
+            setBody(initializeRequest())
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val responseBody = response.bodyAsText()
+        val body = Json.parseToJsonElement(responseBody).jsonObject
+        val result = body.getValue("result").jsonObject
+        val capabilities = result.getValue("capabilities").jsonObject
+        val serverInfo = result.getValue("serverInfo").jsonObject
+
+        assertFalse("_meta" in result, responseBody)
+        assertFalse("instructions" in result, responseBody)
+        assertFalse("prompts" in capabilities, responseBody)
+        assertFalse("logging" in capabilities, responseBody)
+        assertFalse("completions" in capabilities, responseBody)
+        assertFalse("experimental" in capabilities, responseBody)
+        assertFalse("extensions" in capabilities, responseBody)
+        assertFalse("title" in serverInfo, responseBody)
+        assertFalse("websiteUrl" in serverInfo, responseBody)
+        assertFalse("icons" in serverInfo, responseBody)
     }
 
     @Test
@@ -167,6 +199,21 @@ class McpRoutesTest {
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
         assertTrue(response.bodyAsText().contains("Invalid or missing bearer token"))
+    }
+
+    @Test
+    fun `POST v1 mcp parse error keeps null json rpc id`() = testApplication {
+        setupApp()
+
+        val response = client.post("/v1/mcp") {
+            mcpHeaders()
+            setBody("{")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals(JsonNull, body["id"])
+        assertTrue("error" in body)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- serialize exact-path /v1/mcp JSON-RPC responses before global ContentNegotiation
- omit optional null MCP protocol fields that strict clients reject
- preserve JSON-RPC error responses with id: null

## Validation
- ./gradlew :test --tests com.moneat.mcp.routes.McpRoutesTest
- ./gradlew detekt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP JSON-RPC responses are now served as application/json text content and automatically omit null optional fields for cleaner output.
  * Error responses without an identifier preserve a null id in the encoded output; batched JSON-RPC responses are correctly encoded.

* **Tests**
  * Added tests for initialize response field omission, JSON parse error handling (preserving null id), and batched request parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->