### PR TITLE
refactor: default logs grouping to level

### DIFF
--- a/dashboard/src/components/logs/LogExplorer.tsx
+++ b/dashboard/src/components/logs/LogExplorer.tsx
@@ -36,6 +36,7 @@ import {
   type LogViewSearch,
   parseFacetFiltersFromUrl,
   parseLevelsFromUrl,
+  resolveLogGroupBy,
   serializeLogViewState,
 } from '@/components/logs/logViewUrlState'
 import {logIntervalToMs} from '@/components/logs/logInterval'
@@ -124,7 +125,7 @@ export function LogExplorer({
         customFrom: urlSearch.from || '',
         customTo: urlSearch.to || '',
         vizMode: urlSearch.viz || 'timeseries' as LogVizMode,
-        groupBy: urlSearch.groupBy || '',
+        groupBy: resolveLogGroupBy(urlSearch.groupBy),
         topField: urlSearch.topField || 'service',
         cursor: urlSearch.cursor || null,
         selectedLogId: urlSearch.logId || null,
@@ -138,7 +139,7 @@ export function LogExplorer({
       customFrom: '',
       customTo: '',
       vizMode: 'timeseries' as LogVizMode,
-      groupBy: '',
+      groupBy: resolveLogGroupBy(undefined),
       topField: 'service',
       cursor: null,
       selectedLogId: null,
@@ -221,7 +222,7 @@ export function LogExplorer({
       setCustomFrom(urlSearch.from || '')
       setCustomTo(urlSearch.to || '')
       setVizMode(urlSearch.viz || 'timeseries')
-      setGroupBy(urlSearch.groupBy || '')
+      setGroupBy(resolveLogGroupBy(urlSearch.groupBy))
       setTopField(urlSearch.topField || 'service')
       setCursor(urlSearch.cursor || null)
     })

--- a/dashboard/src/components/logs/README.md
+++ b/dashboard/src/components/logs/README.md
@@ -36,7 +36,7 @@ All viewer state is encoded in URL query parameters, enabling:
 | `from` | `string` | Custom range start (ISO) | `?from=2024-01-15T10:00:00Z` |
 | `to` | `string` | Custom range end (ISO) | `?to=2024-01-15T11:00:00Z` |
 | `viz` | `string` | Visualization mode | `?viz=table` |
-| `groupBy` | `string` | Group by field (table viz) | `?groupBy=service` |
+| `groupBy` | `string` | Group by field; omitted defaults to level, `none` disables grouping | `?groupBy=service` |
 | `topField` | `string` | Top field (toplist/pie) | `?topField=environment` |
 | `cursor` | `string` | Pagination cursor | `?cursor=abc123` |
 | `logId` | `string` | Selected log ID | `?logId=xyz789` |

--- a/dashboard/src/components/logs/logViewUrlState.test.ts
+++ b/dashboard/src/components/logs/logViewUrlState.test.ts
@@ -16,10 +16,12 @@
 
 import {describe, it, expect} from 'vitest'
 import {
+  NO_LOG_GROUP_BY_URL_VALUE,
   parseLogViewSearch,
-  serializeLogViewState,
   parseFacetFiltersFromUrl,
   parseLevelsFromUrl,
+  resolveLogGroupBy,
+  serializeLogViewState,
 } from './logViewUrlState'
 import type {FacetFilter} from './LogSearchBar'
 
@@ -104,6 +106,16 @@ describe('logViewUrlState', () => {
       const result = parseLogViewSearch({groupBy: 'service', topField: 'level'})
       expect(result.groupBy).toBe('service')
       expect(result.topField).toBe('level')
+    })
+
+    it('should parse explicit no-grouping state', () => {
+      const result = parseLogViewSearch({groupBy: NO_LOG_GROUP_BY_URL_VALUE})
+      expect(result.groupBy).toBe(NO_LOG_GROUP_BY_URL_VALUE)
+    })
+
+    it('should ignore invalid groupBy values', () => {
+      const result = parseLogViewSearch({groupBy: 'message'})
+      expect(result.groupBy).toBeUndefined()
     })
 
     it('should parse cursor and logId', () => {
@@ -220,6 +232,21 @@ describe('logViewUrlState', () => {
       expect(result.topField).toBe('level')
     })
 
+    it('should omit default level grouping', () => {
+      const result = serializeLogViewState({groupBy: 'level'})
+      expect(result.groupBy).toBeUndefined()
+    })
+
+    it('should serialize explicit no-grouping state', () => {
+      const result = serializeLogViewState({groupBy: ''})
+      expect(result.groupBy).toBe(NO_LOG_GROUP_BY_URL_VALUE)
+    })
+
+    it('should include non-default groupBy', () => {
+      const result = serializeLogViewState({groupBy: 'service'})
+      expect(result.groupBy).toBe('service')
+    })
+
     it('should include cursor', () => {
       const result = serializeLogViewState({cursor: 'abc123'})
       expect(result.cursor).toBe('abc123')
@@ -283,6 +310,20 @@ describe('logViewUrlState', () => {
 
     it('should handle single level', () => {
       expect(parseLevelsFromUrl('error')).toEqual(['error'])
+    })
+  })
+
+  describe('resolveLogGroupBy', () => {
+    it('should default missing groupBy to level', () => {
+      expect(resolveLogGroupBy(undefined)).toBe('level')
+    })
+
+    it('should preserve explicit no-grouping state', () => {
+      expect(resolveLogGroupBy(NO_LOG_GROUP_BY_URL_VALUE)).toBe('')
+    })
+
+    it('should preserve valid grouping fields', () => {
+      expect(resolveLogGroupBy('environment')).toBe('environment')
     })
   })
 

--- a/dashboard/src/components/logs/logViewUrlState.ts
+++ b/dashboard/src/components/logs/logViewUrlState.ts
@@ -44,8 +44,12 @@ export interface LogViewSearch {
   logId?: string
 }
 
+export const DEFAULT_LOG_GROUP_BY = 'level'
+export const NO_LOG_GROUP_BY_URL_VALUE = 'none'
+
 const VALID_VIZ_MODES: LogVizMode[] = ['timeseries', 'table', 'toplist', 'pie']
 const VALID_TIME_PRESETS = ['5m', '15m', '30m', '1h', '4h', '12h', '24h', '3d', '7d', '14d', '30d', 'custom']
+const VALID_GROUP_BY_VALUES = [DEFAULT_LOG_GROUP_BY, 'service', 'environment', NO_LOG_GROUP_BY_URL_VALUE]
 
 /**
  * Parse URL search params into normalized log view state.
@@ -107,8 +111,11 @@ export function parseLogViewSearch(search: Record<string, unknown>): LogViewSear
   }
   
   // Group by / top field
-  if (typeof search.groupBy === 'string' && search.groupBy.trim()) {
-    result.groupBy = search.groupBy.trim()
+  if (typeof search.groupBy === 'string') {
+    const groupBy = search.groupBy.trim()
+    if (VALID_GROUP_BY_VALUES.includes(groupBy)) {
+      result.groupBy = groupBy
+    }
   }
   if (typeof search.topField === 'string' && search.topField.trim()) {
     result.topField = search.topField.trim()
@@ -186,7 +193,9 @@ export function serializeLogViewState(state: {
   }
   
   // Group by / top field
-  if (state.groupBy && state.groupBy.trim()) {
+  if (state.groupBy === '') {
+    result.groupBy = NO_LOG_GROUP_BY_URL_VALUE
+  } else if (state.groupBy && state.groupBy.trim() && state.groupBy !== DEFAULT_LOG_GROUP_BY) {
     result.groupBy = state.groupBy.trim()
   }
   if (state.topField && state.topField.trim() && state.topField !== 'service') {
@@ -204,6 +213,12 @@ export function serializeLogViewState(state: {
   }
   
   return result
+}
+
+export function resolveLogGroupBy(groupBy: string | undefined): string {
+  if (groupBy === NO_LOG_GROUP_BY_URL_VALUE) return ''
+  if (groupBy && VALID_GROUP_BY_VALUES.includes(groupBy)) return groupBy
+  return DEFAULT_LOG_GROUP_BY
 }
 
 /**


### PR DESCRIPTION
## Summary
- default the logs aggregate grouping selector to level
- preserve explicit no-grouping links with groupBy=none
- document and test the URL state behavior

## Validation
- npm test -- src/components/logs/logViewUrlState.test.ts
- npm run lint
- npm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL parameter handling for log grouping with improved validation and normalization.
  * Default log grouping now correctly applies by log level.
  * Added support to disable grouping via URL parameter.

* **Documentation**
  * Updated documentation clarifying log grouping defaults and disable option.

* **Tests**
  * Expanded test coverage for log view URL state handling and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->