### PR TITLE
perf(ci): speed up the backend-unit job (~10m → target ~6m)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,19 +53,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Run detekt (Kotlin linter)
-        working-directory: backend
-        run: ./gradlew detekt --no-daemon
-
       - name: Run backend unit tests
         working-directory: backend
         run: ./gradlew test --no-daemon
-        env:
-          COVERAGE_GATE_PHASE: ${{ env.COVERAGE_GATE_PHASE }}
-
-      - name: Generate JaCoCo report
-        working-directory: backend
-        run: ./gradlew jacocoTestReport --no-daemon
         env:
           COVERAGE_GATE_PHASE: ${{ env.COVERAGE_GATE_PHASE }}
 
@@ -90,6 +80,33 @@ jobs:
           name: backend-coverage-report
           path: backend/build/reports/jacoco/test/
 
+  backend-detekt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run detekt (Kotlin linter)
+        working-directory: backend
+        run: ./gradlew detekt --no-daemon
+
       - name: Upload detekt report (Sonar)
         if: success()
         uses: actions/upload-artifact@v7
@@ -101,7 +118,7 @@ jobs:
   sonarqube:
     name: SonarQube Analysis
     if: github.event_name != 'schedule'
-    needs: [backend-unit]
+    needs: [backend-unit, backend-detekt]
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,4 +1,5 @@
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx2g
+org.gradle.caching=true
 # Override enterprise module path (default: ../../moneat-enterprise/backend)
 # enterprisePath=../../moneat-enterprise/backend

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -43,11 +43,14 @@ import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.unmockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -60,6 +63,28 @@ class DatadogIngestRoutesTest {
         private const val DD_API_KEY_HEADER = "DD-API-KEY"
         private const val VALID_KEY = "dd-ingest-test-key"
         private const val ORG_ID = 5
+
+        @JvmStatic
+        @BeforeAll
+        fun installObjectMocks() {
+            mockkObject(
+                DatadogService,
+                DatadogMetricService,
+                DatadogLogService,
+                DatadogEventService,
+                DatadogHostService,
+                MiscIngestionService,
+                DbmIngestionService,
+                DebuggerIngestionService,
+                OrchestratorIngestionService,
+            )
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun removeObjectMocks() {
+            unmockkAll()
+        }
     }
 
     private val quotaService = mockk<BillingQuotaService> {
@@ -70,15 +95,17 @@ class DatadogIngestRoutesTest {
     fun setup() {
         startTestKoin()
         DatadogAuthMiddleware.clearCache()
-        mockkObject(DatadogService)
-        mockkObject(DatadogMetricService)
-        mockkObject(DatadogLogService)
-        mockkObject(DatadogEventService)
-        mockkObject(DatadogHostService)
-        mockkObject(MiscIngestionService)
-        mockkObject(DbmIngestionService)
-        mockkObject(DebuggerIngestionService)
-        mockkObject(OrchestratorIngestionService)
+        clearMocks(
+            DatadogService,
+            DatadogMetricService,
+            DatadogLogService,
+            DatadogEventService,
+            DatadogHostService,
+            MiscIngestionService,
+            DbmIngestionService,
+            DebuggerIngestionService,
+            OrchestratorIngestionService,
+        )
 
         coEvery { DatadogMetricService.enqueueMetrics(any(), any()) } returns 0
         coEvery { DatadogLogService.enqueueLogs(any(), any()) } returns 0
@@ -107,15 +134,6 @@ class DatadogIngestRoutesTest {
 
     @AfterTest
     fun teardown() {
-        unmockkObject(OrchestratorIngestionService)
-        unmockkObject(DebuggerIngestionService)
-        unmockkObject(DbmIngestionService)
-        unmockkObject(MiscIngestionService)
-        unmockkObject(DatadogHostService)
-        unmockkObject(DatadogEventService)
-        unmockkObject(DatadogLogService)
-        unmockkObject(DatadogMetricService)
-        unmockkObject(DatadogService)
         DatadogAuthMiddleware.clearCache()
         stopTestKoin()
     }

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -84,19 +84,21 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.Runs
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.unmockkObject
+import io.mockk.unmockkAll
 import io.mockk.verify
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import kotlin.test.AfterTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -114,6 +116,33 @@ class DatadogRoutesExtendedTest {
         private const val EMPTY_ROWS_JSON = """{"rows":[]}"""
         private const val AGENT_API_KEYS_PATH = "/v1/agent-api-keys"
         private var db: Database? = null
+
+        @JvmStatic
+        @BeforeAll
+        fun installObjectMocks() {
+            mockkObject(
+                DatadogAuthMiddleware,
+                DatadogHostService,
+                DatadogMetricService,
+                DatadogEventService,
+                DatadogLogService,
+                DatadogInfraService,
+                MiscIngestionService,
+                DbmIngestionService,
+                OrchestratorIngestionService,
+                DebuggerIngestionService,
+                TelemetryProxyService,
+                DatadogService,
+                TraceIngestionService,
+                ClickHouseClient,
+            )
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun removeObjectMocks() {
+            unmockkAll()
+        }
     }
 
     private val allowingQuotaService = mockk<BillingQuotaService> {
@@ -138,20 +167,22 @@ class DatadogRoutesExtendedTest {
         )
         DatadogAuthMiddleware.clearCache()
 
-        mockkObject(DatadogAuthMiddleware)
-        mockkObject(DatadogHostService)
-        mockkObject(DatadogMetricService)
-        mockkObject(DatadogEventService)
-        mockkObject(DatadogLogService)
-        mockkObject(DatadogInfraService)
-        mockkObject(MiscIngestionService)
-        mockkObject(DbmIngestionService)
-        mockkObject(OrchestratorIngestionService)
-        mockkObject(DebuggerIngestionService)
-        mockkObject(TelemetryProxyService)
-        mockkObject(DatadogService)
-        mockkObject(TraceIngestionService)
-        mockkObject(ClickHouseClient)
+        clearMocks(
+            DatadogAuthMiddleware,
+            DatadogHostService,
+            DatadogMetricService,
+            DatadogEventService,
+            DatadogLogService,
+            DatadogInfraService,
+            MiscIngestionService,
+            DbmIngestionService,
+            OrchestratorIngestionService,
+            DebuggerIngestionService,
+            TelemetryProxyService,
+            DatadogService,
+            TraceIngestionService,
+            ClickHouseClient,
+        )
 
         coEvery {
             DatadogAuthMiddleware.authenticate(any())
@@ -187,24 +218,6 @@ class DatadogRoutesExtendedTest {
         every { DebuggerIngestionService.enqueueDebuggerLogs(any(), any()) } returns 1
         every { DebuggerIngestionService.enqueueDiagnostics(any(), any()) } returns 1
         every { TelemetryProxyService.acknowledge(any(), any(), any()) } just Runs
-    }
-
-    @AfterTest
-    fun teardown() {
-        unmockkObject(DatadogAuthMiddleware)
-        unmockkObject(DatadogHostService)
-        unmockkObject(DatadogMetricService)
-        unmockkObject(DatadogEventService)
-        unmockkObject(DatadogLogService)
-        unmockkObject(DatadogInfraService)
-        unmockkObject(MiscIngestionService)
-        unmockkObject(DbmIngestionService)
-        unmockkObject(OrchestratorIngestionService)
-        unmockkObject(DebuggerIngestionService)
-        unmockkObject(TelemetryProxyService)
-        unmockkObject(DatadogService)
-        unmockkObject(TraceIngestionService)
-        unmockkObject(ClickHouseClient)
     }
 
     private fun Application.installAuth() {


### PR DESCRIPTION
## Problem

`backend-unit` ran ~10 min, almost entirely the test step (~497s of a ~600s job). Instrumenting the GitHub run + an A/B on CI showed:

- The standard runner is effectively **~2 physical cores** (4 vCPU hyperthreaded), so the test forks were already saturated at the existing `cores/2`. Adding forks gave **no** speedup.
- detekt (~70s) ran **serially ahead** of the tests.
- Two Datadog test classes paid a **~640ms fixed cost per test**: they re-instrumented 13 and 9 `mockkObject(...)` singletons in `@BeforeTest`/`@AfterTest` on *every* test. That's ~89s + ~54s for ~159 otherwise-trivial tests (even the fastest test took 638ms).

## Changes

1. **detekt → its own parallel job** (`backend-detekt`); `sonarqube` now depends on both. Takes ~70s off the `backend-unit` critical path. Also removed the redundant `Generate JaCoCo report` step — the `test` task's finalizer already produces it.
2. **Hoist object-mocking to once-per-class** in `DatadogRoutesExtendedTest` and `DatadogIngestRoutesTest`: `mockkObject(...)` in `@BeforeAll`, `unmockkAll()` in `@AfterAll`, and `clearMocks(...)` + default re-stubs per test (preserves per-test isolation). Drops these classes from ~66s/~54s → ~10s/~7s locally and total backend test self-time from **~378s → ~308s**.
3. **Enable the Gradle build cache** (`org.gradle.caching`).

## Tried and reverted

Raising `maxParallelForks` to all vCPUs plus `org.gradle.parallel`/daemon: the CI A/B proved the runner has only ~2 usable cores, so more forks didn't help and added ~40s of config/compile overhead. Reverted — `build.gradle.kts` is unchanged vs develop.

## Validation

- Full suite green against current develop: **275 classes / 4326 tests / 0 failures**.
- A 1134-test `routes`+`datadog` run confirms no cross-class mock leakage from the shared `unmockkAll()` (JUnit runs classes sequentially within a fork, so `@AfterAll` cleanup is safe).