### PR TITLE
feat: improve flamegraph viewer

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
@@ -180,6 +180,9 @@ fun Route.profileDashboardRoutes() {
                     return@get
                 }
 
+                val sampleType = call.parameters["sampleType"]
+                val thread = call.parameters["thread"]
+
                 val frames = when (meta.source) {
                     "sentry" -> parseSentryProfileToFrames(data)
                     "datadog" -> {
@@ -187,9 +190,9 @@ fun Route.profileDashboardRoutes() {
                         val isJfrPayload =
                             DatadogPprofFlamegraphService.isLikelyJfrPayload(data)
                         if (isJfrType || isJfrPayload) {
-                            DatadogJfrFlamegraphService.parseToFrames(data)
+                            DatadogJfrFlamegraphService.parseToFrames(data, sampleType, thread)
                         } else {
-                            DatadogPprofFlamegraphService.parseToFrames(data)
+                            DatadogPprofFlamegraphService.parseToFrames(data, sampleType, thread)
                         }
                     }
                     else -> emptyFlamegraph()

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphService.kt
@@ -35,7 +35,6 @@ private val logger = KotlinLogging.logger {}
 object DatadogJfrFlamegraphService {
 
     private const val JFR_MAGIC_LAST_BYTE_INDEX = 3
-    private const val MAX_THREADS = 50
 
     private data class MutableFrame(
         val name: String,

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphService.kt
@@ -17,6 +17,7 @@
 package com.moneat.datadog.services
 
 import com.moneat.datadog.decompression.DecompressionService
+import jdk.jfr.consumer.RecordedEvent
 import jdk.jfr.consumer.RecordedFrame
 import jdk.jfr.consumer.RecordedStackTrace
 import jdk.jfr.consumer.RecordingFile
@@ -27,12 +28,14 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import mu.KotlinLogging
 import java.nio.file.Files
+import java.nio.file.Path
 
 private val logger = KotlinLogging.logger {}
 
 object DatadogJfrFlamegraphService {
 
     private const val JFR_MAGIC_LAST_BYTE_INDEX = 3
+    private const val MAX_THREADS = 50
 
     private data class MutableFrame(
         val name: String,
@@ -40,48 +43,38 @@ object DatadogJfrFlamegraphService {
         val children: MutableMap<String, MutableFrame> = mutableMapOf(),
     )
 
-    fun parseToFrames(data: ByteArray): JsonObject {
+    /** A logical profile dimension (CPU, allocations, lock contention, …). */
+    private data class SampleKind(val key: String, val label: String, val unit: String)
+
+    private data class CollectedSample(
+        val frames: List<String>,
+        val typeKey: String,
+        val thread: String,
+        val weight: Long,
+    )
+
+    private val CPU = SampleKind("cpu", "CPU", "samples")
+    private val ALLOC = SampleKind("alloc", "Allocations", "bytes")
+    private val LOCK = SampleKind("lock", "Lock contention", "ns")
+    private val BLOCK = SampleKind("block", "Blocking", "ns")
+
+    /**
+     * Parse a JFR recording into a flamegraph tree for the requested sample type
+     * and thread, alongside the full set of available types and threads so the
+     * UI can offer selectors. Passing null falls back to the dominant type and
+     * all threads.
+     */
+    fun parseToFrames(
+        data: ByteArray,
+        sampleType: String? = null,
+        thread: String? = null,
+    ): JsonObject {
         return runCatching {
             val payload = DecompressionService.decompress(data, null)
             if (!hasJfrMagic(payload)) {
                 emptyFlamegraph()
             } else {
-                val root = MutableFrame("(root)")
-                val tmp = Files.createTempFile("moneat-profile-", ".jfr")
-                try {
-                    Files.write(tmp, payload)
-                    RecordingFile(tmp).use { recording ->
-                        while (recording.hasMoreEvents()) {
-                            val event = recording.readEvent()
-                            val eventName = event.eventType.name
-                            if (!isSampleLikeEvent(eventName)) continue
-                            val names = resolveFrames(event.stackTrace)
-                            if (names.isEmpty()) continue
-
-                            var current = root
-                            names.forEach { name ->
-                                val child = current.children.getOrPut(name) {
-                                    MutableFrame(name)
-                                }
-                                child.value += 1
-                                current = child
-                            }
-                        }
-                    }
-                } finally {
-                    runCatching { Files.deleteIfExists(tmp) }
-                }
-
-                buildJsonObject {
-                    put(
-                        "frames",
-                        buildJsonArray {
-                            root.children.values
-                                .sortedByDescending { it.value }
-                                .forEach { add(toJson(it)) }
-                        }
-                    )
-                }
+                buildResponse(collectSamples(payload), sampleType, thread)
             }
         }.onFailure { e ->
             logger.warn(e) { "Failed to parse Datadog JFR payload into flamegraph frames" }
@@ -90,12 +83,83 @@ object DatadogJfrFlamegraphService {
         }
     }
 
+    private fun collectSamples(payload: ByteArray): List<CollectedSample> {
+        val collected = ArrayList<CollectedSample>()
+        val tmp = Files.createTempFile("moneat-profile-", ".jfr")
+        try {
+            Files.write(tmp, payload)
+            readSamples(tmp, collected)
+        } finally {
+            runCatching { Files.deleteIfExists(tmp) }
+        }
+        return collected
+    }
+
+    private fun readSamples(tmp: Path, into: MutableList<CollectedSample>) {
+        RecordingFile(tmp).use { recording ->
+            while (recording.hasMoreEvents()) {
+                collectFromEvent(recording.readEvent())?.let { into += it }
+            }
+        }
+    }
+
+    private fun collectFromEvent(event: RecordedEvent): CollectedSample? {
+        val kind = sampleKindFor(event.eventType.name) ?: return null
+        val names = resolveFrames(event.stackTrace)
+        if (names.isEmpty()) return null
+        val weight = eventWeight(event, kind)
+        if (weight <= 0L) return null
+        return CollectedSample(names, kind.key, threadName(event), weight)
+    }
+
+    private fun buildResponse(
+        collected: List<CollectedSample>,
+        requestedType: String?,
+        requestedThread: String?,
+    ): JsonObject {
+        if (collected.isEmpty()) return emptyFlamegraph()
+
+        val typeTotals = LinkedHashMap<String, Long>()
+        val threadTotals = HashMap<String, Long>()
+        for (sample in collected) {
+            typeTotals.merge(sample.typeKey, sample.weight, Long::plus)
+            threadTotals.merge(sample.thread, sample.weight, Long::plus)
+        }
+
+        val selectedType = requestedType?.takeIf(typeTotals::containsKey)
+            ?: typeTotals.maxByOrNull { it.value }?.key
+            ?: return emptyFlamegraph()
+        val selectedThread = requestedThread
+            ?.takeIf { it.isNotBlank() && it != "all" && threadTotals.containsKey(it) }
+
+        val root = MutableFrame("(root)")
+        for (sample in collected) {
+            if (sample.typeKey != selectedType) continue
+            if (selectedThread != null && sample.thread != selectedThread) continue
+            var current = root
+            for (name in sample.frames) {
+                val child = current.children.getOrPut(name) { MutableFrame(name) }
+                child.value += sample.weight
+                current = child
+            }
+        }
+
+        val unit = kindOf(selectedType)?.unit ?: "samples"
+        val totalSamples = root.children.values.sumOf { it.value }
+        return buildJsonObject {
+            put("frames", framesJson(root))
+            put("sampleTypes", sampleTypesJson(typeTotals))
+            put("threads", threadsJson(threadTotals))
+            put("selectedSampleType", selectedType)
+            if (selectedThread != null) put("selectedThread", selectedThread)
+            put("unit", unit)
+            put("totalSamples", totalSamples)
+        }
+    }
+
     private fun resolveFrames(stack: RecordedStackTrace?): List<String> {
         if (stack == null) return emptyList()
-        val names = stack.frames
-            .mapNotNull { frameName(it) }
-            .asReversed()
-        return names
+        return stack.frames.mapNotNull { frameName(it) }.asReversed()
     }
 
     private fun frameName(frame: RecordedFrame): String? {
@@ -110,10 +174,80 @@ object DatadogJfrFlamegraphService {
         }
     }
 
-    private fun isSampleLikeEvent(name: String): Boolean {
-        return name == "jdk.ExecutionSample" ||
-            name == "jdk.NativeMethodSample" ||
-            name.startsWith("datadog.")
+    private fun sampleKindFor(name: String): SampleKind? = when {
+        name == "jdk.ExecutionSample" || name == "jdk.NativeMethodSample" -> CPU
+        name == "datadog.ExecutionSample" || name == "datadog.MethodSample" -> CPU
+        name.contains("Allocation") -> ALLOC
+        name.contains("Monitor") || name.contains("Lock") -> LOCK
+        name.endsWith("Block") || name.contains("ThreadPark") -> BLOCK
+        name.startsWith("datadog.") -> CPU
+        else -> null
+    }
+
+    private fun kindOf(key: String): SampleKind? =
+        listOf(CPU, ALLOC, LOCK, BLOCK).firstOrNull { it.key == key }
+
+    private fun eventWeight(event: RecordedEvent, kind: SampleKind): Long = when (kind.key) {
+        "alloc" -> firstLong(event, "weight", "allocationSize", "objectSize") ?: 1L
+        "lock", "block" -> runCatching { event.duration.toNanos() }.getOrDefault(1L).coerceAtLeast(1L)
+        else -> 1L
+    }
+
+    private fun firstLong(event: RecordedEvent, vararg fields: String): Long? {
+        for (field in fields) {
+            if (event.hasField(field)) {
+                val value = runCatching { event.getLong(field) }.getOrNull()
+                if (value != null && value > 0L) return value
+            }
+        }
+        return null
+    }
+
+    private fun threadName(event: RecordedEvent): String {
+        val thread = (
+            if (event.hasField("sampledThread")) {
+                runCatching { event.getThread("sampledThread") }.getOrNull()
+            } else {
+                null
+            }
+            ) ?: event.thread
+        return thread?.javaName?.takeIf { it.isNotBlank() }
+            ?: thread?.osName?.takeIf { it.isNotBlank() }
+            ?: "unknown"
+    }
+
+    private fun framesJson(root: MutableFrame): JsonArray = buildJsonArray {
+        root.children.values.sortedByDescending { it.value }.forEach { add(toJson(it)) }
+    }
+
+    private fun sampleTypesJson(typeTotals: Map<String, Long>): JsonArray = buildJsonArray {
+        typeTotals.entries
+            .sortedByDescending { it.value }
+            .mapNotNull { kindOf(it.key) }
+            .forEach { kind ->
+                add(
+                    buildJsonObject {
+                        put("key", kind.key)
+                        put("label", kind.label)
+                        put("unit", kind.unit)
+                    },
+                )
+            }
+    }
+
+    private fun threadsJson(threadTotals: Map<String, Long>): JsonArray = buildJsonArray {
+        threadTotals.entries
+            .sortedByDescending { it.value }
+            .take(MAX_THREADS)
+            .forEach { (name, total) ->
+                add(
+                    buildJsonObject {
+                        put("id", name)
+                        put("label", name)
+                        put("samples", total)
+                    },
+                )
+            }
     }
 
     private fun hasJfrMagic(data: ByteArray): Boolean {
@@ -139,6 +273,10 @@ object DatadogJfrFlamegraphService {
 
     private fun emptyFlamegraph(): JsonObject = buildJsonObject {
         put("frames", JsonArray(emptyList()))
+        put("sampleTypes", JsonArray(emptyList()))
+        put("threads", JsonArray(emptyList()))
+        put("unit", "samples")
+        put("totalSamples", 0L)
     }
 
     private val JFR_MAGIC = byteArrayOf('F'.code.toByte(), 'L'.code.toByte(), 'R'.code.toByte(), 0x00)

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphService.kt
@@ -35,7 +35,6 @@ private val logger = KotlinLogging.logger {}
 
 private const val HEX_RADIX = 16
 private const val JFR_MAGIC_LAST_INDEX = 3
-private const val MAX_THREADS = 50
 private val THREAD_LABEL_KEYS = listOf("thread name", "thread")
 
 object DatadogPprofFlamegraphService {

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphService.kt
@@ -35,6 +35,8 @@ private val logger = KotlinLogging.logger {}
 
 private const val HEX_RADIX = 16
 private const val JFR_MAGIC_LAST_INDEX = 3
+private const val MAX_THREADS = 50
+private val THREAD_LABEL_KEYS = listOf("thread name", "thread")
 
 object DatadogPprofFlamegraphService {
 
@@ -56,11 +58,15 @@ object DatadogPprofFlamegraphService {
     )
 
     private data class ValueType(val typeIdx: Long, val unitIdx: Long)
+    private data class Label(val keyIdx: Long, val strIdx: Long)
     private data class Sample(
         val locationIds: List<Long>,
         val locationIdx: List<Long>,
         val values: List<Long>,
+        val labels: List<Label> = emptyList(),
     )
+
+    private data class SampleTypeMeta(val index: Int, val key: String, val unit: String)
     private data class Mapping(
         val id: Long,
         val filenameIdx: Long,
@@ -80,29 +86,65 @@ object DatadogPprofFlamegraphService {
         val filenameIdx: Long,
     )
 
-    fun parseToFrames(data: ByteArray): JsonObject {
+    fun parseToFrames(
+        data: ByteArray,
+        sampleType: String? = null,
+        thread: String? = null,
+    ): JsonObject {
         return runCatching {
             val payload = normalizePayload(data)
             if (hasJfrMagic(payload)) {
                 logger.debug { "Skipping flamegraph parse for JFR payload" }
                 emptyFlamegraph()
             } else {
-                val profile = decodeProfile(payload)
-                val roots = buildFrameTree(profile)
-                buildJsonObject {
-                    put(
-                        "frames",
-                        buildJsonArray {
-                            roots.sortedByDescending { it.value }
-                                .forEach { add(toJson(it)) }
-                        }
-                    )
-                }
+                buildResponse(decodeProfile(payload), sampleType, thread)
             }
         }.onFailure { e ->
             logger.warn(e) { "Failed to parse Datadog pprof payload into flamegraph frames" }
         }.getOrElse {
             emptyFlamegraph()
+        }
+    }
+
+    private fun buildResponse(
+        profile: PprofProfile,
+        requestedType: String?,
+        requestedThread: String?,
+    ): JsonObject {
+        if (profile.samples.isEmpty()) return emptyFlamegraph()
+
+        val types = profile.sampleTypes.mapIndexed { idx, vt ->
+            SampleTypeMeta(
+                index = idx,
+                key = stringAt(profile.strings, vt.typeIdx).ifBlank { "sample$idx" },
+                unit = stringAt(profile.strings, vt.unitIdx),
+            )
+        }
+        val selected = types.firstOrNull { it.key == requestedType }
+            ?: types.getOrNull(resolveValueIndex(profile))
+            ?: types.firstOrNull()
+            ?: return emptyFlamegraph()
+
+        val threadTotals = computeThreadTotals(profile, selected.index)
+        val selectedThread = requestedThread
+            ?.takeIf { it.isNotBlank() && it != "all" && threadTotals.containsKey(it) }
+
+        val roots = buildFrameTree(profile, selected.index, selectedThread)
+        val total = roots.sumOf { it.value }
+
+        return buildJsonObject {
+            put(
+                "frames",
+                buildJsonArray {
+                    roots.sortedByDescending { it.value }.forEach { add(toJson(it)) }
+                },
+            )
+            put("sampleTypes", sampleTypesJson(types))
+            put("threads", threadsJson(threadTotals))
+            put("selectedSampleType", selected.key)
+            if (selectedThread != null) put("selectedThread", selectedThread)
+            put("unit", selected.unit.ifBlank { "samples" })
+            put("totalSamples", total)
         }
     }
 
@@ -128,17 +170,19 @@ object DatadogPprofFlamegraphService {
         }.getOrDefault(false)
     }
 
-    private fun buildFrameTree(profile: PprofProfile): List<MutableFrame> {
+    private fun buildFrameTree(
+        profile: PprofProfile,
+        valueIndex: Int,
+        selectedThread: String?,
+    ): List<MutableFrame> {
         if (profile.samples.isEmpty()) return emptyList()
-        val valueIndex = resolveValueIndex(profile)
         val root = MutableFrame("(root)")
 
         profile.samples.forEach { sample ->
-            val weight = sample.values.getOrNull(valueIndex)
-                ?: sample.values.lastOrNull()
-                ?: return@forEach
-
-            val normalizedWeight = if (weight == Long.MIN_VALUE) Long.MAX_VALUE else kotlin.math.abs(weight)
+            if (selectedThread != null && threadOf(profile, sample) != selectedThread) {
+                return@forEach
+            }
+            val normalizedWeight = sampleWeight(sample, valueIndex)
             if (normalizedWeight == 0L) return@forEach
 
             val names = resolveSampleFrames(profile, sample)
@@ -153,6 +197,64 @@ object DatadogPprofFlamegraphService {
         }
 
         return root.children.values.toList()
+    }
+
+    private fun sampleWeight(sample: Sample, valueIndex: Int): Long {
+        val weight = sample.values.getOrNull(valueIndex)
+            ?: sample.values.lastOrNull()
+            ?: return 0L
+        return if (weight == Long.MIN_VALUE) Long.MAX_VALUE else kotlin.math.abs(weight)
+    }
+
+    private fun computeThreadTotals(profile: PprofProfile, valueIndex: Int): Map<String, Long> {
+        val totals = LinkedHashMap<String, Long>()
+        profile.samples.forEach { sample ->
+            val thread = threadOf(profile, sample) ?: return@forEach
+            val weight = sampleWeight(sample, valueIndex)
+            if (weight == 0L) return@forEach
+            totals.merge(thread, weight, Long::plus)
+        }
+        return totals
+    }
+
+    private fun threadOf(profile: PprofProfile, sample: Sample): String? {
+        for (key in THREAD_LABEL_KEYS) {
+            val label = sample.labels.firstOrNull {
+                stringAt(profile.strings, it.keyIdx) == key
+            }
+            if (label != null) {
+                val value = stringAt(profile.strings, label.strIdx)
+                if (value.isNotBlank()) return value
+            }
+        }
+        return null
+    }
+
+    private fun sampleTypesJson(types: List<SampleTypeMeta>): JsonArray = buildJsonArray {
+        types.forEach { t ->
+            add(
+                buildJsonObject {
+                    put("key", t.key)
+                    put("label", t.key)
+                    put("unit", t.unit.ifBlank { "samples" })
+                },
+            )
+        }
+    }
+
+    private fun threadsJson(threadTotals: Map<String, Long>): JsonArray = buildJsonArray {
+        threadTotals.entries
+            .sortedByDescending { it.value }
+            .take(MAX_THREADS)
+            .forEach { (name, total) ->
+                add(
+                    buildJsonObject {
+                        put("id", name)
+                        put("label", name)
+                        put("samples", total)
+                    },
+                )
+            }
     }
 
     private fun resolveSampleFrames(
@@ -313,6 +415,7 @@ object DatadogPprofFlamegraphService {
         val locationIds = mutableListOf<Long>()
         val locationIdx = mutableListOf<Long>()
         val values = mutableListOf<Long>()
+        val labels = mutableListOf<Label>()
 
         while (!input.isAtEnd) {
             when (val tag = input.readTag()) {
@@ -321,6 +424,7 @@ object DatadogPprofFlamegraphService {
                 (1 shl FIELD_SHIFT) or 2 -> readPackedUInt64(input.readByteArray(), locationIds)
                 (2 shl FIELD_SHIFT) or 0 -> values += input.readInt64()
                 (2 shl FIELD_SHIFT) or 2 -> readPackedInt64(input.readByteArray(), values)
+                (FIELD_3 shl FIELD_SHIFT) or 2 -> labels += decodeLabel(input.readByteArray())
                 (FIELD_4 shl FIELD_SHIFT) or 0 -> locationIdx += input.readUInt64()
                 (FIELD_4 shl FIELD_SHIFT) or 2 -> readPackedUInt64(input.readByteArray(), locationIdx)
                 else -> input.skipField(tag)
@@ -331,7 +435,23 @@ object DatadogPprofFlamegraphService {
             locationIds = locationIds,
             locationIdx = locationIdx,
             values = values,
+            labels = labels,
         )
+    }
+
+    private fun decodeLabel(bytes: ByteArray): Label {
+        val input = CodedInputStream.newInstance(bytes)
+        var keyIdx = 0L
+        var strIdx = 0L
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or 0 -> keyIdx = input.readInt64()
+                (2 shl FIELD_SHIFT) or 0 -> strIdx = input.readInt64()
+                else -> input.skipField(tag)
+            }
+        }
+        return Label(keyIdx = keyIdx, strIdx = strIdx)
     }
 
     private fun decodeMapping(bytes: ByteArray): Mapping {
@@ -462,6 +582,10 @@ object DatadogPprofFlamegraphService {
 
     private fun emptyFlamegraph(): JsonObject = buildJsonObject {
         put("frames", JsonArray(emptyList()))
+        put("sampleTypes", JsonArray(emptyList()))
+        put("threads", JsonArray(emptyList()))
+        put("unit", "samples")
+        put("totalSamples", 0L)
     }
 
     private val JFR_MAGIC = byteArrayOf('F'.code.toByte(), 'L'.code.toByte(), 'R'.code.toByte(), 0x00)

--- a/backend/src/main/kotlin/com/moneat/datadog/services/FlamegraphConstants.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/FlamegraphConstants.kt
@@ -1,0 +1,19 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.services
+
+internal const val MAX_THREADS = 50

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -26,6 +26,8 @@ import com.moneat.datadog.models.DdResourceStatsResponse
 import com.moneat.datadog.models.DdServiceMapResponse
 import com.moneat.datadog.models.DdTraceListResponse
 import com.moneat.datadog.services.DatadogHostService
+import com.moneat.datadog.services.DatadogJfrFlamegraphService
+import com.moneat.datadog.services.DatadogPprofFlamegraphService
 import com.moneat.datadog.services.DdResourceStatsQuery
 import com.moneat.datadog.services.DdTraceListQuery
 import com.moneat.datadog.services.ProfileIngestionService
@@ -47,6 +49,10 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -506,33 +512,73 @@ class DatadogQueryRoutesTest {
     fun `profile flamegraph forwards datadog pprof selectors`() = testApplication {
         installProfileRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val payload = "pprof-payload".toByteArray()
         coEvery {
             ProfileIngestionService.getProfileMeta(10, "profile-pprof")
         } returns ProfileIngestionService.ProfileMeta("profile-key", "cpu", "datadog")
-        every { ProfileStorageService.read("profile-key") } returns "not-a-pprof".toByteArray()
+        every { ProfileStorageService.read("profile-key") } returns payload
 
-        val resp = client.get("/v1/profiles/profile-pprof/flamegraph?sampleType=cpu&thread=all") {
-            withAuth(token)
+        mockkObject(DatadogPprofFlamegraphService)
+        try {
+            every { DatadogPprofFlamegraphService.isLikelyJfrPayload(payload) } returns false
+            every {
+                DatadogPprofFlamegraphService.parseToFrames(payload, "cpu", "worker-1")
+            } returns selectorFlamegraph("cpu", "worker-1")
+
+            val resp = client.get("/v1/profiles/profile-pprof/flamegraph?sampleType=cpu&thread=worker-1") {
+                withAuth(token)
+            }
+
+            assertEquals(HttpStatusCode.OK, resp.status)
+            val body = resp.bodyAsText()
+            assertTrue(body.contains("\"selectedSampleType\":\"cpu\""))
+            assertTrue(body.contains("\"selectedThread\":\"worker-1\""))
+            verify(exactly = 1) {
+                DatadogPprofFlamegraphService.parseToFrames(payload, "cpu", "worker-1")
+            }
+        } finally {
+            unmockkObject(DatadogPprofFlamegraphService)
         }
-
-        assertEquals(HttpStatusCode.OK, resp.status)
-        assertTrue(resp.bodyAsText().contains("\"frames\""))
     }
 
     @Test
     fun `profile flamegraph forwards datadog jfr selectors`() = testApplication {
         installProfileRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val payload = "jfr-payload".toByteArray()
         coEvery {
             ProfileIngestionService.getProfileMeta(10, "profile-jfr")
         } returns ProfileIngestionService.ProfileMeta("jfr-key", "jfr", "datadog")
-        every { ProfileStorageService.read("jfr-key") } returns "not-a-jfr".toByteArray()
+        every { ProfileStorageService.read("jfr-key") } returns payload
 
-        val resp = client.get("/v1/profiles/profile-jfr/flamegraph?sampleType=cpu&thread=all") {
-            withAuth(token)
+        mockkObject(DatadogJfrFlamegraphService)
+        try {
+            every {
+                DatadogJfrFlamegraphService.parseToFrames(payload, "cpu", "all")
+            } returns selectorFlamegraph("cpu", "all")
+
+            val resp = client.get("/v1/profiles/profile-jfr/flamegraph?sampleType=cpu&thread=all") {
+                withAuth(token)
+            }
+
+            assertEquals(HttpStatusCode.OK, resp.status)
+            val body = resp.bodyAsText()
+            assertTrue(body.contains("\"selectedSampleType\":\"cpu\""))
+            assertTrue(body.contains("\"selectedThread\":\"all\""))
+            verify(exactly = 1) {
+                DatadogJfrFlamegraphService.parseToFrames(payload, "cpu", "all")
+            }
+        } finally {
+            unmockkObject(DatadogJfrFlamegraphService)
         }
+    }
 
-        assertEquals(HttpStatusCode.OK, resp.status)
-        assertTrue(resp.bodyAsText().contains("\"frames\""))
+    private fun selectorFlamegraph(
+        sampleType: String,
+        thread: String,
+    ) = buildJsonObject {
+        put("frames", buildJsonArray {})
+        put("selectedSampleType", sampleType)
+        put("selectedThread", thread)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -29,12 +29,14 @@ import com.moneat.datadog.services.DatadogHostService
 import com.moneat.datadog.services.DdResourceStatsQuery
 import com.moneat.datadog.services.DdTraceListQuery
 import com.moneat.datadog.services.ProfileIngestionService
+import com.moneat.datadog.services.ProfileStorageService
 import com.moneat.datadog.services.TraceIngestionService
 import com.moneat.testsupport.RouteTestSupport
 import com.moneat.testsupport.RouteTestSupport.installJwtAuth
 import com.moneat.testsupport.RouteTestSupport.withAuth
 import com.moneat.testsupport.startTestKoin
 import com.moneat.testsupport.stopTestKoin
+import io.ktor.client.statement.bodyAsText
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
@@ -49,6 +51,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DatadogQueryRoutesTest {
 
@@ -58,6 +61,7 @@ class DatadogQueryRoutesTest {
         mockkObject(DatadogHostService)
         mockkObject(TraceIngestionService)
         mockkObject(ProfileIngestionService)
+        mockkObject(ProfileStorageService)
 
         every { DatadogHostService.listHosts(any<Int>()) } returns emptyList()
         every { DatadogHostService.getHost(any<Int>(), any<Int>()) } returns null
@@ -78,10 +82,12 @@ class DatadogQueryRoutesTest {
         coEvery { ProfileIngestionService.listProfiles(any(), any(), any(), any(), any(), any()) } returns
             DdProfileListResponse(emptyList(), 0L)
         coEvery { ProfileIngestionService.getProfileMeta(any(), any()) } returns null
+        every { ProfileStorageService.read(any()) } returns null
     }
 
     @AfterTest
     fun teardown() {
+        unmockkObject(ProfileStorageService)
         unmockkObject(ProfileIngestionService)
         unmockkObject(TraceIngestionService)
         unmockkObject(DatadogHostService)
@@ -494,5 +500,39 @@ class DatadogQueryRoutesTest {
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get("/v1/profiles/unknown-id/flamegraph") { withAuth(token) }
         assertEquals(HttpStatusCode.NotFound, resp.status)
+    }
+
+    @Test
+    fun `profile flamegraph forwards datadog pprof selectors`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        coEvery {
+            ProfileIngestionService.getProfileMeta(10, "profile-pprof")
+        } returns ProfileIngestionService.ProfileMeta("profile-key", "cpu", "datadog")
+        every { ProfileStorageService.read("profile-key") } returns "not-a-pprof".toByteArray()
+
+        val resp = client.get("/v1/profiles/profile-pprof/flamegraph?sampleType=cpu&thread=all") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, resp.status)
+        assertTrue(resp.bodyAsText().contains("\"frames\""))
+    }
+
+    @Test
+    fun `profile flamegraph forwards datadog jfr selectors`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        coEvery {
+            ProfileIngestionService.getProfileMeta(10, "profile-jfr")
+        } returns ProfileIngestionService.ProfileMeta("jfr-key", "jfr", "datadog")
+        every { ProfileStorageService.read("jfr-key") } returns "not-a-jfr".toByteArray()
+
+        val resp = client.get("/v1/profiles/profile-jfr/flamegraph?sampleType=cpu&thread=all") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, resp.status)
+        assertTrue(resp.bodyAsText().contains("\"frames\""))
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphServiceTest.kt
@@ -22,10 +22,14 @@ import jdk.jfr.Name
 import jdk.jfr.Recording
 import jdk.jfr.StackTrace
 import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.util.zip.GZIPOutputStream
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class DatadogJfrFlamegraphServiceTest {
@@ -51,6 +55,32 @@ class DatadogJfrFlamegraphServiceTest {
     fun `parseToFrames returns empty for invalid payload`() {
         val result = DatadogJfrFlamegraphService.parseToFrames("not-a-jfr".toByteArray())
         assertTrue(result["frames"]!!.jsonArray.isEmpty())
+    }
+
+    @Test
+    fun `parseToFrames reports sample types and threads`() {
+        val jfr = buildJfrWithDatadogSample()
+        val result = DatadogJfrFlamegraphService.parseToFrames(jfr)
+
+        val sampleTypes = result["sampleTypes"]!!.jsonArray
+        assertTrue(
+            sampleTypes.any { it.jsonObject["key"]!!.jsonPrimitive.content == "cpu" },
+        )
+        assertTrue(result["threads"]!!.jsonArray.isNotEmpty())
+        assertTrue(result["totalSamples"]!!.jsonPrimitive.long > 0)
+        assertEquals("cpu", result["selectedSampleType"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `parseToFrames filters by thread`() {
+        val jfr = buildJfrWithDatadogSample()
+        val all = DatadogJfrFlamegraphService.parseToFrames(jfr)
+        val threadId = all["threads"]!!.jsonArray
+            .first().jsonObject["id"]!!.jsonPrimitive.content
+
+        val filtered = DatadogJfrFlamegraphService.parseToFrames(jfr, thread = threadId)
+        assertTrue(filtered["frames"]!!.jsonArray.isNotEmpty())
+        assertEquals(threadId, filtered["selectedThread"]!!.jsonPrimitive.content)
     }
 
     @Name("datadog.TestSample")

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphServiceTest.kt
@@ -30,6 +30,7 @@ import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.util.zip.GZIPOutputStream
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DatadogJfrFlamegraphServiceTest {
@@ -293,8 +294,10 @@ class DatadogJfrFlamegraphServiceTest {
             { workerSamplePath() },
             WORKER_THREAD_NAME,
         )
+        worker.isDaemon = true
         worker.start()
-        worker.join()
+        worker.join(WORKER_JOIN_TIMEOUT_MILLIS)
+        assertFalse(worker.isAlive, "Worker thread did not finish in time")
     }
 
     private fun workerSamplePath() {
@@ -314,5 +317,6 @@ class DatadogJfrFlamegraphServiceTest {
         private const val ALLOCATION_SIZE_BYTES = 512L
         private const val ALLOCATION_TOTAL_BYTES = ALLOCATION_WEIGHT_BYTES + ALLOCATION_SIZE_BYTES
         private const val WORKER_THREAD_NAME = "flamegraph-worker"
+        private const val WORKER_JOIN_TIMEOUT_MILLIS = 2_000L
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogJfrFlamegraphServiceTest.kt
@@ -83,10 +83,128 @@ class DatadogJfrFlamegraphServiceTest {
         assertEquals(threadId, filtered["selectedThread"]!!.jsonPrimitive.content)
     }
 
+    @Test
+    fun `parseToFrames reports allocation lock and block samples`() {
+        val jfr = buildJfrWithExtendedSamples()
+        val result = DatadogJfrFlamegraphService.parseToFrames(jfr)
+        val typeKeys = result["sampleTypes"]!!.jsonArray
+            .map { it.jsonObject["key"]!!.jsonPrimitive.content }
+
+        assertTrue(typeKeys.containsAll(listOf("cpu", "alloc", "lock", "block")))
+
+        val alloc = DatadogJfrFlamegraphService.parseToFrames(
+            jfr,
+            sampleType = "alloc",
+        )
+        assertEquals("alloc", alloc["selectedSampleType"]!!.jsonPrimitive.content)
+        assertEquals("bytes", alloc["unit"]!!.jsonPrimitive.content)
+        assertTrue(alloc["totalSamples"]!!.jsonPrimitive.long >= ALLOCATION_TOTAL_BYTES)
+
+        val lock = DatadogJfrFlamegraphService.parseToFrames(
+            jfr,
+            sampleType = "lock",
+        )
+        assertEquals("lock", lock["selectedSampleType"]!!.jsonPrimitive.content)
+        assertEquals("ns", lock["unit"]!!.jsonPrimitive.content)
+        assertTrue(lock["totalSamples"]!!.jsonPrimitive.long > 0L)
+
+        val block = DatadogJfrFlamegraphService.parseToFrames(
+            jfr,
+            sampleType = "block",
+        )
+        assertEquals("block", block["selectedSampleType"]!!.jsonPrimitive.content)
+        assertEquals("ns", block["unit"]!!.jsonPrimitive.content)
+        assertTrue(block["totalSamples"]!!.jsonPrimitive.long > 0L)
+    }
+
+    @Test
+    fun `parseToFrames falls back from unknown selectors`() {
+        val result = DatadogJfrFlamegraphService.parseToFrames(
+            buildJfrWithExtendedSamples(),
+            sampleType = "unknown",
+            thread = "all",
+        )
+
+        assertTrue(result["frames"]!!.jsonArray.isNotEmpty())
+        assertTrue(
+            result["sampleTypes"]!!.jsonArray.any {
+                it.jsonObject["key"]!!.jsonPrimitive.content ==
+                    result["selectedSampleType"]!!.jsonPrimitive.content
+            },
+        )
+    }
+
+    @Test
+    fun `parseToFrames filters one thread from multi-thread recording`() {
+        val jfr = buildJfrWithExtendedSamples()
+        val all = DatadogJfrFlamegraphService.parseToFrames(jfr)
+        val workerThread = all["threads"]!!.jsonArray
+            .map { it.jsonObject["id"]!!.jsonPrimitive.content }
+            .first { it == WORKER_THREAD_NAME }
+
+        val filtered = DatadogJfrFlamegraphService.parseToFrames(
+            jfr,
+            sampleType = "cpu",
+            thread = workerThread,
+        )
+
+        assertEquals(workerThread, filtered["selectedThread"]!!.jsonPrimitive.content)
+        assertTrue(filtered["frames"]!!.jsonArray.isNotEmpty())
+    }
+
     @Name("datadog.TestSample")
     @Label("Datadog Test Sample")
     @StackTrace(true)
     class DatadogTestSampleEvent : Event()
+
+    @Name("datadog.ExecutionSample")
+    @Label("Datadog Execution Sample")
+    @StackTrace(true)
+    class DatadogExecutionSampleEvent : Event()
+
+    @Name("datadog.MethodSample")
+    @Label("Datadog Method Sample")
+    @StackTrace(true)
+    class DatadogMethodSampleEvent : Event()
+
+    @Name("example.ObjectAllocationSample")
+    @Label("Allocation Sample")
+    @StackTrace(true)
+    class AllocationWeightSampleEvent : Event() {
+        @field:Name("weight")
+        var weight: Long = ALLOCATION_WEIGHT_BYTES
+    }
+
+    @Name("example.AllocationSizeSample")
+    @Label("Allocation Size Sample")
+    @StackTrace(true)
+    class AllocationSizeSampleEvent : Event() {
+        @field:Name("allocationSize")
+        var allocationSize: Long = ALLOCATION_SIZE_BYTES
+    }
+
+    @Name("example.MonitorWait")
+    @Label("Monitor Wait Sample")
+    @StackTrace(true)
+    class MonitorWaitSampleEvent : Event()
+
+    @Name("example.ThreadPark")
+    @Label("Thread Park Sample")
+    @StackTrace(true)
+    class ThreadParkSampleEvent : Event()
+
+    @Name("datadog.SampledThread")
+    @Label("Sampled Thread Sample")
+    @StackTrace(true)
+    class SampledThreadSampleEvent : Event() {
+        @field:Name("sampledThread")
+        var sampledThread: Thread = Thread.currentThread()
+    }
+
+    @Name("example.NotProfile")
+    @Label("Ignored Event")
+    @StackTrace(true)
+    class IgnoredEvent : Event()
 
     private fun buildJfrWithDatadogSample(): ByteArray {
         val recording = Recording()
@@ -107,6 +225,35 @@ class DatadogJfrFlamegraphServiceTest {
         }
     }
 
+    private fun buildJfrWithExtendedSamples(): ByteArray {
+        val recording = Recording()
+        recording.enableSample(DatadogExecutionSampleEvent::class.java)
+        recording.enableSample(DatadogMethodSampleEvent::class.java)
+        recording.enableSample(AllocationWeightSampleEvent::class.java)
+        recording.enableSample(AllocationSizeSampleEvent::class.java)
+        recording.enableSample(MonitorWaitSampleEvent::class.java)
+        recording.enableSample(ThreadParkSampleEvent::class.java)
+        recording.enableSample(SampledThreadSampleEvent::class.java)
+        recording.enableSample(IgnoredEvent::class.java)
+        recording.start()
+        emitExtendedSamples()
+        emitWorkerSample()
+        recording.stop()
+
+        val tmp = Files.createTempFile("moneat-jfr-extended-test-", ".jfr")
+        return try {
+            recording.dump(tmp)
+            Files.readAllBytes(tmp)
+        } finally {
+            recording.close()
+            runCatching { Files.deleteIfExists(tmp) }
+        }
+    }
+
+    private fun Recording.enableSample(eventType: Class<out Event>) {
+        enable(eventType).withoutThreshold().withStackTrace()
+    }
+
     private fun emitSampleEvent() {
         samplePathOuter()
     }
@@ -119,11 +266,53 @@ class DatadogJfrFlamegraphServiceTest {
         DatadogTestSampleEvent().commit()
     }
 
+    private fun emitExtendedSamples() {
+        DatadogExecutionSampleEvent().commit()
+        DatadogMethodSampleEvent().commit()
+        AllocationWeightSampleEvent().commit()
+        AllocationSizeSampleEvent().commit()
+        commitTimed(MonitorWaitSampleEvent())
+        commitTimed(ThreadParkSampleEvent())
+        SampledThreadSampleEvent().commit()
+        IgnoredEvent().commit()
+    }
+
+    private fun commitTimed(event: Event) {
+        event.begin()
+        timedSamplePath()
+        event.end()
+        event.commit()
+    }
+
+    private fun timedSamplePath() {
+        DatadogMethodSampleEvent().shouldCommit()
+    }
+
+    private fun emitWorkerSample() {
+        val worker = Thread(
+            { workerSamplePath() },
+            WORKER_THREAD_NAME,
+        )
+        worker.start()
+        worker.join()
+    }
+
+    private fun workerSamplePath() {
+        DatadogExecutionSampleEvent().commit()
+    }
+
     private fun gzip(bytes: ByteArray): ByteArray {
         val out = ByteArrayOutputStream()
         GZIPOutputStream(out).use { gzip ->
             gzip.write(bytes)
         }
         return out.toByteArray()
+    }
+
+    private companion object {
+        private const val ALLOCATION_WEIGHT_BYTES = 256L
+        private const val ALLOCATION_SIZE_BYTES = 512L
+        private const val ALLOCATION_TOTAL_BYTES = ALLOCATION_WEIGHT_BYTES + ALLOCATION_SIZE_BYTES
+        private const val WORKER_THREAD_NAME = "flamegraph-worker"
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphServiceTest.kt
@@ -70,6 +70,47 @@ class DatadogPprofFlamegraphServiceTest {
     }
 
     @Test
+    fun `parseToFrames lists sample types and threads`() {
+        val result = DatadogPprofFlamegraphService.parseToFrames(buildMultiTypeProfile())
+
+        val typeKeys = result["sampleTypes"]!!.jsonArray
+            .map { it.jsonObject["key"]!!.jsonPrimitive.content }
+        assertTrue(typeKeys.containsAll(listOf("samples", "cpu")))
+
+        val threadIds = result["threads"]!!.jsonArray
+            .map { it.jsonObject["id"]!!.jsonPrimitive.content }
+        assertTrue(threadIds.containsAll(listOf("worker-1", "worker-2")))
+
+        assertEquals("samples", result["selectedSampleType"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `parseToFrames switches sample type`() {
+        val result = DatadogPprofFlamegraphService.parseToFrames(
+            buildMultiTypeProfile(),
+            sampleType = "cpu",
+        )
+
+        assertEquals("cpu", result["selectedSampleType"]!!.jsonPrimitive.content)
+        assertEquals("nanoseconds", result["unit"]!!.jsonPrimitive.content)
+        val main = result["frames"]!!.jsonArray[0].jsonObject
+        assertEquals(1000L, main["value"]!!.jsonPrimitive.long)
+    }
+
+    @Test
+    fun `parseToFrames filters by thread`() {
+        val result = DatadogPprofFlamegraphService.parseToFrames(
+            buildMultiTypeProfile(),
+            thread = "worker-1",
+        )
+
+        assertEquals("worker-1", result["selectedThread"]!!.jsonPrimitive.content)
+        val main = result["frames"]!!.jsonArray[0].jsonObject
+        assertEquals("main", main["name"]!!.jsonPrimitive.content)
+        assertEquals(60L, main["value"]!!.jsonPrimitive.long)
+    }
+
+    @Test
     fun `parseToFrames returns empty frames for invalid payload`() {
         val result = DatadogPprofFlamegraphService.parseToFrames(
             "not-a-pprof".toByteArray()
@@ -239,6 +280,97 @@ class DatadogPprofFlamegraphServiceTest {
             profile.writeString(6, "handler")
             profile.writeString(6, "db.query")
             profile.writeString(6, "app.go")
+
+            // default_sample_type = "samples"
+            profile.writeInt64(14, 1)
+        }
+    }
+
+    private fun buildMultiTypeProfile(): ByteArray {
+        return encodeMessage { profile ->
+            // sample_type = [{samples,count}, {cpu,nanoseconds}]
+            listOf(1L to 2L, 7L to 8L).forEach { (typeIdx, unitIdx) ->
+                profile.writeMessageField(
+                    1,
+                    encodeMessage { vt ->
+                        vt.writeInt64(1, typeIdx)
+                        vt.writeInt64(2, unitIdx)
+                    },
+                )
+            }
+
+            // sample #1: main -> handler -> db.query; values [60, 600]; thread worker-1
+            profile.writeMessageField(
+                2,
+                encodeMessage { sample ->
+                    sample.writeUInt64(1, 3)
+                    sample.writeUInt64(1, 2)
+                    sample.writeUInt64(1, 1)
+                    sample.writeInt64(2, 60)
+                    sample.writeInt64(2, 600)
+                    sample.writeMessageField(
+                        3,
+                        encodeMessage { label ->
+                            label.writeInt64(1, 9)
+                            label.writeInt64(2, 10)
+                        },
+                    )
+                },
+            )
+
+            // sample #2: main -> handler; values [40, 400]; thread worker-2
+            profile.writeMessageField(
+                2,
+                encodeMessage { sample ->
+                    sample.writeUInt64(1, 2)
+                    sample.writeUInt64(1, 1)
+                    sample.writeInt64(2, 40)
+                    sample.writeInt64(2, 400)
+                    sample.writeMessageField(
+                        3,
+                        encodeMessage { label ->
+                            label.writeInt64(1, 9)
+                            label.writeInt64(2, 11)
+                        },
+                    )
+                },
+            )
+
+            // locations 1..3 -> functions 1..3 (function id == location id)
+            (1L..3L).forEach { id ->
+                profile.writeMessageField(
+                    4,
+                    encodeMessage { loc ->
+                        loc.writeUInt64(1, id)
+                        loc.writeMessageField(
+                            4,
+                            encodeMessage { line ->
+                                line.writeUInt64(1, id)
+                                line.writeInt64(2, id * 10)
+                            },
+                        )
+                    },
+                )
+            }
+
+            // functions: name string indices 3=main, 4=handler, 5=db.query
+            listOf(1L to 3L, 2L to 4L, 3L to 5L).forEach { (id, nameIdx) ->
+                profile.writeMessageField(
+                    5,
+                    encodeMessage { fn ->
+                        fn.writeUInt64(1, id)
+                        fn.writeInt64(2, nameIdx)
+                        fn.writeInt64(3, nameIdx)
+                        fn.writeInt64(4, 6)
+                    },
+                )
+            }
+
+            // string_table
+            listOf(
+                "", "samples", "count", "main", "handler", "db.query", "app.go",
+                "cpu", "nanoseconds", "thread name", "worker-1", "worker-2",
+            ).forEach { profile.writeString(6, it) }
 
             // default_sample_type = "samples"
             profile.writeInt64(14, 1)

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogPprofFlamegraphServiceTest.kt
@@ -111,6 +111,32 @@ class DatadogPprofFlamegraphServiceTest {
     }
 
     @Test
+    fun `parseToFrames returns empty when samples have no sample types`() {
+        val result = DatadogPprofFlamegraphService.parseToFrames(buildProfileWithoutSampleTypes())
+
+        assertTrue(result["frames"]!!.jsonArray.isEmpty())
+    }
+
+    @Test
+    fun `parseToFrames falls back to last value when selected index is missing`() {
+        val result = DatadogPprofFlamegraphService.parseToFrames(
+            buildMissingSelectedValueProfile(),
+            sampleType = "cpu",
+        )
+
+        assertEquals("cpu", result["selectedSampleType"]!!.jsonPrimitive.content)
+        assertEquals(17L, result["totalSamples"]!!.jsonPrimitive.long)
+    }
+
+    @Test
+    fun `parseToFrames ignores samples without values`() {
+        val result = DatadogPprofFlamegraphService.parseToFrames(buildSampleWithoutValuesProfile())
+
+        assertTrue(result["frames"]!!.jsonArray.isEmpty())
+        assertEquals(0L, result["totalSamples"]!!.jsonPrimitive.long)
+    }
+
+    @Test
     fun `parseToFrames returns empty frames for invalid payload`() {
         val result = DatadogPprofFlamegraphService.parseToFrames(
             "not-a-pprof".toByteArray()
@@ -377,6 +403,94 @@ class DatadogPprofFlamegraphServiceTest {
         }
     }
 
+    private fun buildProfileWithoutSampleTypes(): ByteArray {
+        return encodeMessage { profile ->
+            profile.writeMessageField(
+                2,
+                encodeMessage { sample ->
+                    sample.writeUInt64(1, 1)
+                    sample.writeInt64(2, 1)
+                    sample.writeMessageField(
+                        3,
+                        encodeMessage { label ->
+                            label.writeString(UNKNOWN_FIELD_NUMBER, "ignored")
+                        },
+                    )
+                },
+            )
+        }
+    }
+
+    private fun buildMissingSelectedValueProfile(): ByteArray {
+        return buildSingleFrameProfile { sample ->
+            sample.writeInt64(2, FALLBACK_SAMPLE_VALUE)
+        }
+    }
+
+    private fun buildSampleWithoutValuesProfile(): ByteArray {
+        return buildSingleFrameProfile { sample ->
+            sample.writeMessageField(
+                3,
+                encodeMessage { label ->
+                    label.writeInt64(1, 9)
+                    label.writeInt64(2, 10)
+                },
+            )
+        }
+    }
+
+    private fun buildSingleFrameProfile(
+        writeSampleValues: (CodedOutputStream) -> Unit,
+    ): ByteArray {
+        return encodeMessage { profile ->
+            listOf(1L to 2L, 7L to 8L).forEach { (typeIdx, unitIdx) ->
+                profile.writeMessageField(
+                    1,
+                    encodeMessage { vt ->
+                        vt.writeInt64(1, typeIdx)
+                        vt.writeInt64(2, unitIdx)
+                    },
+                )
+            }
+
+            profile.writeMessageField(
+                2,
+                encodeMessage { sample ->
+                    sample.writeUInt64(1, 1)
+                    writeSampleValues(sample)
+                },
+            )
+
+            profile.writeMessageField(
+                4,
+                encodeMessage { location ->
+                    location.writeUInt64(1, 1)
+                    location.writeMessageField(
+                        4,
+                        encodeMessage { line ->
+                            line.writeUInt64(1, 1)
+                            line.writeInt64(2, 10)
+                        },
+                    )
+                },
+            )
+            profile.writeMessageField(
+                5,
+                encodeMessage { fn ->
+                    fn.writeUInt64(1, 1)
+                    fn.writeInt64(2, 3)
+                    fn.writeInt64(3, 3)
+                    fn.writeInt64(4, 6)
+                },
+            )
+            listOf(
+                "", "samples", "count", "main", "handler", "db.query", "app.go",
+                "cpu", "nanoseconds", "thread name", "worker-1",
+            ).forEach { profile.writeString(6, it) }
+            profile.writeInt64(14, 1)
+        }
+    }
+
     private fun gzip(bytes: ByteArray): ByteArray {
         val out = ByteArrayOutputStream()
         GZIPOutputStream(out).use { gzip ->
@@ -400,5 +514,10 @@ class DatadogPprofFlamegraphServiceTest {
         writeTag(fieldNumber, 2)
         writeUInt32NoTag(bytes.size)
         writeRawBytes(bytes)
+    }
+
+    private companion object {
+        private const val FALLBACK_SAMPLE_VALUE = 17L
+        private const val UNKNOWN_FIELD_NUMBER = 99
     }
 }

--- a/dashboard/src/components/profiling/AppPackageSelect.tsx
+++ b/dashboard/src/components/profiling/AppPackageSelect.tsx
@@ -1,0 +1,101 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {ChevronsUpDown} from 'lucide-react'
+import {Button} from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+import type {NamespaceStat} from './frameModel'
+
+interface Props {
+  namespaces: NamespaceStat[]
+  /** Raw comma-separated prefixes the user has chosen (empty = auto-detect). */
+  value: string
+  /** Prefixes actually applied (used to show the auto-detected default). */
+  effective: string[]
+  onChange: (csv: string) => void
+}
+
+function parse(value: string): string[] {
+  return value.split(',').map((s) => s.trim()).filter(Boolean)
+}
+
+export function AppPackageSelect({namespaces, value, effective, onChange}: Props) {
+  const selected = parse(value)
+  const isAuto = selected.length === 0
+
+  const toggle = (ns: string) => {
+    const next = selected.includes(ns)
+      ? selected.filter((s) => s !== ns)
+      : [...selected, ns]
+    onChange(next.join(','))
+  }
+
+  let label: string
+  if (!isAuto) {
+    label = selected.length === 1 ? selected[0] : `${selected.length} selected`
+  } else if (effective[0]) {
+    label = `Auto · ${effective[0]}`
+  } else {
+    label = 'Auto-detect'
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 w-full justify-between text-[11px] font-mono font-normal"
+        >
+          <span className="truncate">{label}</span>
+          <ChevronsUpDown className="h-3.5 w-3.5 opacity-50 shrink-0" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="w-[var(--radix-popper-anchor-width)] min-w-52 max-h-72"
+      >
+        <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          Detected namespaces
+        </DropdownMenuLabel>
+        {namespaces.length === 0 && (
+          <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+            None detected — type a prefix below.
+          </div>
+        )}
+        {namespaces.map((ns) => (
+          <DropdownMenuCheckboxItem
+            key={ns.namespace}
+            checked={selected.includes(ns.namespace)}
+            onCheckedChange={() => toggle(ns.namespace)}
+            onSelect={(e) => e.preventDefault()}
+            className="text-[11px] font-mono"
+          >
+            <span className="truncate">{ns.namespace}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+        {!isAuto && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => onChange('')} className="text-[11px]">
+              Reset to auto-detect
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/dashboard/src/components/profiling/CompareBar.tsx
+++ b/dashboard/src/components/profiling/CompareBar.tsx
@@ -1,0 +1,128 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {Loader2, X, GitCompare} from 'lucide-react'
+import {Button} from '@/components/ui/button'
+import {type DiffResult, type FunctionDelta, diffColor} from './frameModel'
+
+export interface CompareProfile {
+  profileId: string
+  label: string
+}
+
+interface Props {
+  profiles: CompareProfile[]
+  compareId: string | null
+  loading: boolean
+  diff: DiffResult | null
+  onChange: (id: string | null) => void
+  onSelect: (name: string) => void
+}
+
+export function CompareBar({profiles, compareId, loading, diff, onChange, onSelect}: Props) {
+  return (
+    <div className="border rounded-lg p-2 space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+          <GitCompare className="h-3.5 w-3.5" />
+          Compare to baseline:
+        </span>
+        <select
+          value={compareId ?? ''}
+          onChange={(e) => onChange(e.target.value || null)}
+          className="h-7 text-xs rounded-md border bg-background px-2 max-w-xs"
+        >
+          <option value="">— none —</option>
+          {profiles.map((p) => (
+            <option key={p.profileId} value={p.profileId}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+        {loading && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+        {compareId && (
+          <Button variant="ghost" size="sm" className="h-7 px-2 text-[11px]" onClick={() => onChange(null)}>
+            <X className="h-3 w-3 mr-0.5" />
+            Clear
+          </Button>
+        )}
+        {diff && (
+          <span className="ml-auto flex items-center gap-3 text-[10px] text-muted-foreground">
+            <LegendDot color={diffColor(3)} label="hotter now" />
+            <LegendDot color={diffColor(-3)} label="cooler now" />
+          </span>
+        )}
+      </div>
+
+      {diff && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <DeltaList
+            title="Top increases"
+            entries={diff.topRegressions}
+            onSelect={onSelect}
+          />
+          <DeltaList
+            title="Top decreases"
+            entries={diff.topImprovements}
+            onSelect={onSelect}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DeltaList({
+  title,
+  entries,
+  onSelect,
+}: {
+  title: string
+  entries: FunctionDelta[]
+  onSelect: (name: string) => void
+}) {
+  return (
+    <div className="border rounded-md overflow-hidden">
+      <div className="px-2 py-1 bg-muted/50 text-[10px] font-medium text-muted-foreground border-b">
+        {title}
+      </div>
+      <div className="max-h-[150px] overflow-y-auto">
+        {entries.length === 0 && (
+          <p className="px-2 py-2 text-[11px] text-muted-foreground">No significant change.</p>
+        )}
+        {entries.map((d) => (
+          <button
+            key={d.name}
+            type="button"
+            onClick={() => onSelect(d.name)}
+            className="w-full flex items-center gap-2 px-2 py-1 text-left text-[11px] hover:bg-muted/40"
+          >
+            <span
+              className="w-2 h-2 rounded-sm shrink-0"
+              style={{backgroundColor: diffColor(d.deltaPercent)}}
+            />
+            <span className="font-mono truncate flex-1">{d.name}</span>
+            <span className="tabular-nums shrink-0 text-muted-foreground">
+              {d.deltaPercent >= 0 ? '+' : ''}
+              {d.deltaPercent.toFixed(1)}%
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function LegendDot({color, label}: {color: string; label: string}) {
+  return (
+    <span className="flex items-center gap-1">
+      <span className="inline-block w-2 h-2 rounded-sm" style={{backgroundColor: color}} />
+      {label}
+    </span>
+  )
+}

--- a/dashboard/src/components/profiling/Flamegraph.tsx
+++ b/dashboard/src/components/profiling/Flamegraph.tsx
@@ -6,86 +6,153 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {useMemo, useState, useCallback, useRef} from 'react'
+import {useMemo, useState, useCallback, useRef, useEffect} from 'react'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
-import {RotateCcw, Search, ChevronRight} from 'lucide-react'
-
-interface FlamegraphFrame {
-  name: string
-  value: number
-  children: FlamegraphFrame[]
-  self?: number
-}
+import {
+  RotateCcw,
+  Search,
+  ChevronRight,
+  ChevronUp,
+  ChevronDown,
+  X,
+  Regex,
+  GitCompare,
+  Download,
+  SquareFunction,
+} from 'lucide-react'
+import {
+  type FlameNode,
+  type FrameKind,
+  type ColorMode,
+  type TopFunctionScope,
+  type TopFunctionSort,
+  type ClassifyOptions,
+  normalizeLanguage,
+  classifyFrame,
+  annotateSelf,
+  collapseFrames,
+  collapseRecursion,
+  invertFrames,
+  sumValues,
+  detectAppNamespaces,
+  computeTopFunctions,
+  computeDiff,
+  colorFor,
+  diffColor,
+  packageOf,
+  shortName,
+} from './frameModel'
+import {FlamegraphLegend} from './FlamegraphLegend'
+import {TopFunctionsPanel} from './TopFunctionsPanel'
+import {FlamegraphMinimap, type MiniRect} from './FlamegraphMinimap'
+import {CompareBar, type CompareProfile} from './CompareBar'
+import {ThreadSampleTypeSelectors} from './ThreadSampleTypeSelectors'
+import {AppPackageSelect} from './AppPackageSelect'
+import type {SampleTypeInfo, ThreadInfo} from '@/lib/api/types/profiles'
+import {
+  type ExportFrame,
+  framesToSvg,
+  svgDimensions,
+  downloadSvg,
+  downloadPng,
+} from './flamegraphExport'
 
 interface Props {
-  frames?: FlamegraphFrame[]
+  frames?: FlameNode[]
   emptyMessage?: string
+  /** Profile runtime/language (jvm, go, …) used to classify frames. */
+  language?: string
+  /** Service name; UI preferences are remembered per service. */
+  service?: string
+  /** Optional content (e.g. profile metadata) rendered atop the sidebar. */
+  meta?: React.ReactNode
+  /** Candidate baseline profiles for diff/compare. */
+  compareProfiles?: CompareProfile[]
+  compareId?: string | null
+  onCompareChange?: (id: string | null) => void
+  /** Baseline flamegraph for the selected compare profile. */
+  baselineFrames?: FlameNode[]
+  baselineLoading?: boolean
+  /** Available profile dimensions (from the flamegraph response). */
+  sampleTypes?: SampleTypeInfo[]
+  threads?: ThreadInfo[]
+  selectedSampleType?: string
+  selectedThread?: string | null
+  unit?: string
+  onSampleTypeChange?: (key: string) => void
+  onThreadChange?: (id: string | null) => void
 }
 
-const PACKAGE_COLORS: [RegExp, string][] = [
-  [/^java\./,            'hsl(220, 45%, 48%)'],
-  [/^javax\./,           'hsl(220, 40%, 52%)'],
-  [/^jdk\./,             'hsl(210, 40%, 46%)'],
-  [/^sun\./,             'hsl(210, 35%, 50%)'],
-  [/^com\.sun\./,        'hsl(210, 35%, 50%)'],
-  [/^kotlin\./,          'hsl(275, 45%, 52%)'],
-  [/^kotlinx\./,         'hsl(275, 40%, 56%)'],
-  [/^io\.ktor\./,        'hsl(160, 50%, 40%)'],
-  [/^io\.netty\./,       'hsl(175, 45%, 42%)'],
-  [/^org\.jetbrains\./,  'hsl(290, 35%, 50%)'],
-  [/^org\.apache\./,     'hsl(28, 70%, 48%)'],
-  [/^org\.slf4j\./,      'hsl(42, 60%, 46%)'],
-  [/^com\.zaxxer\./,     'hsl(130, 40%, 44%)'],
-  [/^org\.postgresql\./, 'hsl(200, 55%, 44%)'],
-  [/^com\.clickhouse\./, 'hsl(14, 60%, 50%)'],
-  [/^redis\./,           'hsl(5, 65%, 48%)'],
-  [/^io\.lettuce\./,     'hsl(5, 55%, 52%)'],
-  [/^com\.moneat\./,     'hsl(142, 55%, 42%)'],
-]
+type DenoiseMode = 'off' | 'dim' | 'hide'
+type Orientation = 'topdown' | 'bottomup'
 
-const FALLBACK_COLORS = [
-  'hsl(14, 65%, 50%)',
-  'hsl(28, 70%, 48%)',
-  'hsl(42, 60%, 46%)',
-  'hsl(55, 55%, 42%)',
-  'hsl(130, 40%, 44%)',
-  'hsl(160, 45%, 42%)',
-  'hsl(200, 50%, 48%)',
-  'hsl(240, 38%, 52%)',
-  'hsl(260, 40%, 50%)',
-  'hsl(340, 45%, 48%)',
-]
-
-function frameColor(name: string): string {
-  for (const [pattern, color] of PACKAGE_COLORS) {
-    if (pattern.test(name)) return color
-  }
-  let hash = 0
-  for (let i = 0; i < name.length; i++) {
-    hash = (hash * 31 + name.charCodeAt(i)) | 0
-  }
-  return FALLBACK_COLORS[Math.abs(hash) % FALLBACK_COLORS.length]
+interface FlamegraphPrefs {
+  colorMode: ColorMode
+  denoise: DenoiseMode
+  appPrefix: string
+  orientation: Orientation
+  foldRecursion: boolean
+  minWidth: number
 }
 
-function packageOf(name: string): string {
-  const lastDot = name.lastIndexOf('.')
-  if (lastDot === -1) return name
-  return name.slice(0, lastDot)
+const DEFAULT_PREFS: FlamegraphPrefs = {
+  colorMode: 'package',
+  denoise: 'off',
+  appPrefix: '',
+  orientation: 'topdown',
+  foldRecursion: false,
+  minWidth: 0.05,
+}
+
+const ROW_HEIGHT = 22
+const DIM_COLOR = 'hsl(220, 8%, 34%)'
+const VIRTUAL_BUFFER = 4
+const MIN_SEARCH_CHARS = 3
+
+function prefsKey(service?: string): string {
+  return `moneat.flamegraph.${service || 'default'}`
+}
+
+function loadPrefs(service?: string): FlamegraphPrefs {
+  try {
+    const raw = localStorage.getItem(prefsKey(service))
+    if (raw) return {...DEFAULT_PREFS, ...JSON.parse(raw)}
+  } catch {
+    // ignore malformed/inaccessible storage
+  }
+  return DEFAULT_PREFS
+}
+
+function parsePrefixes(value: string): string[] {
+  return value.split(',').map((s) => s.trim()).filter(Boolean)
+}
+
+function copyText(text: string) {
+  try {
+    void navigator.clipboard?.writeText(text)
+  } catch {
+    // clipboard unavailable
+  }
 }
 
 interface FlatFrame {
-  frame: FlamegraphFrame
+  frame: FlameNode
   depth: number
   x: number
   width: number
+  path: string[]
+  kind: FrameKind
 }
 
 function flattenFrames(
-  frames: FlamegraphFrame[],
+  frames: FlameNode[],
   totalValue: number,
-  depth: number = 0,
-  x: number = 0,
+  classifyOpts: ClassifyOptions,
+  minWidth: number,
+  basePath: string[] = [],
+  depth = 0,
+  x = 0,
 ): FlatFrame[] {
   if (totalValue <= 0) return []
   const result: FlatFrame[] = []
@@ -93,82 +160,171 @@ function flattenFrames(
 
   for (const frame of frames) {
     const width = (frame.value / totalValue) * 100
-    if (width < 0.05) {
+    if (width < minWidth) {
       currentX += width
       continue
     }
-
-    result.push({frame, depth, x: currentX, width})
+    const path = [...basePath, frame.name]
+    result.push({
+      frame,
+      depth,
+      x: currentX,
+      width,
+      path,
+      kind: classifyFrame(frame.name, classifyOpts),
+    })
     result.push(
-      ...flattenFrames(frame.children, totalValue, depth + 1, currentX),
+      ...flattenFrames(frame.children, totalValue, classifyOpts, minWidth, path, depth + 1, currentX),
     )
     currentX += width
   }
   return result
 }
 
-interface TopFunction {
-  name: string
-  selfValue: number
-  totalValue: number
-  selfPercent: number
-  totalPercent: number
-}
-
-function computeTopFunctions(
-  frames: FlamegraphFrame[],
-  totalSamples: number,
-): TopFunction[] {
-  const map = new Map<string, {self: number; total: number}>()
-
-  function walk(f: FlamegraphFrame) {
-    const existing = map.get(f.name) ?? {self: 0, total: 0}
-    existing.total += f.value
-    existing.self += f.self ?? 0
-    map.set(f.name, existing)
-    for (const child of f.children) walk(child)
+function resolveFocus(frames: FlameNode[], path: string[]): FlameNode | null {
+  let level = frames
+  let node: FlameNode | null = null
+  for (const name of path) {
+    const found = level.find((f) => f.name === name)
+    if (!found) return null
+    node = found
+    level = found.children
   }
-  for (const f of frames) walk(f)
-
-  const entries = Array.from(map.entries()).map(([name, {self: selfValue, total: totalValue}]) => ({
-    name,
-    selfValue,
-    totalValue,
-    selfPercent: totalSamples > 0 ? (selfValue / totalSamples) * 100 : 0,
-    totalPercent: totalSamples > 0 ? (totalValue / totalSamples) * 100 : 0,
-  }))
-
-  const hasSelfData = entries.some((f) => f.selfValue > 0)
-
-  return entries
-    .filter((f) => (hasSelfData ? f.selfPercent > 0.1 : f.totalPercent > 0.1))
-    .sort((a, b) => (hasSelfData ? b.selfValue - a.selfValue : b.totalValue - a.totalValue))
-    .slice(0, 20)
+  return node
 }
 
-const ROW_HEIGHT = 22
+function buildMatcher(
+  query: string,
+  useRegex: boolean,
+): {test: (name: string) => boolean; error: boolean} {
+  if (query.length < MIN_SEARCH_CHARS) return {test: () => false, error: false}
+  if (useRegex) {
+    try {
+      const re = new RegExp(query, 'i')
+      return {test: (n) => re.test(n), error: false}
+    } catch {
+      return {test: () => false, error: true}
+    }
+  }
+  const lower = query.toLowerCase()
+  return {test: (n) => n.toLowerCase().includes(lower), error: false}
+}
 
-export function Flamegraph({frames, emptyMessage}: Props) {
-  const [focusStack, setFocusStack] = useState<FlamegraphFrame[]>([])
+export function Flamegraph({
+  frames,
+  emptyMessage,
+  language,
+  service,
+  meta,
+  compareProfiles,
+  compareId = null,
+  onCompareChange,
+  baselineFrames,
+  baselineLoading = false,
+  sampleTypes = [],
+  threads = [],
+  selectedSampleType,
+  selectedThread = null,
+  unit,
+  onSampleTypeChange,
+  onThreadChange,
+}: Props) {
+  const [prefs, setPrefs] = useState<FlamegraphPrefs>(() => loadPrefs(service))
+  const [activeService, setActiveService] = useState(service)
+  const [focusPath, setFocusPath] = useState<string[]>([])
   const [searchQuery, setSearchQuery] = useState('')
+  const [useRegex, setUseRegex] = useState(false)
+  const [matchState, setMatchState] = useState({key: '', index: 0})
   const [hoveredFrame, setHoveredFrame] = useState<FlatFrame | null>(null)
-  const [showTopFunctions, setShowTopFunctions] = useState(false)
+  const [showTopFunctions, setShowTopFunctions] = useState(true)
+  const [showCompare, setShowCompare] = useState(false)
+  const [topScope, setTopScope] = useState<TopFunctionScope>('app')
+  const [topSort, setTopSort] = useState<TopFunctionSort>('self')
+  const [scrollTop, setScrollTop] = useState(0)
+  const [viewportH, setViewportH] = useState(0)
+
   const tooltipRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const hoveredRef = useRef<FlatFrame | null>(null)
 
-  const focusFrame = focusStack.length > 0 ? focusStack[focusStack.length - 1] : null
+  // Adjust state during render when the service prop changes.
+  if (service !== activeService) {
+    setActiveService(service)
+    setPrefs(loadPrefs(service))
+    setFocusPath([])
+  }
 
-  const totalValue = useMemo(() => {
-    if (!frames?.length) return 0
-    return frames.reduce((sum, f) => sum + f.value, 0)
-  }, [frames])
+  useEffect(() => {
+    try {
+      localStorage.setItem(prefsKey(service), JSON.stringify(prefs))
+    } catch {
+      // ignore inaccessible storage
+    }
+  }, [prefs, service])
+
+  // Track scroll + viewport size for virtualization and the minimap.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(() => {
+      setScrollTop(el.scrollTop)
+      setViewportH(el.clientHeight)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  const updatePrefs = useCallback((patch: Partial<FlamegraphPrefs>) => {
+    setPrefs((prev) => ({...prev, ...patch}))
+  }, [])
+
+  const lang = useMemo(() => normalizeLanguage(language), [language])
+
+  const detected = useMemo(
+    () => (frames?.length ? detectAppNamespaces(frames, lang, 12) : []),
+    [frames, lang],
+  )
+
+  const appPrefixes = useMemo(() => {
+    const manual = parsePrefixes(prefs.appPrefix)
+    if (manual.length) return manual
+    return detected.slice(0, 1).map((d) => d.namespace)
+  }, [prefs.appPrefix, detected])
+
+  const classifyOpts = useMemo<ClassifyOptions>(
+    () => ({language: lang, appPrefixes}),
+    [lang, appPrefixes],
+  )
+
+  const profileTotal = useMemo(
+    () => (frames?.length ? sumValues(frames) : 0),
+    [frames],
+  )
+
+  const displayFrames = useMemo(() => {
+    if (!frames?.length) return []
+    let base = frames
+    if (prefs.denoise === 'hide') {
+      base = collapseFrames(base, (n) => classifyFrame(n.name, classifyOpts) !== 'app')
+    }
+    if (prefs.foldRecursion) base = collapseRecursion(base)
+    if (prefs.orientation === 'bottomup') base = invertFrames(base)
+    return annotateSelf(base)
+  }, [frames, prefs.denoise, prefs.foldRecursion, prefs.orientation, classifyOpts])
+
+  const focusFrame = useMemo(
+    () => (focusPath.length ? resolveFocus(displayFrames, focusPath) : null),
+    [displayFrames, focusPath],
+  )
 
   const flatFrames = useMemo(() => {
-    if (!frames?.length) return []
-    const rootFrames = focusFrame ? [focusFrame] : frames
-    const rootTotal = focusFrame?.value ?? totalValue
-    return flattenFrames(rootFrames, rootTotal)
-  }, [frames, focusFrame, totalValue])
+    if (!displayFrames.length) return []
+    const roots = focusFrame ? [focusFrame] : displayFrames
+    const rootTotal = focusFrame?.value ?? sumValues(displayFrames)
+    const basePath = focusFrame ? focusPath.slice(0, -1) : []
+    return flattenFrames(roots, rootTotal, classifyOpts, prefs.minWidth, basePath)
+  }, [displayFrames, focusFrame, focusPath, classifyOpts, prefs.minWidth])
 
   const maxDepth = useMemo(
     () => Math.max(0, ...flatFrames.map((f) => f.depth)),
@@ -177,63 +333,186 @@ export function Flamegraph({frames, emptyMessage}: Props) {
 
   const topFunctions = useMemo(() => {
     if (!frames?.length) return []
-    return computeTopFunctions(frames, totalValue)
-  }, [frames, totalValue])
+    return computeTopFunctions(frames, profileTotal, {
+      language: lang,
+      appPrefixes,
+      scope: topScope,
+      sortBy: topSort,
+    })
+  }, [frames, profileTotal, lang, appPrefixes, topScope, topSort])
 
-  const searchLower = searchQuery.toLowerCase()
-  const hasSearch = searchQuery.length > 1
-
-  const matchCount = useMemo(() => {
-    if (!hasSearch) return 0
-    return flatFrames.filter((ff) =>
-      ff.frame.name.toLowerCase().includes(searchLower),
-    ).length
-  }, [flatFrames, searchLower, hasSearch])
-
-  const handleZoomIn = useCallback(
-    (frame: FlamegraphFrame) => {
-      if (frame.children.length > 0 && frame !== focusFrame) {
-        setFocusStack((prev) => [...prev, frame])
-      }
-    },
-    [focusFrame],
+  const hasSearch = searchQuery.length >= MIN_SEARCH_CHARS
+  const matcher = useMemo(
+    () => buildMatcher(searchQuery, useRegex),
+    [searchQuery, useRegex],
   )
 
-  const handleZoomBack = useCallback((toIndex: number) => {
-    setFocusStack((prev) => prev.slice(0, toIndex))
+  const matchIndices = useMemo(() => {
+    if (!hasSearch) return []
+    const indices: number[] = []
+    flatFrames.forEach((ff, i) => {
+      if (matcher.test(ff.frame.name)) indices.push(i)
+    })
+    return indices
+  }, [flatFrames, matcher, hasSearch])
+
+  // Reset the active match when the query changes (during render).
+  const searchKey = `${searchQuery}|${useRegex}`
+  if (matchState.key !== searchKey) setMatchState({key: searchKey, index: 0})
+  const currentMatch = Math.min(matchState.index, Math.max(matchIndices.length - 1, 0))
+
+  const colorOf = useCallback(
+    (name: string) =>
+      colorFor(name, {mode: prefs.colorMode, language: lang, appPrefixes}),
+    [prefs.colorMode, lang, appPrefixes],
+  )
+
+  const diff = useMemo(
+    () => (baselineFrames?.length && frames?.length ? computeDiff(frames, baselineFrames) : null),
+    [frames, baselineFrames],
+  )
+
+  const frameColorFor = useCallback(
+    (ff: FlatFrame) => {
+      if (diff) return diffColor(diff.deltaByName.get(ff.frame.name) ?? 0)
+      if (prefs.denoise === 'dim' && ff.kind !== 'app') return DIM_COLOR
+      return colorOf(ff.frame.name)
+    },
+    [diff, prefs.denoise, colorOf],
+  )
+
+  const matchCount = matchIndices.length
+  const gotoMatch = useCallback(
+    (dir: number) => {
+      if (!matchCount) return
+      setMatchState((s) => ({
+        key: s.key,
+        index: ((s.index + dir) % matchCount + matchCount) % matchCount,
+      }))
+    },
+    [matchCount],
+  )
+
+  // Scroll the active match into view.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el || !matchIndices.length) return
+    const ff = flatFrames[matchIndices[currentMatch]]
+    if (!ff) return
+    el.scrollTo({top: Math.max(ff.depth * ROW_HEIGHT - el.clientHeight / 2, 0), behavior: 'smooth'})
+  }, [currentMatch, matchIndices, flatFrames])
+
+  const handleZoomIn = useCallback((ff: FlatFrame) => {
+    if (ff.frame.children.length > 0) setFocusPath(ff.path)
   }, [])
 
-  const handleReset = useCallback(() => {
-    setFocusStack([])
+  const handleReset = useCallback(() => setFocusPath([]), [])
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    setScrollTop(el.scrollTop)
+    setViewportH(el.clientHeight)
+  }, [])
+
+  const handleMinimapScroll = useCallback((fraction: number) => {
+    const el = containerRef.current
+    if (!el) return
+    el.scrollTop = Math.max(0, fraction * el.scrollHeight - el.clientHeight / 2)
   }, [])
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
       if (!tooltipRef.current || !hoveredFrame) return
       const el = tooltipRef.current
-      const vw = window.innerWidth
-      const vh = window.innerHeight
-
       let left = e.clientX + 14
       let top = e.clientY - 10
-
-      if (left + 320 > vw) left = e.clientX - 320
-      if (top + 100 > vh) top = e.clientY - 100
-
+      if (left + 320 > window.innerWidth) left = e.clientX - 320
+      if (top + 120 > window.innerHeight) top = e.clientY - 120
       el.style.left = `${left}px`
       el.style.top = `${top}px`
     },
     [hoveredFrame],
   )
 
+  // Keyboard shortcuts.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement | null)?.tagName
+      const typing = tag === 'INPUT' || tag === 'TEXTAREA'
+      if (e.key === '/' && !typing) {
+        e.preventDefault()
+        searchInputRef.current?.focus()
+        return
+      }
+      if (e.key === 'Escape') {
+        setFocusPath([])
+        setSearchQuery('')
+        return
+      }
+      if (typing) return
+      if (e.key === 'n') gotoMatch(1)
+      else if (e.key === 'N') gotoMatch(-1)
+      else if (e.key === 'f') updatePrefs({denoise: prefs.denoise === 'hide' ? 'off' : 'hide'})
+      else if (e.key === 'i') {
+        updatePrefs({orientation: prefs.orientation === 'bottomup' ? 'topdown' : 'bottomup'})
+      } else if (e.key === 'c' && hoveredRef.current) {
+        copyText(hoveredRef.current.path.join(';'))
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [gotoMatch, updatePrefs, prefs.denoise, prefs.orientation])
+
+  const visibleFrames = useMemo(() => {
+    if (viewportH <= 0) return flatFrames
+    const start = Math.floor(scrollTop / ROW_HEIGHT) - VIRTUAL_BUFFER
+    const end = Math.ceil((scrollTop + viewportH) / ROW_HEIGHT) + VIRTUAL_BUFFER
+    return flatFrames.filter((ff) => ff.depth >= start && ff.depth <= end)
+  }, [flatFrames, scrollTop, viewportH])
+
+  const activeMatchFrame = matchIndices.length
+    ? (flatFrames[matchIndices[currentMatch]] ?? null)
+    : null
+
+  const miniRects = useMemo<MiniRect[]>(
+    () => flatFrames.map((ff) => ({depth: ff.depth, x: ff.x, width: ff.width, color: frameColorFor(ff)})),
+    [flatFrames, frameColorFor],
+  )
+
+  const handleExport = useCallback(
+    async (format: 'svg' | 'png') => {
+      const exportFrames: ExportFrame[] = flatFrames.map((ff) => ({
+        name: ff.frame.name,
+        depth: ff.depth,
+        x: ff.x,
+        width: ff.width,
+        color: frameColorFor(ff),
+      }))
+      if (!exportFrames.length) return
+      const opts = {width: 1600, rowHeight: ROW_HEIGHT, title: `${service || 'profile'} — flamegraph`}
+      const svg = framesToSvg(exportFrames, opts)
+      const base = `flamegraph-${(service || 'profile').replace(/[^a-z0-9_-]+/gi, '_')}`
+      try {
+        if (format === 'svg') {
+          downloadSvg(svg, `${base}.svg`)
+        } else {
+          const {width, height} = svgDimensions(exportFrames, opts)
+          await downloadPng(svg, width, height, `${base}.png`)
+        }
+      } catch {
+        // export failed (e.g., canvas unavailable)
+      }
+    },
+    [flatFrames, frameColorFor, service],
+  )
+
   if (!frames?.length) {
     return (
       <div className="text-center py-12 text-muted-foreground">
-        <p className="font-medium">
-          {emptyMessage || 'No profile data available'}
-        </p>
+        <p className="font-medium">{emptyMessage || 'No profile data available'}</p>
         <p className="text-sm mt-1">
-          Upload a pprof file or wait for profile data to be collected.
+          Upload a pprof/JFR file or wait for profile data to be collected.
         </p>
       </div>
     )
@@ -242,144 +521,253 @@ export function Flamegraph({frames, emptyMessage}: Props) {
   const chartHeight = (maxDepth + 1) * ROW_HEIGHT + 4
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 gap-y-3">
-      {/* Toolbar */}
-      <div className="flex items-center gap-2 flex-wrap">
-        <div className="relative flex-1 min-w-[200px] max-w-sm">
+    <div className="flex flex-col lg:flex-row flex-1 min-h-0 gap-3">
+      {/* Controls + meta sidebar (right) */}
+      <aside className="flex flex-col gap-2 lg:order-2 lg:w-80 lg:shrink-0 lg:overflow-y-auto lg:pr-1">
+        {meta}
+        {/* Search */}
+        <div className="relative">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
           <Input
-            placeholder="Search functions…"
+            ref={searchInputRef}
+            placeholder="Search functions… (/)"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-8 h-8 text-xs"
+            className={`pl-8 pr-20 h-8 text-xs ${matcher.error ? 'border-destructive' : ''}`}
           />
-          {hasSearch && (
-            <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] text-muted-foreground">
-              {matchCount} match{matchCount !== 1 ? 'es' : ''}
-            </span>
-          )}
-        </div>
-        <Button
-          variant={showTopFunctions ? 'secondary' : 'outline'}
-          size="sm"
-          className="h-8 text-xs"
-          onClick={() => setShowTopFunctions((v) => !v)}
-        >
-          Top Functions
-        </Button>
-        {focusStack.length > 0 && (
-          <Button variant="ghost" size="sm" className="h-8 text-xs" onClick={handleReset}>
-            <RotateCcw className="h-3 w-3 mr-1" />
-            Reset Zoom
-          </Button>
-        )}
-      </div>
-
-      {/* Zoom breadcrumbs */}
-      {focusStack.length > 0 && (
-        <div className="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto">
-          <button
-            onClick={handleReset}
-            className="hover:text-foreground transition-colors shrink-0"
-          >
-            root
-          </button>
-          {focusStack.map((f, i) => (
-            <span key={i} className="flex items-center gap-1 shrink-0">
-              <ChevronRight className="h-3 w-3" />
-              <button
-                onClick={() => handleZoomBack(i + 1)}
-                className="hover:text-foreground transition-colors truncate max-w-[200px]"
-                title={f.name}
-              >
-                {shortName(f.name)}
-              </button>
-            </span>
-          ))}
-        </div>
-      )}
-
-      {/* Top functions table */}
-      {showTopFunctions && topFunctions.length > 0 && (
-        <div className="border rounded-lg overflow-hidden">
-          <div className="max-h-[260px] overflow-y-auto">
-            <table className="w-full text-xs">
-              <thead className="bg-muted/50 sticky top-0">
-                <tr className="border-b">
-                  <th className="text-left py-1.5 px-3 font-medium text-muted-foreground">Function</th>
-                  <th className="text-right py-1.5 px-3 font-medium text-muted-foreground w-24">Self</th>
-                  <th className="text-right py-1.5 px-3 font-medium text-muted-foreground w-24">Total</th>
-                </tr>
-              </thead>
-              <tbody>
-                {topFunctions.map((fn) => (
-                  <tr
-                    key={fn.name}
-                    className="border-b last:border-0 hover:bg-muted/30 cursor-default"
-                  >
-                    <td className="py-1 px-3">
-                      <div className="flex items-center gap-2">
-                        <div
-                          className="w-2 h-2 rounded-sm shrink-0"
-                          style={{backgroundColor: frameColor(fn.name)}}
-                        />
-                        <span className="font-mono truncate" title={fn.name}>
-                          {fn.name}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="py-1 px-3 text-right font-mono tabular-nums">
-                      <span className="text-foreground">{fn.selfPercent.toFixed(1)}%</span>
-                      <span className="text-muted-foreground ml-1">({fn.selfValue.toLocaleString()})</span>
-                    </td>
-                    <td className="py-1 px-3 text-right font-mono tabular-nums">
-                      <span className="text-foreground">{fn.totalPercent.toFixed(1)}%</span>
-                      <span className="text-muted-foreground ml-1">({fn.totalValue.toLocaleString()})</span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+            {searchQuery.length > 0 && !hasSearch && (
+              <span className="text-[10px] text-muted-foreground">3+ chars</span>
+            )}
+            {hasSearch && (
+              <span className="text-[10px] text-muted-foreground tabular-nums">
+                {matchIndices.length ? currentMatch + 1 : 0}/{matchIndices.length}
+              </span>
+            )}
+            <IconBtn label="Previous match (N)" onClick={() => gotoMatch(-1)} disabled={!matchIndices.length}>
+              <ChevronUp className="h-3.5 w-3.5" />
+            </IconBtn>
+            <IconBtn label="Next match (n)" onClick={() => gotoMatch(1)} disabled={!matchIndices.length}>
+              <ChevronDown className="h-3.5 w-3.5" />
+            </IconBtn>
+            <IconBtn label="Regex" active={useRegex} onClick={() => setUseRegex((v) => !v)}>
+              <Regex className="h-3.5 w-3.5" />
+            </IconBtn>
           </div>
         </div>
+
+        {/* Selectors */}
+        {(onSampleTypeChange || onThreadChange) && (
+          <ThreadSampleTypeSelectors
+            sampleTypes={sampleTypes}
+            threads={threads}
+            selectedSampleType={selectedSampleType}
+            selectedThread={selectedThread}
+            unit={unit}
+            onSampleTypeChange={(k) => onSampleTypeChange?.(k)}
+            onThreadChange={(id) => onThreadChange?.(id)}
+          />
+        )}
+
+        {/* Display */}
+        <SidebarField label="Color">
+          <Segmented>
+            <SegButton active={prefs.colorMode === 'package'} onClick={() => updatePrefs({colorMode: 'package'})}>
+              Package
+            </SegButton>
+            <SegButton active={prefs.colorMode === 'kind'} onClick={() => updatePrefs({colorMode: 'kind'})}>
+              Kind
+            </SegButton>
+          </Segmented>
+        </SidebarField>
+
+        <SidebarField label="Frames">
+          <Segmented>
+            <SegButton active={prefs.denoise === 'off'} onClick={() => updatePrefs({denoise: 'off'})}>
+              Full
+            </SegButton>
+            <SegButton active={prefs.denoise === 'dim'} onClick={() => updatePrefs({denoise: 'dim'})}>
+              Dim
+            </SegButton>
+            <SegButton active={prefs.denoise === 'hide'} onClick={() => updatePrefs({denoise: 'hide'})}>
+              Hide
+            </SegButton>
+          </Segmented>
+        </SidebarField>
+
+        <SidebarField label="View">
+          <Segmented>
+            <SegButton active={prefs.orientation === 'topdown'} onClick={() => updatePrefs({orientation: 'topdown'})}>
+              Top-down
+            </SegButton>
+            <SegButton active={prefs.orientation === 'bottomup'} onClick={() => updatePrefs({orientation: 'bottomup'})}>
+              Bottom-up
+            </SegButton>
+          </Segmented>
+        </SidebarField>
+
+        <label className="flex items-center justify-between gap-2 cursor-pointer">
+          <span className="text-[11px] text-muted-foreground">Fold recursion</span>
+          <input
+            type="checkbox"
+            checked={prefs.foldRecursion}
+            onChange={() => updatePrefs({foldRecursion: !prefs.foldRecursion})}
+            className="accent-current h-3.5 w-3.5 cursor-pointer"
+          />
+        </label>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[11px] text-muted-foreground shrink-0">Min width</span>
+          <div className="flex items-center gap-2 w-40">
+            <input
+              type="range"
+              min={0.02}
+              max={2}
+              step={0.02}
+              value={prefs.minWidth}
+              onChange={(e) => updatePrefs({minWidth: Number(e.target.value)})}
+              className="flex-1 accent-current"
+            />
+            <span className="text-[10px] text-muted-foreground tabular-nums w-10 text-right">
+              {prefs.minWidth.toFixed(2)}%
+            </span>
+          </div>
+        </div>
+
+        {/* Your code */}
+        <SidebarField label="Your code">
+          <AppPackageSelect
+            namespaces={detected}
+            value={prefs.appPrefix}
+            effective={appPrefixes}
+            onChange={(csv) => updatePrefs({appPrefix: csv})}
+          />
+          <div className="flex items-center gap-1 mt-1.5">
+            <Input
+              placeholder="custom prefix…"
+              value={prefs.appPrefix}
+              onChange={(e) => updatePrefs({appPrefix: e.target.value})}
+              className="h-7 text-[11px] flex-1 font-mono"
+            />
+            {prefs.appPrefix && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                title="Reset to auto-detect"
+                onClick={() => updatePrefs({appPrefix: ''})}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        </SidebarField>
+
+        {/* Export */}
+        <div className="flex gap-1.5 pt-1">
+          <Button variant="outline" size="sm" className="h-8 text-xs flex-1" onClick={() => handleExport('svg')}>
+            <Download className="h-3 w-3 mr-1" />
+            SVG
+          </Button>
+          <Button variant="outline" size="sm" className="h-8 text-xs flex-1" onClick={() => handleExport('png')}>
+            <Download className="h-3 w-3 mr-1" />
+            PNG
+          </Button>
+          {focusPath.length > 0 && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              title="Reset zoom"
+              onClick={handleReset}
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+
+      </aside>
+
+      {/* Main — flamegraph */}
+      <div className="flex flex-col flex-1 min-h-0 gap-2 lg:order-1">
+        {/* Zoom breadcrumbs */}
+        {focusPath.length > 0 && (
+          <div className="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto shrink-0">
+            <button onClick={handleReset} className="hover:text-foreground transition-colors shrink-0">
+              root
+            </button>
+            {focusPath.map((name, i) => (
+              <span key={`${name}-${i}`} className="flex items-center gap-1 shrink-0">
+                <ChevronRight className="h-3 w-3" />
+                <button
+                  onClick={() => setFocusPath((prev) => prev.slice(0, i + 1))}
+                  className="hover:text-foreground transition-colors truncate max-w-[280px]"
+                  title={name}
+                >
+                  {shortName(name)}
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+      {/* Minimap overview */}
+      {chartHeight > viewportH && viewportH > 0 && (
+        <FlamegraphMinimap
+          rects={miniRects}
+          rows={maxDepth + 1}
+          chartHeight={chartHeight}
+          scrollTop={scrollTop}
+          viewportHeight={viewportH}
+          onScrollToFraction={handleMinimapScroll}
+        />
       )}
 
       {/* Flamegraph (icicle – root at top) */}
       <div
         ref={containerRef}
-        className="border rounded-lg overflow-x-auto overflow-y-auto relative flex-1 min-h-0"
+        className="border rounded-lg overflow-auto relative flex-1 min-h-0"
+        onScroll={handleScroll}
         onMouseMove={handleMouseMove}
-        onMouseLeave={() => setHoveredFrame(null)}
+        onMouseLeave={() => {
+          setHoveredFrame(null)
+          hoveredRef.current = null
+        }}
       >
-        <div
-          className="relative"
-          style={{height: chartHeight, minWidth: '100%'}}
-        >
-          {flatFrames.map((ff, i) => {
-            const top = ff.depth * ROW_HEIGHT + 2
-            const isMatch = hasSearch && ff.frame.name.toLowerCase().includes(searchLower)
-            const isDimmed = hasSearch && !isMatch
-            const color = frameColor(ff.frame.name)
+        <div className="relative" style={{height: chartHeight, minWidth: '100%'}}>
+          {visibleFrames.map((ff) => {
+            const isMatch = hasSearch && matcher.test(ff.frame.name)
+            const isActiveMatch = ff === activeMatchFrame
+            const dimmed = !diff && prefs.denoise === 'dim' && ff.kind !== 'app'
+            let opacity = dimmed ? 0.5 : 1
+            if (hasSearch && !isMatch) opacity = Math.min(opacity, 0.2)
 
             return (
               <div
-                key={`${ff.depth}-${ff.x}-${i}`}
+                key={ff.path.join('')}
                 className="absolute cursor-pointer group"
                 style={{
                   left: `${ff.x}%`,
-                  top,
+                  top: ff.depth * ROW_HEIGHT + 2,
                   width: `${Math.max(ff.width - 0.04, 0.04)}%`,
                   height: ROW_HEIGHT - 1,
                 }}
-                onMouseEnter={() => setHoveredFrame(ff)}
-                onClick={() => handleZoomIn(ff.frame)}
+                onMouseEnter={() => {
+                  setHoveredFrame(ff)
+                  hoveredRef.current = ff
+                }}
+                onClick={() => handleZoomIn(ff)}
               >
                 <div
                   className="w-full h-full rounded-[2px] overflow-hidden flex items-center transition-opacity group-hover:brightness-110"
                   style={{
-                    backgroundColor: color,
-                    opacity: isDimmed ? 0.25 : 1,
-                    outline: isMatch ? '1.5px solid white' : undefined,
+                    backgroundColor: frameColorFor(ff),
+                    opacity,
+                    outline: isActiveMatch
+                      ? '2px solid hsl(48 100% 60%)'
+                      : isMatch
+                        ? '1.5px solid white'
+                        : undefined,
                   }}
                 >
                   {ff.width > 2.5 && (
@@ -397,24 +785,57 @@ export function Flamegraph({frames, emptyMessage}: Props) {
         </div>
       </div>
 
-      {/* Color legend */}
-      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-muted-foreground pt-1 shrink-0">
-        {[
-          ['com.moneat', 'hsl(142, 55%, 42%)'],
-          ['io.ktor', 'hsl(160, 50%, 40%)'],
-          ['kotlin/kotlinx', 'hsl(275, 45%, 52%)'],
-          ['java/jdk', 'hsl(220, 45%, 48%)'],
-          ['io.netty', 'hsl(175, 45%, 42%)'],
-          ['other', 'hsl(14, 65%, 50%)'],
-        ].map(([label, color]) => (
-          <span key={label} className="flex items-center gap-1">
-            <span
-              className="inline-block w-2 h-2 rounded-sm"
-              style={{backgroundColor: color}}
-            />
-            {label}
-          </span>
-        ))}
+        {/* Legend + panel toggles on one row */}
+        <div className="flex items-center justify-between gap-2 shrink-0">
+          <div className="min-w-0 flex-1">
+            <FlamegraphLegend mode={prefs.colorMode} namespaces={detected} appPrefixes={appPrefixes} />
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <IconBtn
+              label="Top Functions"
+              active={showTopFunctions}
+              onClick={() => setShowTopFunctions((v) => !v)}
+            >
+              <SquareFunction className="h-3.5 w-3.5" />
+            </IconBtn>
+            {compareProfiles && compareProfiles.length > 0 && (
+              <IconBtn
+                label="Compare profiles"
+                active={showCompare || !!compareId}
+                onClick={() => setShowCompare((v) => !v)}
+              >
+                <GitCompare className="h-3.5 w-3.5" />
+              </IconBtn>
+            )}
+          </div>
+        </div>
+
+        {/* Top functions */}
+        {showTopFunctions && (
+          <TopFunctionsPanel
+            functions={topFunctions}
+            scope={topScope}
+            sortBy={topSort}
+            hasAppPrefixes={appPrefixes.length > 0}
+            onScopeChange={setTopScope}
+            onSortChange={setTopSort}
+            onSelect={setSearchQuery}
+            onCopy={copyText}
+            colorOf={colorOf}
+          />
+        )}
+
+        {/* Compare / diff */}
+        {showCompare && compareProfiles && (
+          <CompareBar
+            profiles={compareProfiles}
+            compareId={compareId}
+            loading={baselineLoading}
+            diff={diff}
+            onChange={(id) => onCompareChange?.(id)}
+            onSelect={setSearchQuery}
+          />
+        )}
       </div>
 
       {/* Tooltip */}
@@ -422,10 +843,7 @@ export function Flamegraph({frames, emptyMessage}: Props) {
         <div
           ref={tooltipRef}
           className="fixed z-50 pointer-events-none max-w-sm"
-          style={{
-            left: -9999,
-            top: -9999,
-          }}
+          style={{left: -9999, top: -9999}}
         >
           <div className="bg-popover border rounded-lg px-3 py-2 text-xs space-y-1.5">
             <p className="font-semibold text-popover-foreground break-all leading-snug">
@@ -433,29 +851,31 @@ export function Flamegraph({frames, emptyMessage}: Props) {
             </p>
             <div className="text-muted-foreground space-y-0.5">
               <p>
+                Total:{' '}
                 <span className="text-popover-foreground font-medium">
                   {hoveredFrame.frame.value.toLocaleString()}
                 </span>{' '}
-                samples ({hoveredFrame.width.toFixed(1)}% of total)
+                ({pctOf(hoveredFrame.frame.value, profileTotal).toFixed(1)}%)
               </p>
-              {hoveredFrame.frame.self != null && hoveredFrame.frame.self > 0 && (
-                <p>
-                  Self:{' '}
-                  <span className="text-popover-foreground font-medium">
-                    {hoveredFrame.frame.self.toLocaleString()}
-                  </span>{' '}
-                  samples
-                </p>
-              )}
+              <p>
+                Self:{' '}
+                <span className="text-popover-foreground font-medium">
+                  {(hoveredFrame.frame.self ?? 0).toLocaleString()}
+                </span>{' '}
+                ({pctOf(hoveredFrame.frame.self ?? 0, profileTotal).toFixed(1)}%)
+              </p>
               <p className="text-[10px] text-muted-foreground/70 pt-0.5">
-                {packageOf(hoveredFrame.frame.name)}
+                {KIND_LABEL[hoveredFrame.kind]} · {packageOf(hoveredFrame.frame.name)}
+              </p>
+              <p className="text-[10px] text-muted-foreground/50 pt-0.5">
+                click to zoom · press c to copy stack
               </p>
             </div>
             <div
               className="h-1 rounded-full mt-1"
               style={{
-                width: `${Math.max(hoveredFrame.width, 4)}%`,
-                backgroundColor: frameColor(hoveredFrame.frame.name),
+                width: `${Math.max(pctOf(hoveredFrame.frame.value, profileTotal), 4)}%`,
+                backgroundColor: colorOf(hoveredFrame.frame.name),
               }}
             />
           </div>
@@ -465,12 +885,78 @@ export function Flamegraph({frames, emptyMessage}: Props) {
   )
 }
 
-function shortName(fullName: string): string {
-  const parenIdx = fullName.indexOf('(')
-  const base = parenIdx > -1 ? fullName.slice(0, parenIdx) : fullName
-  const parts = base.split('.')
-  if (parts.length <= 2) return fullName
-  const className = parts[parts.length - 2]
-  const method = parts[parts.length - 1]
-  return `${className}.${method}${parenIdx > -1 ? '()' : ''}`
+const KIND_LABEL: Record<FrameKind, string> = {
+  app: 'your code',
+  library: 'library',
+  runtime: 'runtime / system',
+}
+
+function pctOf(value: number, total: number): number {
+  return total > 0 ? (value / total) * 100 : 0
+}
+
+function SidebarField({label, children}: {label: string; children: React.ReactNode}) {
+  return (
+    <div className="space-y-1">
+      <span className="block text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      {children}
+    </div>
+  )
+}
+
+function Segmented({children}: {children: React.ReactNode}) {
+  return <div className="flex rounded-md border p-0.5 gap-0.5 [&>button]:flex-1">{children}</div>
+}
+
+function SegButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center justify-center whitespace-nowrap h-7 px-2 rounded text-[11px] transition-colors ${
+        active ? 'bg-secondary text-secondary-foreground' : 'text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function IconBtn({
+  label,
+  active,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string
+  active?: boolean
+  disabled?: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className={`h-6 w-6 inline-flex items-center justify-center rounded transition-colors disabled:opacity-30 ${
+        active ? 'bg-secondary text-secondary-foreground' : 'text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {children}
+    </button>
+  )
 }

--- a/dashboard/src/components/profiling/Flamegraph.tsx
+++ b/dashboard/src/components/profiling/Flamegraph.tsx
@@ -116,7 +116,7 @@ function prefsKey(service?: string): string {
 
 function loadPrefs(service?: string): FlamegraphPrefs {
   try {
-    const raw = localStorage.getItem(prefsKey(service))
+    const raw = globalThis.localStorage.getItem(prefsKey(service))
     if (raw) return {...DEFAULT_PREFS, ...JSON.parse(raw)}
   } catch {
     // ignore malformed/inaccessible storage
@@ -257,7 +257,7 @@ export function Flamegraph({
 
   useEffect(() => {
     try {
-      localStorage.setItem(prefsKey(service), JSON.stringify(prefs))
+      globalThis.localStorage.setItem(prefsKey(service), JSON.stringify(prefs))
     } catch {
       // ignore inaccessible storage
     }
@@ -427,8 +427,8 @@ export function Flamegraph({
       const el = tooltipRef.current
       let left = e.clientX + 14
       let top = e.clientY - 10
-      if (left + 320 > window.innerWidth) left = e.clientX - 320
-      if (top + 120 > window.innerHeight) top = e.clientY - 120
+      if (left + 320 > globalThis.window.innerWidth) left = e.clientX - 320
+      if (top + 120 > globalThis.window.innerHeight) top = e.clientY - 120
       el.style.left = `${left}px`
       el.style.top = `${top}px`
     },
@@ -460,8 +460,8 @@ export function Flamegraph({
         copyText(hoveredRef.current.path.join(';'))
       }
     }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    globalThis.window.addEventListener('keydown', onKey)
+    return () => globalThis.window.removeEventListener('keydown', onKey)
   }, [gotoMatch, updatePrefs, prefs.denoise, prefs.orientation])
 
   const visibleFrames = useMemo(() => {
@@ -744,7 +744,7 @@ export function Flamegraph({
 
             return (
               <div
-                key={ff.path.join('')}
+                key={ff.path.join(';')}
                 className="absolute cursor-pointer group"
                 style={{
                   left: `${ff.x}%`,

--- a/dashboard/src/components/profiling/FlamegraphLegend.tsx
+++ b/dashboard/src/components/profiling/FlamegraphLegend.tsx
@@ -1,0 +1,69 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {
+  type ColorMode,
+  type NamespaceStat,
+  kindColor,
+  packageColor,
+} from './frameModel'
+
+interface Props {
+  mode: ColorMode
+  namespaces: NamespaceStat[]
+  appPrefixes: string[]
+}
+
+interface LegendEntry {
+  label: string
+  color: string
+}
+
+export function FlamegraphLegend({mode, namespaces, appPrefixes}: Props) {
+  const entries = mode === 'kind'
+    ? kindEntries()
+    : packageEntries(namespaces, appPrefixes)
+
+  return (
+    <div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-muted-foreground pt-1 shrink-0">
+      {entries.map((entry) => (
+        <span key={entry.label} className="flex items-center gap-1">
+          <span
+            className="inline-block w-2 h-2 rounded-sm"
+            style={{backgroundColor: entry.color}}
+          />
+          {entry.label}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function kindEntries(): LegendEntry[] {
+  return [
+    {label: 'your code', color: kindColor('app')},
+    {label: 'library', color: kindColor('library')},
+    {label: 'runtime / system', color: kindColor('runtime')},
+  ]
+}
+
+function packageEntries(
+  namespaces: NamespaceStat[],
+  appPrefixes: string[],
+): LegendEntry[] {
+  const top = namespaces.slice(0, 6).map((ns) => ({
+    label: appPrefixes.includes(ns.namespace)
+      ? `${ns.namespace} (you)`
+      : ns.namespace,
+    color: packageColor(`${ns.namespace}.`),
+  }))
+  if (namespaces.length > 6) {
+    top.push({label: 'other', color: packageColor('zzz.unmatched')})
+  }
+  return top
+}

--- a/dashboard/src/components/profiling/FlamegraphMinimap.tsx
+++ b/dashboard/src/components/profiling/FlamegraphMinimap.tsx
@@ -1,0 +1,117 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {useEffect, useRef, useState, useCallback} from 'react'
+
+export interface MiniRect {
+  depth: number
+  x: number
+  width: number
+  color: string
+}
+
+interface Props {
+  rects: MiniRect[]
+  rows: number
+  chartHeight: number
+  scrollTop: number
+  viewportHeight: number
+  onScrollToFraction: (fraction: number) => void
+}
+
+const MINIMAP_HEIGHT = 56
+
+export function FlamegraphMinimap({
+  rects,
+  rows,
+  chartHeight,
+  scrollTop,
+  viewportHeight,
+  onScrollToFraction,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(600)
+  const draggingRef = useRef(false)
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const observer = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width
+      if (w) setWidth(Math.max(120, Math.floor(w)))
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = width * dpr
+    canvas.height = MINIMAP_HEIGHT * dpr
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, width, MINIMAP_HEIGHT)
+
+    const rowH = MINIMAP_HEIGHT / Math.max(rows, 1)
+    for (const r of rects) {
+      ctx.fillStyle = r.color
+      const px = (r.x / 100) * width
+      const pw = Math.max((r.width / 100) * width, 0.5)
+      ctx.fillRect(px, r.depth * rowH, pw, Math.max(rowH - 0.5, 1))
+    }
+
+    // Viewport indicator.
+    if (chartHeight > 0 && viewportHeight < chartHeight) {
+      const top = (scrollTop / chartHeight) * MINIMAP_HEIGHT
+      const h = (viewportHeight / chartHeight) * MINIMAP_HEIGHT
+      ctx.fillStyle = 'rgba(255,255,255,0.12)'
+      ctx.fillRect(0, top, width, h)
+      ctx.strokeStyle = 'rgba(255,255,255,0.6)'
+      ctx.lineWidth = 1
+      ctx.strokeRect(0.5, top + 0.5, width - 1, Math.max(h - 1, 1))
+    }
+  }, [rects, rows, width, scrollTop, viewportHeight, chartHeight])
+
+  const scrollFromEvent = useCallback(
+    (clientY: number) => {
+      const canvas = canvasRef.current
+      if (!canvas) return
+      const rect = canvas.getBoundingClientRect()
+      const fraction = (clientY - rect.top) / rect.height
+      onScrollToFraction(Math.min(Math.max(fraction, 0), 1))
+    },
+    [onScrollToFraction],
+  )
+
+  return (
+    <div ref={wrapRef} className="w-full">
+      <canvas
+        ref={canvasRef}
+        className="w-full rounded border cursor-pointer block"
+        style={{height: MINIMAP_HEIGHT}}
+        onMouseDown={(e) => {
+          draggingRef.current = true
+          scrollFromEvent(e.clientY)
+        }}
+        onMouseMove={(e) => {
+          if (draggingRef.current) scrollFromEvent(e.clientY)
+        }}
+        onMouseUp={() => {
+          draggingRef.current = false
+        }}
+        onMouseLeave={() => {
+          draggingRef.current = false
+        }}
+      />
+    </div>
+  )
+}

--- a/dashboard/src/components/profiling/FlamegraphMinimap.tsx
+++ b/dashboard/src/components/profiling/FlamegraphMinimap.tsx
@@ -53,7 +53,7 @@ export function FlamegraphMinimap({
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
-    const dpr = window.devicePixelRatio || 1
+    const dpr = globalThis.window?.devicePixelRatio ?? 1
     canvas.width = width * dpr
     canvas.height = MINIMAP_HEIGHT * dpr
     const ctx = canvas.getContext('2d')
@@ -98,18 +98,21 @@ export function FlamegraphMinimap({
         ref={canvasRef}
         className="w-full rounded border cursor-pointer block"
         style={{height: MINIMAP_HEIGHT}}
-        onMouseDown={(e) => {
+        onPointerDown={(e) => {
           draggingRef.current = true
+          e.currentTarget.setPointerCapture(e.pointerId)
           scrollFromEvent(e.clientY)
         }}
-        onMouseMove={(e) => {
+        onPointerMove={(e) => {
           if (draggingRef.current) scrollFromEvent(e.clientY)
         }}
-        onMouseUp={() => {
+        onPointerUp={(e) => {
           draggingRef.current = false
+          e.currentTarget.releasePointerCapture(e.pointerId)
         }}
-        onMouseLeave={() => {
+        onPointerCancel={(e) => {
           draggingRef.current = false
+          e.currentTarget.releasePointerCapture(e.pointerId)
         }}
       />
     </div>

--- a/dashboard/src/components/profiling/ThreadSampleTypeSelectors.tsx
+++ b/dashboard/src/components/profiling/ThreadSampleTypeSelectors.tsx
@@ -1,0 +1,76 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import type {SampleTypeInfo, ThreadInfo} from '@/lib/api/types/profiles'
+
+interface Props {
+  sampleTypes: SampleTypeInfo[]
+  threads: ThreadInfo[]
+  selectedSampleType?: string
+  selectedThread?: string | null
+  unit?: string
+  onSampleTypeChange: (key: string) => void
+  onThreadChange: (id: string | null) => void
+}
+
+const SELECT_CLASS =
+  'h-7 w-full text-[11px] rounded-md border bg-background px-1.5'
+const LABEL_CLASS =
+  'block text-[10px] font-medium uppercase tracking-wide text-muted-foreground'
+
+export function ThreadSampleTypeSelectors({
+  sampleTypes,
+  threads,
+  selectedSampleType,
+  selectedThread,
+  unit,
+  onSampleTypeChange,
+  onThreadChange,
+}: Props) {
+  const showTypes = sampleTypes.length > 1
+  const showThreads = threads.length > 0
+  if (!showTypes && !showThreads) return null
+
+  return (
+    <>
+      {showTypes && (
+        <div className="space-y-1">
+          <span className={LABEL_CLASS}>Type{unit ? ` (${unit})` : ''}</span>
+          <select
+            value={selectedSampleType ?? sampleTypes[0]?.key}
+            onChange={(e) => onSampleTypeChange(e.target.value)}
+            className={SELECT_CLASS}
+          >
+            {sampleTypes.map((t) => (
+              <option key={t.key} value={t.key}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      {showThreads && (
+        <div className="space-y-1">
+          <span className={LABEL_CLASS}>Thread</span>
+          <select
+            value={selectedThread ?? ''}
+            onChange={(e) => onThreadChange(e.target.value || null)}
+            className={SELECT_CLASS}
+          >
+            <option value="">All threads</option>
+            {threads.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.label} ({t.samples.toLocaleString()})
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </>
+  )
+}

--- a/dashboard/src/components/profiling/TopFunctionsPanel.tsx
+++ b/dashboard/src/components/profiling/TopFunctionsPanel.tsx
@@ -1,0 +1,189 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {ArrowDown, Copy} from 'lucide-react'
+import {Button} from '@/components/ui/button'
+import type {
+  TopFunction,
+  TopFunctionScope,
+  TopFunctionSort,
+} from './frameModel'
+
+interface Props {
+  functions: TopFunction[]
+  scope: TopFunctionScope
+  sortBy: TopFunctionSort
+  hasAppPrefixes: boolean
+  onScopeChange: (scope: TopFunctionScope) => void
+  onSortChange: (sort: TopFunctionSort) => void
+  onSelect: (name: string) => void
+  onCopy: (name: string) => void
+  colorOf: (name: string) => string
+}
+
+export function TopFunctionsPanel({
+  functions,
+  scope,
+  sortBy,
+  hasAppPrefixes,
+  onScopeChange,
+  onSortChange,
+  onSelect,
+  onCopy,
+  colorOf,
+}: Props) {
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between gap-2 px-3 py-1.5 bg-muted/50 border-b">
+        <div className="flex items-center gap-1">
+          <ScopeButton
+            label="All"
+            active={scope === 'all'}
+            onClick={() => onScopeChange('all')}
+          />
+          <ScopeButton
+            label="My code"
+            active={scope === 'app'}
+            disabled={!hasAppPrefixes}
+            onClick={() => onScopeChange('app')}
+          />
+        </div>
+        <span className="text-[10px] text-muted-foreground">
+          {functions.length} function{functions.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+      <div className="max-h-[260px] overflow-y-auto">
+        <table className="w-full text-xs">
+          <thead className="bg-muted sticky top-0 z-10">
+            <tr className="border-b">
+              <th className="text-left py-1.5 px-3 font-medium text-muted-foreground">
+                Function
+              </th>
+              <SortHeader
+                label="Self"
+                active={sortBy === 'self'}
+                onClick={() => onSortChange('self')}
+              />
+              <SortHeader
+                label="Total"
+                active={sortBy === 'total'}
+                onClick={() => onSortChange('total')}
+              />
+            </tr>
+          </thead>
+          <tbody>
+            {functions.length === 0 && (
+              <tr>
+                <td
+                  colSpan={3}
+                  className="py-4 px-3 text-center text-muted-foreground"
+                >
+                  No functions match this scope.
+                </td>
+              </tr>
+            )}
+            {functions.map((fn) => (
+              <tr
+                key={fn.name}
+                className="border-b last:border-0 hover:bg-muted/40 cursor-pointer"
+                onClick={() => onSelect(fn.name)}
+                title={`${fn.name}\nClick to highlight in the flamegraph`}
+              >
+                <td className="py-1 px-3">
+                  <div className="flex items-center gap-2 group/row">
+                    <span
+                      className="w-2 h-2 rounded-sm shrink-0"
+                      style={{backgroundColor: colorOf(fn.name)}}
+                    />
+                    <span className="font-mono truncate">{fn.name}</span>
+                    <button
+                      type="button"
+                      title="Copy function name"
+                      aria-label="Copy function name"
+                      className="ml-auto shrink-0 opacity-0 group-hover/row:opacity-100 text-muted-foreground hover:text-foreground transition-opacity"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onCopy(fn.name)
+                      }}
+                    >
+                      <Copy className="h-3 w-3" />
+                    </button>
+                  </div>
+                </td>
+                <ValueCell percent={fn.selfPercent} value={fn.selfValue} />
+                <ValueCell percent={fn.totalPercent} value={fn.totalValue} />
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function ScopeButton({
+  label,
+  active,
+  disabled,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  disabled?: boolean
+  onClick: () => void
+}) {
+  return (
+    <Button
+      variant={active ? 'secondary' : 'ghost'}
+      size="sm"
+      className="h-6 px-2 text-[11px]"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {label}
+    </Button>
+  )
+}
+
+function SortHeader({
+  label,
+  active,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <th className="text-right py-1.5 px-3 font-medium text-muted-foreground w-28">
+      <button
+        type="button"
+        onClick={onClick}
+        className={`inline-flex items-center gap-1 hover:text-foreground transition-colors ${
+          active ? 'text-foreground' : ''
+        }`}
+      >
+        {label}
+        <ArrowDown
+          className={`h-3 w-3 transition-opacity ${active ? 'opacity-100' : 'opacity-0'}`}
+        />
+      </button>
+    </th>
+  )
+}
+
+function ValueCell({percent, value}: {percent: number; value: number}) {
+  return (
+    <td className="py-1 px-3 text-right font-mono tabular-nums">
+      <span className="text-foreground">{percent.toFixed(1)}%</span>
+      <span className="text-muted-foreground ml-1">
+        ({value.toLocaleString()})
+      </span>
+    </td>
+  )
+}

--- a/dashboard/src/components/profiling/__tests__/Flamegraph.test.tsx
+++ b/dashboard/src/components/profiling/__tests__/Flamegraph.test.tsx
@@ -1,0 +1,89 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {describe, it, expect, beforeEach, vi} from 'vitest'
+import {render, screen, fireEvent} from '@testing-library/react'
+import {Flamegraph} from '../Flamegraph'
+import type {FlameNode} from '../frameModel'
+
+const FRAMES: FlameNode[] = [
+  {
+    name: 'com.moneat.svc.A.run',
+    value: 100,
+    children: [
+      {name: 'java.lang.Thread.run', value: 60, children: []},
+      {name: 'com.moneat.svc.B.work', value: 40, children: []},
+    ],
+  },
+]
+
+describe('Flamegraph', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders the toolbar, a frame label and the legend', () => {
+    render(<Flamegraph frames={FRAMES} language="jvm" service="svc-a" />)
+    expect(screen.getByPlaceholderText(/Search functions/)).toBeInTheDocument()
+    expect(screen.getByText('Hide')).toBeInTheDocument()
+    expect(screen.getAllByText('A.run').length).toBeGreaterThan(0)
+    // "Your code" multi-select shows the auto-detected namespace.
+    expect(screen.getByText(/Auto/)).toBeInTheDocument()
+  })
+
+  it('scopes Top Functions between all and app', () => {
+    render(<Flamegraph frames={FRAMES} language="jvm" service="svc-b" />)
+    // Panel is open by default and scoped to "My code" — runtime frames hidden.
+    expect(screen.queryByText('java.lang.Thread.run')).not.toBeInTheDocument()
+    expect(screen.getByText('com.moneat.svc.A.run')).toBeInTheDocument()
+
+    // Switching to "All" reveals runtime frames.
+    fireEvent.click(screen.getByText('All'))
+    expect(screen.getByText('java.lang.Thread.run')).toBeInTheDocument()
+  })
+
+  it('toggles bottom-up, hide-system and kind colouring without crashing', () => {
+    render(<Flamegraph frames={FRAMES} language="jvm" service="svc-c" />)
+    fireEvent.click(screen.getByText('Bottom-up'))
+    fireEvent.click(screen.getByText('Hide'))
+    fireEvent.click(screen.getByText('Kind'))
+    expect(screen.getByText('your code')).toBeInTheDocument()
+  })
+
+  it('renders sample-type and thread selectors and fires changes', () => {
+    const onSampleTypeChange = vi.fn()
+    const onThreadChange = vi.fn()
+    render(
+      <Flamegraph
+        frames={FRAMES}
+        language="jvm"
+        service="svc-d"
+        sampleTypes={[
+          {key: 'cpu', label: 'CPU', unit: 'samples'},
+          {key: 'alloc', label: 'Allocations', unit: 'bytes'},
+        ]}
+        threads={[{id: 'main', label: 'main', samples: 100}]}
+        selectedSampleType="cpu"
+        selectedThread={null}
+        unit="samples"
+        onSampleTypeChange={onSampleTypeChange}
+        onThreadChange={onThreadChange}
+      />,
+    )
+    fireEvent.change(screen.getByDisplayValue('CPU'), {target: {value: 'alloc'}})
+    expect(onSampleTypeChange).toHaveBeenCalledWith('alloc')
+
+    fireEvent.change(screen.getByDisplayValue('All threads'), {target: {value: 'main'}})
+    expect(onThreadChange).toHaveBeenCalledWith('main')
+  })
+
+  it('renders an empty state when there are no frames', () => {
+    render(<Flamegraph frames={[]} emptyMessage="Nothing here" />)
+    expect(screen.getByText('Nothing here')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/profiling/__tests__/Flamegraph.test.tsx
+++ b/dashboard/src/components/profiling/__tests__/Flamegraph.test.tsx
@@ -6,8 +6,8 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {describe, it, expect, beforeEach, vi} from 'vitest'
-import {render, screen, fireEvent} from '@testing-library/react'
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import {render, screen, fireEvent, waitFor} from '@testing-library/react'
 import {Flamegraph} from '../Flamegraph'
 import type {FlameNode} from '../frameModel'
 
@@ -24,7 +24,15 @@ const FRAMES: FlameNode[] = [
 
 describe('Flamegraph', () => {
   beforeEach(() => {
-    localStorage.clear()
+    globalThis.localStorage.clear()
+    if (!HTMLElement.prototype.scrollTo) {
+      HTMLElement.prototype.scrollTo = vi.fn()
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('renders the toolbar, a frame label and the legend', () => {
@@ -50,8 +58,14 @@ describe('Flamegraph', () => {
   it('toggles bottom-up, hide-system and kind colouring without crashing', () => {
     render(<Flamegraph frames={FRAMES} language="jvm" service="svc-c" />)
     fireEvent.click(screen.getByText('Bottom-up'))
+    fireEvent.click(screen.getByText('Dim'))
     fireEvent.click(screen.getByText('Hide'))
     fireEvent.click(screen.getByText('Kind'))
+    fireEvent.click(screen.getByLabelText('Fold recursion'))
+    fireEvent.change(screen.getByPlaceholderText('custom prefix…'), {
+      target: {value: 'com.moneat'},
+    })
+    fireEvent.click(screen.getByTitle('Reset to auto-detect'))
     expect(screen.getByText('your code')).toBeInTheDocument()
   })
 
@@ -85,5 +99,105 @@ describe('Flamegraph', () => {
   it('renders an empty state when there are no frames', () => {
     render(<Flamegraph frames={[]} emptyMessage="Nothing here" />)
     expect(screen.getByText('Nothing here')).toBeInTheDocument()
+  })
+
+  it('searches, cycles matches, zooms and copies the hovered stack', () => {
+    const writeText = vi.fn()
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: {writeText},
+    })
+    render(<Flamegraph frames={FRAMES} language="jvm" service="svc-search" />)
+
+    const search = screen.getByPlaceholderText(/Search functions/)
+    fireEvent.keyDown(globalThis.window, {key: '/'})
+    expect(search).toHaveFocus()
+
+    fireEvent.change(search, {target: {value: 'co'}})
+    expect(screen.getByText('3+ chars')).toBeInTheDocument()
+
+    fireEvent.change(search, {target: {value: 'B\\.work'}})
+    fireEvent.click(screen.getByLabelText('Regex'))
+    expect(screen.getByText('1/1')).toBeInTheDocument()
+    fireEvent.keyDown(globalThis.window, {key: 'n'})
+    fireEvent.keyDown(globalThis.window, {key: 'N'})
+
+    fireEvent.change(search, {target: {value: 'foo('}})
+    expect(search).toHaveClass('border-destructive')
+
+    const frameLabel = screen.getByText('A.run')
+    const frame = frameLabel.closest('.group') as HTMLElement
+    fireEvent.mouseEnter(frame)
+    fireEvent.keyDown(globalThis.window, {key: 'c'})
+    expect(writeText).toHaveBeenCalledWith('com.moneat.svc.A.run')
+
+    fireEvent.click(frame)
+    expect(screen.getByTitle('Reset zoom')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('root'))
+    expect(screen.queryByTitle('Reset zoom')).not.toBeInTheDocument()
+
+    fireEvent.keyDown(globalThis.window, {key: 'Escape'})
+    expect(search).toHaveValue('')
+  })
+
+  it('opens comparison details and applies selected baselines', () => {
+    const onCompareChange = vi.fn()
+    render(
+      <Flamegraph
+        frames={FRAMES}
+        baselineFrames={[{name: 'com.moneat.svc.A.run', value: 100, children: []}]}
+        language="jvm"
+        service="svc-compare"
+        compareProfiles={[{profileId: 'base-1', label: 'Earlier profile'}]}
+        compareId="base-1"
+        baselineLoading
+        onCompareChange={onCompareChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByLabelText('Compare profiles'))
+    expect(screen.getByText('Compare to baseline:')).toBeInTheDocument()
+    fireEvent.change(screen.getByRole('combobox'), {target: {value: ''}})
+    expect(onCompareChange).toHaveBeenCalledWith(null)
+    fireEvent.click(screen.getByRole('button', {name: /com\.moneat\.svc\.B\.work/}))
+    expect(screen.getByPlaceholderText(/Search functions/)).toHaveValue(
+      'com.moneat.svc.B.work',
+    )
+  })
+
+  it('exports visible frames as SVG and PNG', async () => {
+    const context = {
+      scale: vi.fn(),
+      drawImage: vi.fn(),
+    }
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      context as unknown as CanvasRenderingContext2D,
+    )
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL')
+      .mockReturnValue('data:image/png;base64,abc')
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    vi.stubGlobal('URL', {
+      ...globalThis.URL,
+      createObjectURL: vi.fn(() => 'blob:flamegraph'),
+      revokeObjectURL: vi.fn(),
+    })
+    vi.stubGlobal('Image', class {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+
+      set src(_value: string) {
+        this.onload?.()
+      }
+    })
+
+    render(<Flamegraph frames={FRAMES} language="jvm" service="svc export" />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'SVG'}))
+    fireEvent.click(screen.getByRole('button', {name: 'PNG'}))
+
+    await waitFor(() => {
+      expect(click).toHaveBeenCalledTimes(2)
+    })
+    expect(context.drawImage).toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/profiling/__tests__/flamegraphExport.test.ts
+++ b/dashboard/src/components/profiling/__tests__/flamegraphExport.test.ts
@@ -6,13 +6,18 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {describe, it, expect} from 'vitest'
-import {framesToSvg, svgDimensions, type ExportFrame} from '../flamegraphExport'
+import {describe, it, expect, vi, afterEach} from 'vitest'
+import {downloadPng, framesToSvg, svgDimensions, type ExportFrame} from '../flamegraphExport'
 
 const FRAMES: ExportFrame[] = [
   {name: 'com.app.A.run', depth: 0, x: 0, width: 100, color: 'hsl(142,55%,42%)'},
   {name: 'a<b>&c', depth: 1, x: 0, width: 50, color: '#ffffff'},
 ]
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 describe('framesToSvg', () => {
   it('emits a rect per frame and escapes labels/title', () => {
@@ -27,5 +32,46 @@ describe('framesToSvg', () => {
     const {width, height} = svgDimensions(FRAMES, {width: 800, rowHeight: 20})
     expect(width).toBe(800)
     expect(height).toBeGreaterThan(40)
+  })
+})
+
+describe('downloadPng', () => {
+  it('rasterizes the SVG and revokes the object URL', async () => {
+    const context = {
+      scale: vi.fn(),
+      drawImage: vi.fn(),
+    }
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      context as unknown as CanvasRenderingContext2D,
+    )
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue('data:image/png;base64,abc')
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    const createObjectURL = vi.fn(() => 'blob:flamegraph')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', {
+      ...globalThis.URL,
+      createObjectURL,
+      revokeObjectURL,
+    })
+    vi.stubGlobal('Image', class {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+
+      set src(_value: string) {
+        this.onload?.()
+      }
+    })
+    Object.defineProperty(globalThis.window, 'devicePixelRatio', {
+      configurable: true,
+      value: 2,
+    })
+
+    await downloadPng('<svg />', 100, 50, 'flamegraph.png')
+
+    expect(createObjectURL).toHaveBeenCalled()
+    expect(context.scale).toHaveBeenCalledWith(2, 2)
+    expect(context.drawImage).toHaveBeenCalledWith(expect.any(Object), 0, 0, 100, 50)
+    expect(click).toHaveBeenCalled()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:flamegraph')
   })
 })

--- a/dashboard/src/components/profiling/__tests__/flamegraphExport.test.ts
+++ b/dashboard/src/components/profiling/__tests__/flamegraphExport.test.ts
@@ -1,0 +1,31 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {describe, it, expect} from 'vitest'
+import {framesToSvg, svgDimensions, type ExportFrame} from '../flamegraphExport'
+
+const FRAMES: ExportFrame[] = [
+  {name: 'com.app.A.run', depth: 0, x: 0, width: 100, color: 'hsl(142,55%,42%)'},
+  {name: 'a<b>&c', depth: 1, x: 0, width: 50, color: '#ffffff'},
+]
+
+describe('framesToSvg', () => {
+  it('emits a rect per frame and escapes labels/title', () => {
+    const svg = framesToSvg(FRAMES, {width: 800, rowHeight: 20, title: 't & <x>'})
+    expect(svg.startsWith('<svg')).toBe(true)
+    expect((svg.match(/<rect/g) || []).length).toBeGreaterThanOrEqual(3)
+    expect(svg).toContain('&amp;')
+    expect(svg).not.toContain('a<b>')
+  })
+
+  it('derives height from the deepest frame', () => {
+    const {width, height} = svgDimensions(FRAMES, {width: 800, rowHeight: 20})
+    expect(width).toBe(800)
+    expect(height).toBeGreaterThan(40)
+  })
+})

--- a/dashboard/src/components/profiling/__tests__/frameModel.test.ts
+++ b/dashboard/src/components/profiling/__tests__/frameModel.test.ts
@@ -1,0 +1,233 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {describe, it, expect} from 'vitest'
+import {
+  type FlameNode,
+  normalizeLanguage,
+  matchesNamespace,
+  classifyFrame,
+  annotateSelf,
+  collapseFrames,
+  collapseRecursion,
+  invertFrames,
+  detectAppNamespaces,
+  filterToNamespaces,
+  computeTopFunctions,
+  computeDiff,
+  topLevelNamespace,
+} from '../frameModel'
+
+function node(name: string, value: number, children: FlameNode[] = []): FlameNode {
+  return {name, value, children}
+}
+
+describe('normalizeLanguage', () => {
+  it('maps known runtimes', () => {
+    expect(normalizeLanguage('jvm')).toBe('jvm')
+    expect(normalizeLanguage('Java')).toBe('jvm')
+    expect(normalizeLanguage('kotlin')).toBe('jvm')
+    expect(normalizeLanguage('golang')).toBe('go')
+    expect(normalizeLanguage('go')).toBe('go')
+    expect(normalizeLanguage('python')).toBe('python')
+    expect(normalizeLanguage('nodejs')).toBe('nodejs')
+    expect(normalizeLanguage(undefined)).toBe('unknown')
+  })
+})
+
+describe('matchesNamespace', () => {
+  it('respects segment boundaries', () => {
+    expect(matchesNamespace('com.moneat.Foo.bar', 'com.moneat')).toBe(true)
+    expect(matchesNamespace('com.moneat', 'com.moneat')).toBe(true)
+    expect(matchesNamespace('com.moneat$Inner', 'com.moneat')).toBe(true)
+    expect(matchesNamespace('com.moneaty.Foo', 'com.moneat')).toBe(false)
+    expect(matchesNamespace('github.com/acme/x.F', 'github.com/acme')).toBe(true)
+  })
+})
+
+describe('classifyFrame (jvm)', () => {
+  const jvm = (appPrefixes: string[] = []) =>
+    ({language: 'jvm' as const, appPrefixes})
+
+  it('detects runtime, library and app', () => {
+    expect(classifyFrame('java.lang.Thread.run', jvm())).toBe('runtime')
+    expect(
+      classifyFrame(
+        'kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run',
+        jvm(),
+      ),
+    ).toBe('runtime')
+    expect(classifyFrame('io.netty.channel.Foo.bar', jvm())).toBe('library')
+    expect(classifyFrame('kotlinx.serialization.Json.encode', jvm())).toBe('library')
+  })
+
+  it('treats unknown frames as app until prefixes are known, then library', () => {
+    expect(classifyFrame('com.moneat.svc.Foo.bar', jvm())).toBe('app')
+    expect(classifyFrame('com.moneat.svc.Foo.bar', jvm(['com.moneat']))).toBe('app')
+    expect(classifyFrame('com.other.Lib.x', jvm(['com.moneat']))).toBe('library')
+  })
+})
+
+describe('classifyFrame (go)', () => {
+  const go = (appPrefixes: string[] = []) => ({language: 'go' as const, appPrefixes})
+
+  it('separates stdlib, vendor and app', () => {
+    expect(classifyFrame('runtime.main', go())).toBe('runtime')
+    expect(classifyFrame('net/http.(*conn).serve', go())).toBe('runtime')
+    expect(classifyFrame('golang.org/x/net/http2.run', go())).toBe('library')
+    expect(classifyFrame('github.com/acme/api/h.Handle', go())).toBe('app')
+    expect(
+      classifyFrame('github.com/gorilla/mux.ServeHTTP', go(['github.com/acme/api'])),
+    ).toBe('library')
+  })
+})
+
+describe('annotateSelf', () => {
+  it('computes self as value minus children', () => {
+    const [root] = annotateSelf([node('a', 10, [node('b', 4), node('c', 3)])])
+    expect(root.self).toBe(3)
+    expect(root.children[0].self).toBe(4)
+  })
+})
+
+describe('collapseFrames', () => {
+  const opts = {language: 'jvm' as const, appPrefixes: ['com.app']}
+  const hideRuntime = (n: FlameNode) =>
+    classifyFrame(n.name, opts) === 'runtime'
+
+  it('grafts app children onto nearest survivor and reattributes self', () => {
+    const tree = [
+      node('com.app.A.run', 10, [
+        node('java.lang.Thread.run', 10, [node('com.app.B.work', 6)]),
+      ]),
+    ]
+    const [a] = collapseFrames(tree, hideRuntime)
+    expect(a.name).toBe('com.app.A.run')
+    expect(a.children).toHaveLength(1)
+    expect(a.children[0].name).toBe('com.app.B.work')
+    // The hidden runtime frame's self (4) bubbles up to A.
+    const [annotated] = annotateSelf(collapseFrames(tree, hideRuntime))
+    expect(annotated.self).toBe(4)
+  })
+
+  it('merges same-named siblings after grafting', () => {
+    const tree = [
+      node('com.app.A.run', 10, [
+        node('java.lang.Thread.run', 5, [node('com.app.B.work', 3)]),
+        node('jdk.internal.X.y', 5, [node('com.app.B.work', 2)]),
+      ]),
+    ]
+    const [a] = collapseFrames(tree, hideRuntime)
+    expect(a.children).toHaveLength(1)
+    expect(a.children[0]).toMatchObject({name: 'com.app.B.work', value: 5})
+  })
+})
+
+describe('collapseRecursion', () => {
+  it('folds a self-recursive chain', () => {
+    const tree = [node('rec', 10, [node('rec', 8, [node('rec', 5, [node('leaf', 5)])])])]
+    const [r] = collapseRecursion(tree)
+    expect(r.name).toBe('rec')
+    expect(r.children).toHaveLength(1)
+    expect(r.children[0].name).toBe('leaf')
+  })
+})
+
+describe('invertFrames', () => {
+  it('roots the tree at the hottest leaves', () => {
+    const result = invertFrames([
+      node('main', 10, [node('a', 6), node('b', 4)]),
+    ])
+    expect(result.map((r) => r.name)).toEqual(['a', 'b'])
+    expect(result[0]).toMatchObject({name: 'a', value: 6})
+    expect(result[0].children[0]).toMatchObject({name: 'main', value: 6})
+  })
+})
+
+describe('detectAppNamespaces', () => {
+  it('ranks the dominant non-runtime namespace first', () => {
+    const tree = [
+      node('com.moneat.svc.A.run', 10, [
+        node('java.lang.Thread.run', 4),
+        node('com.moneat.svc.B.x', 3),
+      ]),
+    ]
+    const ns = detectAppNamespaces(tree, 'jvm')
+    expect(ns[0].namespace).toBe('com.moneat')
+    expect(ns[0].self).toBe(6)
+    expect(ns.some((n) => n.namespace.startsWith('java'))).toBe(false)
+  })
+})
+
+describe('filterToNamespaces', () => {
+  it('keeps only paths reaching the namespace', () => {
+    const tree = [
+      node('java.lang.Thread.run', 10, [node('com.app.A.run', 6)]),
+      node('io.netty.X.y', 4),
+    ]
+    const filtered = filterToNamespaces(tree, ['com.app'])
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].children[0].name).toBe('com.app.A.run')
+  })
+})
+
+describe('computeTopFunctions', () => {
+  const tree = [
+    node('com.moneat.svc.A.run', 10, [
+      node('java.lang.Thread.run', 4),
+      node('com.moneat.svc.B.x', 3),
+    ]),
+  ]
+
+  it('ranks by self and supports app-only scope', () => {
+    const all = computeTopFunctions(tree, 10, {
+      language: 'jvm',
+      appPrefixes: ['com.moneat'],
+      scope: 'all',
+      sortBy: 'self',
+    })
+    expect(all[0].name).toBe('java.lang.Thread.run')
+
+    const appOnly = computeTopFunctions(tree, 10, {
+      language: 'jvm',
+      appPrefixes: ['com.moneat'],
+      scope: 'app',
+      sortBy: 'self',
+    })
+    expect(appOnly.some((f) => f.name.startsWith('java'))).toBe(false)
+    expect(appOnly[0].name).toBe('com.moneat.svc.A.run')
+    expect(appOnly[0].selfPercent).toBeCloseTo(30)
+  })
+})
+
+describe('computeDiff', () => {
+  it('flags hotter functions as regressions and missing ones as improvements', () => {
+    const current = [node('f.a', 10, [node('f.b', 4)])]
+    const baseline = [node('f.a', 10, [node('f.b', 8)])]
+    const diff = computeDiff(current, baseline)
+    expect(diff.topRegressions[0].name).toBe('f.a')
+    expect(diff.topRegressions[0].deltaPercent).toBeCloseTo(40)
+    expect(diff.topImprovements[0].name).toBe('f.b')
+  })
+
+  it('reports removed functions as improvements', () => {
+    const current = [node('x', 10)]
+    const baseline = [node('x', 6), node('y', 4)]
+    const diff = computeDiff(current, baseline)
+    expect(diff.topImprovements.some((d) => d.name === 'y')).toBe(true)
+  })
+})
+
+describe('topLevelNamespace', () => {
+  it('uses two segments for jvm and the module path for go', () => {
+    expect(topLevelNamespace('com.moneat.datadog.Foo.bar', 'jvm')).toBe('com.moneat')
+    expect(topLevelNamespace('github.com/acme/api/h.Handle', 'go')).toBe(
+      'github.com/acme/api',
+    )
+  })
+})

--- a/dashboard/src/components/profiling/__tests__/frameModel.test.ts
+++ b/dashboard/src/components/profiling/__tests__/frameModel.test.ts
@@ -20,6 +20,12 @@ import {
   filterToNamespaces,
   computeTopFunctions,
   computeDiff,
+  colorFor,
+  diffColor,
+  packageColor,
+  packageOf,
+  shortName,
+  sumValues,
   topLevelNamespace,
 } from '../frameModel'
 
@@ -36,6 +42,10 @@ describe('normalizeLanguage', () => {
     expect(normalizeLanguage('go')).toBe('go')
     expect(normalizeLanguage('python')).toBe('python')
     expect(normalizeLanguage('nodejs')).toBe('nodejs')
+    expect(normalizeLanguage('ts')).toBe('nodejs')
+    expect(normalizeLanguage('ruby')).toBe('ruby')
+    expect(normalizeLanguage('dotnet')).toBe('dotnet')
+    expect(normalizeLanguage('php')).toBe('php')
     expect(normalizeLanguage(undefined)).toBe('unknown')
   })
 })
@@ -87,11 +97,40 @@ describe('classifyFrame (go)', () => {
   })
 })
 
+describe('classifyFrame (python and node)', () => {
+  it('separates runtime, dependencies and app frames', () => {
+    expect(classifyFrame('<built-in>.len', {language: 'python', appPrefixes: []}))
+      .toBe('runtime')
+    expect(classifyFrame('/venv/lib/site-packages/flask/app.py', {
+      language: 'python',
+      appPrefixes: [],
+    })).toBe('library')
+    expect(classifyFrame('/srv/app/handler.py', {
+      language: 'python',
+      appPrefixes: ['/srv/app'],
+    })).toBe('app')
+
+    expect(classifyFrame('node:internal/process/task_queues', {
+      language: 'nodejs',
+      appPrefixes: [],
+    })).toBe('runtime')
+    expect(classifyFrame('/app/node_modules/react/index.js', {
+      language: 'nodejs',
+      appPrefixes: ['/app/src'],
+    })).toBe('library')
+    expect(classifyFrame('/app/src/server.ts', {
+      language: 'nodejs',
+      appPrefixes: ['/app/src'],
+    })).toBe('app')
+  })
+})
+
 describe('annotateSelf', () => {
   it('computes self as value minus children', () => {
     const [root] = annotateSelf([node('a', 10, [node('b', 4), node('c', 3)])])
     expect(root.self).toBe(3)
     expect(root.children[0].self).toBe(4)
+    expect(sumValues(root.children)).toBe(7)
   })
 })
 
@@ -165,6 +204,11 @@ describe('detectAppNamespaces', () => {
 })
 
 describe('filterToNamespaces', () => {
+  it('returns the original forest when no prefixes are selected', () => {
+    const tree = [node('com.app.A.run', 4)]
+    expect(filterToNamespaces(tree, [])).toBe(tree)
+  })
+
   it('keeps only paths reaching the namespace', () => {
     const tree = [
       node('java.lang.Thread.run', 10, [node('com.app.A.run', 6)]),
@@ -203,6 +247,19 @@ describe('computeTopFunctions', () => {
     expect(appOnly[0].name).toBe('com.moneat.svc.A.run')
     expect(appOnly[0].selfPercent).toBeCloseTo(30)
   })
+
+  it('ranks by total and falls back when profile total is zero', () => {
+    const ranked = computeTopFunctions(tree, 0, {
+      language: 'jvm',
+      appPrefixes: ['com.moneat'],
+      scope: 'all',
+      sortBy: 'total',
+      limit: 2,
+    })
+    expect(ranked).toHaveLength(2)
+    expect(ranked[0].name).toBe('com.moneat.svc.A.run')
+    expect(ranked[0].totalPercent).toBe(1000)
+  })
 })
 
 describe('computeDiff', () => {
@@ -229,5 +286,28 @@ describe('topLevelNamespace', () => {
     expect(topLevelNamespace('github.com/acme/api/h.Handle', 'go')).toBe(
       'github.com/acme/api',
     )
+    expect(topLevelNamespace('main.main', 'go')).toBe('main')
+    expect(topLevelNamespace('worker.run', 'python')).toBe('worker')
+  })
+})
+
+describe('colors and name formatting', () => {
+  it('uses deterministic package, kind and diff colors', () => {
+    expect(packageColor('com.moneat.service.Handler.run')).toBe('hsl(142, 55%, 42%)')
+    expect(packageColor('unknown.package.Handler.run')).toMatch(/^hsl\(/)
+    expect(colorFor('java.lang.Thread.run', {
+      mode: 'kind',
+      language: 'jvm',
+      appPrefixes: [],
+    })).toBe('hsl(220, 8%, 42%)')
+    expect(diffColor(6)).toContain('hsl(0')
+    expect(diffColor(-6)).toContain('hsl(210')
+    expect(diffColor(0)).toBe('hsl(220, 6%, 40%)')
+  })
+
+  it('formats packages and compact frame names', () => {
+    expect(packageOf('com.moneat.Service.run(java.lang.String)')).toBe('com.moneat.Service')
+    expect(shortName('com.moneat.Service.run(java.lang.String)')).toBe('Service.run()')
+    expect(shortName('main')).toBe('main')
   })
 })

--- a/dashboard/src/components/profiling/__tests__/profilingComponents.test.tsx
+++ b/dashboard/src/components/profiling/__tests__/profilingComponents.test.tsx
@@ -1,0 +1,303 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {describe, it, expect, vi, afterEach} from 'vitest'
+import {render, screen, fireEvent} from '@testing-library/react'
+import {AppPackageSelect} from '../AppPackageSelect'
+import {CompareBar, type CompareProfile} from '../CompareBar'
+import {FlamegraphLegend} from '../FlamegraphLegend'
+import {FlamegraphMinimap, type MiniRect} from '../FlamegraphMinimap'
+import {ThreadSampleTypeSelectors} from '../ThreadSampleTypeSelectors'
+import {TopFunctionsPanel} from '../TopFunctionsPanel'
+import type {DiffResult, TopFunction} from '../frameModel'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('AppPackageSelect', () => {
+  it('summarizes auto-detected and manual namespace selections', () => {
+    const onChange = vi.fn()
+    const namespaces = [
+      {namespace: 'com.moneat', self: 70, total: 100},
+      {namespace: 'com.worker', self: 20, total: 30},
+    ]
+
+    const {rerender} = render(
+      <AppPackageSelect
+        namespaces={namespaces}
+        value=""
+        effective={['com.moneat']}
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByText('Auto · com.moneat')).toBeInTheDocument()
+
+    rerender(
+      <AppPackageSelect
+        namespaces={namespaces}
+        value="com.moneat,com.worker"
+        effective={['com.moneat']}
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByText('2 selected')).toBeInTheDocument()
+  })
+})
+
+describe('CompareBar', () => {
+  const profiles: CompareProfile[] = [
+    {profileId: 'base-1', label: 'Baseline one'},
+    {profileId: 'base-2', label: 'Baseline two'},
+  ]
+
+  const diff: DiffResult = {
+    deltaByName: new Map([['com.app.Hot.run', 4.5]]),
+    topRegressions: [
+      {
+        name: 'com.app.Hot.run',
+        currentPercent: 6,
+        basePercent: 1.5,
+        deltaPercent: 4.5,
+      },
+    ],
+    topImprovements: [],
+  }
+
+  it('changes, clears and selects comparison deltas', () => {
+    const onChange = vi.fn()
+    const onSelect = vi.fn()
+    render(
+      <CompareBar
+        profiles={profiles}
+        compareId="base-1"
+        loading
+        diff={diff}
+        onChange={onChange}
+        onSelect={onSelect}
+      />,
+    )
+
+    fireEvent.change(screen.getByRole('combobox'), {target: {value: 'base-2'}})
+    expect(onChange).toHaveBeenCalledWith('base-2')
+
+    fireEvent.change(screen.getByRole('combobox'), {target: {value: ''}})
+    expect(onChange).toHaveBeenCalledWith(null)
+
+    fireEvent.click(screen.getByRole('button', {name: /Clear/}))
+    expect(onChange).toHaveBeenLastCalledWith(null)
+
+    fireEvent.click(screen.getByRole('button', {name: /com\.app\.Hot\.run/}))
+    expect(onSelect).toHaveBeenCalledWith('com.app.Hot.run')
+    expect(screen.getByText('No significant change.')).toBeInTheDocument()
+  })
+})
+
+describe('ThreadSampleTypeSelectors', () => {
+  it('renders nothing without selectable dimensions', () => {
+    const {container} = render(
+      <ThreadSampleTypeSelectors
+        sampleTypes={[{key: 'cpu', label: 'CPU', unit: 'samples'}]}
+        threads={[]}
+        onSampleTypeChange={vi.fn()}
+        onThreadChange={vi.fn()}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders thread-only selectors and clears thread selection', () => {
+    const onThreadChange = vi.fn()
+    render(
+      <ThreadSampleTypeSelectors
+        sampleTypes={[{key: 'cpu', label: 'CPU', unit: 'samples'}]}
+        threads={[{id: 'main', label: 'main', samples: 1234}]}
+        selectedThread="main"
+        onSampleTypeChange={vi.fn()}
+        onThreadChange={onThreadChange}
+      />,
+    )
+
+    expect(screen.queryByText(/Type/)).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('main (1,234)')).toBeInTheDocument()
+    fireEvent.change(screen.getByRole('combobox'), {target: {value: ''}})
+    expect(onThreadChange).toHaveBeenCalledWith(null)
+  })
+})
+
+describe('FlamegraphLegend', () => {
+  it('marks selected app namespaces and groups overflow packages', () => {
+    render(
+      <FlamegraphLegend
+        mode="package"
+        appPrefixes={['com.moneat']}
+        namespaces={[
+          {namespace: 'com.moneat', self: 6, total: 10},
+          {namespace: 'com.alpha', self: 5, total: 8},
+          {namespace: 'com.beta', self: 4, total: 7},
+          {namespace: 'com.gamma', self: 3, total: 6},
+          {namespace: 'com.delta', self: 2, total: 5},
+          {namespace: 'com.epsilon', self: 1, total: 4},
+          {namespace: 'com.zeta', self: 1, total: 3},
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('com.moneat (you)')).toBeInTheDocument()
+    expect(screen.getByText('other')).toBeInTheDocument()
+  })
+
+  it('renders the kind legend', () => {
+    render(<FlamegraphLegend mode="kind" namespaces={[]} appPrefixes={[]} />)
+    expect(screen.getByText('runtime / system')).toBeInTheDocument()
+  })
+})
+
+describe('TopFunctionsPanel', () => {
+  const functions: TopFunction[] = [
+    {
+      name: 'com.app.Hot.run',
+      kind: 'app',
+      selfValue: 25,
+      totalValue: 80,
+      selfPercent: 25,
+      totalPercent: 80,
+    },
+  ]
+
+  it('fires scope, sort, select and copy actions', () => {
+    const onScopeChange = vi.fn()
+    const onSortChange = vi.fn()
+    const onSelect = vi.fn()
+    const onCopy = vi.fn()
+    render(
+      <TopFunctionsPanel
+        functions={functions}
+        scope="app"
+        sortBy="self"
+        hasAppPrefixes
+        onScopeChange={onScopeChange}
+        onSortChange={onSortChange}
+        onSelect={onSelect}
+        onCopy={onCopy}
+        colorOf={() => 'hsl(142, 60%, 45%)'}
+      />,
+    )
+
+    expect(screen.getByText('1 function')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', {name: 'All'}))
+    expect(onScopeChange).toHaveBeenCalledWith('all')
+
+    fireEvent.click(screen.getByRole('button', {name: /Total/}))
+    expect(onSortChange).toHaveBeenCalledWith('total')
+
+    fireEvent.click(screen.getByText('com.app.Hot.run'))
+    expect(onSelect).toHaveBeenCalledWith('com.app.Hot.run')
+
+    fireEvent.click(screen.getByLabelText('Copy function name'))
+    expect(onCopy).toHaveBeenCalledWith('com.app.Hot.run')
+  })
+
+  it('shows the empty app-scope state and disables app scope without prefixes', () => {
+    render(
+      <TopFunctionsPanel
+        functions={[]}
+        scope="all"
+        sortBy="total"
+        hasAppPrefixes={false}
+        onScopeChange={vi.fn()}
+        onSortChange={vi.fn()}
+        onSelect={vi.fn()}
+        onCopy={vi.fn()}
+        colorOf={() => 'hsl(142, 60%, 45%)'}
+      />,
+    )
+
+    expect(screen.getByText('0 functions')).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'My code'})).toBeDisabled()
+    expect(screen.getByText('No functions match this scope.')).toBeInTheDocument()
+  })
+})
+
+describe('FlamegraphMinimap', () => {
+  const rects: MiniRect[] = [
+    {depth: 0, x: 0, width: 100, color: 'hsl(142, 60%, 45%)'},
+    {depth: 1, x: 25, width: 50, color: 'hsl(205, 32%, 46%)'},
+  ]
+
+  it('draws frames and keeps pointer scrubbing captured', () => {
+    const context = {
+      setTransform: vi.fn(),
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      strokeRect: vi.fn(),
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+    }
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      context as unknown as CanvasRenderingContext2D,
+    )
+    HTMLCanvasElement.prototype.setPointerCapture = vi.fn()
+    HTMLCanvasElement.prototype.releasePointerCapture = vi.fn()
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+
+      observe(target: Element) {
+        this.callback([
+          {
+            target,
+            contentRect: {width: 360},
+          } as ResizeObserverEntry,
+        ], this as unknown as ResizeObserver)
+      }
+
+      disconnect() {}
+      unobserve() {}
+    })
+
+    const onScrollToFraction = vi.fn()
+    render(
+      <FlamegraphMinimap
+        rects={rects}
+        rows={2}
+        chartHeight={400}
+        scrollTop={40}
+        viewportHeight={100}
+        onScrollToFraction={onScrollToFraction}
+      />,
+    )
+
+    const canvas = document.querySelector('canvas') as HTMLCanvasElement
+    Object.defineProperty(canvas, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        top: 0,
+        left: 0,
+        width: 600,
+        height: 56,
+        right: 600,
+        bottom: 56,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    })
+
+    expect(context.fillRect).toHaveBeenCalled()
+    fireEvent.pointerDown(canvas, {clientY: 14, pointerId: 1})
+    fireEvent.pointerMove(canvas, {clientY: 70, pointerId: 1})
+    fireEvent.pointerUp(canvas, {clientY: 70, pointerId: 1})
+
+    expect(canvas.setPointerCapture).toHaveBeenCalledWith(1)
+    expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1)
+    expect(onScrollToFraction).toHaveBeenNthCalledWith(1, 0.25)
+    expect(onScrollToFraction).toHaveBeenLastCalledWith(1)
+  })
+})

--- a/dashboard/src/components/profiling/flamegraphExport.ts
+++ b/dashboard/src/components/profiling/flamegraphExport.ts
@@ -1,0 +1,135 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Render the flamegraph model to a standalone SVG (and PNG) for sharing in bug
+// reports, docs, and PRs. Dependency-free: the SVG is generated from the same
+// flattened model the screen renderer uses; the PNG is rasterised in-browser.
+
+import {shortName} from './frameModel'
+
+export interface ExportFrame {
+  name: string
+  depth: number
+  /** Left offset as a percentage (0–100). */
+  x: number
+  /** Width as a percentage (0–100). */
+  width: number
+  color: string
+}
+
+export interface ExportOptions {
+  width: number
+  rowHeight: number
+  title?: string
+}
+
+const BG = '#0b0f17'
+const HEADER = 28
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function framesToSvg(frames: ExportFrame[], opts: ExportOptions): string {
+  const {width, rowHeight} = opts
+  const maxDepth = frames.reduce((m, f) => Math.max(m, f.depth), 0)
+  const height = HEADER + (maxDepth + 1) * rowHeight + 4
+
+  const parts: string[] = []
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+      `viewBox="0 0 ${width} ${height}" font-family="ui-monospace, monospace">`,
+  )
+  parts.push(`<rect width="${width}" height="${height}" fill="${BG}"/>`)
+  if (opts.title) {
+    parts.push(
+      `<text x="8" y="18" fill="#cbd5e1" font-size="13" font-weight="600">${escapeXml(
+        opts.title,
+      )}</text>`,
+    )
+  }
+
+  for (const f of frames) {
+    const x = (f.x / 100) * width
+    const w = Math.max((f.width / 100) * width - 1, 0.5)
+    const y = HEADER + f.depth * rowHeight
+    const h = rowHeight - 1
+    parts.push(`<rect x="${x.toFixed(2)}" y="${y}" width="${w.toFixed(2)}" height="${h}" rx="2" fill="${f.color}"/>`)
+    const label = shortName(f.name)
+    const maxChars = Math.floor(w / 6.2)
+    if (maxChars >= 3 && label.length > 0) {
+      const text = label.length > maxChars ? `${label.slice(0, maxChars - 1)}…` : label
+      parts.push(
+        `<text x="${(x + 3).toFixed(2)}" y="${y + h - 6}" fill="#ffffff" font-size="11">${escapeXml(
+          text,
+        )}</text>`,
+      )
+    }
+  }
+
+  parts.push('</svg>')
+  return parts.join('')
+}
+
+export function svgDimensions(frames: ExportFrame[], opts: ExportOptions): {
+  width: number
+  height: number
+} {
+  const maxDepth = frames.reduce((m, f) => Math.max(m, f.depth), 0)
+  return {width: opts.width, height: HEADER + (maxDepth + 1) * opts.rowHeight + 4}
+}
+
+export function triggerDownload(href: string, filename: string) {
+  const a = document.createElement('a')
+  a.href = href
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+}
+
+export function downloadSvg(svg: string, filename: string) {
+  const blob = new Blob([svg], {type: 'image/svg+xml;charset=utf-8'})
+  const url = URL.createObjectURL(blob)
+  triggerDownload(url, filename)
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+export async function downloadPng(
+  svg: string,
+  width: number,
+  height: number,
+  filename: string,
+): Promise<void> {
+  const scale = window.devicePixelRatio || 2
+  const blob = new Blob([svg], {type: 'image/svg+xml;charset=utf-8'})
+  const url = URL.createObjectURL(blob)
+  try {
+    const img = new Image()
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = () => reject(new Error('Failed to render flamegraph image'))
+      img.src = url
+    })
+    const canvas = document.createElement('canvas')
+    canvas.width = width * scale
+    canvas.height = height * scale
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Canvas not available')
+    ctx.scale(scale, scale)
+    ctx.drawImage(img, 0, 0, width, height)
+    const dataUrl = canvas.toDataURL('image/png')
+    triggerDownload(dataUrl, filename)
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}

--- a/dashboard/src/components/profiling/flamegraphExport.ts
+++ b/dashboard/src/components/profiling/flamegraphExport.ts
@@ -110,7 +110,7 @@ export async function downloadPng(
   height: number,
   filename: string,
 ): Promise<void> {
-  const scale = window.devicePixelRatio || 2
+  const scale = globalThis.window?.devicePixelRatio ?? 2
   const blob = new Blob([svg], {type: 'image/svg+xml;charset=utf-8'})
   const url = URL.createObjectURL(blob)
   try {

--- a/dashboard/src/components/profiling/frameModel.ts
+++ b/dashboard/src/components/profiling/frameModel.ts
@@ -1,0 +1,622 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Pure, dependency-free helpers for the flamegraph viewer. Everything that
+// transforms the frame tree (classification, self-time, collapsing, inversion,
+// top-functions, diff, colours) lives here so it can be unit tested without
+// rendering. The React component is a thin orchestrator over these functions.
+
+export interface FlameNode {
+  name: string
+  value: number
+  children: FlameNode[]
+  /** Samples spent in this frame itself (value minus the sum of children). */
+  self?: number
+}
+
+export type FrameKind = 'app' | 'library' | 'runtime'
+
+export type ColorMode = 'package' | 'kind'
+
+export type ProfileLanguage =
+  | 'jvm'
+  | 'go'
+  | 'python'
+  | 'nodejs'
+  | 'ruby'
+  | 'dotnet'
+  | 'php'
+  | 'unknown'
+
+export interface ClassifyOptions {
+  language: ProfileLanguage
+  /** Namespaces the user considers their own code (detected or manual). */
+  appPrefixes: string[]
+}
+
+// ─────────────────────────── language ───────────────────────────
+
+export function normalizeLanguage(language?: string | null): ProfileLanguage {
+  const l = (language || '').toLowerCase()
+  if (/jvm|java|kotlin|scala|groovy/.test(l)) return 'jvm'
+  if (/golang|(^|[^a-z])go([^a-z]|$)/.test(l)) return 'go'
+  if (/python|cpython|\bpy\b/.test(l)) return 'python'
+  if (/node|javascript|typescript|\bjs\b|\bts\b/.test(l)) return 'nodejs'
+  if (/ruby|\brb\b/.test(l)) return 'ruby'
+  if (/dotnet|\.net|csharp|c#/.test(l)) return 'dotnet'
+  if (/php/.test(l)) return 'php'
+  return 'unknown'
+}
+
+// ─────────────────────────── namespaces ───────────────────────────
+
+/** True when `name` is inside `prefix` respecting a `.`, `/` or `$` boundary. */
+export function matchesNamespace(name: string, prefix: string): boolean {
+  if (!prefix) return false
+  if (name === prefix) return true
+  if (!name.startsWith(prefix)) return false
+  const next = name.charAt(prefix.length)
+  return next === '.' || next === '/' || next === '$'
+}
+
+function matchesAny(name: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((p) => matchesNamespace(name, p))
+}
+
+// ─────────────────────────── classification ───────────────────────────
+
+const JVM_RUNTIME_PREFIXES = [
+  'java', 'javax', 'jdk', 'sun', 'com.sun',
+  'kotlin', 'kotlinx.coroutines',
+  'scala', 'groovy', 'org.codehaus.groovy',
+] as const
+
+const JVM_LIBRARY_PREFIXES = [
+  'io.ktor', 'io.netty', 'io.lettuce', 'io.micrometer', 'io.grpc',
+  'io.opentelemetry', 'kotlinx', 'org.apache', 'org.slf4j', 'ch.qos.logback',
+  'org.springframework', 'org.hibernate', 'org.jetbrains', 'reactor',
+  'com.zaxxer', 'com.clickhouse', 'org.postgresql', 'redis.clients',
+  'com.fasterxml.jackson', 'com.google', 'okhttp3', 'retrofit2',
+  'org.eclipse', 'org.junit', 'io.mockk', 'com.squareup',
+] as const
+
+const GO_VENDOR_HOSTS = [
+  'golang.org', 'google.golang.org', 'gopkg.in', 'go.uber.org',
+  'go.opentelemetry.io',
+] as const
+
+const PY_RUNTIME_MARKERS = [
+  '<built-in>', '<frozen', '<string>', 'importlib', 'threading.',
+  'asyncio.', 'concurrent.futures', 'runpy.',
+] as const
+
+const NODE_RUNTIME_MARKERS = ['node:', 'internal/'] as const
+
+/** Third-party Go import paths begin with a domain segment (contains a dot). */
+function hasGoDomain(name: string): boolean {
+  const slash = name.indexOf('/')
+  if (slash === -1) return false
+  return name.slice(0, slash).includes('.')
+}
+
+function includesAny(name: string, markers: readonly string[]): boolean {
+  return markers.some((m) => name.includes(m))
+}
+
+function classifyJvm(name: string): FrameKind | null {
+  if (matchesAny(name, JVM_RUNTIME_PREFIXES)) return 'runtime'
+  if (matchesAny(name, JVM_LIBRARY_PREFIXES)) return 'library'
+  return null
+}
+
+function classifyGo(name: string): FrameKind | null {
+  if (!hasGoDomain(name)) return 'runtime'
+  if (matchesAny(name, GO_VENDOR_HOSTS)) return 'library'
+  return null
+}
+
+function classifyPython(name: string): FrameKind | null {
+  if (includesAny(name, PY_RUNTIME_MARKERS)) return 'runtime'
+  if (name.includes('site-packages') || name.includes('dist-packages')) {
+    return 'library'
+  }
+  return null
+}
+
+function classifyNode(name: string): FrameKind | null {
+  if (includesAny(name, NODE_RUNTIME_MARKERS)) return 'runtime'
+  if (name.includes('node_modules')) return 'library'
+  return null
+}
+
+function classifyByLanguage(
+  name: string,
+  language: ProfileLanguage,
+): FrameKind | null {
+  switch (language) {
+    case 'jvm': return classifyJvm(name)
+    case 'go': return classifyGo(name)
+    case 'python': return classifyPython(name)
+    case 'nodejs': return classifyNode(name)
+    default: return null
+  }
+}
+
+/**
+ * Classify a frame as the user's own code, a third-party library, or
+ * language runtime/system noise.
+ *
+ * When app prefixes are known, anything not matching them and not recognised
+ * as runtime is treated as a library. When no prefixes are known yet, an
+ * unrecognised frame is optimistically treated as app code so the user's code
+ * is never hidden before detection runs.
+ */
+export function classifyFrame(name: string, opts: ClassifyOptions): FrameKind {
+  if (matchesAny(name, opts.appPrefixes)) return 'app'
+  const byLang = classifyByLanguage(name, opts.language)
+  if (byLang) return byLang
+  return opts.appPrefixes.length > 0 ? 'library' : 'app'
+}
+
+// ─────────────────────────── self-time ───────────────────────────
+
+/** Returns a new forest with `self = value − Σ children.value` on every node. */
+export function annotateSelf(frames: FlameNode[]): FlameNode[] {
+  return frames.map(annotateNode)
+}
+
+function annotateNode(node: FlameNode): FlameNode {
+  const children = node.children.map(annotateNode)
+  const childSum = sumValues(children)
+  return {...node, children, self: Math.max(node.value - childSum, 0)}
+}
+
+export function sumValues(frames: FlameNode[]): number {
+  return frames.reduce((acc, f) => acc + f.value, 0)
+}
+
+// ─────────────────────────── collapse / hide ───────────────────────────
+
+/**
+ * Remove frames matching `shouldHide`, grafting their kept descendants onto the
+ * nearest surviving ancestor and merging same-named siblings. Hidden frames'
+ * self-time is reattributed to that ancestor (recompute self via annotateSelf).
+ */
+export function collapseFrames(
+  frames: FlameNode[],
+  shouldHide: (node: FlameNode) => boolean,
+): FlameNode[] {
+  const lifted: FlameNode[] = []
+  for (const frame of frames) {
+    const children = collapseFrames(frame.children, shouldHide)
+    if (shouldHide(frame)) {
+      lifted.push(...children)
+    } else {
+      lifted.push({name: frame.name, value: frame.value, children})
+    }
+  }
+  return mergeSiblings(lifted)
+}
+
+function mergeSiblings(nodes: FlameNode[]): FlameNode[] {
+  const byName = new Map<string, FlameNode>()
+  for (const node of nodes) {
+    const existing = byName.get(node.name)
+    if (existing) {
+      existing.value += node.value
+      existing.children.push(...node.children)
+    } else {
+      byName.set(node.name, {
+        name: node.name,
+        value: node.value,
+        children: [...node.children],
+      })
+    }
+  }
+  return Array.from(byName.values())
+    .map((n) => ({...n, children: mergeSiblings(n.children)}))
+    .sort((a, b) => b.value - a.value)
+}
+
+/** Collapse immediate recursion (a frame that directly calls itself). */
+export function collapseRecursion(frames: FlameNode[]): FlameNode[] {
+  return frames.map(collapseRecursiveNode)
+}
+
+function collapseRecursiveNode(node: FlameNode): FlameNode {
+  let value = node.value
+  let children = node.children
+  // Fold a chain of same-named direct descendants into this node.
+  while (children.length === 1 && children[0].name === node.name) {
+    value = Math.max(value, children[0].value)
+    children = children[0].children
+  }
+  return {
+    name: node.name,
+    value,
+    children: children.map(collapseRecursiveNode),
+  }
+}
+
+// ─────────────────────────── inversion (bottom-up) ───────────────────────────
+
+interface MutableNode {
+  name: string
+  value: number
+  children: Map<string, MutableNode>
+}
+
+/**
+ * Build a bottom-up ("hottest leaves") tree: each frame's self-time is pushed
+ * up its reversed caller chain, so the widest roots are the functions that burn
+ * the most self-time, with their callers stacked beneath.
+ */
+export function invertFrames(frames: FlameNode[]): FlameNode[] {
+  const annotated = annotateSelf(frames)
+  const roots = new Map<string, MutableNode>()
+  const path: string[] = []
+
+  function visit(node: FlameNode) {
+    path.push(node.name)
+    const self = node.self ?? 0
+    if (self > 0) insertReversedPath(roots, path, self)
+    for (const child of node.children) visit(child)
+    path.pop()
+  }
+  for (const frame of annotated) visit(frame)
+
+  return materialize(roots)
+}
+
+function insertReversedPath(
+  roots: Map<string, MutableNode>,
+  path: string[],
+  weight: number,
+) {
+  let level = roots
+  for (let i = path.length - 1; i >= 0; i--) {
+    const name = path[i]
+    let node = level.get(name)
+    if (!node) {
+      node = {name, value: 0, children: new Map()}
+      level.set(name, node)
+    }
+    node.value += weight
+    level = node.children
+  }
+}
+
+function materialize(nodes: Map<string, MutableNode>): FlameNode[] {
+  return Array.from(nodes.values())
+    .map((n) => ({name: n.name, value: n.value, children: materialize(n.children)}))
+    .sort((a, b) => b.value - a.value)
+}
+
+// ─────────────────────────── namespace detection ───────────────────────────
+
+export interface NamespaceStat {
+  namespace: string
+  self: number
+  total: number
+}
+
+/** First 2 package segments for JVM, module path for Go, else the package. */
+export function topLevelNamespace(
+  name: string,
+  language: ProfileLanguage,
+): string {
+  const base = stripSignature(name)
+  if (language === 'go') return goModulePath(base)
+  if (language === 'jvm') {
+    const parts = base.split('.')
+    if (parts.length <= 2) return base
+    return `${parts[0]}.${parts[1]}`
+  }
+  return packageOf(base)
+}
+
+function goModulePath(name: string): string {
+  if (!hasGoDomain(name)) {
+    const slash = name.indexOf('/')
+    return slash === -1 ? packageOf(name) : name.slice(0, slash)
+  }
+  const segments = name.split('/')
+  return segments.slice(0, 3).join('/')
+}
+
+/**
+ * Rank candidate "your code" namespaces by self-time, excluding recognised
+ * runtime and library frames. The top entry is a good default app prefix.
+ */
+export function detectAppNamespaces(
+  frames: FlameNode[],
+  language: ProfileLanguage,
+  limit = 5,
+): NamespaceStat[] {
+  const annotated = annotateSelf(frames)
+  const stats = new Map<string, {self: number; total: number}>()
+  const opts: ClassifyOptions = {language, appPrefixes: []}
+
+  function walk(node: FlameNode) {
+    if (classifyFrame(node.name, opts) === 'app') {
+      const ns = topLevelNamespace(node.name, language)
+      const entry = stats.get(ns) ?? {self: 0, total: 0}
+      entry.self += node.self ?? 0
+      entry.total += node.value
+      stats.set(ns, entry)
+    }
+    for (const child of node.children) walk(child)
+  }
+  for (const frame of annotated) walk(frame)
+
+  return Array.from(stats.entries())
+    .map(([namespace, v]) => ({namespace, self: v.self, total: v.total}))
+    .filter((s) => s.total > 0)
+    .sort((a, b) => b.self - a.self || b.total - a.total)
+    .slice(0, limit)
+}
+
+// ─────────────────────────── filtering ───────────────────────────
+
+/**
+ * Keep only paths that contain at least one frame inside `prefixes`. Frames are
+ * retained if they (or any descendant) match, so callers remain as context.
+ */
+export function filterToNamespaces(
+  frames: FlameNode[],
+  prefixes: string[],
+): FlameNode[] {
+  if (prefixes.length === 0) return frames
+  const result: FlameNode[] = []
+  for (const frame of frames) {
+    const children = filterToNamespaces(frame.children, prefixes)
+    if (matchesAny(frame.name, prefixes) || children.length > 0) {
+      result.push({name: frame.name, value: frame.value, children})
+    }
+  }
+  return result
+}
+
+// ─────────────────────────── top functions ───────────────────────────
+
+export type TopFunctionScope = 'all' | 'app'
+export type TopFunctionSort = 'self' | 'total'
+
+export interface TopFunction {
+  name: string
+  kind: FrameKind
+  selfValue: number
+  totalValue: number
+  selfPercent: number
+  totalPercent: number
+}
+
+export interface TopFunctionsOptions {
+  language: ProfileLanguage
+  appPrefixes: string[]
+  scope: TopFunctionScope
+  sortBy: TopFunctionSort
+  limit?: number
+}
+
+export function computeTopFunctions(
+  frames: FlameNode[],
+  profileTotal: number,
+  opts: TopFunctionsOptions,
+): TopFunction[] {
+  const annotated = annotateSelf(frames)
+  const classifyOpts: ClassifyOptions = {
+    language: opts.language,
+    appPrefixes: opts.appPrefixes,
+  }
+  const map = new Map<string, {self: number; total: number; kind: FrameKind}>()
+
+  function walk(node: FlameNode) {
+    const kind = classifyFrame(node.name, classifyOpts)
+    const entry = map.get(node.name) ?? {self: 0, total: 0, kind}
+    entry.self += node.self ?? 0
+    entry.total += node.value
+    map.set(node.name, entry)
+    for (const child of node.children) walk(child)
+  }
+  for (const frame of annotated) walk(frame)
+
+  const total = profileTotal > 0 ? profileTotal : 1
+  const limit = opts.limit ?? 25
+
+  return Array.from(map.entries())
+    .map(([name, v]) => ({
+      name,
+      kind: v.kind,
+      selfValue: v.self,
+      totalValue: v.total,
+      selfPercent: (v.self / total) * 100,
+      totalPercent: (v.total / total) * 100,
+    }))
+    .filter((f) => (opts.scope === 'app' ? f.kind === 'app' : true))
+    .filter((f) => f.totalValue > 0)
+    .sort((a, b) =>
+      opts.sortBy === 'self'
+        ? b.selfValue - a.selfValue || b.totalValue - a.totalValue
+        : b.totalValue - a.totalValue || b.selfValue - a.selfValue,
+    )
+    .slice(0, limit)
+}
+
+// ─────────────────────────── diff ───────────────────────────
+
+export interface FunctionDelta {
+  name: string
+  currentPercent: number
+  basePercent: number
+  deltaPercent: number
+}
+
+export interface DiffResult {
+  deltaByName: Map<string, number>
+  topRegressions: FunctionDelta[]
+  topImprovements: FunctionDelta[]
+}
+
+/**
+ * Compare two profiles by self-time share per function (normalised so profiles
+ * with different sample counts are comparable). Positive delta = hotter now.
+ */
+export function computeDiff(
+  current: FlameNode[],
+  baseline: FlameNode[],
+  limit = 15,
+): DiffResult {
+  const currentSelf = selfPercentByName(current)
+  const baseSelf = selfPercentByName(baseline)
+
+  const names = new Set<string>([...currentSelf.keys(), ...baseSelf.keys()])
+  const deltas: FunctionDelta[] = []
+  const deltaByName = new Map<string, number>()
+
+  for (const name of names) {
+    const cur = currentSelf.get(name) ?? 0
+    const base = baseSelf.get(name) ?? 0
+    const delta = cur - base
+    deltaByName.set(name, delta)
+    if (Math.abs(delta) >= 0.05) {
+      deltas.push({name, currentPercent: cur, basePercent: base, deltaPercent: delta})
+    }
+  }
+
+  const byDeltaDesc = [...deltas].sort((a, b) => b.deltaPercent - a.deltaPercent)
+  return {
+    deltaByName,
+    topRegressions: byDeltaDesc.filter((d) => d.deltaPercent > 0).slice(0, limit),
+    topImprovements: byDeltaDesc
+      .filter((d) => d.deltaPercent < 0)
+      .reverse()
+      .slice(0, limit),
+  }
+}
+
+function selfPercentByName(frames: FlameNode[]): Map<string, number> {
+  const annotated = annotateSelf(frames)
+  const total = sumValues(frames) || 1
+  const map = new Map<string, number>()
+  function walk(node: FlameNode) {
+    map.set(node.name, (map.get(node.name) ?? 0) + (node.self ?? 0))
+    for (const child of node.children) walk(child)
+  }
+  for (const frame of annotated) walk(frame)
+  for (const [name, self] of map) map.set(name, (self / total) * 100)
+  return map
+}
+
+// ─────────────────────────── colours ───────────────────────────
+
+const PACKAGE_COLORS: [RegExp, string][] = [
+  [/^java\./,            'hsl(220, 45%, 48%)'],
+  [/^javax\./,           'hsl(220, 40%, 52%)'],
+  [/^jdk\./,             'hsl(210, 40%, 46%)'],
+  [/^sun\./,             'hsl(210, 35%, 50%)'],
+  [/^com\.sun\./,        'hsl(210, 35%, 50%)'],
+  [/^kotlin\./,          'hsl(275, 45%, 52%)'],
+  [/^kotlinx\./,         'hsl(275, 40%, 56%)'],
+  [/^io\.ktor\./,        'hsl(160, 50%, 40%)'],
+  [/^io\.netty\./,       'hsl(175, 45%, 42%)'],
+  [/^org\.jetbrains\./,  'hsl(290, 35%, 50%)'],
+  [/^org\.apache\./,     'hsl(28, 70%, 48%)'],
+  [/^org\.slf4j\./,      'hsl(42, 60%, 46%)'],
+  [/^com\.zaxxer\./,     'hsl(130, 40%, 44%)'],
+  [/^org\.postgresql\./, 'hsl(200, 55%, 44%)'],
+  [/^com\.clickhouse\./, 'hsl(14, 60%, 50%)'],
+  [/^redis\./,           'hsl(5, 65%, 48%)'],
+  [/^io\.lettuce\./,     'hsl(5, 55%, 52%)'],
+  [/^com\.moneat\./,     'hsl(142, 55%, 42%)'],
+]
+
+const FALLBACK_COLORS = [
+  'hsl(14, 65%, 50%)',
+  'hsl(28, 70%, 48%)',
+  'hsl(42, 60%, 46%)',
+  'hsl(55, 55%, 42%)',
+  'hsl(130, 40%, 44%)',
+  'hsl(160, 45%, 42%)',
+  'hsl(200, 50%, 48%)',
+  'hsl(240, 38%, 52%)',
+  'hsl(260, 40%, 50%)',
+  'hsl(340, 45%, 48%)',
+]
+
+const KIND_COLORS: Record<FrameKind, string> = {
+  app: 'hsl(142, 60%, 45%)',
+  library: 'hsl(205, 32%, 46%)',
+  runtime: 'hsl(220, 8%, 42%)',
+}
+
+export function kindColor(kind: FrameKind): string {
+  return KIND_COLORS[kind]
+}
+
+export function packageColor(name: string): string {
+  for (const [pattern, color] of PACKAGE_COLORS) {
+    if (pattern.test(name)) return color
+  }
+  let hash = 0
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0
+  }
+  return FALLBACK_COLORS[Math.abs(hash) % FALLBACK_COLORS.length]
+}
+
+export interface ColorContext {
+  mode: ColorMode
+  language: ProfileLanguage
+  appPrefixes: string[]
+}
+
+export function colorFor(name: string, ctx: ColorContext): string {
+  if (ctx.mode === 'kind') {
+    return kindColor(
+      classifyFrame(name, {language: ctx.language, appPrefixes: ctx.appPrefixes}),
+    )
+  }
+  return packageColor(name)
+}
+
+/** Red for hotter-now, blue for cooler-now, grey for unchanged. */
+export function diffColor(deltaPercent: number): string {
+  const magnitude = Math.min(Math.abs(deltaPercent) / 5, 1)
+  const lightness = 60 - magnitude * 22
+  if (deltaPercent > 0.05) return `hsl(0, ${30 + magnitude * 45}%, ${lightness}%)`
+  if (deltaPercent < -0.05) return `hsl(210, ${30 + magnitude * 45}%, ${lightness}%)`
+  return 'hsl(220, 6%, 40%)'
+}
+
+// ─────────────────────────── name formatting ───────────────────────────
+
+function stripSignature(name: string): string {
+  const paren = name.indexOf('(')
+  return paren > -1 ? name.slice(0, paren) : name
+}
+
+export function packageOf(name: string): string {
+  const base = stripSignature(name)
+  const lastDot = base.lastIndexOf('.')
+  if (lastDot === -1) return base
+  return base.slice(0, lastDot)
+}
+
+/** Compact `Class.method()` label from a fully-qualified frame name. */
+export function shortName(fullName: string): string {
+  const paren = fullName.indexOf('(')
+  const base = paren > -1 ? fullName.slice(0, paren) : fullName
+  const slash = base.lastIndexOf('/')
+  const afterSlash = slash > -1 ? base.slice(slash + 1) : base
+  const parts = afterSlash.split('.')
+  if (parts.length <= 2) return fullName
+  const className = parts[parts.length - 2]
+  const method = parts[parts.length - 1]
+  return `${className}.${method}${paren > -1 ? '()' : ''}`
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -404,6 +404,16 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Tailwind v4's Preflight no longer sets `cursor: pointer` on buttons, so raw
+     <button>/<select> controls show the default arrow. Restore the pointer for
+     interactive elements globally instead of adding `cursor-pointer` per control. */
+  button:not(:disabled),
+  [role="button"]:not(:disabled),
+  label[for],
+  select:not(:disabled),
+  summary {
+    cursor: pointer;
+  }
   /* Prevent Radix scroll lock from hiding the scrollbar (causes layout shift). Radix has no prop to disable this. */
   body[data-scroll-locked] {
     overflow: visible !important;

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -409,6 +409,9 @@
      interactive elements globally instead of adding `cursor-pointer` per control. */
   button:not(:disabled),
   [role="button"]:not(:disabled),
+  input[type="button"]:not(:disabled),
+  input[type="submit"]:not(:disabled),
+  input[type="reset"]:not(:disabled),
   label[for],
   select:not(:disabled),
   summary {

--- a/dashboard/src/lib/api/modules/profiles.ts
+++ b/dashboard/src/lib/api/modules/profiles.ts
@@ -71,7 +71,16 @@ export function profilesMethods(core: ApiClientCore) {
       }
     },
 
-    getProfileFlamegraph: (profileId: string) =>
-      core.request<FlamegraphResponse>(`${base}/profiles/${profileId}/flamegraph`),
+    getProfileFlamegraph: (
+      profileId: string,
+      params: {sampleType?: string | null; thread?: string | null} = {}
+    ) => {
+      const searchParams = new URLSearchParams()
+      if (params.sampleType) searchParams.set('sampleType', params.sampleType)
+      if (params.thread) searchParams.set('thread', params.thread)
+      return core.request<FlamegraphResponse>(
+        urlWithQuery(`${base}/profiles/${profileId}/flamegraph`, searchParams.toString())
+      )
+    },
   }
 }

--- a/dashboard/src/lib/api/types/profiles.ts
+++ b/dashboard/src/lib/api/types/profiles.ts
@@ -40,8 +40,27 @@ export interface FlamegraphFrame {
   name: string
   value: number
   children: FlamegraphFrame[]
+  self?: number
+}
+
+export interface SampleTypeInfo {
+  key: string
+  label: string
+  unit: string
+}
+
+export interface ThreadInfo {
+  id: string
+  label: string
+  samples: number
 }
 
 export interface FlamegraphResponse {
   frames: FlamegraphFrame[]
+  sampleTypes?: SampleTypeInfo[]
+  threads?: ThreadInfo[]
+  selectedSampleType?: string
+  selectedThread?: string | null
+  unit?: string
+  totalSamples?: number
 }

--- a/dashboard/src/routes/profiles.$profileId.tsx
+++ b/dashboard/src/routes/profiles.$profileId.tsx
@@ -6,11 +6,11 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
+import {useState, useMemo} from 'react'
 import {createFileRoute, Link} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {Flamegraph} from '@/components/profiling/Flamegraph'
-import {Card, CardContent} from '@/components/ui/card'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {
@@ -87,13 +87,47 @@ function ProfileDetailPage() {
     (p) => p.profileId === profileId,
   )
 
+  const [sampleType, setSampleType] = useState<string | null>(null)
+  const [thread, setThread] = useState<string | null>(null)
+  const [compareId, setCompareId] = useState<string | null>(null)
+
   const {data: flamegraphData, isLoading: isFlamegraphLoading} = useQuery({
-    queryKey: ['profileFlamegraph', profileId],
-    queryFn: () => api.getProfileFlamegraph(profileId),
+    queryKey: ['profileFlamegraph', profileId, sampleType, thread],
+    queryFn: () => api.getProfileFlamegraph(profileId, {sampleType, thread}),
     enabled: api.isAuthenticated() && !!profileId,
   })
 
   const frames = flamegraphData?.frames
+
+  const compareProfiles = useMemo(() => {
+    if (!profile || !profilesData?.profiles) return []
+    return profilesData.profiles
+      .filter(
+        (p) =>
+          p.profileId !== profileId &&
+          p.service === profile.service &&
+          p.profileType === profile.profileType,
+      )
+      .map((p) => ({
+        profileId: p.profileId,
+        label: `${formatTime(p.startTime)} · ${p.host || p.version || p.profileId.slice(0, 8)}`,
+      }))
+  }, [profilesData, profile, profileId])
+
+  const {data: baselineData, isLoading: baselineLoading} = useQuery({
+    queryKey: ['profileFlamegraph', compareId, sampleType, thread],
+    queryFn: () => api.getProfileFlamegraph(compareId as string, {sampleType, thread}),
+    enabled: api.isAuthenticated() && !!compareId,
+  })
+
+  // Reset selectors and comparison when navigating to another profile.
+  const [activeProfileId, setActiveProfileId] = useState(profileId)
+  if (profileId !== activeProfileId) {
+    setActiveProfileId(profileId)
+    setSampleType(null)
+    setThread(null)
+    setCompareId(null)
+  }
 
   if (isLoading) {
     return (
@@ -113,6 +147,61 @@ function ProfileDetailPage() {
   }
 
   const tagEntries = profile ? Object.entries(profile.tags) : []
+
+  const sidebarMeta = (
+    <div className="rounded-lg border p-2.5 space-y-2 shrink-0">
+      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
+        <MetaItem icon={Server} label="Service" value={profile.service || '—'} />
+        <MetaItem icon={Globe} label="Environment" value={profile.env || '—'} />
+        <MetaItem icon={HardDrive} label="Host" value={profile.host || '—'} mono />
+        <MetaItem icon={Timer} label="Duration" value={formatDuration(profile.durationNs)} mono />
+        <MetaItem icon={Layers} label="Size" value={formatBytes(profile.sizeBytes)} mono />
+        <MetaItem
+          icon={Code2}
+          label="Runtime"
+          value={
+            profile.runtime
+              ? `${profile.language} / ${profile.runtime}`
+              : profile.language || '—'
+          }
+        />
+      </div>
+      {(profile.startTime || profile.version) && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-2 border-t text-[11px] text-muted-foreground">
+          {profile.startTime && (
+            <span className="flex items-center gap-1.5">
+              <Clock className="h-3 w-3" />
+              {formatTime(profile.startTime)}
+              {profile.endTime && <> — {formatTime(profile.endTime)}</>}
+            </span>
+          )}
+          {profile.version && (
+            <span className="flex items-center gap-1.5">
+              <Tag className="h-3 w-3" />
+              v{profile.version}
+            </span>
+          )}
+        </div>
+      )}
+      {tagEntries.length > 0 && (
+        <div className="pt-2 border-t space-y-1">
+          {tagEntries.map(([k, v]) => (
+            <div
+              key={k}
+              className="grid grid-cols-[minmax(0,7rem)_1fr] gap-2 text-[10px] font-mono leading-tight"
+            >
+              <span className="text-muted-foreground truncate" title={k}>
+                {k}
+              </span>
+              <span className="truncate" title={v}>
+                {v}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 
   return (
     <div
@@ -170,91 +259,7 @@ function ProfileDetailPage() {
         </Button>
       </div>
 
-      {/* Metadata grid */}
-      {profile && (
-        <Card>
-          <CardContent className="py-2 px-3">
-            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-x-4 gap-y-2">
-              <MetaItem
-                icon={Server}
-                label="Service"
-                value={profile.service || '—'}
-              />
-              <MetaItem
-                icon={Globe}
-                label="Environment"
-                value={profile.env || '—'}
-              />
-              <MetaItem
-                icon={HardDrive}
-                label="Host"
-                value={profile.host || '—'}
-                mono
-              />
-              <MetaItem
-                icon={Timer}
-                label="Duration"
-                value={formatDuration(profile.durationNs)}
-                mono
-              />
-              <MetaItem
-                icon={Layers}
-                label="Size"
-                value={formatBytes(profile.sizeBytes)}
-                mono
-              />
-              <MetaItem
-                icon={Code2}
-                label="Runtime"
-                value={
-                  profile.runtime
-                    ? `${profile.language} / ${profile.runtime}`
-                    : profile.language || '—'
-                }
-              />
-            </div>
-            {(profile.startTime || profile.version) && (
-              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 pt-2 border-t text-[11px] text-muted-foreground">
-                {profile.startTime && (
-                  <span className="flex items-center gap-1.5">
-                    <Clock className="h-3 w-3" />
-                    {formatTime(profile.startTime)}
-                    {profile.endTime && (
-                      <> — {formatTime(profile.endTime)}</>
-                    )}
-                  </span>
-                )}
-                {profile.version && (
-                  <span className="flex items-center gap-1.5">
-                    <Tag className="h-3 w-3" />
-                    v{profile.version}
-                  </span>
-                )}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Tags */}
-      {tagEntries.length > 0 && (
-        <div className="flex flex-wrap items-center gap-1">
-          <span className="text-[11px] font-medium text-muted-foreground mr-0.5">
-            Tags
-          </span>
-          {tagEntries.map(([k, v]) => (
-            <Badge
-              key={k}
-              variant="outline"
-              className="text-[10px] font-mono py-0 h-4"
-            >
-              {k}
-              <span className="text-muted-foreground mx-0.5">=</span>
-              {v}
-            </Badge>
-          ))}
-        </div>
-      )}
+      {/* Metadata + tags now live in the flamegraph sidebar (meta prop). */}
 
       {/* Flamegraph */}
       <div className="flex flex-col flex-1 min-h-0">
@@ -268,6 +273,21 @@ function ProfileDetailPage() {
         </div>
         <Flamegraph
           frames={frames}
+          language={profile.language || profile.runtime}
+          service={profile.service}
+          meta={sidebarMeta}
+          compareProfiles={compareProfiles}
+          compareId={compareId}
+          onCompareChange={setCompareId}
+          baselineFrames={baselineData?.frames}
+          baselineLoading={baselineLoading}
+          sampleTypes={flamegraphData?.sampleTypes}
+          threads={flamegraphData?.threads}
+          selectedSampleType={flamegraphData?.selectedSampleType}
+          selectedThread={flamegraphData?.selectedThread ?? null}
+          unit={flamegraphData?.unit}
+          onSampleTypeChange={setSampleType}
+          onThreadChange={setThread}
           emptyMessage={
             isFlamegraphLoading
               ? 'Loading flamegraph data…'


### PR DESCRIPTION
## Summary

Overhauls the continuous-profiling flamegraph viewer and the JFR/pprof parsing behind it.

### Frontend
- Rewrites the flamegraph viewer (`Flamegraph.tsx`) with a zoomable canvas, **minimap**, **legend**, and an interactive **top-functions panel**.
- Adds **profile comparison / diff** (`CompareBar`) to contrast two profiles.
- Adds **sample-type** and **thread** selectors, plus **app-package** namespace selection for focusing on first-party frames.
- Introduces a shared **frame model** (`frameModel.ts`) with language-aware frame classification, package/kind color modes, top-function and diff computation.
- Adds flamegraph **export** (`flamegraphExport.ts`).
- Reworks the profile detail route to drive the new viewer.

### Backend
- Richer **JFR** and **pprof** parsing (`DatadogJfrFlamegraphService`, `DatadogPprofFlamegraphService`): multiple sample types, per-thread breakdown, and value units surfaced to the viewer.
- Wires the new fields through `ProfileDashboardRoutes`.
- Adds parser unit tests for both services.

## Test plan
- `dashboard`: unit tests for `Flamegraph`, `frameModel`, and `flamegraphExport` are included.
- `backend`: `DatadogJfrFlamegraphServiceTest` / `DatadogPprofFlamegraphServiceTest` cover the new parsing paths.
- Manual: open a profile and verify the flamegraph, minimap, legend, top-functions, sample-type/thread switching, and compare/diff.

## Notes
This is the first of two stacked PRs. A follow-up reworks the `/profiles` page into a service-centric explorer that reuses this viewer for aggregated flamegraphs; it will be opened against `develop` once this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich flamegraph viewer: sample/thread selectors, minimap, legend, top-functions panel, compare baseline + visual diffs, export to SVG/PNG, app-package selector, and improved search/controls.

* **API**
  * Flamegraph endpoint and client now accept/return sample type, thread, unit, selected values, and total samples.

* **Tests**
  * Expanded unit and UI tests covering parsing, model logic, export, selectors, and end-to-end flamegraph UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->