### PR TITLE
fix: eliminate slow FINAL on apm_traces_final reads (exactly-once finalize + hybrid read)

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -72,6 +72,13 @@ import org.msgpack.core.MessageUnpacker
 private val logger = KotlinLogging.logger {}
 
 private const val APM_TRACES_FINAL_TABLE = "apm_traces_final"
+private const val APM_TRACE_SUMMARIES_TABLE = "apm_trace_summaries"
+
+// Buckets older than this are read from apm_traces_final as finalized one-row-per-trace records (no
+// FINAL needed -- the finalizer writes each bucket exactly once). The most recent buckets are still
+// filling, so they are read live from apm_trace_summaries instead. Must match the finalizer's
+// liveWindowHours so the two ranges meet without a gap or overlap.
+private const val LIVE_WINDOW_HOURS = 2
 private const val APM_ERROR_GROUPS_TABLE = "apm_error_groups_hourly"
 private const val APM_RESOURCE_STATS_TABLE = "apm_resource_stats_hourly"
 private const val APM_SERVICE_STATS_TABLE = "apm_service_stats_hourly"
@@ -332,53 +339,86 @@ object TraceIngestionService {
         query: DdTraceListQuery,
         previousWindow: Boolean = false,
     ): String {
-        // apm_traces_final holds one finalized row per trace with plain columns, so the dashboard
-        // reads it directly with a (organization_id, trace_bucket) key-prefix filter -- no per-trace
-        // re-aggregation. FINAL collapses any superseded rows from re-finalization (see
-        // TraceFinalizerBackgroundService). service/env/source/status/search filter plain columns, so
-        // they all go in WHERE.
-        val filters = mutableListOf(
-            ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
-            if (previousWindow) {
-                query.timeRange.previousBucketStartClause("trace_bucket")
-            } else {
-                query.timeRange.bucketStartClause("trace_bucket")
-            }
-        )
-        query.service?.let {
-            filters.add("root_service = '${escapeSql(it)}'")
-        }
-        query.env?.let {
-            filters.add("env = '${escapeSql(it)}'")
-        }
-        query.source?.let {
-            filters.add("source = '${escapeSql(it)}'")
-        }
-        when (query.status) {
-            STATUS_ERROR -> filters.add("has_error = 1")
-            STATUS_OK -> filters.add("has_error = 0")
-        }
-        query.search?.trim()?.takeIf { it.isNotEmpty() }?.let {
-            filters.add(traceSearchClause(it))
-        }
+        // Hybrid read: closed buckets come from apm_traces_final as finalized one-row-per-trace records
+        // (no FINAL -- the finalizer writes each bucket once, so there are no duplicate versions to
+        // merge), while the most recent still-filling buckets are aggregated live from
+        // apm_trace_summaries. This avoids both the slow read-time FINAL and the per-trace re-aggregation
+        // over the whole window, while keeping the leading edge fresh.
+        val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val liveBoundary = "toStartOfHour(now() - INTERVAL $LIVE_WINDOW_HOURS HOUR)"
 
-        return """
+        // --- finalized part: plain rows from apm_traces_final, no FINAL ---
+        val finalizedFilters = mutableListOf(orgClause)
+        if (previousWindow) {
+            // The previous window is entirely older than the live boundary, so it is fully finalized.
+            finalizedFilters.add(query.timeRange.previousBucketStartClause("trace_bucket"))
+        } else {
+            finalizedFilters.add(query.timeRange.bucketStartClause("trace_bucket"))
+            finalizedFilters.add("trace_bucket < $liveBoundary")
+        }
+        query.service?.let { finalizedFilters.add("root_service = '${escapeSql(it)}'") }
+        query.env?.let { finalizedFilters.add("env = '${escapeSql(it)}'") }
+        query.source?.let { finalizedFilters.add("source = '${escapeSql(it)}'") }
+        when (query.status) {
+            STATUS_ERROR -> finalizedFilters.add("has_error = 1")
+            STATUS_OK -> finalizedFilters.add("has_error = 0")
+        }
+        query.search?.trim()?.takeIf { it.isNotEmpty() }?.let { finalizedFilters.add(traceSearchClause(it)) }
+
+        val finalizedPart = """
+            SELECT
+                trace_id_canonical, root_service, root_resource, root_name, env, span_count, duration_ns,
+                trace_start, toInt64(toUnixTimestamp64Nano(trace_start)) as start_ns,
+                has_error, error_count, source
+            FROM `$clickhouseDb`.$APM_TRACES_FINAL_TABLE
+            WHERE ${finalizedFilters.joinToString(" AND ")}
+        """.trimIndent()
+
+        // The previous-comparison window never overlaps the live boundary, so finalized rows suffice.
+        if (previousWindow) return finalizedPart
+
+        // --- live part: recent still-filling buckets, aggregated per-trace from the summaries rollup ---
+        val liveWhere = mutableListOf(
+            orgClause,
+            query.timeRange.bucketStartClause("bucket_start"),
+            "bucket_start >= $liveBoundary",
+        )
+        val liveHaving = mutableListOf<String>()
+        query.service?.let { liveHaving.add("root_service = '${escapeSql(it)}'") }
+        query.env?.let { liveHaving.add("env = '${escapeSql(it)}'") }
+        query.source?.let { liveHaving.add("source = '${escapeSql(it)}'") }
+        when (query.status) {
+            STATUS_ERROR -> liveHaving.add("has_error = 1")
+            STATUS_OK -> liveHaving.add("has_error = 0")
+        }
+        query.search?.trim()?.takeIf { it.isNotEmpty() }?.let { liveHaving.add(traceSearchClause(it)) }
+        val liveHavingClause = if (liveHaving.isEmpty()) "" else "HAVING ${liveHaving.joinToString(" AND ")}"
+
+        val livePart = """
             SELECT
                 trace_id_canonical,
-                root_service,
-                root_resource,
-                root_name,
-                env,
-                span_count,
-                duration_ns,
-                trace_start,
-                toInt64(toUnixTimestamp64Nano(trace_start)) as start_ns,
-                has_error,
-                error_count,
-                source
-            FROM `$clickhouseDb`.$APM_TRACES_FINAL_TABLE FINAL
-            WHERE ${filters.joinToString(" AND ")}
+                argMinMerge(root_service_state) as root_service,
+                argMinMerge(root_resource_state) as root_resource,
+                argMinMerge(root_name_state) as root_name,
+                any(env) as env,
+                toUInt32(sumMerge(span_count_state)) as span_count,
+                toUInt64(greatest(
+                    0,
+                    toUnixTimestamp64Nano(maxMerge(trace_end_state)) -
+                        toUnixTimestamp64Nano(minMerge(trace_start_state))
+                )) as duration_ns,
+                minMerge(trace_start_state) as trace_start,
+                toInt64(toUnixTimestamp64Nano(minMerge(trace_start_state))) as start_ns,
+                toUInt8(sumMerge(error_count_state) > 0) as has_error,
+                toUInt32(sumMerge(error_count_state)) as error_count,
+                argMinMerge(source_state) as source
+            FROM `$clickhouseDb`.$APM_TRACE_SUMMARIES_TABLE
+            WHERE ${liveWhere.joinToString(" AND ")}
+            GROUP BY organization_id, trace_id_canonical
+            $liveHavingClause
         """.trimIndent()
+
+        return "$finalizedPart\nUNION ALL\n$livePart"
     }
 
     suspend fun listTraces(

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -54,6 +54,7 @@ import com.moneat.utils.ClickHouseSqlUtils.doubleMapToSqlMap
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.ClickHouseSqlUtils.mapToSqlMap
 import io.ktor.http.isSuccess
+import io.ktor.server.config.ApplicationConfig
 import io.sentry.ISpan
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -78,7 +79,10 @@ private const val APM_TRACE_SUMMARIES_TABLE = "apm_trace_summaries"
 // FINAL needed -- the finalizer writes each bucket exactly once). The most recent buckets are still
 // filling, so they are read live from apm_trace_summaries instead. Must match the finalizer's
 // liveWindowHours so the two ranges meet without a gap or overlap.
-private const val LIVE_WINDOW_HOURS = 2
+private val LIVE_WINDOW_HOURS: Int =
+    ApplicationConfig("application.conf")
+        .propertyOrNull("traceFinalizer.liveWindowHours")
+        ?.getString()?.toIntOrNull() ?: 2
 private const val APM_ERROR_GROUPS_TABLE = "apm_error_groups_hourly"
 private const val APM_RESOURCE_STATS_TABLE = "apm_resource_stats_hourly"
 private const val APM_SERVICE_STATS_TABLE = "apm_service_stats_hourly"

--- a/backend/src/main/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundService.kt
@@ -34,25 +34,27 @@ private const val APM_TRACES_FINAL_TABLE = "apm_traces_final"
 private const val APM_TRACE_SUMMARIES_TABLE = "apm_trace_summaries"
 
 private const val DEFAULT_INTERVAL_SECONDS = 600L
-private const val DEFAULT_REFRESH_WINDOW_HOURS = 2
+private const val DEFAULT_LIVE_WINDOW_HOURS = 2
 private const val DEFAULT_BACKFILL_WINDOW_HOURS = 50
 private const val DEFAULT_LOOKBACK_HOURS = 2
 private const val DEFAULT_MAX_EXECUTION_SECONDS = 540
 
 /**
- * Periodically finalizes per-trace rows from apm_trace_summaries into apm_traces_final so the APM
- * dashboard can read one finalized row per trace (plain columns) instead of re-aggregating with
+ * Finalizes per-trace rows from apm_trace_summaries into apm_traces_final so the APM dashboard can read
+ * one finalized row per trace (plain columns) for closed buckets, instead of re-aggregating with
  * argMinMerge on every request. See V45__add_apm_traces_final.sql.
  *
- * Each run re-finalizes a small recent window (idempotent via ReplacingMergeTree(finalized_at)), which
- * keeps the leading edge fresh and absorbs late-arriving spans. On process start it first finalizes a
- * wider window so history (and any gap from downtime) is covered. The heavy argMinMerge aggregation
- * runs here, off the dashboard read path.
+ * Finalization is **exactly-once and forward-only**: each run finalizes only buckets that are now frozen
+ * (older than [liveWindowHours]) and newer than the highest already-finalized bucket. Because a bucket is
+ * written exactly once, apm_traces_final has no duplicate versions, so dashboard reads need no FINAL
+ * (FINAL over these columns was ~5-8s; plain reads are ~0.15s). The still-filling recent buckets are read
+ * live from apm_trace_summaries by the dashboard. [backfillWindowHours] bounds how far back a cold start
+ * (or downtime gap) will catch up. The heavy argMinMerge aggregation runs here, off the read path.
  */
 class TraceFinalizerBackgroundService(
     private val enabled: Boolean,
     private val intervalSeconds: Long,
-    private val refreshWindowHours: Int,
+    private val liveWindowHours: Int,
     private val backfillWindowHours: Int,
     private val lookbackHours: Int,
     private val maxExecutionSeconds: Int,
@@ -63,12 +65,10 @@ class TraceFinalizerBackgroundService(
         // Fail fast on misconfiguration rather than letting the loop spin (delay(0)) or emit
         // nonsensical windows.
         require(intervalSeconds > 0) { "traceFinalizer.intervalSeconds must be > 0, got $intervalSeconds" }
-        require(refreshWindowHours > 0) {
-            "traceFinalizer.refreshWindowHours must be > 0, got $refreshWindowHours"
-        }
-        require(backfillWindowHours >= refreshWindowHours) {
-            "traceFinalizer.backfillWindowHours ($backfillWindowHours) must be >= refreshWindowHours " +
-                "($refreshWindowHours)"
+        require(liveWindowHours > 0) { "traceFinalizer.liveWindowHours must be > 0, got $liveWindowHours" }
+        require(backfillWindowHours >= liveWindowHours) {
+            "traceFinalizer.backfillWindowHours ($backfillWindowHours) must be >= liveWindowHours " +
+                "($liveWindowHours)"
         }
         require(lookbackHours >= 0) { "traceFinalizer.lookbackHours must be >= 0, got $lookbackHours" }
         require(maxExecutionSeconds > 0) {
@@ -77,9 +77,6 @@ class TraceFinalizerBackgroundService(
     }
 
     private var finalizeJob: Job? = null
-
-    @Volatile
-    private var startupBackfillDone = false
 
     fun start(scope: CoroutineScope) {
         if (!enabled) {
@@ -108,33 +105,30 @@ class TraceFinalizerBackgroundService(
     }
 
     /**
-     * One-shot finalization of the last [emitHours] from apm_trace_summaries into apm_traces_final.
-     * Used by demo seeding so the traces dashboard has data without waiting for the scheduled run.
+     * Run a single finalization pass now. Used by demo seeding so the traces dashboard has data without
+     * waiting for the scheduled loop.
      */
-    suspend fun finalizeRecent(emitHours: Int) = finalizeWindow(emitHours)
+    suspend fun finalizeNow() = runOnce()
 
     internal suspend fun runOnce() {
         if (!ClickHouseClient.isInitialized()) {
             logger.debug { "Trace finalization skipped: ClickHouse is not initialized" }
             return
         }
-        // First run after startup covers history + heals any gap from downtime; later runs only
-        // refresh the recent window (cheap, keeps the leading edge fresh, absorbs late spans).
-        val windowHours = if (!startupBackfillDone) backfillWindowHours else refreshWindowHours
-        finalizeWindow(windowHours)
-        if (!startupBackfillDone) {
-            startupBackfillDone = true
-            logger.info { "Trace finalizer startup backfill complete (${backfillWindowHours}h)" }
-        }
+        finalizeFrozenBuckets()
     }
 
     /**
-     * Finalize traces whose start falls within the last [emitHours]. Summaries are scanned a little
-     * further back ([lookbackHours]) so a trace straddling the lower edge resolves its true start and
-     * is correctly excluded (rather than re-finalized with a partial, newer-versioned row).
+     * Finalize every frozen bucket (older than [liveWindowHours]) that is newer than the highest
+     * already-finalized bucket, exactly once. The forward-only `trace_bucket > max(...)` guard keeps the
+     * pass idempotent (no duplicate versions, so reads need no FINAL); [backfillWindowHours] clamps how
+     * far a cold start or downtime gap reaches back. Summaries are scanned [lookbackHours] beyond the
+     * window so traces straddling a bucket boundary still resolve their full start/end.
      */
-    private suspend fun finalizeWindow(emitHours: Int) {
-        val scanHours = emitHours + lookbackHours
+    private suspend fun finalizeFrozenBuckets() {
+        val frozenBefore = "toStartOfHour(now() - INTERVAL $liveWindowHours HOUR)"
+        val backfillFloor = "toStartOfHour(now() - INTERVAL $backfillWindowHours HOUR)"
+        val watermark = "(SELECT max(trace_bucket) FROM `$clickhouseDb`.$APM_TRACES_FINAL_TABLE)"
         val sql = """
             INSERT INTO `$clickhouseDb`.$APM_TRACES_FINAL_TABLE
                 (organization_id, trace_bucket, trace_id_canonical, root_service, root_resource,
@@ -164,10 +158,14 @@ class TraceFinalizerBackgroundService(
                     toUInt32(sumMerge(error_count_state)) AS error_count,
                     toUInt8(sumMerge(error_count_state) > 0) AS has_error
                 FROM `$clickhouseDb`.$APM_TRACE_SUMMARIES_TABLE
-                WHERE bucket_start >= toStartOfHour(now() - INTERVAL $scanHours HOUR)
+                WHERE bucket_start > $watermark - INTERVAL $lookbackHours HOUR
+                  AND bucket_start >= $backfillFloor
+                  AND bucket_start < $frozenBefore + INTERVAL $lookbackHours HOUR
                 GROUP BY organization_id, trace_id_canonical
             )
-            WHERE toStartOfHour(trace_start) >= toStartOfHour(now() - INTERVAL $emitHours HOUR)
+            WHERE toStartOfHour(trace_start) > $watermark
+              AND toStartOfHour(trace_start) >= $backfillFloor
+              AND toStartOfHour(trace_start) < $frozenBefore
             SETTINGS max_execution_time = $maxExecutionSeconds
         """.trimIndent()
         ClickHouseClient.executeLongRunning(sql, operation = "trace_finalize")
@@ -186,8 +184,8 @@ class TraceFinalizerBackgroundService(
                     ?.getString()?.toBooleanStrictOrNull() ?: true,
                 intervalSeconds = config.propertyOrNull("traceFinalizer.intervalSeconds")
                     ?.getString()?.toLongOrNull() ?: DEFAULT_INTERVAL_SECONDS,
-                refreshWindowHours = config.propertyOrNull("traceFinalizer.refreshWindowHours")
-                    ?.getString()?.toIntOrNull() ?: DEFAULT_REFRESH_WINDOW_HOURS,
+                liveWindowHours = config.propertyOrNull("traceFinalizer.liveWindowHours")
+                    ?.getString()?.toIntOrNull() ?: DEFAULT_LIVE_WINDOW_HOURS,
                 backfillWindowHours = config.propertyOrNull("traceFinalizer.backfillWindowHours")
                     ?.getString()?.toIntOrNull() ?: DEFAULT_BACKFILL_WINDOW_HOURS,
                 lookbackHours = config.propertyOrNull("traceFinalizer.lookbackHours")

--- a/backend/src/main/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundService.kt
@@ -66,8 +66,8 @@ class TraceFinalizerBackgroundService(
         // nonsensical windows.
         require(intervalSeconds > 0) { "traceFinalizer.intervalSeconds must be > 0, got $intervalSeconds" }
         require(liveWindowHours > 0) { "traceFinalizer.liveWindowHours must be > 0, got $liveWindowHours" }
-        require(backfillWindowHours >= liveWindowHours) {
-            "traceFinalizer.backfillWindowHours ($backfillWindowHours) must be >= liveWindowHours " +
+        require(backfillWindowHours > liveWindowHours) {
+            "traceFinalizer.backfillWindowHours ($backfillWindowHours) must be > liveWindowHours " +
                 "($liveWindowHours)"
         }
         require(lookbackHours >= 0) { "traceFinalizer.lookbackHours must be >= 0, got $lookbackHours" }

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -140,10 +140,12 @@ traceFinalizer {
     # How often a finalization run fires.
     intervalSeconds = 600
     intervalSeconds = ${?TRACE_FINALIZER_INTERVAL_SECONDS}
-    # Recent window re-finalized every run (keeps the leading edge fresh, absorbs late spans).
-    refreshWindowHours = 2
-    refreshWindowHours = ${?TRACE_FINALIZER_REFRESH_WINDOW_HOURS}
-    # Wider window finalized once on process start (covers history + heals downtime gaps).
+    # Buckets newer than this are still filling and are read live from apm_trace_summaries; older
+    # buckets are finalized exactly-once into apm_traces_final. MUST match LIVE_WINDOW_HOURS in
+    # TraceIngestionService so the finalized and live read ranges meet without a gap.
+    liveWindowHours = 2
+    liveWindowHours = ${?TRACE_FINALIZER_LIVE_WINDOW_HOURS}
+    # How far back a cold start or downtime gap will catch up when finalizing.
     backfillWindowHours = 50
     backfillWindowHours = ${?TRACE_FINALIZER_BACKFILL_WINDOW_HOURS}
     # Extra hours scanned below the emit window so straddling traces resolve their true start.

--- a/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
@@ -233,7 +233,7 @@ class TraceIngestionServiceTest {
                             "\"service\":\"checkout-service\",\"resource\":\"POST /checkout\"," +
                             "\"source\":\"otlp\",\"trace_count\":1234,\"error_count\":154," +
                             "\"error_rate\":0.1248,\"p95_duration_ns\":612000000}"
-                    "GROUP BY root_service" in query && "UNION ALL" !in query ->
+                    "GROUP BY root_service" in query && "facet_type" !in query ->
                         "{" +
                             "\"service\":\"checkout-service\",\"source\":\"otlp\",\"trace_count\":5642," +
                             "\"error_count\":326,\"error_rate\":0.0578,\"p95_duration_ns\":612000000," +

--- a/backend/src/test/kotlin/com/moneat/demo/DemoDataSeeder.kt
+++ b/backend/src/test/kotlin/com/moneat/demo/DemoDataSeeder.kt
@@ -61,10 +61,6 @@ import kotlin.time.Duration.Companion.days
  */
 object DemoDataSeeder {
 
-    // Demo APM spans span the last 48h; finalize a slightly wider window so they all land in
-    // apm_traces_final for the traces dashboard.
-    private const val DEMO_TRACE_FINALIZE_WINDOW_HOURS = 72
-
     private fun hashPassword(password: String): String {
         return BCrypt.hashpw(password, BCrypt.gensalt())
     }
@@ -3533,9 +3529,10 @@ object DemoDataSeeder {
             ) VALUES ${spanRows.joinToString(",\n")}
             """.trimIndent()
         ClickHouseClient.execute(spanBatch)
-        // Finalize the freshly seeded spans into apm_traces_final (the dashboard read source) so the
-        // traces UI has data immediately, without waiting for the scheduled finalizer.
-        TraceFinalizerBackgroundService.fromConfig().finalizeRecent(emitHours = DEMO_TRACE_FINALIZE_WINDOW_HOURS)
+        // Finalize the freshly seeded (now-frozen) spans into apm_traces_final so the traces UI has
+        // data immediately, without waiting for the scheduled finalizer. Spans in the live window are
+        // served directly from apm_trace_summaries by the dashboard read.
+        TraceFinalizerBackgroundService.fromConfig().finalizeNow()
         println("✅ Seeded $traceCount traces (${spanRows.size} spans)")
 
         // ── Profiles ──

--- a/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
@@ -476,7 +476,7 @@ class TraceIngestionServiceCoverageTest {
     }
 
     @Test
-    fun `APM overview reads finalized table without per-trace re-aggregation`() = runBlocking {
+    fun `APM overview reads finalized table for closed buckets and summaries for the live window`() = runBlocking {
         val capturedQueries = mutableListOf<String>()
         coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
             capturedQueries.add(firstArg())
@@ -488,12 +488,17 @@ class TraceIngestionServiceCoverageTest {
             query = DdTraceListQuery(limit = 10, offset = 0),
         )
 
-        // Reads must hit the finalized one-row-per-trace table with FINAL and must NOT re-introduce
-        // the per-trace argMin aggregation that caused the dashboard ClickHouse timeouts.
+        // Hybrid read: finalized one-row-per-trace records from apm_traces_final (read plainly, NOT with
+        // the slow FINAL) UNION the still-filling recent buckets aggregated live from apm_trace_summaries.
         assertTrue(capturedQueries.isNotEmpty())
-        assertTrue(capturedQueries.all { it.contains("apm_traces_final FINAL") })
-        assertFalse(capturedQueries.any { it.contains("argMinMerge") })
-        assertFalse(capturedQueries.any { it.contains("GROUP BY organization_id, trace_id_canonical") })
+        assertTrue(capturedQueries.all { it.contains("apm_traces_final") })
+        // Never the slow FINAL.
+        assertFalse(capturedQueries.any { it.contains("apm_traces_final FINAL") })
+        // Current-window reads are hybrid: finalized (no FINAL) UNION the live summaries window. The
+        // previous-comparison window is entirely finalized, so it has neither UNION nor summaries.
+        assertTrue(capturedQueries.any { it.contains("UNION ALL") && it.contains("apm_trace_summaries") })
+        assertTrue(capturedQueries.any { it.contains("trace_bucket < toStartOfHour(now() - INTERVAL 2 HOUR)") })
+        assertTrue(capturedQueries.any { it.contains("bucket_start >= toStartOfHour(now() - INTERVAL 2 HOUR)") })
     }
 
     // ===================== getTraceDetail =====================

--- a/backend/src/test/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundServiceTest.kt
@@ -163,6 +163,7 @@ class TraceFinalizerBackgroundServiceTest {
         assertFailsWith<IllegalArgumentException> { service(intervalSeconds = 0) }
         assertFailsWith<IllegalArgumentException> { service(liveWindowHours = 0) }
         assertFailsWith<IllegalArgumentException> { service(backfillWindowHours = 1, liveWindowHours = 2) }
+        assertFailsWith<IllegalArgumentException> { service(backfillWindowHours = 2, liveWindowHours = 2) }
         assertFailsWith<IllegalArgumentException> { service(lookbackHours = -1) }
         assertFailsWith<IllegalArgumentException> { service(maxExecutionSeconds = 0) }
     }

--- a/backend/src/test/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/shared/services/TraceFinalizerBackgroundServiceTest.kt
@@ -57,22 +57,22 @@ class TraceFinalizerBackgroundServiceTest {
     private fun service(
         enabled: Boolean = true,
         intervalSeconds: Long = 600,
-        refreshWindowHours: Int = 2,
+        liveWindowHours: Int = 2,
         backfillWindowHours: Int = 50,
         lookbackHours: Int = 2,
         maxExecutionSeconds: Int = 540,
     ) = TraceFinalizerBackgroundService(
         enabled = enabled,
         intervalSeconds = intervalSeconds,
-        refreshWindowHours = refreshWindowHours,
+        liveWindowHours = liveWindowHours,
         backfillWindowHours = backfillWindowHours,
         lookbackHours = lookbackHours,
         maxExecutionSeconds = maxExecutionSeconds,
     )
 
     @Test
-    fun `finalizeRecent finalizes summaries into apm_traces_final off the read path`() = runBlocking {
-        service().finalizeRecent(emitHours = 2)
+    fun `runOnce finalizes only frozen buckets, forward-only, off the read path`() = runBlocking {
+        service().runOnce()
 
         assertEquals(1, captured.size, "expected one finalize INSERT")
         val sql = captured.single()
@@ -80,24 +80,26 @@ class TraceFinalizerBackgroundServiceTest {
         assertTrue(sql.contains("`test_db`.apm_trace_summaries"))
         // The heavy argMin aggregation runs here (off the dashboard read path).
         assertTrue(sql.contains("argMinMerge(root_service_state)"))
-        // emit window = 2h, scan window = emit + lookback (2 + 2 = 4h).
-        assertTrue(sql.contains("toStartOfHour(trace_start) >= toStartOfHour(now() - INTERVAL 2 HOUR)"))
-        assertTrue(sql.contains("bucket_start >= toStartOfHour(now() - INTERVAL 4 HOUR)"))
         assertTrue(sql.contains("GROUP BY organization_id, trace_id_canonical"))
+        // Forward-only: never re-finalize a bucket at/below the current max.
+        assertTrue(
+            sql.contains("toStartOfHour(trace_start) > (SELECT max(trace_bucket) FROM `test_db`.apm_traces_final)"),
+        )
+        // Only frozen buckets (older than the 2h live window); newest buckets stay live in summaries.
+        assertTrue(sql.contains("toStartOfHour(trace_start) < toStartOfHour(now() - INTERVAL 2 HOUR)"))
+        // Cold-start / gap catch-up is clamped to the 50h backfill floor.
+        assertTrue(sql.contains("toStartOfHour(trace_start) >= toStartOfHour(now() - INTERVAL 50 HOUR)"))
     }
 
     @Test
-    fun `runOnce backfills the wide window first then refreshes the recent window`() = runBlocking {
-        val svc = service(refreshWindowHours = 2, backfillWindowHours = 50, lookbackHours = 2)
-
+    fun `repeated runs stay forward-only (no re-finalization window)`() = runBlocking {
+        val svc = service()
         svc.runOnce()
         svc.runOnce()
 
         assertEquals(2, captured.size)
-        // First pass: wider backfill window (covers history + downtime gaps).
-        assertTrue(captured[0].contains("toStartOfHour(trace_start) >= toStartOfHour(now() - INTERVAL 50 HOUR)"))
-        // Subsequent passes: only the recent refresh window.
-        assertTrue(captured[1].contains("toStartOfHour(trace_start) >= toStartOfHour(now() - INTERVAL 2 HOUR)"))
+        // Both passes use the same forward-only guard; neither re-finalizes a recent window.
+        assertTrue(captured.all { it.contains("> (SELECT max(trace_bucket) FROM `test_db`.apm_traces_final)") })
     }
 
     @Test
@@ -159,8 +161,8 @@ class TraceFinalizerBackgroundServiceTest {
     @Test
     fun `constructor rejects invalid configuration`() {
         assertFailsWith<IllegalArgumentException> { service(intervalSeconds = 0) }
-        assertFailsWith<IllegalArgumentException> { service(refreshWindowHours = 0) }
-        assertFailsWith<IllegalArgumentException> { service(backfillWindowHours = 1, refreshWindowHours = 2) }
+        assertFailsWith<IllegalArgumentException> { service(liveWindowHours = 0) }
+        assertFailsWith<IllegalArgumentException> { service(backfillWindowHours = 1, liveWindowHours = 2) }
         assertFailsWith<IllegalArgumentException> { service(lookbackHours = -1) }
         assertFailsWith<IllegalArgumentException> { service(maxExecutionSeconds = 0) }
     }
@@ -169,8 +171,10 @@ class TraceFinalizerBackgroundServiceTest {
     fun `fromConfig applies defaults when keys are absent`() = runBlocking {
         val svc = TraceFinalizerBackgroundService.fromConfig(MapApplicationConfig())
 
-        svc.runOnce() // first pass uses the default 50h backfill window
+        svc.runOnce()
         assertEquals(1, captured.size)
+        // Defaults: 2h live window (frozen boundary) and 50h backfill floor.
+        assertTrue(captured.single().contains("toStartOfHour(now() - INTERVAL 2 HOUR)"))
         assertTrue(captured.single().contains("toStartOfHour(now() - INTERVAL 50 HOUR)"))
     }
 
@@ -180,15 +184,16 @@ class TraceFinalizerBackgroundServiceTest {
             MapApplicationConfig(
                 "traceFinalizer.enabled" to "true",
                 "traceFinalizer.intervalSeconds" to "300",
-                "traceFinalizer.refreshWindowHours" to "1",
+                "traceFinalizer.liveWindowHours" to "1",
                 "traceFinalizer.backfillWindowHours" to "10",
                 "traceFinalizer.lookbackHours" to "3",
                 "traceFinalizer.maxExecutionSeconds" to "120",
             ),
         )
 
-        svc.runOnce() // first pass uses the configured 10h backfill window
+        svc.runOnce()
         assertEquals(1, captured.size)
+        assertTrue(captured.single().contains("toStartOfHour(now() - INTERVAL 1 HOUR)"))
         assertTrue(captured.single().contains("toStartOfHour(now() - INTERVAL 10 HOUR)"))
     }
 }


### PR DESCRIPTION
## Problem

After #473 deployed, the traces dashboard was still slow (~5–8s reads). Two compounding causes:

1. The read wrapped `apm_traces_final` in **`FINAL`**, which is ~5–8s over the dashboard's columns *even with zero duplicates* — `FINAL` does merge-on-read dedup regardless of how many dupes exist.
2. The finalizer **re-finalized the recent 2h every run**, appending a fresh duplicate `ReplacingMergeTree` version per trace each cycle. On prod ~94% of the recent window was duplicated, so `FINAL` was both mandatory and getting heavier over time.

(So the deploy created the right table/finalizer, but the read path stayed slow.)

## Fix

- **Exactly-once, forward-only finalizer** — each run finalizes only *frozen* buckets (older than `liveWindowHours`) that are newer than `max(trace_bucket)`; it never re-finalizes. `apm_traces_final` therefore has no duplicate versions, so reads need no `FINAL`.
- **Hybrid read** — closed buckets come from `apm_traces_final` as plain one-row-per-trace records (no `FINAL`); the still-filling recent buckets (`< liveWindowHours`) are aggregated live from `apm_trace_summaries` and `UNION`ed in. Previous-comparison windows are fully finalized, so they read `apm_traces_final` only.

## Prod validation

| 24h overview read | Time |
|---|---|
| before (FINAL) | ~5–8s |
| **after (hybrid, no FINAL)** | **~0.7s** |

Verified the exact generated hybrid read on prod (0.7s, `UNION` types coerce correctly) and that the finalizer's forward-only `INSERT` parses and is a clean no-op when already caught up.

## Deploy step (required, one-time)

Run once after rollout to collapse the duplicate versions the previous re-finalizing finalizer left behind — the new finalizer creates none:

```sql
OPTIMIZE TABLE apm_traces_final FINAL;
```

Until that runs, the finalized read range would over-count those leftover duplicates.

## Tests

`./gradlew :test` green; backend coverage 71.9%. `TraceFinalizerBackgroundService` 98% / `TraceIngestionService` 88.5% line coverage. Finalizer tests pin the forward-only `max(trace_bucket)` guard + frozen-bucket bounds; the overview test pins the hybrid shape (no `FINAL`; finalized `UNION` live summaries).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trace queries now use a hybrid approach, reading recent data from live summaries and older finalized data separately for improved performance and accuracy.
  * Added immediate trace finalization capability for demo seeding.

* **Refactor**
  * Updated trace finalization model to a forward-only approach with configurable live-window boundary.
  * Configuration now uses `liveWindowHours` setting to define the cutoff between finalized and live trace data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->