### PR TITLE
fix: stop retrying 4xx errors in React Query

### DIFF
--- a/dashboard/src/lib/__tests__/query-retry.test.ts
+++ b/dashboard/src/lib/__tests__/query-retry.test.ts
@@ -1,0 +1,32 @@
+import {describe, it, expect} from 'vitest'
+import {shouldRetryQuery, MAX_QUERY_RETRIES} from '@/lib/query-retry'
+
+describe('shouldRetryQuery', () => {
+  it('does not retry 404 errors', () => {
+    expect(shouldRetryQuery(0, {status: 404})).toBe(false)
+  })
+
+  it('does not retry any 4xx client error', () => {
+    for (const status of [400, 401, 403, 404, 409, 422, 429]) {
+      expect(shouldRetryQuery(0, {status})).toBe(false)
+    }
+  })
+
+  it('retries 5xx server errors up to the limit', () => {
+    expect(shouldRetryQuery(0, {status: 500})).toBe(true)
+    expect(shouldRetryQuery(MAX_QUERY_RETRIES - 1, {status: 503})).toBe(true)
+    expect(shouldRetryQuery(MAX_QUERY_RETRIES, {status: 500})).toBe(false)
+  })
+
+  it('retries errors without a status (e.g. network failures) up to the limit', () => {
+    const networkError = new Error('NETWORK_ERROR')
+    expect(shouldRetryQuery(0, networkError)).toBe(true)
+    expect(shouldRetryQuery(MAX_QUERY_RETRIES, networkError)).toBe(false)
+  })
+
+  it('handles null and undefined errors', () => {
+    expect(shouldRetryQuery(0, null)).toBe(true)
+    expect(shouldRetryQuery(0, undefined)).toBe(true)
+    expect(shouldRetryQuery(MAX_QUERY_RETRIES, null)).toBe(false)
+  })
+})

--- a/dashboard/src/lib/query-retry.ts
+++ b/dashboard/src/lib/query-retry.ts
@@ -1,0 +1,33 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+export const MAX_QUERY_RETRIES = 3
+
+/**
+ * Default retry predicate for React Query.
+ *
+ * Client errors (4xx) — notably 404 Not Found — are not transient and will
+ * never succeed on retry, so we surface them immediately instead of hammering
+ * the backend. Errors without a status (e.g. network failures) and server
+ * errors (5xx) are retried up to {@link MAX_QUERY_RETRIES} times.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  const status = (error as {status?: number} | null | undefined)?.status
+  if (typeof status === 'number' && status >= 400 && status < 500) {
+    return false
+  }
+  return failureCount < MAX_QUERY_RETRIES
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -24,6 +24,7 @@ import {TooltipProvider} from './components/ui/tooltip'
 import {HelmetProvider} from 'react-helmet-async'
 import * as Sentry from '@sentry/react'
 import {initAnalytics} from './lib/analytics'
+import {shouldRetryQuery} from './lib/query-retry'
 import './index.css'
 
 // Initialize Sentry (error monitoring)
@@ -71,7 +72,11 @@ if (import.meta.env.VITE_DD_APPLICATION_ID && import.meta.env.VITE_DD_CLIENT_TOK
   })
 }
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {retry: shouldRetryQuery},
+  },
+})
 
 const router = createRouter({
   routeTree,


### PR DESCRIPTION
## Summary

- `QueryClient` was created with no retry config, so React Query's default (3 retries on every failure) applied to 4xx responses app-wide — 404s would be requested 4× before surfacing
- Adds `shouldRetryQuery` in `src/lib/query-retry.ts`: any 4xx is surfaced immediately; 5xx and network errors still retry up to 3 times
- Wires the predicate into `QueryClient` defaults in `main.tsx` so every `useQuery` in the app inherits it without per-query changes
- The API client already attaches `.status` to thrown errors (`client.ts:72-77`), so the predicate works without any changes to the fetch layer

## Test plan

- [ ] `vitest run src/lib/__tests__/query-retry.test.ts` — 5 unit cases (404, all 4xx, 5xx retry limit, network/no-status, null/undefined): all green
- [ ] Manually hit a dashboard that loads a non-existent resource and confirm the error surfaces immediately without repeated network calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved API query retry behavior with smarter error handling—client errors no longer retry, while server errors and network failures retry up to 3 times before stopping.

* **Tests**
  * Added comprehensive test coverage for retry logic across various error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->