### PR TITLE
fix: backend Docker build with ee module

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,6 +11,13 @@ FROM --platform=$BUILDPLATFORM gradle:9-jdk17 AS build
 WORKDIR /app
 COPY backend/build.gradle.kts backend/settings.gradle.kts backend/gradle.properties ./
 COPY backend/gradle ./gradle
+# settings.gradle.kts includes :ee at ../ee/backend, so the project directory
+# must exist before any Gradle invocation configures the build.
+COPY ee/backend/build.gradle.kts \
+     ee/backend/detekt.yml \
+     ee/backend/detekt-format.yml \
+     ee/backend/license-header.txt \
+     /ee/backend/
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle dependencies --no-daemon --build-cache || true
 COPY backend/src ./src


### PR DESCRIPTION
## Summary
- Copy the enterprise backend Gradle/config files before the Docker build stage runs `gradle dependencies`.
- Keep the full `ee/backend` source copy later, immediately before `shadowJar`.

## Root Cause
`backend/settings.gradle.kts` always includes `:ee` from `../ee/backend`. Inside the Docker build stage, `WORKDIR /app` makes that path resolve to `/ee/backend`, but the Dockerfile invoked Gradle before that directory existed. Gradle 9 rejects configuring a project whose directory is missing.

## Impact
This restores backend Docker image builds while preserving the dependency-cache layer for Gradle resolution.

## Validation
- `cd backend && ./gradlew dependencies --no-daemon --build-cache`
- `cd backend && ./gradlew shadowJar --no-daemon --build-cache`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include additional Gradle build dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->