### PR TITLE
feat: add service-centric profiles explorer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,9 @@ To avoid Sonar code smells and keep code consistent:
 
 - **Keep cognitive complexity low (≤15)** – extract helper functions when logic gets nested:
   - Use `runCatching { }.getOrNull()` only in non-suspending, synchronous helpers (e.g., parsing/mapping functions). **Avoid in suspending/coroutine contexts**: `runCatching` swallows all `Throwable`s including `CancellationException`, which can break coroutine cancellation. In suspend functions, use `suspendRunCatching` from `com.moneat.utils` instead — it rethrows `CancellationException` automatically and composes with the `Result` API (`getOrElse`, `getOrNull`, `getOrDefault`, `onFailure`). Keep the manual `catch (e: CancellationException) { throw e }` pattern only when `Result` doesn't compose cleanly (e.g. the catch block mutates state and then rethrows).
+  - In Ktor route handlers, `coroutineScope`, `async`, workers, and other coroutine paths, wrap failures with
+    `suspendRunCatching { ... }` whenever the guarded call may suspend. Reserve plain `runCatching` for synchronous
+    parsing/formatting helpers.
   - Extract complex parsing or mapping into private functions
   - Prefer early returns over nested conditionals
 

--- a/backend/src/main/kotlin/com/moneat/datadog/models/DatadogProfileModels.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/models/DatadogProfileModels.kt
@@ -64,3 +64,58 @@ data class DdProfileListResponse(
     val profiles: List<DdProfileResponse>,
     val totalCount: Long,
 )
+
+/** A profile type and how many profiles of that type a service has. */
+@Serializable
+data class DdProfileTypeCount(
+    val profileType: String,
+    val count: Long,
+)
+
+/** A single bucket in a per-service activity sparkline (ts = epoch millis). */
+@Serializable
+data class DdProfileSeriesPoint(
+    val ts: Long,
+    val count: Long,
+)
+
+/** Per-service rollup powering the Profiles overview cards. */
+@Serializable
+data class DdProfileServiceSummary(
+    val service: String,
+    val languages: List<String>,
+    val runtimes: List<String>,
+    val environments: List<String>,
+    val types: List<DdProfileTypeCount>,
+    val hostCount: Long,
+    val profileCount: Long,
+    val totalSizeBytes: Long,
+    val firstSeen: String,
+    val lastSeen: String,
+    val avgDurationNs: Long,
+    val series: List<DdProfileSeriesPoint>,
+)
+
+@Serializable
+data class DdProfileServicesResponse(
+    val services: List<DdProfileServiceSummary>,
+    val totalProfiles: Long,
+    val totalSizeBytes: Long,
+    val serviceCount: Int,
+    val hostCount: Long,
+    val typeCount: Int,
+)
+
+/** A bucket in a service/window profile-volume time series (ts = epoch millis). */
+@Serializable
+data class DdProfileTimeseriesPoint(
+    val ts: Long,
+    val count: Long,
+    val sizeBytes: Long,
+)
+
+@Serializable
+data class DdProfileTimeseriesResponse(
+    val points: List<DdProfileTimeseriesPoint>,
+    val bucketSeconds: Long,
+)

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
@@ -75,7 +75,8 @@ fun Route.profileDashboardRoutes() {
 
 private suspend fun ApplicationCall.handleListProfiles() {
     val orgId = requireOrgId() ?: return
-    val limit = (parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceAtMost(MAX_LIMIT)
+    val limit = (parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+    val offset = (parameters["offset"]?.toIntOrNull() ?: 0).coerceAtLeast(0)
     val query = DdProfileListQuery(
         service = parameters["service"],
         profileType = parameters["type"],
@@ -86,7 +87,7 @@ private suspend fun ApplicationCall.handleListProfiles() {
         fromMs = parameters["from"]?.toLongOrNull(),
         toMs = parameters["to"]?.toLongOrNull(),
         limit = limit,
-        offset = parameters["offset"]?.toIntOrNull() ?: 0,
+        offset = offset,
     )
 
     suspendRunCatching { ProfileIngestionService.listProfiles(orgId, query) }
@@ -131,6 +132,11 @@ private suspend fun ApplicationCall.handleMergedFlamegraph() {
     val now = System.currentTimeMillis()
     val fromMs = parameters["from"]?.toLongOrNull() ?: (now - HOUR_MS)
     val toMs = parameters["to"]?.toLongOrNull() ?: now
+    if (toMs <= fromMs) {
+        respond(HttpStatusCode.BadRequest, mapOf(ERROR_KEY to "Invalid time range"))
+        return
+    }
+
     val query = ProfileMergeFlamegraphQuery(
         organizationId = orgId,
         filters = profileFilters(includeVersion = true),
@@ -232,7 +238,11 @@ private suspend fun ApplicationCall.requireProfileMeta(
     orgId: Int,
     profileId: String,
 ): ProfileIngestionService.ProfileMeta? {
-    val meta = ProfileIngestionService.getProfileMeta(orgId, profileId)
+    val meta = suspendRunCatching { ProfileIngestionService.getProfileMeta(orgId, profileId) }
+        .getOrElse {
+            respondGenericError(this, "getProfileMeta", it)
+            return null
+        }
     if (meta == null) {
         respondProfileNotFound()
     }

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
@@ -20,8 +20,13 @@ import com.moneat.datadog.decompression.DecompressionService
 import com.moneat.datadog.services.DdProfileListQuery
 import com.moneat.datadog.services.ProfileFlamegraphParser
 import com.moneat.datadog.services.ProfileIngestionService
+import com.moneat.datadog.services.ProfileMergeFlamegraphQuery
 import com.moneat.datadog.services.ProfileMergeService
+import com.moneat.datadog.services.ProfileQueryFilters
 import com.moneat.datadog.services.ProfileStorageService
+import com.moneat.datadog.services.ProfileTimeWindow
+import com.moneat.datadog.services.ProfileTimeseriesQuery
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -46,6 +51,8 @@ private const val ERROR_KEY = "error"
 private const val INVALID_TOKEN = "Invalid token"
 private const val GENERIC_ERROR = "Failed to load profiling data"
 private const val DEFAULT_TIMESERIES_BUCKETS = 48
+private const val MISSING_PROFILE_ID = "Missing profileId"
+private const val PROFILE_NOT_FOUND = "Profile not found"
 private const val HOUR_MS = 3_600_000L
 private const val DAY_MS = 86_400_000L
 
@@ -55,218 +62,185 @@ private fun ApplicationCall.orgIdOrNull(): Int? =
 fun Route.profileDashboardRoutes() {
     authenticate("auth-jwt") {
         route("/v1/profiles") {
-            // GET /v1/profiles - list raw profiles
-            get {
-                val orgId = call.orgIdOrNull() ?: return@get call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf(ERROR_KEY to INVALID_TOKEN),
-                )
-                val limit = (call.parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT)
-                    .coerceAtMost(MAX_LIMIT)
-                val query = DdProfileListQuery(
-                    service = call.parameters["service"],
-                    profileType = call.parameters["type"],
-                    source = call.parameters["source"],
-                    env = call.parameters["env"],
-                    host = call.parameters["host"],
-                    version = call.parameters["version"],
-                    fromMs = call.parameters["from"]?.toLongOrNull(),
-                    toMs = call.parameters["to"]?.toLongOrNull(),
-                    limit = limit,
-                    offset = call.parameters["offset"]?.toIntOrNull() ?: 0,
-                )
-
-                runCatching { ProfileIngestionService.listProfiles(orgId, query) }
-                    .onSuccess { call.respond(it) }
-                    .onFailure { respondGenericError(call, "listProfiles", it) }
-            }
-
-            // GET /v1/profiles/services - per-service rollup for the overview
-            get("/services") {
-                val orgId = call.orgIdOrNull() ?: return@get call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf(ERROR_KEY to INVALID_TOKEN),
-                )
-                val fromMs = call.parameters["from"]?.toLongOrNull()
-                val toMs = call.parameters["to"]?.toLongOrNull()
-
-                runCatching { ProfileIngestionService.listServices(orgId, fromMs, toMs) }
-                    .onSuccess { call.respond(it) }
-                    .onFailure { respondGenericError(call, "listServices", it) }
-            }
-
-            // GET /v1/profiles/timeseries - profile-volume buckets for a window
-            get("/timeseries") {
-                val orgId = call.orgIdOrNull() ?: return@get call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf(ERROR_KEY to INVALID_TOKEN),
-                )
-                val now = System.currentTimeMillis()
-                val fromMs = call.parameters["from"]?.toLongOrNull() ?: (now - DAY_MS)
-                val toMs = call.parameters["to"]?.toLongOrNull() ?: now
-                if (toMs <= fromMs) {
-                    return@get call.respond(
-                        HttpStatusCode.BadRequest,
-                        mapOf(ERROR_KEY to "Invalid time range"),
-                    )
-                }
-                val buckets = call.parameters["buckets"]?.toIntOrNull()
-                    ?: DEFAULT_TIMESERIES_BUCKETS
-
-                runCatching {
-                    ProfileIngestionService.timeseries(
-                        organizationId = orgId,
-                        service = call.parameters["service"],
-                        profileType = call.parameters["type"],
-                        env = call.parameters["env"],
-                        host = call.parameters["host"],
-                        fromMs = fromMs,
-                        toMs = toMs,
-                        buckets = buckets,
-                    )
-                }
-                    .onSuccess { call.respond(it) }
-                    .onFailure { respondGenericError(call, "timeseries", it) }
-            }
-
-            // GET /v1/profiles/merged-flamegraph - aggregate over a window
-            get("/merged-flamegraph") {
-                val orgId = call.orgIdOrNull() ?: return@get call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf(ERROR_KEY to INVALID_TOKEN),
-                )
-                val now = System.currentTimeMillis()
-                val fromMs = call.parameters["from"]?.toLongOrNull() ?: (now - HOUR_MS)
-                val toMs = call.parameters["to"]?.toLongOrNull() ?: now
-                val maxProfiles = call.parameters["maxProfiles"]?.toIntOrNull()
-                    ?: ProfileMergeService.DEFAULT_MAX_PROFILES
-
-                runCatching {
-                    ProfileMergeService.mergeFlamegraph(
-                        organizationId = orgId,
-                        service = call.parameters["service"],
-                        profileType = call.parameters["type"],
-                        env = call.parameters["env"],
-                        host = call.parameters["host"],
-                        version = call.parameters["version"],
-                        fromMs = fromMs,
-                        toMs = toMs,
-                        sampleType = call.parameters["sampleType"],
-                        thread = call.parameters["thread"],
-                        maxProfiles = maxProfiles,
-                    )
-                }
-                    .onSuccess {
-                        call.respondText(it.toString(), ContentType.Application.Json)
-                    }
-                    .onFailure { respondGenericError(call, "mergeFlamegraph", it) }
-            }
-
-            // GET /v1/profiles/{profileId} - single profile metadata
-            get("/{profileId}") {
-                val orgId = call.orgIdOrNull() ?: return@get call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf(ERROR_KEY to INVALID_TOKEN),
-                )
-                val profileId = call.parameters["profileId"] ?: return@get call.respond(
-                    HttpStatusCode.BadRequest,
-                    mapOf(ERROR_KEY to "Missing profileId"),
-                )
-
-                val profile = runCatching {
-                    ProfileIngestionService.getProfile(orgId, profileId)
-                }.getOrElse {
-                    return@get respondGenericError(call, "getProfile", it)
-                }
-                if (profile == null) {
-                    call.respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to "Profile not found"))
-                } else {
-                    call.respond(profile)
-                }
-            }
-
-            // GET /v1/profiles/{profileId}/download - raw profile bytes
-            get("/{profileId}/download") {
-                val orgId = call.orgIdOrNull() ?: return@get call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf(ERROR_KEY to INVALID_TOKEN),
-                )
-                val profileId = call.parameters["profileId"] ?: return@get call.respond(
-                    HttpStatusCode.BadRequest,
-                    mapOf(ERROR_KEY to "Missing profileId"),
-                )
-
-                val meta = ProfileIngestionService.getProfileMeta(orgId, profileId)
-                if (meta == null) {
-                    call.respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to "Profile not found"))
-                    return@get
-                }
-
-                val data = ProfileStorageService.read(meta.storageKey)
-                if (data == null) {
-                    call.respond(
-                        HttpStatusCode.NotFound,
-                        mapOf(ERROR_KEY to "Profile data not found"),
-                    )
-                    return@get
-                }
-
-                val normalizedType = meta.profileType.lowercase()
-                val downloadData = if (normalizedType == "jfr") {
-                    runCatching { DecompressionService.decompress(data, null) }.getOrElse { data }
-                } else {
-                    data
-                }
-
-                val fileName = profileDownloadFilename(profileId, normalizedType, downloadData)
-                call.response.headers.append(
-                    HttpHeaders.ContentDisposition,
-                    "attachment; filename=\"$fileName\"",
-                )
-                call.respondBytes(
-                    downloadData,
-                    ContentType.Application.OctetStream,
-                    HttpStatusCode.OK,
-                )
-            }
-
-            // GET /v1/profiles/{profileId}/flamegraph - single-profile flamegraph
-            get("/{profileId}/flamegraph") {
-                val orgId = call.orgIdOrNull() ?: return@get call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf(ERROR_KEY to INVALID_TOKEN),
-                )
-                val profileId = call.parameters["profileId"] ?: return@get call.respond(
-                    HttpStatusCode.BadRequest,
-                    mapOf(ERROR_KEY to "Missing profileId"),
-                )
-
-                val meta = ProfileIngestionService.getProfileMeta(orgId, profileId)
-                if (meta == null) {
-                    call.respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to "Profile not found"))
-                    return@get
-                }
-
-                val data = ProfileStorageService.read(meta.storageKey)
-                if (data == null) {
-                    call.respondText(
-                        ProfileFlamegraphParser.emptyFlamegraph().toString(),
-                        ContentType.Application.Json,
-                    )
-                    return@get
-                }
-
-                val frames = ProfileFlamegraphParser.parse(
-                    source = meta.source,
-                    profileType = meta.profileType,
-                    data = data,
-                    sampleType = call.parameters["sampleType"],
-                    thread = call.parameters["thread"],
-                )
-                call.respondText(frames.toString(), ContentType.Application.Json)
-            }
+            get { call.handleListProfiles() }
+            get("/services") { call.handleListServices() }
+            get("/timeseries") { call.handleTimeseries() }
+            get("/merged-flamegraph") { call.handleMergedFlamegraph() }
+            get("/{profileId}") { call.handleGetProfile() }
+            get("/{profileId}/download") { call.handleDownloadProfile() }
+            get("/{profileId}/flamegraph") { call.handleProfileFlamegraph() }
         }
     }
+}
+
+private suspend fun ApplicationCall.handleListProfiles() {
+    val orgId = requireOrgId() ?: return
+    val limit = (parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceAtMost(MAX_LIMIT)
+    val query = DdProfileListQuery(
+        service = parameters["service"],
+        profileType = parameters["type"],
+        source = parameters["source"],
+        env = parameters["env"],
+        host = parameters["host"],
+        version = parameters["version"],
+        fromMs = parameters["from"]?.toLongOrNull(),
+        toMs = parameters["to"]?.toLongOrNull(),
+        limit = limit,
+        offset = parameters["offset"]?.toIntOrNull() ?: 0,
+    )
+
+    suspendRunCatching { ProfileIngestionService.listProfiles(orgId, query) }
+        .onSuccess { respond(it) }
+        .onFailure { respondGenericError(this, "listProfiles", it) }
+}
+
+private suspend fun ApplicationCall.handleListServices() {
+    val orgId = requireOrgId() ?: return
+    val fromMs = parameters["from"]?.toLongOrNull()
+    val toMs = parameters["to"]?.toLongOrNull()
+
+    suspendRunCatching { ProfileIngestionService.listServices(orgId, fromMs, toMs) }
+        .onSuccess { respond(it) }
+        .onFailure { respondGenericError(this, "listServices", it) }
+}
+
+private suspend fun ApplicationCall.handleTimeseries() {
+    val orgId = requireOrgId() ?: return
+    val now = System.currentTimeMillis()
+    val fromMs = parameters["from"]?.toLongOrNull() ?: (now - DAY_MS)
+    val toMs = parameters["to"]?.toLongOrNull() ?: now
+    if (toMs <= fromMs) {
+        respond(HttpStatusCode.BadRequest, mapOf(ERROR_KEY to "Invalid time range"))
+        return
+    }
+
+    val query = ProfileTimeseriesQuery(
+        organizationId = orgId,
+        filters = profileFilters(),
+        window = ProfileTimeWindow(fromMs, toMs),
+        buckets = parameters["buckets"]?.toIntOrNull() ?: DEFAULT_TIMESERIES_BUCKETS,
+    )
+
+    suspendRunCatching { ProfileIngestionService.timeseries(query) }
+        .onSuccess { respond(it) }
+        .onFailure { respondGenericError(this, "timeseries", it) }
+}
+
+private suspend fun ApplicationCall.handleMergedFlamegraph() {
+    val orgId = requireOrgId() ?: return
+    val now = System.currentTimeMillis()
+    val fromMs = parameters["from"]?.toLongOrNull() ?: (now - HOUR_MS)
+    val toMs = parameters["to"]?.toLongOrNull() ?: now
+    val query = ProfileMergeFlamegraphQuery(
+        organizationId = orgId,
+        filters = profileFilters(includeVersion = true),
+        window = ProfileTimeWindow(fromMs, toMs),
+        sampleType = parameters["sampleType"],
+        thread = parameters["thread"],
+        maxProfiles = parameters["maxProfiles"]?.toIntOrNull() ?: ProfileMergeService.DEFAULT_MAX_PROFILES,
+    )
+
+    suspendRunCatching { ProfileMergeService.mergeFlamegraph(query) }
+        .onSuccess { respondText(it.toString(), ContentType.Application.Json) }
+        .onFailure { respondGenericError(this, "mergeFlamegraph", it) }
+}
+
+private suspend fun ApplicationCall.handleGetProfile() {
+    val orgId = requireOrgId() ?: return
+    val profileId = requireProfileId() ?: return
+    val profile = suspendRunCatching { ProfileIngestionService.getProfile(orgId, profileId) }
+        .getOrElse {
+            respondGenericError(this, "getProfile", it)
+            return
+        }
+
+    if (profile == null) {
+        respondProfileNotFound()
+        return
+    }
+    respond(profile)
+}
+
+private suspend fun ApplicationCall.handleDownloadProfile() {
+    val orgId = requireOrgId() ?: return
+    val profileId = requireProfileId() ?: return
+    val meta = requireProfileMeta(orgId, profileId) ?: return
+    val data = ProfileStorageService.read(meta.storageKey)
+    if (data == null) {
+        respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to "Profile data not found"))
+        return
+    }
+
+    val normalizedType = meta.profileType.lowercase()
+    val downloadData = if (normalizedType == "jfr") {
+        suspendRunCatching { DecompressionService.decompress(data, null) }.getOrElse { data }
+    } else {
+        data
+    }
+
+    val fileName = profileDownloadFilename(profileId, normalizedType, downloadData)
+    response.headers.append(HttpHeaders.ContentDisposition, "attachment; filename=\"$fileName\"")
+    respondBytes(downloadData, ContentType.Application.OctetStream, HttpStatusCode.OK)
+}
+
+private suspend fun ApplicationCall.handleProfileFlamegraph() {
+    val orgId = requireOrgId() ?: return
+    val profileId = requireProfileId() ?: return
+    val meta = requireProfileMeta(orgId, profileId) ?: return
+    val data = ProfileStorageService.read(meta.storageKey)
+    if (data == null) {
+        respondText(ProfileFlamegraphParser.emptyFlamegraph().toString(), ContentType.Application.Json)
+        return
+    }
+
+    val frames = ProfileFlamegraphParser.parse(
+        source = meta.source,
+        profileType = meta.profileType,
+        data = data,
+        sampleType = parameters["sampleType"],
+        thread = parameters["thread"],
+    )
+    respondText(frames.toString(), ContentType.Application.Json)
+}
+
+private fun ApplicationCall.profileFilters(includeVersion: Boolean = false): ProfileQueryFilters =
+    ProfileQueryFilters(
+        service = parameters["service"],
+        profileType = parameters["type"],
+        env = parameters["env"],
+        host = parameters["host"],
+        version = if (includeVersion) parameters["version"] else null,
+    )
+
+private suspend fun ApplicationCall.requireOrgId(): Int? {
+    val orgId = orgIdOrNull()
+    if (orgId == null) {
+        respond(HttpStatusCode.Unauthorized, mapOf(ERROR_KEY to INVALID_TOKEN))
+    }
+    return orgId
+}
+
+private suspend fun ApplicationCall.requireProfileId(): String? {
+    val profileId = parameters["profileId"]
+    if (profileId == null) {
+        respond(HttpStatusCode.BadRequest, mapOf(ERROR_KEY to MISSING_PROFILE_ID))
+    }
+    return profileId
+}
+
+private suspend fun ApplicationCall.requireProfileMeta(
+    orgId: Int,
+    profileId: String,
+): ProfileIngestionService.ProfileMeta? {
+    val meta = ProfileIngestionService.getProfileMeta(orgId, profileId)
+    if (meta == null) {
+        respondProfileNotFound()
+    }
+    return meta
+}
+
+private suspend fun ApplicationCall.respondProfileNotFound() {
+    respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to PROFILE_NOT_FOUND))
 }
 
 private suspend fun respondGenericError(call: ApplicationCall, op: String, error: Throwable) {

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
@@ -17,13 +17,15 @@
 package com.moneat.datadog.routes
 
 import com.moneat.datadog.decompression.DecompressionService
-import com.moneat.datadog.services.DatadogJfrFlamegraphService
-import com.moneat.datadog.services.DatadogPprofFlamegraphService
+import com.moneat.datadog.services.DdProfileListQuery
+import com.moneat.datadog.services.ProfileFlamegraphParser
 import com.moneat.datadog.services.ProfileIngestionService
+import com.moneat.datadog.services.ProfileMergeService
 import com.moneat.datadog.services.ProfileStorageService
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
@@ -33,78 +35,170 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.int
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
-import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 private const val DEFAULT_LIMIT = 50
 private const val MAX_LIMIT = 200
+private const val ORG_CLAIM = "orgId"
+private const val ERROR_KEY = "error"
+private const val INVALID_TOKEN = "Invalid token"
+private const val GENERIC_ERROR = "Failed to load profiling data"
+private const val DEFAULT_TIMESERIES_BUCKETS = 48
+private const val HOUR_MS = 3_600_000L
+private const val DAY_MS = 86_400_000L
+
+private fun ApplicationCall.orgIdOrNull(): Int? =
+    principal<JWTPrincipal>()?.payload?.getClaim(ORG_CLAIM)?.asInt()
 
 fun Route.profileDashboardRoutes() {
     authenticate("auth-jwt") {
         route("/v1/profiles") {
-            // GET /v1/dd/profiles - list profiles
+            // GET /v1/profiles - list raw profiles
             get {
-                val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
-                    ?: return@get call.respond(
-                        HttpStatusCode.Unauthorized,
-                        mapOf("error" to "Invalid token")
-                    )
-                val service = call.parameters["service"]
-                val profileType = call.parameters["type"]
-                val source = call.parameters["source"]
-                val limit = (
-                    call.parameters["limit"]
-                        ?.toIntOrNull() ?: DEFAULT_LIMIT
-                    )
-                    .coerceAtMost(MAX_LIMIT)
-                val offset = call.parameters["offset"]
-                    ?.toIntOrNull() ?: 0
-
-                val result = ProfileIngestionService.listProfiles(
-                    orgId,
-                    service,
-                    profileType,
-                    source,
-                    limit,
-                    offset
+                val orgId = call.orgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf(ERROR_KEY to INVALID_TOKEN),
                 )
-                call.respond(result)
+                val limit = (call.parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT)
+                    .coerceAtMost(MAX_LIMIT)
+                val query = DdProfileListQuery(
+                    service = call.parameters["service"],
+                    profileType = call.parameters["type"],
+                    source = call.parameters["source"],
+                    env = call.parameters["env"],
+                    host = call.parameters["host"],
+                    version = call.parameters["version"],
+                    fromMs = call.parameters["from"]?.toLongOrNull(),
+                    toMs = call.parameters["to"]?.toLongOrNull(),
+                    limit = limit,
+                    offset = call.parameters["offset"]?.toIntOrNull() ?: 0,
+                )
+
+                runCatching { ProfileIngestionService.listProfiles(orgId, query) }
+                    .onSuccess { call.respond(it) }
+                    .onFailure { respondGenericError(call, "listProfiles", it) }
             }
 
-            // GET /v1/profiles/{profileId}/download - pprof
-            get("/{profileId}/download") {
-                val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
-                    ?: return@get call.respond(
-                        HttpStatusCode.Unauthorized,
-                        mapOf("error" to "Invalid token")
-                    )
-                val profileId = call.parameters["profileId"]
-                    ?: return@get call.respond(
-                        HttpStatusCode.BadRequest,
-                        mapOf("error" to "Missing profileId")
-                    )
-
-                val meta = ProfileIngestionService.getProfileMeta(
-                    orgId,
-                    profileId
+            // GET /v1/profiles/services - per-service rollup for the overview
+            get("/services") {
+                val orgId = call.orgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf(ERROR_KEY to INVALID_TOKEN),
                 )
-                if (meta == null) {
-                    call.respond(
-                        HttpStatusCode.NotFound,
-                        mapOf("error" to "Profile not found")
+                val fromMs = call.parameters["from"]?.toLongOrNull()
+                val toMs = call.parameters["to"]?.toLongOrNull()
+
+                runCatching { ProfileIngestionService.listServices(orgId, fromMs, toMs) }
+                    .onSuccess { call.respond(it) }
+                    .onFailure { respondGenericError(call, "listServices", it) }
+            }
+
+            // GET /v1/profiles/timeseries - profile-volume buckets for a window
+            get("/timeseries") {
+                val orgId = call.orgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf(ERROR_KEY to INVALID_TOKEN),
+                )
+                val now = System.currentTimeMillis()
+                val fromMs = call.parameters["from"]?.toLongOrNull() ?: (now - DAY_MS)
+                val toMs = call.parameters["to"]?.toLongOrNull() ?: now
+                if (toMs <= fromMs) {
+                    return@get call.respond(
+                        HttpStatusCode.BadRequest,
+                        mapOf(ERROR_KEY to "Invalid time range"),
                     )
+                }
+                val buckets = call.parameters["buckets"]?.toIntOrNull()
+                    ?: DEFAULT_TIMESERIES_BUCKETS
+
+                runCatching {
+                    ProfileIngestionService.timeseries(
+                        organizationId = orgId,
+                        service = call.parameters["service"],
+                        profileType = call.parameters["type"],
+                        env = call.parameters["env"],
+                        host = call.parameters["host"],
+                        fromMs = fromMs,
+                        toMs = toMs,
+                        buckets = buckets,
+                    )
+                }
+                    .onSuccess { call.respond(it) }
+                    .onFailure { respondGenericError(call, "timeseries", it) }
+            }
+
+            // GET /v1/profiles/merged-flamegraph - aggregate over a window
+            get("/merged-flamegraph") {
+                val orgId = call.orgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf(ERROR_KEY to INVALID_TOKEN),
+                )
+                val now = System.currentTimeMillis()
+                val fromMs = call.parameters["from"]?.toLongOrNull() ?: (now - HOUR_MS)
+                val toMs = call.parameters["to"]?.toLongOrNull() ?: now
+                val maxProfiles = call.parameters["maxProfiles"]?.toIntOrNull()
+                    ?: ProfileMergeService.DEFAULT_MAX_PROFILES
+
+                runCatching {
+                    ProfileMergeService.mergeFlamegraph(
+                        organizationId = orgId,
+                        service = call.parameters["service"],
+                        profileType = call.parameters["type"],
+                        env = call.parameters["env"],
+                        host = call.parameters["host"],
+                        version = call.parameters["version"],
+                        fromMs = fromMs,
+                        toMs = toMs,
+                        sampleType = call.parameters["sampleType"],
+                        thread = call.parameters["thread"],
+                        maxProfiles = maxProfiles,
+                    )
+                }
+                    .onSuccess {
+                        call.respondText(it.toString(), ContentType.Application.Json)
+                    }
+                    .onFailure { respondGenericError(call, "mergeFlamegraph", it) }
+            }
+
+            // GET /v1/profiles/{profileId} - single profile metadata
+            get("/{profileId}") {
+                val orgId = call.orgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf(ERROR_KEY to INVALID_TOKEN),
+                )
+                val profileId = call.parameters["profileId"] ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf(ERROR_KEY to "Missing profileId"),
+                )
+
+                val profile = runCatching {
+                    ProfileIngestionService.getProfile(orgId, profileId)
+                }.getOrElse {
+                    return@get respondGenericError(call, "getProfile", it)
+                }
+                if (profile == null) {
+                    call.respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to "Profile not found"))
+                } else {
+                    call.respond(profile)
+                }
+            }
+
+            // GET /v1/profiles/{profileId}/download - raw profile bytes
+            get("/{profileId}/download") {
+                val orgId = call.orgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf(ERROR_KEY to INVALID_TOKEN),
+                )
+                val profileId = call.parameters["profileId"] ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf(ERROR_KEY to "Missing profileId"),
+                )
+
+                val meta = ProfileIngestionService.getProfileMeta(orgId, profileId)
+                if (meta == null) {
+                    call.respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to "Profile not found"))
                     return@get
                 }
 
@@ -112,30 +206,23 @@ fun Route.profileDashboardRoutes() {
                 if (data == null) {
                     call.respond(
                         HttpStatusCode.NotFound,
-                        mapOf("error" to "Profile data not found")
+                        mapOf(ERROR_KEY to "Profile data not found"),
                     )
                     return@get
                 }
 
                 val normalizedType = meta.profileType.lowercase()
                 val downloadData = if (normalizedType == "jfr") {
-                    runCatching {
-                        DecompressionService.decompress(data, null)
-                    }.getOrElse { data }
+                    runCatching { DecompressionService.decompress(data, null) }.getOrElse { data }
                 } else {
                     data
                 }
 
-                val fileName = profileDownloadFilename(
-                    profileId = profileId,
-                    profileType = normalizedType,
-                    data = downloadData
-                )
+                val fileName = profileDownloadFilename(profileId, normalizedType, downloadData)
                 call.response.headers.append(
                     HttpHeaders.ContentDisposition,
-                    "attachment; filename=\"$fileName\""
+                    "attachment; filename=\"$fileName\"",
                 )
-
                 call.respondBytes(
                     downloadData,
                     ContentType.Application.OctetStream,
@@ -143,75 +230,50 @@ fun Route.profileDashboardRoutes() {
                 )
             }
 
-            // GET /v1/profiles/{profileId}/flamegraph
+            // GET /v1/profiles/{profileId}/flamegraph - single-profile flamegraph
             get("/{profileId}/flamegraph") {
-                val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
-                    ?: return@get call.respond(
-                        HttpStatusCode.Unauthorized,
-                        mapOf("error" to "Invalid token")
-                    )
-                val profileId = call.parameters["profileId"]
-                    ?: return@get call.respond(
-                        HttpStatusCode.BadRequest,
-                        mapOf("error" to "Missing profileId")
-                    )
+                val orgId = call.orgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    mapOf(ERROR_KEY to INVALID_TOKEN),
+                )
+                val profileId = call.parameters["profileId"] ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    mapOf(ERROR_KEY to "Missing profileId"),
+                )
 
-                val meta =
-                    ProfileIngestionService.getProfileMeta(
-                        orgId,
-                        profileId
-                    )
+                val meta = ProfileIngestionService.getProfileMeta(orgId, profileId)
                 if (meta == null) {
-                    call.respond(
-                        HttpStatusCode.NotFound,
-                        mapOf("error" to "Profile not found")
-                    )
+                    call.respond(HttpStatusCode.NotFound, mapOf(ERROR_KEY to "Profile not found"))
                     return@get
                 }
 
                 val data = ProfileStorageService.read(meta.storageKey)
                 if (data == null) {
                     call.respondText(
-                        emptyFlamegraph().toString(),
+                        ProfileFlamegraphParser.emptyFlamegraph().toString(),
                         ContentType.Application.Json,
                     )
                     return@get
                 }
 
-                val sampleType = call.parameters["sampleType"]
-                val thread = call.parameters["thread"]
-
-                val frames = when (meta.source) {
-                    "sentry" -> parseSentryProfileToFrames(data)
-                    "datadog" -> {
-                        val isJfrType = meta.profileType.equals("jfr", ignoreCase = true)
-                        val isJfrPayload =
-                            DatadogPprofFlamegraphService.isLikelyJfrPayload(data)
-                        if (isJfrType || isJfrPayload) {
-                            DatadogJfrFlamegraphService.parseToFrames(data, sampleType, thread)
-                        } else {
-                            DatadogPprofFlamegraphService.parseToFrames(data, sampleType, thread)
-                        }
-                    }
-                    else -> emptyFlamegraph()
-                }
-
-                call.respondText(
-                    frames.toString(),
-                    ContentType.Application.Json,
+                val frames = ProfileFlamegraphParser.parse(
+                    source = meta.source,
+                    profileType = meta.profileType,
+                    data = data,
+                    sampleType = call.parameters["sampleType"],
+                    thread = call.parameters["thread"],
                 )
+                call.respondText(frames.toString(), ContentType.Application.Json)
             }
         }
     }
 }
 
-private fun emptyFlamegraph(): JsonObject = buildJsonObject {
-    put("frames", buildJsonArray {})
+private suspend fun respondGenericError(call: ApplicationCall, op: String, error: Throwable) {
+    // Never surface ClickHouse/query internals to the client.
+    logger.error(error) { "Profile dashboard query failed: $op" }
+    call.respond(HttpStatusCode.InternalServerError, mapOf(ERROR_KEY to GENERIC_ERROR))
 }
-
-private val profileJson = Json { ignoreUnknownKeys = true }
 
 private fun profileDownloadFilename(
     profileId: String,
@@ -230,101 +292,4 @@ private fun isGzip(data: ByteArray): Boolean {
     return data.size >= 2 &&
         data[0] == 0x1f.toByte() &&
         data[1] == 0x8b.toByte()
-}
-
-/**
- * Parse a Sentry profile JSON (frames[], stacks[], samples[])
- * into FlamegraphFrame[] tree format.
- */
-private fun parseSentryProfileToFrames(
-    data: ByteArray,
-): Map<String, Any> {
-    return suspendRunCatching {
-        val root = profileJson.parseToJsonElement(
-            String(data)
-        ).jsonObject
-        val profileObj = root["profile"]?.jsonObject
-            ?: return buildJsonObject {
-                put("frames", buildJsonArray {})
-            }
-
-        val frames = profileObj["frames"]?.jsonArray
-            ?: return buildJsonObject {
-                put("frames", buildJsonArray {})
-            }
-        val stacks = profileObj["stacks"]?.jsonArray
-            ?: return buildJsonObject {
-                put("frames", buildJsonArray {})
-            }
-        val samples = profileObj["samples"]?.jsonArray
-            ?: return buildJsonObject {
-                put("frames", buildJsonArray {})
-            }
-
-        data class MutableFrame(
-            val name: String,
-            var value: Int = 0,
-            val children: MutableMap<String, MutableFrame> =
-                mutableMapOf(),
-        )
-
-        val rootFrame = MutableFrame("(root)")
-
-        for (sample in samples) {
-            val stackIdx = sample.jsonObject["stack_id"]
-                ?.jsonPrimitive?.int ?: continue
-            if (stackIdx >= stacks.size) continue
-            val stack = stacks[stackIdx].jsonArray
-
-            // Walk from bottom (root) to top (leaf)
-            var current = rootFrame
-            for (i in stack.size - 1 downTo 0) {
-                val frameIdx = stack[i].jsonPrimitive.int
-                if (frameIdx >= frames.size) continue
-                val frameObj = frames[frameIdx].jsonObject
-                val fn = frameObj["function"]
-                    ?.jsonPrimitive?.content ?: "unknown"
-                val module = frameObj["module"]
-                    ?.jsonPrimitive?.content
-                val name = if (module != null) {
-                    "$module.$fn"
-                } else {
-                    fn
-                }
-                current = current.children.getOrPut(name) {
-                    MutableFrame(name)
-                }
-                current.value++
-            }
-        }
-
-        fun toJson(f: MutableFrame): JsonObject = buildJsonObject {
-            put("name", f.name)
-            put("value", f.value)
-            put(
-                "children",
-                buildJsonArray {
-                    for (child in f.children.values.sortedByDescending {
-                        it.value
-                    }) {
-                        add(toJson(child))
-                    }
-                }
-            )
-        }
-
-        buildJsonObject {
-            put(
-                "frames",
-                buildJsonArray {
-                    for (child in rootFrame.children.values
-                        .sortedByDescending { it.value }) {
-                        add(toJson(child))
-                    }
-                }
-            )
-        }
-    }.getOrElse { _ ->
-        buildJsonObject { put("frames", buildJsonArray {}) }
-    }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileFlamegraphParser.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileFlamegraphParser.kt
@@ -16,8 +16,8 @@
 
 package com.moneat.datadog.services
 
-import com.moneat.utils.suspendRunCatching
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -37,7 +37,20 @@ import kotlinx.serialization.json.put
 object ProfileFlamegraphParser {
     private const val SENTRY_SOURCE = "sentry"
     private const val DATADOG_SOURCE = "datadog"
+    private const val JFR_PROFILE_TYPE = "jfr"
     private val json = Json { ignoreUnknownKeys = true }
+
+    private data class SentryProfileData(
+        val frames: JsonArray,
+        val stacks: JsonArray,
+        val samples: JsonArray,
+    )
+
+    private data class MutableFrame(
+        val name: String,
+        var value: Int = 0,
+        val children: MutableMap<String, MutableFrame> = mutableMapOf(),
+    )
 
     fun emptyFlamegraph(): JsonObject = buildJsonObject {
         put("frames", buildJsonArray {})
@@ -53,7 +66,7 @@ object ProfileFlamegraphParser {
         return when (source) {
             SENTRY_SOURCE -> parseSentryProfileToFrames(data)
             DATADOG_SOURCE -> {
-                val isJfrType = profileType.equals("jfr", ignoreCase = true)
+                val isJfrType = profileType.lowercase() == JFR_PROFILE_TYPE
                 val isJfrPayload = DatadogPprofFlamegraphService.isLikelyJfrPayload(data)
                 if (isJfrType || isJfrPayload) {
                     DatadogJfrFlamegraphService.parseToFrames(data, sampleType, thread)
@@ -70,64 +83,59 @@ object ProfileFlamegraphParser {
      * into the flamegraph tree format.
      */
     private fun parseSentryProfileToFrames(data: ByteArray): JsonObject {
-        return suspendRunCatching {
+        val sentryData = parseSentryData(data) ?: return emptyFlamegraph()
+        val rootFrame = MutableFrame("(root)")
+        sentryData.samples.forEach { sample ->
+            addSampleToFrameTree(sample.jsonObject, sentryData.stacks, sentryData.frames, rootFrame)
+        }
+        return buildJsonObject {
+            put("frames", childrenToJson(rootFrame))
+        }
+    }
+
+    private fun parseSentryData(data: ByteArray): SentryProfileData? {
+        return runCatching {
             val root = json.parseToJsonElement(String(data)).jsonObject
-            val profileObj = root["profile"]?.jsonObject ?: return emptyFlamegraph()
-            val frames = profileObj["frames"]?.jsonArray ?: return emptyFlamegraph()
-            val stacks = profileObj["stacks"]?.jsonArray ?: return emptyFlamegraph()
-            val samples = profileObj["samples"]?.jsonArray ?: return emptyFlamegraph()
-
-            data class MutableFrame(
-                val name: String,
-                var value: Int = 0,
-                val children: MutableMap<String, MutableFrame> = mutableMapOf(),
+            val profileObj = root["profile"]?.jsonObject ?: return null
+            SentryProfileData(
+                frames = profileObj["frames"]?.jsonArray ?: return null,
+                stacks = profileObj["stacks"]?.jsonArray ?: return null,
+                samples = profileObj["samples"]?.jsonArray ?: return null,
             )
+        }.getOrNull()
+    }
 
-            val rootFrame = MutableFrame("(root)")
+    private fun addSampleToFrameTree(
+        sample: JsonObject,
+        stacks: JsonArray,
+        frames: JsonArray,
+        rootFrame: MutableFrame,
+    ) {
+        val stackIdx = sample["stack_id"]?.jsonPrimitive?.int ?: return
+        val stack = stacks.getOrNull(stackIdx)?.jsonArray ?: return
+        var current = rootFrame
+        for (i in stack.size - 1 downTo 0) {
+            val frameIdx = stack[i].jsonPrimitive.int
+            val frameObj = frames.getOrNull(frameIdx)?.jsonObject ?: continue
+            val name = sentryFrameName(frameObj)
+            current = current.children.getOrPut(name) { MutableFrame(name) }
+            current.value++
+        }
+    }
 
-            for (sample in samples) {
-                val stackIdx = sample.jsonObject["stack_id"]
-                    ?.jsonPrimitive?.int ?: continue
-                if (stackIdx >= stacks.size) continue
-                val stack = stacks[stackIdx].jsonArray
+    private fun sentryFrameName(frameObj: JsonObject): String {
+        val function = frameObj["function"]?.jsonPrimitive?.content ?: "unknown"
+        val module = frameObj["module"]?.jsonPrimitive?.content
+        return if (module != null) "$module.$function" else function
+    }
 
-                // Walk from bottom (root) to top (leaf)
-                var current = rootFrame
-                for (i in stack.size - 1 downTo 0) {
-                    val frameIdx = stack[i].jsonPrimitive.int
-                    if (frameIdx >= frames.size) continue
-                    val frameObj = frames[frameIdx].jsonObject
-                    val fn = frameObj["function"]?.jsonPrimitive?.content ?: "unknown"
-                    val module = frameObj["module"]?.jsonPrimitive?.content
-                    val name = if (module != null) "$module.$fn" else fn
-                    current = current.children.getOrPut(name) { MutableFrame(name) }
-                    current.value++
-                }
-            }
+    private fun childrenToJson(parent: MutableFrame): JsonArray = buildJsonArray {
+        parent.children.values.sortedByDescending { it.value }.forEach { add(frameToJson(it)) }
+    }
 
-            fun toJson(f: MutableFrame): JsonObject = buildJsonObject {
-                put("name", f.name)
-                put("value", f.value)
-                put(
-                    "children",
-                    buildJsonArray {
-                        for (child in f.children.values.sortedByDescending { it.value }) {
-                            add(toJson(child))
-                        }
-                    },
-                )
-            }
-
-            buildJsonObject {
-                put(
-                    "frames",
-                    buildJsonArray {
-                        for (child in rootFrame.children.values.sortedByDescending { it.value }) {
-                            add(toJson(child))
-                        }
-                    },
-                )
-            }
-        }.getOrElse { emptyFlamegraph() }
+    private fun frameToJson(frame: MutableFrame): JsonObject = buildJsonObject {
+        put("name", frame.name)
+        put("value", frame.value)
+        put("children", childrenToJson(frame))
     }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileFlamegraphParser.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileFlamegraphParser.kt
@@ -1,0 +1,133 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.services
+
+import com.moneat.utils.suspendRunCatching
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Turns a stored profile payload into the flamegraph JSON shape consumed by the
+ * dashboard ({ frames, sampleTypes, threads, selectedSampleType, unit, totalSamples }).
+ *
+ * Single source of truth for the source/type → parser dispatch, shared by the
+ * per-profile flamegraph route and [ProfileMergeService].
+ */
+object ProfileFlamegraphParser {
+    private const val SENTRY_SOURCE = "sentry"
+    private const val DATADOG_SOURCE = "datadog"
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun emptyFlamegraph(): JsonObject = buildJsonObject {
+        put("frames", buildJsonArray {})
+    }
+
+    fun parse(
+        source: String,
+        profileType: String,
+        data: ByteArray,
+        sampleType: String?,
+        thread: String?,
+    ): JsonObject {
+        return when (source) {
+            SENTRY_SOURCE -> parseSentryProfileToFrames(data)
+            DATADOG_SOURCE -> {
+                val isJfrType = profileType.equals("jfr", ignoreCase = true)
+                val isJfrPayload = DatadogPprofFlamegraphService.isLikelyJfrPayload(data)
+                if (isJfrType || isJfrPayload) {
+                    DatadogJfrFlamegraphService.parseToFrames(data, sampleType, thread)
+                } else {
+                    DatadogPprofFlamegraphService.parseToFrames(data, sampleType, thread)
+                }
+            }
+            else -> emptyFlamegraph()
+        }
+    }
+
+    /**
+     * Parse a Sentry profile JSON (frames[], stacks[], samples[])
+     * into the flamegraph tree format.
+     */
+    private fun parseSentryProfileToFrames(data: ByteArray): JsonObject {
+        return suspendRunCatching {
+            val root = json.parseToJsonElement(String(data)).jsonObject
+            val profileObj = root["profile"]?.jsonObject ?: return emptyFlamegraph()
+            val frames = profileObj["frames"]?.jsonArray ?: return emptyFlamegraph()
+            val stacks = profileObj["stacks"]?.jsonArray ?: return emptyFlamegraph()
+            val samples = profileObj["samples"]?.jsonArray ?: return emptyFlamegraph()
+
+            data class MutableFrame(
+                val name: String,
+                var value: Int = 0,
+                val children: MutableMap<String, MutableFrame> = mutableMapOf(),
+            )
+
+            val rootFrame = MutableFrame("(root)")
+
+            for (sample in samples) {
+                val stackIdx = sample.jsonObject["stack_id"]
+                    ?.jsonPrimitive?.int ?: continue
+                if (stackIdx >= stacks.size) continue
+                val stack = stacks[stackIdx].jsonArray
+
+                // Walk from bottom (root) to top (leaf)
+                var current = rootFrame
+                for (i in stack.size - 1 downTo 0) {
+                    val frameIdx = stack[i].jsonPrimitive.int
+                    if (frameIdx >= frames.size) continue
+                    val frameObj = frames[frameIdx].jsonObject
+                    val fn = frameObj["function"]?.jsonPrimitive?.content ?: "unknown"
+                    val module = frameObj["module"]?.jsonPrimitive?.content
+                    val name = if (module != null) "$module.$fn" else fn
+                    current = current.children.getOrPut(name) { MutableFrame(name) }
+                    current.value++
+                }
+            }
+
+            fun toJson(f: MutableFrame): JsonObject = buildJsonObject {
+                put("name", f.name)
+                put("value", f.value)
+                put(
+                    "children",
+                    buildJsonArray {
+                        for (child in f.children.values.sortedByDescending { it.value }) {
+                            add(toJson(child))
+                        }
+                    },
+                )
+            }
+
+            buildJsonObject {
+                put(
+                    "frames",
+                    buildJsonArray {
+                        for (child in rootFrame.children.values.sortedByDescending { it.value }) {
+                            add(toJson(child))
+                        }
+                    },
+                )
+            }
+        }.getOrElse { emptyFlamegraph() }
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
@@ -20,6 +20,12 @@ import com.moneat.config.ClickHouseClient
 import com.moneat.datadog.models.DdProfileEvent
 import com.moneat.datadog.models.DdProfileListResponse
 import com.moneat.datadog.models.DdProfileResponse
+import com.moneat.datadog.models.DdProfileSeriesPoint
+import com.moneat.datadog.models.DdProfileServiceSummary
+import com.moneat.datadog.models.DdProfileServicesResponse
+import com.moneat.datadog.models.DdProfileTimeseriesPoint
+import com.moneat.datadog.models.DdProfileTimeseriesResponse
+import com.moneat.datadog.models.DdProfileTypeCount
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
@@ -27,6 +33,7 @@ import io.ktor.http.isSuccess
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
@@ -40,6 +47,34 @@ import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
+/** Server-side filters/paging for the profile list endpoint. */
+data class DdProfileListQuery(
+    val service: String? = null,
+    val profileType: String? = null,
+    val source: String? = null,
+    val env: String? = null,
+    val host: String? = null,
+    val version: String? = null,
+    val fromMs: Long? = null,
+    val toMs: Long? = null,
+    val limit: Int = 50,
+    val offset: Int = 0,
+)
+
+/** A profile selected for inclusion in a merged flamegraph. */
+data class ProfileMergeCandidate(
+    val profileId: String,
+    val storageKey: String,
+    val profileType: String,
+    val source: String,
+)
+
+/** Sampled merge candidates plus the total profiles in the window. */
+data class ProfileMergeSelection(
+    val totalInWindow: Long,
+    val candidates: List<ProfileMergeCandidate>,
+)
+
 object ProfileIngestionService {
     private val clickhouseDb by lazy { ClickHouseClient.getDatabase() }
     private val json = Json { ignoreUnknownKeys = true }
@@ -47,6 +82,14 @@ object ProfileIngestionService {
 
     private const val NANOS_PER_MILLI = 1_000_000L
     private const val MIN_PROFILE_PARTS = 3
+    private const val DEFAULT_SOURCE = "datadog"
+    private const val MILLIS_PER_SECOND_L = 1000L
+    private const val DEFAULT_SERVICES_LIMIT = 200
+    private const val SPARKLINE_LOOKBACK_SECONDS = 86_400L
+    private const val SPARKLINE_BUCKETS = 24
+    private const val MIN_BUCKET_SECONDS = 60L
+    private const val MAX_TIMESERIES_BUCKETS = 500
+    private const val MERGE_MAX_PROFILES = 50
 
     private data class LockEntry(val mutex: Mutex = Mutex(), val refs: AtomicInteger = AtomicInteger(0))
     private val sessionLocks = ConcurrentHashMap<String, LockEntry>()
@@ -191,7 +234,7 @@ object ProfileIngestionService {
                 '${escapeSql(storageKey)}',
                 ${mapToSqlMap(tags)},
                 ${fileParts.sumOf { it.second.size.toLong() }},
-                'datadog'
+                '$DEFAULT_SOURCE'
             )
         """.trimIndent()
 
@@ -215,25 +258,21 @@ object ProfileIngestionService {
 
     suspend fun listProfiles(
         organizationId: Int,
-        service: String?,
-        profileType: String?,
-        source: String?,
-        limit: Int,
-        offset: Int,
+        query: DdProfileListQuery,
     ): DdProfileListResponse {
-        val filters = mutableListOf(
-            ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val whereClause = buildProfileFilters(
+            organizationId,
+            service = query.service,
+            profileType = query.profileType,
+            source = query.source,
+            env = query.env,
+            host = query.host,
+            version = query.version,
+            fromMs = query.fromMs,
+            toMs = query.toMs,
         )
-        service?.let {
-            filters.add("service = '${escapeSql(it)}'")
-        }
-        profileType?.let {
-            filters.add("profile_type = '${escapeSql(it)}'")
-        }
-        source?.let {
-            filters.add("source = '${escapeSql(it)}'")
-        }
-        val whereClause = filters.joinToString(" AND ")
+        val limit = query.limit
+        val offset = query.offset
 
         val countQuery = """
             SELECT count()
@@ -268,56 +307,258 @@ object ProfileIngestionService {
         } else {
             result.trim().lines()
                 .filter { it.isNotBlank() }
-                .map { line ->
-                    val obj = json.parseToJsonElement(line).jsonObject
-                    val tagsMap = parseJsonStringMap(obj["tags"])
-                    val serviceFromColumn =
-                        obj["service"]?.jsonPrimitive?.content ?: ""
-                    val service = if (serviceFromColumn.isNotBlank()) {
-                        serviceFromColumn
-                    } else {
-                        firstNonBlankTag(
-                            tagsMap,
-                            "service",
-                            "service.name",
-                            "service_name"
-                        )
-                    }
-                    DdProfileResponse(
-                        profileId = obj["profile_id"]!!
-                            .jsonPrimitive.content,
-                        host = obj["host"]?.jsonPrimitive?.content
-                            ?: "",
-                        service = service,
-                        env = obj["env"]?.jsonPrimitive?.content
-                            ?: "",
-                        version = obj["version"]?.jsonPrimitive?.content
-                            ?: "",
-                        runtime = obj["runtime"]?.jsonPrimitive?.content
-                            ?: "",
-                        language = obj["language"]?.jsonPrimitive?.content
-                            ?: "",
-                        profileType = obj["profile_type"]!!
-                            .jsonPrimitive.content,
-                        startTime = obj["start_time"]!!
-                            .jsonPrimitive.content,
-                        endTime = obj["end_time"]!!
-                            .jsonPrimitive.content,
-                        durationNs = obj["duration_ns"]!!
-                            .jsonPrimitive.long,
-                        sizeBytes = obj["size_bytes"]!!
-                            .jsonPrimitive.long,
-                        tags = tagsMap,
-                        source = obj["source"]?.jsonPrimitive?.content
-                            ?: "datadog",
-                    )
-                }
+                .map { parseProfileRow(it) }
         }
 
         return DdProfileListResponse(
             profiles = profiles,
             totalCount = totalCount
         )
+    }
+
+    /** Fetch a single profile's metadata by id (null when not found). */
+    suspend fun getProfile(
+        organizationId: Int,
+        profileId: String,
+    ): DdProfileResponse? {
+        val query = """
+            SELECT
+                toString(profile_id) as profile_id,
+                host, service, env, version,
+                runtime, language, profile_type,
+                toString(start_time) as start_time,
+                toString(end_time) as end_time,
+                duration_ns, storage_key,
+                tags, size_bytes, source
+            FROM `$clickhouseDb`.profiles
+            WHERE ${ClickHouseQueryUtils.orgIdClause(organizationId.toLong())}
+              AND toString(profile_id) = '${escapeSql(profileId)}'
+            LIMIT 1
+            FORMAT JSONEachRow
+        """.trimIndent()
+        val result = ClickHouseClient.executeWithFormat(query, "")
+        val line = result.trim().lines().firstOrNull { it.isNotBlank() }
+            ?: return null
+        return parseProfileRow(line)
+    }
+
+    /**
+     * Per-service rollup powering the Profiles overview. Counts/sizes/hosts
+     * are over the full window (or all retained data when [fromMs]/[toMs] are
+     * null); each service carries a small activity sparkline.
+     */
+    suspend fun listServices(
+        organizationId: Int,
+        fromMs: Long?,
+        toMs: Long?,
+    ): DdProfileServicesResponse {
+        val whereClause = buildProfileFilters(
+            organizationId,
+            fromMs = fromMs,
+            toMs = toMs,
+        )
+
+        val rollupQuery = """
+            SELECT
+                service,
+                count() AS profileCount,
+                uniqExact(host) AS hostCount,
+                sum(size_bytes) AS totalSizeBytes,
+                toString(min(start_time)) AS firstSeen,
+                toString(max(start_time)) AS lastSeen,
+                toUInt64(round(avg(duration_ns))) AS avgDurationNs,
+                arrayFilter(x -> x != '', groupUniqArray(env)) AS environments,
+                arrayFilter(x -> x != '', groupUniqArray(language)) AS languages,
+                arrayFilter(x -> x != '', groupUniqArray(runtime)) AS runtimes
+            FROM `$clickhouseDb`.profiles
+            WHERE $whereClause
+            GROUP BY service
+            ORDER BY profileCount DESC
+            LIMIT $DEFAULT_SERVICES_LIMIT
+            FORMAT JSONEachRow
+        """.trimIndent()
+
+        val typesQuery = """
+            SELECT service, profile_type AS profileType, count() AS count
+            FROM `$clickhouseDb`.profiles
+            WHERE $whereClause
+            GROUP BY service, profile_type
+            FORMAT JSONEachRow
+        """.trimIndent()
+
+        val sparkStep = sparklineStepSeconds(fromMs, toMs)
+        val sparkWhere = if (fromMs != null && toMs != null) {
+            whereClause
+        } else {
+            "$whereClause AND start_time >= now() - INTERVAL $SPARKLINE_LOOKBACK_SECONDS SECOND"
+        }
+        val sparkQuery = """
+            SELECT
+                service,
+                toUnixTimestamp64Milli(
+                    toStartOfInterval(start_time, INTERVAL $sparkStep SECOND)
+                ) AS ts,
+                count() AS count
+            FROM `$clickhouseDb`.profiles
+            WHERE $sparkWhere
+            GROUP BY service, ts
+            ORDER BY ts
+            FORMAT JSONEachRow
+        """.trimIndent()
+
+        val typeCounts = mutableMapOf<String, MutableList<DdProfileTypeCount>>()
+        parseJsonRows(ClickHouseClient.executeWithFormat(typesQuery, "")).forEach { obj ->
+            val svc = obj["service"]?.jsonPrimitive?.content ?: ""
+            typeCounts.getOrPut(svc) { mutableListOf() }.add(
+                DdProfileTypeCount(
+                    profileType = obj["profileType"]?.jsonPrimitive?.content ?: "",
+                    count = obj["count"]?.jsonPrimitive?.long ?: 0,
+                )
+            )
+        }
+
+        val series = mutableMapOf<String, MutableList<DdProfileSeriesPoint>>()
+        parseJsonRows(ClickHouseClient.executeWithFormat(sparkQuery, "")).forEach { obj ->
+            val svc = obj["service"]?.jsonPrimitive?.content ?: ""
+            series.getOrPut(svc) { mutableListOf() }.add(
+                DdProfileSeriesPoint(
+                    ts = obj["ts"]?.jsonPrimitive?.long ?: 0,
+                    count = obj["count"]?.jsonPrimitive?.long ?: 0,
+                )
+            )
+        }
+
+        val services = parseJsonRows(
+            ClickHouseClient.executeWithFormat(rollupQuery, "")
+        ).map { obj ->
+            val svc = obj["service"]?.jsonPrimitive?.content ?: ""
+            DdProfileServiceSummary(
+                service = svc,
+                languages = stringArray(obj["languages"]),
+                runtimes = stringArray(obj["runtimes"]),
+                environments = stringArray(obj["environments"]),
+                types = typeCounts[svc]?.sortedByDescending { it.count } ?: emptyList(),
+                hostCount = obj["hostCount"]?.jsonPrimitive?.long ?: 0,
+                profileCount = obj["profileCount"]?.jsonPrimitive?.long ?: 0,
+                totalSizeBytes = obj["totalSizeBytes"]?.jsonPrimitive?.long ?: 0,
+                firstSeen = obj["firstSeen"]?.jsonPrimitive?.content ?: "",
+                lastSeen = obj["lastSeen"]?.jsonPrimitive?.content ?: "",
+                avgDurationNs = obj["avgDurationNs"]?.jsonPrimitive?.long ?: 0,
+                series = series[svc] ?: emptyList(),
+            )
+        }
+
+        return DdProfileServicesResponse(
+            services = services,
+            totalProfiles = services.sumOf { it.profileCount },
+            totalSizeBytes = services.sumOf { it.totalSizeBytes },
+            serviceCount = services.size,
+            hostCount = services.sumOf { it.hostCount },
+            typeCount = services.flatMap { s -> s.types.map { it.profileType } }
+                .toSet().size,
+        )
+    }
+
+    /** Profile-volume time series for a service over a window. */
+    suspend fun timeseries(
+        organizationId: Int,
+        service: String?,
+        profileType: String?,
+        env: String?,
+        host: String?,
+        fromMs: Long,
+        toMs: Long,
+        buckets: Int,
+    ): DdProfileTimeseriesResponse {
+        val safeBuckets = buckets.coerceIn(1, MAX_TIMESERIES_BUCKETS)
+        val windowSec = ((toMs - fromMs) / MILLIS_PER_SECOND_L).coerceAtLeast(1)
+        val stepSeconds = (windowSec / safeBuckets).coerceAtLeast(MIN_BUCKET_SECONDS)
+        val whereClause = buildProfileFilters(
+            organizationId,
+            service = service,
+            profileType = profileType,
+            env = env,
+            host = host,
+            fromMs = fromMs,
+            toMs = toMs,
+        )
+        val query = """
+            SELECT
+                toUnixTimestamp64Milli(
+                    toStartOfInterval(start_time, INTERVAL $stepSeconds SECOND)
+                ) AS ts,
+                count() AS count,
+                sum(size_bytes) AS sizeBytes
+            FROM `$clickhouseDb`.profiles
+            WHERE $whereClause
+            GROUP BY ts
+            ORDER BY ts
+            FORMAT JSONEachRow
+        """.trimIndent()
+        val points = parseJsonRows(ClickHouseClient.executeWithFormat(query, "")).map { obj ->
+            DdProfileTimeseriesPoint(
+                ts = obj["ts"]?.jsonPrimitive?.long ?: 0,
+                count = obj["count"]?.jsonPrimitive?.long ?: 0,
+                sizeBytes = obj["sizeBytes"]?.jsonPrimitive?.long ?: 0,
+            )
+        }
+        return DdProfileTimeseriesResponse(points = points, bucketSeconds = stepSeconds)
+    }
+
+    /**
+     * Evenly sample up to [maxProfiles] profiles across the window so a wide
+     * window stays representative without reading every stored blob.
+     */
+    suspend fun selectProfilesForMerge(
+        organizationId: Int,
+        service: String?,
+        profileType: String?,
+        env: String?,
+        host: String?,
+        version: String?,
+        fromMs: Long,
+        toMs: Long,
+        maxProfiles: Int,
+    ): ProfileMergeSelection {
+        val cap = maxProfiles.coerceIn(1, MERGE_MAX_PROFILES)
+        val whereClause = buildProfileFilters(
+            organizationId,
+            service = service,
+            profileType = profileType,
+            env = env,
+            host = host,
+            version = version,
+            fromMs = fromMs,
+            toMs = toMs,
+        )
+        val query = """
+            WITH
+                (SELECT count() FROM `$clickhouseDb`.profiles WHERE $whereClause) AS total,
+                greatest(intDiv(total + $cap - 1, $cap), 1) AS stride
+            SELECT toString(profile_id) AS profile_id, storage_key,
+                   profile_type AS profileType, source, total
+            FROM (
+                SELECT profile_id, storage_key, profile_type, source, start_time,
+                       row_number() OVER (ORDER BY start_time) AS rn
+                FROM `$clickhouseDb`.profiles
+                WHERE $whereClause
+            )
+            WHERE (rn - 1) % stride = 0
+            ORDER BY start_time
+            LIMIT $cap
+            FORMAT JSONEachRow
+        """.trimIndent()
+        val rows = parseJsonRows(ClickHouseClient.executeWithFormat(query, ""))
+        val total = rows.firstOrNull()?.get("total")?.jsonPrimitive?.long ?: 0
+        val candidates = rows.map { obj ->
+            ProfileMergeCandidate(
+                profileId = obj["profile_id"]?.jsonPrimitive?.content ?: "",
+                storageKey = obj["storage_key"]?.jsonPrimitive?.content ?: "",
+                profileType = obj["profileType"]?.jsonPrimitive?.content ?: "",
+                source = obj["source"]?.jsonPrimitive?.content ?: DEFAULT_SOURCE,
+            )
+        }.filter { it.storageKey.isNotBlank() }
+        return ProfileMergeSelection(totalInWindow = total, candidates = candidates)
     }
 
     suspend fun getProfileStorageKey(
@@ -365,13 +606,98 @@ object ProfileIngestionService {
         return if (parts.size >= MIN_PROFILE_PARTS) {
             ProfileMeta(parts[0], parts[1], parts[2])
         } else if (parts.size >= 2) {
-            ProfileMeta(parts[0], parts[1], "datadog")
+            ProfileMeta(parts[0], parts[1], DEFAULT_SOURCE)
         } else {
             null
         }
     }
 
     // --- Internal helpers ---
+
+    private fun buildProfileFilters(
+        organizationId: Int,
+        service: String? = null,
+        profileType: String? = null,
+        source: String? = null,
+        env: String? = null,
+        host: String? = null,
+        version: String? = null,
+        fromMs: Long? = null,
+        toMs: Long? = null,
+    ): String {
+        val filters = mutableListOf(
+            ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        )
+        service?.takeIf { it.isNotBlank() }?.let {
+            filters.add("service = '${escapeSql(it)}'")
+        }
+        profileType?.takeIf { it.isNotBlank() }?.let {
+            filters.add("profile_type = '${escapeSql(it)}'")
+        }
+        source?.takeIf { it.isNotBlank() }?.let {
+            filters.add("source = '${escapeSql(it)}'")
+        }
+        env?.takeIf { it.isNotBlank() }?.let {
+            filters.add("env = '${escapeSql(it)}'")
+        }
+        host?.takeIf { it.isNotBlank() }?.let {
+            filters.add("host = '${escapeSql(it)}'")
+        }
+        version?.takeIf { it.isNotBlank() }?.let {
+            filters.add("version = '${escapeSql(it)}'")
+        }
+        fromMs?.let { filters.add("start_time >= fromUnixTimestamp64Milli($it)") }
+        toMs?.let { filters.add("start_time < fromUnixTimestamp64Milli($it)") }
+        return filters.joinToString(" AND ")
+    }
+
+    private fun parseProfileRow(line: String): DdProfileResponse {
+        val obj = json.parseToJsonElement(line).jsonObject
+        val tagsMap = parseJsonStringMap(obj["tags"])
+        val serviceFromColumn = obj["service"]?.jsonPrimitive?.content ?: ""
+        val service = serviceFromColumn.ifBlank {
+            firstNonBlankTag(tagsMap, "service", "service.name", "service_name")
+        }
+        return DdProfileResponse(
+            profileId = obj["profile_id"]!!.jsonPrimitive.content,
+            host = obj["host"]?.jsonPrimitive?.content ?: "",
+            service = service,
+            env = obj["env"]?.jsonPrimitive?.content ?: "",
+            version = obj["version"]?.jsonPrimitive?.content ?: "",
+            runtime = obj["runtime"]?.jsonPrimitive?.content ?: "",
+            language = obj["language"]?.jsonPrimitive?.content ?: "",
+            profileType = obj["profile_type"]!!.jsonPrimitive.content,
+            startTime = obj["start_time"]!!.jsonPrimitive.content,
+            endTime = obj["end_time"]!!.jsonPrimitive.content,
+            durationNs = obj["duration_ns"]!!.jsonPrimitive.long,
+            sizeBytes = obj["size_bytes"]!!.jsonPrimitive.long,
+            tags = tagsMap,
+            source = obj["source"]?.jsonPrimitive?.content ?: DEFAULT_SOURCE,
+        )
+    }
+
+    private fun parseJsonRows(raw: String): List<kotlinx.serialization.json.JsonObject> {
+        if (raw.isBlank()) return emptyList()
+        return raw.trim().lines()
+            .filter { it.isNotBlank() }
+            .map { json.parseToJsonElement(it).jsonObject }
+    }
+
+    private fun stringArray(
+        element: kotlinx.serialization.json.JsonElement?,
+    ): List<String> {
+        return element?.jsonArray
+            ?.mapNotNull { it.jsonPrimitive.content.takeIf { c -> c.isNotBlank() } }
+            ?: emptyList()
+    }
+
+    private fun sparklineStepSeconds(fromMs: Long?, toMs: Long?): Long {
+        if (fromMs == null || toMs == null || toMs <= fromMs) {
+            return SPARKLINE_LOOKBACK_SECONDS / SPARKLINE_BUCKETS
+        }
+        val windowSec = (toMs - fromMs) / MILLIS_PER_SECOND_L
+        return (windowSec / SPARKLINE_BUCKETS).coerceAtLeast(MIN_BUCKET_SECONDS)
+    }
 
     private data class ExistingSession(
         val profileId: String,

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
@@ -29,6 +29,7 @@ import com.moneat.datadog.models.DdProfileTypeCount
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -43,7 +44,6 @@ import java.time.format.DateTimeParseException
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
@@ -61,6 +61,46 @@ data class DdProfileListQuery(
     val offset: Int = 0,
 )
 
+/** Shared dimensions used by profile dashboard queries. */
+data class ProfileQueryFilters(
+    val service: String? = null,
+    val profileType: String? = null,
+    val source: String? = null,
+    val env: String? = null,
+    val host: String? = null,
+    val version: String? = null,
+)
+
+/** Optional lower/upper time bounds for ClickHouse profile filters. */
+data class ProfileTimeFilter(
+    val fromMs: Long? = null,
+    val toMs: Long? = null,
+)
+
+/** Required time window for dashboard aggregations. */
+data class ProfileTimeWindow(
+    val fromMs: Long,
+    val toMs: Long,
+) {
+    fun toFilter(): ProfileTimeFilter = ProfileTimeFilter(fromMs, toMs)
+}
+
+/** Profile-volume time-series query shape. */
+data class ProfileTimeseriesQuery(
+    val organizationId: Int,
+    val filters: ProfileQueryFilters,
+    val window: ProfileTimeWindow,
+    val buckets: Int,
+)
+
+/** Candidate sampling query shape for merged flamegraphs. */
+data class ProfileMergeSelectionQuery(
+    val organizationId: Int,
+    val filters: ProfileQueryFilters,
+    val window: ProfileTimeWindow,
+    val maxProfiles: Int,
+)
+
 /** A profile selected for inclusion in a merged flamegraph. */
 data class ProfileMergeCandidate(
     val profileId: String,
@@ -74,6 +114,16 @@ data class ProfileMergeSelection(
     val totalInWindow: Long,
     val candidates: List<ProfileMergeCandidate>,
 )
+
+private fun DdProfileListQuery.toFilters(): ProfileQueryFilters =
+    ProfileQueryFilters(
+        service = service,
+        profileType = profileType,
+        source = source,
+        env = env,
+        host = host,
+        version = version,
+    )
 
 object ProfileIngestionService {
     private val clickhouseDb by lazy { ClickHouseClient.getDatabase() }
@@ -261,15 +311,9 @@ object ProfileIngestionService {
         query: DdProfileListQuery,
     ): DdProfileListResponse {
         val whereClause = buildProfileFilters(
-            organizationId,
-            service = query.service,
-            profileType = query.profileType,
-            source = query.source,
-            env = query.env,
-            host = query.host,
-            version = query.version,
-            fromMs = query.fromMs,
-            toMs = query.toMs,
+            organizationId = organizationId,
+            filters = query.toFilters(),
+            timeFilter = ProfileTimeFilter(query.fromMs, query.toMs),
         )
         val limit = query.limit
         val offset = query.offset
@@ -285,7 +329,7 @@ object ProfileIngestionService {
         )
         val totalCount = countResult.trim().toLongOrNull() ?: 0
 
-        val query = """
+        val listQuery = """
             SELECT
                 toString(profile_id) as profile_id,
                 host, service, env, version,
@@ -301,7 +345,7 @@ object ProfileIngestionService {
             FORMAT JSONEachRow
         """.trimIndent()
 
-        val result = ClickHouseClient.executeWithFormat(query, "")
+        val result = ClickHouseClient.executeWithFormat(listQuery, "")
         val profiles = if (result.isBlank()) {
             emptyList()
         } else {
@@ -353,9 +397,8 @@ object ProfileIngestionService {
         toMs: Long?,
     ): DdProfileServicesResponse {
         val whereClause = buildProfileFilters(
-            organizationId,
-            fromMs = fromMs,
-            toMs = toMs,
+            organizationId = organizationId,
+            timeFilter = ProfileTimeFilter(fromMs, toMs),
         )
 
         val rollupQuery = """
@@ -460,29 +503,18 @@ object ProfileIngestionService {
     }
 
     /** Profile-volume time series for a service over a window. */
-    suspend fun timeseries(
-        organizationId: Int,
-        service: String?,
-        profileType: String?,
-        env: String?,
-        host: String?,
-        fromMs: Long,
-        toMs: Long,
-        buckets: Int,
-    ): DdProfileTimeseriesResponse {
-        val safeBuckets = buckets.coerceIn(1, MAX_TIMESERIES_BUCKETS)
+    suspend fun timeseries(query: ProfileTimeseriesQuery): DdProfileTimeseriesResponse {
+        val safeBuckets = query.buckets.coerceIn(1, MAX_TIMESERIES_BUCKETS)
+        val fromMs = query.window.fromMs
+        val toMs = query.window.toMs
         val windowSec = ((toMs - fromMs) / MILLIS_PER_SECOND_L).coerceAtLeast(1)
         val stepSeconds = (windowSec / safeBuckets).coerceAtLeast(MIN_BUCKET_SECONDS)
         val whereClause = buildProfileFilters(
-            organizationId,
-            service = service,
-            profileType = profileType,
-            env = env,
-            host = host,
-            fromMs = fromMs,
-            toMs = toMs,
+            organizationId = query.organizationId,
+            filters = query.filters,
+            timeFilter = query.window.toFilter(),
         )
-        val query = """
+        val sql = """
             SELECT
                 toUnixTimestamp64Milli(
                     toStartOfInterval(start_time, INTERVAL $stepSeconds SECOND)
@@ -495,7 +527,7 @@ object ProfileIngestionService {
             ORDER BY ts
             FORMAT JSONEachRow
         """.trimIndent()
-        val points = parseJsonRows(ClickHouseClient.executeWithFormat(query, "")).map { obj ->
+        val points = parseJsonRows(ClickHouseClient.executeWithFormat(sql, "")).map { obj ->
             DdProfileTimeseriesPoint(
                 ts = obj["ts"]?.jsonPrimitive?.long ?: 0,
                 count = obj["count"]?.jsonPrimitive?.long ?: 0,
@@ -509,29 +541,14 @@ object ProfileIngestionService {
      * Evenly sample up to [maxProfiles] profiles across the window so a wide
      * window stays representative without reading every stored blob.
      */
-    suspend fun selectProfilesForMerge(
-        organizationId: Int,
-        service: String?,
-        profileType: String?,
-        env: String?,
-        host: String?,
-        version: String?,
-        fromMs: Long,
-        toMs: Long,
-        maxProfiles: Int,
-    ): ProfileMergeSelection {
-        val cap = maxProfiles.coerceIn(1, MERGE_MAX_PROFILES)
+    suspend fun selectProfilesForMerge(query: ProfileMergeSelectionQuery): ProfileMergeSelection {
+        val cap = query.maxProfiles.coerceIn(1, MERGE_MAX_PROFILES)
         val whereClause = buildProfileFilters(
-            organizationId,
-            service = service,
-            profileType = profileType,
-            env = env,
-            host = host,
-            version = version,
-            fromMs = fromMs,
-            toMs = toMs,
+            organizationId = query.organizationId,
+            filters = query.filters,
+            timeFilter = query.window.toFilter(),
         )
-        val query = """
+        val sql = """
             WITH
                 (SELECT count() FROM `$clickhouseDb`.profiles WHERE $whereClause) AS total,
                 greatest(intDiv(total + $cap - 1, $cap), 1) AS stride
@@ -548,7 +565,7 @@ object ProfileIngestionService {
             LIMIT $cap
             FORMAT JSONEachRow
         """.trimIndent()
-        val rows = parseJsonRows(ClickHouseClient.executeWithFormat(query, ""))
+        val rows = parseJsonRows(ClickHouseClient.executeWithFormat(sql, ""))
         val total = rows.firstOrNull()?.get("total")?.jsonPrimitive?.long ?: 0
         val candidates = rows.map { obj ->
             ProfileMergeCandidate(
@@ -616,39 +633,33 @@ object ProfileIngestionService {
 
     private fun buildProfileFilters(
         organizationId: Int,
-        service: String? = null,
-        profileType: String? = null,
-        source: String? = null,
-        env: String? = null,
-        host: String? = null,
-        version: String? = null,
-        fromMs: Long? = null,
-        toMs: Long? = null,
+        filters: ProfileQueryFilters = ProfileQueryFilters(),
+        timeFilter: ProfileTimeFilter = ProfileTimeFilter(),
     ): String {
-        val filters = mutableListOf(
+        val clauses = mutableListOf(
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
         )
-        service?.takeIf { it.isNotBlank() }?.let {
-            filters.add("service = '${escapeSql(it)}'")
+        filters.service?.takeIf { it.isNotBlank() }?.let {
+            clauses.add("service = '${escapeSql(it)}'")
         }
-        profileType?.takeIf { it.isNotBlank() }?.let {
-            filters.add("profile_type = '${escapeSql(it)}'")
+        filters.profileType?.takeIf { it.isNotBlank() }?.let {
+            clauses.add("profile_type = '${escapeSql(it)}'")
         }
-        source?.takeIf { it.isNotBlank() }?.let {
-            filters.add("source = '${escapeSql(it)}'")
+        filters.source?.takeIf { it.isNotBlank() }?.let {
+            clauses.add("source = '${escapeSql(it)}'")
         }
-        env?.takeIf { it.isNotBlank() }?.let {
-            filters.add("env = '${escapeSql(it)}'")
+        filters.env?.takeIf { it.isNotBlank() }?.let {
+            clauses.add("env = '${escapeSql(it)}'")
         }
-        host?.takeIf { it.isNotBlank() }?.let {
-            filters.add("host = '${escapeSql(it)}'")
+        filters.host?.takeIf { it.isNotBlank() }?.let {
+            clauses.add("host = '${escapeSql(it)}'")
         }
-        version?.takeIf { it.isNotBlank() }?.let {
-            filters.add("version = '${escapeSql(it)}'")
+        filters.version?.takeIf { it.isNotBlank() }?.let {
+            clauses.add("version = '${escapeSql(it)}'")
         }
-        fromMs?.let { filters.add("start_time >= fromUnixTimestamp64Milli($it)") }
-        toMs?.let { filters.add("start_time < fromUnixTimestamp64Milli($it)") }
-        return filters.joinToString(" AND ")
+        timeFilter.fromMs?.let { clauses.add("start_time >= fromUnixTimestamp64Milli($it)") }
+        timeFilter.toMs?.let { clauses.add("start_time < fromUnixTimestamp64Milli($it)") }
+        return clauses.joinToString(" AND ")
     }
 
     private fun parseProfileRow(line: String): DdProfileResponse {

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileMergeService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileMergeService.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.services
 
+import com.moneat.utils.suspendRunCatching
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -34,6 +35,16 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import java.util.concurrent.atomic.AtomicLong
+
+/** Request for an aggregated flamegraph across a profile query window. */
+data class ProfileMergeFlamegraphQuery(
+    val organizationId: Int,
+    val filters: ProfileQueryFilters,
+    val window: ProfileTimeWindow,
+    val sampleType: String?,
+    val thread: String?,
+    val maxProfiles: Int,
+)
 
 /**
  * Aggregates the individual profiles in a service/time window into a single
@@ -55,29 +66,14 @@ object ProfileMergeService {
         val children: LinkedHashMap<String, MutableFrame> = LinkedHashMap(),
     )
 
-    suspend fun mergeFlamegraph(
-        organizationId: Int,
-        service: String?,
-        profileType: String?,
-        env: String?,
-        host: String?,
-        version: String?,
-        fromMs: Long,
-        toMs: Long,
-        sampleType: String?,
-        thread: String?,
-        maxProfiles: Int,
-    ): JsonObject {
+    suspend fun mergeFlamegraph(query: ProfileMergeFlamegraphQuery): JsonObject {
         val selection = ProfileIngestionService.selectProfilesForMerge(
-            organizationId = organizationId,
-            service = service,
-            profileType = profileType,
-            env = env,
-            host = host,
-            version = version,
-            fromMs = fromMs,
-            toMs = toMs,
-            maxProfiles = maxProfiles,
+            ProfileMergeSelectionQuery(
+                organizationId = query.organizationId,
+                filters = query.filters,
+                window = query.window,
+                maxProfiles = query.maxProfiles,
+            ),
         )
         if (selection.candidates.isEmpty()) {
             return emptyMerged(mergedCount = 0, total = selection.totalInWindow)
@@ -94,13 +90,13 @@ object ProfileMergeService {
                         if (totalBytes.addAndGet(data.size.toLong()) > MAX_TOTAL_BYTES) {
                             return@withPermit null
                         }
-                        runCatching {
+                        suspendRunCatching {
                             ProfileFlamegraphParser.parse(
                                 source = candidate.source,
                                 profileType = candidate.profileType,
                                 data = data,
-                                sampleType = sampleType,
-                                thread = thread,
+                                sampleType = query.sampleType,
+                                thread = query.thread,
                             )
                         }.getOrNull()
                     }
@@ -108,7 +104,7 @@ object ProfileMergeService {
             }.awaitAll().filterNotNull()
         }
 
-        return mergeParsed(parsed, thread, selection.totalInWindow)
+        return mergeParsed(parsed, query.thread, selection.totalInWindow)
     }
 
     private fun mergeParsed(

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileMergeService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileMergeService.kt
@@ -1,0 +1,213 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.services
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Aggregates the individual profiles in a service/time window into a single
+ * merged flamegraph by summing their parsed frame trees. Powers the service
+ * explorer's "aggregated over the window" view.
+ *
+ * Bounded by design: [ProfileIngestionService.selectProfilesForMerge] evenly
+ * samples at most a capped number of profiles across the window, and blobs are
+ * read+parsed with limited parallelism under a total-bytes guard.
+ */
+object ProfileMergeService {
+    const val DEFAULT_MAX_PROFILES = 25
+    private const val MAX_PARALLELISM = 8
+    private const val MAX_TOTAL_BYTES = 256L * 1024 * 1024
+
+    private class MutableFrame(
+        val name: String,
+        var value: Long = 0,
+        val children: LinkedHashMap<String, MutableFrame> = LinkedHashMap(),
+    )
+
+    suspend fun mergeFlamegraph(
+        organizationId: Int,
+        service: String?,
+        profileType: String?,
+        env: String?,
+        host: String?,
+        version: String?,
+        fromMs: Long,
+        toMs: Long,
+        sampleType: String?,
+        thread: String?,
+        maxProfiles: Int,
+    ): JsonObject {
+        val selection = ProfileIngestionService.selectProfilesForMerge(
+            organizationId = organizationId,
+            service = service,
+            profileType = profileType,
+            env = env,
+            host = host,
+            version = version,
+            fromMs = fromMs,
+            toMs = toMs,
+            maxProfiles = maxProfiles,
+        )
+        if (selection.candidates.isEmpty()) {
+            return emptyMerged(mergedCount = 0, total = selection.totalInWindow)
+        }
+
+        val semaphore = Semaphore(MAX_PARALLELISM)
+        val totalBytes = AtomicLong(0)
+        val parsed = coroutineScope {
+            selection.candidates.map { candidate ->
+                async(Dispatchers.IO) {
+                    semaphore.withPermit {
+                        val data = ProfileStorageService.read(candidate.storageKey)
+                            ?: return@withPermit null
+                        if (totalBytes.addAndGet(data.size.toLong()) > MAX_TOTAL_BYTES) {
+                            return@withPermit null
+                        }
+                        runCatching {
+                            ProfileFlamegraphParser.parse(
+                                source = candidate.source,
+                                profileType = candidate.profileType,
+                                data = data,
+                                sampleType = sampleType,
+                                thread = thread,
+                            )
+                        }.getOrNull()
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+
+        return mergeParsed(parsed, thread, selection.totalInWindow)
+    }
+
+    private fun mergeParsed(
+        parsed: List<JsonObject>,
+        thread: String?,
+        total: Long,
+    ): JsonObject {
+        if (parsed.isEmpty()) return emptyMerged(0, total)
+
+        val root = MutableFrame("(root)")
+        val sampleTypes = LinkedHashMap<String, JsonObject>()
+        val threadSamples = LinkedHashMap<String, Long>()
+        val threadLabels = HashMap<String, String>()
+        var totalSamples = 0L
+        var unit = "samples"
+        var selectedSampleType: String? = null
+
+        for (obj in parsed) {
+            obj["frames"]?.jsonArray?.let { mergeInto(root, it) }
+            totalSamples += obj["totalSamples"]?.jsonPrimitive?.longOrNull ?: 0
+            obj["unit"]?.jsonPrimitive?.contentOrNull?.let { unit = it }
+            if (selectedSampleType == null) {
+                selectedSampleType = obj["selectedSampleType"]?.jsonPrimitive?.contentOrNull
+            }
+            obj["sampleTypes"]?.jsonArray?.forEach { st ->
+                val key = st.jsonObject["key"]?.jsonPrimitive?.contentOrNull
+                if (key != null) sampleTypes.putIfAbsent(key, st.jsonObject)
+            }
+            obj["threads"]?.jsonArray?.forEach { th ->
+                val o = th.jsonObject
+                val id = o["id"]?.jsonPrimitive?.contentOrNull ?: return@forEach
+                threadSamples.merge(id, o["samples"]?.jsonPrimitive?.longOrNull ?: 0, Long::plus)
+                o["label"]?.jsonPrimitive?.contentOrNull?.let { threadLabels[id] = it }
+            }
+        }
+
+        return buildJsonObject {
+            put("frames", rootFramesJson(root))
+            put(
+                "sampleTypes",
+                buildJsonArray { sampleTypes.values.forEach { add(it) } },
+            )
+            put(
+                "threads",
+                buildJsonArray {
+                    threadSamples.entries
+                        .sortedByDescending { it.value }
+                        .forEach { (id, samples) ->
+                            add(
+                                buildJsonObject {
+                                    put("id", id)
+                                    put("label", threadLabels[id] ?: id)
+                                    put("samples", samples)
+                                },
+                            )
+                        }
+                },
+            )
+            selectedSampleType?.let { put("selectedSampleType", it) }
+            thread?.takeIf { it.isNotBlank() && it != "all" }?.let { put("selectedThread", it) }
+            put("unit", unit)
+            put("totalSamples", totalSamples)
+            put("mergedCount", parsed.size)
+            put("totalCount", total)
+        }
+    }
+
+    private fun mergeInto(parent: MutableFrame, framesArr: JsonArray) {
+        for (element in framesArr) {
+            val obj = element.jsonObject
+            val name = obj["name"]?.jsonPrimitive?.contentOrNull ?: continue
+            val value = obj["value"]?.jsonPrimitive?.longOrNull ?: 0L
+            val child = parent.children.getOrPut(name) { MutableFrame(name) }
+            child.value += value
+            obj["children"]?.jsonArray?.let { mergeInto(child, it) }
+        }
+    }
+
+    private fun rootFramesJson(root: MutableFrame): JsonArray = buildJsonArray {
+        root.children.values.sortedByDescending { it.value }.forEach { add(frameToJson(it)) }
+    }
+
+    private fun frameToJson(frame: MutableFrame): JsonObject = buildJsonObject {
+        put("name", frame.name)
+        put("value", frame.value)
+        put(
+            "children",
+            buildJsonArray {
+                frame.children.values
+                    .sortedByDescending { it.value }
+                    .forEach { add(frameToJson(it)) }
+            },
+        )
+    }
+
+    private fun emptyMerged(mergedCount: Int, total: Long): JsonObject = buildJsonObject {
+        put("frames", buildJsonArray {})
+        put("mergedCount", mergedCount)
+        put("totalCount", total)
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileMergeService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileMergeService.kt
@@ -31,7 +31,6 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.long
 import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import java.util.concurrent.atomic.AtomicLong

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -97,16 +97,10 @@ class DatadogQueryRoutesTest {
         coEvery { ProfileIngestionService.getProfile(any(), any()) } returns null
         coEvery { ProfileIngestionService.listServices(any(), any(), any()) } returns
             DdProfileServicesResponse(emptyList(), 0L, 0L, 0, 0L, 0)
-        coEvery {
-            ProfileIngestionService.timeseries(
-                any(), any(), any(), any(), any(), any(), any(), any(),
-            )
-        } returns DdProfileTimeseriesResponse(emptyList(), 60L)
-        coEvery {
-            ProfileMergeService.mergeFlamegraph(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-            )
-        } returns buildJsonObject { put("frames", buildJsonArray {}) }
+        coEvery { ProfileIngestionService.timeseries(any()) } returns DdProfileTimeseriesResponse(emptyList(), 60L)
+        coEvery { ProfileMergeService.mergeFlamegraph(any()) } returns buildJsonObject {
+            put("frames", buildJsonArray {})
+        }
     }
 
     @AfterTest
@@ -512,11 +506,57 @@ class DatadogQueryRoutesTest {
     }
 
     @Test
+    fun `profiles list returns ok with jwt and clamps limit`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get(
+            "/v1/profiles?service=api&type=cpu&source=datadog&env=prod&host=h1&version=v1" +
+                "&from=100&to=200&limit=500&offset=3",
+        ) {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, resp.status)
+        coVerify {
+            ProfileIngestionService.listProfiles(
+                10,
+                match {
+                    it.service == "api" &&
+                        it.profileType == "cpu" &&
+                        it.source == "datadog" &&
+                        it.env == "prod" &&
+                        it.host == "h1" &&
+                        it.version == "v1" &&
+                        it.fromMs == 100L &&
+                        it.toMs == 200L &&
+                        it.limit == 200 &&
+                        it.offset == 3
+                },
+            )
+        }
+    }
+
+    @Test
     fun `profile download returns not found for unknown profile`() = testApplication {
         installProfileRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get("/v1/profiles/unknown-id/download") { withAuth(token) }
         assertEquals(HttpStatusCode.NotFound, resp.status)
+    }
+
+    @Test
+    fun `profile download returns raw profile bytes when found`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        coEvery {
+            ProfileIngestionService.getProfileMeta(10, "profile-download")
+        } returns ProfileIngestionService.ProfileMeta("profile-key", "cpu", "datadog")
+        every { ProfileStorageService.read("profile-key") } returns "raw-profile".toByteArray()
+
+        val resp = client.get("/v1/profiles/profile-download/download") { withAuth(token) }
+
+        assertEquals(HttpStatusCode.OK, resp.status)
+        assertEquals("raw-profile", resp.bodyAsText())
     }
 
     @Test
@@ -629,6 +669,33 @@ class DatadogQueryRoutesTest {
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get("/v1/profiles/timeseries?from=200&to=100") { withAuth(token) }
         assertEquals(HttpStatusCode.BadRequest, resp.status)
+    }
+
+    @Test
+    fun `profile timeseries returns ok with jwt and forwards filters`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get(
+            "/v1/profiles/timeseries?service=api&type=cpu&env=prod&host=h1&from=1000&to=61000&buckets=10",
+        ) {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, resp.status)
+        coVerify {
+            ProfileIngestionService.timeseries(
+                match {
+                    it.organizationId == 10 &&
+                        it.filters.service == "api" &&
+                        it.filters.profileType == "cpu" &&
+                        it.filters.env == "prod" &&
+                        it.filters.host == "h1" &&
+                        it.window.fromMs == 1000L &&
+                        it.window.toMs == 61000L &&
+                        it.buckets == 10
+                },
+            )
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -537,6 +537,23 @@ class DatadogQueryRoutesTest {
     }
 
     @Test
+    fun `profiles list normalizes invalid paging values`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get("/v1/profiles?limit=0&offset=-10") { withAuth(token) }
+
+        assertEquals(HttpStatusCode.OK, resp.status)
+        coVerify {
+            ProfileIngestionService.listProfiles(
+                10,
+                match {
+                    it.limit == 1 && it.offset == 0
+                },
+            )
+        }
+    }
+
+    @Test
     fun `profile download returns not found for unknown profile`() = testApplication {
         installProfileRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
@@ -557,6 +574,19 @@ class DatadogQueryRoutesTest {
 
         assertEquals(HttpStatusCode.OK, resp.status)
         assertEquals("raw-profile", resp.bodyAsText())
+    }
+
+    @Test
+    fun `profile download returns generic error when metadata lookup fails`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        coEvery {
+            ProfileIngestionService.getProfileMeta(10, "profile-error")
+        } throws IllegalStateException("metadata failed")
+
+        val resp = client.get("/v1/profiles/profile-error/download") { withAuth(token) }
+
+        assertEquals(HttpStatusCode.InternalServerError, resp.status)
     }
 
     @Test
@@ -713,6 +743,18 @@ class DatadogQueryRoutesTest {
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get("/v1/profiles/merged-flamegraph?service=api") { withAuth(token) }
         assertEquals(HttpStatusCode.OK, resp.status)
+    }
+
+    @Test
+    fun `merged flamegraph rejects inverted range`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get("/v1/profiles/merged-flamegraph?from=200&to=100") { withAuth(token) }
+
+        assertEquals(HttpStatusCode.BadRequest, resp.status)
+        coVerify(exactly = 0) {
+            ProfileMergeService.mergeFlamegraph(any())
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -22,6 +22,9 @@ import com.moneat.datadog.models.DdApmOverviewPreviousStats
 import com.moneat.datadog.models.DdApmOverviewResponse
 import com.moneat.datadog.models.DdApmOverviewStats
 import com.moneat.datadog.models.DdProfileListResponse
+import com.moneat.datadog.models.DdProfileResponse
+import com.moneat.datadog.models.DdProfileServicesResponse
+import com.moneat.datadog.models.DdProfileTimeseriesResponse
 import com.moneat.datadog.models.DdResourceStatsResponse
 import com.moneat.datadog.models.DdServiceMapResponse
 import com.moneat.datadog.models.DdTraceListResponse
@@ -31,6 +34,7 @@ import com.moneat.datadog.services.DatadogPprofFlamegraphService
 import com.moneat.datadog.services.DdResourceStatsQuery
 import com.moneat.datadog.services.DdTraceListQuery
 import com.moneat.datadog.services.ProfileIngestionService
+import com.moneat.datadog.services.ProfileMergeService
 import com.moneat.datadog.services.ProfileStorageService
 import com.moneat.datadog.services.TraceIngestionService
 import com.moneat.testsupport.RouteTestSupport
@@ -38,9 +42,9 @@ import com.moneat.testsupport.RouteTestSupport.installJwtAuth
 import com.moneat.testsupport.RouteTestSupport.withAuth
 import com.moneat.testsupport.startTestKoin
 import com.moneat.testsupport.stopTestKoin
-import io.ktor.client.statement.bodyAsText
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
@@ -50,14 +54,14 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 class DatadogQueryRoutesTest {
 
@@ -67,6 +71,7 @@ class DatadogQueryRoutesTest {
         mockkObject(DatadogHostService)
         mockkObject(TraceIngestionService)
         mockkObject(ProfileIngestionService)
+        mockkObject(ProfileMergeService)
         mockkObject(ProfileStorageService)
 
         every { DatadogHostService.listHosts(any<Int>()) } returns emptyList()
@@ -85,14 +90,28 @@ class DatadogQueryRoutesTest {
             DdServiceMapResponse(emptyList())
         coEvery { TraceIngestionService.getApmErrors(any(), any(), any(), any(), any(), any()) } returns
             DdApmErrorsResponse(emptyList(), 0L)
-        coEvery { ProfileIngestionService.listProfiles(any(), any(), any(), any(), any(), any()) } returns
+        coEvery { ProfileIngestionService.listProfiles(any(), any()) } returns
             DdProfileListResponse(emptyList(), 0L)
         coEvery { ProfileIngestionService.getProfileMeta(any(), any()) } returns null
         every { ProfileStorageService.read(any()) } returns null
+        coEvery { ProfileIngestionService.getProfile(any(), any()) } returns null
+        coEvery { ProfileIngestionService.listServices(any(), any(), any()) } returns
+            DdProfileServicesResponse(emptyList(), 0L, 0L, 0, 0L, 0)
+        coEvery {
+            ProfileIngestionService.timeseries(
+                any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        } returns DdProfileTimeseriesResponse(emptyList(), 60L)
+        coEvery {
+            ProfileMergeService.mergeFlamegraph(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        } returns buildJsonObject { put("frames", buildJsonArray {}) }
     }
 
     @AfterTest
     fun teardown() {
+        unmockkObject(ProfileMergeService)
         unmockkObject(ProfileStorageService)
         unmockkObject(ProfileIngestionService)
         unmockkObject(TraceIngestionService)
@@ -581,4 +600,91 @@ class DatadogQueryRoutesTest {
         put("selectedSampleType", sampleType)
         put("selectedThread", thread)
     }
+
+    // ──── Profile aggregation routes ────
+
+    @Test
+    fun `profile services returns 401 without jwt`() = testApplication {
+        installProfileRoutes()()
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/profiles/services").status)
+    }
+
+    @Test
+    fun `profile services returns ok with jwt`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get("/v1/profiles/services") { withAuth(token) }
+        assertEquals(HttpStatusCode.OK, resp.status)
+    }
+
+    @Test
+    fun `profile timeseries returns 401 without jwt`() = testApplication {
+        installProfileRoutes()()
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/profiles/timeseries").status)
+    }
+
+    @Test
+    fun `profile timeseries rejects inverted range`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get("/v1/profiles/timeseries?from=200&to=100") { withAuth(token) }
+        assertEquals(HttpStatusCode.BadRequest, resp.status)
+    }
+
+    @Test
+    fun `merged flamegraph returns 401 without jwt`() = testApplication {
+        installProfileRoutes()()
+        assertEquals(
+            HttpStatusCode.Unauthorized,
+            client.get("/v1/profiles/merged-flamegraph").status,
+        )
+    }
+
+    @Test
+    fun `merged flamegraph returns ok with jwt`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get("/v1/profiles/merged-flamegraph?service=api") { withAuth(token) }
+        assertEquals(HttpStatusCode.OK, resp.status)
+    }
+
+    @Test
+    fun `profile metadata returns 401 without jwt`() = testApplication {
+        installProfileRoutes()()
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/profiles/some-id").status)
+    }
+
+    @Test
+    fun `profile metadata returns not found for unknown profile`() = testApplication {
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get("/v1/profiles/unknown-id") { withAuth(token) }
+        assertEquals(HttpStatusCode.NotFound, resp.status)
+    }
+
+    @Test
+    fun `profile metadata returns profile when found`() = testApplication {
+        coEvery { ProfileIngestionService.getProfile(any(), any()) } returns sampleProfile()
+        installProfileRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get("/v1/profiles/known-id") { withAuth(token) }
+        assertEquals(HttpStatusCode.OK, resp.status)
+    }
+
+    private fun sampleProfile(): DdProfileResponse = DdProfileResponse(
+        profileId = "known-id",
+        host = "h1",
+        service = "api",
+        env = "prod",
+        version = "1.0.0",
+        runtime = "jvm",
+        language = "jvm",
+        profileType = "jfr",
+        startTime = "2026-05-28 12:00:00.000",
+        endTime = "2026-05-28 12:01:00.000",
+        durationNs = 60_000_000_000L,
+        sizeBytes = 2_000_000L,
+        tags = emptyMap(),
+        source = "datadog",
+    )
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileFlamegraphParserTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileFlamegraphParserTest.kt
@@ -5,6 +5,14 @@
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 package com.moneat.datadog.services
 

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileFlamegraphParserTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileFlamegraphParserTest.kt
@@ -1,0 +1,85 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package com.moneat.datadog.services
+
+import com.moneat.datadog.buildJfrLikePayload
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProfileFlamegraphParserTest {
+
+    @Test
+    fun `parse returns empty frames for unknown source`() {
+        val result = ProfileFlamegraphParser.parse(
+            source = "mystery",
+            profileType = "cpu",
+            data = "whatever".toByteArray(),
+            sampleType = null,
+            thread = null,
+        )
+        assertTrue(result["frames"]!!.jsonArray.isEmpty())
+    }
+
+    @Test
+    fun `parse builds a frame tree from a sentry profile`() {
+        val sentry = """
+            {"profile":{
+              "frames":[{"function":"f0"},{"function":"f1"}],
+              "stacks":[[1,0]],
+              "samples":[{"stack_id":0},{"stack_id":0}]
+            }}
+        """.trimIndent().toByteArray()
+
+        val result = ProfileFlamegraphParser.parse(
+            source = "sentry",
+            profileType = "cpu",
+            data = sentry,
+            sampleType = null,
+            thread = null,
+        )
+
+        val frames = result["frames"]!!.jsonArray
+        assertEquals(1, frames.size)
+        val f0 = frames[0].jsonObject
+        assertEquals("f0", f0["name"]!!.jsonPrimitive.content)
+        assertEquals(2, f0["value"]!!.jsonPrimitive.content.toInt())
+        val f1 = f0["children"]!!.jsonArray[0].jsonObject
+        assertEquals("f1", f1["name"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `parse returns empty frames for malformed sentry payload`() {
+        val result = ProfileFlamegraphParser.parse(
+            source = "sentry",
+            profileType = "cpu",
+            data = "not json".toByteArray(),
+            sampleType = null,
+            thread = null,
+        )
+        assertTrue(result["frames"]!!.jsonArray.isEmpty())
+    }
+
+    @Test
+    fun `parse routes a jfr payload through the datadog parser without crashing`() {
+        val result = ProfileFlamegraphParser.parse(
+            source = "datadog",
+            profileType = "jfr",
+            data = buildJfrLikePayload(),
+            sampleType = null,
+            thread = null,
+        )
+        // A synthetic JFR payload yields no usable samples, but the call must
+        // return the standard shape rather than throwing.
+        assertTrue(result.containsKey("frames"))
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
@@ -16,9 +16,15 @@
 
 package com.moneat.datadog.services
 
+import com.moneat.config.ClickHouseClient
 import com.moneat.datadog.models.DdProfileEndpoint
 import com.moneat.datadog.models.DdProfileEvent
 import com.moneat.utils.ClickHouseSqlUtils
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import kotlin.test.assertEquals
@@ -260,4 +266,195 @@ class ProfileIngestionServiceTest {
             "Should escape quotes in map entries"
         )
     }
+
+    // ──── Dashboard query tests ────
+
+    @Test
+    fun `listProfiles applies filters and maps rows`() = runBlocking {
+        val queries = mutableListOf<String>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val sql = firstArg<String>()
+                queries.add(sql)
+                if (sql.contains("SELECT count()")) {
+                    "1"
+                } else {
+                    profileJsonRow()
+                }
+            }
+
+            val response = ProfileIngestionService.listProfiles(
+                organizationId = 42,
+                query = DdProfileListQuery(
+                    service = "api",
+                    profileType = "cpu",
+                    source = "datadog",
+                    env = "prod",
+                    host = "host-a",
+                    version = "v1",
+                    fromMs = 1000,
+                    toMs = 2000,
+                    limit = 5,
+                    offset = 2,
+                ),
+            )
+
+            assertEquals(1, response.totalCount)
+            assertEquals("profile-1", response.profiles.single().profileId)
+            assertEquals("api", response.profiles.single().service)
+            assertTrue(queries.any { it.contains("service = 'api'") })
+            assertTrue(queries.any { it.contains("start_time >= fromUnixTimestamp64Milli(1000)") })
+            assertTrue(queries.any { it.contains("LIMIT 5 OFFSET 2") })
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `listServices maps rollups type counts and sparkline series`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val sql = firstArg<String>()
+                when {
+                    sql.contains("profile_type AS profileType") ->
+                        """{"service":"api","profileType":"cpu","count":3}"""
+                    sql.contains("GROUP BY service, ts") ->
+                        """{"service":"api","ts":1000,"count":2}"""
+                    else -> profileServiceRollupJson()
+                }
+            }
+
+            val response = ProfileIngestionService.listServices(
+                organizationId = 42,
+                fromMs = 1000,
+                toMs = 2000,
+            )
+
+            val service = response.services.single()
+            assertEquals("api", service.service)
+            assertEquals(listOf("java"), service.languages)
+            assertEquals("cpu", service.types.single().profileType)
+            assertEquals(3, service.profileCount)
+            assertEquals(2, service.series.single().count)
+            assertEquals(3, response.totalProfiles)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `timeseries maps buckets and applies query filters`() = runBlocking {
+        val queries = mutableListOf<String>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                firstArg<String>().also { queries.add(it) }
+                """{"ts":60000,"count":4,"sizeBytes":4096}"""
+            }
+
+            val response = ProfileIngestionService.timeseries(
+                ProfileTimeseriesQuery(
+                    organizationId = 42,
+                    filters = ProfileQueryFilters(
+                        service = "api",
+                        profileType = "cpu",
+                        env = "prod",
+                        host = "host-a",
+                    ),
+                    window = ProfileTimeWindow(fromMs = 0, toMs = 120_000),
+                    buckets = 2,
+                ),
+            )
+
+            assertEquals(60, response.bucketSeconds)
+            assertEquals(4, response.points.single().count)
+            assertEquals(4096, response.points.single().sizeBytes)
+            assertTrue(queries.single().contains("profile_type = 'cpu'"))
+            assertTrue(queries.single().contains("host = 'host-a'"))
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `selectProfilesForMerge caps candidates and defaults missing source`() = runBlocking {
+        val queries = mutableListOf<String>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                firstArg<String>().also { queries.add(it) }
+                """
+                    {"profile_id":"profile-1","storage_key":"key-1","profileType":"jfr","total":7}
+                    {"profile_id":"profile-2","storage_key":"","profileType":"cpu","source":"sentry","total":7}
+                """.trimIndent()
+            }
+
+            val selection = ProfileIngestionService.selectProfilesForMerge(
+                ProfileMergeSelectionQuery(
+                    organizationId = 42,
+                    filters = ProfileQueryFilters(service = "api", version = "v1"),
+                    window = ProfileTimeWindow(fromMs = 1000, toMs = 2000),
+                    maxProfiles = 500,
+                ),
+            )
+
+            assertEquals(7, selection.totalInWindow)
+            assertEquals("profile-1", selection.candidates.single().profileId)
+            assertEquals("datadog", selection.candidates.single().source)
+            assertTrue(queries.single().contains("LIMIT 50"))
+            assertTrue(queries.single().contains("version = 'v1'"))
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getProfile and getProfileMeta map ClickHouse rows`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val sql = firstArg<String>()
+                if (sql.contains("FORMAT JSONEachRow")) {
+                    profileJsonRow()
+                } else {
+                    "key-1\tcpu"
+                }
+            }
+
+            val profile = ProfileIngestionService.getProfile(organizationId = 42, profileId = "profile-1")
+            val meta = ProfileIngestionService.getProfileMeta(organizationId = 42, profileId = "profile-1")
+
+            assertEquals("profile-1", profile?.profileId)
+            assertEquals("key-1", meta?.storageKey)
+            assertEquals("cpu", meta?.profileType)
+            assertEquals("datadog", meta?.source)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    private fun profileJsonRow(): String = compactJson(
+        """{"profile_id":"profile-1",""",
+        """"host":"host-a","service":"api","env":"prod","version":"v1",""",
+        """"runtime":"jvm","language":"java","profile_type":"cpu",""",
+        """"start_time":"2026-01-01 00:00:00","end_time":"2026-01-01 00:00:01",""",
+        """"duration_ns":1000,"storage_key":"key-1","tags":{"service":"api"},""",
+        """"size_bytes":123,"source":"datadog"}""",
+    )
+
+    private fun profileServiceRollupJson(): String = compactJson(
+        """{"service":"api","languages":["java"],"runtimes":["jvm"],"environments":["prod"],""",
+        """"hostCount":2,"profileCount":3,"totalSizeBytes":900,""",
+        """"firstSeen":"2026-01-01 00:00:00","lastSeen":"2026-01-01 00:10:00",""",
+        """"avgDurationNs":123}""",
+    )
+
+    private fun compactJson(vararg parts: String): String = parts.joinToString("")
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ProfileIngestionServiceTest {
@@ -313,6 +314,82 @@ class ProfileIngestionServiceTest {
     }
 
     @Test
+    fun `listProfiles and profile lookups handle empty ClickHouse results`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val sql = firstArg<String>()
+                if (sql.contains("SELECT count()")) {
+                    "not-a-number"
+                } else {
+                    "\n"
+                }
+            }
+
+            val response = ProfileIngestionService.listProfiles(
+                organizationId = 42,
+                query = DdProfileListQuery(limit = 999),
+            )
+            val profile = ProfileIngestionService.getProfile(
+                organizationId = 42,
+                profileId = "missing-profile",
+            )
+            val storageKey = ProfileIngestionService.getProfileStorageKey(
+                organizationId = 42,
+                profileId = "missing-profile",
+            )
+            val meta = ProfileIngestionService.getProfileMeta(
+                organizationId = 42,
+                profileId = "missing-profile",
+            )
+
+            assertEquals(0, response.totalCount)
+            assertTrue(response.profiles.isEmpty())
+            assertNull(profile)
+            assertNull(storageKey)
+            assertNull(meta)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `listProfiles maps optional defaults and service tag fallback`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val sql = firstArg<String>()
+                if (sql.contains("SELECT count()")) {
+                    "1"
+                } else {
+                    compactJson(
+                        """{"profile_id":"profile-2","service":"","profile_type":"cpu",""",
+                        """"start_time":"2026-01-01 00:00:00","end_time":"2026-01-01 00:00:01",""",
+                        """"duration_ns":42,"size_bytes":7,"tags":{"service.name":"fallback-api"}}""",
+                    )
+                }
+            }
+
+            val profile = ProfileIngestionService.listProfiles(
+                organizationId = 42,
+                query = DdProfileListQuery(),
+            ).profiles.single()
+
+            assertEquals("fallback-api", profile.service)
+            assertEquals("", profile.host)
+            assertEquals("", profile.env)
+            assertEquals("", profile.version)
+            assertEquals("", profile.runtime)
+            assertEquals("", profile.language)
+            assertEquals("datadog", profile.source)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
     fun `listServices maps rollups type counts and sparkline series`() = runBlocking {
         mockkObject(ClickHouseClient)
         try {
@@ -341,6 +418,52 @@ class ProfileIngestionServiceTest {
             assertEquals(3, service.profileCount)
             assertEquals(2, service.series.single().count)
             assertEquals(3, response.totalProfiles)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `listServices maps sparse rows and default lookback sparkline`() = runBlocking {
+        val queries = mutableListOf<String>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val sql = firstArg<String>()
+                queries.add(sql)
+                when {
+                    sql.contains("profile_type AS profileType") ->
+                        """{"service":"","count":1}"""
+                    sql.contains("GROUP BY service, ts") ->
+                        """{"service":"","count":2}"""
+                    else ->
+                        """{"service":"","languages":["","kotlin"]}"""
+                }
+            }
+
+            val response = ProfileIngestionService.listServices(
+                organizationId = 42,
+                fromMs = null,
+                toMs = null,
+            )
+
+            val service = response.services.single()
+            assertEquals("", service.service)
+            assertEquals(listOf("kotlin"), service.languages)
+            assertTrue(service.runtimes.isEmpty())
+            assertTrue(service.environments.isEmpty())
+            assertEquals("", service.types.single().profileType)
+            assertEquals(1, service.types.single().count)
+            assertEquals(0, service.hostCount)
+            assertEquals(0, service.profileCount)
+            assertEquals(0, service.totalSizeBytes)
+            assertEquals("", service.firstSeen)
+            assertEquals("", service.lastSeen)
+            assertEquals(0, service.avgDurationNs)
+            assertEquals(0, service.series.single().ts)
+            assertEquals(2, service.series.single().count)
+            assertTrue(queries.any { it.contains("now() - INTERVAL") })
         } finally {
             unmockkObject(ClickHouseClient)
         }
@@ -382,6 +505,32 @@ class ProfileIngestionServiceTest {
     }
 
     @Test
+    fun `timeseries maps sparse rows and clamps invalid bucket count`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } returns "{}"
+
+            val response = ProfileIngestionService.timeseries(
+                ProfileTimeseriesQuery(
+                    organizationId = 42,
+                    filters = ProfileQueryFilters(),
+                    window = ProfileTimeWindow(fromMs = 0, toMs = 500),
+                    buckets = 0,
+                ),
+            )
+
+            val point = response.points.single()
+            assertEquals(60, response.bucketSeconds)
+            assertEquals(0, point.ts)
+            assertEquals(0, point.count)
+            assertEquals(0, point.sizeBytes)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
     fun `selectProfilesForMerge caps candidates and defaults missing source`() = runBlocking {
         val queries = mutableListOf<String>()
         mockkObject(ClickHouseClient)
@@ -415,6 +564,52 @@ class ProfileIngestionServiceTest {
     }
 
     @Test
+    fun `selectProfilesForMerge handles blank and sparse candidate rows`() = runBlocking {
+        val queries = mutableListOf<String>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                firstArg<String>().also { queries.add(it) }
+                if (queries.size == 1) {
+                    "\n"
+                } else {
+                    """{"storage_key":"key-1"}"""
+                }
+            }
+
+            val emptySelection = ProfileIngestionService.selectProfilesForMerge(
+                ProfileMergeSelectionQuery(
+                    organizationId = 42,
+                    filters = ProfileQueryFilters(),
+                    window = ProfileTimeWindow(fromMs = 1000, toMs = 2000),
+                    maxProfiles = 0,
+                ),
+            )
+            val sparseSelection = ProfileIngestionService.selectProfilesForMerge(
+                ProfileMergeSelectionQuery(
+                    organizationId = 42,
+                    filters = ProfileQueryFilters(),
+                    window = ProfileTimeWindow(fromMs = 1000, toMs = 2000),
+                    maxProfiles = 1,
+                ),
+            )
+
+            val candidate = sparseSelection.candidates.single()
+            assertEquals(0, emptySelection.totalInWindow)
+            assertTrue(emptySelection.candidates.isEmpty())
+            assertEquals(0, sparseSelection.totalInWindow)
+            assertEquals("", candidate.profileId)
+            assertEquals("key-1", candidate.storageKey)
+            assertEquals("", candidate.profileType)
+            assertEquals("datadog", candidate.source)
+            assertTrue(queries.first().contains("LIMIT 1"))
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
     fun `getProfile and getProfileMeta map ClickHouse rows`() = runBlocking {
         mockkObject(ClickHouseClient)
         try {
@@ -434,6 +629,23 @@ class ProfileIngestionServiceTest {
             assertEquals("profile-1", profile?.profileId)
             assertEquals("key-1", meta?.storageKey)
             assertEquals("cpu", meta?.profileType)
+            assertEquals("datadog", meta?.source)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getProfileMeta defaults source for legacy tab separated rows`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } returns "key-legacy\tjfr"
+
+            val meta = ProfileIngestionService.getProfileMeta(organizationId = 42, profileId = "profile-legacy")
+
+            assertEquals("key-legacy", meta?.storageKey)
+            assertEquals("jfr", meta?.profileType)
             assertEquals("datadog", meta?.source)
         } finally {
             unmockkObject(ClickHouseClient)

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
@@ -5,6 +5,14 @@
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 package com.moneat.datadog.services
 

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
@@ -104,14 +104,68 @@ class ProfileMergeServiceTest {
         put("totalSamples", 10)
     }
 
+    private fun sparseProfileFlamegraph(): JsonObject = buildJsonObject {
+        put(
+            "frames",
+            buildJsonArray {
+                add(buildJsonObject {})
+                add(
+                    buildJsonObject {
+                        put("name", "worker")
+                        put(
+                            "children",
+                            buildJsonArray {
+                                add(
+                                    buildJsonObject {
+                                        put("name", "leaf")
+                                    },
+                                )
+                            },
+                        )
+                    },
+                )
+            },
+        )
+        put(
+            "sampleTypes",
+            buildJsonArray {
+                add(buildJsonObject {})
+                add(
+                    buildJsonObject {
+                        put("key", "wall")
+                        put("label", "Wall")
+                    },
+                )
+            },
+        )
+        put(
+            "threads",
+            buildJsonArray {
+                add(buildJsonObject {})
+                add(
+                    buildJsonObject {
+                        put("id", "all")
+                    },
+                )
+                add(
+                    buildJsonObject {
+                        put("id", "t1")
+                        put("samples", 7)
+                    },
+                )
+            },
+        )
+    }
+
     private fun mergeQuery(
         sampleType: String? = null,
+        thread: String? = null,
     ) = ProfileMergeFlamegraphQuery(
         organizationId = 1,
         filters = ProfileQueryFilters(service = "api", profileType = "jfr"),
         window = ProfileTimeWindow(fromMs = 0, toMs = 1000),
         sampleType = sampleType,
-        thread = null,
+        thread = thread,
         maxProfiles = 25,
     )
 
@@ -166,5 +220,70 @@ class ProfileMergeServiceTest {
 
         assertTrue(out["frames"]!!.jsonArray.isEmpty())
         assertEquals(0, out["mergedCount"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `mergeFlamegraph skips unreadable and failed profile parses`() {
+        coEvery {
+            ProfileIngestionService.selectProfilesForMerge(any())
+        } returns ProfileMergeSelection(
+            totalInWindow = 3,
+            candidates = listOf(
+                ProfileMergeCandidate("p1", "missing", "jfr", "datadog"),
+                ProfileMergeCandidate("p2", "bad", "jfr", "datadog"),
+                ProfileMergeCandidate("p3", "good", "jfr", "datadog"),
+            ),
+        )
+        every { ProfileStorageService.read("missing") } returns null
+        every { ProfileStorageService.read("bad") } returns "bad".toByteArray()
+        every { ProfileStorageService.read("good") } returns "good".toByteArray()
+        every {
+            ProfileFlamegraphParser.parse(any(), any(), match { it.decodeToString() == "bad" }, any(), any())
+        } throws IllegalArgumentException("bad profile")
+        every {
+            ProfileFlamegraphParser.parse(any(), any(), match { it.decodeToString() == "good" }, any(), any())
+        } returns sparseProfileFlamegraph()
+
+        val out = runBlocking {
+            ProfileMergeService.mergeFlamegraph(mergeQuery(thread = "t1"))
+        }
+
+        assertEquals(1, out["mergedCount"]!!.jsonPrimitive.int)
+        assertEquals(3, out["totalCount"]!!.jsonPrimitive.int)
+        assertEquals("t1", out["selectedThread"]!!.jsonPrimitive.content)
+        assertEquals("samples", out["unit"]!!.jsonPrimitive.content)
+        assertEquals(0, out["totalSamples"]!!.jsonPrimitive.int)
+
+        val frame = out["frames"]!!.jsonArray.single().jsonObject
+        assertEquals("worker", frame["name"]!!.jsonPrimitive.content)
+        assertEquals(0, frame["value"]!!.jsonPrimitive.int)
+        assertEquals("leaf", frame["children"]!!.jsonArray.single().jsonObject["name"]!!.jsonPrimitive.content)
+
+        val sampleType = out["sampleTypes"]!!.jsonArray.single().jsonObject
+        assertEquals("wall", sampleType["key"]!!.jsonPrimitive.content)
+        val threads = out["threads"]!!.jsonArray
+        assertEquals("t1", threads[0].jsonObject["label"]!!.jsonPrimitive.content)
+        assertEquals("all", threads[1].jsonObject["label"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `mergeFlamegraph omits selectedThread for all thread selection`() {
+        coEvery {
+            ProfileIngestionService.selectProfilesForMerge(any())
+        } returns ProfileMergeSelection(
+            totalInWindow = 1,
+            candidates = listOf(ProfileMergeCandidate("p1", "key1", "jfr", "datadog")),
+        )
+        every { ProfileStorageService.read("key1") } returns "payload".toByteArray()
+        every {
+            ProfileFlamegraphParser.parse(any(), any(), any(), any(), any())
+        } returns singleProfileFlamegraph()
+
+        val out = runBlocking {
+            ProfileMergeService.mergeFlamegraph(mergeQuery(thread = "all"))
+        }
+
+        assertEquals(null, out["selectedThread"])
+        assertEquals(1, out["mergedCount"]!!.jsonPrimitive.int)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
@@ -104,12 +104,21 @@ class ProfileMergeServiceTest {
         put("totalSamples", 10)
     }
 
+    private fun mergeQuery(
+        sampleType: String? = null,
+    ) = ProfileMergeFlamegraphQuery(
+        organizationId = 1,
+        filters = ProfileQueryFilters(service = "api", profileType = "jfr"),
+        window = ProfileTimeWindow(fromMs = 0, toMs = 1000),
+        sampleType = sampleType,
+        thread = null,
+        maxProfiles = 25,
+    )
+
     @Test
     fun `mergeFlamegraph sums frame values and unions dimensions across profiles`() {
         coEvery {
-            ProfileIngestionService.selectProfilesForMerge(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(),
-            )
+            ProfileIngestionService.selectProfilesForMerge(any())
         } returns ProfileMergeSelection(
             totalInWindow = 2,
             candidates = listOf(
@@ -123,19 +132,7 @@ class ProfileMergeServiceTest {
         } returns singleProfileFlamegraph()
 
         val out = runBlocking {
-            ProfileMergeService.mergeFlamegraph(
-                organizationId = 1,
-                service = "api",
-                profileType = "jfr",
-                env = null,
-                host = null,
-                version = null,
-                fromMs = 0,
-                toMs = 1000,
-                sampleType = "cpu",
-                thread = null,
-                maxProfiles = 25,
-            )
+            ProfileMergeService.mergeFlamegraph(mergeQuery(sampleType = "cpu"))
         }
 
         assertEquals(2, out["mergedCount"]!!.jsonPrimitive.int)
@@ -160,25 +157,11 @@ class ProfileMergeServiceTest {
     @Test
     fun `mergeFlamegraph returns empty result when no profiles match`() {
         coEvery {
-            ProfileIngestionService.selectProfilesForMerge(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(),
-            )
+            ProfileIngestionService.selectProfilesForMerge(any())
         } returns ProfileMergeSelection(totalInWindow = 0, candidates = emptyList())
 
         val out = runBlocking {
-            ProfileMergeService.mergeFlamegraph(
-                organizationId = 1,
-                service = "api",
-                profileType = "jfr",
-                env = null,
-                host = null,
-                version = null,
-                fromMs = 0,
-                toMs = 1000,
-                sampleType = null,
-                thread = null,
-                maxProfiles = 25,
-            )
+            ProfileMergeService.mergeFlamegraph(mergeQuery())
         }
 
         assertTrue(out["frames"]!!.jsonArray.isEmpty())

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileMergeServiceTest.kt
@@ -1,0 +1,179 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package com.moneat.datadog.services
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProfileMergeServiceTest {
+
+    @BeforeTest
+    fun setup() {
+        mockkObject(ProfileIngestionService)
+        mockkObject(ProfileStorageService)
+        mockkObject(ProfileFlamegraphParser)
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkObject(ProfileFlamegraphParser)
+        unmockkObject(ProfileStorageService)
+        unmockkObject(ProfileIngestionService)
+    }
+
+    private fun singleProfileFlamegraph(): JsonObject = buildJsonObject {
+        put(
+            "frames",
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        put("name", "main")
+                        put("value", 10)
+                        put(
+                            "children",
+                            buildJsonArray {
+                                add(
+                                    buildJsonObject {
+                                        put("name", "work")
+                                        put("value", 6)
+                                        put("children", buildJsonArray {})
+                                    },
+                                )
+                            },
+                        )
+                    },
+                )
+            },
+        )
+        put(
+            "sampleTypes",
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        put("key", "cpu")
+                        put("label", "CPU")
+                        put("unit", "samples")
+                    },
+                )
+            },
+        )
+        put(
+            "threads",
+            buildJsonArray {
+                add(
+                    buildJsonObject {
+                        put("id", "t1")
+                        put("label", "main")
+                        put("samples", 10)
+                    },
+                )
+            },
+        )
+        put("selectedSampleType", "cpu")
+        put("unit", "samples")
+        put("totalSamples", 10)
+    }
+
+    @Test
+    fun `mergeFlamegraph sums frame values and unions dimensions across profiles`() {
+        coEvery {
+            ProfileIngestionService.selectProfilesForMerge(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        } returns ProfileMergeSelection(
+            totalInWindow = 2,
+            candidates = listOf(
+                ProfileMergeCandidate("p1", "key1", "jfr", "datadog"),
+                ProfileMergeCandidate("p2", "key2", "jfr", "datadog"),
+            ),
+        )
+        every { ProfileStorageService.read(any()) } returns "payload".toByteArray()
+        every {
+            ProfileFlamegraphParser.parse(any(), any(), any(), any(), any())
+        } returns singleProfileFlamegraph()
+
+        val out = runBlocking {
+            ProfileMergeService.mergeFlamegraph(
+                organizationId = 1,
+                service = "api",
+                profileType = "jfr",
+                env = null,
+                host = null,
+                version = null,
+                fromMs = 0,
+                toMs = 1000,
+                sampleType = "cpu",
+                thread = null,
+                maxProfiles = 25,
+            )
+        }
+
+        assertEquals(2, out["mergedCount"]!!.jsonPrimitive.int)
+        assertEquals(2, out["totalCount"]!!.jsonPrimitive.int)
+        assertEquals(20, out["totalSamples"]!!.jsonPrimitive.int)
+
+        val main = out["frames"]!!.jsonArray[0].jsonObject
+        assertEquals("main", main["name"]!!.jsonPrimitive.content)
+        assertEquals(20, main["value"]!!.jsonPrimitive.int)
+        val work = main["children"]!!.jsonArray[0].jsonObject
+        assertEquals(12, work["value"]!!.jsonPrimitive.int)
+
+        // Threads are summed by id; sample types are unioned by key.
+        val threads = out["threads"]!!.jsonArray
+        assertEquals(1, threads.size)
+        assertEquals(20, threads[0].jsonObject["samples"]!!.jsonPrimitive.int)
+        val sampleTypes = out["sampleTypes"]!!.jsonArray
+        assertEquals(1, sampleTypes.size)
+        assertEquals("cpu", sampleTypes[0].jsonObject["key"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `mergeFlamegraph returns empty result when no profiles match`() {
+        coEvery {
+            ProfileIngestionService.selectProfilesForMerge(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        } returns ProfileMergeSelection(totalInWindow = 0, candidates = emptyList())
+
+        val out = runBlocking {
+            ProfileMergeService.mergeFlamegraph(
+                organizationId = 1,
+                service = "api",
+                profileType = "jfr",
+                env = null,
+                host = null,
+                version = null,
+                fromMs = 0,
+                toMs = 1000,
+                sampleType = null,
+                thread = null,
+                maxProfiles = 25,
+            )
+        }
+
+        assertTrue(out["frames"]!!.jsonArray.isEmpty())
+        assertEquals(0, out["mergedCount"]!!.jsonPrimitive.int)
+    }
+}

--- a/dashboard/src/components/profiling/ProfileList.tsx
+++ b/dashboard/src/components/profiling/ProfileList.tsx
@@ -212,6 +212,7 @@ export function ProfileList({
                 <Button
                   variant="ghost"
                   size="icon"
+                  aria-label={`Download profile ${profile.profileId}`}
                   className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
                   onClick={(e) => {
                     e.stopPropagation()

--- a/dashboard/src/components/profiling/ProfileList.tsx
+++ b/dashboard/src/components/profiling/ProfileList.tsx
@@ -31,7 +31,6 @@ import {
   Clock,
   Code2,
   Download,
-  ExternalLink,
   HardDrive,
   Layers,
   Loader2,
@@ -41,74 +40,77 @@ import {
 import {useMemo} from 'react'
 import {Link} from '@tanstack/react-router'
 import {formatRelativeTime} from '@/lib/utils'
+import {ProfilingEmptyState} from './ProfilingEmptyState'
+import {ProfileStatCard} from './ProfileStatCard'
+import {
+  formatBytes,
+  formatDuration,
+  parseUtcDate,
+  profileTypeBadgeClass,
+} from './profileFormat'
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
-}
+const EMBEDDED_LIMIT = 100
+const DEFAULT_LIMIT = 50
 
-function formatDuration(ns: number): string {
-  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(0)}ms`
-  return `${(ns / 1_000_000_000).toFixed(1)}s`
-}
-
-function parseUtcDate(value: string): Date {
-  if (value.includes('T')) return new Date(value)
-  return new Date(value + ' UTC')
-}
-
-const TYPE_COLORS: Record<string, string> = {
-  cpu: 'bg-orange-500/15 text-orange-400 border-orange-500/30',
-  wall: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
-  heap: 'bg-green-500/15 text-green-400 border-green-500/30',
-  alloc: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
-  goroutine: 'bg-purple-500/15 text-purple-400 border-purple-500/30',
-  mutex: 'bg-red-500/15 text-red-400 border-red-500/30',
-  block: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/30',
-}
-
-function profileTypeBadgeClass(type: string): string {
-  const key = type.toLowerCase()
-  for (const [k, v] of Object.entries(TYPE_COLORS)) {
-    if (key.includes(k)) return v
-  }
-  return 'bg-secondary text-secondary-foreground'
+interface ProfileScope {
+  service?: string
+  env?: string
+  type?: string
+  from?: number
+  to?: number
 }
 
 interface Props {
-  serviceFilter: string
-  onServiceFilterChange: (val: string) => void
-  typeFilter: string
-  onTypeFilterChange: (val: string) => void
+  /** Embedded mode: scoped, compact list with no stats/filter chrome. */
+  embedded?: boolean
+  scope?: ProfileScope
+  serviceFilter?: string
+  onServiceFilterChange?: (val: string) => void
+  typeFilter?: string
+  onTypeFilterChange?: (val: string) => void
 }
 
 export function ProfileList({
-  serviceFilter,
+  embedded = false,
+  scope,
+  serviceFilter = '',
   onServiceFilterChange,
-  typeFilter,
+  typeFilter = '',
   onTypeFilterChange,
 }: Props) {
   const {data, isLoading} = useQuery({
-    queryKey: ['profiles', serviceFilter, typeFilter],
+    queryKey: embedded
+      ? ['profiles', 'embedded', scope]
+      : ['profiles', serviceFilter, typeFilter],
     queryFn: () =>
-      api.getProfiles({
-        service: serviceFilter || undefined,
-        type: typeFilter || undefined,
-        limit: 50,
-      }),
+      api.getProfiles(
+        embedded
+          ? {
+              service: scope?.service,
+              env: scope?.env,
+              type: scope?.type,
+              from: scope?.from,
+              to: scope?.to,
+              limit: EMBEDDED_LIMIT,
+            }
+          : {
+              service: serviceFilter || undefined,
+              type: typeFilter || undefined,
+              limit: DEFAULT_LIMIT,
+            },
+      ),
     enabled: api.isAuthenticated(),
   })
 
   const profiles = data?.profiles ?? []
 
   const stats = useMemo(() => {
-    if (profiles.length === 0) return null
+    if (embedded || profiles.length === 0) return null
 
     const services = new Set(profiles.map((p) => p.service))
     const types = new Set(profiles.map((p) => p.profileType))
     const totalSize = profiles.reduce((sum, p) => sum + p.sizeBytes, 0)
-    const durations = profiles.map((p) => p.durationNs).sort((a, b) => a - b)
+    const durations = profiles.map((p) => p.durationNs)
     const avgDuration =
       durations.reduce((sum, d) => sum + d, 0) / durations.length
 
@@ -119,7 +121,7 @@ export function ProfileList({
       totalSize,
       avgDuration,
     }
-  }, [profiles, data?.totalCount])
+  }, [embedded, profiles, data?.totalCount])
 
   const availableTypes = useMemo(
     () => [...new Set(profiles.map((p) => p.profileType))].sort(),
@@ -135,7 +137,103 @@ export function ProfileList({
   }
 
   if (profiles.length === 0) {
+    if (embedded) {
+      return (
+        <p className="text-xs text-muted-foreground py-6 text-center">
+          No profiles in this window.
+        </p>
+      )
+    }
     return <ProfilingEmptyState />
+  }
+
+  const table = (
+    <Table className="[&_th]:h-8 [&_th]:px-2 [&_th]:text-xs [&_td]:py-1.5 [&_td]:px-2 [&_td]:text-xs">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Service</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead className="hidden md:table-cell">Environment</TableHead>
+          <TableHead className="hidden lg:table-cell">Host</TableHead>
+          <TableHead>Duration</TableHead>
+          <TableHead className="hidden sm:table-cell">Size</TableHead>
+          <TableHead>Time</TableHead>
+          <TableHead className="w-[48px]" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {profiles.map((profile: ProfileResponse) => {
+          const parsedStart = parseUtcDate(profile.startTime)
+          return (
+            <TableRow key={profile.profileId} className="group">
+              <TableCell>
+                <div className="flex items-center gap-2 min-w-0">
+                  <Link
+                    to="/profiles/$profileId"
+                    params={{profileId: profile.profileId}}
+                    className="font-medium text-primary hover:underline truncate"
+                  >
+                    {profile.service || '(unknown)'}
+                  </Link>
+                  {profile.language && (
+                    <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
+                      {profile.language}
+                    </span>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell>
+                <Badge
+                  variant="outline"
+                  className={`text-[11px] border ${profileTypeBadgeClass(profile.profileType)}`}
+                >
+                  {profile.profileType}
+                </Badge>
+              </TableCell>
+              <TableCell className="hidden md:table-cell text-muted-foreground">
+                {profile.env || '—'}
+              </TableCell>
+              <TableCell className="hidden lg:table-cell text-muted-foreground font-mono truncate max-w-[140px]">
+                {profile.host || '—'}
+              </TableCell>
+              <TableCell className="font-mono tabular-nums">
+                {formatDuration(profile.durationNs)}
+              </TableCell>
+              <TableCell className="hidden sm:table-cell font-mono tabular-nums text-muted-foreground">
+                {formatBytes(profile.sizeBytes)}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                <span title={parsedStart.toLocaleString()}>
+                  <Clock className="h-3 w-3 inline mr-1 -mt-px" />
+                  {formatRelativeTime(parsedStart.getTime())}
+                </span>
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    api.downloadProfile(
+                      profile.profileId,
+                      undefined,
+                      profile.profileType,
+                    )
+                  }}
+                >
+                  <Download className="h-3.5 w-3.5" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+
+  if (embedded) {
+    return table
   }
 
   return (
@@ -147,14 +245,14 @@ export function ProfileList({
           <Input
             placeholder="Filter by service..."
             value={serviceFilter}
-            onChange={(e) => onServiceFilterChange(e.target.value)}
+            onChange={(e) => onServiceFilterChange?.(e.target.value)}
             className="pl-8 h-7 text-xs"
           />
         </div>
         {availableTypes.length > 1 && (
           <Select
             value={typeFilter || '__all'}
-            onValueChange={(v) => onTypeFilterChange(v === '__all' ? '' : v)}
+            onValueChange={(v) => onTypeFilterChange?.(v === '__all' ? '' : v)}
           >
             <SelectTrigger className="h-7 w-[140px] text-xs">
               <SelectValue placeholder="All types" />
@@ -174,27 +272,27 @@ export function ProfileList({
       {/* Summary stats */}
       {stats && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-1.5">
-          <StatCard
+          <ProfileStatCard
             label="Total Profiles"
             value={stats.totalProfiles.toLocaleString()}
             icon={<Layers className="h-3.5 w-3.5" />}
           />
-          <StatCard
+          <ProfileStatCard
             label="Services"
             value={String(stats.serviceCount)}
             icon={<Server className="h-3.5 w-3.5" />}
           />
-          <StatCard
+          <ProfileStatCard
             label="Profile Types"
             value={String(stats.typeCount)}
             icon={<Code2 className="h-3.5 w-3.5" />}
           />
-          <StatCard
+          <ProfileStatCard
             label="Avg Duration"
             value={formatDuration(stats.avgDuration)}
             icon={<Activity className="h-3.5 w-3.5" />}
           />
-          <StatCard
+          <ProfileStatCard
             label="Total Size"
             value={formatBytes(stats.totalSize)}
             icon={<HardDrive className="h-3.5 w-3.5" />}
@@ -203,141 +301,7 @@ export function ProfileList({
       )}
 
       {/* Table */}
-      <div className="rounded-lg border">
-        <Table className="[&_th]:h-8 [&_th]:px-2 [&_th]:text-xs [&_td]:py-1.5 [&_td]:px-2 [&_td]:text-xs">
-          <TableHeader>
-            <TableRow>
-              <TableHead>Service</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead className="hidden md:table-cell">
-                Environment
-              </TableHead>
-              <TableHead className="hidden lg:table-cell">Host</TableHead>
-              <TableHead>Duration</TableHead>
-              <TableHead className="hidden sm:table-cell">Size</TableHead>
-              <TableHead>Time</TableHead>
-              <TableHead className="w-[48px]" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {profiles.map((profile: ProfileResponse) => {
-              const parsedStart = parseUtcDate(profile.startTime)
-              return (
-                <TableRow key={profile.profileId} className="group">
-                  <TableCell>
-                    <div className="flex items-center gap-2 min-w-0">
-                      <Link
-                        to="/profiles/$profileId"
-                        params={{profileId: profile.profileId}}
-                        className="font-medium text-primary hover:underline truncate"
-                      >
-                        {profile.service || '(unknown)'}
-                      </Link>
-                      {profile.language && (
-                        <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
-                          {profile.language}
-                        </span>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      variant="outline"
-                      className={`text-[11px] border ${profileTypeBadgeClass(profile.profileType)}`}
-                    >
-                      {profile.profileType}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell text-muted-foreground">
-                    {profile.env || '—'}
-                  </TableCell>
-                  <TableCell className="hidden lg:table-cell text-muted-foreground font-mono truncate max-w-[140px]">
-                    {profile.host || '—'}
-                  </TableCell>
-                  <TableCell className="font-mono tabular-nums">
-                    {formatDuration(profile.durationNs)}
-                  </TableCell>
-                  <TableCell className="hidden sm:table-cell font-mono tabular-nums text-muted-foreground">
-                    {formatBytes(profile.sizeBytes)}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    <span title={parsedStart.toLocaleString()}>
-                      <Clock className="h-3 w-3 inline mr-1 -mt-px" />
-                      {formatRelativeTime(parsedStart.getTime())}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        api.downloadProfile(
-                          profile.profileId,
-                          undefined,
-                          profile.profileType
-                        )
-                      }}
-                    >
-                      <Download className="h-3.5 w-3.5" />
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              )
-            })}
-          </TableBody>
-        </Table>
-      </div>
-    </div>
-  )
-}
-
-function ProfilingEmptyState() {
-  return (
-    <div className="rounded-xl border border-dashed py-10 px-4 max-w-lg mx-auto bg-card">
-      <div className="flex flex-col items-center text-center">
-        <div className="h-12 w-12 rounded-full bg-gradient-to-br from-violet-500/20 to-orange-500/20 border border-violet-500/20 flex items-center justify-center mb-3">
-          <Layers className="h-5 w-5 text-violet-500 dark:text-violet-400" />
-        </div>
-        <p className="font-semibold text-sm text-foreground">No profiles yet</p>
-        <p className="text-xs text-muted-foreground mt-1 max-w-sm">
-          Set up continuous profiling in your application or compatible agent to
-          start collecting flamegraph data.
-        </p>
-        <a
-          href="https://moneat.io/docs/sdk-setup"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 mt-3 text-xs font-medium text-primary hover:underline"
-        >
-          Read the setup guide
-          <ExternalLink className="h-3.5 w-3.5" />
-        </a>
-      </div>
-    </div>
-  )
-}
-
-
-function StatCard({
-  label,
-  value,
-  icon,
-}: {
-  label: string
-  value: string
-  icon: React.ReactNode
-}) {
-  return (
-    <div className="rounded-lg border bg-card px-2.5 py-2 flex flex-col gap-0.5">
-      <div className="flex items-center gap-1 text-muted-foreground">
-        {icon}
-        <span className="text-[11px] font-medium">{label}</span>
-      </div>
-      <span className="text-lg font-bold tabular-nums tracking-tight">
-        {value}
-      </span>
+      <div className="rounded-lg border">{table}</div>
     </div>
   )
 }

--- a/dashboard/src/components/profiling/ProfileServiceList.tsx
+++ b/dashboard/src/components/profiling/ProfileServiceList.tsx
@@ -1,0 +1,224 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {useMemo} from 'react'
+import {useQuery} from '@tanstack/react-query'
+import {Link} from '@tanstack/react-router'
+import {Bar, BarChart as RechartsBarChart, ResponsiveContainer} from 'recharts'
+import {
+  Activity,
+  Clock,
+  Code2,
+  HardDrive,
+  Layers,
+  Loader2,
+  Search,
+  Server,
+} from 'lucide-react'
+import {api, type ProfileServiceSummary} from '@/lib/api'
+import {Card} from '@/components/ui/card'
+import {Badge} from '@/components/ui/badge'
+import {Input} from '@/components/ui/input'
+import {cn, formatRelativeTime} from '@/lib/utils'
+import {getNow} from '@/lib/demo'
+import {ProfilingEmptyState} from './ProfilingEmptyState'
+import {ProfileStatCard} from './ProfileStatCard'
+import {
+  LIVE_THRESHOLD_MS,
+  formatBytes,
+  formatCompact,
+  parseUtcDate,
+  profileTypeBadgeClass,
+} from './profileFormat'
+
+interface Props {
+  serviceFilter: string
+  onServiceFilterChange: (val: string) => void
+}
+
+export function ProfileServiceList({serviceFilter, onServiceFilterChange}: Props) {
+  const {data, isLoading} = useQuery({
+    queryKey: ['profileServices'],
+    queryFn: () => api.getProfileServices(),
+    enabled: api.isAuthenticated(),
+  })
+
+  const services = data?.services ?? []
+
+  const filtered = useMemo(() => {
+    const q = serviceFilter.trim().toLowerCase()
+    if (!q) return services
+    return services.filter((s) => s.service.toLowerCase().includes(q))
+  }, [services, serviceFilter])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (services.length === 0) {
+    return <ProfilingEmptyState />
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="relative max-w-xs">
+        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+        <Input
+          placeholder="Filter by service..."
+          value={serviceFilter}
+          onChange={(e) => onServiceFilterChange(e.target.value)}
+          className="pl-8 h-7 text-xs"
+        />
+      </div>
+
+      {data && (
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-1.5">
+          <ProfileStatCard
+            label="Total Profiles"
+            value={data.totalProfiles.toLocaleString()}
+            icon={<Layers className="h-3.5 w-3.5" />}
+          />
+          <ProfileStatCard
+            label="Services"
+            value={String(data.serviceCount)}
+            icon={<Server className="h-3.5 w-3.5" />}
+          />
+          <ProfileStatCard
+            label="Profile Types"
+            value={String(data.typeCount)}
+            icon={<Code2 className="h-3.5 w-3.5" />}
+          />
+          <ProfileStatCard
+            label="Hosts"
+            value={data.hostCount.toLocaleString()}
+            icon={<Activity className="h-3.5 w-3.5" />}
+          />
+          <ProfileStatCard
+            label="Total Size"
+            value={formatBytes(data.totalSizeBytes)}
+            icon={<HardDrive className="h-3.5 w-3.5" />}
+          />
+        </div>
+      )}
+
+      {filtered.length === 0 ? (
+        <p className="text-xs text-muted-foreground py-6 text-center">
+          No services match "{serviceFilter}".
+        </p>
+      ) : (
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((service) => (
+            <ServiceCard key={service.service || '(unknown)'} service={service} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ServiceCard({service}: {service: ProfileServiceSummary}) {
+  const lastSeenMs = parseUtcDate(service.lastSeen).getTime()
+  const isLive =
+    Number.isFinite(lastSeenMs) && getNow() - lastSeenMs < LIVE_THRESHOLD_MS
+  const language = service.languages[0] || service.runtimes[0] || ''
+
+  return (
+    <Link
+      to="/profiles/service/$service"
+      params={{service: service.service || '(unknown)'}}
+      className="block group focus:outline-none"
+    >
+      <Card className="h-full p-3 space-y-2 transition-colors group-hover:border-primary/40 group-hover:bg-accent/30 group-focus-visible:border-primary/60">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span
+              className={cn(
+                'h-1.5 w-1.5 rounded-full shrink-0',
+                isLive ? 'bg-emerald-500 animate-pulse' : 'bg-muted-foreground/30',
+              )}
+              title={isLive ? 'Receiving profiles' : 'Idle'}
+            />
+            <span className="font-semibold text-sm truncate group-hover:text-primary">
+              {service.service || '(unknown)'}
+            </span>
+          </div>
+          {language && (
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
+              {language}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between text-[11px] text-muted-foreground gap-2">
+          <span className="truncate" title={service.environments.join(', ')}>
+            {service.environments.length > 0 ? service.environments.join(', ') : '—'}
+          </span>
+          <span className="shrink-0">
+            {service.hostCount} {service.hostCount === 1 ? 'host' : 'hosts'}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-1">
+          {service.types.slice(0, 5).map((t) => (
+            <Badge
+              key={t.profileType}
+              variant="outline"
+              className={cn('text-[10px] border', profileTypeBadgeClass(t.profileType))}
+            >
+              {t.profileType} {formatCompact(t.count)}
+            </Badge>
+          ))}
+        </div>
+
+        <div className="flex items-end justify-between gap-2 pt-0.5">
+          <div className="text-[11px] text-muted-foreground space-y-0.5 min-w-0">
+            <div className="font-mono tabular-nums">
+              {service.profileCount.toLocaleString()} · {formatBytes(service.totalSizeBytes)}
+            </div>
+            <div className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {Number.isFinite(lastSeenMs) ? formatRelativeTime(lastSeenMs) : '—'}
+            </div>
+          </div>
+          <div className="w-20 h-7 shrink-0">
+            <Sparkline data={service.series} live={isLive} />
+          </div>
+        </div>
+      </Card>
+    </Link>
+  )
+}
+
+function Sparkline({
+  data,
+  live,
+}: {
+  data: ProfileServiceSummary['series']
+  live: boolean
+}) {
+  if (!data || data.length === 0) {
+    return <div className="h-full w-full rounded bg-muted/40" />
+  }
+  const color = live ? 'hsl(var(--chart-1))' : 'hsl(var(--muted-foreground) / 0.4)'
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <RechartsBarChart data={data} margin={{top: 2, right: 0, bottom: 0, left: 0}}>
+        <Bar
+          dataKey="count"
+          fill={color}
+          radius={[1, 1, 0, 0]}
+          isAnimationActive={false}
+        />
+      </RechartsBarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/dashboard/src/components/profiling/ProfileStatCard.tsx
+++ b/dashboard/src/components/profiling/ProfileStatCard.tsx
@@ -1,0 +1,29 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import type React from 'react'
+
+export function ProfileStatCard({
+  label,
+  value,
+  icon,
+}: {
+  label: string
+  value: string
+  icon: React.ReactNode
+}) {
+  return (
+    <div className="rounded-lg border bg-card px-2.5 py-2 flex flex-col gap-0.5">
+      <div className="flex items-center gap-1 text-muted-foreground">
+        {icon}
+        <span className="text-[11px] font-medium">{label}</span>
+      </div>
+      <span className="text-lg font-bold tabular-nums tracking-tight">{value}</span>
+    </div>
+  )
+}

--- a/dashboard/src/components/profiling/ProfilingEmptyState.tsx
+++ b/dashboard/src/components/profiling/ProfilingEmptyState.tsx
@@ -1,0 +1,35 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {ExternalLink, Layers} from 'lucide-react'
+
+export function ProfilingEmptyState() {
+  return (
+    <div className="rounded-xl border border-dashed py-10 px-4 max-w-lg mx-auto bg-card">
+      <div className="flex flex-col items-center text-center">
+        <div className="h-12 w-12 rounded-full bg-gradient-to-br from-violet-500/20 to-orange-500/20 border border-violet-500/20 flex items-center justify-center mb-3">
+          <Layers className="h-5 w-5 text-violet-500 dark:text-violet-400" />
+        </div>
+        <p className="font-semibold text-sm text-foreground">No profiles yet</p>
+        <p className="text-xs text-muted-foreground mt-1 max-w-sm">
+          Set up continuous profiling in your application or compatible agent to
+          start collecting flamegraph data.
+        </p>
+        <a
+          href="https://moneat.io/docs/sdk-setup"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 mt-3 text-xs font-medium text-primary hover:underline"
+        >
+          Read the setup guide
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/profiling/ServiceExplorer.tsx
+++ b/dashboard/src/components/profiling/ServiceExplorer.tsx
@@ -1,0 +1,469 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {useMemo, useState} from 'react'
+import {useQuery} from '@tanstack/react-query'
+import {Link} from '@tanstack/react-router'
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import {ArrowLeft, Clock, Layers, Loader2, Server, X} from 'lucide-react'
+import {api} from '@/lib/api'
+import {Flamegraph} from '@/components/profiling/Flamegraph'
+import {ProfileList} from '@/components/profiling/ProfileList'
+import {Button} from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {cn, formatRelativeTime} from '@/lib/utils'
+import {getNow} from '@/lib/demo'
+import {formatBytes, formatDuration, parseUtcDate} from './profileFormat'
+
+const ALL_ENVS = '__all'
+const MERGE_PROFILE_CAP = 25
+
+const RANGES: Record<string, {label: string; ms: number}> = {
+  '1h': {label: '1h', ms: 60 * 60 * 1000},
+  '6h': {label: '6h', ms: 6 * 60 * 60 * 1000},
+  '24h': {label: '24h', ms: 24 * 60 * 60 * 1000},
+  '7d': {label: '7d', ms: 7 * 24 * 60 * 60 * 1000},
+}
+type RangeKey = keyof typeof RANGES
+
+interface Props {
+  service: string
+}
+
+export function ServiceExplorer({service}: Props) {
+  const [env, setEnv] = useState<string>(ALL_ENVS)
+  const [rangeKey, setRangeKey] = useState<RangeKey>('24h')
+  const [selectedType, setSelectedType] = useState<string | null>(null)
+  const [sampleType, setSampleType] = useState<string | null>(null)
+  const [thread, setThread] = useState<string | null>(null)
+  const [zoom, setZoom] = useState<{from: number; to: number} | null>(null)
+  const [showBrowse, setShowBrowse] = useState(false)
+
+  const {data: servicesData, isLoading: servicesLoading} = useQuery({
+    queryKey: ['profileServices'],
+    queryFn: () => api.getProfileServices(),
+    enabled: api.isAuthenticated(),
+  })
+  const summary = servicesData?.services.find((s) => s.service === service)
+
+  const range = useMemo(() => {
+    const to = getNow()
+    return {from: to - RANGES[rangeKey].ms, to}
+  }, [rangeKey])
+  const mergeWindow = zoom ?? range
+
+  const envParam = env === ALL_ENVS ? undefined : env
+  const effectiveType =
+    selectedType ?? summary?.types[0]?.profileType ?? undefined
+
+  const {data: timeseries} = useQuery({
+    queryKey: ['profileTimeseries', service, envParam, effectiveType, range.from, range.to],
+    queryFn: () =>
+      api.getProfileTimeseries({
+        service,
+        env: envParam,
+        type: effectiveType,
+        from: range.from,
+        to: range.to,
+        buckets: 48,
+      }),
+    enabled: api.isAuthenticated(),
+  })
+
+  const {data: merged, isFetching: mergeFetching} = useQuery({
+    queryKey: [
+      'mergedFlamegraph',
+      service,
+      envParam,
+      effectiveType,
+      mergeWindow.from,
+      mergeWindow.to,
+      sampleType,
+      thread,
+    ],
+    queryFn: () =>
+      api.getMergedFlamegraph({
+        service,
+        env: envParam,
+        type: effectiveType,
+        from: mergeWindow.from,
+        to: mergeWindow.to,
+        sampleType,
+        thread,
+        maxProfiles: MERGE_PROFILE_CAP,
+      }),
+    enabled: api.isAuthenticated(),
+  })
+
+  const bucketMs = (timeseries?.bucketSeconds ?? 0) * 1000
+  const buckets = useMemo(
+    () =>
+      buildTimelineBuckets(
+        timeseries?.points ?? [],
+        bucketMs,
+        range.from,
+        range.to,
+      ),
+    [timeseries?.points, bucketMs, range.from, range.to],
+  )
+
+  const handleTypeChange = (type: string) => {
+    setSelectedType(type)
+    setSampleType(null)
+    setThread(null)
+  }
+
+  const handleRangeChange = (key: RangeKey) => {
+    setRangeKey(key)
+    setZoom(null)
+  }
+
+  const toggleBucket = (ts: number) => {
+    if (!bucketMs) return
+    if (zoom && zoom.from === ts) {
+      setZoom(null)
+    } else {
+      setZoom({from: ts, to: ts + bucketMs})
+    }
+  }
+
+  if (servicesLoading) {
+    return (
+      <div className="p-3 flex flex-col items-center justify-center py-16 gap-2">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <p className="text-xs text-muted-foreground">Loading service…</p>
+      </div>
+    )
+  }
+
+  const types = summary?.types ?? []
+  const environments = summary?.environments ?? []
+  const language = summary?.languages[0] || summary?.runtimes[0] || undefined
+
+  const metaSidebar = (
+    <div className="rounded-lg border p-2.5 space-y-2 shrink-0 text-[11px]">
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
+        <Meta label="Hosts" value={String(summary?.hostCount ?? 0)} />
+        <Meta
+          label="Avg duration"
+          value={summary ? formatDuration(summary.avgDurationNs) : '—'}
+        />
+        <Meta label="Total size" value={summary ? formatBytes(summary.totalSizeBytes) : '—'} />
+        <Meta
+          label="Profiles"
+          value={(summary?.profileCount ?? 0).toLocaleString()}
+        />
+      </div>
+      {merged && (
+        <div className="pt-2 border-t text-muted-foreground">
+          Aggregated from{' '}
+          <span className="text-foreground font-medium">{merged.mergedCount ?? 0}</span> of{' '}
+          <span className="text-foreground font-medium">{merged.totalCount ?? 0}</span>{' '}
+          profiles in window
+        </div>
+      )}
+      {summary && (
+        <div className="pt-2 border-t flex items-center gap-1 text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          {Number.isFinite(parseUtcDate(summary.lastSeen).getTime())
+            ? `last ${formatRelativeTime(parseUtcDate(summary.lastSeen).getTime())}`
+            : '—'}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <div
+      className="flex flex-col overflow-hidden p-3 gap-y-2"
+      style={{height: 'calc(100vh - var(--header-height, 0px))'}}
+    >
+      {/* Header + controls */}
+      <div className="flex items-start justify-between gap-2 shrink-0 flex-wrap">
+        <div className="flex items-start gap-2 min-w-0">
+          <Button variant="ghost" size="icon" className="h-7 w-7 mt-0.5 shrink-0" asChild>
+            <Link to="/profiles">
+              <ArrowLeft className="h-3.5 w-3.5" />
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Server className="h-4 w-4 text-muted-foreground" />
+              <h1 className="text-lg font-bold tracking-tight leading-tight truncate">
+                {service}
+              </h1>
+              {language && (
+                <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded">
+                  {language}
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Aggregated flamegraph across the selected window
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {types.length > 1 && (
+            <Select value={effectiveType} onValueChange={handleTypeChange}>
+              <SelectTrigger className="h-7 w-[130px] text-xs">
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent>
+                {types.map((t) => (
+                  <SelectItem key={t.profileType} value={t.profileType}>
+                    {t.profileType} ({t.count.toLocaleString()})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {environments.length > 1 && (
+            <Select value={env} onValueChange={setEnv}>
+              <SelectTrigger className="h-7 w-[150px] text-xs">
+                <SelectValue placeholder="All environments" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_ENVS}>All environments</SelectItem>
+                {environments.map((e) => (
+                  <SelectItem key={e} value={e}>
+                    {e}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <div className="inline-flex rounded-md border p-0.5 text-xs">
+            {(Object.keys(RANGES) as RangeKey[]).map((key) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => handleRangeChange(key)}
+                className={cn(
+                  'px-2 py-1 rounded font-medium transition-colors',
+                  rangeKey === key
+                    ? 'bg-secondary text-secondary-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {RANGES[key].label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Volume timeline */}
+      <div className="rounded-lg border bg-card px-2 pt-1.5 pb-1 shrink-0">
+        <div className="flex items-center justify-between px-1 mb-0.5">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+            Profile volume
+          </span>
+          {zoom ? (
+            <button
+              type="button"
+              onClick={() => setZoom(null)}
+              className="inline-flex items-center gap-1 text-[10px] text-primary hover:underline"
+            >
+              <X className="h-3 w-3" />
+              {new Date(zoom.from).toLocaleString()} — clear selection
+            </button>
+          ) : (
+            <span className="text-[10px] text-muted-foreground">
+              click a bar to focus the flamegraph on that window
+            </span>
+          )}
+        </div>
+        <VolumeTimeline
+          buckets={buckets}
+          rangeMs={RANGES[rangeKey].ms}
+          selectedFrom={zoom?.from ?? null}
+          onSelect={toggleBucket}
+        />
+      </div>
+
+      {/* Merged flamegraph */}
+      <div className="flex flex-col flex-1 min-h-0">
+        <div className="flex items-center justify-between mb-1.5">
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+            Merged flamegraph
+          </h2>
+          {mergeFetching && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+          )}
+        </div>
+        <Flamegraph
+          frames={merged?.frames}
+          language={language}
+          service={service}
+          meta={metaSidebar}
+          sampleTypes={merged?.sampleTypes}
+          threads={merged?.threads}
+          selectedSampleType={merged?.selectedSampleType}
+          selectedThread={merged?.selectedThread ?? null}
+          unit={merged?.unit}
+          onSampleTypeChange={setSampleType}
+          onThreadChange={setThread}
+          emptyMessage={
+            mergeFetching
+              ? 'Aggregating profiles…'
+              : 'No profiling data in this window'
+          }
+        />
+      </div>
+
+      {/* Browse raw profiles in window */}
+      <div className="shrink-0">
+        <button
+          type="button"
+          onClick={() => setShowBrowse((v) => !v)}
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <Layers className="h-3.5 w-3.5" />
+          {showBrowse ? 'Hide' : 'Browse'} individual profiles in window
+        </button>
+        {showBrowse && (
+          <div className="mt-1.5 max-h-64 overflow-auto rounded-lg border">
+            <ProfileList
+              embedded
+              scope={{
+                service,
+                env: envParam,
+                type: effectiveType,
+                from: mergeWindow.from,
+                to: mergeWindow.to,
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Meta({label, value}: {label: string; value: string}) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[10px] text-muted-foreground leading-none mb-0.5">{label}</p>
+      <p className="text-xs font-medium tabular-nums truncate">{value}</p>
+    </div>
+  )
+}
+
+interface TimelineBucket {
+  ts: number
+  count: number
+}
+
+function VolumeTimeline({
+  buckets,
+  rangeMs,
+  selectedFrom,
+  onSelect,
+}: {
+  buckets: TimelineBucket[]
+  rangeMs: number
+  selectedFrom: number | null
+  onSelect: (ts: number) => void
+}) {
+  if (buckets.length === 0) {
+    return (
+      <div className="h-[72px] flex items-center justify-center text-[11px] text-muted-foreground">
+        No activity in this window
+      </div>
+    )
+  }
+  const showDate = rangeMs > 24 * 60 * 60 * 1000
+  return (
+    <ResponsiveContainer width="100%" height={72}>
+      <RechartsBarChart
+        data={buckets}
+        margin={{top: 2, right: 4, bottom: 0, left: 4}}
+        onClick={(state) => {
+          const payload = (
+            state as {activePayload?: Array<{payload?: TimelineBucket}>}
+          )?.activePayload?.[0]?.payload
+          if (payload) onSelect(payload.ts)
+        }}
+      >
+        <XAxis
+          dataKey="ts"
+          tickFormatter={(ts: number) => formatTick(ts, showDate)}
+          tick={{fontSize: 9, fill: 'hsl(var(--muted-foreground))'}}
+          axisLine={false}
+          tickLine={false}
+          minTickGap={28}
+        />
+        <YAxis hide />
+        <Tooltip
+          cursor={{fill: 'hsl(var(--muted) / 0.4)'}}
+          labelFormatter={(ts) => new Date(ts as number).toLocaleString()}
+          formatter={(value) => [`${value} profiles`, '']}
+          contentStyle={{
+            fontSize: 11,
+            borderRadius: 6,
+            border: '1px solid hsl(var(--border))',
+            background: 'hsl(var(--popover))',
+          }}
+        />
+        <Bar dataKey="count" radius={[1, 1, 0, 0]} isAnimationActive={false} cursor="pointer">
+          {buckets.map((b) => (
+            <Cell
+              key={b.ts}
+              fill={
+                selectedFrom === b.ts
+                  ? 'hsl(var(--chart-2))'
+                  : 'hsl(var(--chart-1))'
+              }
+            />
+          ))}
+        </Bar>
+      </RechartsBarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function buildTimelineBuckets(
+  points: {ts: number; count: number}[],
+  bucketMs: number,
+  from: number,
+  to: number,
+): TimelineBucket[] {
+  if (bucketMs <= 0) {
+    return points.map((p) => ({ts: p.ts, count: p.count}))
+  }
+  const counts = new Map(points.map((p) => [p.ts, p.count]))
+  const start = Math.floor(from / bucketMs) * bucketMs
+  const out: TimelineBucket[] = []
+  for (let t = start; t < to; t += bucketMs) {
+    out.push({ts: t, count: counts.get(t) ?? 0})
+  }
+  return out
+}
+
+function formatTick(ts: number, showDate: boolean): string {
+  const d = new Date(ts)
+  const time = d.toLocaleTimeString(undefined, {hour: '2-digit', minute: '2-digit'})
+  if (!showDate) return time
+  return `${d.toLocaleDateString(undefined, {month: 'numeric', day: 'numeric'})} ${time}`
+}

--- a/dashboard/src/components/profiling/__tests__/profileDashboardComponents.test.tsx
+++ b/dashboard/src/components/profiling/__tests__/profileDashboardComponents.test.tsx
@@ -1,0 +1,506 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import type React from 'react'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {fireEvent, render, screen, waitFor, within} from '@testing-library/react'
+import {Layers} from 'lucide-react'
+import {ProfileList} from '../ProfileList'
+import {ProfileServiceList} from '../ProfileServiceList'
+import {ProfileStatCard} from '../ProfileStatCard'
+import {ProfilingEmptyState} from '../ProfilingEmptyState'
+import {ServiceExplorer} from '../ServiceExplorer'
+import {renderWithQueryClient} from '@/test/utils'
+import {Route as ProfileDetailRoute} from '@/routes/profiles.$profileId'
+import {Route as ProfilesIndexRoute} from '@/routes/profiles.index'
+import {Route as ProfileServiceRoute} from '@/routes/profiles.service.$service'
+
+const NOW_MS = 1_700_000_000_000
+const RANGE_24H_START = NOW_MS - 24 * 60 * 60 * 1000
+
+const mockRouteParams = vi.hoisted(() => ({
+  value: {} as Record<string, string>,
+}))
+
+const mockApi = vi.hoisted(() => ({
+  downloadProfile: vi.fn(),
+  getMergedFlamegraph: vi.fn(),
+  getProfile: vi.fn(),
+  getProfileFlamegraph: vi.fn(),
+  getProfiles: vi.fn(),
+  getProfileServices: vi.fn(),
+  getProfileTimeseries: vi.fn(),
+  isAuthenticated: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({api: mockApi}))
+vi.mock('@/lib/demo', () => ({
+  getNow: () => NOW_MS,
+  getNowDate: () => new Date(NOW_MS),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (
+    options: {component: React.ComponentType} & Record<string, unknown>,
+  ) => ({
+    ...options,
+    options,
+    useParams: () => mockRouteParams.value,
+  }),
+  Link: ({
+    children,
+    to,
+    params,
+    className,
+  }: {
+    children: React.ReactNode
+    to?: string
+    params?: Record<string, string>
+    className?: string
+  }) => {
+    const href = Object.entries(params ?? {}).reduce(
+      (acc, [key, value]) => acc.replace(`$${key}`, value),
+      to ?? '#',
+    )
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+vi.mock('recharts', () => ({
+  Bar: ({children}: {children?: React.ReactNode}) => <div data-testid="bar">{children}</div>,
+  BarChart: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode
+    onClick?: (state: unknown) => void
+  }) => (
+    <div
+      data-testid="bar-chart"
+      onClick={() =>
+        onClick?.({activePayload: [{payload: {ts: RANGE_24H_START, count: 2}}]})
+      }
+    >
+      {children}
+    </div>
+  ),
+  Cell: () => <span data-testid="cell" />,
+  ResponsiveContainer: ({children}: {children?: React.ReactNode}) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}))
+
+vi.mock('@/components/profiling/Flamegraph', () => ({
+  Flamegraph: ({
+    emptyMessage,
+    meta,
+    onSampleTypeChange,
+    onThreadChange,
+    service,
+  }: {
+    emptyMessage?: string
+    meta?: React.ReactNode
+    onSampleTypeChange?: (value: string | null) => void
+    onThreadChange?: (value: string | null) => void
+    service?: string
+  }) => (
+    <section aria-label="mock flamegraph">
+      <p>{service}</p>
+      <p>{emptyMessage}</p>
+      {meta}
+      <button type="button" onClick={() => onSampleTypeChange?.('wall')}>
+        Pick sample type
+      </button>
+      <button type="button" onClick={() => onThreadChange?.('main')}>
+        Pick thread
+      </button>
+    </section>
+  ),
+}))
+
+const profile = {
+  profileId: 'prof-1',
+  host: 'host-a',
+  service: 'checkout',
+  env: 'prod',
+  version: '1.2.3',
+  runtime: 'jvm',
+  language: 'java',
+  profileType: 'jfr',
+  startTime: '2026-05-29T14:00:00Z',
+  endTime: '2026-05-29T14:01:00Z',
+  durationNs: 60_000_000_000,
+  sizeBytes: 2_048,
+  tags: {},
+  source: 'datadog',
+}
+
+const workerProfile = {
+  ...profile,
+  profileId: 'prof-2',
+  service: 'worker',
+  profileType: 'pprof',
+  language: 'go',
+  sizeBytes: 4_096,
+}
+
+const checkoutSummary = {
+  service: 'checkout',
+  languages: ['java'],
+  runtimes: ['jvm'],
+  environments: ['prod', 'staging'],
+  types: [
+    {profileType: 'jfr', count: 4},
+    {profileType: 'pprof', count: 1},
+  ],
+  hostCount: 3,
+  profileCount: 5,
+  totalSizeBytes: 8_192,
+  firstSeen: '2026-05-29T13:00:00Z',
+  lastSeen: new Date(NOW_MS - 2_000).toISOString(),
+  avgDurationNs: 30_000_000_000,
+  series: [
+    {ts: RANGE_24H_START, count: 1},
+    {ts: RANGE_24H_START + 60_000, count: 2},
+  ],
+}
+
+const workerSummary = {
+  ...checkoutSummary,
+  service: 'worker',
+  languages: [],
+  runtimes: ['go'],
+  environments: ['prod'],
+  types: [{profileType: 'pprof', count: 2}],
+  hostCount: 1,
+  profileCount: 2,
+  lastSeen: 'not-a-date',
+  series: [],
+}
+
+const servicesResponse = {
+  services: [checkoutSummary, workerSummary],
+  totalProfiles: 7,
+  totalSizeBytes: 12_288,
+  serviceCount: 2,
+  hostCount: 4,
+  typeCount: 2,
+}
+
+function resetProfileApiMocks() {
+  mockApi.downloadProfile.mockResolvedValue(undefined)
+  mockApi.getProfile.mockResolvedValue(profile)
+  mockApi.getProfileFlamegraph.mockResolvedValue({
+    frames: [{name: 'root', value: 10, children: []}],
+    sampleTypes: [{key: 'wall', label: 'Wall', unit: 'samples'}],
+    threads: [{id: 'main', label: 'main', samples: 12}],
+    selectedSampleType: 'wall',
+    selectedThread: null,
+    unit: 'samples',
+  })
+  mockApi.getProfiles.mockResolvedValue({
+    profiles: [profile, workerProfile],
+    totalCount: 2,
+  })
+  mockApi.getProfileServices.mockResolvedValue(servicesResponse)
+  mockApi.getProfileTimeseries.mockResolvedValue({
+    bucketSeconds: 60,
+    points: [
+      {ts: RANGE_24H_START, count: 2, sizeBytes: 2048},
+      {ts: RANGE_24H_START + 60_000, count: 1, sizeBytes: 1024},
+    ],
+  })
+  mockApi.getMergedFlamegraph.mockResolvedValue({
+    frames: [{name: 'root', value: 10, children: []}],
+    mergedCount: 2,
+    totalCount: 5,
+    sampleTypes: [{key: 'wall', label: 'Wall', unit: 'samples'}],
+    threads: [{id: 'main', label: 'main', samples: 12}],
+    selectedSampleType: 'wall',
+    selectedThread: null,
+    unit: 'samples',
+  })
+  mockApi.isAuthenticated.mockReturnValue(true)
+}
+
+function getRouteComponent(route: unknown): React.ComponentType {
+  const candidate = route as {
+    component?: React.ComponentType
+    options?: {component?: React.ComponentType}
+  }
+  const component = candidate.component ?? candidate.options?.component
+  if (!component) throw new Error('Route component missing')
+  return component
+}
+
+beforeEach(() => {
+  sessionStorage.setItem('authenticated', 'true')
+  mockRouteParams.value = {}
+  resetProfileApiMocks()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  sessionStorage.clear()
+  localStorage.clear()
+})
+
+describe('Profile overview widgets', () => {
+  it('renders the profile stat card and empty state', () => {
+    render(
+      <>
+        <ProfileStatCard
+          label="Services"
+          value="12"
+          icon={<Layers className="h-3.5 w-3.5" />}
+        />
+        <ProfilingEmptyState />
+      </>,
+    )
+
+    expect(screen.getByText('Services')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('No profiles yet')).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /Read the setup guide/})).toHaveAttribute(
+      'href',
+      'https://moneat.io/docs/sdk-setup',
+    )
+  })
+})
+
+describe('ProfileList', () => {
+  it('renders filters, summary stats, table rows, and download actions', async () => {
+    const onServiceFilterChange = vi.fn()
+    const onTypeFilterChange = vi.fn()
+
+    renderWithQueryClient(
+      <ProfileList
+        serviceFilter="checkout"
+        onServiceFilterChange={onServiceFilterChange}
+        typeFilter="jfr"
+        onTypeFilterChange={onTypeFilterChange}
+      />,
+    )
+
+    expect(await screen.findByRole('link', {name: /checkout/})).toBeInTheDocument()
+    expect(mockApi.getProfiles).toHaveBeenCalledWith({
+      service: 'checkout',
+      type: 'jfr',
+      limit: 50,
+    })
+    expect(screen.getByText('Total Profiles')).toBeInTheDocument()
+    expect(screen.getByText('Avg Duration')).toBeInTheDocument()
+    expect(screen.getByText('java')).toBeInTheDocument()
+    expect(screen.getByText('worker')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Filter by service...'), {
+      target: {value: 'api'},
+    })
+    expect(onServiceFilterChange).toHaveBeenCalledWith('api')
+
+    fireEvent.click(screen.getByRole('button', {name: 'Download profile prof-1'}))
+    expect(mockApi.downloadProfile).toHaveBeenCalledWith('prof-1', undefined, 'jfr')
+  })
+
+  it('uses embedded scope filters and renders the compact empty state', async () => {
+    mockApi.getProfiles.mockResolvedValueOnce({profiles: [], totalCount: 0})
+
+    renderWithQueryClient(
+      <ProfileList
+        embedded
+        scope={{
+          service: 'checkout',
+          env: 'prod',
+          type: 'jfr',
+          from: 10,
+          to: 20,
+        }}
+      />,
+    )
+
+    expect(await screen.findByText('No profiles in this window.')).toBeInTheDocument()
+    expect(mockApi.getProfiles).toHaveBeenCalledWith({
+      service: 'checkout',
+      env: 'prod',
+      type: 'jfr',
+      from: 10,
+      to: 20,
+      limit: 100,
+    })
+  })
+})
+
+describe('ProfileServiceList', () => {
+  it('renders service rollups and filters the card grid', async () => {
+    const onServiceFilterChange = vi.fn()
+
+    renderWithQueryClient(
+      <ProfileServiceList
+        serviceFilter=""
+        onServiceFilterChange={onServiceFilterChange}
+      />,
+    )
+
+    expect(await screen.findByRole('link', {name: /checkout/})).toBeInTheDocument()
+    expect(screen.getByText('Total Size')).toBeInTheDocument()
+    expect(screen.getByText('java')).toBeInTheDocument()
+    expect(screen.getByText('go')).toBeInTheDocument()
+    expect(screen.getByText('jfr 4')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Filter by service...'), {
+      target: {value: 'worker'},
+    })
+    expect(onServiceFilterChange).toHaveBeenCalledWith('worker')
+  })
+
+  it('shows the no-match message when the local filter excludes every service', async () => {
+    renderWithQueryClient(
+      <ProfileServiceList
+        serviceFilter="missing"
+        onServiceFilterChange={vi.fn()}
+      />,
+    )
+
+    expect(await screen.findByText('No services match "missing".')).toBeInTheDocument()
+  })
+})
+
+describe('ServiceExplorer', () => {
+  it('loads profile aggregations and opens the scoped raw profile browser', async () => {
+    renderWithQueryClient(<ServiceExplorer service="checkout" />)
+
+    expect(await screen.findByRole('heading', {name: 'checkout'})).toBeInTheDocument()
+    expect(screen.getByText('Merged flamegraph')).toBeInTheDocument()
+    expect(screen.getByLabelText('mock flamegraph')).toHaveTextContent(
+      'Aggregated from',
+    )
+
+    expect(mockApi.getProfileTimeseries).toHaveBeenCalledWith({
+      service: 'checkout',
+      env: undefined,
+      type: 'jfr',
+      from: RANGE_24H_START,
+      to: NOW_MS,
+      buckets: 48,
+    })
+    expect(mockApi.getMergedFlamegraph).toHaveBeenCalledWith({
+      service: 'checkout',
+      env: undefined,
+      type: 'jfr',
+      from: RANGE_24H_START,
+      to: NOW_MS,
+      sampleType: null,
+      thread: null,
+      maxProfiles: 25,
+    })
+
+    fireEvent.click(screen.getByTestId('bar-chart'))
+    await waitFor(() =>
+      expect(mockApi.getMergedFlamegraph).toHaveBeenLastCalledWith({
+        service: 'checkout',
+        env: undefined,
+        type: 'jfr',
+        from: RANGE_24H_START,
+        to: RANGE_24H_START + 60_000,
+        sampleType: null,
+        thread: null,
+        maxProfiles: 25,
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: /Browse individual profiles/}))
+    const table = await screen.findByRole('table')
+    expect(within(table).getByRole('link', {name: /checkout/})).toBeInTheDocument()
+    expect(mockApi.getProfiles).toHaveBeenLastCalledWith({
+      service: 'checkout',
+      env: undefined,
+      type: 'jfr',
+      from: RANGE_24H_START,
+      to: RANGE_24H_START + 60_000,
+      limit: 100,
+    })
+  })
+
+  it('renders fallback metadata for services without finite timestamps', async () => {
+    renderWithQueryClient(<ServiceExplorer service="worker" />)
+
+    expect(await screen.findByRole('heading', {name: 'worker'})).toBeInTheDocument()
+    expect(screen.getByText('go')).toBeInTheDocument()
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+})
+
+describe('profile routes', () => {
+  it('switches the profiles index between services and all profiles', async () => {
+    const ProfilesIndexComponent = getRouteComponent(ProfilesIndexRoute)
+
+    renderWithQueryClient(<ProfilesIndexComponent />)
+
+    expect(await screen.findByRole('heading', {name: 'Profiles'})).toBeInTheDocument()
+    expect(await screen.findByRole('link', {name: /checkout/})).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: 'All profiles'}))
+    expect(await screen.findByRole('table')).toBeInTheDocument()
+    expect(mockApi.getProfiles).toHaveBeenCalledWith({
+      service: undefined,
+      type: undefined,
+      limit: 50,
+    })
+  })
+
+  it('renders a profile detail route and forwards download/profile queries', async () => {
+    mockRouteParams.value = {profileId: 'prof-1'}
+    const ProfileDetailComponent = getRouteComponent(ProfileDetailRoute)
+
+    renderWithQueryClient(<ProfileDetailComponent />)
+
+    expect(await screen.findByRole('heading', {name: 'checkout'})).toBeInTheDocument()
+    expect(screen.getByText('prof-1')).toBeInTheDocument()
+    expect(screen.getByLabelText('mock flamegraph')).toHaveTextContent('Service')
+
+    expect(mockApi.getProfile).toHaveBeenCalledWith('prof-1')
+    expect(mockApi.getProfileFlamegraph).toHaveBeenCalledWith('prof-1', {
+      sampleType: null,
+      thread: null,
+    })
+    expect(mockApi.getProfiles).toHaveBeenCalledWith({
+      service: 'checkout',
+      type: 'jfr',
+      limit: 50,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: /Download JFR/}))
+    expect(mockApi.downloadProfile).toHaveBeenCalledWith('prof-1', undefined, 'jfr')
+  })
+
+  it('renders the service explorer route with the service route param', async () => {
+    mockRouteParams.value = {service: 'checkout'}
+    const ProfileServiceComponent = getRouteComponent(ProfileServiceRoute)
+
+    renderWithQueryClient(<ProfileServiceComponent />)
+
+    expect(await screen.findByRole('heading', {name: 'checkout'})).toBeInTheDocument()
+    expect(mockApi.getMergedFlamegraph).toHaveBeenCalledWith({
+      service: 'checkout',
+      env: undefined,
+      type: 'jfr',
+      from: RANGE_24H_START,
+      to: NOW_MS,
+      sampleType: null,
+      thread: null,
+      maxProfiles: 25,
+    })
+  })
+})

--- a/dashboard/src/components/profiling/__tests__/profileFormat.test.ts
+++ b/dashboard/src/components/profiling/__tests__/profileFormat.test.ts
@@ -1,0 +1,52 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {describe, it, expect} from 'vitest'
+import {
+  formatBytes,
+  formatCompact,
+  formatDuration,
+  parseUtcDate,
+  profileTypeBadgeClass,
+} from '../profileFormat'
+
+describe('profileFormat', () => {
+  it('formats byte sizes across units', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(2048)).toBe('2.0 KB')
+    expect(formatBytes(2 * 1024 * 1024)).toBe('2.0 MB')
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe('3.00 GB')
+  })
+
+  it('formats durations from nanoseconds', () => {
+    expect(formatDuration(0)).toBe('—')
+    expect(formatDuration(500_000_000)).toBe('500ms')
+    expect(formatDuration(60_000_000_000)).toBe('60.0s')
+  })
+
+  it('parses ClickHouse UTC timestamps and ISO strings', () => {
+    expect(parseUtcDate('2026-05-28 12:00:00.000').getTime()).toBe(
+      Date.UTC(2026, 4, 28, 12, 0, 0, 0),
+    )
+    expect(parseUtcDate('2026-05-28T12:00:00.000Z').getTime()).toBe(
+      Date.UTC(2026, 4, 28, 12, 0, 0, 0),
+    )
+    expect(Number.isNaN(parseUtcDate('').getTime())).toBe(true)
+  })
+
+  it('formats compact counts', () => {
+    expect(formatCompact(950)).toBe('950')
+    expect(formatCompact(41_000)).toBe('41K')
+  })
+
+  it('maps known profile types to themed badge classes', () => {
+    expect(profileTypeBadgeClass('cpu')).toContain('orange')
+    expect(profileTypeBadgeClass('heap')).toContain('green')
+    expect(profileTypeBadgeClass('jfr')).toBe('bg-secondary text-secondary-foreground')
+  })
+})

--- a/dashboard/src/components/profiling/profileFormat.ts
+++ b/dashboard/src/components/profiling/profileFormat.ts
@@ -1,0 +1,61 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Shared formatting + classification helpers for the profiling pages.
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+export function formatDuration(ns: number): string {
+  if (ns <= 0) return '—'
+  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(0)}ms`
+  return `${(ns / 1_000_000_000).toFixed(1)}s`
+}
+
+/** ClickHouse `toString(DateTime64)` yields "2026-05-28 19:52:00.000" (UTC). */
+export function parseUtcDate(value: string): Date {
+  if (!value) return new Date(NaN)
+  if (value.includes('T')) return new Date(value)
+  // Normalize the space-separated UTC timestamp to ISO so it parses everywhere.
+  return new Date(`${value.replace(' ', 'T')}Z`)
+}
+
+const compactFormatter = new Intl.NumberFormat('en', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+
+/** Compact count, e.g. 41_000 -> "41K". */
+export function formatCompact(value: number): string {
+  return compactFormatter.format(value)
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  cpu: 'bg-orange-500/15 text-orange-400 border-orange-500/30',
+  wall: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
+  heap: 'bg-green-500/15 text-green-400 border-green-500/30',
+  alloc: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
+  goroutine: 'bg-purple-500/15 text-purple-400 border-purple-500/30',
+  mutex: 'bg-red-500/15 text-red-400 border-red-500/30',
+  block: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/30',
+}
+
+export function profileTypeBadgeClass(type: string): string {
+  const key = type.toLowerCase()
+  for (const [k, v] of Object.entries(TYPE_COLORS)) {
+    if (key.includes(k)) return v
+  }
+  return 'bg-secondary text-secondary-foreground'
+}
+
+/** A profile is "live" if its most recent profile arrived within ~5 minutes. */
+export const LIVE_THRESHOLD_MS = 5 * 60 * 1000

--- a/dashboard/src/lib/api/modules/__tests__/profiles.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/profiles.test.ts
@@ -86,4 +86,106 @@ describe('Profiles API', () => {
     const result = await api.getProfileFlamegraph('prof-123')
     expect(result).toEqual(mockFlamegraph)
   })
+
+  it('forwards env/host/version/from/to filters to getProfiles', async () => {
+    server.use(
+      http.get(`${API_BASE}/v1/profiles`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('env')).toBe('prod')
+        expect(url.searchParams.get('host')).toBe('h1')
+        expect(url.searchParams.get('version')).toBe('1.0.0')
+        expect(url.searchParams.get('from')).toBe('10')
+        expect(url.searchParams.get('to')).toBe('20')
+        return HttpResponse.json({ profiles: [], totalCount: 0 })
+      })
+    )
+
+    await api.getProfiles({
+      env: 'prod',
+      host: 'h1',
+      version: '1.0.0',
+      from: 10,
+      to: 20,
+    })
+  })
+
+  // ──── getProfile ────
+
+  it('fetches a single profile by id', async () => {
+    const mock = { profileId: 'p1', service: 'api' }
+    server.use(
+      http.get(`${API_BASE}/v1/profiles/p1`, () => HttpResponse.json(mock))
+    )
+    const result = await api.getProfile('p1')
+    expect(result).toEqual(mock)
+  })
+
+  // ──── getProfileServices ────
+
+  it('fetches the service rollup with a time window', async () => {
+    const mock = {
+      services: [],
+      totalProfiles: 0,
+      totalSizeBytes: 0,
+      serviceCount: 0,
+      hostCount: 0,
+      typeCount: 0,
+    }
+    server.use(
+      http.get(`${API_BASE}/v1/profiles/services`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('from')).toBe('100')
+        expect(url.searchParams.get('to')).toBe('200')
+        return HttpResponse.json(mock)
+      })
+    )
+    const result = await api.getProfileServices({ from: 100, to: 200 })
+    expect(result).toEqual(mock)
+  })
+
+  // ──── getProfileTimeseries ────
+
+  it('fetches the volume time series with params', async () => {
+    const mock = { points: [], bucketSeconds: 60 }
+    server.use(
+      http.get(`${API_BASE}/v1/profiles/timeseries`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('service')).toBe('api')
+        expect(url.searchParams.get('from')).toBe('0')
+        expect(url.searchParams.get('to')).toBe('1000')
+        expect(url.searchParams.get('buckets')).toBe('48')
+        return HttpResponse.json(mock)
+      })
+    )
+    const result = await api.getProfileTimeseries({
+      service: 'api',
+      from: 0,
+      to: 1000,
+      buckets: 48,
+    })
+    expect(result).toEqual(mock)
+  })
+
+  // ──── getMergedFlamegraph ────
+
+  it('fetches the merged flamegraph with params', async () => {
+    const mock = { frames: [], mergedCount: 0, totalCount: 0 }
+    server.use(
+      http.get(`${API_BASE}/v1/profiles/merged-flamegraph`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('service')).toBe('api')
+        expect(url.searchParams.get('type')).toBe('jfr')
+        expect(url.searchParams.get('sampleType')).toBe('cpu')
+        expect(url.searchParams.get('maxProfiles')).toBe('25')
+        return HttpResponse.json(mock)
+      })
+    )
+    const result = await api.getMergedFlamegraph({
+      service: 'api',
+      type: 'jfr',
+      sampleType: 'cpu',
+      maxProfiles: 25,
+    })
+    expect(result).toEqual(mock)
+  })
 })

--- a/dashboard/src/lib/api/modules/profiles.ts
+++ b/dashboard/src/lib/api/modules/profiles.ts
@@ -18,7 +18,11 @@ import type { ApiClientCore } from '../client'
 import { urlWithQuery, filenameFromContentDisposition } from '../utils'
 import type {
   ProfileListResponse,
+  ProfileResponse,
+  ProfileServicesResponse,
+  ProfileTimeseriesResponse,
   FlamegraphResponse,
+  MergedFlamegraphResponse,
 } from '../types'
 
 export function profilesMethods(core: ApiClientCore) {
@@ -30,6 +34,11 @@ export function profilesMethods(core: ApiClientCore) {
         service?: string
         type?: string
         source?: string
+        env?: string
+        host?: string
+        version?: string
+        from?: number
+        to?: number
         limit?: number
         offset?: number
       } = {}
@@ -38,10 +47,77 @@ export function profilesMethods(core: ApiClientCore) {
       if (params.service) searchParams.set('service', params.service)
       if (params.type) searchParams.set('type', params.type)
       if (params.source) searchParams.set('source', params.source)
+      if (params.env) searchParams.set('env', params.env)
+      if (params.host) searchParams.set('host', params.host)
+      if (params.version) searchParams.set('version', params.version)
+      if (params.from != null) searchParams.set('from', String(params.from))
+      if (params.to != null) searchParams.set('to', String(params.to))
       if (params.limit != null) searchParams.set('limit', String(params.limit))
       if (params.offset != null) searchParams.set('offset', String(params.offset))
       const qs = searchParams.toString()
       return core.request<ProfileListResponse>(urlWithQuery(`${base}/profiles`, qs))
+    },
+
+    getProfile: (profileId: string) =>
+      core.request<ProfileResponse>(`${base}/profiles/${profileId}`),
+
+    getProfileServices: (params: {from?: number; to?: number} = {}) => {
+      const sp = new URLSearchParams()
+      if (params.from != null) sp.set('from', String(params.from))
+      if (params.to != null) sp.set('to', String(params.to))
+      return core.request<ProfileServicesResponse>(
+        urlWithQuery(`${base}/profiles/services`, sp.toString())
+      )
+    },
+
+    getProfileTimeseries: (params: {
+      service?: string
+      type?: string
+      env?: string
+      host?: string
+      from: number
+      to: number
+      buckets?: number
+    }) => {
+      const sp = new URLSearchParams()
+      if (params.service) sp.set('service', params.service)
+      if (params.type) sp.set('type', params.type)
+      if (params.env) sp.set('env', params.env)
+      if (params.host) sp.set('host', params.host)
+      sp.set('from', String(params.from))
+      sp.set('to', String(params.to))
+      if (params.buckets != null) sp.set('buckets', String(params.buckets))
+      return core.request<ProfileTimeseriesResponse>(
+        urlWithQuery(`${base}/profiles/timeseries`, sp.toString())
+      )
+    },
+
+    getMergedFlamegraph: (params: {
+      service?: string
+      type?: string
+      env?: string
+      host?: string
+      version?: string
+      from?: number
+      to?: number
+      sampleType?: string | null
+      thread?: string | null
+      maxProfiles?: number
+    }) => {
+      const sp = new URLSearchParams()
+      if (params.service) sp.set('service', params.service)
+      if (params.type) sp.set('type', params.type)
+      if (params.env) sp.set('env', params.env)
+      if (params.host) sp.set('host', params.host)
+      if (params.version) sp.set('version', params.version)
+      if (params.from != null) sp.set('from', String(params.from))
+      if (params.to != null) sp.set('to', String(params.to))
+      if (params.sampleType) sp.set('sampleType', params.sampleType)
+      if (params.thread) sp.set('thread', params.thread)
+      if (params.maxProfiles != null) sp.set('maxProfiles', String(params.maxProfiles))
+      return core.request<MergedFlamegraphResponse>(
+        urlWithQuery(`${base}/profiles/merged-flamegraph`, sp.toString())
+      )
     },
 
     downloadProfile: async (

--- a/dashboard/src/lib/api/types/profiles.ts
+++ b/dashboard/src/lib/api/types/profiles.ts
@@ -64,3 +64,58 @@ export interface FlamegraphResponse {
   unit?: string
   totalSamples?: number
 }
+
+/** A merged flamegraph aggregated across multiple profiles in a window. */
+export interface MergedFlamegraphResponse extends FlamegraphResponse {
+  /** Number of profiles actually merged into this flamegraph. */
+  mergedCount?: number
+  /** Total profiles matching the window (mergedCount may be a sample of this). */
+  totalCount?: number
+}
+
+export interface ProfileTypeCount {
+  profileType: string
+  count: number
+}
+
+/** A bucket of profile-volume activity (ts = epoch millis). */
+export interface ProfileSeriesPoint {
+  ts: number
+  count: number
+}
+
+/** Per-service rollup powering the Profiles overview cards. */
+export interface ProfileServiceSummary {
+  service: string
+  languages: string[]
+  runtimes: string[]
+  environments: string[]
+  types: ProfileTypeCount[]
+  hostCount: number
+  profileCount: number
+  totalSizeBytes: number
+  firstSeen: string
+  lastSeen: string
+  avgDurationNs: number
+  series: ProfileSeriesPoint[]
+}
+
+export interface ProfileServicesResponse {
+  services: ProfileServiceSummary[]
+  totalProfiles: number
+  totalSizeBytes: number
+  serviceCount: number
+  hostCount: number
+  typeCount: number
+}
+
+export interface ProfileTimeseriesPoint {
+  ts: number
+  count: number
+  sizeBytes: number
+}
+
+export interface ProfileTimeseriesResponse {
+  points: ProfileTimeseriesPoint[]
+  bucketSeconds: number
+}

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -132,6 +132,7 @@ import { Route as AdminAttributionRouteImport } from './routes/admin.attribution
 import { Route as PerformanceTracesIndexRouteImport } from './routes/performance.traces.index'
 import { Route as MonitoringKubernetesIndexRouteImport } from './routes/monitoring.kubernetes.index'
 import { Route as ProjectsProjectIdSettingsRouteImport } from './routes/projects.$projectId.settings'
+import { Route as ProfilesServiceServiceRouteImport } from './routes/profiles.service.$service'
 import { Route as PerformanceTracesTraceIdRouteImport } from './routes/performance.traces.$traceId'
 import { Route as OnCallIncidentsIncidentIdRouteImport } from './routes/on-call.incidents.$incidentId'
 import { Route as OnCallDeclaredIncidentsIncidentIdRouteImport } from './routes/on-call.declared-incidents.$incidentId'
@@ -767,6 +768,11 @@ const ProjectsProjectIdSettingsRoute =
     path: '/settings',
     getParentRoute: () => ProjectsProjectIdRoute,
   } as any)
+const ProfilesServiceServiceRoute = ProfilesServiceServiceRouteImport.update({
+  id: '/service/$service',
+  path: '/service/$service',
+  getParentRoute: () => ProfilesRoute,
+} as any)
 const PerformanceTracesTraceIdRoute =
   PerformanceTracesTraceIdRouteImport.update({
     id: '/$traceId',
@@ -974,6 +980,7 @@ export interface FileRoutesByFullPath {
   '/on-call/declared-incidents/$incidentId': typeof OnCallDeclaredIncidentsIncidentIdRoute
   '/on-call/incidents/$incidentId': typeof OnCallIncidentsIncidentIdRoute
   '/performance/traces/$traceId': typeof PerformanceTracesTraceIdRoute
+  '/profiles/service/$service': typeof ProfilesServiceServiceRoute
   '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
   '/monitoring/kubernetes/': typeof MonitoringKubernetesIndexRoute
   '/performance/traces/': typeof PerformanceTracesIndexRoute
@@ -1097,6 +1104,7 @@ export interface FileRoutesByTo {
   '/on-call/declared-incidents/$incidentId': typeof OnCallDeclaredIncidentsIncidentIdRoute
   '/on-call/incidents/$incidentId': typeof OnCallIncidentsIncidentIdRoute
   '/performance/traces/$traceId': typeof PerformanceTracesTraceIdRoute
+  '/profiles/service/$service': typeof ProfilesServiceServiceRoute
   '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
   '/monitoring/kubernetes': typeof MonitoringKubernetesIndexRoute
   '/performance/traces': typeof PerformanceTracesIndexRoute
@@ -1236,6 +1244,7 @@ export interface FileRoutesById {
   '/on-call/declared-incidents/$incidentId': typeof OnCallDeclaredIncidentsIncidentIdRoute
   '/on-call/incidents/$incidentId': typeof OnCallIncidentsIncidentIdRoute
   '/performance/traces/$traceId': typeof PerformanceTracesTraceIdRoute
+  '/profiles/service/$service': typeof ProfilesServiceServiceRoute
   '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
   '/monitoring/kubernetes/': typeof MonitoringKubernetesIndexRoute
   '/performance/traces/': typeof PerformanceTracesIndexRoute
@@ -1376,6 +1385,7 @@ export interface FileRouteTypes {
     | '/on-call/declared-incidents/$incidentId'
     | '/on-call/incidents/$incidentId'
     | '/performance/traces/$traceId'
+    | '/profiles/service/$service'
     | '/projects/$projectId/settings'
     | '/monitoring/kubernetes/'
     | '/performance/traces/'
@@ -1499,6 +1509,7 @@ export interface FileRouteTypes {
     | '/on-call/declared-incidents/$incidentId'
     | '/on-call/incidents/$incidentId'
     | '/performance/traces/$traceId'
+    | '/profiles/service/$service'
     | '/projects/$projectId/settings'
     | '/monitoring/kubernetes'
     | '/performance/traces'
@@ -1637,6 +1648,7 @@ export interface FileRouteTypes {
     | '/on-call/declared-incidents/$incidentId'
     | '/on-call/incidents/$incidentId'
     | '/performance/traces/$traceId'
+    | '/profiles/service/$service'
     | '/projects/$projectId/settings'
     | '/monitoring/kubernetes/'
     | '/performance/traces/'
@@ -2579,6 +2591,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdSettingsRouteImport
       parentRoute: typeof ProjectsProjectIdRoute
     }
+    '/profiles/service/$service': {
+      id: '/profiles/service/$service'
+      path: '/service/$service'
+      fullPath: '/profiles/service/$service'
+      preLoaderRoute: typeof ProfilesServiceServiceRouteImport
+      parentRoute: typeof ProfilesRoute
+    }
     '/performance/traces/$traceId': {
       id: '/performance/traces/$traceId'
       path: '/$traceId'
@@ -2950,11 +2969,13 @@ const PerformanceRouteWithChildren = PerformanceRoute._addFileChildren(
 interface ProfilesRouteChildren {
   ProfilesProfileIdRoute: typeof ProfilesProfileIdRoute
   ProfilesIndexRoute: typeof ProfilesIndexRoute
+  ProfilesServiceServiceRoute: typeof ProfilesServiceServiceRoute
 }
 
 const ProfilesRouteChildren: ProfilesRouteChildren = {
   ProfilesProfileIdRoute: ProfilesProfileIdRoute,
   ProfilesIndexRoute: ProfilesIndexRoute,
+  ProfilesServiceServiceRoute: ProfilesServiceServiceRoute,
 }
 
 const ProfilesRouteWithChildren = ProfilesRoute._addFileChildren(

--- a/dashboard/src/routes/profiles.$profileId.tsx
+++ b/dashboard/src/routes/profiles.$profileId.tsx
@@ -77,15 +77,12 @@ function profileTypeBadgeClass(type: string): string {
 function ProfileDetailPage() {
   const {profileId} = Route.useParams()
 
-  const {data: profilesData, isLoading} = useQuery({
-    queryKey: ['profiles', {limit: 200}],
-    queryFn: () => api.getProfiles({limit: 200}),
-    enabled: api.isAuthenticated(),
+  const {data: profile, isLoading} = useQuery({
+    queryKey: ['profile', profileId],
+    queryFn: () => api.getProfile(profileId),
+    enabled: api.isAuthenticated() && !!profileId,
+    retry: false,
   })
-
-  const profile = profilesData?.profiles?.find(
-    (p) => p.profileId === profileId,
-  )
 
   const [sampleType, setSampleType] = useState<string | null>(null)
   const [thread, setThread] = useState<string | null>(null)
@@ -99,20 +96,26 @@ function ProfileDetailPage() {
 
   const frames = flamegraphData?.frames
 
+  const {data: comparableData} = useQuery({
+    queryKey: ['profilesCompare', profile?.service, profile?.profileType],
+    queryFn: () =>
+      api.getProfiles({
+        service: profile?.service || undefined,
+        type: profile?.profileType || undefined,
+        limit: 50,
+      }),
+    enabled: api.isAuthenticated() && !!profile,
+  })
+
   const compareProfiles = useMemo(() => {
-    if (!profile || !profilesData?.profiles) return []
-    return profilesData.profiles
-      .filter(
-        (p) =>
-          p.profileId !== profileId &&
-          p.service === profile.service &&
-          p.profileType === profile.profileType,
-      )
+    const list = comparableData?.profiles ?? []
+    return list
+      .filter((p) => p.profileId !== profileId)
       .map((p) => ({
         profileId: p.profileId,
         label: `${formatTime(p.startTime)} · ${p.host || p.version || p.profileId.slice(0, 8)}`,
       }))
-  }, [profilesData, profile, profileId])
+  }, [comparableData, profileId])
 
   const {data: baselineData, isLoading: baselineLoading} = useQuery({
     queryKey: ['profileFlamegraph', compareId, sampleType, thread],
@@ -217,7 +220,7 @@ function ProfileDetailPage() {
             className="h-7 w-7 mt-0.5 shrink-0"
             asChild
           >
-            <Link to="/profiles" search={{tab: 'sentry'}}>
+            <Link to="/profiles">
               <ArrowLeft className="h-3.5 w-3.5" />
             </Link>
           </Button>

--- a/dashboard/src/routes/profiles.index.tsx
+++ b/dashboard/src/routes/profiles.index.tsx
@@ -7,31 +7,79 @@
 // (at your option) any later version.
 
 import {createFileRoute} from '@tanstack/react-router'
-import {ProfileList} from '@/components/profiling/ProfileList'
 import {useState} from 'react'
+import {ProfileServiceList} from '@/components/profiling/ProfileServiceList'
+import {ProfileList} from '@/components/profiling/ProfileList'
+import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/profiles/')({
   component: ProfilesIndexPage,
 })
 
+type ProfilesView = 'services' | 'all'
+
 function ProfilesIndexPage() {
+  const [view, setView] = useState<ProfilesView>('services')
   const [serviceFilter, setServiceFilter] = useState('')
   const [typeFilter, setTypeFilter] = useState('')
 
   return (
     <div className="p-3 space-y-2">
-      <div>
-        <h1 className="text-lg font-bold tracking-tight">Profiles</h1>
-        <p className="text-muted-foreground text-xs mt-0.5">
-          Continuous profiling data from your applications
-        </p>
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h1 className="text-lg font-bold tracking-tight">Profiles</h1>
+          <p className="text-muted-foreground text-xs mt-0.5">
+            Continuous profiling data from your applications
+          </p>
+        </div>
+        <div className="inline-flex rounded-md border p-0.5 text-xs shrink-0">
+          <ViewToggle active={view === 'services'} onClick={() => setView('services')}>
+            Services
+          </ViewToggle>
+          <ViewToggle active={view === 'all'} onClick={() => setView('all')}>
+            All profiles
+          </ViewToggle>
+        </div>
       </div>
-      <ProfileList
-        serviceFilter={serviceFilter}
-        onServiceFilterChange={setServiceFilter}
-        typeFilter={typeFilter}
-        onTypeFilterChange={setTypeFilter}
-      />
+
+      {view === 'services' ? (
+        <ProfileServiceList
+          serviceFilter={serviceFilter}
+          onServiceFilterChange={setServiceFilter}
+        />
+      ) : (
+        <ProfileList
+          serviceFilter={serviceFilter}
+          onServiceFilterChange={setServiceFilter}
+          typeFilter={typeFilter}
+          onTypeFilterChange={setTypeFilter}
+        />
+      )}
     </div>
+  )
+}
+
+function ViewToggle({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'px-2.5 py-1 rounded font-medium transition-colors',
+        active
+          ? 'bg-secondary text-secondary-foreground'
+          : 'text-muted-foreground hover:text-foreground',
+      )}
+    >
+      {children}
+    </button>
   )
 }

--- a/dashboard/src/routes/profiles.service.$service.tsx
+++ b/dashboard/src/routes/profiles.service.$service.tsx
@@ -1,0 +1,19 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {createFileRoute} from '@tanstack/react-router'
+import {ServiceExplorer} from '@/components/profiling/ServiceExplorer'
+
+export const Route = createFileRoute('/profiles/service/$service')({
+  component: ServiceExplorerPage,
+})
+
+function ServiceExplorerPage() {
+  const {service} = Route.useParams()
+  return <ServiceExplorer service={service} />
+}


### PR DESCRIPTION
## Summary

Reworks `/profiles` from a flat, reverse-chronological list of raw 60-second profile uploads into a **service-centric explorer**. With continuous profiling, every upload looks nearly identical (same service, type, env, host, duration), so the old list gave no signal about what to open. This pivots to the model used by Pyroscope/Datadog/Grafana: pick a *service*, then explore an *aggregated* view over a *time range*.

### Frontend
- **Services overview** (`ProfileServiceList`): cards per service with language/runtime, environments, per-type counts, host count, total size, a live-activity dot, and a volume sparkline. Answers "which one do I click."
- **Service explorer** (`ServiceExplorer`, new route `/profiles/service/$service`): env + time-range selectors, a clickable **volume timeline** (click a bar to focus the flamegraph on that window), and an **aggregated/merged flamegraph** across the window that reuses the existing flamegraph viewer (sample-type/thread selectors, top functions, diff). Shows "aggregated from N of M profiles."
- Collapsible "browse individual profiles in window" (scoped reuse of the existing list).
- Keeps an "All profiles" toggle for the raw list; preserves the empty state.
- **Fix:** the profile detail page now fetches a profile by id (`getProfile`) instead of scanning the most recent 200, so deep links to older profiles work.

### Backend (no schema migration)
- `GET /v1/profiles/services` — per-service rollup (counts, hosts, envs, types, sizes, first/last seen) + activity sparkline, via bounded ClickHouse `GROUP BY`.
- `GET /v1/profiles/timeseries` — profile-volume buckets for a service/window.
- `GET /v1/profiles/merged-flamegraph` — aggregate flamegraph: evenly samples up to a capped number of profiles across the window, reads + parses them with bounded parallelism, and sums the frame trees (`ProfileMergeService`).
- `GET /v1/profiles/{id}` — single profile metadata.
- Extracts the source/type → parser dispatch into `ProfileFlamegraphParser` (shared by the per-profile and merged paths). DB internals never leak to clients.

## Test plan
- **Backend:** `DatadogQueryRoutesTest` (new endpoints), `ProfileMergeServiceTest` (merge math), `ProfileFlamegraphParserTest`, `ProfileIngestionServiceTest` — all pass.
- **Frontend:** API-module tests for the new methods + `profileFormat` unit tests; `tsc` + eslint clean.
- Not yet exercised against a live stack with real profile data — recommend a smoke test of the merged-flamegraph path before merge.

## Notes
Stacked on #476 (now merged). Coverage for the larger new explorer components is still light; will follow up to satisfy the coverage/Sonar gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Services view with per‑service summaries, live indicators, sparklines, and a service explorer (timeline, zoomable buckets, merged flamegraph with sample/thread/max selection)
  * Profile volume timeseries, service rollups, expanded filters (env/host/version/from/to), direct profile view with metadata & downloadable payload, embedded profile list mode, stat cards, and empty-state UI
* **Tests**
  * Extensive unit/integration tests covering parsing, listing, timeseries, merging, API clients and UI routes
* **Documentation**
  * Clarified coroutine error-handling guidance in Kotlin docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->