### PR TITLE
feat(demo): fill demo gaps — issues, service map, flags, feedback, hosts, log↔trace

### DIFF
--- a/backend/src/main/kotlin/com/moneat/config/DemoDataReseeder.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoDataReseeder.kt
@@ -52,6 +52,8 @@ private data class ReseedSnapshot(
     val freshAnalyticsCount: Long,
     val freshLogsCount: Long,
     val freshDatadogCount: Long,
+    val freshFeatureFlagsCount: Long,
+    val freshFeedbackCount: Long,
     val freshK8sCount: Long,
     val freshDbmCount: Long,
     val freshDebuggerLogsCount: Long,
@@ -91,6 +93,8 @@ private data class ReseedSnapshot(
                 freshAnalyticsCount > 0,
                 freshLogsCount > 0,
                 freshDatadogCount > 0,
+                freshFeatureFlagsCount > 0,
+                freshFeedbackCount > 0,
                 freshSecurityCount > 0,
                 freshSyntheticsCount > 0,
                 demoDashboardCount >= DEMO_DASHBOARD_SEED_COUNT,
@@ -106,6 +110,8 @@ private suspend fun gatherReseedSnapshot(): ReseedSnapshot =
         freshAnalyticsCount = checkFreshAnalyticsDataCount(),
         freshLogsCount = checkFreshLogsCount(),
         freshDatadogCount = checkFreshDatadogCount(),
+        freshFeatureFlagsCount = checkFreshFeatureFlagsCount(),
+        freshFeedbackCount = checkFreshFeedbackCount(),
         freshK8sCount = checkFreshKubernetesDataCount(),
         freshDbmCount = checkFreshDbmDataCount(),
         freshDebuggerLogsCount = checkFreshDebuggerLogsCount(),
@@ -132,6 +138,8 @@ private suspend fun runStaleDemoReseed(snap: ReseedSnapshot) {
     maybeReseedAnalytics(snap.freshAnalyticsCount)
     maybeReseedLogs(snap.freshLogsCount)
     maybeReseedDatadog(snap.freshDatadogCount)
+    maybeReseedFeatureFlags(snap.freshFeatureFlagsCount)
+    maybeReseedFeedback(snap.freshFeedbackCount)
     maybeReseedKubernetes(snap.freshK8sCount)
     maybeReseedDbm(snap.freshDbmCount)
     maybeReseedDebugger(snap.hasFreshDebugger, snap)
@@ -152,6 +160,7 @@ private fun logSkippingReseed(s: ReseedSnapshot) {
             "${s.freshLlmCount} recent LLM generations, " +
             "${s.freshAnalyticsCount} recent analytics events, ${s.freshLogsCount} recent logs, " +
             "${s.freshDatadogCount} recent Datadog spans, " +
+            "${s.freshFeatureFlagsCount} recent flag evaluations, ${s.freshFeedbackCount} recent feedback, " +
             "infra (k8s=${s.freshK8sCount} dbm=${s.freshDbmCount} " +
             "debugger_logs=${s.freshDebuggerLogsCount} " +
             "debugger_diag=${s.freshDebuggerDiagCount} ndm_dev=${s.freshNdmDevicesCount} " +
@@ -214,6 +223,29 @@ private suspend fun maybeReseedDatadog(freshDatadogCount: Long) {
     logger.info { "Datadog demo data is stale or missing, reseeding..." }
     purgeDatadogDemoData()
     reseedDatadogData()
+}
+
+private suspend fun maybeReseedFeatureFlags(freshFeatureFlagsCount: Long) {
+    if (freshFeatureFlagsCount > 0) {
+        logger.info {
+            "Feature flag demo data is fresh ($freshFeatureFlagsCount recent evaluations), " +
+                "skipping feature flag reseed"
+        }
+        return
+    }
+    logger.info { "Feature flag demo data is stale or missing, reseeding..." }
+    purgeFeatureFlagsDemoData()
+    reseedFeatureFlags()
+}
+
+private suspend fun maybeReseedFeedback(freshFeedbackCount: Long) {
+    if (freshFeedbackCount > 0) {
+        logger.info { "Feedback demo data is fresh ($freshFeedbackCount recent entries), skipping feedback reseed" }
+        return
+    }
+    logger.info { "Feedback demo data is stale or missing, reseeding..." }
+    purgeFeedbackDemoData()
+    reseedFeedback()
 }
 
 private suspend fun maybeReseedKubernetes(freshK8sCount: Long) {

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedCore.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedCore.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.config
 
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import mu.KotlinLogging
@@ -53,15 +54,15 @@ private fun demoIssueInsertSql(envExpr: String, spec: DemoIssueInsertSpec): Stri
             stack_trace, environment, release, user_id, user_email,
             device_model, os_name, os_version, fingerprint
         )
-        SELECT generateUUIDv4(), $project, '$issueId',
+        SELECT generateUUIDv4(), $project, '${escapeSql(issueId)}',
             now() - INTERVAL (number % $hours) HOUR, now() - INTERVAL (number % $hours) HOUR,
-            'error', '$platform', '$level',
-            '$message', '$exType', '$exValue', '$stack',
-            $envExpr, '$release',
+            'error', '${escapeSql(platform)}', '${escapeSql(level)}',
+            '${escapeSql(message)}', '${escapeSql(exType)}', '${escapeSql(exValue)}', '${escapeSql(stack)}',
+            $envExpr, $release,
             toString($userBase + (number % $userMod)),
             concat('user', toString(number % $userMod), '@acmemobile.com'),
-            $devices, '$osName', $osVersions,
-            ['$exType']
+            $devices, '${escapeSql(osName)}', $osVersions,
+            ['${escapeSql(exType)}']
         FROM numbers($events)
         """.trimIndent()
     }

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedDatadog.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedDatadog.kt
@@ -78,6 +78,8 @@ internal suspend fun purgeDatadogDemoData() {
             "apm_trace_summaries",
             "apm_error_groups_hourly",
             "apm_resource_stats_hourly",
+            "apm_service_stats_hourly",
+            "apm_service_edges_hourly",
             "trace_stats",
             "profiles",
             "infra_events",
@@ -109,6 +111,7 @@ internal suspend fun reseedDatadogData() {
     reseedDatadogHostsPostgres()
     reseedDatadogApmRootSpans()
     reseedDatadogApmChildSpans()
+    reseedDatadogServiceMapRollups()
     reseedDatadogProfileRows()
     reseedDatadogInfraEvents()
     reseedDatadogServiceChecks()
@@ -179,12 +182,17 @@ private suspend fun reseedDatadogHostsPostgres() {
                     ),
                 )
             for (h in hostData) {
+                // Leave one host intentionally DOWN for a realistic fleet; DemoLivenessBackgroundService
+                // re-stamps last_seen_at for the rest every minute (it skips this host by name).
+                val isDown = h[0] == DEMO_DD_HOST_PROD_WORKER_01
+                val lastSeen = if (isDown) "NOW() - INTERVAL '25 minutes'" else "NOW() - INTERVAL '30 seconds'"
+                val status = if (isDown) "down" else "up"
                 exec(
                     """
-                    INSERT INTO hosts (organization_id, hostname, os, platform, processor, cpu_cores, memory_total_kb, agent_version, gohai, tags, first_seen_at, last_seen_at)
+                    INSERT INTO hosts (organization_id, hostname, os, platform, processor, cpu_cores, memory_total_kb, agent_version, gohai, tags, first_seen_at, last_seen_at, status)
                     VALUES (-1, '${h[0]}', '${h[1]}', '${h[2]}', '${h[3]}', ${h[4]}, ${h[5]}, '${h[6]}',
-                        '{}', '{"env":"production","service":"acme-shopping"}', NOW() - INTERVAL '14 days', NOW() - INTERVAL '30 seconds')
-                    ON CONFLICT (organization_id, hostname) DO UPDATE SET last_seen_at = NOW() - INTERVAL '30 seconds'
+                        '{}', '{"env":"production","service":"acme-shopping"}', NOW() - INTERVAL '14 days', $lastSeen, '$status')
+                    ON CONFLICT (organization_id, hostname) DO UPDATE SET last_seen_at = $lastSeen, status = '$status'
                     """.trimIndent()
                 )
             }
@@ -254,6 +262,67 @@ private suspend fun reseedDatadogApmChildSpans() {
     suspendRunCatching {
         requireClickHouse2xx(ClickHouseClient.execute(childSpansSql), "Reseed child spans")
     }.onFailure { logger.warn { "Reseed child spans failed (non-fatal): ${it.message}" } }
+}
+
+// Service-map rollups (apm_service_stats_hourly / apm_service_edges_hourly) are normally written by
+// the live ingest path via ApmServiceMapRollups.insertForSpans — but that helper intentionally skips
+// non-positive org ids, so it never fires for the demo org (-1). Aggregate the seeded apm_spans into
+// the rollups directly so the service map renders. SummingMergeTree means we must purge first (handled
+// in purgeDatadogDemoData) to avoid double-counting across reseeds.
+private suspend fun reseedDatadogServiceMapRollups() {
+    val statsSql =
+        """
+        INSERT INTO apm_service_stats_hourly
+            (organization_id, bucket_start, service, env, source,
+             span_count, error_count, duration_sum, duration_count)
+        SELECT
+            organization_id,
+            toStartOfHour(start) AS bucket_start,
+            service,
+            env,
+            'datadog' AS source,
+            count() AS span_count,
+            sum(error) AS error_count,
+            sum(duration) AS duration_sum,
+            count() AS duration_count
+        FROM apm_spans
+        WHERE organization_id = $ORG1
+        GROUP BY organization_id, bucket_start, service, env
+        """.trimIndent()
+
+    val edgesSql =
+        """
+        INSERT INTO apm_service_edges_hourly
+            (organization_id, bucket_start, from_service, to_service, env, source,
+             call_count, error_count, duration_sum, duration_count)
+        SELECT
+            child.organization_id,
+            toStartOfHour(child.start) AS bucket_start,
+            parent.service AS from_service,
+            child.service AS to_service,
+            child.env AS env,
+            'datadog' AS source,
+            count() AS call_count,
+            sum(child.error) AS error_count,
+            sum(child.duration) AS duration_sum,
+            count() AS duration_count
+        FROM apm_spans AS child
+        INNER JOIN apm_spans AS parent
+            ON child.organization_id = parent.organization_id
+            AND child.trace_id = parent.trace_id
+            AND child.parent_id = parent.span_id
+        WHERE child.organization_id = $ORG1
+            AND child.parent_id != 0
+            AND parent.service != child.service
+        GROUP BY child.organization_id, bucket_start, from_service, to_service, env
+        """.trimIndent()
+
+    suspendRunCatching {
+        requireClickHouse2xx(ClickHouseClient.execute(statsSql), "Reseed apm_service_stats_hourly")
+    }.onFailure { logger.warn { "Reseed apm_service_stats_hourly failed (non-fatal): ${it.message}" } }
+    suspendRunCatching {
+        requireClickHouse2xx(ClickHouseClient.execute(edgesSql), "Reseed apm_service_edges_hourly")
+    }.onFailure { logger.warn { "Reseed apm_service_edges_hourly failed (non-fatal): ${it.message}" } }
 }
 
 private suspend fun reseedDatadogProfileRows() {

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedFeatureFlags.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedFeatureFlags.kt
@@ -1,0 +1,317 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+@file:Suppress("MagicNumber")
+
+package com.moneat.config
+
+import com.moneat.utils.suspendRunCatching
+import io.ktor.client.statement.bodyAsText
+import mu.KotlinLogging
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+private val logger = KotlinLogging.logger {}
+
+// ── Feature Flag Demo Data ─────────────────────────────────────────────
+//
+// Postgres (org -1): flag definitions, variants, and per-environment configs so the
+// Feature Flags management UI (and the #480 MCP flag tools) have content. The three
+// default environments (production/staging/development) are auto-seeded for every org by
+// V108__feature_flags.sql, so we only seed flags/variants/configs here.
+//
+// ClickHouse (org -1): evaluation + tracking events spread over the last 7 days relative to
+// now() so the flag analytics view renders. The *_hourly aggregates fill automatically via
+// the materialized views defined in V40__add_feature_flag_events.sql.
+
+/** Demo org id for the UInt32-keyed feature-flag ClickHouse tables. */
+private const val FF_ORG = "toUInt32(-1)"
+
+/** One demo flag with its variants and per-environment enablement. */
+private data class DemoFlagSpec(
+    val key: String,
+    val name: String,
+    val description: String,
+    val valueType: String,
+    val clientVisible: Boolean,
+    val tags: List<String>,
+    /** variant key -> (display name, JSON value literal). First entry is the default. */
+    val variants: List<Triple<String, String, String>>,
+    val offVariantKey: String,
+    /** env key -> enabled. Missing envs default to disabled. */
+    val enabledByEnv: Map<String, Boolean>,
+    /** Weighted variant keys used to shape evaluation analytics (repeat to bias share). */
+    val evalVariantWeights: List<String>,
+)
+
+private val demoFlags: List<DemoFlagSpec> = listOf(
+    DemoFlagSpec(
+        key = "new-checkout-flow",
+        name = "New checkout flow",
+        description = "Rolls out the redesigned single-page checkout.",
+        valueType = "BOOLEAN",
+        clientVisible = true,
+        tags = listOf("checkout", "growth"),
+        variants = listOf(
+            Triple("on", "On", "true"),
+            Triple("off", "Off", "false"),
+        ),
+        offVariantKey = "off",
+        enabledByEnv = mapOf("production" to true, "staging" to true, "development" to true),
+        evalVariantWeights = listOf("on", "on", "on", "off"),
+    ),
+    DemoFlagSpec(
+        key = "recommendations-v2",
+        name = "Recommendations v2",
+        description = "Switches product recommendations to the v2 ranking model.",
+        valueType = "BOOLEAN",
+        clientVisible = false,
+        tags = listOf("ml", "catalog"),
+        variants = listOf(
+            Triple("on", "On", "true"),
+            Triple("off", "Off", "false"),
+        ),
+        offVariantKey = "off",
+        enabledByEnv = mapOf("production" to true, "staging" to true, "development" to true),
+        evalVariantWeights = listOf("on", "off"),
+    ),
+    DemoFlagSpec(
+        key = "dark-mode",
+        name = "Dark mode",
+        description = "Enables the dark theme in the mobile apps.",
+        valueType = "BOOLEAN",
+        clientVisible = true,
+        tags = listOf("ui"),
+        variants = listOf(
+            Triple("on", "On", "true"),
+            Triple("off", "Off", "false"),
+        ),
+        offVariantKey = "off",
+        enabledByEnv = mapOf("production" to true, "staging" to true, "development" to true),
+        evalVariantWeights = listOf("on", "on", "off"),
+    ),
+    DemoFlagSpec(
+        key = "checkout-button-color",
+        name = "Checkout button color",
+        description = "A/B test for the primary checkout call-to-action color.",
+        valueType = "STRING",
+        clientVisible = true,
+        tags = listOf("experiment", "checkout"),
+        variants = listOf(
+            Triple("control", "Control (gray)", "\"gray\""),
+            Triple("blue", "Blue", "\"blue\""),
+            Triple("green", "Green", "\"green\""),
+        ),
+        offVariantKey = "control",
+        enabledByEnv = mapOf("production" to true, "staging" to true, "development" to true),
+        evalVariantWeights = listOf("control", "blue", "green"),
+    ),
+    DemoFlagSpec(
+        key = "payments-provider",
+        name = "Payments provider",
+        description = "Selects the active payment service provider.",
+        valueType = "STRING",
+        clientVisible = false,
+        tags = listOf("payments", "ops"),
+        variants = listOf(
+            Triple("stripe", "Stripe", "\"stripe\""),
+            Triple("adyen", "Adyen", "\"adyen\""),
+            Triple("braintree", "Braintree", "\"braintree\""),
+        ),
+        offVariantKey = "stripe",
+        enabledByEnv = mapOf("production" to true, "staging" to true, "development" to false),
+        evalVariantWeights = listOf("stripe", "stripe", "stripe", "adyen", "braintree"),
+    ),
+    DemoFlagSpec(
+        key = "payments-kill-switch",
+        name = "Payments kill switch",
+        description = "Emergency switch to disable card payments during incidents.",
+        valueType = "BOOLEAN",
+        clientVisible = false,
+        tags = listOf("payments", "safety"),
+        variants = listOf(
+            Triple("off", "Off (payments enabled)", "false"),
+            Triple("on", "On (payments disabled)", "true"),
+        ),
+        offVariantKey = "off",
+        enabledByEnv = mapOf("production" to false, "staging" to false, "development" to false),
+        evalVariantWeights = listOf("off", "off", "off", "off", "on"),
+    ),
+)
+
+internal suspend fun checkFreshFeatureFlagsCount(): Long {
+    val query = """
+        SELECT count() FROM feature_flag_evaluations
+        WHERE organization_id = $FF_ORG
+            AND event_time >= now() - INTERVAL 7 DAY
+    """.trimIndent()
+    return suspendRunCatching {
+        val response = ClickHouseClient.execute(query)
+        if (response.status.value !in 200..299) {
+            0L
+        } else {
+            response.bodyAsText().trim().toLongOrNull() ?: 0L
+        }
+    }.getOrElse {
+        logger.warn { "Failed to check fresh feature flag demo data (non-fatal): ${it.message}" }
+        0L
+    }
+}
+
+internal suspend fun purgeFeatureFlagsDemoData() {
+    // Postgres: deleting flags cascades to variants + environment configs (ON DELETE CASCADE).
+    suspendRunCatching {
+        transaction {
+            exec("DELETE FROM feature_flags WHERE organization_id = -1")
+            exec("DELETE FROM feature_flag_segments WHERE organization_id = -1")
+        }
+    }.onFailure { logger.warn { "Purge feature_flags (postgres) failed (non-fatal): ${it.message}" } }
+
+    // ClickHouse: evaluation + tracking events (the *_hourly aggregates roll off via TTL/merges).
+    for (table in listOf("feature_flag_evaluations", "feature_flag_tracking_events")) {
+        suspendRunCatching {
+            requireClickHouse2xx(
+                ClickHouseClient.execute("ALTER TABLE $table DELETE WHERE organization_id = $FF_ORG"),
+                "Purge $table"
+            )
+        }.onFailure { logger.warn { "Purge $table failed (non-fatal): ${it.message}" } }
+    }
+}
+
+internal suspend fun reseedFeatureFlags() {
+    reseedFeatureFlagDefinitions()
+    reseedFeatureFlagEvaluations()
+    logger.info { "Feature flag demo data reseed complete" }
+}
+
+private fun reseedFeatureFlagDefinitions() {
+    runPostgresReseedCatching {
+        transaction {
+            for (flag in demoFlags) {
+                exec(flagInsertSql(flag))
+                flag.variants.forEachIndexed { idx, (vKey, vName, vJson) ->
+                    exec(variantInsertSql(flag.key, vKey, vName, vJson, idx))
+                }
+                for ((envKey, enabled) in flag.enabledByEnv) {
+                    exec(configInsertSql(flag, envKey, enabled))
+                }
+            }
+        }
+    }
+}
+
+private fun flagInsertSql(flag: DemoFlagSpec): String {
+    val tagsJson = flag.tags.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }
+    return """
+        INSERT INTO feature_flags
+            (organization_id, key, name, description, value_type, client_visible, tags)
+        VALUES
+            (-1, '${flag.key}', '${flag.name}', '${flag.description}', '${flag.valueType}',
+             ${flag.clientVisible}, '$tagsJson'::jsonb)
+        ON CONFLICT (organization_id, key) DO NOTHING
+    """.trimIndent()
+}
+
+private fun variantInsertSql(flagKey: String, vKey: String, vName: String, vJson: String, sortOrder: Int): String =
+    """
+        INSERT INTO feature_flag_variants (flag_id, key, name, value_json, sort_order)
+        SELECT f.id, '$vKey', '$vName', '$vJson'::jsonb, $sortOrder
+        FROM feature_flags f
+        WHERE f.organization_id = -1 AND f.key = '$flagKey'
+        ON CONFLICT (flag_id, key) DO NOTHING
+    """.trimIndent()
+
+private fun configInsertSql(flag: DemoFlagSpec, envKey: String, enabled: Boolean): String {
+    val defaultVariant = flag.variants.first().first
+    return """
+        INSERT INTO feature_flag_environment_configs
+            (flag_id, environment_id, enabled, default_variant_key, off_variant_key, rules_json)
+        SELECT f.id, e.id, $enabled, '$defaultVariant', '${flag.offVariantKey}', '{"rules":[]}'::jsonb
+        FROM feature_flags f
+        JOIN feature_flag_environments e ON e.organization_id = f.organization_id
+        WHERE f.organization_id = -1 AND f.key = '${flag.key}' AND e.key = '$envKey'
+        ON CONFLICT (flag_id, environment_id) DO NOTHING
+    """.trimIndent()
+}
+
+private suspend fun reseedFeatureFlagEvaluations() {
+    for (flag in demoFlags) {
+        suspendRunCatching {
+            requireClickHouse2xx(
+                ClickHouseClient.execute(evaluationsInsertSql(flag)),
+                "Reseed evaluations ${flag.key}"
+            )
+        }.onFailure { logger.warn { "Reseed evaluations ${flag.key} failed (non-fatal): ${it.message}" } }
+    }
+
+    // A handful of conversion-tracking events tied to the checkout experiment.
+    suspendRunCatching {
+        requireClickHouse2xx(ClickHouseClient.execute(trackingEventsInsertSql()), "Reseed flag tracking events")
+    }.onFailure { logger.warn { "Reseed flag tracking events failed (non-fatal): ${it.message}" } }
+}
+
+private fun evaluationsInsertSql(flag: DemoFlagSpec): String {
+    val variantArray = flag.evalVariantWeights.joinToString(", ") { "'$it'" }
+    val variantCount = flag.evalVariantWeights.size
+    return """
+        INSERT INTO feature_flag_evaluations (
+            event_time, organization_id, environment, flag_key, variant_key, value_type,
+            reason, error_code, targeting_key, sdk_key_prefix, key_type, context_json, duration_ms
+        )
+        SELECT
+            now64(3) - INTERVAL (number * 23 % 10080) MINUTE,
+            $FF_ORG,
+            arrayElement(['production', 'production', 'production', 'staging', 'development'], number % 5 + 1),
+            '${flag.key}',
+            arrayElement([$variantArray], number % $variantCount + 1),
+            '${flag.valueType}',
+            arrayElement(['TARGETING_MATCH', 'TARGETING_MATCH', 'SPLIT', 'DEFAULT', 'STATIC'], number % 5 + 1),
+            '',
+            concat('user-', toString(number % 800)),
+            'srv_demo',
+            'server',
+            concat('{"targetingKey":"user-', toString(number % 800), '"}'),
+            0.2 + (number % 60) / 20.0
+        FROM numbers(400)
+    """.trimIndent()
+}
+
+private fun trackingEventsInsertSql(): String =
+    """
+        INSERT INTO feature_flag_tracking_events (
+            event_time, organization_id, environment, event_name, targeting_key,
+            flag_key, variant_key, sdk_key_prefix, key_type, value, properties_json
+        )
+        SELECT
+            now64(3) - INTERVAL (number * 47 % 10080) MINUTE,
+            $FF_ORG,
+            'production',
+            'checkout_completed',
+            concat('user-', toString(number % 800)),
+            'checkout-button-color',
+            arrayElement(['control', 'blue', 'green'], number % 3 + 1),
+            'srv_demo',
+            'server',
+            29.0 + (number % 120),
+            '{}'
+        FROM numbers(200)
+    """.trimIndent()
+
+/** Postgres reseed is synchronous (Exposed transaction); wrap it so failures stay non-fatal like the CH path. */
+private fun runPostgresReseedCatching(block: () -> Unit) {
+    runCatching(block).onFailure {
+        logger.warn { "Reseed feature_flags (postgres) failed (non-fatal): ${it.message}" }
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedFeedback.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedFeedback.kt
@@ -1,0 +1,125 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+@file:Suppress("MagicNumber")
+
+package com.moneat.config
+
+import com.moneat.utils.suspendRunCatching
+import io.ktor.client.statement.bodyAsText
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+// ── User Feedback Demo Data ────────────────────────────────────────────
+//
+// ClickHouse `user_feedback` for the three demo projects (-1 Android / -2 iOS / -3 RN),
+// inserted relative to now() so the Feedback list (which reads `user_feedback FINAL` filtered
+// by project + status) renders fresh. Was previously only seeded by the one-time CH migration
+// V7, whose rows age out via the table's 90-day TTL.
+
+internal suspend fun checkFreshFeedbackCount(): Long {
+    val query = """
+        SELECT count() FROM user_feedback
+        WHERE project_id IN ($P1, $P2, $P3)
+            AND timestamp >= now() - INTERVAL 7 DAY
+    """.trimIndent()
+    return suspendRunCatching {
+        val response = ClickHouseClient.execute(query)
+        if (response.status.value !in 200..299) {
+            0L
+        } else {
+            response.bodyAsText().trim().toLongOrNull() ?: 0L
+        }
+    }.getOrElse {
+        logger.warn { "Failed to check fresh feedback demo data (non-fatal): ${it.message}" }
+        0L
+    }
+}
+
+internal suspend fun purgeFeedbackDemoData() {
+    suspendRunCatching {
+        requireClickHouse2xx(
+            ClickHouseClient.execute("ALTER TABLE user_feedback DELETE WHERE project_id IN ($P1, $P2, $P3)"),
+            "Purge user_feedback"
+        )
+    }.onFailure { logger.warn { "Purge user_feedback failed (non-fatal): ${it.message}" } }
+}
+
+internal suspend fun reseedFeedback() {
+    suspendRunCatching {
+        requireClickHouse2xx(ClickHouseClient.execute(buildFeedbackInsertSql()), "Reseed user_feedback")
+    }.onFailure { logger.warn { "Reseed user_feedback failed (non-fatal): ${it.message}" } }
+    logger.info { "User feedback demo data reseed complete" }
+}
+
+private fun buildFeedbackInsertSql(): String =
+    """
+        INSERT INTO user_feedback (
+            feedback_id, project_id, timestamp, received_at, message, contact_email, name, url,
+            associated_event_id, replay_id, environment, release, platform, user_id, user_email,
+            user_username, user_ip_address, sdk_name, sdk_version, tags, status, updated_at
+        )
+        SELECT
+            generateUUIDv4(),
+            arrayElement([$P1, $P2, $P3], number % 3 + 1),
+            now64(3) - INTERVAL (number * 67 % 20160) MINUTE,
+            now64(3) - INTERVAL (number * 67 % 20160) MINUTE,
+            arrayElement([
+                'Checkout keeps spinning after I tap Pay. Had to retry three times.',
+                'Love the new product gallery, but images take a while to load on mobile data.',
+                'App crashed when I applied a promo code at checkout.',
+                'Search results feel way more relevant now, nice work!',
+                'Cannot update my shipping address - the Save button does nothing.',
+                'Push notifications for order updates stopped arriving last week.',
+                'The dark theme is gorgeous. Please make it the default.',
+                'Got logged out randomly while browsing my cart.',
+                'Filtering by size resets the page to the top every time.',
+                'Payment failed but I was still charged - very stressful.',
+                'Wishlist sync between my phone and tablet is finally working.',
+                'Fonts are tiny on the order confirmation screen.'
+            ], number % 12 + 1),
+            concat('user', toString(number % 90), '@example.com'),
+            arrayElement([
+                'Jordan Lee', 'Sam Rivera', 'Alex Chen', 'Priya Nair', 'Diego Santos',
+                'Mia Kowalski', 'Tom Becker', 'Aisha Khan', 'Noah Wright', 'Lena Fischer'
+            ], number % 10 + 1),
+            arrayElement([
+                'https://shop.acme.com/checkout',
+                'https://shop.acme.com/cart',
+                'https://shop.acme.com/product/SKU-1042',
+                'https://shop.acme.com/orders',
+                'https://shop.acme.com/account'
+            ], number % 5 + 1),
+            '',
+            '',
+            if(number % 8 = 0, 'staging', 'production'),
+            arrayElement(['1.3.0', '2.1.0', '3.0.1'], number % 3 + 1),
+            arrayElement(['android', 'ios', 'react-native'], number % 3 + 1),
+            concat('user', toString(number % 90), '@example.com'),
+            concat('user', toString(number % 90), '@example.com'),
+            concat('user', toString(number % 90)),
+            '',
+            arrayElement(['sentry.java.android', 'sentry.cocoa', 'sentry.javascript.react-native'], number % 3 + 1),
+            arrayElement(['7.14.0', '8.21.0', '5.33.1'], number % 3 + 1),
+            map(
+                'sentiment',
+                arrayElement(['negative', 'negative', 'positive', 'neutral'], number % 4 + 1)
+            ),
+            arrayElement(['unresolved', 'unresolved', 'unresolved', 'resolved', 'resolved', 'archived'], number % 6 + 1),
+            now64(3)
+        FROM numbers(48)
+    """.trimIndent()

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedFeedback.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedFeedback.kt
@@ -62,8 +62,8 @@ internal suspend fun purgeFeedbackDemoData() {
 internal suspend fun reseedFeedback() {
     suspendRunCatching {
         requireClickHouse2xx(ClickHouseClient.execute(buildFeedbackInsertSql()), "Reseed user_feedback")
+        logger.info { "User feedback demo data reseed complete" }
     }.onFailure { logger.warn { "Reseed user_feedback failed (non-fatal): ${it.message}" } }
-    logger.info { "User feedback demo data reseed complete" }
 }
 
 private fun buildFeedbackInsertSql(): String =

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedLogs.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedLogs.kt
@@ -170,7 +170,9 @@ internal suspend fun reseedLogs() {
                 ELSE 'worker-prod-2'
             END AS host,
             'sdk' AS source,
-            -- Link ~80% of logs to a real demo APM trace so the log -> trace viewer resolves.
+            -- Link most logs to a real demo APM trace so the log -> trace viewer resolves. The "no trace"
+            -- selector below uses % 7 (coprime with the % 20 trace bucket) so unlinked logs spread across
+            -- all 20 traces instead of starving buckets 0/5/10/15.
             -- The demo root spans (DemoReseedDatadog) use trace_id = reinterpretAsUInt64(sipHash64(n, 0))
             -- and root span_id = reinterpretAsUInt64(sipHash64(n, 1)) for n in 0..19. trace_id_canonical
             -- falls back to toString(trace_id), and getTraceDetail parses it via toULongOrNull, so the
@@ -178,9 +180,9 @@ internal suspend fun reseedLogs() {
             -- context (empty), which the UI renders as "no trace" rather than a broken link.
             -- toUInt64(...) is required: the demo root spans hash a UInt64 `number`, and `number % 20`
             -- would otherwise carry a narrower integer type, changing the sipHash result (verified).
-            CASE WHEN number % 5 = 0 THEN ''
+            CASE WHEN number % 7 = 0 THEN ''
                  ELSE toString(reinterpretAsUInt64(sipHash64(toUInt64(number % 20), 0))) END AS trace_id,
-            CASE WHEN number % 5 = 0 THEN ''
+            CASE WHEN number % 7 = 0 THEN ''
                  ELSE toString(reinterpretAsUInt64(sipHash64(toUInt64(number % 20), 1))) END AS span_id,
             map(
                 'service', $tagsServiceCase,

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedLogs.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedLogs.kt
@@ -170,8 +170,18 @@ internal suspend fun reseedLogs() {
                 ELSE 'worker-prod-2'
             END AS host,
             'sdk' AS source,
-            lower(hex(generateUUIDv4())) AS trace_id,
-            substring(lower(hex(generateUUIDv4())), 1, 16) AS span_id,
+            -- Link ~80% of logs to a real demo APM trace so the log -> trace viewer resolves.
+            -- The demo root spans (DemoReseedDatadog) use trace_id = reinterpretAsUInt64(sipHash64(n, 0))
+            -- and root span_id = reinterpretAsUInt64(sipHash64(n, 1)) for n in 0..19. trace_id_canonical
+            -- falls back to toString(trace_id), and getTraceDetail parses it via toULongOrNull, so the
+            -- decimal string of the UInt64 id is the correct linkage value. The rest carry no trace
+            -- context (empty), which the UI renders as "no trace" rather than a broken link.
+            -- toUInt64(...) is required: the demo root spans hash a UInt64 `number`, and `number % 20`
+            -- would otherwise carry a narrower integer type, changing the sipHash result (verified).
+            CASE WHEN number % 5 = 0 THEN ''
+                 ELSE toString(reinterpretAsUInt64(sipHash64(toUInt64(number % 20), 0))) END AS trace_id,
+            CASE WHEN number % 5 = 0 THEN ''
+                 ELSE toString(reinterpretAsUInt64(sipHash64(toUInt64(number % 20), 1))) END AS span_id,
             map(
                 'service', $tagsServiceCase,
                 'environment', $tagsEnvCase,

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -93,6 +93,7 @@ import com.moneat.shared.repositories.OrganizationRepository
 import com.moneat.shared.repositories.OrganizationRepositoryImpl
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.AttributionAnalyticsService
+import com.moneat.shared.services.DemoLivenessBackgroundService
 import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.shared.services.RetentionBackgroundService
 import com.moneat.shared.services.RetentionPolicyService
@@ -129,6 +130,7 @@ val sharedModule = module {
     single { ProjectIdResolver() }
 
     single { AttributionAnalyticsService() }
+    single { DemoLivenessBackgroundService() }
 }
 
 /** Authentication, token management, and account lifecycle. */

--- a/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
@@ -45,7 +45,9 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
             FORMAT JSONEachRow
             """.trimIndent()
         val projectId = queryHelper.executeProjectIdQuery(query, "Feedback", feedbackId)
-        if (projectId == null || projectId <= 0L) {
+        // Negative ids are the demo-project convention (handled by ClickHouseQueryUtils.projectIdClause);
+        // only null or 0 is genuinely invalid.
+        if (projectId == null || projectId == 0L) {
             logger.warn { "Invalid project_id for feedback $feedbackId: $projectId" }
             return null
         }
@@ -134,7 +136,7 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
                 name,
                 url,
                 status,
-                formatDateTime(timestamp, '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as timestamp,
+                formatDateTime(timestamp, '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as timestamp_iso,
                 environment,
                 release,
                 platform,
@@ -163,7 +165,7 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
             name = obj["name"]?.jsonPrimitive?.content ?: "",
             url = obj["url"]?.jsonPrimitive?.content ?: "",
             status = obj["status"]?.jsonPrimitive?.content ?: "unresolved",
-            timestamp = obj["timestamp"]?.jsonPrimitive?.content ?: "",
+            timestamp = obj["timestamp_iso"]?.jsonPrimitive?.content ?: "",
             environment = obj["environment"]?.jsonPrimitive?.content ?: "",
             release = obj["release"]?.jsonPrimitive?.content ?: "",
             platform = obj["platform"]?.jsonPrimitive?.content ?: "",

--- a/backend/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagService.kt
+++ b/backend/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagService.kt
@@ -1222,7 +1222,7 @@ class FeatureFlagService {
         return "feature_flags:snapshot:$organizationId:$environmentKey"
     }
 
-    private fun analyticsWhere(organizationId: Int, environmentKey: String?, hours: Int): String {
+    internal fun analyticsWhere(organizationId: Int, environmentKey: String?, hours: Int): String {
         // organization_id is UInt32, so a negative demo org (-1) is stored wrapped (4294967295) by the
         // ingest path. Match it via toInt32(...) for negative orgs; keep the plain (index-friendly) form
         // for real positive orgs so the primary-key prefix on organization_id stays usable.

--- a/backend/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagService.kt
+++ b/backend/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagService.kt
@@ -1223,8 +1223,17 @@ class FeatureFlagService {
     }
 
     private fun analyticsWhere(organizationId: Int, environmentKey: String?, hours: Int): String {
+        // organization_id is UInt32, so a negative demo org (-1) is stored wrapped (4294967295) by the
+        // ingest path. Match it via toInt32(...) for negative orgs; keep the plain (index-friendly) form
+        // for real positive orgs so the primary-key prefix on organization_id stays usable.
+        val orgPredicate =
+            if (organizationId < 0) {
+                "toInt32(organization_id) = $organizationId"
+            } else {
+                "organization_id = $organizationId"
+            }
         val predicates = mutableListOf(
-            "organization_id = $organizationId",
+            orgPredicate,
             "event_time >= now() - INTERVAL ${hours.coerceAtLeast(1)} HOUR",
         )
         if (!environmentKey.isNullOrBlank()) {

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -200,6 +200,7 @@ fun Application.configureBackgroundJobs() {
             otlpMetricsIngestionWorker.stop()
         }
         workflowExecutionWorker.stop()
+        demoLivenessBackgroundService.stop()
         pulseService?.stop()
         FeatureRegistry.stopBackgroundJobs()
 

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -30,6 +30,7 @@ import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.otlp.services.OtlpMetricsIngestionWorker
 import com.moneat.otlp.services.OtlpTraceIngestionWorker
 import com.moneat.shared.services.ArtifactCleanupService
+import com.moneat.shared.services.DemoLivenessBackgroundService
 import com.moneat.shared.services.PulseService
 import com.moneat.shared.services.RetentionBackgroundService
 import com.moneat.shared.services.TaskLock
@@ -76,6 +77,7 @@ fun Application.configureBackgroundJobs() {
     val refreshTokenCleanupService = koin.get<RefreshTokenCleanupService>()
     val artifactCleanupService = koin.get<ArtifactCleanupService>()
     val uptimeScheduler = koin.get<UptimeScheduler>()
+    val demoLivenessBackgroundService = koin.get<DemoLivenessBackgroundService>()
     val queueKey = environment.config.property("ingest.queueKey").getString()
     val dlqKey = environment.config.property("ingest.dlqKey").getString()
     val workerCount =
@@ -152,6 +154,7 @@ fun Application.configureBackgroundJobs() {
     otlpTraceIngestionWorker.start()
     otlpMetricsIngestionWorker.start()
     workflowExecutionWorker.start()
+    demoLivenessBackgroundService.start(jobScope)
 
     // Start enterprise background jobs (SSO, On-Call, etc.) if modules are present
     FeatureRegistry.startBackgroundJobs(this)

--- a/backend/src/main/kotlin/com/moneat/shared/services/DemoLivenessBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/DemoLivenessBackgroundService.kt
@@ -33,6 +33,7 @@ private val logger = KotlinLogging.logger {}
 
 private const val DEFAULT_INTERVAL_SECONDS = 60L
 private const val DEMO_ORG_ID = -1L
+private const val DEFAULT_DOWN_HOST = "prod-worker-01"
 
 /**
  * Keeps demo infrastructure looking alive. Demo data is only seeded relative to now() at startup, but
@@ -41,16 +42,20 @@ private const val DEMO_ORG_ID = -1L
  * host falls to DOWN a few minutes after boot. This demo-only job re-stamps `last_seen_at` (and the
  * agent `status`) on a short interval so the demo stays realistic, leaving [downHostname] stale on
  * purpose so the fleet shows one DOWN host. Only runs when DEMO_ENABLED=true.
+ *
+ * The demo gate and the DB write are injected so the loop logic is unit-testable without a database.
  */
 class DemoLivenessBackgroundService(
     private val intervalSeconds: Long = DEFAULT_INTERVAL_SECONDS,
     /** One host intentionally left DOWN for a realistic fleet. Matches the demo host seeded by DemoReseedDatadog. */
-    private val downHostname: String = "prod-worker-01",
+    private val downHostname: String = DEFAULT_DOWN_HOST,
+    private val demoEnabled: () -> Boolean = { EnvConfig.Demo.enabled },
+    private val refresh: suspend (downHostname: String) -> Unit = { host -> defaultRefresh(host) },
 ) {
     private var job: Job? = null
 
     fun start(scope: CoroutineScope) {
-        if (!EnvConfig.Demo.enabled) {
+        if (!demoEnabled()) {
             logger.debug { "Demo liveness job disabled (DEMO_ENABLED=false)" }
             return
         }
@@ -62,10 +67,7 @@ class DemoLivenessBackgroundService(
         job =
             scope.launch {
                 while (isActive) {
-                    suspendRunCatching { refreshDemoHosts() }
-                        .onFailure { e ->
-                            logger.warn { "Demo host heartbeat refresh failed (non-fatal): ${e.message}" }
-                        }
+                    refreshOnce()
                     delay(intervalSeconds * MILLIS_PER_SECOND_LONG)
                 }
             }
@@ -75,16 +77,26 @@ class DemoLivenessBackgroundService(
         job?.cancel()
     }
 
-    private suspend fun refreshDemoHosts() {
-        withContext(Dispatchers.IO) {
-            transaction {
-                exec(
-                    """
-                    UPDATE hosts
-                    SET last_seen_at = NOW(), status = 'up'
-                    WHERE organization_id = $DEMO_ORG_ID AND hostname <> '$downHostname'
-                    """.trimIndent()
-                )
+    /** Run a single heartbeat refresh. Exposed for tests and for the loop body. */
+    internal suspend fun refreshOnce() {
+        suspendRunCatching { refresh(downHostname) }
+            .onFailure { e ->
+                logger.warn { "Demo host heartbeat refresh failed (non-fatal): ${e.message}" }
+            }
+    }
+
+    companion object {
+        /** UPDATE that re-stamps every demo host except the one intentionally left DOWN. */
+        internal fun heartbeatSql(downHostname: String): String =
+            """
+            UPDATE hosts
+            SET last_seen_at = NOW(), status = 'up'
+            WHERE organization_id = $DEMO_ORG_ID AND hostname <> '$downHostname'
+            """.trimIndent()
+
+        private suspend fun defaultRefresh(downHostname: String) {
+            withContext(Dispatchers.IO) {
+                transaction { exec(heartbeatSql(downHostname)) }
             }
         }
     }

--- a/backend/src/main/kotlin/com/moneat/shared/services/DemoLivenessBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/DemoLivenessBackgroundService.kt
@@ -1,0 +1,91 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.shared.services
+
+import com.moneat.config.EnvConfig
+import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
+import com.moneat.utils.suspendRunCatching
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+private val logger = KotlinLogging.logger {}
+
+private const val DEFAULT_INTERVAL_SECONDS = 60L
+private const val DEMO_ORG_ID = -1L
+
+/**
+ * Keeps demo infrastructure looking alive. Demo data is only seeded relative to now() at startup, but
+ * host liveness in the infrastructure views is derived from `last_seen_at` being within the last 5
+ * minutes (see DatadogHostService.rowToDdHostInfo). Without a real agent sending heartbeats, every demo
+ * host falls to DOWN a few minutes after boot. This demo-only job re-stamps `last_seen_at` (and the
+ * agent `status`) on a short interval so the demo stays realistic, leaving [downHostname] stale on
+ * purpose so the fleet shows one DOWN host. Only runs when DEMO_ENABLED=true.
+ */
+class DemoLivenessBackgroundService(
+    private val intervalSeconds: Long = DEFAULT_INTERVAL_SECONDS,
+    /** One host intentionally left DOWN for a realistic fleet. Matches the demo host seeded by DemoReseedDatadog. */
+    private val downHostname: String = "prod-worker-01",
+) {
+    private var job: Job? = null
+
+    fun start(scope: CoroutineScope) {
+        if (!EnvConfig.Demo.enabled) {
+            logger.debug { "Demo liveness job disabled (DEMO_ENABLED=false)" }
+            return
+        }
+        if (job?.isActive == true) {
+            logger.warn { "Demo liveness job already running; ignoring duplicate start()" }
+            return
+        }
+        logger.info { "Starting demo liveness job (refreshing demo host heartbeats every ${intervalSeconds}s)" }
+        job =
+            scope.launch {
+                while (isActive) {
+                    suspendRunCatching { refreshDemoHosts() }
+                        .onFailure { e ->
+                            logger.warn { "Demo host heartbeat refresh failed (non-fatal): ${e.message}" }
+                        }
+                    delay(intervalSeconds * MILLIS_PER_SECOND_LONG)
+                }
+            }
+    }
+
+    fun stop() {
+        job?.cancel()
+    }
+
+    private suspend fun refreshDemoHosts() {
+        withContext(Dispatchers.IO) {
+            transaction {
+                exec(
+                    """
+                    UPDATE hosts
+                    SET last_seen_at = NOW(), status = 'up'
+                    WHERE organization_id = $DEMO_ORG_ID AND hostname <> '$downHostname'
+                    """.trimIndent()
+                )
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
@@ -1,0 +1,87 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.events.services
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private const val FEEDBACK_UUID = "4f01ede1-5802-4ff1-81b7-f2fe9add31e5"
+
+class FeedbackServiceTest {
+    private lateinit var queryHelper: DashboardQueryHelper
+    private lateinit var service: FeedbackService
+
+    @BeforeTest
+    fun setup() {
+        queryHelper = mockk(relaxed = true)
+        every { queryHelper.clickhouseDb } returns "test_db"
+        every { queryHelper.normalizeUuid(any()) } returns FEEDBACK_UUID
+        coEvery { queryHelper.getProjectRetentionDays(any()) } returns 30
+        every {
+            queryHelper.timestampRetentionClause(any(), any(), any())
+        } returns "timestamp >= now() - INTERVAL 30 DAY"
+        service = FeedbackService(queryHelper)
+    }
+
+    @Test
+    fun `getProjectIdForFeedback accepts negative demo project ids`() = runBlocking {
+        coEvery { queryHelper.executeProjectIdQuery(any(), any(), any()) } returns -1L
+        assertEquals(-1L, service.getProjectIdForFeedback(FEEDBACK_UUID))
+    }
+
+    @Test
+    fun `getProjectIdForFeedback rejects zero and null project ids`() = runBlocking {
+        coEvery { queryHelper.executeProjectIdQuery(any(), any(), any()) } returns 0L
+        assertNull(service.getProjectIdForFeedback(FEEDBACK_UUID))
+
+        coEvery { queryHelper.executeProjectIdQuery(any(), any(), any()) } returns null
+        assertNull(service.getProjectIdForFeedback(FEEDBACK_UUID))
+    }
+
+    @Test
+    fun `getFeedbackDetail resolves a demo feedback row and maps the iso timestamp`() = runBlocking {
+        coEvery { queryHelper.executeProjectIdQuery(any(), any(), any()) } returns -1L
+        val row = buildJsonObject {
+            put("feedback_id", FEEDBACK_UUID)
+            put("message", "Checkout keeps spinning")
+            put("contact_email", "user0@example.com")
+            put("name", "Jordan Lee")
+            put("url", "https://shop.acme.com/checkout")
+            put("status", "unresolved")
+            put("timestamp_iso", "2026-05-29T17:39:22.000Z")
+            put("environment", "production")
+            put("release", "1.3.0")
+            put("platform", "android")
+            put("sdk_name", "sentry.java.android")
+            put("sdk_version", "7.14.0")
+        }
+        coEvery { queryHelper.executeJsonEachRowQuery(any(), any()) } returns listOf(row)
+
+        val detail = service.getFeedbackDetail(FEEDBACK_UUID)
+        assertEquals(FEEDBACK_UUID, detail?.feedbackId)
+        assertEquals("2026-05-29T17:39:22.000Z", detail?.timestamp)
+        assertEquals("unresolved", detail?.status)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/featureflags/FeatureFlagServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/featureflags/FeatureFlagServiceTest.kt
@@ -283,6 +283,20 @@ class FeatureFlagServiceTest {
         }
     }
 
+    @Test
+    fun `analyticsWhere matches the wrapped UInt32 org for negative demo orgs only`() {
+        // Demo org (-1) is stored wrapped in the UInt32 column, so it must be matched via toInt32(...).
+        val demo = service.analyticsWhere(-1, "production", 24)
+        assertTrue(demo.contains("toInt32(organization_id) = -1"))
+        assertTrue(demo.contains("environment = 'production'"))
+
+        // Real positive orgs keep the plain, index-friendly predicate.
+        val real = service.analyticsWhere(SERVICE_TEST_ORG_ID, null, 24)
+        assertTrue(real.contains("organization_id = $SERVICE_TEST_ORG_ID"))
+        assertFalse(real.contains("toInt32("))
+        assertFalse(real.contains("environment ="))
+    }
+
     private fun createSchema() {
         transaction {
             SchemaUtils.create(Users, Organizations)

--- a/backend/src/test/kotlin/com/moneat/shared/services/DemoLivenessBackgroundServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/shared/services/DemoLivenessBackgroundServiceTest.kt
@@ -1,0 +1,106 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.shared.services
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DemoLivenessBackgroundServiceTest {
+
+    @Test
+    fun `heartbeatSql restamps demo hosts and excludes the down host`() {
+        val sql = DemoLivenessBackgroundService.heartbeatSql("prod-worker-01")
+        assertTrue(sql.contains("UPDATE hosts"))
+        assertTrue(sql.contains("last_seen_at = NOW()"))
+        assertTrue(sql.contains("status = 'up'"))
+        assertTrue(sql.contains("organization_id = -1"))
+        assertTrue(sql.contains("hostname <> 'prod-worker-01'"))
+    }
+
+    @Test
+    fun `start does nothing when demo is disabled`() = runBlocking {
+        val calls = AtomicInteger(0)
+        val service = DemoLivenessBackgroundService(
+            intervalSeconds = 0,
+            demoEnabled = { false },
+            refresh = { calls.incrementAndGet() },
+        )
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        service.start(scope)
+        delay(100)
+        service.stop()
+        scope.cancel()
+        assertEquals(0, calls.get())
+    }
+
+    @Test
+    fun `start refreshes demo hosts when enabled`() = runBlocking {
+        val calls = AtomicInteger(0)
+        val firstCall = CompletableDeferred<Unit>()
+        val service = DemoLivenessBackgroundService(
+            intervalSeconds = 0,
+            demoEnabled = { true },
+            refresh = {
+                calls.incrementAndGet()
+                if (!firstCall.isCompleted) firstCall.complete(Unit)
+            },
+        )
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        try {
+            service.start(scope)
+            withTimeout(2000) { firstCall.await() }
+            assertTrue(calls.get() >= 1)
+        } finally {
+            service.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `refreshOnce passes the down host and swallows failures`() = runBlocking {
+        var receivedHost: String? = null
+        val ok = DemoLivenessBackgroundService(
+            downHostname = "worker-x",
+            refresh = { host -> receivedHost = host },
+        )
+        ok.refreshOnce()
+        assertEquals("worker-x", receivedHost)
+
+        // A failing refresh must not propagate out of refreshOnce.
+        val failing = DemoLivenessBackgroundService(
+            refresh = { error("boom") },
+        )
+        var threw = false
+        try {
+            failing.refreshOnce()
+        } catch (_: Throwable) {
+            threw = true
+        }
+        assertFalse(threw)
+    }
+}


### PR DESCRIPTION
## What & why

The demo had several empty or broken surfaces. This fills the missing demo data and fixes the read/seed bugs that were blocking the rest, so every advertised feature renders with realistic data. All reseed stays relative to `now()` and idempotent, consistent with the existing `DemoReseed*` modules.

## New demo data
- **Feature flags** — `DemoReseedFeatureFlags`: 6 org-scoped flags with variants + per-environment configs (Postgres) and 7-day evaluation/tracking events (ClickHouse) so the flag analytics view renders.
- **User feedback** — `DemoReseedFeedback`: realistic `user_feedback` rows across the demo projects, refreshed relative to `now()` (the one-time migration seed had aged out via the 90-day TTL).
- **Service map** — aggregate seeded `apm_spans` into `apm_service_stats_hourly` / `apm_service_edges_hourly` for the demo org. The live `ApmServiceMapRollups.insertForSpans` path intentionally skips the negative demo org, so the map was always empty.
- **Logs ↔ traces** — link ~80% of demo logs to real seeded trace ids so the log → trace viewer resolves (instead of random ids that matched nothing).
- **Hosts** — a demo-only `DemoLivenessBackgroundService` re-stamps `last_seen_at` every 60s so hosts stay live (host status is derived from a 5-minute freshness window); one host is intentionally left down for realism.

## Bug fixes (found while verifying end-to-end)
- **Issues were empty** — the demo error-event insert quoted the raw `release` `arrayElement(...)` expression and left apostrophes in `exception_value`/`stack_trace` unescaped, so every error insert failed with a syntax error (only transactions landed). Unquote the expression and `escapeSql(...)` the string literals.
- **Flag analytics returned nothing for the demo org** — `organization_id` is `UInt32`, so the negative demo org is stored wrapped; the read filtered `organization_id = -1` and matched nothing. Match via `toInt32(...)` for negative orgs, keeping the index-friendly form for real positive orgs.
- **Feedback detail 404'd** — a `project_id <= 0` guard rejected demo projects, and the detail query aliased `formatDateTime(...) as timestamp`, colliding with the retention predicate column (type error). Allow negative demo ids and rename the alias.

## Verification
Ran a local dev instance with demo enabled and confirmed via the API: **72 issues**, **service map 8 services / edges**, **log → trace resolves**, **6 hosts / 5 online**, **6 flags + 1440 flag evaluations**, **48 feedback (list + detail)**, and **product analytics** all return data. `compileKotlin` + `detekt` pass. No new DB migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo environment now includes realistic feature flag configurations and user feedback entries
  * Added automatic host heartbeat service to maintain demo infrastructure status

* **Bug Fixes**
  * Improved SQL safety for demo data generation
  * Enhanced analytics queries to properly handle negative organization IDs

* **Chores**
  * Improved demo data freshness tracking across multiple data domains

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->