### PR TITLE
fix: skip non-object lines when parsing ClickHouse JSONEachRow responses

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -469,8 +469,8 @@ object TraceIngestionService {
                 } else {
                     result.trim().lines()
                         .filter { it.isNotBlank() }
-                        .map { line ->
-                            val obj = json.parseToJsonElement(line).jsonObject
+                        .mapNotNull { line ->
+                            val obj = parseRowOrNull(line) ?: return@mapNotNull null
                             DdTraceListItem(
                                 traceId = obj["trace_id_canonical"]!!
                                     .jsonPrimitive.content,
@@ -777,11 +777,31 @@ object TraceIngestionService {
         query: String,
         parentSpan: ISpan?,
     ): List<JsonObject> {
-        val result = executeDashboardQuery(query, "", parentSpan)
-        if (result.isBlank()) return emptyList()
-        return result.trim().lines()
+        val lines = executeDashboardQuery(query, "", parentSpan)
+            .lines()
             .filter { it.isNotBlank() }
-            .map { line -> json.parseToJsonElement(line).jsonObject }
+        val rows = lines.mapNotNull(::parseRowOrNull)
+        if (rows.size != lines.size) {
+            logger.warn {
+                "Dropped ${lines.size - rows.size} non-object line(s) from ClickHouse JSONEachRow response"
+            }
+        }
+        return rows
+    }
+
+    /**
+     * Safely parse one line of a ClickHouse `FORMAT JSONEachRow` response into a [JsonObject].
+     *
+     * Every well-formed row is a JSON object, so a line that parses to a non-object — or fails
+     * to parse at all — is not row data. Such lines appear when ClickHouse streams an error
+     * *after* it has already sent a 200 (e.g. a mid-stream query timeout): the trailing
+     * exception text is appended past the point [ClickHouseClient.executeWithFormat] inspects
+     * for errors. Returning null lets callers skip the line instead of throwing, so a single
+     * malformed line cannot turn a partial result into an unhandled 500.
+     */
+    private fun parseRowOrNull(line: String): JsonObject? {
+        if (line.isBlank()) return null
+        return runCatching { json.parseToJsonElement(line) }.getOrNull() as? JsonObject
     }
 
     private fun emptyOverviewStats(previousStats: DdApmOverviewPreviousStats): DdApmOverviewStats =
@@ -859,8 +879,8 @@ object TraceIngestionService {
 
         val spans = result.trim().lines()
             .filter { it.isNotBlank() }
-            .map { line ->
-                val obj = json.parseToJsonElement(line).jsonObject
+            .mapNotNull { line ->
+                val obj = parseRowOrNull(line) ?: return@mapNotNull null
                 DdSpanResponse(
                     spanId = obj["span_id_out"]!!.jsonPrimitive.content,
                     traceId = obj["trace_id_out"]!!.jsonPrimitive.content,
@@ -916,8 +936,8 @@ object TraceIngestionService {
         } else {
             result.trim().lines()
                 .filter { it.isNotBlank() }
-                .map { line ->
-                    val obj = json.parseToJsonElement(line).jsonObject
+                .mapNotNull { line ->
+                    val obj = parseRowOrNull(line) ?: return@mapNotNull null
                     DdServiceMapEntry(
                         service = obj["service"]!!
                             .jsonPrimitive.content,
@@ -956,7 +976,7 @@ object TraceIngestionService {
             callsResult.trim().lines()
                 .filter { it.isNotBlank() }
                 .forEach { line ->
-                    val obj = json.parseToJsonElement(line).jsonObject
+                    val obj = parseRowOrNull(line) ?: return@forEach
                     val from = obj["from_service"]!!
                         .jsonPrimitive.content
                     val to = obj["to_service"]!!
@@ -1032,8 +1052,8 @@ object TraceIngestionService {
         } else {
             result.trim().lines()
                 .filter { it.isNotBlank() }
-                .mapIndexed { index, line ->
-                    val obj = json.parseToJsonElement(line).jsonObject
+                .mapIndexedNotNull { index, line ->
+                    val obj = parseRowOrNull(line) ?: return@mapIndexedNotNull null
                     val svc = obj["service"]!!
                         .jsonPrimitive.content
                     val res = obj["resource"]!!
@@ -1074,8 +1094,8 @@ object TraceIngestionService {
         } else {
             serviceFacetsResult.trim().lines()
                 .filter { it.isNotBlank() }
-                .map { line ->
-                    val obj = json.parseToJsonElement(line).jsonObject
+                .mapNotNull { line ->
+                    val obj = parseRowOrNull(line) ?: return@mapNotNull null
                     DdApmServiceFacet(
                         service = obj["service"]!!
                             .jsonPrimitive.content,
@@ -1168,8 +1188,8 @@ object TraceIngestionService {
         } else {
             result.trim().lines()
                 .filter { it.isNotBlank() }
-                .map { line ->
-                    val obj = json.parseToJsonElement(line).jsonObject
+                .mapNotNull { line ->
+                    val obj = parseRowOrNull(line) ?: return@mapNotNull null
                     val totalHits = obj["total_hits"]!!.jsonPrimitive.long
                     val totalErrors = obj["total_errors"]!!
                         .jsonPrimitive.long

--- a/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/TraceIngestionServiceTest.kt
@@ -280,6 +280,42 @@ class TraceIngestionServiceTest {
         }
     }
 
+    @Test
+    fun `getApmOverview skips streamed ClickHouse error lines instead of failing`() = runBlocking {
+        // Regression: ClickHouse can append a non-object line (e.g. a mid-stream Code 159
+        // timeout) after it has already streamed a 200 response. That line slips past the
+        // error check in executeWithFormat and previously crashed `.jsonObject` with
+        // "Element class JsonLiteral is not a JsonObject" -> unhandled 500 on /v1/traces/overview.
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val query = firstArg<String>()
+                if ("facet_type" in query) {
+                    // Valid rows interleaved with a bare literal and a raw exception fragment.
+                    "{\"facet_type\":\"service\",\"value\":\"web\",\"count\":\"5\"}\n" +
+                        "159\n" +
+                        "Code: 159. DB::Exception: Timeout exceeded\n" +
+                        "{\"facet_type\":\"source\",\"value\":\"otlp\",\"count\":\"3\"}"
+                } else {
+                    ""
+                }
+            }
+
+            val overview = TraceIngestionService.getApmOverview(
+                organizationId = 10,
+                query = DdTraceListQuery(),
+            )
+
+            // The malformed lines are skipped; the surrounding valid facet rows survive.
+            assertEquals("web", overview.facets.services.single().value)
+            assertEquals("otlp", overview.facets.sources.single().value)
+            assertTrue(overview.facets.environments.isEmpty())
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
     // ──── JSON PARSING TESTS ────
 
     @Test


### PR DESCRIPTION
## Problem

Recent `moneat-backend` error logs show `GET /v1/traces/overview` returning **500** with:

> `IllegalArgumentException: Element class kotlinx.serialization.json.JsonLiteral is not a JsonObject`

(3 events, last seen 2026-05-29; Moneat Backend issue `2440564d211e1683`). The stack trace points at `TraceIngestionService.jsonRows`.

## Root cause

`jsonRows()` parses a ClickHouse `FORMAT JSONEachRow` body one line at a time and force-casts each line with `.jsonObject`:

```kotlin
result.trim().lines().filter { it.isNotBlank() }
    .map { line -> json.parseToJsonElement(line).jsonObject }
```

Every well-formed row is a JSON object, so this normally works. But ClickHouse can append a **non-object** line when it streams an error *after* it has already sent a `200` — e.g. the mid-stream `Code 159` query timeout that is also firing on this same endpoint (issue `84c627b8…`). That trailing text lands past the point `ClickHouseClient.executeWithFormat` checks for errors (`isClickHouseError` only matches a body that *starts* with `Code:`), so it reaches `jsonRows`, where the unguarded `.jsonObject` cast throws and surfaces as an unhandled 500.

The same unguarded pattern existed at **8 sites** in this file (trace list, trace detail, service map, error groups, resource stats, overview), so each of those endpoints could 500 the same way.

## Fix

Add a shared `parseRowOrNull()` helper that parses a single line and returns `null` for anything that isn't a JSON object (or fails to parse), and route all 8 row-parse sites through it. A malformed / streamed-error line is now skipped instead of crashing the request, so the endpoint degrades to a partial result rather than a 500. `jsonRows` logs how many lines it dropped.

## Testing

- New regression test `getApmOverview skips streamed ClickHouse error lines instead of failing` reproduces the exact crash (a bare `JsonLiteral` line and a raw `Code: 159…` fragment interleaved with valid rows) and asserts the valid facets still come through.
- `./gradlew :test --tests "*TraceIngestionServiceTest" --tests "*TraceIngestionServiceCoverageTest"` → **50 tests, 0 failures**.
- `./gradlew :detekt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience in trace data processing to gracefully handle and skip malformed entries without failing.

* **Tests**
  * Added regression test to verify proper handling of malformed data during trace ingestion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->