### PR TITLE
Add workflow graph canvas and execution controls

### DIFF
--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -91,10 +91,22 @@ data class WorkflowStepDefinition(
 )
 
 @Serializable
+data class WorkflowNodeTypeDefinition(
+    val type: String,
+    val kind: String? = null,
+    val name: String,
+    val label: String,
+    val description: String,
+    val params: List<WorkflowStepParamDefinition> = emptyList(),
+    @SerialName("branch_labels") val branchLabels: List<String> = emptyList()
+)
+
+@Serializable
 data class WorkflowCatalogResponse(
     val resources: List<WorkflowResourceDefinition>,
     val triggers: List<WorkflowTriggerDefinition>,
-    val steps: List<WorkflowStepDefinition>
+    val steps: List<WorkflowStepDefinition>,
+    @SerialName("node_types") val nodeTypes: List<WorkflowNodeTypeDefinition> = emptyList()
 )
 
 object WorkflowCatalog {
@@ -242,8 +254,78 @@ object WorkflowCatalog {
         )
     )
 
+    val nodeTypes = listOf(
+        WorkflowNodeTypeDefinition(
+            type = "trigger",
+            name = "trigger",
+            label = "Trigger",
+            description = "Starts a workflow from a telemetry event."
+        ),
+        WorkflowNodeTypeDefinition(
+            type = "condition",
+            kind = "if",
+            name = "condition.if",
+            label = "If / else",
+            description = "Routes execution based on a set of conditions.",
+            branchLabels = listOf("true", "false")
+        ),
+        WorkflowNodeTypeDefinition(
+            type = "condition",
+            kind = "switch",
+            name = "condition.switch",
+            label = "Switch",
+            description = "Routes execution to the first matching case.",
+            branchLabels = listOf("case", "default")
+        ),
+        WorkflowNodeTypeDefinition(
+            type = "control",
+            kind = "sleep",
+            name = "control.sleep",
+            label = "Sleep",
+            description = "Pauses execution for a bounded duration.",
+            params = listOf(
+                WorkflowStepParamDefinition("duration", "Duration", "String", "ISO-8601 duration, for example PT5M")
+            )
+        ),
+        WorkflowNodeTypeDefinition(
+            type = "control",
+            kind = "wait_until",
+            name = "control.wait_until",
+            label = "Wait until",
+            description = "Waits until conditions match or a timeout is reached.",
+            params = listOf(
+                WorkflowStepParamDefinition("timeout", "Timeout", "String", "ISO-8601 duration, for example PT30M")
+            ),
+            branchLabels = listOf("true", "timeout")
+        ),
+        WorkflowNodeTypeDefinition(
+            type = "control",
+            kind = "for_each",
+            name = "control.for_each",
+            label = "For each",
+            description = "Runs a branch once per item from a scoped list.",
+            params = listOf(
+                WorkflowStepParamDefinition("items_reference", "Items reference", "String"),
+                WorkflowStepParamDefinition("item_variable", "Item variable", "String", required = false),
+                WorkflowStepParamDefinition("max_items", "Maximum items", "Number", required = false)
+            ),
+            branchLabels = listOf("body", "done")
+        ),
+        WorkflowNodeTypeDefinition(
+            type = "control",
+            kind = "while",
+            name = "control.while",
+            label = "While",
+            description = "Repeats a branch while conditions match, with a hard cap.",
+            params = listOf(
+                WorkflowStepParamDefinition("max_iterations", "Maximum iterations", "Number", required = false)
+            ),
+            branchLabels = listOf("body", "done")
+        )
+    )
+
     fun response(): WorkflowCatalogResponse =
-        WorkflowCatalogResponse(resources = resources, triggers = triggers, steps = steps)
+        WorkflowCatalogResponse(resources = resources, triggers = triggers, steps = steps, nodeTypes = nodeTypes)
 
     fun trigger(name: String): WorkflowTriggerDefinition? = triggers.firstOrNull { it.name == name }
 

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowConditionEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowConditionEvaluator.kt
@@ -1,0 +1,104 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.engine
+
+import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.workflowStringValue
+import com.moneat.workflows.models.workflowValue
+import kotlinx.serialization.json.JsonElement
+
+private const val SEVERITY_CRITICAL_RANK = 4
+private const val SEVERITY_HIGH_RANK = 3
+private const val SEVERITY_MEDIUM_RANK = 2
+private const val SEVERITY_LOW_RANK = 1
+private const val SEVERITY_UNKNOWN_RANK = 0
+
+object WorkflowConditionEvaluator {
+    fun matchesAll(
+        triggerName: String,
+        conditions: List<WorkflowConditionConfig>,
+        scope: Map<String, JsonElement>
+    ): Boolean =
+        conditions.all { condition ->
+            val actual = scope.workflowValue(condition.reference)?.workflowStringValue()
+            val resourceType = WorkflowCatalog.scopeType(triggerName, condition.reference)
+            evaluate(resourceType, actual, condition.operation, condition.value)
+        }
+
+    fun matchesAny(
+        triggerName: String,
+        conditions: List<WorkflowConditionConfig>,
+        scope: Map<String, JsonElement>
+    ): Boolean =
+        conditions.isEmpty() || conditions.any { condition ->
+            val actual = scope.workflowValue(condition.reference)?.workflowStringValue()
+            val resourceType = WorkflowCatalog.scopeType(triggerName, condition.reference)
+            evaluate(resourceType, actual, condition.operation, condition.value)
+        }
+
+    fun evaluate(
+        resourceType: String?,
+        actual: String?,
+        operation: String,
+        expected: String?
+    ): Boolean =
+        when (operation) {
+            "is_set" -> !actual.isNullOrBlank()
+            "is_not_set" -> actual.isNullOrBlank()
+            "eq" -> equalsIgnoringCase(actual, expected)
+            "neq" -> !equalsIgnoringCase(actual, expected)
+            "contains" -> actual?.contains(expected.orEmpty(), ignoreCase = true) == true
+            "not_contains" -> actual?.contains(expected.orEmpty(), ignoreCase = true) != true
+            "gt", "gte", "lt", "lte" -> compareNumbers(actual, expected, operation)
+            "at_least" -> {
+                val expectedRank = severityRank(expected)
+                resourceType == "AlertSeverity" && expectedRank > 0 && severityRank(actual) >= expectedRank
+            }
+            else -> false
+        }
+
+    private fun compareNumbers(
+        actual: String?,
+        expected: String?,
+        operation: String
+    ): Boolean {
+        val actualNumber = actual?.toDoubleOrNull() ?: return false
+        val expectedNumber = expected?.toDoubleOrNull() ?: return false
+        return when (operation) {
+            "gt" -> actualNumber > expectedNumber
+            "gte" -> actualNumber >= expectedNumber
+            "lt" -> actualNumber < expectedNumber
+            "lte" -> actualNumber <= expectedNumber
+            else -> false
+        }
+    }
+
+    private fun equalsIgnoringCase(
+        actual: String?,
+        expected: String?
+    ): Boolean =
+        actual != null && actual.compareTo(expected.orEmpty(), ignoreCase = true) == 0
+
+    private fun severityRank(value: String?): Int =
+        when (value?.uppercase()) {
+            "CRITICAL" -> SEVERITY_CRITICAL_RANK
+            "HIGH" -> SEVERITY_HIGH_RANK
+            "MEDIUM" -> SEVERITY_MEDIUM_RANK
+            "LOW" -> SEVERITY_LOW_RANK
+            else -> SEVERITY_UNKNOWN_RANK
+        }
+}

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/LinearGraphAdapter.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/LinearGraphAdapter.kt
@@ -16,13 +16,107 @@
 
 package com.moneat.workflows.engine.temporal
 
+import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowGraphEdge
+import com.moneat.workflows.models.WorkflowGraphNode
 import com.moneat.workflows.models.WorkflowStepConfig
+import com.moneat.workflows.models.workflowStringValue
+import kotlinx.serialization.json.JsonPrimitive
 
 object LinearGraphAdapter {
     fun fromSteps(steps: List<WorkflowStepConfig>): List<LinearWorkflowNode> =
         steps.mapIndexed { index, step ->
             LinearWorkflowNode(id = "step-${index + 1}", step = step)
         }
+
+    fun graphFromLegacy(
+        triggerName: String,
+        conditions: List<WorkflowConditionConfig>,
+        steps: List<WorkflowStepConfig>
+    ): WorkflowGraphConfig {
+        val triggerNode = WorkflowGraphNode(
+            id = TRIGGER_NODE_ID,
+            type = NODE_TYPE_TRIGGER,
+            trigger = triggerName
+        )
+        val conditionNode =
+            if (conditions.isEmpty()) {
+                null
+            } else {
+                WorkflowGraphNode(
+                    id = LEGACY_CONDITION_NODE_ID,
+                    type = NODE_TYPE_CONDITION,
+                    kind = CONDITION_KIND_IF,
+                    conditions = conditions
+                )
+            }
+        val actionNodes = steps.mapIndexed { index, step ->
+            WorkflowGraphNode(
+                id = "step-${index + 1}",
+                type = NODE_TYPE_ACTION,
+                action = step.name,
+                params = step.params.mapValues { (_, value) -> JsonPrimitive(value) },
+                continueOnError = true
+            )
+        }
+        return WorkflowGraphConfig(
+            nodes = listOfNotNull(triggerNode, conditionNode) + actionNodes,
+            edges = legacyEdges(conditionNode != null, actionNodes)
+        )
+    }
+
+    fun stepsFromGraph(graph: WorkflowGraphConfig): List<WorkflowStepConfig> =
+        graph.nodes
+            .filter { node -> node.type == NODE_TYPE_ACTION && !node.action.isNullOrBlank() }
+            .map { node ->
+                WorkflowStepConfig(
+                    name = checkNotNull(node.action),
+                    params = node.params.mapValues { (_, value) -> value.workflowParamValue() }
+                )
+            }
+
+    fun conditionsFromGraph(graph: WorkflowGraphConfig): List<WorkflowConditionConfig> =
+        graph.nodes
+            .firstOrNull { node -> node.type == NODE_TYPE_CONDITION && node.kind == CONDITION_KIND_IF }
+            ?.conditions
+            .orEmpty()
+
+    private fun legacyEdges(
+        hasCondition: Boolean,
+        actionNodes: List<WorkflowGraphNode>
+    ): List<WorkflowGraphEdge> {
+        val edges = mutableListOf<WorkflowGraphEdge>()
+        val firstAction = actionNodes.firstOrNull()
+        when {
+            hasCondition && firstAction != null -> {
+                edges += WorkflowGraphEdge(TRIGGER_NODE_ID, LEGACY_CONDITION_NODE_ID)
+                edges += WorkflowGraphEdge(LEGACY_CONDITION_NODE_ID, firstAction.id, branch = "true")
+            }
+            hasCondition -> edges += WorkflowGraphEdge(TRIGGER_NODE_ID, LEGACY_CONDITION_NODE_ID)
+            firstAction != null -> edges += WorkflowGraphEdge(TRIGGER_NODE_ID, firstAction.id)
+        }
+        actionNodes.zipWithNext().forEach { (from, to) ->
+            edges += WorkflowGraphEdge(from.id, to.id)
+        }
+        return edges
+    }
+
+    private fun kotlinx.serialization.json.JsonElement.workflowParamValue(): String =
+        workflowStringValue()
+
+    const val TRIGGER_NODE_ID = "trigger"
+    const val LEGACY_CONDITION_NODE_ID = "conditions"
+    const val NODE_TYPE_TRIGGER = "trigger"
+    const val NODE_TYPE_CONDITION = "condition"
+    const val NODE_TYPE_ACTION = "action"
+    const val NODE_TYPE_CONTROL = "control"
+    const val CONDITION_KIND_IF = "if"
+    const val CONDITION_KIND_SWITCH = "switch"
+    const val CONTROL_KIND_SLEEP = "sleep"
+    const val CONTROL_KIND_WAIT_UNTIL = "wait_until"
+    const val CONTROL_KIND_FOR_EACH = "for_each"
+    const val CONTROL_KIND_WHILE = "while"
 }
 
 data class LinearWorkflowNode(

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/TemporalWorkflowExecutionEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/TemporalWorkflowExecutionEngine.kt
@@ -39,8 +39,7 @@ class TemporalWorkflowExecutionEngine(
                     workflowId = request.workflowId,
                     workflowVersionId = request.workflowVersionId,
                     organizationId = request.organizationId,
-                    triggerName = request.triggerName,
-                    scope = request.scope
+                    triggerName = request.triggerName
                 )
             )
         return WorkflowStartResult(execution.workflowId, execution.runId)

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowActivities.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowActivities.kt
@@ -17,16 +17,21 @@
 package com.moneat.workflows.engine.temporal
 
 import com.moneat.utils.suspendRunCatching
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowRunSteps
 import com.moneat.workflows.models.WorkflowRunStepProgress
 import com.moneat.workflows.models.WorkflowRuns
 import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowVersions
+import com.moneat.workflows.models.workflowJson
 import com.moneat.workflows.services.WorkflowActionExecutor
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
@@ -45,13 +50,14 @@ class ExecuteActionActivityImpl(
                 actionExecutor.executeStep(
                     organizationId = input.organizationId,
                     step = input.step,
-                    scope = input.scope
+                    scope = input.scope.toWorkflowValues()
                 )
             }.fold(
                 onSuccess = {
                     ExecuteActionResult(
                         status = STATUS_COMPLETE,
-                        completedAt = Clock.System.now().toString()
+                        completedAt = Clock.System.now().toString(),
+                        output = it.toRuntimeValues()
                     )
                 },
                 onFailure = { error ->
@@ -66,7 +72,7 @@ class ExecuteActionActivityImpl(
 }
 
 class PersistRunActivityImpl : PersistRunActivity {
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = workflowJson
 
     override fun loadRun(input: LoadRunInput): WorkflowRunExecutionSnapshot? =
         transaction {
@@ -85,9 +91,11 @@ class PersistRunActivityImpl : PersistRunActivity {
                 runId = input.runId,
                 organizationId = runRow[WorkflowRuns.organizationId],
                 workflowVersionId = runRow[WorkflowRuns.workflowVersionId],
+                triggerName = runRow[WorkflowRuns.triggerName],
                 steps = decodeSteps(versionRow),
-                progress = decodeProgress(runRow[WorkflowRuns.progress]),
-                scope = decodeScope(runRow[WorkflowRuns.scope])
+                graph = decodeGraph(versionRow).toRuntimeGraph(),
+                progress = decodeProgress(runRow[WorkflowRuns.progress]).toRuntimeProgress(),
+                scope = decodeScope(runRow[WorkflowRuns.scope]).toRuntimeValues()
             )
         }
 
@@ -99,7 +107,7 @@ class PersistRunActivityImpl : PersistRunActivity {
         transaction {
             WorkflowRuns.update({ WorkflowRuns.id eq input.runId }) {
                 it[status] = STATUS_COMPLETE
-                it[progress] = json.encodeToString(input.progress)
+                it[progress] = json.encodeToString(input.progress.toWorkflowProgress())
                 it[completedAt] = Clock.System.now()
                 it[errorMessage] = null
                 it[failedAt] = null
@@ -111,11 +119,23 @@ class PersistRunActivityImpl : PersistRunActivity {
         transaction {
             WorkflowRuns.update({ WorkflowRuns.id eq input.runId }) {
                 it[status] = STATUS_FAILED
-                it[progress] = json.encodeToString(input.progress)
+                it[progress] = json.encodeToString(input.progress.toWorkflowProgress())
                 it[errorMessage] = input.errorMessage
                 it[failedAt] = Clock.System.now()
             }
         }
+    }
+
+    override fun markStepRunning(input: PersistRunStepInput) {
+        upsertStep(input.copy(status = STATUS_RUNNING))
+    }
+
+    override fun markStepComplete(input: PersistRunStepInput) {
+        upsertStep(input.copy(status = STATUS_COMPLETE))
+    }
+
+    override fun markStepFailed(input: PersistRunStepInput) {
+        upsertStep(input.copy(status = STATUS_FAILED))
     }
 
     fun updateTemporalRunId(
@@ -133,12 +153,12 @@ class PersistRunActivityImpl : PersistRunActivity {
     private fun updateRunProgress(
         runId: Int,
         status: String,
-        progress: List<WorkflowRunStepProgress>
+        progress: List<RuntimeWorkflowRunStepProgress>
     ) {
         transaction {
             WorkflowRuns.update({ WorkflowRuns.id eq runId }) {
                 it[WorkflowRuns.status] = status
-                it[WorkflowRuns.progress] = json.encodeToString(progress)
+                it[WorkflowRuns.progress] = json.encodeToString(progress.toWorkflowProgress())
                 it[WorkflowRuns.errorMessage] = null
                 it[WorkflowRuns.failedAt] = null
             }
@@ -148,11 +168,52 @@ class PersistRunActivityImpl : PersistRunActivity {
     private fun decodeSteps(row: ResultRow): List<WorkflowStepConfig> =
         row[WorkflowVersions.steps].takeIf { it.isNotBlank() }?.let { decode(it) } ?: emptyList()
 
+    private fun decodeGraph(row: ResultRow): WorkflowGraphConfig =
+        row[WorkflowVersions.graph].takeIf { it.isNotBlank() }?.let { decode(it) } ?: WorkflowGraphConfig()
+
     private fun decodeProgress(raw: String): List<WorkflowRunStepProgress> =
         raw.takeIf { it.isNotBlank() }?.let { decode(it) } ?: emptyList()
 
-    private fun decodeScope(raw: String): Map<String, String> =
+    private fun decodeScope(raw: String): Map<String, JsonElement> =
         raw.takeIf { it.isNotBlank() }?.let { decode(it) } ?: emptyMap()
+
+    private fun upsertStep(input: PersistRunStepInput) {
+        transaction {
+            val existing =
+                WorkflowRunSteps
+                    .selectAll()
+                    .where {
+                        (WorkflowRunSteps.runId eq input.runId) and
+                            (WorkflowRunSteps.nodeId eq input.nodeId) and
+                            (WorkflowRunSteps.attempt eq input.attempt)
+                    }.firstOrNull()
+            val now = Clock.System.now()
+            if (existing == null) {
+                WorkflowRunSteps.insert {
+                    it[runId] = input.runId
+                    it[nodeId] = input.nodeId
+                    it[type] = input.type
+                    it[status] = input.status
+                    it[startedAt] = now
+                    it[completedAt] = input.completedAtForStatus(now)
+                    it[WorkflowRunSteps.input] = json.encodeToString(input.input.toWorkflowValues())
+                    it[output] = json.encodeToString(input.output.toWorkflowValues())
+                    it[errorMessage] = input.errorMessage
+                    it[attempt] = input.attempt
+                }
+            } else {
+                WorkflowRunSteps.update({ WorkflowRunSteps.id eq existing[WorkflowRunSteps.id] }) {
+                    it[status] = input.status
+                    it[completedAt] = input.completedAtForStatus(now)
+                    it[output] = json.encodeToString(input.output.toWorkflowValues())
+                    it[errorMessage] = input.errorMessage
+                }
+            }
+        }
+    }
+
+    private fun PersistRunStepInput.completedAtForStatus(now: kotlin.time.Instant): kotlin.time.Instant? =
+        if (status == STATUS_COMPLETE || status == STATUS_FAILED) now else null
 
     private inline fun <reified T> decode(raw: String): T =
         json.decodeFromString(raw)

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowDirectRunExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowDirectRunExecutor.kt
@@ -58,6 +58,7 @@ class WorkflowDirectRunExecutor(
         graph: WorkflowGraphConfig,
         initialProgress: List<WorkflowRunStepProgress>
     ): List<WorkflowRunStepProgress> {
+        // Direct fallback runs execute actions only; Temporal-owned waits and loops are marked complete.
         var progress = initialProgress.map { item ->
             if (item.type == LinearGraphAdapter.NODE_TYPE_ACTION) item else item.copy(status = STATUS_COMPLETE)
         }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowDirectRunExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowDirectRunExecutor.kt
@@ -16,11 +16,11 @@
 
 package com.moneat.workflows.engine.temporal
 
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowGraphNode
 import com.moneat.workflows.models.WorkflowRunStepProgress
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
+import com.moneat.workflows.models.WorkflowStepConfig
+import com.moneat.workflows.models.workflowStringValue
 
 private const val STATUS_COMPLETE = "complete"
 private const val STATUS_FAILED = "failed"
@@ -35,51 +35,117 @@ class WorkflowDirectRunExecutor(
         val snapshot = persistActivity.loadRun(LoadRunInput(runId)) ?: return WorkflowInterpreterResult(
             status = STATUS_COMPLETE
         )
-        val initialProgress = snapshot.progress.ifEmpty {
-            LinearGraphAdapter.fromSteps(snapshot.steps).map { node ->
-                WorkflowRunStepProgress(step = node.step.name, status = STATUS_PENDING)
-            }
-        }
-        persistActivity.markRunning(PersistRunProgressInput(runId, STATUS_RUNNING, initialProgress))
-        val stepResults =
-            coroutineScope {
-                LinearGraphAdapter.fromSteps(snapshot.steps).mapIndexed { index, node ->
-                    async(Dispatchers.IO) {
-                        val existing = initialProgress.getOrNull(index)
-                        if (existing?.status == STATUS_COMPLETE) return@async index to existing
-                        val result =
-                            actionActivity.execute(
-                                ExecuteActionInput(
-                                    organizationId = snapshot.organizationId,
-                                    step = node.step,
-                                    scope = snapshot.scope
-                                )
-                            )
-                        index to WorkflowRunStepProgress(
-                            step = node.step.name,
-                            status = result.status,
-                            completedAt = result.completedAt,
-                            errorMessage = result.errorMessage
-                        )
-                    }
-                }
-            }.awaitAll()
-        val progress = initialProgress.updateFrom(stepResults)
+        val graph = snapshot.graph.toWorkflowGraphConfig().normalized(snapshot.triggerName, snapshot.steps)
+        val initialProgress = snapshot.progress.toWorkflowProgress().ifEmpty { graph.initialProgress() }
+        persistActivity.markRunning(PersistRunProgressInput(runId, STATUS_RUNNING, initialProgress.toRuntimeProgress()))
+        val progress = executeActions(runId, snapshot, graph, initialProgress)
         val failedStep = progress.firstOrNull { step -> step.status == STATUS_FAILED }
         return if (failedStep == null) {
-            persistActivity.markComplete(PersistRunProgressInput(runId, STATUS_COMPLETE, progress))
-            WorkflowInterpreterResult(status = STATUS_COMPLETE, progress = progress)
+            val runtimeProgress = progress.toRuntimeProgress()
+            persistActivity.markComplete(PersistRunProgressInput(runId, STATUS_COMPLETE, runtimeProgress))
+            WorkflowInterpreterResult(status = STATUS_COMPLETE, progress = runtimeProgress)
         } else {
             val message = failedStep.errorMessage ?: "Unknown workflow step error"
-            persistActivity.markFailed(PersistRunFailureInput(runId, progress, message))
-            WorkflowInterpreterResult(status = STATUS_FAILED, progress = progress, errorMessage = message)
+            val runtimeProgress = progress.toRuntimeProgress()
+            persistActivity.markFailed(PersistRunFailureInput(runId, runtimeProgress, message))
+            WorkflowInterpreterResult(status = STATUS_FAILED, progress = runtimeProgress, errorMessage = message)
         }
     }
 
-    private fun List<WorkflowRunStepProgress>.updateFrom(
-        replacements: List<Pair<Int, WorkflowRunStepProgress>>
+    private fun executeActions(
+        runId: Int,
+        snapshot: WorkflowRunExecutionSnapshot,
+        graph: WorkflowGraphConfig,
+        initialProgress: List<WorkflowRunStepProgress>
     ): List<WorkflowRunStepProgress> {
-        val byIndex = replacements.toMap()
-        return mapIndexed { index, item -> byIndex[index] ?: item }
+        var progress = initialProgress.map { item ->
+            if (item.type == LinearGraphAdapter.NODE_TYPE_ACTION) item else item.copy(status = STATUS_COMPLETE)
+        }
+        graph.nodes
+            .filter { node -> node.type == LinearGraphAdapter.NODE_TYPE_ACTION }
+            .forEach { node ->
+                val result = executeActionNode(runId, snapshot, node)
+                progress = progress.map { item -> if (item.nodeId == node.id) result else item }
+            }
+        return progress
     }
+
+    private fun executeActionNode(
+        runId: Int,
+        snapshot: WorkflowRunExecutionSnapshot,
+        node: WorkflowGraphNode
+    ): WorkflowRunStepProgress {
+        val step = WorkflowStepConfig(
+            name = node.action.orEmpty(),
+            params = node.params.mapValues { (_, value) -> value.workflowStringValue() }
+        )
+        persistActivity.markStepRunning(
+            PersistRunStepInput(runId, node.id, node.type, STATUS_RUNNING, snapshot.scope)
+        )
+        val result =
+            actionActivity.execute(
+                ExecuteActionInput(
+                    organizationId = snapshot.organizationId,
+                    step = step,
+                    scope = snapshot.scope
+                )
+            )
+        val progress =
+            WorkflowRunStepProgress(
+                step = step.name,
+                status = result.status,
+                nodeId = node.id,
+                type = node.type,
+                completedAt = result.completedAt,
+                output = result.output.toWorkflowValues(),
+                errorMessage = result.errorMessage
+            )
+        persistStep(runId, node, result)
+        return progress
+    }
+
+    private fun persistStep(
+        runId: Int,
+        node: WorkflowGraphNode,
+        result: ExecuteActionResult
+    ) {
+        val input = emptyMap<String, String>()
+        val stepInput =
+            PersistRunStepInput(
+                runId = runId,
+                nodeId = node.id,
+                type = node.type,
+                status = result.status,
+                input = input,
+                output = result.output,
+                errorMessage = result.errorMessage
+            )
+        if (result.status == STATUS_FAILED) {
+            persistActivity.markStepFailed(stepInput)
+        } else {
+            persistActivity.markStepComplete(stepInput)
+        }
+    }
+
+    private fun WorkflowGraphConfig.normalized(
+        triggerName: String,
+        steps: List<WorkflowStepConfig>
+    ): WorkflowGraphConfig =
+        if (nodes.isEmpty()) {
+            LinearGraphAdapter.graphFromLegacy(triggerName, emptyList(), steps)
+        } else {
+            this
+        }
+
+    private fun WorkflowGraphConfig.initialProgress(): List<WorkflowRunStepProgress> =
+        nodes
+            .filter { node -> node.type != LinearGraphAdapter.NODE_TYPE_TRIGGER }
+            .map { node ->
+                WorkflowRunStepProgress(
+                    step = node.action ?: node.kind ?: node.id,
+                    status = STATUS_PENDING,
+                    nodeId = node.id,
+                    type = node.type
+                )
+            }
 }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowEngineModels.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowEngineModels.kt
@@ -16,8 +16,18 @@
 
 package com.moneat.workflows.engine.temporal
 
+import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowGraphEdge
+import com.moneat.workflows.models.WorkflowGraphNode
+import com.moneat.workflows.models.WorkflowRetryConfig
 import com.moneat.workflows.models.WorkflowRunStepProgress
+import com.moneat.workflows.models.WorkflowSwitchCaseConfig
 import com.moneat.workflows.models.WorkflowStepConfig
+import com.moneat.workflows.models.workflowJson
+import com.moneat.workflows.models.workflowStringValue
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 
 const val WORKFLOW_TASK_QUEUE = "moneat-workflows-trusted"
 internal const val ORGANIZATION_SEARCH_ATTRIBUTE = "organizationId"
@@ -31,7 +41,7 @@ data class WorkflowStartRequest(
     val triggerName: String,
     val onceFor: String,
     val temporalWorkflowId: String,
-    val scope: Map<String, String>
+    val scope: Map<String, JsonElement>
 )
 
 data class WorkflowStartResult(
@@ -44,13 +54,12 @@ data class WorkflowInterpreterInput(
     var workflowId: Int = 0,
     var workflowVersionId: Int = 0,
     var organizationId: Int = 0,
-    var triggerName: String = "",
-    var scope: Map<String, String> = emptyMap()
+    var triggerName: String = ""
 )
 
 data class WorkflowInterpreterResult(
     var status: String = "",
-    var progress: List<WorkflowRunStepProgress> = emptyList(),
+    var progress: List<RuntimeWorkflowRunStepProgress> = emptyList(),
     var errorMessage: String? = null
 )
 
@@ -63,6 +72,7 @@ data class ExecuteActionInput(
 data class ExecuteActionResult(
     var status: String = "",
     var completedAt: String = "",
+    var output: Map<String, String> = emptyMap(),
     var errorMessage: String? = null
 )
 
@@ -74,19 +84,152 @@ data class WorkflowRunExecutionSnapshot(
     var runId: Int = 0,
     var organizationId: Int = 0,
     var workflowVersionId: Int = 0,
+    var triggerName: String = "",
     var steps: List<WorkflowStepConfig> = emptyList(),
-    var progress: List<WorkflowRunStepProgress> = emptyList(),
+    var graph: RuntimeWorkflowGraphConfig = RuntimeWorkflowGraphConfig(),
+    var progress: List<RuntimeWorkflowRunStepProgress> = emptyList(),
     var scope: Map<String, String> = emptyMap()
 )
 
 data class PersistRunProgressInput(
     var runId: Int = 0,
     var status: String = "",
-    var progress: List<WorkflowRunStepProgress> = emptyList()
+    var progress: List<RuntimeWorkflowRunStepProgress> = emptyList()
 )
 
 data class PersistRunFailureInput(
     var runId: Int = 0,
-    var progress: List<WorkflowRunStepProgress> = emptyList(),
+    var progress: List<RuntimeWorkflowRunStepProgress> = emptyList(),
     var errorMessage: String = ""
 )
+
+data class PersistRunStepInput(
+    var runId: Int = 0,
+    var nodeId: String = "",
+    var type: String = "",
+    var status: String = "",
+    var input: Map<String, String> = emptyMap(),
+    var output: Map<String, String> = emptyMap(),
+    var errorMessage: String? = null,
+    var attempt: Int = 1
+)
+
+data class RuntimeWorkflowGraphConfig(
+    var nodes: List<RuntimeWorkflowGraphNode> = emptyList(),
+    var edges: List<RuntimeWorkflowGraphEdge> = emptyList()
+)
+
+data class RuntimeWorkflowGraphNode(
+    var id: String = "",
+    var type: String = "",
+    var trigger: String? = null,
+    var kind: String? = null,
+    var action: String? = null,
+    var params: Map<String, String> = emptyMap(),
+    var conditions: List<WorkflowConditionConfig> = emptyList(),
+    var cases: List<WorkflowSwitchCaseConfig> = emptyList(),
+    var retry: WorkflowRetryConfig? = null,
+    var continueOnError: Boolean = false
+)
+
+data class RuntimeWorkflowGraphEdge(
+    var from: String = "",
+    var to: String = "",
+    var branch: String? = null,
+    var on: String? = null
+)
+
+data class RuntimeWorkflowRunStepProgress(
+    var step: String = "",
+    var status: String = "",
+    var nodeId: String? = null,
+    var type: String? = null,
+    var completedAt: String? = null,
+    var output: Map<String, String> = emptyMap(),
+    var errorMessage: String? = null
+)
+
+fun WorkflowGraphConfig.toRuntimeGraph(): RuntimeWorkflowGraphConfig =
+    RuntimeWorkflowGraphConfig(
+        nodes = nodes.map { node -> node.toRuntimeGraphNode() },
+        edges = edges.map { edge ->
+            RuntimeWorkflowGraphEdge(edge.from, edge.to, edge.branch, edge.on)
+        }
+    )
+
+fun RuntimeWorkflowGraphConfig.toWorkflowGraphConfig(): WorkflowGraphConfig =
+    WorkflowGraphConfig(
+        nodes = nodes.map { node -> node.toWorkflowGraphNode() },
+        edges = edges.map { edge ->
+            WorkflowGraphEdge(edge.from, edge.to, edge.branch, edge.on)
+        }
+    )
+
+fun Map<String, JsonElement>.toRuntimeValues(): Map<String, String> =
+    mapValues { (_, value) -> workflowJson.encodeToString(JsonElement.serializer(), value) }
+
+fun Map<String, String>.toWorkflowValues(): Map<String, JsonElement> =
+    mapValues { (_, value) -> decodeRuntimeValue(value) }
+
+fun List<WorkflowRunStepProgress>.toRuntimeProgress(): List<RuntimeWorkflowRunStepProgress> =
+    map { step -> step.toRuntimeProgress() }
+
+fun List<RuntimeWorkflowRunStepProgress>.toWorkflowProgress(): List<WorkflowRunStepProgress> =
+    map { step -> step.toWorkflowProgress() }
+
+private fun WorkflowGraphNode.toRuntimeGraphNode(): RuntimeWorkflowGraphNode =
+    RuntimeWorkflowGraphNode(
+        id = id,
+        type = type,
+        trigger = trigger,
+        kind = kind,
+        action = action,
+        params = params.mapValues { (_, value) -> value.workflowStringValue() },
+        conditions = conditions,
+        cases = cases,
+        retry = retry,
+        continueOnError = continueOnError
+    )
+
+private fun RuntimeWorkflowGraphNode.toWorkflowGraphNode(): WorkflowGraphNode =
+    WorkflowGraphNode(
+        id = id,
+        type = type,
+        trigger = trigger,
+        kind = kind,
+        action = action,
+        params = params.mapValues { (_, value) -> JsonPrimitive(value) },
+        conditions = conditions,
+        cases = cases,
+        retry = retry,
+        continueOnError = continueOnError
+    )
+
+private fun WorkflowRunStepProgress.toRuntimeProgress(): RuntimeWorkflowRunStepProgress =
+    RuntimeWorkflowRunStepProgress(
+        step = step,
+        status = status,
+        nodeId = nodeId,
+        type = type,
+        completedAt = completedAt,
+        output = output.toRuntimeValues(),
+        errorMessage = errorMessage
+    )
+
+private fun RuntimeWorkflowRunStepProgress.toWorkflowProgress(): WorkflowRunStepProgress =
+    WorkflowRunStepProgress(
+        step = step,
+        status = status,
+        nodeId = nodeId,
+        type = type,
+        completedAt = completedAt,
+        output = output.toWorkflowValues(),
+        errorMessage = errorMessage
+    )
+
+private fun decodeRuntimeValue(value: String): JsonElement =
+    runCatching {
+        workflowJson.decodeFromString(JsonElement.serializer(), value)
+    }.getOrElse {
+        JsonPrimitive(value)
+    }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflow.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflow.kt
@@ -16,22 +16,34 @@
 
 package com.moneat.workflows.engine.temporal
 
+import com.moneat.workflows.engine.WorkflowConditionEvaluator
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowGraphEdge
+import com.moneat.workflows.models.WorkflowGraphNode
 import com.moneat.workflows.models.WorkflowRunStepProgress
+import com.moneat.workflows.models.WorkflowStepConfig
+import com.moneat.workflows.models.workflowArrayValue
+import com.moneat.workflows.models.workflowStringValue
+import com.moneat.workflows.models.workflowValue
 import io.temporal.activity.ActivityInterface
 import io.temporal.activity.ActivityMethod
 import io.temporal.activity.ActivityOptions
-import io.temporal.workflow.Async
-import io.temporal.workflow.Promise
+import io.temporal.common.RetryOptions
 import io.temporal.workflow.Workflow
 import io.temporal.workflow.WorkflowInterface
 import io.temporal.workflow.WorkflowMethod
 import java.time.Duration
+import java.time.Instant
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 
 private const val STATUS_COMPLETE = "complete"
 private const val STATUS_FAILED = "failed"
 private const val STATUS_RUNNING = "running"
 private const val STATUS_PENDING = "pending"
 private const val ACTIVITY_TIMEOUT_SECONDS = 30L
+private const val DEFAULT_MAX_ITEMS = 100
+const val MAX_WHILE_ITERATIONS = 2_000
 
 @WorkflowInterface
 interface WorkflowInterpreterWorkflow {
@@ -58,6 +70,15 @@ interface PersistRunActivity {
 
     @ActivityMethod
     fun markFailed(input: PersistRunFailureInput)
+
+    @ActivityMethod
+    fun markStepRunning(input: PersistRunStepInput)
+
+    @ActivityMethod
+    fun markStepComplete(input: PersistRunStepInput)
+
+    @ActivityMethod
+    fun markStepFailed(input: PersistRunStepInput)
 }
 
 class WorkflowInterpreterWorkflowImpl : WorkflowInterpreterWorkflow {
@@ -66,80 +87,316 @@ class WorkflowInterpreterWorkflowImpl : WorkflowInterpreterWorkflow {
             .newBuilder()
             .setStartToCloseTimeout(Duration.ofSeconds(ACTIVITY_TIMEOUT_SECONDS))
             .build()
-    private val actions = Workflow.newActivityStub(ExecuteActionActivity::class.java, activityOptions)
     private val runs = Workflow.newActivityStub(PersistRunActivity::class.java, activityOptions)
 
     override fun run(input: WorkflowInterpreterInput): WorkflowInterpreterResult {
         val snapshot = runs.loadRun(LoadRunInput(runId = input.runId))
             ?: return WorkflowInterpreterResult(status = STATUS_COMPLETE)
+        val graph = snapshot.graph.toWorkflowGraphConfig().normalized(input.triggerName, snapshot.steps)
+        val initialProgress = snapshot.progress.toWorkflowProgress().ifEmpty { graph.initialProgress() }
+        runs.markRunning(PersistRunProgressInput(input.runId, STATUS_RUNNING, initialProgress.toRuntimeProgress()))
 
-        val initialProgress = snapshot.progress.ifEmpty {
-            LinearGraphAdapter.fromSteps(snapshot.steps)
-                .map { node -> WorkflowRunStepProgress(step = node.step.name, status = STATUS_PENDING) }
+        val context = GraphExecutionContext(input, snapshot, graph, initialProgress)
+        val triggerNode = graph.nodes.firstOrNull { node -> node.type == LinearGraphAdapter.NODE_TYPE_TRIGGER }
+        if (triggerNode != null) {
+            context.executeFrom(triggerNode.id)
         }
-        runs.markRunning(PersistRunProgressInput(input.runId, STATUS_RUNNING, initialProgress))
 
-        val promises = startActionPromises(snapshot, initialProgress)
-        Promise.allOf(promises).get()
-
-        val progress = progressFromResults(initialProgress, promises)
-        val failedStep = progress.firstOrNull { step -> step.status == STATUS_FAILED }
-        return if (failedStep == null) {
-            runs.markComplete(PersistRunProgressInput(input.runId, STATUS_COMPLETE, progress))
-            WorkflowInterpreterResult(status = STATUS_COMPLETE, progress = progress)
-        } else {
-            val message = failedStep.errorMessage ?: "Unknown workflow step error"
-            runs.markFailed(PersistRunFailureInput(input.runId, progress, message))
-            WorkflowInterpreterResult(status = STATUS_FAILED, progress = progress, errorMessage = message)
-        }
+        return context.completeRun()
     }
 
-    private fun startActionPromises(
-        snapshot: WorkflowRunExecutionSnapshot,
+    private fun WorkflowGraphConfig.normalized(
+        triggerName: String,
+        steps: List<WorkflowStepConfig>
+    ): WorkflowGraphConfig =
+        if (nodes.isEmpty()) {
+            LinearGraphAdapter.graphFromLegacy(triggerName, emptyList(), steps)
+        } else {
+            this
+        }
+
+    private fun WorkflowGraphConfig.initialProgress(): List<WorkflowRunStepProgress> =
+        nodes
+            .filter { node -> node.type != LinearGraphAdapter.NODE_TYPE_TRIGGER }
+            .map { node ->
+                WorkflowRunStepProgress(
+                    step = node.displayName(),
+                    status = STATUS_PENDING,
+                    nodeId = node.id,
+                    type = node.type
+                )
+            }
+
+    private fun WorkflowGraphNode.displayName(): String =
+        action ?: kind ?: trigger ?: id
+
+    private inner class GraphExecutionContext(
+        private val input: WorkflowInterpreterInput,
+        private val snapshot: WorkflowRunExecutionSnapshot,
+        private val graph: WorkflowGraphConfig,
         initialProgress: List<WorkflowRunStepProgress>
-    ): List<Promise<ActionProgressResult>> =
-        LinearGraphAdapter.fromSteps(snapshot.steps).mapIndexed { index, node ->
-            val existing = initialProgress.getOrNull(index)
-            if (existing?.status == STATUS_COMPLETE) {
-                Async.function { ActionProgressResult(index, existing) }
-            } else {
-                Async.function { executeAction(index, snapshot, node.step) }
+    ) {
+        private val nodesById = graph.nodes.associateBy { node -> node.id }
+        private val edgesBySource = graph.edges.groupBy { edge -> edge.from }
+        private val scope = snapshot.scope.toWorkflowValues().toMutableMap()
+        private var progress = initialProgress
+        private var errorMessage: String? = null
+
+        fun executeFrom(nodeId: String) {
+            val node = nodesById[nodeId] ?: return
+            when (node.type) {
+                LinearGraphAdapter.NODE_TYPE_TRIGGER -> follow(node)
+                LinearGraphAdapter.NODE_TYPE_CONDITION -> executeCondition(node)
+                LinearGraphAdapter.NODE_TYPE_ACTION -> executeAction(node)
+                LinearGraphAdapter.NODE_TYPE_CONTROL -> executeControl(node)
             }
         }
 
-    private fun executeAction(
-        index: Int,
-        snapshot: WorkflowRunExecutionSnapshot,
-        step: com.moneat.workflows.models.WorkflowStepConfig
-    ): ActionProgressResult {
-        val result =
-            actions.execute(
-                ExecuteActionInput(
-                    organizationId = snapshot.organizationId,
-                    step = step,
-                    scope = snapshot.scope
+        fun completeRun(): WorkflowInterpreterResult {
+            val failedStep = progress.firstOrNull { step -> step.status == STATUS_FAILED }
+            val failure = errorMessage ?: failedStep?.errorMessage
+            return if (failure == null) {
+                val runtimeProgress = progress.toRuntimeProgress()
+                runs.markComplete(PersistRunProgressInput(input.runId, STATUS_COMPLETE, runtimeProgress))
+                WorkflowInterpreterResult(status = STATUS_COMPLETE, progress = runtimeProgress)
+            } else {
+                val runtimeProgress = progress.toRuntimeProgress()
+                runs.markFailed(PersistRunFailureInput(input.runId, runtimeProgress, failure))
+                WorkflowInterpreterResult(status = STATUS_FAILED, progress = runtimeProgress, errorMessage = failure)
+            }
+        }
+
+        private fun executeCondition(node: WorkflowGraphNode) {
+            markNodeRunning(node, emptyMap())
+            val branch =
+                if (node.kind == LinearGraphAdapter.CONDITION_KIND_SWITCH) {
+                    switchBranch(node)
+                } else if (WorkflowConditionEvaluator.matchesAll(input.triggerName, node.conditions, scope)) {
+                    "true"
+                } else {
+                    "false"
+                }
+            markNodeComplete(node, mapOf("branch" to JsonPrimitive(branch)))
+            follow(node, branch = branch)
+        }
+
+        private fun switchBranch(node: WorkflowGraphNode): String {
+            val matchedCase =
+                node.cases.firstOrNull { item ->
+                    WorkflowConditionEvaluator.matchesAll(input.triggerName, item.conditions, scope)
+                }
+            return matchedCase?.name ?: "default"
+        }
+
+        private fun executeAction(node: WorkflowGraphNode) {
+            val action = node.action ?: return
+            val step = WorkflowStepConfig(action, node.params.mapValues { (_, value) -> value.workflowStringValue() })
+            val actions = Workflow.newActivityStub(ExecuteActionActivity::class.java, activityOptionsFor(node))
+            markNodeRunning(node, scope)
+            val result = actions.execute(ExecuteActionInput(snapshot.organizationId, step, scope.toRuntimeValues()))
+            val output = result.output.toWorkflowValues()
+            if (result.status == STATUS_COMPLETE) {
+                mergeStepOutput(node, output)
+                markNodeComplete(node, output, result.completedAt)
+                follow(node)
+                return
+            }
+            markNodeFailed(node, result.errorMessage ?: "Unknown workflow step error", result.completedAt)
+            val errorEdge = edgesBySource[node.id].orEmpty().firstOrNull { edge -> edge.on == "error" }
+            when {
+                errorEdge != null -> executeFrom(errorEdge.to)
+                node.continueOnError -> follow(node)
+                else -> errorMessage = result.errorMessage ?: "Unknown workflow step error"
+            }
+        }
+
+        private fun executeControl(node: WorkflowGraphNode) {
+            when (node.kind) {
+                LinearGraphAdapter.CONTROL_KIND_SLEEP -> executeSleep(node)
+                LinearGraphAdapter.CONTROL_KIND_WAIT_UNTIL -> executeWaitUntil(node)
+                LinearGraphAdapter.CONTROL_KIND_FOR_EACH -> executeForEach(node)
+                LinearGraphAdapter.CONTROL_KIND_WHILE -> executeWhile(node)
+                else -> {
+                    markNodeFailed(node, "Unsupported control node ${node.kind}")
+                    errorMessage = "Unsupported control node ${node.kind}"
+                }
+            }
+        }
+
+        private fun executeSleep(node: WorkflowGraphNode) {
+            val duration = Duration.parse(node.params["duration"]?.workflowStringValue() ?: "PT0S")
+            markNodeRunning(node, emptyMap())
+            Workflow.sleep(duration)
+            markNodeComplete(node, mapOf("duration" to JsonPrimitive(duration.toString())))
+            follow(node)
+        }
+
+        private fun executeWaitUntil(node: WorkflowGraphNode) {
+            val timeout = Duration.parse(node.params["timeout"]?.workflowStringValue() ?: "PT1M")
+            markNodeRunning(node, emptyMap())
+            val matched = Workflow.await(timeout) {
+                WorkflowConditionEvaluator.matchesAll(input.triggerName, node.conditions, scope)
+            }
+            val branch = if (matched) "true" else "timeout"
+            markNodeComplete(node, mapOf("branch" to JsonPrimitive(branch)))
+            follow(node, branch)
+        }
+
+        private fun executeForEach(node: WorkflowGraphNode) {
+            val itemReference = node.params["items_reference"]?.workflowStringValue().orEmpty()
+            val itemVariable = node.params["item_variable"]?.workflowStringValue()?.ifBlank { null } ?: "item"
+            val maxItems = boundedIntParam(node, "max_items", DEFAULT_MAX_ITEMS)
+            val items = scope.workflowValue(itemReference)?.workflowArrayValue().orEmpty().take(maxItems)
+            markNodeRunning(node, mapOf("items" to JsonPrimitive(itemReference)))
+            items.forEachIndexed { index, item ->
+                scope[itemVariable] = item
+                scope["$itemVariable.index"] = JsonPrimitive(index)
+                follow(node, branch = "body")
+            }
+            markNodeComplete(node, mapOf("count" to JsonPrimitive(items.size)))
+            follow(node, branch = "done")
+        }
+
+        private fun executeWhile(node: WorkflowGraphNode) {
+            val maxIterations = boundedIntParam(node, "max_iterations", MAX_WHILE_ITERATIONS)
+            markNodeRunning(node, emptyMap())
+            var iterations = 0
+            while (iterations < maxIterations &&
+                WorkflowConditionEvaluator.matchesAll(input.triggerName, node.conditions, scope)
+            ) {
+                iterations += 1
+                follow(node, branch = "body")
+                if (errorMessage != null) break
+            }
+            if (iterations >= maxIterations) {
+                markNodeFailed(node, "While node ${node.id} reached the iteration cap")
+                errorMessage = "While node ${node.id} reached the iteration cap"
+                return
+            }
+            markNodeComplete(node, mapOf("iterations" to JsonPrimitive(iterations)))
+            follow(node, branch = "done")
+        }
+
+        private fun follow(
+            node: WorkflowGraphNode,
+            branch: String? = null
+        ) {
+            if (errorMessage != null) return
+            val nextEdges = edgesBySource[node.id].orEmpty().filter { edge -> edge.matches(branch) }
+            nextEdges.forEach { edge -> executeFrom(edge.to) }
+        }
+
+        private fun WorkflowGraphEdge.matches(branch: String?): Boolean {
+            if (on == "error") return false
+            if (branch == null) return this.branch == null
+            return this.branch == branch
+        }
+
+        private fun activityOptionsFor(node: WorkflowGraphNode): ActivityOptions {
+            val retry = node.retry ?: return activityOptions
+            val builder =
+                RetryOptions
+                    .newBuilder()
+                    .setMaximumAttempts(retry.maxAttempts)
+                    .setInitialInterval(Duration.parse(retry.initialInterval))
+                    .setBackoffCoefficient(retry.backoffCoefficient)
+            retry.maximumInterval?.let { value -> builder.setMaximumInterval(Duration.parse(value)) }
+            if (retry.nonRetryableErrorTypes.isNotEmpty()) {
+                builder.setDoNotRetry(*retry.nonRetryableErrorTypes.toTypedArray())
+            }
+            return ActivityOptions
+                .newBuilder(activityOptions)
+                .setRetryOptions(builder.build())
+                .build()
+        }
+
+        private fun mergeStepOutput(
+            node: WorkflowGraphNode,
+            output: Map<String, JsonElement>
+        ) {
+            output.forEach { (key, value) ->
+                scope["steps.${node.id}.output.$key"] = value
+            }
+        }
+
+        private fun markNodeRunning(
+            node: WorkflowGraphNode,
+            nodeInput: Map<String, JsonElement>
+        ) {
+            updateProgress(node, STATUS_RUNNING, null, emptyMap(), null)
+            runs.markStepRunning(
+                PersistRunStepInput(
+                    input.runId,
+                    node.id,
+                    node.type,
+                    STATUS_RUNNING,
+                    nodeInput.toRuntimeValues()
                 )
             )
-        val progress =
-            WorkflowRunStepProgress(
-                step = step.name,
-                status = result.status,
-                completedAt = result.completedAt,
-                errorMessage = result.errorMessage
+            runs.markRunning(PersistRunProgressInput(input.runId, STATUS_RUNNING, progress.toRuntimeProgress()))
+        }
+
+        private fun markNodeComplete(
+            node: WorkflowGraphNode,
+            output: Map<String, JsonElement>,
+            completedAt: String = Instant.ofEpochMilli(Workflow.currentTimeMillis()).toString()
+        ) {
+            updateProgress(node, STATUS_COMPLETE, completedAt, output, null)
+            runs.markStepComplete(
+                PersistRunStepInput(
+                    runId = input.runId,
+                    nodeId = node.id,
+                    type = node.type,
+                    status = STATUS_COMPLETE,
+                    output = output.toRuntimeValues()
+                )
             )
-        return ActionProgressResult(index, progress)
-    }
+            runs.markRunning(PersistRunProgressInput(input.runId, STATUS_RUNNING, progress.toRuntimeProgress()))
+        }
 
-    private fun progressFromResults(
-        initialProgress: List<WorkflowRunStepProgress>,
-        promises: List<Promise<ActionProgressResult>>
-    ): List<WorkflowRunStepProgress> {
-        val replacements = promises.map { promise -> promise.get() }.associateBy { result -> result.index }
-        return initialProgress.mapIndexed { index, item -> replacements[index]?.progress ?: item }
-    }
+        private fun markNodeFailed(
+            node: WorkflowGraphNode,
+            message: String,
+            completedAt: String = Instant.ofEpochMilli(Workflow.currentTimeMillis()).toString()
+        ) {
+            updateProgress(node, STATUS_FAILED, completedAt, emptyMap(), message)
+            runs.markStepFailed(
+                PersistRunStepInput(
+                    runId = input.runId,
+                    nodeId = node.id,
+                    type = node.type,
+                    status = STATUS_FAILED,
+                    errorMessage = message
+                )
+            )
+            runs.markRunning(PersistRunProgressInput(input.runId, STATUS_RUNNING, progress.toRuntimeProgress()))
+        }
 
-    private data class ActionProgressResult(
-        val index: Int,
-        val progress: WorkflowRunStepProgress
-    )
+        private fun updateProgress(
+            node: WorkflowGraphNode,
+            status: String,
+            completedAt: String?,
+            output: Map<String, JsonElement>,
+            message: String?
+        ) {
+            progress = progress.map { item ->
+                if (item.nodeId == node.id || item.step == node.displayName()) {
+                    item.copy(status = status, completedAt = completedAt, output = output, errorMessage = message)
+                } else {
+                    item
+                }
+            }
+        }
+
+        private fun boundedIntParam(
+            node: WorkflowGraphNode,
+            paramName: String,
+            defaultValue: Int
+        ): Int =
+            node.params[paramName]
+                ?.workflowStringValue()
+                ?.toIntOrNull()
+                ?.coerceIn(1, MAX_WHILE_ITERATIONS)
+                ?: defaultValue
+    }
 }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflow.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflow.kt
@@ -29,6 +29,7 @@ import io.temporal.activity.ActivityInterface
 import io.temporal.activity.ActivityMethod
 import io.temporal.activity.ActivityOptions
 import io.temporal.common.RetryOptions
+import io.temporal.failure.ActivityFailure
 import io.temporal.workflow.Workflow
 import io.temporal.workflow.WorkflowInterface
 import io.temporal.workflow.WorkflowMethod
@@ -193,7 +194,16 @@ class WorkflowInterpreterWorkflowImpl : WorkflowInterpreterWorkflow {
             val step = WorkflowStepConfig(action, node.params.mapValues { (_, value) -> value.workflowStringValue() })
             val actions = Workflow.newActivityStub(ExecuteActionActivity::class.java, activityOptionsFor(node))
             markNodeRunning(node, scope)
-            val result = actions.execute(ExecuteActionInput(snapshot.organizationId, step, scope.toRuntimeValues()))
+            val result =
+                try {
+                    actions.execute(ExecuteActionInput(snapshot.organizationId, step, scope.toRuntimeValues()))
+                } catch (failure: ActivityFailure) {
+                    handleActionFailure(node, failure.workflowStepMessage())
+                    return
+                } catch (failure: RuntimeException) {
+                    handleActionFailure(node, failure.workflowStepMessage())
+                    return
+                }
             val output = result.output.toWorkflowValues()
             if (result.status == STATUS_COMPLETE) {
                 mergeStepOutput(node, output)
@@ -201,14 +211,25 @@ class WorkflowInterpreterWorkflowImpl : WorkflowInterpreterWorkflow {
                 follow(node)
                 return
             }
-            markNodeFailed(node, result.errorMessage ?: "Unknown workflow step error", result.completedAt)
+            handleActionFailure(node, result.errorMessage ?: "Unknown workflow step error", result.completedAt)
+        }
+
+        private fun handleActionFailure(
+            node: WorkflowGraphNode,
+            message: String,
+            completedAt: String = Instant.ofEpochMilli(Workflow.currentTimeMillis()).toString()
+        ) {
+            markNodeFailed(node, message, completedAt)
             val errorEdge = edgesBySource[node.id].orEmpty().firstOrNull { edge -> edge.on == "error" }
             when {
                 errorEdge != null -> executeFrom(errorEdge.to)
                 node.continueOnError -> follow(node)
-                else -> errorMessage = result.errorMessage ?: "Unknown workflow step error"
+                else -> errorMessage = message
             }
         }
+
+        private fun RuntimeException.workflowStepMessage(): String =
+            cause?.message ?: message ?: "Unknown workflow step error"
 
         private fun executeControl(node: WorkflowGraphNode) {
             when (node.kind) {
@@ -248,12 +269,18 @@ class WorkflowInterpreterWorkflowImpl : WorkflowInterpreterWorkflow {
             val maxItems = boundedIntParam(node, "max_items", DEFAULT_MAX_ITEMS)
             val items = scope.workflowValue(itemReference)?.workflowArrayValue().orEmpty().take(maxItems)
             markNodeRunning(node, mapOf("items" to JsonPrimitive(itemReference)))
+            var completedItems = 0
             items.forEachIndexed { index, item ->
                 scope[itemVariable] = item
                 scope["$itemVariable.index"] = JsonPrimitive(index)
                 follow(node, branch = "body")
+                if (errorMessage != null) {
+                    markNodeFailed(node, errorMessage ?: "For-each body failed")
+                    return
+                }
+                completedItems += 1
             }
-            markNodeComplete(node, mapOf("count" to JsonPrimitive(items.size)))
+            markNodeComplete(node, mapOf("count" to JsonPrimitive(completedItems)))
             follow(node, branch = "done")
         }
 
@@ -283,7 +310,10 @@ class WorkflowInterpreterWorkflowImpl : WorkflowInterpreterWorkflow {
         ) {
             if (errorMessage != null) return
             val nextEdges = edgesBySource[node.id].orEmpty().filter { edge -> edge.matches(branch) }
-            nextEdges.forEach { edge -> executeFrom(edge.to) }
+            for (edge in nextEdges) {
+                if (errorMessage != null) return
+                executeFrom(edge.to)
+            }
         }
 
         private fun WorkflowGraphEdge.matches(branch: String?): Boolean {
@@ -380,7 +410,9 @@ class WorkflowInterpreterWorkflowImpl : WorkflowInterpreterWorkflow {
             message: String?
         ) {
             progress = progress.map { item ->
-                if (item.nodeId == node.id || item.step == node.displayName()) {
+                val matchesNode = item.nodeId == node.id ||
+                    (item.nodeId.isNullOrBlank() && item.step == node.displayName())
+                if (matchesNode) {
                     item.copy(status = status, completedAt = completedAt, output = output, errorMessage = message)
                 } else {
                     item

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
@@ -20,6 +20,7 @@ import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.jsonb
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.datetime.timestamp
@@ -115,7 +116,7 @@ data class WorkflowGraphNode(
     val trigger: String? = null,
     val kind: String? = null,
     val action: String? = null,
-    val params: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    val params: Map<String, JsonElement> = emptyMap(),
     val conditions: List<WorkflowConditionConfig> = emptyList(),
     val cases: List<WorkflowSwitchCaseConfig> = emptyList(),
     val retry: WorkflowRetryConfig? = null,
@@ -140,7 +141,7 @@ data class WorkflowGraphConfig(
 data class WorkflowPreviewRequest(
     @SerialName("trigger_name") val triggerName: String,
     val steps: List<WorkflowStepConfig> = emptyList(),
-    val scope: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    val scope: Map<String, JsonElement> = emptyMap(),
     val graph: WorkflowGraphConfig? = null,
     @SerialName("node_id") val nodeId: String? = null
 )
@@ -195,7 +196,7 @@ data class WorkflowRunStepProgress(
     @SerialName("node_id") val nodeId: String? = null,
     val type: String? = null,
     @SerialName("completed_at") val completedAt: String? = null,
-    val output: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    val output: Map<String, JsonElement> = emptyMap(),
     @SerialName("error_message") val errorMessage: String? = null
 )
 
@@ -222,7 +223,7 @@ data class UpdateWorkflowRequest(
 
 @Serializable
 data class ManualWorkflowRunRequest(
-    val scope: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap()
+    val scope: Map<String, JsonElement> = emptyMap()
 )
 
 @Serializable
@@ -253,8 +254,8 @@ data class WorkflowRunStepResponse(
     val status: String,
     @SerialName("started_at") val startedAt: String? = null,
     @SerialName("completed_at") val completedAt: String? = null,
-    val input: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
-    val output: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    val input: Map<String, JsonElement> = emptyMap(),
+    val output: Map<String, JsonElement> = emptyMap(),
     @SerialName("error_message") val errorMessage: String? = null,
     val attempt: Int
 )
@@ -279,5 +280,5 @@ data class WorkflowRunResponse(
 data class WorkflowTriggerEvent(
     @SerialName("trigger_name") val triggerName: String,
     @SerialName("organization_id") val organizationId: Int,
-    val scope: Map<String, kotlinx.serialization.json.JsonElement>
+    val scope: Map<String, JsonElement>
 )

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
@@ -39,6 +39,10 @@ object WorkflowVersions : IntIdTable("workflow_versions") {
     val version = integer("version")
     val conditions = jsonb("conditions").default("[]")
     val steps = jsonb("steps").default("[]")
+    val graph = jsonb("graph").default("""{"nodes":[],"edges":[]}""")
+    val published = bool("published").default(false)
+    val inputSchema = jsonb("input_schema").default("{}")
+    val tags = jsonb("tags").default("[]")
     val onceForTemplate = jsonb("once_for_template").default("[]")
     val engineConfig = jsonb("engine_config").default("{}")
     val mostRecent = bool("most_recent").default(true)
@@ -62,6 +66,19 @@ object WorkflowRuns : IntIdTable("workflow_runs") {
     val failedAt = timestamp("failed_at").nullable()
 }
 
+object WorkflowRunSteps : IntIdTable("workflow_run_steps") {
+    val runId = integer("run_id").references(WorkflowRuns.id, onDelete = ReferenceOption.CASCADE)
+    val nodeId = varchar("node_id", 120)
+    val type = varchar("type", 64)
+    val status = varchar("status", 32)
+    val startedAt = timestamp("started_at").nullable()
+    val completedAt = timestamp("completed_at").nullable()
+    val input = jsonb("input").default("{}")
+    val output = jsonb("output").default("{}")
+    val errorMessage = text("error_message").nullable()
+    val attempt = integer("attempt").default(1)
+}
+
 @Serializable
 data class WorkflowConditionConfig(
     val reference: String,
@@ -76,10 +93,56 @@ data class WorkflowStepConfig(
 )
 
 @Serializable
+data class WorkflowRetryConfig(
+    @SerialName("max_attempts") val maxAttempts: Int = 1,
+    @SerialName("initial_interval") val initialInterval: String = "PT1S",
+    @SerialName("backoff_coefficient") val backoffCoefficient: Double = 2.0,
+    @SerialName("maximum_interval") val maximumInterval: String? = null,
+    @SerialName("non_retryable_error_types") val nonRetryableErrorTypes: List<String> = emptyList()
+)
+
+@Serializable
+data class WorkflowSwitchCaseConfig(
+    val name: String,
+    val label: String? = null,
+    val conditions: List<WorkflowConditionConfig> = emptyList()
+)
+
+@Serializable
+data class WorkflowGraphNode(
+    val id: String,
+    val type: String,
+    val trigger: String? = null,
+    val kind: String? = null,
+    val action: String? = null,
+    val params: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    val conditions: List<WorkflowConditionConfig> = emptyList(),
+    val cases: List<WorkflowSwitchCaseConfig> = emptyList(),
+    val retry: WorkflowRetryConfig? = null,
+    @SerialName("continue_on_error") val continueOnError: Boolean = false
+)
+
+@Serializable
+data class WorkflowGraphEdge(
+    val from: String,
+    val to: String,
+    val branch: String? = null,
+    val on: String? = null
+)
+
+@Serializable
+data class WorkflowGraphConfig(
+    val nodes: List<WorkflowGraphNode> = emptyList(),
+    val edges: List<WorkflowGraphEdge> = emptyList()
+)
+
+@Serializable
 data class WorkflowPreviewRequest(
     @SerialName("trigger_name") val triggerName: String,
-    val steps: List<WorkflowStepConfig>,
-    val scope: Map<String, String> = emptyMap()
+    val steps: List<WorkflowStepConfig> = emptyList(),
+    val scope: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    val graph: WorkflowGraphConfig? = null,
+    @SerialName("node_id") val nodeId: String? = null
 )
 
 @Serializable
@@ -129,7 +192,10 @@ data class WorkflowPreviewField(
 data class WorkflowRunStepProgress(
     val step: String,
     val status: String,
+    @SerialName("node_id") val nodeId: String? = null,
+    val type: String? = null,
     @SerialName("completed_at") val completedAt: String? = null,
+    val output: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
     @SerialName("error_message") val errorMessage: String? = null
 )
 
@@ -140,6 +206,7 @@ data class CreateWorkflowRequest(
     val enabled: Boolean = true,
     val conditions: List<WorkflowConditionConfig> = emptyList(),
     val steps: List<WorkflowStepConfig> = emptyList(),
+    val graph: WorkflowGraphConfig? = null,
     @SerialName("once_for_template") val onceForTemplate: List<String> = emptyList()
 )
 
@@ -149,7 +216,13 @@ data class UpdateWorkflowRequest(
     val enabled: Boolean? = null,
     val conditions: List<WorkflowConditionConfig>? = null,
     val steps: List<WorkflowStepConfig>? = null,
+    val graph: WorkflowGraphConfig? = null,
     @SerialName("once_for_template") val onceForTemplate: List<String>? = null
+)
+
+@Serializable
+data class ManualWorkflowRunRequest(
+    val scope: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap()
 )
 
 @Serializable
@@ -159,14 +232,31 @@ data class WorkflowResponse(
     @SerialName("trigger_name") val triggerName: String,
     val enabled: Boolean,
     val version: Int,
+    val published: Boolean,
     @SerialName("system_key") val systemKey: String? = null,
     val conditions: List<WorkflowConditionConfig>,
     val steps: List<WorkflowStepConfig>,
+    val graph: WorkflowGraphConfig,
     @SerialName("once_for_template") val onceForTemplate: List<String>,
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
     @SerialName("last_run_at") val lastRunAt: String? = null,
     @SerialName("run_count") val runCount: Long = 0
+)
+
+@Serializable
+data class WorkflowRunStepResponse(
+    val id: Int,
+    @SerialName("run_id") val runId: Int,
+    @SerialName("node_id") val nodeId: String,
+    val type: String,
+    val status: String,
+    @SerialName("started_at") val startedAt: String? = null,
+    @SerialName("completed_at") val completedAt: String? = null,
+    val input: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    val output: Map<String, kotlinx.serialization.json.JsonElement> = emptyMap(),
+    @SerialName("error_message") val errorMessage: String? = null,
+    val attempt: Int
 )
 
 @Serializable
@@ -178,6 +268,7 @@ data class WorkflowRunResponse(
     @SerialName("once_for") val onceFor: String,
     val status: String,
     val progress: List<WorkflowRunStepProgress>,
+    val steps: List<WorkflowRunStepResponse> = emptyList(),
     @SerialName("error_message") val errorMessage: String? = null,
     @SerialName("created_at") val createdAt: String,
     @SerialName("completed_at") val completedAt: String? = null,
@@ -188,5 +279,5 @@ data class WorkflowRunResponse(
 data class WorkflowTriggerEvent(
     @SerialName("trigger_name") val triggerName: String,
     @SerialName("organization_id") val organizationId: Int,
-    val scope: Map<String, String>
+    val scope: Map<String, kotlinx.serialization.json.JsonElement>
 )

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowScope.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowScope.kt
@@ -1,0 +1,67 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.models
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+
+val workflowJson: Json = Json {
+    ignoreUnknownKeys = true
+}
+
+fun Map<String, String>.typedWorkflowScope(): Map<String, JsonElement> =
+    mapValues { (_, value) -> JsonPrimitive(value) }
+
+fun Map<String, JsonElement>.workflowStringView(): Map<String, String> =
+    mapValues { (_, value) -> value.workflowStringValue() }
+
+fun JsonElement.workflowStringValue(): String =
+    when (this) {
+        is JsonNull -> ""
+        is JsonPrimitive -> booleanOrNull?.toString() ?: doubleOrNull?.toString() ?: contentOrNull.orEmpty()
+        else -> workflowJson.encodeToString(this)
+    }
+
+fun Map<String, JsonElement>.asWorkflowJsonObject(): JsonObject =
+    JsonObject(this)
+
+fun JsonElement.workflowObjectValue(): Map<String, JsonElement> =
+    (this as? JsonObject)?.jsonObject ?: emptyMap()
+
+fun JsonElement.workflowArrayValue(): List<JsonElement> =
+    (this as? JsonArray)?.toList() ?: emptyList()
+
+fun Map<String, JsonElement>.workflowValue(reference: String): JsonElement? =
+    this[reference] ?: nestedWorkflowValue(reference)
+
+private fun Map<String, JsonElement>.nestedWorkflowValue(reference: String): JsonElement? {
+    val segments = reference.split('.')
+    var current: JsonElement = this[segments.firstOrNull() ?: return null] ?: return null
+    segments.drop(1).forEach { segment ->
+        current = (current as? JsonObject)?.get(segment) ?: return null
+    }
+    return current
+}

--- a/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
@@ -21,6 +21,7 @@ import com.moneat.utils.suspendRunCatching
 import com.moneat.org.services.OrgMembershipService
 import com.moneat.org.services.OrgRole
 import com.moneat.workflows.models.CreateWorkflowRequest
+import com.moneat.workflows.models.ManualWorkflowRunRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowPreviewRequest
 import com.moneat.workflows.services.WorkflowService
@@ -163,6 +164,43 @@ fun Route.workflowRoutes() {
                         ?.coerceIn(MIN_WORKFLOW_RUN_LIMIT, MAX_WORKFLOW_RUN_LIMIT)
                         ?: DEFAULT_WORKFLOW_RUN_LIMIT
                 call.respond(workflowService.listRuns(organizationId, workflowId, limit))
+            }
+
+            post("$WORKFLOW_ID_ROUTE/publish") {
+                val organizationId = currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
+                ensureWorkflowAdmin(membershipService, organizationId) ?: return@post
+                val workflowId = workflowIdFromPath() ?: return@post call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val workflow = workflowService.publishWorkflow(organizationId, workflowId)
+                    ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse(WORKFLOW_NOT_FOUND_MESSAGE))
+                call.respond(workflow)
+            }
+
+            post("$WORKFLOW_ID_ROUTE/unpublish") {
+                val organizationId = currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
+                ensureWorkflowAdmin(membershipService, organizationId) ?: return@post
+                val workflowId = workflowIdFromPath() ?: return@post call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val workflow = workflowService.unpublishWorkflow(organizationId, workflowId)
+                    ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse(WORKFLOW_NOT_FOUND_MESSAGE))
+                call.respond(workflow)
+            }
+
+            post("$WORKFLOW_ID_ROUTE/run") {
+                val organizationId = currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
+                ensureWorkflowAdmin(membershipService, organizationId) ?: return@post
+                val workflowId = workflowIdFromPath() ?: return@post call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val request = call.receive<ManualWorkflowRunRequest>()
+                val run = workflowService.runWorkflow(organizationId, workflowId, request)
+                    ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse(WORKFLOW_NOT_FOUND_MESSAGE))
+                call.respond(HttpStatusCode.Accepted, run)
             }
         }
     }

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowActionExecutor.kt
@@ -23,6 +23,9 @@ import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Users
 import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowTestMessageResult
+import com.moneat.workflows.models.workflowStringView
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -37,14 +40,25 @@ class WorkflowActionExecutor(
     suspend fun executeStep(
         organizationId: Int,
         step: WorkflowStepConfig,
-        scope: Map<String, String>
-    ) {
-        if (!notificationStepEnabled(step.name, scope)) return
+        scope: Map<String, JsonElement>
+    ): Map<String, JsonElement> {
+        val stringScope = scope.workflowStringView()
+        if (!notificationStepEnabled(step.name, stringScope)) {
+            return mapOf("skipped" to JsonPrimitive(true))
+        }
 
-        when (step.name) {
-            EMAIL_ORG_STEP -> sendOrganizationEmail(organizationId, step.params, scope)
-            SLACK_STEP -> executeSlackStep(organizationId, step, scope)
-            DISCORD_STEP -> executeDiscordStep(organizationId, step, scope)
+        return when (step.name) {
+            EMAIL_ORG_STEP -> mapOf(
+                "recipient_count" to JsonPrimitive(
+                    sendOrganizationEmail(
+                        organizationId,
+                        step.params,
+                        stringScope
+                    )
+                )
+            )
+            SLACK_STEP -> executeSlackStep(organizationId, step, stringScope)
+            DISCORD_STEP -> executeDiscordStep(organizationId, step, stringScope)
             else -> throw IllegalArgumentException("Unknown workflow step ${step.name}")
         }
     }
@@ -125,7 +139,7 @@ class WorkflowActionExecutor(
         organizationId: Int,
         step: WorkflowStepConfig,
         scope: Map<String, String>
-    ) {
+    ): Map<String, JsonElement> {
         val skipIfUnconfigured = step.params[SKIP_IF_UNCONFIGURED_PARAM]?.toBooleanStrictOrNull() ?: true
         val sent =
             if (step.usesAlertLifecycleFormat()) {
@@ -141,13 +155,14 @@ class WorkflowActionExecutor(
         check(sent) {
             "Slack workflow message was not sent"
         }
+        return mapOf("sent" to JsonPrimitive(sent))
     }
 
     private suspend fun executeDiscordStep(
         organizationId: Int,
         step: WorkflowStepConfig,
         scope: Map<String, String>
-    ) {
+    ): Map<String, JsonElement> {
         val skipIfUnconfigured = step.params[SKIP_IF_UNCONFIGURED_PARAM]?.toBooleanStrictOrNull() ?: true
         val sent =
             if (step.usesAlertLifecycleFormat()) {
@@ -164,6 +179,7 @@ class WorkflowActionExecutor(
         check(sent) {
             "Discord workflow message was not sent"
         }
+        return mapOf("sent" to JsonPrimitive(sent))
     }
 
     private suspend fun sendTestMessageStepOrThrow(

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowGraphValidator.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowGraphValidator.kt
@@ -1,0 +1,251 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.services
+
+import com.moneat.workflows.engine.WorkflowCatalog
+import com.moneat.workflows.engine.temporal.LinearGraphAdapter
+import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowGraphNode
+import com.moneat.workflows.models.WorkflowStepConfig
+import com.moneat.workflows.models.workflowStringValue
+
+private const val DEFAULT_MAX_LOOP_ITEMS = 100
+private const val MAX_LOOP_ITEMS = 2_000
+
+class WorkflowGraphValidator {
+    fun validate(
+        triggerName: String,
+        graph: WorkflowGraphConfig,
+        onceForTemplate: List<String>
+    ) {
+        val trigger = WorkflowCatalog.trigger(triggerName)
+            ?: throw IllegalArgumentException("Unknown workflow trigger $triggerName")
+        val triggerNodes = graph.nodes.filter { node -> node.type == LinearGraphAdapter.NODE_TYPE_TRIGGER }
+        require(triggerNodes.size == 1) { "Workflow graph must contain exactly one trigger node" }
+        require(triggerNodes.single().trigger == triggerName) {
+            "Workflow trigger node must match $triggerName"
+        }
+        require(graph.nodes.map { node -> node.id }.toSet().size == graph.nodes.size) {
+            "Workflow graph node IDs must be unique"
+        }
+        validateEdges(graph)
+        validateReachability(graph, triggerNodes.single())
+        validateCycles(graph)
+        validateNodeConfigs(triggerName, graph)
+        val scopeReferences = trigger.scope.map { it.name }.toSet()
+        onceForTemplate.forEach { reference ->
+            require(reference in scopeReferences) { "Unknown once-for reference $reference" }
+        }
+    }
+
+    fun validateLegacy(
+        triggerName: String,
+        conditions: List<WorkflowConditionConfig>,
+        steps: List<WorkflowStepConfig>,
+        onceForTemplate: List<String>
+    ) {
+        validate(
+            triggerName = triggerName,
+            graph = LinearGraphAdapter.graphFromLegacy(triggerName, conditions, steps),
+            onceForTemplate = onceForTemplate
+        )
+    }
+
+    private fun validateEdges(graph: WorkflowGraphConfig) {
+        val nodesById = graph.nodes.associateBy { node -> node.id }
+        graph.edges.forEach { edge ->
+            val from = nodesById[edge.from] ?: throw IllegalArgumentException("Unknown graph edge source ${edge.from}")
+            require(edge.to in nodesById) { "Unknown graph edge target ${edge.to}" }
+            if (!edge.branch.isNullOrBlank()) {
+                require(
+                    from.type == LinearGraphAdapter.NODE_TYPE_CONDITION ||
+                        from.type == LinearGraphAdapter.NODE_TYPE_CONTROL
+                ) {
+                    "Branch edges must start from condition or control nodes"
+                }
+            }
+            if (edge.on == "error") {
+                require(from.type == LinearGraphAdapter.NODE_TYPE_ACTION) {
+                    "Error edges must start from action nodes"
+                }
+            }
+        }
+    }
+
+    private fun validateReachability(
+        graph: WorkflowGraphConfig,
+        triggerNode: WorkflowGraphNode
+    ) {
+        val edgesBySource = graph.edges.groupBy { edge -> edge.from }
+        val reachable = mutableSetOf<String>()
+        fun visit(nodeId: String) {
+            if (!reachable.add(nodeId)) return
+            edgesBySource[nodeId].orEmpty().forEach { edge -> visit(edge.to) }
+        }
+        visit(triggerNode.id)
+        val orphan = graph.nodes.firstOrNull { node -> node.id !in reachable }
+        require(orphan == null) { "Workflow graph contains unreachable node ${orphan?.id}" }
+    }
+
+    private fun validateCycles(graph: WorkflowGraphConfig) {
+        val nodesById = graph.nodes.associateBy { node -> node.id }
+        val edgesBySource = graph.edges.groupBy { edge -> edge.from }
+        val visiting = mutableListOf<String>()
+        val visited = mutableSetOf<String>()
+        fun visit(nodeId: String) {
+            if (nodeId in visited) return
+            val cycleStart = visiting.indexOf(nodeId)
+            if (cycleStart >= 0) {
+                val cycle = visiting.drop(cycleStart)
+                require(cycle.any { id -> nodesById[id]?.isLoopControl() == true }) {
+                    "Workflow graph contains an illegal cycle"
+                }
+                return
+            }
+            visiting += nodeId
+            edgesBySource[nodeId].orEmpty().forEach { edge -> visit(edge.to) }
+            visiting.removeLast()
+            visited += nodeId
+        }
+        graph.nodes
+            .filter { node -> node.type == LinearGraphAdapter.NODE_TYPE_TRIGGER }
+            .forEach { node -> visit(node.id) }
+    }
+
+    private fun validateNodeConfigs(
+        triggerName: String,
+        graph: WorkflowGraphConfig
+    ) {
+        graph.nodes.forEach { node ->
+            when (node.type) {
+                LinearGraphAdapter.NODE_TYPE_TRIGGER -> Unit
+                LinearGraphAdapter.NODE_TYPE_CONDITION -> validateConditionNode(triggerName, node)
+                LinearGraphAdapter.NODE_TYPE_ACTION -> validateActionNode(node)
+                LinearGraphAdapter.NODE_TYPE_CONTROL -> validateControlNode(triggerName, node)
+                else -> throw IllegalArgumentException("Unsupported workflow graph node type ${node.type}")
+            }
+        }
+    }
+
+    private fun validateConditionNode(
+        triggerName: String,
+        node: WorkflowGraphNode
+    ) {
+        require(
+            node.kind == LinearGraphAdapter.CONDITION_KIND_IF ||
+                node.kind == LinearGraphAdapter.CONDITION_KIND_SWITCH
+        ) {
+            "Unsupported condition node kind ${node.kind}"
+        }
+        if (node.kind == LinearGraphAdapter.CONDITION_KIND_SWITCH) {
+            require(node.cases.isNotEmpty()) { "Switch node ${node.id} must define at least one case" }
+            node.cases.forEach { item -> validateConditions(triggerName, item.conditions) }
+        } else {
+            validateConditions(triggerName, node.conditions)
+        }
+    }
+
+    private fun validateActionNode(node: WorkflowGraphNode) {
+        val action = node.action ?: throw IllegalArgumentException("Action node ${node.id} is missing an action")
+        val definition = WorkflowCatalog.step(action)
+            ?: throw IllegalArgumentException("Unknown workflow step $action")
+        definition.params.filter { param -> param.required }.forEach { param ->
+            require(!node.params[param.name]?.workflowStringValue().isNullOrBlank()) {
+                "Missing required parameter ${param.name} for $action"
+            }
+        }
+        node.retry?.let { retry ->
+            require(retry.maxAttempts in 1..MAX_LOOP_ITEMS) {
+                "Retry attempts for ${node.id} must be between 1 and $MAX_LOOP_ITEMS"
+            }
+        }
+    }
+
+    private fun validateControlNode(
+        triggerName: String,
+        node: WorkflowGraphNode
+    ) {
+        when (node.kind) {
+            LinearGraphAdapter.CONTROL_KIND_SLEEP -> {
+                require(!node.params["duration"]?.workflowStringValue().isNullOrBlank()) {
+                    "Sleep node ${node.id} must define duration"
+                }
+            }
+            LinearGraphAdapter.CONTROL_KIND_WAIT_UNTIL -> validateConditions(triggerName, node.conditions)
+            LinearGraphAdapter.CONTROL_KIND_FOR_EACH -> validateBoundedControl(node, "max_items")
+            LinearGraphAdapter.CONTROL_KIND_WHILE -> {
+                validateBoundedControl(node, "max_iterations")
+                validateConditions(triggerName, node.conditions)
+            }
+            else -> throw IllegalArgumentException("Unsupported control node kind ${node.kind}")
+        }
+    }
+
+    private fun validateBoundedControl(
+        node: WorkflowGraphNode,
+        paramName: String
+    ) {
+        val value =
+            node.params[paramName]
+                ?.workflowStringValue()
+                ?.toIntOrNull()
+                ?: DEFAULT_MAX_LOOP_ITEMS
+        require(value in 1..MAX_LOOP_ITEMS) {
+            "Control node ${node.id} must set $paramName between 1 and $MAX_LOOP_ITEMS"
+        }
+    }
+
+    private fun validateConditions(
+        triggerName: String,
+        conditions: List<WorkflowConditionConfig>
+    ) {
+        val trigger = checkNotNull(WorkflowCatalog.trigger(triggerName))
+        val scopeReferences = trigger.scope.map { it.name }.toSet()
+        conditions.forEach { condition ->
+            require(condition.reference in scopeReferences || condition.reference.startsWith("steps.")) {
+                "Unknown workflow condition reference ${condition.reference}"
+            }
+            if (condition.reference in scopeReferences) {
+                validateScopeCondition(triggerName, condition)
+            }
+        }
+    }
+
+    private fun validateScopeCondition(
+        triggerName: String,
+        condition: WorkflowConditionConfig
+    ) {
+        val resourceType = checkNotNull(WorkflowCatalog.scopeType(triggerName, condition.reference))
+        val resource = checkNotNull(WorkflowCatalog.resources.firstOrNull { item -> item.type == resourceType })
+        require(resource.operations.any { operation -> operation.name == condition.operation }) {
+            "Unsupported operation ${condition.operation} for ${condition.reference}"
+        }
+        if (condition.operation.requiresConditionValue()) {
+            require(!condition.value.isNullOrBlank()) {
+                "Missing value for ${condition.reference} ${condition.operation}"
+            }
+        }
+    }
+
+    private fun WorkflowGraphNode.isLoopControl(): Boolean =
+        type == LinearGraphAdapter.NODE_TYPE_CONTROL &&
+            kind in setOf(LinearGraphAdapter.CONTROL_KIND_FOR_EACH, LinearGraphAdapter.CONTROL_KIND_WHILE)
+
+    private fun String.requiresConditionValue(): Boolean =
+        this !in setOf("is_set", "is_not_set")
+}

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -25,7 +25,9 @@ import com.moneat.notifications.services.SlackService
 import com.moneat.shared.models.Organizations
 import com.moneat.utils.suspendRunCatching
 import com.moneat.workflows.engine.WorkflowCatalog
+import com.moneat.workflows.engine.WorkflowConditionEvaluator
 import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
+import com.moneat.workflows.engine.temporal.LinearGraphAdapter
 import com.moneat.workflows.engine.temporal.PersistRunActivityImpl
 import com.moneat.workflows.engine.temporal.PersistRunFailureInput
 import com.moneat.workflows.engine.temporal.TemporalClientProvider
@@ -34,21 +36,29 @@ import com.moneat.workflows.engine.temporal.WorkflowDirectRunExecutor
 import com.moneat.workflows.engine.temporal.WorkflowExecutionEngine
 import com.moneat.workflows.engine.temporal.WorkflowStartRequest
 import com.moneat.workflows.models.CreateWorkflowRequest
+import com.moneat.workflows.models.ManualWorkflowRunRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowGraphConfig
 import com.moneat.workflows.models.WorkflowPreviewRequest
 import com.moneat.workflows.models.WorkflowPreviewResponse
 import com.moneat.workflows.models.WorkflowResponse
 import com.moneat.workflows.models.WorkflowRunResponse
+import com.moneat.workflows.models.WorkflowRunStepResponse
 import com.moneat.workflows.models.WorkflowRunStepProgress
 import com.moneat.workflows.models.WorkflowRuns
+import com.moneat.workflows.models.WorkflowRunSteps
 import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowTestMessageResponse
 import com.moneat.workflows.models.WorkflowTriggerEvent
 import com.moneat.workflows.models.WorkflowVersions
 import com.moneat.workflows.models.Workflows
+import com.moneat.workflows.models.typedWorkflowScope
+import com.moneat.workflows.models.workflowJson
+import com.moneat.workflows.models.workflowObjectValue
+import com.moneat.workflows.models.workflowStringView
+import com.moneat.workflows.models.workflowStringValue
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
@@ -66,17 +76,13 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import java.security.MessageDigest
+import java.util.UUID
 import kotlin.time.Clock
 
 private val logger = KotlinLogging.logger {}
 private const val UNIQUE_VIOLATION_SQL_STATE = "23505"
 private const val TEMPORAL_WORKFLOW_ID_HASH_LENGTH = 32
 private const val UNSIGNED_BYTE_MASK = 0xff
-private const val SEVERITY_CRITICAL_RANK = 4
-private const val SEVERITY_HIGH_RANK = 3
-private const val SEVERITY_MEDIUM_RANK = 2
-private const val SEVERITY_LOW_RANK = 1
-private const val SEVERITY_UNKNOWN_RANK = 0
 private const val DEFAULT_WORKFLOW_READ_ONLY_MESSAGE = "Default workflows cannot be modified"
 private val ALERT_CHANNEL_REFERENCES =
     setOf(ALERT_CHANNEL_EMAIL_REFERENCE, ALERT_CHANNEL_SLACK_REFERENCE, ALERT_CHANNEL_DISCORD_REFERENCE)
@@ -105,7 +111,8 @@ class WorkflowService(
     private val runPersistence: PersistRunActivityImpl = PersistRunActivityImpl(),
     private val executionEngine: WorkflowExecutionEngine = TemporalWorkflowExecutionEngine(TemporalClientProvider())
 ) {
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = workflowJson
+    private val graphValidator = WorkflowGraphValidator()
     private val directRunExecutor =
         WorkflowDirectRunExecutor(
             ExecuteActionActivityImpl(actionExecutor),
@@ -116,9 +123,16 @@ class WorkflowService(
 
     fun previewWorkflow(request: WorkflowPreviewRequest): WorkflowPreviewResponse {
         val scope = previewScopeForRequest(request)
+        val graph = request.graph ?: LinearGraphAdapter.graphFromLegacy(request.triggerName, emptyList(), request.steps)
+        val selectedSteps =
+            request.nodeId
+                ?.let { nodeId -> graph.nodes.filter { node -> node.id == nodeId } }
+                ?.filter { node -> node.type == LinearGraphAdapter.NODE_TYPE_ACTION }
+                ?.map { node -> WorkflowStepConfig(node.action.orEmpty(), node.params.stringParams()) }
+                ?: request.steps
         return WorkflowPreviewResponse(
-            scope = scope,
-            previews = request.steps.map { step -> stepRenderer.renderStepPreview(step, scope) }
+            scope = scope.workflowStringView(),
+            previews = selectedSteps.map { step -> stepRenderer.renderStepPreview(step, scope.workflowStringView()) }
         )
     }
 
@@ -127,21 +141,22 @@ class WorkflowService(
         request: WorkflowPreviewRequest
     ): WorkflowTestMessageResponse {
         val scope = previewScopeForRequest(request)
+        val stringScope = scope.workflowStringView()
         return WorkflowTestMessageResponse(
-            scope = scope,
+            scope = stringScope,
             results = request.steps.map { step ->
-                actionExecutor.sendTestMessageStep(organizationId, step, scope)
+                actionExecutor.sendTestMessageStep(organizationId, step, stringScope)
             }
         )
     }
 
-    private fun previewScopeForRequest(request: WorkflowPreviewRequest): Map<String, String> {
+    private fun previewScopeForRequest(request: WorkflowPreviewRequest): Map<String, JsonElement> {
         val trigger = WorkflowCatalog.trigger(request.triggerName)
             ?: throw IllegalArgumentException("Unknown workflow trigger ${request.triggerName}")
         request.steps.forEach { step ->
             WorkflowCatalog.step(step.name) ?: throw IllegalArgumentException("Unknown workflow step ${step.name}")
         }
-        return stepRenderer.sampleScopeForTrigger(trigger.name) + request.scope
+        return stepRenderer.sampleScopeForTrigger(trigger.name).typedWorkflowScope() + request.scope
     }
 
     fun ensureDefaultWorkflowsForOrganization(organizationId: Int) {
@@ -174,6 +189,12 @@ class WorkflowService(
                     version = 1,
                     conditions = emptyList(),
                     steps = definition.steps,
+                    graph = LinearGraphAdapter.graphFromLegacy(
+                        definition.triggerName,
+                        emptyList(),
+                        definition.steps
+                    ),
+                    published = true,
                     onceForTemplate = definition.onceForTemplate,
                     now = now
                 )
@@ -224,6 +245,11 @@ class WorkflowService(
     ): WorkflowResponse {
         validateCreateRequest(request)
         val now = Clock.System.now()
+        val graph = request.graph ?: LinearGraphAdapter.graphFromLegacy(
+            request.triggerName,
+            request.conditions,
+            request.steps
+        )
         val workflowId =
             transaction {
                 val id =
@@ -240,6 +266,8 @@ class WorkflowService(
                     version = 1,
                     conditions = request.conditions,
                     steps = request.steps,
+                    graph = graph,
+                    published = false,
                     onceForTemplate = request.onceForTemplate,
                     now = now
                 )
@@ -269,16 +297,25 @@ class WorkflowService(
             val triggerName = workflowRow[Workflows.triggerName]
             val conditions = request.conditions ?: currentVersion.conditions
             val steps = request.steps ?: currentVersion.steps
+            val graph = request.graph ?: if (request.conditions != null || request.steps != null) {
+                LinearGraphAdapter.graphFromLegacy(triggerName, conditions, steps)
+            } else {
+                currentVersion.graph
+            }
             val onceForTemplate = request.onceForTemplate ?: currentVersion.onceForTemplate
 
-            validateWorkflowConfig(triggerName, conditions, steps, onceForTemplate)
+            validateWorkflowConfig(triggerName, graph, onceForTemplate)
             Workflows.update({ (Workflows.id eq workflowId) and (Workflows.organizationId eq organizationId) }) {
                 trimmedName?.let { value -> it[name] = value }
                 request.enabled?.let { value -> it[enabled] = value }
                 it[updatedAt] = now
             }
 
-            val configChanged = request.conditions != null || request.steps != null || request.onceForTemplate != null
+            val configChanged =
+                request.conditions != null ||
+                    request.steps != null ||
+                    request.graph != null ||
+                    request.onceForTemplate != null
             if (configChanged) {
                 WorkflowVersions.update(
                     { (WorkflowVersions.workflowId eq workflowId) and (WorkflowVersions.mostRecent eq true) }
@@ -290,6 +327,8 @@ class WorkflowService(
                     version = currentVersion.version + 1,
                     conditions = conditions,
                     steps = steps,
+                    graph = graph,
+                    published = false,
                     onceForTemplate = onceForTemplate,
                     now = now
                 )
@@ -318,6 +357,49 @@ class WorkflowService(
                 (Workflows.id eq workflowId) and (Workflows.organizationId eq organizationId)
             } > 0
         }
+    }
+
+    fun publishWorkflow(
+        organizationId: Int,
+        workflowId: Int
+    ): WorkflowResponse? {
+        setWorkflowPublished(organizationId, workflowId, true)
+        return getWorkflow(organizationId, workflowId)
+    }
+
+    fun unpublishWorkflow(
+        organizationId: Int,
+        workflowId: Int
+    ): WorkflowResponse? {
+        setWorkflowPublished(organizationId, workflowId, false)
+        return getWorkflow(organizationId, workflowId)
+    }
+
+    suspend fun runWorkflow(
+        organizationId: Int,
+        workflowId: Int,
+        request: ManualWorkflowRunRequest = ManualWorkflowRunRequest()
+    ): WorkflowRunResponse? {
+        val run =
+            transaction {
+                val workflowRow =
+                    Workflows
+                        .selectAll()
+                        .where { (Workflows.id eq workflowId) and (Workflows.organizationId eq organizationId) }
+                        .firstOrNull() ?: return@transaction null
+                val version = latestVersion(workflowId) ?: return@transaction null
+                val triggerScope = stepRenderer.sampleScopeForTrigger(workflowRow[Workflows.triggerName])
+                    .typedWorkflowScope()
+                val event =
+                    WorkflowTriggerEvent(
+                        triggerName = workflowRow[Workflows.triggerName],
+                        organizationId = organizationId,
+                        scope = triggerScope + request.scope
+                    )
+                createRun(event, WorkflowCandidate(workflowId, version), manualOnceFor(), force = true)
+            } ?: return null
+        startTemporalExecution(run)
+        return listRuns(organizationId, workflowId, limit = 1).firstOrNull { item -> item.id == run.runId }
     }
 
     fun listRuns(
@@ -381,7 +463,7 @@ class WorkflowService(
                     ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
                     ALERT_URL_REFERENCE to moneatUrl,
                     ORGANIZATION_ID_REFERENCE to organizationId.toString()
-                )
+                ).typedWorkflowScope()
             )
         )
     }
@@ -398,7 +480,11 @@ class WorkflowService(
                             (Workflows.enabled eq true)
                     }.mapNotNull { workflowRow ->
                         latestVersion(workflowRow[Workflows.id].value)?.let { version ->
-                            WorkflowCandidate(workflowRow[Workflows.id].value, version)
+                            if (version.published) {
+                                WorkflowCandidate(workflowRow[Workflows.id].value, version)
+                            } else {
+                                null
+                            }
                         }
                     }
             }
@@ -408,7 +494,7 @@ class WorkflowService(
             val onceForTemplate =
                 candidate.version.onceForTemplate.ifEmpty { trigger.defaultOnceForTemplate }
             val onceFor = buildOnceFor(onceForTemplate, event.scope)
-            val run = createRun(event, candidate, onceFor)
+            val run = createRun(event, candidate, onceFor, force = false)
             if (run != null) startTemporalExecution(run)
         }
     }
@@ -420,10 +506,11 @@ class WorkflowService(
     private fun createRun(
         event: WorkflowTriggerEvent,
         candidate: WorkflowCandidate,
-        onceFor: String
+        onceFor: String,
+        force: Boolean
     ): WorkflowStartRequest? =
         transaction {
-            if (workflowRunExists(candidate.workflowId, onceFor)) return@transaction null
+            if (!force && workflowRunExists(candidate.workflowId, onceFor)) return@transaction null
             val temporalWorkflowId = temporalWorkflowId(candidate.workflowId, onceFor)
             try {
                 val runId = WorkflowRuns.insertAndGetId {
@@ -469,6 +556,29 @@ class WorkflowService(
                     (WorkflowRuns.onceFor eq onceFor)
             }.count() > 0
 
+    private fun setWorkflowPublished(
+        organizationId: Int,
+        workflowId: Int,
+        published: Boolean
+    ) {
+        transaction {
+            val hasWorkflow =
+                Workflows
+                    .selectAll()
+                    .where { (Workflows.id eq workflowId) and (Workflows.organizationId eq organizationId) }
+                    .count() > 0
+            if (!hasWorkflow) return@transaction
+            WorkflowVersions.update(
+                { (WorkflowVersions.workflowId eq workflowId) and (WorkflowVersions.mostRecent eq true) }
+            ) {
+                it[WorkflowVersions.published] = published
+            }
+        }
+    }
+
+    private fun manualOnceFor(): String =
+        "manual:${UUID.randomUUID()}"
+
     private suspend fun startTemporalExecution(request: WorkflowStartRequest) {
         suspendRunCatching {
             executionEngine.start(request)
@@ -508,6 +618,8 @@ class WorkflowService(
         version: Int,
         conditions: List<WorkflowConditionConfig>,
         steps: List<WorkflowStepConfig>,
+        graph: WorkflowGraphConfig,
+        published: Boolean,
         onceForTemplate: List<String>,
         now: kotlin.time.Instant
     ) {
@@ -516,8 +628,12 @@ class WorkflowService(
             it[WorkflowVersions.version] = version
             it[WorkflowVersions.conditions] = json.encodeToString(conditions)
             it[WorkflowVersions.steps] = json.encodeToString(steps)
+            it[WorkflowVersions.graph] = json.encodeToString(graph)
+            it[WorkflowVersions.published] = published
+            it[WorkflowVersions.inputSchema] = "{}"
+            it[WorkflowVersions.tags] = "[]"
             it[WorkflowVersions.onceForTemplate] = json.encodeToString(onceForTemplate)
-            it[engineConfig] = json.encodeToString(buildEngineConfig(conditions, steps, onceForTemplate))
+            it[engineConfig] = json.encodeToString(buildEngineConfig(conditions, steps, graph, onceForTemplate))
             it[mostRecent] = true
             it[createdAt] = now
         }
@@ -525,120 +641,36 @@ class WorkflowService(
 
     private fun validateCreateRequest(request: CreateWorkflowRequest) {
         require(request.name.isNotBlank()) { "Workflow name is required" }
-        validateWorkflowConfig(request.triggerName, request.conditions, request.steps, request.onceForTemplate)
+        val graph = request.graph ?: LinearGraphAdapter.graphFromLegacy(
+            request.triggerName,
+            request.conditions,
+            request.steps
+        )
+        validateWorkflowConfig(request.triggerName, graph, request.onceForTemplate)
     }
 
     private fun validateWorkflowConfig(
         triggerName: String,
-        conditions: List<WorkflowConditionConfig>,
-        steps: List<WorkflowStepConfig>,
+        graph: WorkflowGraphConfig,
         onceForTemplate: List<String>
     ) {
-        val trigger = WorkflowCatalog.trigger(triggerName)
-            ?: throw IllegalArgumentException("Unknown workflow trigger $triggerName")
-        val scopeReferences = trigger.scope.map { it.name }.toSet()
-        conditions.forEach { condition ->
-            require(condition.reference in scopeReferences) {
-                "Unknown workflow condition reference ${condition.reference}"
-            }
-            val resourceType = checkNotNull(WorkflowCatalog.scopeType(triggerName, condition.reference))
-            val resource = checkNotNull(WorkflowCatalog.resources.firstOrNull { it.type == resourceType })
-            require(resource.operations.any { it.name == condition.operation }) {
-                "Unsupported operation ${condition.operation} for ${condition.reference}"
-            }
-            if (condition.operation.requiresConditionValue()) {
-                require(!condition.value.isNullOrBlank()) {
-                    "Missing value for ${condition.reference} ${condition.operation}"
-                }
-            }
-        }
-        onceForTemplate.forEach { reference ->
-            require(reference in scopeReferences) { "Unknown once-for reference $reference" }
-        }
-        steps.forEach { step ->
-            val definition = WorkflowCatalog.step(step.name)
-                ?: throw IllegalArgumentException("Unknown workflow step ${step.name}")
-            definition.params.filter { it.required }.forEach { param ->
-                require(!step.params[param.name].isNullOrBlank()) {
-                    "Missing required parameter ${param.name} for ${step.name}"
-                }
-            }
-        }
+        graphValidator.validate(triggerName, graph, onceForTemplate)
     }
 
     private fun conditionsMatch(
         triggerName: String,
         conditions: List<WorkflowConditionConfig>,
-        scope: Map<String, String>
+        scope: Map<String, JsonElement>
     ): Boolean =
-        conditions.all { condition ->
-            val actual = scope[condition.reference]
-            val resourceType = WorkflowCatalog.scopeType(triggerName, condition.reference)
-            evaluateCondition(resourceType, actual, condition.operation, condition.value)
-        }
-
-    private fun evaluateCondition(
-        resourceType: String?,
-        actual: String?,
-        operation: String,
-        expected: String?
-    ): Boolean =
-        when (operation) {
-            "is_set" -> !actual.isNullOrBlank()
-            "is_not_set" -> actual.isNullOrBlank()
-            "eq" -> equalsIgnoringCase(actual, expected)
-            "neq" -> !equalsIgnoringCase(actual, expected)
-            "contains" -> actual?.contains(expected.orEmpty(), ignoreCase = true) == true
-            "not_contains" -> actual?.contains(expected.orEmpty(), ignoreCase = true) != true
-            "gt", "gte", "lt", "lte" -> compareNumbers(actual, expected, operation)
-            "at_least" -> {
-                val expectedRank = severityRank(expected)
-                resourceType == "AlertSeverity" && expectedRank > 0 && severityRank(actual) >= expectedRank
-            }
-            else -> false
-        }
-
-    private fun compareNumbers(
-        actual: String?,
-        expected: String?,
-        operation: String
-    ): Boolean {
-        val actualNumber = actual?.toDoubleOrNull() ?: return false
-        val expectedNumber = expected?.toDoubleOrNull() ?: return false
-        return when (operation) {
-            "gt" -> actualNumber > expectedNumber
-            "gte" -> actualNumber >= expectedNumber
-            "lt" -> actualNumber < expectedNumber
-            "lte" -> actualNumber <= expectedNumber
-            else -> false
-        }
-    }
-
-    private fun equalsIgnoringCase(
-        actual: String?,
-        expected: String?
-    ): Boolean =
-        actual != null && actual.compareTo(expected.orEmpty(), ignoreCase = true) == 0
-
-    private fun severityRank(value: String?): Int =
-        when (value?.uppercase()) {
-            "CRITICAL" -> SEVERITY_CRITICAL_RANK
-            "HIGH" -> SEVERITY_HIGH_RANK
-            "MEDIUM" -> SEVERITY_MEDIUM_RANK
-            "LOW" -> SEVERITY_LOW_RANK
-            else -> SEVERITY_UNKNOWN_RANK
-        }
-
-    private fun String.requiresConditionValue(): Boolean =
-        this !in setOf("is_set", "is_not_set")
+        WorkflowConditionEvaluator.matchesAll(triggerName, conditions, scope)
 
     private fun buildOnceFor(
         onceForTemplate: List<String>,
-        scope: Map<String, String>
+        scope: Map<String, JsonElement>
     ): String =
         onceForTemplate
             .ifEmpty { listOf(ALERT_DEDUPLICATION_KEY_REFERENCE) }
-            .joinToString("|") { reference -> "$reference=${scope[reference].orEmpty()}" }
+            .joinToString("|") { reference -> "$reference=${scope[reference]?.workflowStringValue().orEmpty()}" }
 
     private fun workflowResponse(
         row: ResultRow,
@@ -652,9 +684,11 @@ class WorkflowService(
             triggerName = row[Workflows.triggerName],
             enabled = row[Workflows.enabled],
             version = version.version,
+            published = version.published,
             systemKey = row[Workflows.systemKey],
             conditions = version.conditions,
             steps = version.steps,
+            graph = version.graph,
             onceForTemplate = version.onceForTemplate,
             createdAt = row[Workflows.createdAt].toString(),
             updatedAt = row[Workflows.updatedAt].toString(),
@@ -684,11 +718,33 @@ class WorkflowService(
             onceFor = row[WorkflowRuns.onceFor],
             status = row[WorkflowRuns.status],
             progress = decodeProgress(row[WorkflowRuns.progress]),
+            steps = runSteps(row[WorkflowRuns.id].value),
             errorMessage = row[WorkflowRuns.errorMessage],
             createdAt = row[WorkflowRuns.createdAt].toString(),
             completedAt = row[WorkflowRuns.completedAt]?.toString(),
             failedAt = row[WorkflowRuns.failedAt]?.toString()
         )
+
+    private fun runSteps(runId: Int): List<WorkflowRunStepResponse> =
+        WorkflowRunSteps
+            .selectAll()
+            .where { WorkflowRunSteps.runId eq runId }
+            .orderBy(WorkflowRunSteps.id to SortOrder.ASC)
+            .map { row ->
+                WorkflowRunStepResponse(
+                    id = row[WorkflowRunSteps.id].value,
+                    runId = row[WorkflowRunSteps.runId],
+                    nodeId = row[WorkflowRunSteps.nodeId],
+                    type = row[WorkflowRunSteps.type],
+                    status = row[WorkflowRunSteps.status],
+                    startedAt = row[WorkflowRunSteps.startedAt]?.toString(),
+                    completedAt = row[WorkflowRunSteps.completedAt]?.toString(),
+                    input = decodeJsonElementMap(row[WorkflowRunSteps.input]),
+                    output = decodeJsonElementMap(row[WorkflowRunSteps.output]),
+                    errorMessage = row[WorkflowRunSteps.errorMessage],
+                    attempt = row[WorkflowRunSteps.attempt]
+                )
+            }
 
     private fun versionRecord(row: ResultRow): WorkflowVersionRecord =
         WorkflowVersionRecord(
@@ -696,6 +752,8 @@ class WorkflowService(
             version = row[WorkflowVersions.version],
             conditions = decodeConditions(row[WorkflowVersions.conditions]),
             steps = decodeSteps(row[WorkflowVersions.steps]),
+            graph = decodeGraph(row[WorkflowVersions.graph]),
+            published = row[WorkflowVersions.published],
             onceForTemplate = decodeStringList(row[WorkflowVersions.onceForTemplate])
         )
 
@@ -705,42 +763,61 @@ class WorkflowService(
     private fun decodeSteps(raw: String): List<WorkflowStepConfig> =
         if (raw.isBlank()) emptyList() else json.decodeFromString(raw)
 
+    private fun decodeGraph(raw: String): WorkflowGraphConfig =
+        if (raw.isBlank()) WorkflowGraphConfig() else json.decodeFromString(raw)
+
     private fun decodeStringList(raw: String): List<String> =
         if (raw.isBlank()) emptyList() else json.decodeFromString(raw)
 
     private fun decodeProgress(raw: String): List<WorkflowRunStepProgress> =
         if (raw.isBlank()) emptyList() else json.decodeFromString(raw)
 
-    private fun decodeScope(raw: String): Map<String, String> =
+    private fun decodeScope(raw: String): Map<String, JsonElement> =
         if (raw.isBlank()) emptyMap() else json.decodeFromString(raw)
+
+    private fun decodeJsonElementMap(raw: String): Map<String, JsonElement> =
+        if (raw.isBlank()) emptyMap() else json.decodeFromString<JsonElement>(raw).workflowObjectValue()
+
+    private fun Map<String, JsonElement>.stringParams(): Map<String, String> =
+        mapValues { (_, value) -> value.workflowStringValue() }
 
     private fun buildEngineConfig(
         conditions: List<WorkflowConditionConfig>,
         steps: List<WorkflowStepConfig>,
+        graph: WorkflowGraphConfig,
         onceForTemplate: List<String>
     ): List<String> =
-        (conditions.map { it.reference } + onceForTemplate + steps.flatMap { it.params.values })
+        (
+            conditions.map { it.reference } +
+                graph.nodes.flatMap { node -> node.conditions.map { condition -> condition.reference } } +
+                onceForTemplate +
+                steps.flatMap { it.params.values } +
+                graph.nodes.flatMap { node -> node.params.values.map { value -> value.workflowStringValue() } }
+            )
             .filter { it.startsWith("alert.") || it.startsWith("organization.") }
             .distinct()
 
-    private fun alertScope(event: AlertLifecycleEvent): Map<String, String> =
-        mapOf(
-            ALERT_TITLE_REFERENCE to event.title,
-            ALERT_DESCRIPTION_REFERENCE to event.description,
-            ALERT_SEVERITY_REFERENCE to event.severity.name,
-            ALERT_PRIORITY_REFERENCE to stepRenderer.priorityLabelForSeverity(event.severity.name),
-            ALERT_STATUS_REFERENCE to event.status.name,
-            ALERT_SOURCE_REFERENCE to event.source.name,
-            ALERT_DEDUPLICATION_KEY_REFERENCE to event.deduplicationKey,
-            ALERT_URL_REFERENCE to event.moneatUrl,
-            ORGANIZATION_ID_REFERENCE to event.organizationId.toString()
-        ) + alertMetadataScope(event.metadata)
+    private fun alertScope(event: AlertLifecycleEvent): Map<String, JsonElement> {
+        val baseScope =
+            mapOf(
+                ALERT_TITLE_REFERENCE to event.title,
+                ALERT_DESCRIPTION_REFERENCE to event.description,
+                ALERT_SEVERITY_REFERENCE to event.severity.name,
+                ALERT_PRIORITY_REFERENCE to stepRenderer.priorityLabelForSeverity(event.severity.name),
+                ALERT_STATUS_REFERENCE to event.status.name,
+                ALERT_SOURCE_REFERENCE to event.source.name,
+                ALERT_DEDUPLICATION_KEY_REFERENCE to event.deduplicationKey,
+                ALERT_URL_REFERENCE to event.moneatUrl,
+                ORGANIZATION_ID_REFERENCE to event.organizationId.toString()
+            ).typedWorkflowScope()
+        return baseScope + alertMetadataScope(event.metadata)
+    }
 
-    private fun alertMetadataScope(metadata: Map<String, JsonElement>): Map<String, String> =
+    private fun alertMetadataScope(metadata: Map<String, JsonElement>): Map<String, JsonElement> =
         metadata
             .mapNotNull { (reference, value) ->
                 if (reference !in ALERT_METADATA_REFERENCES) return@mapNotNull null
-                value.workflowScopeValue()?.let { reference to it }
+                value.workflowScopeValue()?.let { reference to JsonPrimitive(it) }
             }.toMap()
 
     private fun JsonElement.workflowScopeValue(): String? {
@@ -861,6 +938,8 @@ private data class WorkflowVersionRecord(
     val version: Int,
     val conditions: List<WorkflowConditionConfig>,
     val steps: List<WorkflowStepConfig>,
+    val graph: WorkflowGraphConfig,
+    val published: Boolean,
     val onceForTemplate: List<String>
 )
 

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -399,8 +399,24 @@ class WorkflowService(
                 createRun(event, WorkflowCandidate(workflowId, version), manualOnceFor(), force = true)
             } ?: return null
         startTemporalExecution(run)
-        return listRuns(organizationId, workflowId, limit = 1).firstOrNull { item -> item.id == run.runId }
+        return getRun(organizationId, workflowId, run.runId)
     }
+
+    private fun getRun(
+        organizationId: Int,
+        workflowId: Int,
+        runId: Int
+    ): WorkflowRunResponse? =
+        transaction {
+            WorkflowRuns
+                .selectAll()
+                .where {
+                    (WorkflowRuns.id eq runId) and
+                        (WorkflowRuns.workflowId eq workflowId) and
+                        (WorkflowRuns.organizationId eq organizationId)
+                }.firstOrNull()
+                ?.let { row -> runResponse(row) }
+        }
 
     fun listRuns(
         organizationId: Int,

--- a/backend/src/main/resources/db/migration/V114__workflow_graph_model.sql
+++ b/backend/src/main/resources/db/migration/V114__workflow_graph_model.sql
@@ -1,0 +1,115 @@
+ALTER TABLE workflow_versions
+    ADD COLUMN graph JSONB NOT NULL DEFAULT '{"nodes":[],"edges":[]}'::JSONB,
+    ADD COLUMN published BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN input_schema JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN tags JSONB NOT NULL DEFAULT '[]'::JSONB;
+
+WITH version_parts AS (
+    SELECT
+        v.id,
+        w.trigger_name,
+        COALESCE(v.conditions, '[]'::JSONB) AS conditions,
+        COALESCE(v.steps, '[]'::JSONB) AS steps,
+        JSONB_ARRAY_LENGTH(COALESCE(v.conditions, '[]'::JSONB)) AS condition_count,
+        JSONB_ARRAY_LENGTH(COALESCE(v.steps, '[]'::JSONB)) AS step_count
+    FROM workflow_versions v
+    INNER JOIN workflows w ON w.id = v.workflow_id
+),
+action_nodes AS (
+    SELECT
+        vp.id,
+        COALESCE(
+            JSONB_AGG(
+                JSONB_BUILD_OBJECT(
+                    'id', 'step-' || step_item.ordinality,
+                    'type', 'action',
+                    'action', step_item.step ->> 'name',
+                    'params', COALESCE(step_item.step -> 'params', '{}'::JSONB),
+                    'continue_on_error', TRUE
+                )
+                ORDER BY step_item.ordinality
+            ),
+            '[]'::JSONB
+        ) AS nodes
+    FROM version_parts vp
+    LEFT JOIN LATERAL JSONB_ARRAY_ELEMENTS(vp.steps) WITH ORDINALITY AS step_item(step, ordinality) ON TRUE
+    GROUP BY vp.id
+),
+graph_edges AS (
+    SELECT
+        vp.id,
+        COALESCE(JSONB_AGG(edge.edge), '[]'::JSONB) AS edges
+    FROM version_parts vp
+    LEFT JOIN LATERAL (
+        SELECT JSONB_BUILD_OBJECT('from', 'trigger', 'to', 'conditions') AS edge
+        WHERE vp.condition_count > 0
+
+        UNION ALL
+
+        SELECT JSONB_STRIP_NULLS(
+            JSONB_BUILD_OBJECT(
+                'from', CASE WHEN vp.condition_count > 0 THEN 'conditions' ELSE 'trigger' END,
+                'to', 'step-1',
+                'branch', CASE WHEN vp.condition_count > 0 THEN 'true' ELSE NULL END
+            )
+        ) AS edge
+        WHERE vp.step_count > 0
+
+        UNION ALL
+
+        SELECT JSONB_BUILD_OBJECT('from', 'step-' || series.n, 'to', 'step-' || (series.n + 1)) AS edge
+        FROM GENERATE_SERIES(1, GREATEST(vp.step_count - 1, 0)) AS series(n)
+    ) edge ON TRUE
+    GROUP BY vp.id
+)
+UPDATE workflow_versions v
+SET
+    graph = JSONB_BUILD_OBJECT(
+        'nodes',
+        JSONB_BUILD_ARRAY(
+            JSONB_BUILD_OBJECT(
+                'id', 'trigger',
+                'type', 'trigger',
+                'trigger', vp.trigger_name
+            )
+        ) ||
+            CASE
+                WHEN vp.condition_count > 0 THEN JSONB_BUILD_ARRAY(
+                    JSONB_BUILD_OBJECT(
+                        'id', 'conditions',
+                        'type', 'condition',
+                        'kind', 'if',
+                        'conditions', vp.conditions
+                    )
+                )
+                ELSE '[]'::JSONB
+            END ||
+            action_nodes.nodes,
+        'edges',
+        graph_edges.edges
+    ),
+    published = TRUE
+FROM version_parts vp
+INNER JOIN action_nodes ON action_nodes.id = vp.id
+INNER JOIN graph_edges ON graph_edges.id = vp.id
+WHERE v.id = vp.id;
+
+CREATE TABLE workflow_run_steps (
+    id SERIAL PRIMARY KEY,
+    run_id INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    node_id VARCHAR(120) NOT NULL,
+    type VARCHAR(64) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    input JSONB NOT NULL DEFAULT '{}'::JSONB,
+    output JSONB NOT NULL DEFAULT '{}'::JSONB,
+    error_message TEXT,
+    attempt INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE UNIQUE INDEX idx_workflow_run_steps_attempt
+    ON workflow_run_steps (run_id, node_id, attempt);
+
+CREATE INDEX idx_workflow_run_steps_run
+    ON workflow_run_steps (run_id, id);

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -36,9 +36,11 @@ import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowConditionConfig
 import com.moneat.workflows.models.WorkflowPreviewRequest
 import com.moneat.workflows.models.WorkflowRuns
+import com.moneat.workflows.models.WorkflowRunSteps
 import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowVersions
 import com.moneat.workflows.models.Workflows
+import com.moneat.workflows.models.typedWorkflowScope
 import com.moneat.workflows.services.WorkflowService
 import io.mockk.clearMocks
 import io.mockk.coEvery
@@ -106,7 +108,8 @@ class WorkflowServiceTest {
             Memberships,
             Workflows,
             WorkflowVersions,
-            WorkflowRuns
+            WorkflowRuns,
+            WorkflowRunSteps
         )
         transaction {
             SchemaUtils.create(Users, Organizations, Memberships, Workflows)
@@ -120,6 +123,10 @@ class WorkflowServiceTest {
                     version INT NOT NULL,
                     conditions TEXT NOT NULL DEFAULT '[]',
                     steps TEXT NOT NULL DEFAULT '[]',
+                    graph TEXT NOT NULL DEFAULT '{"nodes":[],"edges":[]}',
+                    published BOOLEAN NOT NULL DEFAULT FALSE,
+                    input_schema TEXT NOT NULL DEFAULT '{}',
+                    tags TEXT NOT NULL DEFAULT '[]',
                     once_for_template TEXT NOT NULL DEFAULT '[]',
                     engine_config TEXT NOT NULL DEFAULT '{}',
                     most_recent BOOLEAN NOT NULL DEFAULT TRUE,
@@ -171,6 +178,31 @@ class WorkflowServiceTest {
                 """.trimIndent()
             )
             exec("CREATE INDEX idx_workflow_runs_workflow_created ON workflow_runs (workflow_id, created_at DESC)")
+            exec(
+                """
+                CREATE TABLE workflow_run_steps (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    run_id INT NOT NULL,
+                    node_id VARCHAR(120) NOT NULL,
+                    type VARCHAR(64) NOT NULL,
+                    status VARCHAR(32) NOT NULL,
+                    started_at TIMESTAMP,
+                    completed_at TIMESTAMP,
+                    input TEXT NOT NULL DEFAULT '{}',
+                    output TEXT NOT NULL DEFAULT '{}',
+                    error_message TEXT,
+                    attempt INT NOT NULL DEFAULT 1,
+                    CONSTRAINT fk_workflow_run_steps_run_id
+                        FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE UNIQUE INDEX idx_workflow_run_steps_attempt
+                    ON workflow_run_steps (run_id, node_id, attempt)
+                """.trimIndent()
+            )
         }
     }
 
@@ -423,7 +455,7 @@ class WorkflowServiceTest {
                                 )
                             )
                         ),
-                        scope = mapOf("alert.channels.slack" to "false")
+                        scope = mapOf("alert.channels.slack" to "false").typedWorkflowScope()
                     )
                 )
 
@@ -574,6 +606,7 @@ class WorkflowServiceTest {
                         onceForTemplate = listOf("alert.deduplication_key")
                     )
                 )
+            publish(workflow.id)
 
             service.publishAlertTriggered(alertEvent())
             val queuedRun = service.listRuns(orgId, workflow.id).single()
@@ -622,6 +655,7 @@ class WorkflowServiceTest {
                         onceForTemplate = listOf("alert.deduplication_key")
                     )
                 )
+            publish(workflow.id)
 
             service.publishAlertTriggered(alertEvent())
             service.publishAlertTriggered(alertEvent())
@@ -647,7 +681,7 @@ class WorkflowServiceTest {
 
             val completedRun = service.listRuns(orgId, workflow.id).single()
             assertEquals("complete", completedRun.status)
-            assertEquals(3, completedRun.progress.size)
+            assertEquals(4, completedRun.progress.size)
             assertTrue(completedRun.progress.all { it.status == "complete" })
             assertNotNull(service.getWorkflow(orgId, workflow.id)?.lastRunAt)
             assertEquals(1L, service.getWorkflow(orgId, workflow.id)?.runCount)
@@ -697,6 +731,7 @@ class WorkflowServiceTest {
                         steps = listOf(emailStep(), slackStep(), discordStep())
                     )
                 )
+            publish(workflow.id)
             val event =
                 alertEvent().copy(
                     source = AlertSource.DASHBOARD_ALERT,
@@ -742,6 +777,7 @@ class WorkflowServiceTest {
                         steps = listOf(emailStep(), slackStep(), discordStep())
                     )
                 )
+            publish(workflow.id)
 
             service.publishAlertTriggered(alertEvent())
             val queuedRun = service.listRuns(orgId, workflow.id).single()
@@ -789,6 +825,7 @@ class WorkflowServiceTest {
                         )
                     )
                 )
+            publish(workflow.id)
 
             service.publishAlertResolved(
                 organizationId = orgId,
@@ -802,10 +839,11 @@ class WorkflowServiceTest {
             service.executeRun(queuedRun.id)
 
             val failedRun = service.listRuns(orgId, workflow.id).single()
+            val actionProgress = failedRun.progress.filter { it.type == "action" }
             assertEquals("failed", failedRun.status)
             assertEquals("Slack workflow message was not sent", failedRun.errorMessage)
-            assertEquals("failed", failedRun.progress.single().status)
-            assertEquals("Slack workflow message was not sent", failedRun.progress.single().errorMessage)
+            assertEquals("failed", actionProgress.single().status)
+            assertEquals("Slack workflow message was not sent", actionProgress.single().errorMessage)
             coVerify(exactly = 1) {
                 slackService.sendWorkflowMessage(orgId, "Resolved uptime-1", false)
             }
@@ -831,6 +869,8 @@ class WorkflowServiceTest {
                         conditions = listOf(WorkflowConditionConfig("alert.description", "not_contains", "cpu"))
                     )
                 )
+            publish(disabled.id)
+            publish(nonMatching.id)
 
             service.publishAlertTriggered(alertEvent())
 
@@ -847,6 +887,7 @@ class WorkflowServiceTest {
                     orgId,
                     validRequest(name = "Temporal unavailable workflow")
                 )
+            publish(workflow.id)
 
             service.publishAlertTriggered(alertEvent())
 
@@ -911,6 +952,10 @@ class WorkflowServiceTest {
             steps = steps,
             onceForTemplate = onceForTemplate
         )
+
+    private fun publish(workflowId: Int) {
+        assertNotNull(service.publishWorkflow(orgId, workflowId))
+    }
 
     private fun emailStep(): WorkflowStepConfig =
         WorkflowStepConfig(

--- a/backend/src/test/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflowTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflowTest.kt
@@ -16,12 +16,18 @@
 
 package com.moneat.workflows.engine.temporal
 
+import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowGraphEdge
+import com.moneat.workflows.models.WorkflowGraphNode
 import com.moneat.workflows.models.WorkflowStepConfig
 import io.temporal.client.WorkflowClientOptions
 import io.temporal.client.WorkflowOptions
 import io.temporal.testing.TestEnvironmentOptions
 import io.temporal.testing.TestWorkflowEnvironment
 import java.util.Collections
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -59,7 +65,8 @@ class WorkflowInterpreterWorkflowTest {
             val result = harness.workflow.run(input())
 
             assertEquals(STATUS_COMPLETE, result.status)
-            assertEquals(listOf(STATUS_RUNNING, STATUS_COMPLETE), persistActivity.transitions)
+            assertEquals(STATUS_RUNNING, persistActivity.transitions.first())
+            assertEquals(STATUS_COMPLETE, persistActivity.transitions.last())
             assertEquals(
                 listOf("notification.email", "notification.slack"),
                 result.progress.map { step -> step.step }
@@ -89,10 +96,56 @@ class WorkflowInterpreterWorkflowTest {
             val result = harness.workflow.run(input())
 
             assertEquals(STATUS_FAILED, result.status)
-            assertEquals(listOf(STATUS_RUNNING, STATUS_FAILED), persistActivity.transitions)
+            assertEquals(STATUS_RUNNING, persistActivity.transitions.first())
+            assertEquals(STATUS_FAILED, persistActivity.transitions.last())
             assertEquals("notification.discord failed", result.errorMessage)
             assertEquals(STATUS_FAILED, result.progress.last().status)
             assertEquals("notification.discord failed", result.progress.last().errorMessage)
+        }
+    }
+
+    @Test
+    fun `interpreter follows condition branch in graph workflow`() {
+        val actionActivity = RecordingExecuteActionActivity()
+        val persistActivity =
+            RecordingPersistRunActivity(
+                snapshot = snapshot(
+                    graph = WorkflowGraphConfig(
+                        nodes = listOf(
+                            WorkflowGraphNode("trigger", "trigger", trigger = "alert.triggered"),
+                            WorkflowGraphNode(
+                                id = "severity-check",
+                                type = "condition",
+                                kind = "if",
+                                conditions = listOf(
+                                    WorkflowConditionConfig(
+                                        reference = "alert.severity",
+                                        operation = "eq",
+                                        value = "critical"
+                                    )
+                                )
+                            ),
+                            WorkflowGraphNode(
+                                id = "email",
+                                type = "action",
+                                action = "notification.email"
+                            )
+                        ),
+                        edges = listOf(
+                            WorkflowGraphEdge("trigger", "severity-check"),
+                            WorkflowGraphEdge("severity-check", "email", branch = "true")
+                        )
+                    ),
+                    scope = mapOf("alert.severity" to JsonPrimitive("critical"))
+                )
+            )
+
+        runWorkflow(actionActivity, persistActivity).use { harness ->
+            val result = harness.workflow.run(input())
+
+            assertEquals(STATUS_COMPLETE, result.status)
+            assertEquals(listOf("notification.email"), actionActivity.executedSteps)
+            assertEquals(listOf("severity-check", "email"), result.progress.map { step -> step.nodeId })
         }
     }
 
@@ -136,13 +189,19 @@ class WorkflowInterpreterWorkflowTest {
         return TestWorkflowEnvironment.newInstance(options)
     }
 
-    private fun snapshot(steps: List<WorkflowStepConfig>): WorkflowRunExecutionSnapshot =
+    private fun snapshot(
+        steps: List<WorkflowStepConfig> = emptyList(),
+        graph: WorkflowGraphConfig = WorkflowGraphConfig(),
+        scope: Map<String, JsonElement> = emptyMap()
+    ): WorkflowRunExecutionSnapshot =
         WorkflowRunExecutionSnapshot(
             runId = TEST_RUN_ID,
             organizationId = TEST_ORGANIZATION_ID,
             workflowVersionId = TEST_WORKFLOW_VERSION_ID,
             steps = steps,
-            scope = mapOf("alert.title" to "Worker failures detected")
+            graph = graph.toRuntimeGraph(),
+            triggerName = "alert.triggered",
+            scope = scope.toRuntimeValues()
         )
 
     private fun input(): WorkflowInterpreterInput =
@@ -151,8 +210,7 @@ class WorkflowInterpreterWorkflowTest {
             workflowId = TEST_WORKFLOW_ID,
             workflowVersionId = TEST_WORKFLOW_VERSION_ID,
             organizationId = TEST_ORGANIZATION_ID,
-            triggerName = "alert.triggered",
-            scope = mapOf("alert.title" to "Worker failures detected")
+            triggerName = "alert.triggered"
         )
 }
 
@@ -192,7 +250,7 @@ private class RecordingPersistRunActivity(
     private val snapshot: WorkflowRunExecutionSnapshot?
 ) : PersistRunActivity {
     val transitions = mutableListOf<String>()
-    var progress = emptyList<com.moneat.workflows.models.WorkflowRunStepProgress>()
+    var progress = emptyList<RuntimeWorkflowRunStepProgress>()
         private set
 
     @Synchronized
@@ -215,4 +273,10 @@ private class RecordingPersistRunActivity(
         transitions += STATUS_FAILED
         progress = input.progress
     }
+
+    override fun markStepRunning(input: PersistRunStepInput) = Unit
+
+    override fun markStepComplete(input: PersistRunStepInput) = Unit
+
+    override fun markStepFailed(input: PersistRunStepInput) = Unit
 }

--- a/backend/src/test/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflowTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/engine/temporal/WorkflowInterpreterWorkflowTest.kt
@@ -20,12 +20,14 @@ import com.moneat.workflows.models.WorkflowConditionConfig
 import com.moneat.workflows.models.WorkflowGraphConfig
 import com.moneat.workflows.models.WorkflowGraphEdge
 import com.moneat.workflows.models.WorkflowGraphNode
+import com.moneat.workflows.models.WorkflowRetryConfig
 import com.moneat.workflows.models.WorkflowStepConfig
 import io.temporal.client.WorkflowClientOptions
 import io.temporal.client.WorkflowOptions
 import io.temporal.testing.TestEnvironmentOptions
 import io.temporal.testing.TestWorkflowEnvironment
 import java.util.Collections
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
@@ -36,6 +38,7 @@ import kotlin.test.assertTrue
 
 private const val STATUS_COMPLETE = "complete"
 private const val STATUS_FAILED = "failed"
+private const val STATUS_PENDING = "pending"
 private const val STATUS_RUNNING = "running"
 private const val TEST_COMPLETED_AT = "2026-05-29T00:00:00Z"
 private const val TEST_PAYLOAD_KEY = "workflow-test-payload-key-32-bytes"
@@ -149,6 +152,135 @@ class WorkflowInterpreterWorkflowTest {
         }
     }
 
+    @Test
+    fun `interpreter persists activity exceptions as failed nodes`() {
+        val actionActivity = RecordingExecuteActionActivity(throwingSteps = setOf("notification.email"))
+        val persistActivity =
+            RecordingPersistRunActivity(
+                snapshot = snapshot(
+                    graph = WorkflowGraphConfig(
+                        nodes = listOf(
+                            WorkflowGraphNode("trigger", "trigger", trigger = "alert.triggered"),
+                            WorkflowGraphNode(
+                                id = "email",
+                                type = "action",
+                                action = "notification.email",
+                                retry = WorkflowRetryConfig(maxAttempts = 1)
+                            )
+                        ),
+                        edges = listOf(WorkflowGraphEdge("trigger", "email"))
+                    )
+                )
+            )
+
+        runWorkflow(actionActivity, persistActivity).use { harness ->
+            val result = harness.workflow.run(input())
+
+            assertEquals(STATUS_FAILED, result.status)
+            assertEquals(STATUS_FAILED, result.progress.single().status)
+            assertTrue(result.progress.single().errorMessage?.contains("notification.email exploded") == true)
+        }
+    }
+
+    @Test
+    fun `interpreter stops fan out after a branch failure`() {
+        val actionActivity = RecordingExecuteActionActivity(failedSteps = setOf("notification.email"))
+        val persistActivity =
+            RecordingPersistRunActivity(
+                snapshot = snapshot(
+                    graph = WorkflowGraphConfig(
+                        nodes = listOf(
+                            WorkflowGraphNode("trigger", "trigger", trigger = "alert.triggered"),
+                            WorkflowGraphNode("email", "action", action = "notification.email"),
+                            WorkflowGraphNode("slack", "action", action = "notification.slack")
+                        ),
+                        edges = listOf(
+                            WorkflowGraphEdge("trigger", "email"),
+                            WorkflowGraphEdge("trigger", "slack")
+                        )
+                    )
+                )
+            )
+
+        runWorkflow(actionActivity, persistActivity).use { harness ->
+            val result = harness.workflow.run(input())
+
+            assertEquals(STATUS_FAILED, result.status)
+            assertEquals(listOf("notification.email"), actionActivity.executedSteps)
+            assertEquals(listOf(STATUS_FAILED, STATUS_PENDING), result.progress.map { step -> step.status })
+        }
+    }
+
+    @Test
+    fun `interpreter keeps repeated action progress scoped to node id`() {
+        val actionActivity = RecordingExecuteActionActivity(failedSteps = setOf("notification.email"))
+        val persistActivity =
+            RecordingPersistRunActivity(
+                snapshot = snapshot(
+                    graph = WorkflowGraphConfig(
+                        nodes = listOf(
+                            WorkflowGraphNode("trigger", "trigger", trigger = "alert.triggered"),
+                            WorkflowGraphNode("email-1", "action", action = "notification.email"),
+                            WorkflowGraphNode("email-2", "action", action = "notification.email")
+                        ),
+                        edges = listOf(
+                            WorkflowGraphEdge("trigger", "email-1"),
+                            WorkflowGraphEdge("email-1", "email-2")
+                        )
+                    )
+                )
+            )
+
+        runWorkflow(actionActivity, persistActivity).use { harness ->
+            val result = harness.workflow.run(input())
+
+            assertEquals(STATUS_FAILED, result.status)
+            assertEquals(listOf("email-1", "email-2"), result.progress.map { step -> step.nodeId })
+            assertEquals(listOf(STATUS_FAILED, STATUS_PENDING), result.progress.map { step -> step.status })
+        }
+    }
+
+    @Test
+    fun `interpreter marks for each failed when the body fails`() {
+        val actionActivity = RecordingExecuteActionActivity(failedSteps = setOf("notification.email"))
+        val persistActivity =
+            RecordingPersistRunActivity(
+                snapshot = snapshot(
+                    graph = WorkflowGraphConfig(
+                        nodes = listOf(
+                            WorkflowGraphNode("trigger", "trigger", trigger = "alert.triggered"),
+                            WorkflowGraphNode(
+                                id = "loop",
+                                type = "control",
+                                kind = "for_each",
+                                params = mapOf(
+                                    "items_reference" to JsonPrimitive("alert.items"),
+                                    "item_variable" to JsonPrimitive("item"),
+                                    "max_items" to JsonPrimitive("3")
+                                )
+                            ),
+                            WorkflowGraphNode("email", "action", action = "notification.email")
+                        ),
+                        edges = listOf(
+                            WorkflowGraphEdge("trigger", "loop"),
+                            WorkflowGraphEdge("loop", "email", branch = "body")
+                        )
+                    ),
+                    scope = mapOf(
+                        "alert.items" to JsonArray(listOf(JsonPrimitive("first"), JsonPrimitive("second")))
+                    )
+                )
+            )
+
+        runWorkflow(actionActivity, persistActivity).use { harness ->
+            val result = harness.workflow.run(input())
+
+            assertEquals(STATUS_FAILED, result.status)
+            assertEquals(listOf("notification.email"), actionActivity.executedSteps)
+            assertEquals(STATUS_FAILED, result.progress.first { step -> step.nodeId == "loop" }.status)
+        }
+    }
+
     private fun runWorkflow(
         actionActivity: ExecuteActionActivity,
         persistActivity: PersistRunActivity
@@ -228,12 +360,16 @@ private class TestWorkflowHarness(
 // ──── Recording Fakes ────
 
 private class RecordingExecuteActionActivity(
-    private val failedSteps: Set<String> = emptySet()
+    private val failedSteps: Set<String> = emptySet(),
+    private val throwingSteps: Set<String> = emptySet()
 ) : ExecuteActionActivity {
     val executedSteps: MutableList<String> = Collections.synchronizedList(mutableListOf())
 
     override fun execute(input: ExecuteActionInput): ExecuteActionResult {
         executedSteps += input.step.name
+        if (input.step.name in throwingSteps) {
+            throw IllegalStateException("${input.step.name} exploded")
+        }
         return if (input.step.name in failedSteps) {
             ExecuteActionResult(
                 status = STATUS_FAILED,

--- a/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
@@ -28,6 +28,7 @@ import com.moneat.org.repositories.OrgMembershipRepository
 import com.moneat.org.repositories.OrgMembershipRepositoryImpl
 import com.moneat.org.services.OrgMembershipService
 import com.moneat.workflows.engine.WorkflowCatalog
+import com.moneat.workflows.engine.temporal.LinearGraphAdapter
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowConditionConfig
@@ -494,8 +495,14 @@ class WorkflowRoutesTest {
             triggerName = "alert.triggered",
             enabled = true,
             version = 1,
+            published = true,
             conditions = emptyList(),
             steps = listOf(WorkflowStepConfig("notification.email_org", mapOf("subject" to "Alert"))),
+            graph = LinearGraphAdapter.graphFromLegacy(
+                "alert.triggered",
+                emptyList(),
+                listOf(WorkflowStepConfig("notification.email_org", mapOf("subject" to "Alert")))
+            ),
             onceForTemplate = listOf("alert.deduplication_key"),
             createdAt = "2026-01-01T00:00:00Z",
             updatedAt = "2026-01-01T00:00:00Z"

--- a/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowGraphValidatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowGraphValidatorTest.kt
@@ -25,7 +25,12 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class WorkflowGraphValidatorTest {
+
+    // ──── Fixture ────
+
     private val validator = WorkflowGraphValidator()
+
+    // ──── Tests ────
 
     @Test
     fun `validates branching graph`() {
@@ -100,6 +105,8 @@ class WorkflowGraphValidatorTest {
             onceForTemplate = emptyList()
         )
     }
+
+    // ──── Helpers ────
 
     private fun trigger(): WorkflowGraphNode =
         WorkflowGraphNode(id = "trigger", type = "trigger", trigger = "alert.triggered")

--- a/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowGraphValidatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowGraphValidatorTest.kt
@@ -1,0 +1,114 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.services
+
+import com.moneat.workflows.models.WorkflowConditionConfig
+import com.moneat.workflows.models.WorkflowGraphConfig
+import com.moneat.workflows.models.WorkflowGraphEdge
+import com.moneat.workflows.models.WorkflowGraphNode
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class WorkflowGraphValidatorTest {
+    private val validator = WorkflowGraphValidator()
+
+    @Test
+    fun `validates branching graph`() {
+        validator.validate(
+            triggerName = "alert.triggered",
+            graph = WorkflowGraphConfig(
+                nodes = listOf(
+                    trigger(),
+                    WorkflowGraphNode(
+                        id = "condition-1",
+                        type = "condition",
+                        kind = "if",
+                        conditions = listOf(WorkflowConditionConfig("alert.severity", "at_least", "HIGH"))
+                    ),
+                    action("action-1")
+                ),
+                edges = listOf(
+                    WorkflowGraphEdge("trigger", "condition-1"),
+                    WorkflowGraphEdge("condition-1", "action-1", branch = "true")
+                )
+            ),
+            onceForTemplate = listOf("alert.deduplication_key")
+        )
+    }
+
+    @Test
+    fun `rejects orphan nodes and illegal cycles`() {
+        assertFailsWith<IllegalArgumentException> {
+            validator.validate(
+                triggerName = "alert.triggered",
+                graph = WorkflowGraphConfig(nodes = listOf(trigger(), action("orphan"))),
+                onceForTemplate = emptyList()
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            validator.validate(
+                triggerName = "alert.triggered",
+                graph = WorkflowGraphConfig(
+                    nodes = listOf(trigger(), action("a1"), action("a2")),
+                    edges = listOf(
+                        WorkflowGraphEdge("trigger", "a1"),
+                        WorkflowGraphEdge("a1", "a2"),
+                        WorkflowGraphEdge("a2", "a1")
+                    )
+                ),
+                onceForTemplate = emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun `validates bounded loop controls`() {
+        validator.validate(
+            triggerName = "alert.triggered",
+            graph = WorkflowGraphConfig(
+                nodes = listOf(
+                    trigger(),
+                    WorkflowGraphNode(
+                        id = "while-1",
+                        type = "control",
+                        kind = "while",
+                        params = mapOf("max_iterations" to JsonPrimitive("10")),
+                        conditions = listOf(WorkflowConditionConfig("alert.status", "eq", "FIRING"))
+                    ),
+                    action("action-1")
+                ),
+                edges = listOf(
+                    WorkflowGraphEdge("trigger", "while-1"),
+                    WorkflowGraphEdge("while-1", "action-1", branch = "body")
+                )
+            ),
+            onceForTemplate = emptyList()
+        )
+    }
+
+    private fun trigger(): WorkflowGraphNode =
+        WorkflowGraphNode(id = "trigger", type = "trigger", trigger = "alert.triggered")
+
+    private fun action(id: String): WorkflowGraphNode =
+        WorkflowGraphNode(
+            id = id,
+            type = "action",
+            action = "notification.slack",
+            params = mapOf("message" to JsonPrimitive("{{alert.title}}"))
+        )
+}

--- a/dashboard/src/components/workflows/NodeConfigPanel.tsx
+++ b/dashboard/src/components/workflows/NodeConfigPanel.tsx
@@ -1,0 +1,398 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {Trash2} from 'lucide-react'
+import type {
+  WorkflowCatalogResponse,
+  WorkflowConditionConfig,
+  WorkflowGraphNode,
+  WorkflowOperationDefinition,
+  WorkflowScopeReferenceDefinition,
+} from '@/lib/api'
+import {Button} from '@/components/ui/button'
+import {Input} from '@/components/ui/input'
+import {Label} from '@/components/ui/label'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
+import {Switch} from '@/components/ui/switch'
+import {Textarea} from '@/components/ui/textarea'
+import {nodeLabel, stepDefinition, triggerNodeId} from './workflowGraph'
+
+interface NodeConfigPanelProps {
+  node?: WorkflowGraphNode
+  catalog?: WorkflowCatalogResponse
+  triggerName: string
+  onChange: (node: WorkflowGraphNode) => void
+  onRemove: (nodeId: string) => void
+}
+
+export function NodeConfigPanel({
+  node,
+  catalog,
+  triggerName,
+  onChange,
+  onRemove,
+}: NodeConfigPanelProps) {
+  if (!node) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
+        Select a node on the canvas to configure it.
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-4 rounded-md border bg-muted/20 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold">{nodeLabel(node, catalog)}</h3>
+          <p className="text-xs text-muted-foreground">{node.type}</p>
+        </div>
+        {node.id !== triggerNodeId && (
+          <Button type="button" variant="ghost" size="icon" onClick={() => onRemove(node.id)}>
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+      {node.type === 'trigger' && <TriggerFields node={node} catalog={catalog} onChange={onChange} />}
+      {node.type === 'action' && <ActionFields node={node} catalog={catalog} onChange={onChange} />}
+      {node.type === 'condition' && (
+        <ConditionFields node={node} catalog={catalog} triggerName={triggerName} onChange={onChange} />
+      )}
+      {node.type === 'control' && (
+        <ControlFields node={node} catalog={catalog} triggerName={triggerName} onChange={onChange} />
+      )}
+    </div>
+  )
+}
+
+function TriggerFields({
+  node,
+  catalog,
+  onChange,
+}: {
+  node: WorkflowGraphNode
+  catalog?: WorkflowCatalogResponse
+  onChange: (node: WorkflowGraphNode) => void
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label>Trigger</Label>
+      <Select value={node.trigger ?? ''} onValueChange={(trigger) => onChange({...node, trigger})}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {catalog?.triggers.map((trigger) => (
+            <SelectItem key={trigger.name} value={trigger.name}>
+              {trigger.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function ActionFields({
+  node,
+  catalog,
+  onChange,
+}: {
+  node: WorkflowGraphNode
+  catalog?: WorkflowCatalogResponse
+  onChange: (node: WorkflowGraphNode) => void
+}) {
+  const definition = stepDefinition(catalog, node.action)
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label>Action</Label>
+        <Select value={node.action ?? ''} onValueChange={(action) => onChange({...node, action, params: {}})}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {catalog?.steps.map((step) => (
+              <SelectItem key={step.name} value={step.name}>
+                {step.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {definition?.params.map((param) => (
+        <div key={param.name} className="space-y-1.5">
+          <Label>{param.label}</Label>
+          {param.type === 'Text' ? (
+            <Textarea
+              value={String(node.params?.[param.name] ?? '')}
+              onChange={(event) => updateParam(node, param.name, event.target.value, onChange)}
+              className="min-h-24"
+            />
+          ) : (
+            <Input
+              value={String(node.params?.[param.name] ?? '')}
+              onChange={(event) => updateParam(node, param.name, event.target.value, onChange)}
+            />
+          )}
+        </div>
+      ))}
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={node.continue_on_error ?? false}
+          onCheckedChange={(value) => onChange({...node, continue_on_error: value})}
+        />
+        <Label>Continue on error</Label>
+      </div>
+      <RetryFields node={node} onChange={onChange} />
+    </div>
+  )
+}
+
+function ConditionFields({
+  node,
+  catalog,
+  triggerName,
+  onChange,
+}: {
+  node: WorkflowGraphNode
+  catalog?: WorkflowCatalogResponse
+  triggerName: string
+  onChange: (node: WorkflowGraphNode) => void
+}) {
+  return (
+    <div className="space-y-3">
+      <Select value={node.kind ?? 'if'} onValueChange={(kind) => onChange({...node, kind})}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="if">If / else</SelectItem>
+          <SelectItem value="switch">Switch</SelectItem>
+        </SelectContent>
+      </Select>
+      <ConditionList
+        conditions={node.conditions ?? []}
+        catalog={catalog}
+        triggerName={triggerName}
+        onChange={(conditions) => onChange({...node, conditions})}
+      />
+    </div>
+  )
+}
+
+function ControlFields({
+  node,
+  catalog,
+  triggerName,
+  onChange,
+}: {
+  node: WorkflowGraphNode
+  catalog?: WorkflowCatalogResponse
+  triggerName: string
+  onChange: (node: WorkflowGraphNode) => void
+}) {
+  const paramName = node.kind === 'sleep' ? 'duration' : 'timeout'
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label>Control</Label>
+        <Select value={node.kind ?? 'sleep'} onValueChange={(kind) => onChange({...node, kind})}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="sleep">Sleep</SelectItem>
+            <SelectItem value="wait_until">Wait until</SelectItem>
+            <SelectItem value="for_each">For each</SelectItem>
+            <SelectItem value="while">While</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      {(node.kind === 'sleep' || node.kind === 'wait_until') && (
+        <div className="space-y-1.5">
+          <Label>{node.kind === 'sleep' ? 'Duration' : 'Timeout'}</Label>
+          <Input
+            value={String(node.params?.[paramName] ?? '')}
+            placeholder={node.kind === 'sleep' ? 'PT5M' : 'PT30M'}
+            onChange={(event) => updateParam(node, paramName, event.target.value, onChange)}
+          />
+        </div>
+      )}
+      {(node.kind === 'wait_until' || node.kind === 'while') && (
+        <ConditionList
+          conditions={node.conditions ?? []}
+          catalog={catalog}
+          triggerName={triggerName}
+          onChange={(conditions) => onChange({...node, conditions})}
+        />
+      )}
+    </div>
+  )
+}
+
+function RetryFields({
+  node,
+  onChange,
+}: {
+  node: WorkflowGraphNode
+  onChange: (node: WorkflowGraphNode) => void
+}) {
+  const retry = node.retry ?? {
+    max_attempts: 1,
+    initial_interval: 'PT1S',
+    backoff_coefficient: 2,
+    non_retryable_error_types: [],
+  }
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <div className="space-y-1.5">
+        <Label>Attempts</Label>
+        <Input
+          type="number"
+          min={1}
+          value={retry.max_attempts}
+          onChange={(event) => onChange({
+            ...node,
+            retry: {...retry, max_attempts: Number(event.target.value) || 1},
+          })}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label>Backoff</Label>
+        <Input
+          value={retry.initial_interval}
+          onChange={(event) => onChange({...node, retry: {...retry, initial_interval: event.target.value}})}
+        />
+      </div>
+    </div>
+  )
+}
+
+function ConditionList({
+  conditions,
+  catalog,
+  triggerName,
+  onChange,
+}: {
+  conditions: WorkflowConditionConfig[]
+  catalog?: WorkflowCatalogResponse
+  triggerName: string
+  onChange: (conditions: WorkflowConditionConfig[]) => void
+}) {
+  const trigger = catalog?.triggers.find((item) => item.name === triggerName)
+  const firstReference = trigger?.scope[0]
+  const addCondition = () => {
+    if (!firstReference) return
+    const operation = operationsForReference(catalog, firstReference)[0]
+    onChange([...conditions, {reference: firstReference.name, operation: operation?.name ?? 'is_set', value: ''}])
+  }
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label>Conditions</Label>
+        <Button type="button" variant="outline" size="sm" onClick={addCondition}>
+          Add
+        </Button>
+      </div>
+      {conditions.length === 0 ? (
+        <p className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
+          No conditions configured.
+        </p>
+      ) : (
+        conditions.map((condition, index) => (
+          <ConditionRow
+            key={`${condition.reference}-${index}`}
+            condition={condition}
+            catalog={catalog}
+            triggerName={triggerName}
+            onChange={(next) => onChange(conditions.map((item, itemIndex) => (itemIndex === index ? next : item)))}
+            onRemove={() => onChange(conditions.filter((_, itemIndex) => itemIndex !== index))}
+          />
+        ))
+      )}
+    </div>
+  )
+}
+
+function ConditionRow({
+  condition,
+  catalog,
+  triggerName,
+  onChange,
+  onRemove,
+}: {
+  condition: WorkflowConditionConfig
+  catalog?: WorkflowCatalogResponse
+  triggerName: string
+  onChange: (condition: WorkflowConditionConfig) => void
+  onRemove: () => void
+}) {
+  const trigger = catalog?.triggers.find((item) => item.name === triggerName)
+  const reference = trigger?.scope.find((item) => item.name === condition.reference)
+  const operations = operationsForReference(catalog, reference)
+  return (
+    <div className="grid gap-2 rounded-md border bg-background p-2">
+      <Select value={condition.reference} onValueChange={(value) => onChange({...condition, reference: value})}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {trigger?.scope.map((scopeReference) => (
+            <SelectItem key={scopeReference.name} value={scopeReference.name}>
+              {scopeReference.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={condition.operation} onValueChange={(operation) => onChange({...condition, operation})}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {operations.map((operation) => (
+            <SelectItem key={operation.name} value={operation.name}>
+              {operation.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {condition.operation !== 'is_set' && condition.operation !== 'is_not_set' && (
+        <Input value={condition.value ?? ''} onChange={(event) => onChange({...condition, value: event.target.value})} />
+      )}
+      <Button type="button" variant="ghost" size="sm" onClick={onRemove} className="justify-start text-destructive">
+        <Trash2 className="mr-2 h-4 w-4" />
+        Remove
+      </Button>
+    </div>
+  )
+}
+
+function updateParam(
+  node: WorkflowGraphNode,
+  name: string,
+  value: string,
+  onChange: (node: WorkflowGraphNode) => void
+) {
+  onChange({...node, params: {...node.params, [name]: value}})
+}
+
+function operationsForReference(
+  catalog: WorkflowCatalogResponse | undefined,
+  reference: WorkflowScopeReferenceDefinition | undefined
+): WorkflowOperationDefinition[] {
+  const resource = catalog?.resources.find((item) => item.type === reference?.type)
+  return resource?.operations ?? []
+}

--- a/dashboard/src/components/workflows/NodeConfigPanel.tsx
+++ b/dashboard/src/components/workflows/NodeConfigPanel.tsx
@@ -21,6 +21,7 @@ import type {
   WorkflowGraphNode,
   WorkflowOperationDefinition,
   WorkflowScopeReferenceDefinition,
+  WorkflowSwitchCaseConfig,
 } from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
@@ -37,6 +38,9 @@ interface NodeConfigPanelProps {
   onChange: (node: WorkflowGraphNode) => void
   onRemove: (nodeId: string) => void
 }
+
+type ConditionKind = 'if' | 'switch'
+type ControlKind = 'sleep' | 'wait_until' | 'for_each' | 'while'
 
 export function NodeConfigPanel({
   node,
@@ -172,9 +176,10 @@ function ConditionFields({
   triggerName: string
   onChange: (node: WorkflowGraphNode) => void
 }) {
+  const conditionKind = node.kind === 'switch' ? 'switch' : 'if'
   return (
     <div className="space-y-3">
-      <Select value={node.kind ?? 'if'} onValueChange={(kind) => onChange({...node, kind})}>
+      <Select value={conditionKind} onValueChange={(kind) => onChange(nodeForConditionKind(node, kind))}>
         <SelectTrigger>
           <SelectValue />
         </SelectTrigger>
@@ -183,12 +188,21 @@ function ConditionFields({
           <SelectItem value="switch">Switch</SelectItem>
         </SelectContent>
       </Select>
-      <ConditionList
-        conditions={node.conditions ?? []}
-        catalog={catalog}
-        triggerName={triggerName}
-        onChange={(conditions) => onChange({...node, conditions})}
-      />
+      {conditionKind === 'switch' ? (
+        <SwitchCaseList
+          cases={node.cases ?? []}
+          catalog={catalog}
+          triggerName={triggerName}
+          onChange={(cases) => onChange({...node, cases})}
+        />
+      ) : (
+        <ConditionList
+          conditions={node.conditions ?? []}
+          catalog={catalog}
+          triggerName={triggerName}
+          onChange={(conditions) => onChange({...node, conditions})}
+        />
+      )}
     </div>
   )
 }
@@ -205,11 +219,12 @@ function ControlFields({
   onChange: (node: WorkflowGraphNode) => void
 }) {
   const paramName = node.kind === 'sleep' ? 'duration' : 'timeout'
+  const controlKind = controlKindFor(node.kind)
   return (
     <div className="space-y-3">
       <div className="space-y-1.5">
         <Label>Control</Label>
-        <Select value={node.kind ?? 'sleep'} onValueChange={(kind) => onChange({...node, kind})}>
+        <Select value={controlKind} onValueChange={(kind) => onChange(nodeForControlKind(node, kind))}>
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
@@ -231,6 +246,34 @@ function ControlFields({
           />
         </div>
       )}
+      {node.kind === 'for_each' && (
+        <div className="grid gap-2">
+          <div className="space-y-1.5">
+            <Label>Items reference</Label>
+            <Input
+              value={String(node.params?.items_reference ?? '')}
+              placeholder="alert.items"
+              onChange={(event) => updateParam(node, 'items_reference', event.target.value, onChange)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Item variable</Label>
+            <Input
+              value={String(node.params?.item_variable ?? 'item')}
+              onChange={(event) => updateParam(node, 'item_variable', event.target.value, onChange)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Max items</Label>
+            <Input
+              type="number"
+              min={1}
+              value={String(node.params?.max_items ?? '100')}
+              onChange={(event) => updateParam(node, 'max_items', event.target.value, onChange)}
+            />
+          </div>
+        </div>
+      )}
       {(node.kind === 'wait_until' || node.kind === 'while') && (
         <ConditionList
           conditions={node.conditions ?? []}
@@ -238,6 +281,78 @@ function ControlFields({
           triggerName={triggerName}
           onChange={(conditions) => onChange({...node, conditions})}
         />
+      )}
+    </div>
+  )
+}
+
+function SwitchCaseList({
+  cases,
+  catalog,
+  triggerName,
+  onChange,
+}: {
+  cases: WorkflowSwitchCaseConfig[]
+  catalog?: WorkflowCatalogResponse
+  triggerName: string
+  onChange: (cases: WorkflowSwitchCaseConfig[]) => void
+}) {
+  const addCase = () => {
+    const nextNumber = cases.length + 1
+    onChange([...cases, defaultSwitchCase(nextNumber)])
+  }
+  const updateCase = (index: number, nextCase: WorkflowSwitchCaseConfig) => {
+    onChange(cases.map((item, itemIndex) => (itemIndex === index ? nextCase : item)))
+  }
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label>Cases</Label>
+        <Button type="button" variant="outline" size="sm" onClick={addCase}>
+          Add
+        </Button>
+      </div>
+      {cases.length === 0 ? (
+        <p className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
+          No switch cases configured.
+        </p>
+      ) : (
+        cases.map((switchCase, index) => (
+          <div key={`${switchCase.name}-${index}`} className="grid gap-2 rounded-md border bg-background p-2">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label>Branch key</Label>
+                <Input
+                  value={switchCase.name}
+                  onChange={(event) => updateCase(index, {...switchCase, name: event.target.value})}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Label</Label>
+                <Input
+                  value={switchCase.label ?? ''}
+                  onChange={(event) => updateCase(index, {...switchCase, label: event.target.value})}
+                />
+              </div>
+            </div>
+            <ConditionList
+              conditions={switchCase.conditions ?? []}
+              catalog={catalog}
+              triggerName={triggerName}
+              onChange={(conditions) => updateCase(index, {...switchCase, conditions})}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onChange(cases.filter((_, itemIndex) => itemIndex !== index))}
+              className="justify-start text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Remove case
+            </Button>
+          </div>
+        ))
       )}
     </div>
   )
@@ -345,7 +460,14 @@ function ConditionRow({
   const operations = operationsForReference(catalog, reference)
   return (
     <div className="grid gap-2 rounded-md border bg-background p-2">
-      <Select value={condition.reference} onValueChange={(value) => onChange({...condition, reference: value})}>
+      <Select
+        value={condition.reference}
+        onValueChange={(value) => {
+          const nextReference = trigger?.scope.find((item) => item.name === value)
+          const operation = operationsForReference(catalog, nextReference)[0]?.name ?? 'is_set'
+          onChange({...condition, reference: value, operation, value: ''})
+        }}
+      >
         <SelectTrigger>
           <SelectValue />
         </SelectTrigger>
@@ -387,6 +509,61 @@ function updateParam(
   onChange: (node: WorkflowGraphNode) => void
 ) {
   onChange({...node, params: {...node.params, [name]: value}})
+}
+
+function nodeForConditionKind(
+  node: WorkflowGraphNode,
+  kind: string
+): WorkflowGraphNode {
+  const nextKind: ConditionKind = kind === 'switch' ? 'switch' : 'if'
+  if (nextKind === 'switch') {
+    const cases = node.cases?.length ? node.cases : [defaultSwitchCase(1, node.conditions ?? [])]
+    return {...node, kind: nextKind, conditions: [], cases}
+  }
+  return {...node, kind: nextKind, cases: []}
+}
+
+function nodeForControlKind(
+  node: WorkflowGraphNode,
+  kind: string
+): WorkflowGraphNode {
+  const nextKind = controlKindFor(kind)
+  if (nextKind === 'sleep') {
+    return {...node, kind: nextKind, params: {...node.params, duration: String(node.params?.duration ?? 'PT5M')}}
+  }
+  if (nextKind === 'wait_until') {
+    return {...node, kind: nextKind, params: {...node.params, timeout: String(node.params?.timeout ?? 'PT30M')}}
+  }
+  if (nextKind === 'for_each') {
+    return {
+      ...node,
+      kind: nextKind,
+      params: {
+        ...node.params,
+        items_reference: String(node.params?.items_reference ?? ''),
+        item_variable: String(node.params?.item_variable ?? 'item'),
+        max_items: String(node.params?.max_items ?? '100'),
+      },
+      conditions: [],
+    }
+  }
+  return {
+    ...node,
+    kind: nextKind,
+    params: {...node.params, max_iterations: String(node.params?.max_iterations ?? '100')},
+  }
+}
+
+function controlKindFor(kind: string | null | undefined): ControlKind {
+  if (kind === 'wait_until' || kind === 'for_each' || kind === 'while') return kind
+  return 'sleep'
+}
+
+function defaultSwitchCase(
+  nextNumber: number,
+  conditions: WorkflowConditionConfig[] = []
+): WorkflowSwitchCaseConfig {
+  return {name: `case-${nextNumber}`, label: `Case ${nextNumber}`, conditions}
 }
 
 function operationsForReference(

--- a/dashboard/src/components/workflows/NodePalette.tsx
+++ b/dashboard/src/components/workflows/NodePalette.tsx
@@ -1,0 +1,122 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {ReactNode} from 'react'
+import {Bell, GitBranch, Hourglass, Mail, MessageSquare, Plus} from 'lucide-react'
+import type {WorkflowCatalogResponse, WorkflowGraphNode} from '@/lib/api'
+import {Button} from '@/components/ui/button'
+import {defaultParamsForStep} from './workflowGraph'
+
+interface NodePaletteProps {
+  catalog?: WorkflowCatalogResponse
+  onAddNode: (node: Omit<WorkflowGraphNode, 'id'>, prefix: string) => void
+}
+
+export function NodePalette({catalog, onAddNode}: NodePaletteProps) {
+  return (
+    <div className="space-y-3 rounded-md border bg-muted/20 p-3">
+      <div>
+        <h3 className="text-sm font-semibold">Node palette</h3>
+        <p className="text-xs text-muted-foreground">Add branches, waits, and notification actions.</p>
+      </div>
+      <div className="grid gap-2">
+        <PaletteButton
+          icon={<GitBranch className="h-4 w-4" />}
+          label="If / else"
+          onClick={() => onAddNode(conditionNode('if'), 'condition')}
+        />
+        <PaletteButton
+          icon={<GitBranch className="h-4 w-4" />}
+          label="Switch"
+          onClick={() => onAddNode(conditionNode('switch'), 'switch')}
+        />
+        <PaletteButton
+          icon={<Hourglass className="h-4 w-4" />}
+          label="Sleep"
+          onClick={() => onAddNode(controlNode('sleep'), 'sleep')}
+        />
+        <PaletteButton
+          icon={<Hourglass className="h-4 w-4" />}
+          label="Wait until"
+          onClick={() => onAddNode(controlNode('wait_until'), 'wait')}
+        />
+      </div>
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase text-muted-foreground">Actions</p>
+        {catalog?.steps.map((step) => (
+          <PaletteButton
+            key={step.name}
+            icon={stepIcon(step.name)}
+            label={step.label}
+            onClick={() => onAddNode({
+              type: 'action',
+              action: step.name,
+              params: defaultParamsForStep(step),
+              conditions: [],
+              cases: [],
+              continue_on_error: false,
+            }, 'action')}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function PaletteButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <Button type="button" variant="outline" size="sm" onClick={onClick} className="h-9 justify-start gap-2">
+      {icon}
+      <span className="truncate">{label}</span>
+      <Plus className="ml-auto h-3.5 w-3.5" />
+    </Button>
+  )
+}
+
+function conditionNode(kind: 'if' | 'switch'): Omit<WorkflowGraphNode, 'id'> {
+  return {
+    type: 'condition',
+    kind,
+    params: {},
+    conditions: [],
+    cases: kind === 'switch' ? [{name: 'case-1', label: 'Case 1', conditions: []}] : [],
+  }
+}
+
+function controlNode(kind: 'sleep' | 'wait_until'): Omit<WorkflowGraphNode, 'id'> {
+  return {
+    type: 'control',
+    kind,
+    params: kind === 'sleep' ? {duration: 'PT5M'} : {timeout: 'PT30M'},
+    conditions: [],
+    cases: [],
+  }
+}
+
+function stepIcon(stepName: string) {
+  const className = 'h-4 w-4'
+  if (stepName.includes('email')) return <Mail className={className} />
+  if (stepName.includes('discord')) return <Bell className={className} />
+  return <MessageSquare className={className} />
+}

--- a/dashboard/src/components/workflows/NodePalette.tsx
+++ b/dashboard/src/components/workflows/NodePalette.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import type {ReactNode} from 'react'
-import {Bell, GitBranch, Hourglass, Mail, MessageSquare, Plus} from 'lucide-react'
+import {Bell, GitBranch, Hourglass, Mail, MessageSquare, Plus, Slack} from 'lucide-react'
 import type {WorkflowCatalogResponse, WorkflowGraphNode} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {defaultParamsForStep} from './workflowGraph'
@@ -24,6 +24,8 @@ interface NodePaletteProps {
   catalog?: WorkflowCatalogResponse
   onAddNode: (node: Omit<WorkflowGraphNode, 'id'>, prefix: string) => void
 }
+
+type ControlKind = 'sleep' | 'wait_until' | 'for_each' | 'while'
 
 export function NodePalette({catalog, onAddNode}: NodePaletteProps) {
   return (
@@ -52,6 +54,16 @@ export function NodePalette({catalog, onAddNode}: NodePaletteProps) {
           icon={<Hourglass className="h-4 w-4" />}
           label="Wait until"
           onClick={() => onAddNode(controlNode('wait_until'), 'wait')}
+        />
+        <PaletteButton
+          icon={<Hourglass className="h-4 w-4" />}
+          label="For each"
+          onClick={() => onAddNode(controlNode('for_each'), 'loop')}
+        />
+        <PaletteButton
+          icon={<Hourglass className="h-4 w-4" />}
+          label="While"
+          onClick={() => onAddNode(controlNode('while'), 'while')}
         />
       </div>
       <div className="space-y-2">
@@ -104,19 +116,27 @@ function conditionNode(kind: 'if' | 'switch'): Omit<WorkflowGraphNode, 'id'> {
   }
 }
 
-function controlNode(kind: 'sleep' | 'wait_until'): Omit<WorkflowGraphNode, 'id'> {
+function controlNode(kind: ControlKind): Omit<WorkflowGraphNode, 'id'> {
   return {
     type: 'control',
     kind,
-    params: kind === 'sleep' ? {duration: 'PT5M'} : {timeout: 'PT30M'},
+    params: controlParams(kind),
     conditions: [],
     cases: [],
   }
 }
 
+function controlParams(kind: ControlKind): Record<string, string> {
+  if (kind === 'sleep') return {duration: 'PT5M'}
+  if (kind === 'wait_until') return {timeout: 'PT30M'}
+  if (kind === 'for_each') return {items_reference: '', item_variable: 'item', max_items: '100'}
+  return {max_iterations: '100'}
+}
+
 function stepIcon(stepName: string) {
   const className = 'h-4 w-4'
   if (stepName.includes('email')) return <Mail className={className} />
+  if (stepName.includes('slack')) return <Slack className={className} />
   if (stepName.includes('discord')) return <Bell className={className} />
   return <MessageSquare className={className} />
 }

--- a/dashboard/src/components/workflows/WorkflowCanvas.tsx
+++ b/dashboard/src/components/workflows/WorkflowCanvas.tsx
@@ -88,6 +88,7 @@ function WorkflowCanvasNode({data}: {data: CanvasNodeData}) {
   const node = data.graphNode
   const label = nodeLabel(node, data.catalog)
   const subtitle = nodeSubtitle(node)
+  const handles = sourceHandlesForNode(node)
   return (
     <div
       className={cn(
@@ -109,6 +110,16 @@ function WorkflowCanvasNode({data}: {data: CanvasNodeData}) {
         </div>
       </div>
       <Handle className="!h-2 !w-2 !border-border !bg-background" type="source" position={Position.Bottom} />
+      {handles.map((handle, index) => (
+        <Handle
+          key={handle}
+          id={handle}
+          className="!h-2 !w-2 !border-border !bg-background"
+          type="source"
+          position={Position.Right}
+          style={{top: `${branchHandleOffset(index, handles.length)}%`}}
+        />
+      ))}
     </div>
   )
 }
@@ -153,6 +164,7 @@ function graphToFlow(
     id: edgeId(edge, index),
     source: edge.from,
     target: edge.to,
+    sourceHandle: edge.branch ?? undefined,
     label: edge.on === 'error' ? 'error' : edge.branch,
     animated: edge.on === 'error',
     className: edge.on === 'error' ? 'stroke-destructive' : undefined,
@@ -180,6 +192,24 @@ function edgeId(
   index: number
 ): string {
   return `${edge.from}-${edge.to}-${edge.branch ?? edge.on ?? index}`
+}
+
+function sourceHandlesForNode(node: WorkflowGraphNode): string[] {
+  if (node.type === 'condition' && node.kind === 'switch') {
+    return [...(node.cases ?? []).map((item) => item.name).filter(Boolean), 'default']
+  }
+  if (node.type === 'condition') return ['true', 'false']
+  if (node.type === 'control' && node.kind === 'wait_until') return ['true', 'timeout']
+  if (node.type === 'control' && (node.kind === 'for_each' || node.kind === 'while')) return ['body', 'done']
+  return []
+}
+
+function branchHandleOffset(
+  index: number,
+  count: number
+): number {
+  if (count <= 1) return 50
+  return 24 + (index * 52) / (count - 1)
 }
 
 const nodeTypes = {

--- a/dashboard/src/components/workflows/WorkflowCanvas.tsx
+++ b/dashboard/src/components/workflows/WorkflowCanvas.tsx
@@ -1,0 +1,187 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useMemo} from 'react'
+import {Background, Controls, Handle, Position, ReactFlow, type Connection, type Edge, type Node} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import dagre from '@dagrejs/dagre'
+import {GitBranch, Mail, MessageSquare, Timer, Workflow} from 'lucide-react'
+import type {WorkflowCatalogResponse, WorkflowGraphConfig, WorkflowGraphEdge, WorkflowGraphNode} from '@/lib/api'
+import {Badge} from '@/components/ui/badge'
+import {cn} from '@/lib/utils'
+import {nodeLabel} from './workflowGraph'
+
+const nodeWidth = 220
+const nodeHeight = 78
+
+interface WorkflowCanvasProps {
+  graph: WorkflowGraphConfig
+  catalog?: WorkflowCatalogResponse
+  selectedNodeId: string | null
+  onSelectNode: (nodeId: string | null) => void
+  onGraphChange: (graph: WorkflowGraphConfig) => void
+}
+
+interface CanvasNodeData extends Record<string, unknown> {
+  graphNode: WorkflowGraphNode
+  catalog?: WorkflowCatalogResponse
+  selected: boolean
+}
+
+export function WorkflowCanvas({
+  graph,
+  catalog,
+  selectedNodeId,
+  onSelectNode,
+  onGraphChange,
+}: WorkflowCanvasProps) {
+  const flow = useMemo(() => graphToFlow(graph, catalog, selectedNodeId), [catalog, graph, selectedNodeId])
+
+  const handleConnect = (connection: Connection) => {
+    if (!connection.source || !connection.target) return
+    onGraphChange({
+      ...graph,
+      edges: [
+        ...graph.edges,
+        {
+          from: connection.source,
+          to: connection.target,
+          branch: connection.sourceHandle ?? undefined,
+        },
+      ],
+    })
+  }
+
+  return (
+    <div className="h-[560px] min-h-[420px] overflow-hidden rounded-md border bg-background">
+      <ReactFlow
+        nodes={flow.nodes}
+        edges={flow.edges}
+        nodeTypes={nodeTypes}
+        fitView
+        nodesDraggable
+        onConnect={handleConnect}
+        onNodeClick={(_, node) => onSelectNode(node.id)}
+        onPaneClick={() => onSelectNode(null)}
+      >
+        <Background gap={20} />
+        <Controls />
+      </ReactFlow>
+    </div>
+  )
+}
+
+function WorkflowCanvasNode({data}: {data: CanvasNodeData}) {
+  const node = data.graphNode
+  const label = nodeLabel(node, data.catalog)
+  const subtitle = nodeSubtitle(node)
+  return (
+    <div
+      className={cn(
+        'relative w-[220px] rounded-md border bg-card px-3 py-2 text-card-foreground shadow-sm',
+        data.selected && 'border-primary ring-2 ring-primary/20'
+      )}
+    >
+      <Handle className="!h-2 !w-2 !border-border !bg-background" type="target" position={Position.Top} />
+      <div className="flex items-start gap-2">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted/40">
+          <NodeIcon node={node} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="truncate text-sm font-semibold">{label}</p>
+            {node.type === 'trigger' && <Badge className="shrink-0 text-[10px]">Start</Badge>}
+          </div>
+          <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{subtitle}</p>
+        </div>
+      </div>
+      <Handle className="!h-2 !w-2 !border-border !bg-background" type="source" position={Position.Bottom} />
+    </div>
+  )
+}
+
+function NodeIcon({node}: {node: WorkflowGraphNode}) {
+  const className = 'h-4 w-4 text-muted-foreground'
+  if (node.type === 'trigger') return <Workflow className={className} />
+  if (node.type === 'condition') return <GitBranch className={className} />
+  if (node.type === 'control') return <Timer className={className} />
+  if (node.action?.includes('email')) return <Mail className={className} />
+  return <MessageSquare className={className} />
+}
+
+function nodeSubtitle(node: WorkflowGraphNode): string {
+  if (node.type === 'condition') {
+    const count = node.kind === 'switch' ? node.cases?.length ?? 0 : node.conditions?.length ?? 0
+    return count === 0 ? 'No condition configured' : `${count} condition${count === 1 ? '' : 's'}`
+  }
+  if (node.type === 'control') {
+    return String(node.params?.duration ?? node.params?.timeout ?? node.kind ?? 'Control flow')
+  }
+  if (node.type === 'action') {
+    const values = Object.values(node.params ?? {}).map((value) => String(value)).filter(Boolean)
+    return values[0] ?? 'Configure action parameters'
+  }
+  return node.trigger ?? 'Telemetry trigger'
+}
+
+function graphToFlow(
+  graph: WorkflowGraphConfig,
+  catalog: WorkflowCatalogResponse | undefined,
+  selectedNodeId: string | null
+): {nodes: Node<CanvasNodeData>[]; edges: Edge[]} {
+  const layout = layoutGraph(graph)
+  const nodes = graph.nodes.map((node) => ({
+    id: node.id,
+    type: 'workflowNode',
+    position: layout.get(node.id) ?? {x: 0, y: 0},
+    data: {graphNode: node, catalog, selected: node.id === selectedNodeId},
+  }))
+  const edges = graph.edges.map((edge, index) => ({
+    id: edgeId(edge, index),
+    source: edge.from,
+    target: edge.to,
+    label: edge.on === 'error' ? 'error' : edge.branch,
+    animated: edge.on === 'error',
+    className: edge.on === 'error' ? 'stroke-destructive' : undefined,
+  }))
+  return {nodes, edges}
+}
+
+function layoutGraph(graph: WorkflowGraphConfig): Map<string, {x: number; y: number}> {
+  const dagreGraph = new dagre.graphlib.Graph()
+  dagreGraph.setDefaultEdgeLabel(() => ({}))
+  dagreGraph.setGraph({rankdir: 'TB', ranksep: 80, nodesep: 80})
+  graph.nodes.forEach((node) => dagreGraph.setNode(node.id, {width: nodeWidth, height: nodeHeight}))
+  graph.edges.forEach((edge) => dagreGraph.setEdge(edge.from, edge.to))
+  dagre.layout(dagreGraph)
+  return new Map(
+    graph.nodes.map((node) => {
+      const position = dagreGraph.node(node.id)
+      return [node.id, {x: position.x - nodeWidth / 2, y: position.y - nodeHeight / 2}]
+    })
+  )
+}
+
+function edgeId(
+  edge: WorkflowGraphEdge,
+  index: number
+): string {
+  return `${edge.from}-${edge.to}-${edge.branch ?? edge.on ?? index}`
+}
+
+const nodeTypes = {
+  workflowNode: WorkflowCanvasNode,
+}

--- a/dashboard/src/components/workflows/WorkflowPanels.tsx
+++ b/dashboard/src/components/workflows/WorkflowPanels.tsx
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {Bug, CheckCircle2, ExternalLink, Loader2, PauseCircle, PlayCircle, XCircle} from 'lucide-react'
+import {Bug, CheckCircle2, Loader2, PauseCircle, PlayCircle, XCircle} from 'lucide-react'
 import type {WorkflowRunResponse} from '@/lib/api'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Sheet, SheetContent, SheetHeader, SheetTitle} from '@/components/ui/sheet'
-import type {WorkflowValidationIssue} from './workflowGraph'
+import {formatDate, type WorkflowValidationIssue} from './workflowGraph'
 
 interface PublishToggleProps {
   published: boolean
@@ -66,8 +66,8 @@ export function ValidationPanel({issues}: {issues: WorkflowValidationIssue[]}) {
         <p className="text-sm text-muted-foreground">Ready to save or publish.</p>
       ) : (
         <div className="space-y-1.5">
-          {issues.map((issue) => (
-            <div key={issue.message} className="flex items-start gap-2 text-sm">
+          {issues.map((issue, index) => (
+            <div key={`${issue.level}-${index}`} className="flex items-start gap-2 text-sm">
               <Badge variant={issue.level === 'error' ? 'destructive' : 'secondary'} className="mt-0.5">
                 {issue.level}
               </Badge>
@@ -83,12 +83,10 @@ export function ValidationPanel({issues}: {issues: WorkflowValidationIssue[]}) {
 export function RunDebugDrawer({
   run,
   open,
-  showTemporalLink,
   onOpenChange,
 }: {
   run: WorkflowRunResponse | null
   open: boolean
-  showTemporalLink: boolean
   onOpenChange: (open: boolean) => void
 }) {
   return (
@@ -107,12 +105,6 @@ export function RunDebugDrawer({
                 <span className="text-xs text-muted-foreground">{formatDate(run.created_at)}</span>
               </div>
               {run.error_message && <p className="mt-2 text-sm text-destructive">{run.error_message}</p>}
-              {showTemporalLink && (
-                <Button type="button" variant="outline" size="sm" className="mt-3 gap-1.5">
-                  <ExternalLink className="h-3.5 w-3.5" />
-                  Open in Temporal
-                </Button>
-              )}
             </div>
             <div className="space-y-2">
               {run.steps.length === 0 ? (
@@ -142,9 +134,4 @@ export function RunDebugDrawer({
       </SheetContent>
     </Sheet>
   )
-}
-
-function formatDate(value?: string | null): string {
-  if (!value) return 'Never'
-  return new Date(value).toLocaleString()
 }

--- a/dashboard/src/components/workflows/WorkflowPanels.tsx
+++ b/dashboard/src/components/workflows/WorkflowPanels.tsx
@@ -1,0 +1,150 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {Bug, CheckCircle2, ExternalLink, Loader2, PauseCircle, PlayCircle, XCircle} from 'lucide-react'
+import type {WorkflowRunResponse} from '@/lib/api'
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {Sheet, SheetContent, SheetHeader, SheetTitle} from '@/components/ui/sheet'
+import type {WorkflowValidationIssue} from './workflowGraph'
+
+interface PublishToggleProps {
+  published: boolean
+  pending: boolean
+  onPublish: () => void
+  onUnpublish: () => void
+}
+
+export function PublishToggle({published, pending, onPublish, onUnpublish}: PublishToggleProps) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={published ? 'outline' : 'default'}
+      disabled={pending}
+      onClick={published ? onUnpublish : onPublish}
+      className="gap-1.5"
+    >
+      {pending ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : published ? (
+        <PauseCircle className="h-3.5 w-3.5" />
+      ) : (
+        <PlayCircle className="h-3.5 w-3.5" />
+      )}
+      {published ? 'Unpublish' : 'Publish'}
+    </Button>
+  )
+}
+
+export function ValidationPanel({issues}: {issues: WorkflowValidationIssue[]}) {
+  const errors = issues.filter((issue) => issue.level === 'error')
+  return (
+    <div className="rounded-md border bg-muted/20 p-3">
+      <div className="mb-2 flex items-center gap-2">
+        {errors.length === 0 ? (
+          <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+        ) : (
+          <XCircle className="h-4 w-4 text-destructive" />
+        )}
+        <h3 className="text-sm font-semibold">Validation</h3>
+      </div>
+      {issues.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Ready to save or publish.</p>
+      ) : (
+        <div className="space-y-1.5">
+          {issues.map((issue) => (
+            <div key={issue.message} className="flex items-start gap-2 text-sm">
+              <Badge variant={issue.level === 'error' ? 'destructive' : 'secondary'} className="mt-0.5">
+                {issue.level}
+              </Badge>
+              <span className="text-muted-foreground">{issue.message}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function RunDebugDrawer({
+  run,
+  open,
+  showTemporalLink,
+  onOpenChange,
+}: {
+  run: WorkflowRunResponse | null
+  open: boolean
+  showTemporalLink: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Run debug</SheetTitle>
+        </SheetHeader>
+        {!run ? (
+          <p className="mt-4 text-sm text-muted-foreground">Select a run to inspect node status.</p>
+        ) : (
+          <div className="mt-4 space-y-3">
+            <div className="rounded-md border p-3">
+              <div className="flex items-center justify-between gap-2">
+                <Badge variant="outline">{run.status}</Badge>
+                <span className="text-xs text-muted-foreground">{formatDate(run.created_at)}</span>
+              </div>
+              {run.error_message && <p className="mt-2 text-sm text-destructive">{run.error_message}</p>}
+              {showTemporalLink && (
+                <Button type="button" variant="outline" size="sm" className="mt-3 gap-1.5">
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Open in Temporal
+                </Button>
+              )}
+            </div>
+            <div className="space-y-2">
+              {run.steps.length === 0 ? (
+                <p className="rounded-md border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+                  Node-level debug entries have not been recorded for this run.
+                </p>
+              ) : (
+                run.steps.map((step) => (
+                  <div key={step.id} className="rounded-md border p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <Bug className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <p className="truncate text-sm font-medium">{step.node_id}</p>
+                      </div>
+                      <Badge variant="outline">{step.status}</Badge>
+                    </div>
+                    {step.error_message && <p className="mt-2 text-sm text-destructive">{step.error_message}</p>}
+                    <pre className="mt-2 max-h-40 overflow-auto rounded bg-muted/40 p-2 text-[11px]">
+                      {JSON.stringify(step.output, null, 2)}
+                    </pre>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return 'Never'
+  return new Date(value).toLocaleString()
+}

--- a/dashboard/src/components/workflows/workflowGraph.ts
+++ b/dashboard/src/components/workflows/workflowGraph.ts
@@ -1,0 +1,306 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  WorkflowCatalogResponse,
+  WorkflowConditionConfig,
+  WorkflowGraphConfig,
+  WorkflowGraphEdge,
+  WorkflowGraphNode,
+  WorkflowRequest,
+  WorkflowResponse,
+  WorkflowStepConfig,
+  WorkflowStepDefinition,
+} from '@/lib/api'
+
+export const triggerNodeId = 'trigger'
+const legacyConditionNodeId = 'conditions'
+
+export interface WorkflowDraft {
+  id?: number
+  name: string
+  triggerName: string
+  enabled: boolean
+  published: boolean
+  graph: WorkflowGraphConfig
+  onceForTemplate: string
+}
+
+export interface WorkflowValidationIssue {
+  level: 'error' | 'warning'
+  message: string
+}
+
+export function emptyWorkflowDraft(catalog?: WorkflowCatalogResponse): WorkflowDraft {
+  const trigger = catalog?.triggers[0]
+  return {
+    name: '',
+    triggerName: trigger?.name ?? 'alert.triggered',
+    enabled: true,
+    published: false,
+    graph: graphFromLegacy(trigger?.name ?? 'alert.triggered', [], []),
+    onceForTemplate: trigger?.default_once_for_template.join(', ') ?? 'alert.deduplication_key',
+  }
+}
+
+export function draftFromWorkflow(workflow: WorkflowResponse): WorkflowDraft {
+  return {
+    id: workflow.id,
+    name: workflow.name,
+    triggerName: workflow.trigger_name,
+    enabled: workflow.enabled,
+    published: workflow.published,
+    graph: normalizeGraph(workflow),
+    onceForTemplate: workflow.once_for_template.join(', '),
+  }
+}
+
+export function draftToRequest(draft: WorkflowDraft): WorkflowRequest {
+  return {
+    name: draft.name.trim(),
+    trigger_name: draft.triggerName,
+    enabled: draft.enabled,
+    conditions: legacyConditionsFromGraph(draft.graph),
+    steps: stepsFromGraph(draft.graph),
+    graph: draft.graph,
+    once_for_template: splitReferences(draft.onceForTemplate),
+  }
+}
+
+export function normalizeGraph(workflow: WorkflowResponse): WorkflowGraphConfig {
+  if (workflow.graph.nodes.length > 0) return withDefaults(workflow.graph)
+  return graphFromLegacy(workflow.trigger_name, workflow.conditions, workflow.steps)
+}
+
+export function graphFromLegacy(
+  triggerName: string,
+  conditions: WorkflowConditionConfig[],
+  steps: WorkflowStepConfig[]
+): WorkflowGraphConfig {
+  const nodes: WorkflowGraphNode[] = [{
+    id: triggerNodeId,
+    type: 'trigger',
+    trigger: triggerName,
+    params: {},
+    conditions: [],
+    cases: [],
+  }]
+  if (conditions.length > 0) {
+    nodes.push({
+      id: legacyConditionNodeId,
+      type: 'condition',
+      kind: 'if',
+      params: {},
+      conditions,
+      cases: [],
+    })
+  }
+  steps.forEach((step, index) => {
+    nodes.push({
+      id: `step-${index + 1}`,
+      type: 'action',
+      action: step.name,
+      params: step.params,
+      conditions: [],
+      cases: [],
+      continue_on_error: true,
+    })
+  })
+  return {nodes, edges: legacyEdges(conditions.length > 0, steps.length)}
+}
+
+export function addGraphNode(
+  graph: WorkflowGraphConfig,
+  node: WorkflowGraphNode
+): WorkflowGraphConfig {
+  return {...graph, nodes: [...graph.nodes, withNodeDefaults(node)]}
+}
+
+export function updateGraphNode(
+  graph: WorkflowGraphConfig,
+  node: WorkflowGraphNode
+): WorkflowGraphConfig {
+  return {
+    ...graph,
+    nodes: graph.nodes.map((item) => (item.id === node.id ? withNodeDefaults(node) : item)),
+  }
+}
+
+export function removeGraphNode(
+  graph: WorkflowGraphConfig,
+  nodeId: string
+): WorkflowGraphConfig {
+  if (nodeId === triggerNodeId) return graph
+  return {
+    nodes: graph.nodes.filter((node) => node.id !== nodeId),
+    edges: graph.edges.filter((edge) => edge.from !== nodeId && edge.to !== nodeId),
+  }
+}
+
+export function nextNodeId(graph: WorkflowGraphConfig, prefix: string): string {
+  const used = new Set(graph.nodes.map((node) => node.id))
+  let index = graph.nodes.length + 1
+  while (used.has(`${prefix}-${index}`)) index += 1
+  return `${prefix}-${index}`
+}
+
+export function nodeLabel(
+  node: WorkflowGraphNode,
+  catalog?: WorkflowCatalogResponse
+): string {
+  if (node.type === 'trigger') {
+    return catalog?.triggers.find((trigger) => trigger.name === node.trigger)?.label ?? node.trigger ?? 'Trigger'
+  }
+  if (node.type === 'action') {
+    return stepDefinition(catalog, node.action)?.label ?? node.action ?? 'Action'
+  }
+  if (node.type === 'condition') return node.kind === 'switch' ? 'Switch' : 'If / else'
+  if (node.kind === 'wait_until') return 'Wait until'
+  if (node.kind === 'for_each') return 'For each'
+  if (node.kind === 'while') return 'While'
+  return 'Sleep'
+}
+
+export function stepDefinition(
+  catalog: WorkflowCatalogResponse | undefined,
+  stepName: string | null | undefined
+): WorkflowStepDefinition | undefined {
+  return catalog?.steps.find((step) => step.name === stepName)
+}
+
+export function validateDraft(
+  draft: WorkflowDraft,
+  catalog?: WorkflowCatalogResponse
+): WorkflowValidationIssue[] {
+  const issues: WorkflowValidationIssue[] = []
+  if (draft.name.trim().length === 0) issues.push({level: 'error', message: 'Workflow name is required.'})
+  const triggerNodes = draft.graph.nodes.filter((node) => node.type === 'trigger')
+  if (triggerNodes.length !== 1) issues.push({level: 'error', message: 'Graph must contain exactly one trigger.'})
+  const trigger = catalog?.triggers.find((item) => item.name === draft.triggerName)
+  if (!trigger) issues.push({level: 'error', message: 'Select a valid trigger.'})
+  const actionNodes = draft.graph.nodes.filter((node) => node.type === 'action')
+  if (actionNodes.length === 0) issues.push({level: 'warning', message: 'Add an action before publishing.'})
+  const nodeIds = new Set(draft.graph.nodes.map((node) => node.id))
+  draft.graph.edges.forEach((edge) => {
+    if (!nodeIds.has(edge.from) || !nodeIds.has(edge.to)) {
+      issues.push({level: 'error', message: 'Remove edges connected to missing nodes.'})
+    }
+  })
+  actionNodes.forEach((node) => {
+    const definition = stepDefinition(catalog, node.action)
+    if (!definition) {
+      issues.push({level: 'error', message: `Unknown action ${node.action ?? node.id}.`})
+      return
+    }
+    definition.params.filter((param) => param.required).forEach((param) => {
+      const value = String(node.params?.[param.name] ?? '').trim()
+      if (value.length === 0) {
+        issues.push({level: 'error', message: `${definition.label} is missing ${param.label}.`})
+      }
+    })
+  })
+  return issues
+}
+
+export function splitReferences(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+export function formatDate(value?: string | null): string {
+  if (!value) return 'Never'
+  return new Date(value).toLocaleString()
+}
+
+export function statusClass(status: string): string {
+  if (status === 'complete') return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600'
+  if (status === 'failed') return 'border-red-500/30 bg-red-500/10 text-red-600'
+  if (status === 'running') return 'border-blue-500/30 bg-blue-500/10 text-blue-600'
+  return 'border-amber-500/30 bg-amber-500/10 text-amber-600'
+}
+
+export function defaultParamsForStep(step: WorkflowStepDefinition): Record<string, string> {
+  return Object.fromEntries(step.params.map((param) => [param.name, defaultParamValue(param.name, param.type)]))
+}
+
+export function stepsFromGraph(graph: WorkflowGraphConfig): WorkflowStepConfig[] {
+  return graph.nodes
+    .filter((node) => node.type === 'action' && node.action)
+    .map((node) => ({
+      name: node.action ?? '',
+      params: Object.fromEntries(
+        Object.entries(node.params ?? {}).map(([key, value]) => [key, String(value ?? '')])
+      ),
+    }))
+}
+
+function legacyConditionsFromGraph(graph: WorkflowGraphConfig): WorkflowConditionConfig[] {
+  return graph.nodes.find((node) => node.type === 'condition' && node.kind === 'if')?.conditions ?? []
+}
+
+function legacyEdges(
+  hasConditions: boolean,
+  stepCount: number
+): WorkflowGraphEdge[] {
+  const edges: WorkflowGraphEdge[] = []
+  if (hasConditions) edges.push({from: triggerNodeId, to: legacyConditionNodeId})
+  if (stepCount > 0) {
+    edges.push({
+      from: hasConditions ? legacyConditionNodeId : triggerNodeId,
+      to: 'step-1',
+      branch: hasConditions ? 'true' : undefined,
+    })
+  }
+  for (let index = 1; index < stepCount; index += 1) {
+    edges.push({from: `step-${index}`, to: `step-${index + 1}`})
+  }
+  return edges
+}
+
+function withDefaults(graph: WorkflowGraphConfig): WorkflowGraphConfig {
+  return {
+    nodes: graph.nodes.map(withNodeDefaults),
+    edges: graph.edges,
+  }
+}
+
+function withNodeDefaults(node: WorkflowGraphNode): WorkflowGraphNode {
+  return {
+    ...node,
+    params: node.params ?? {},
+    conditions: node.conditions ?? [],
+    cases: node.cases ?? [],
+    continue_on_error: node.continue_on_error ?? false,
+  }
+}
+
+function defaultParamValue(
+  name: string,
+  type: string
+): string {
+  if (name === 'subject') return 'Moneat workflow: {{alert.title}}'
+  if (name === 'title') return 'Moneat workflow'
+  if (type === 'Number') return '100'
+  return [
+    '{{alert.display_title}}',
+    '',
+    'Priority: {{alert.priority}}',
+    'Source: {{alert.source}}',
+    'View: {{alert.url}}',
+  ].join('\n')
+}

--- a/dashboard/src/lib/api/modules/workflows.ts
+++ b/dashboard/src/lib/api/modules/workflows.ts
@@ -17,6 +17,7 @@
 import type {ApiClientCore} from '../client'
 import type {
   WorkflowCatalogResponse,
+  WorkflowJsonValue,
   WorkflowPreviewRequest,
   WorkflowPreviewResponse,
   WorkflowRequest,
@@ -58,6 +59,22 @@ export function workflowsMethods(core: ApiClientCore) {
       core.request<WorkflowResponse>(`${base}/workflows/${id}`, {
         method: 'PUT',
         body: JSON.stringify(request),
+      }),
+
+    publishWorkflow: (id: number) =>
+      core.request<WorkflowResponse>(`${base}/workflows/${id}/publish`, {
+        method: 'POST',
+      }),
+
+    unpublishWorkflow: (id: number) =>
+      core.request<WorkflowResponse>(`${base}/workflows/${id}/unpublish`, {
+        method: 'POST',
+      }),
+
+    runWorkflow: (id: number, scope: Record<string, WorkflowJsonValue> = {}) =>
+      core.request<WorkflowRunResponse>(`${base}/workflows/${id}/run`, {
+        method: 'POST',
+        body: JSON.stringify({scope}),
       }),
 
     deleteWorkflow: (id: number) =>

--- a/dashboard/src/lib/api/types/workflows.ts
+++ b/dashboard/src/lib/api/types/workflows.ts
@@ -25,10 +25,59 @@ export interface WorkflowStepConfig {
   params: Record<string, string>
 }
 
+export type WorkflowJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | WorkflowJsonValue[]
+  | {[key: string]: WorkflowJsonValue}
+
+export interface WorkflowRetryConfig {
+  max_attempts: number
+  initial_interval: string
+  backoff_coefficient: number
+  maximum_interval?: string | null
+  non_retryable_error_types: string[]
+}
+
+export interface WorkflowSwitchCaseConfig {
+  name: string
+  label?: string | null
+  conditions: WorkflowConditionConfig[]
+}
+
+export interface WorkflowGraphNode {
+  id: string
+  type: 'trigger' | 'condition' | 'action' | 'control'
+  trigger?: string | null
+  kind?: string | null
+  action?: string | null
+  params?: Record<string, WorkflowJsonValue>
+  conditions?: WorkflowConditionConfig[]
+  cases?: WorkflowSwitchCaseConfig[]
+  retry?: WorkflowRetryConfig | null
+  continue_on_error?: boolean
+}
+
+export interface WorkflowGraphEdge {
+  from: string
+  to: string
+  branch?: string | null
+  on?: string | null
+}
+
+export interface WorkflowGraphConfig {
+  nodes: WorkflowGraphNode[]
+  edges: WorkflowGraphEdge[]
+}
+
 export interface WorkflowPreviewRequest {
   trigger_name: string
-  steps: WorkflowStepConfig[]
-  scope?: Record<string, string>
+  steps?: WorkflowStepConfig[]
+  scope?: Record<string, WorkflowJsonValue>
+  graph?: WorkflowGraphConfig | null
+  node_id?: string | null
 }
 
 export interface WorkflowPreviewField {
@@ -75,6 +124,7 @@ export interface WorkflowRequest {
   enabled: boolean
   conditions: WorkflowConditionConfig[]
   steps: WorkflowStepConfig[]
+  graph?: WorkflowGraphConfig | null
   once_for_template: string[]
 }
 
@@ -86,9 +136,11 @@ export interface WorkflowResponse {
   trigger_name: string
   enabled: boolean
   version: number
+  published: boolean
   system_key?: string | null
   conditions: WorkflowConditionConfig[]
   steps: WorkflowStepConfig[]
+  graph: WorkflowGraphConfig
   once_for_template: string[]
   created_at: string
   updated_at: string
@@ -99,8 +151,25 @@ export interface WorkflowResponse {
 export interface WorkflowRunStepProgress {
   step: string
   status: string
+  node_id?: string | null
+  type?: string | null
   completed_at?: string | null
+  output: Record<string, WorkflowJsonValue>
   error_message?: string | null
+}
+
+export interface WorkflowRunStepResponse {
+  id: number
+  run_id: number
+  node_id: string
+  type: string
+  status: string
+  started_at?: string | null
+  completed_at?: string | null
+  input: Record<string, WorkflowJsonValue>
+  output: Record<string, WorkflowJsonValue>
+  error_message?: string | null
+  attempt: number
 }
 
 export interface WorkflowRunResponse {
@@ -111,6 +180,7 @@ export interface WorkflowRunResponse {
   once_for: string
   status: string
   progress: WorkflowRunStepProgress[]
+  steps: WorkflowRunStepResponse[]
   error_message?: string | null
   created_at: string
   completed_at?: string | null
@@ -166,8 +236,19 @@ export interface WorkflowStepDefinition {
   params: WorkflowStepParamDefinition[]
 }
 
+export interface WorkflowNodeTypeDefinition {
+  type: string
+  kind?: string | null
+  name: string
+  label: string
+  description: string
+  params: WorkflowStepParamDefinition[]
+  branch_labels: string[]
+}
+
 export interface WorkflowCatalogResponse {
   resources: WorkflowResourceDefinition[]
   triggers: WorkflowTriggerDefinition[]
   steps: WorkflowStepDefinition[]
+  node_types: WorkflowNodeTypeDefinition[]
 }

--- a/dashboard/src/routes/workflows.tsx
+++ b/dashboard/src/routes/workflows.tsx
@@ -74,6 +74,8 @@ export const Route = createFileRoute('/workflows')({
   component: WorkflowsPage,
 })
 
+const noop = () => undefined
+
 function WorkflowsPage() {
   const {toast} = useToast()
   const queryClient = useQueryClient()
@@ -216,7 +218,6 @@ function WorkflowsPage() {
       <RunDebugDrawer
         run={debugRun}
         open={debugRun !== null}
-        showTemporalLink={false}
         onOpenChange={(open) => {
           if (!open) setDebugRun(null)
         }}
@@ -381,8 +382,8 @@ function WorkflowDetail({
             graph={workflow.graph}
             catalog={catalog}
             selectedNodeId={null}
-            onSelectNode={() => undefined}
-            onGraphChange={() => undefined}
+            onSelectNode={noop}
+            onGraphChange={noop}
           />
           <RunsPanel runs={runs} loading={runsLoading} onDebugRun={onDebugRun} />
         </div>

--- a/dashboard/src/routes/workflows.tsx
+++ b/dashboard/src/routes/workflows.tsx
@@ -17,42 +17,37 @@
 import {useMemo, useState} from 'react'
 import {createFileRoute, redirect} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
-import {
-  Activity,
-  Bell,
-  CheckCircle2,
-  Clock3,
-  Code2,
-  Filter,
-  GitBranch,
-  Hash,
-  Eye,
-  Loader2,
-  Mail,
-  MessageSquare,
-  Plus,
-  Save,
-  Send,
-  Trash2,
-  Workflow,
-  X,
-} from 'lucide-react'
+import {Bug, Loader2, PlayCircle, Plus, Save, Trash2, Workflow as WorkflowIcon} from 'lucide-react'
 import {api} from '@/lib/api'
 import type {
   WorkflowCatalogResponse,
-  WorkflowConditionConfig,
-  WorkflowOperationDefinition,
-  WorkflowPreviewResponse,
-  WorkflowRequest,
+  WorkflowGraphConfig,
+  WorkflowGraphNode,
   WorkflowResponse,
   WorkflowRunResponse,
-  WorkflowScopeReferenceDefinition,
-  WorkflowStepConfig,
-  WorkflowStepDefinition,
-  WorkflowStepPreview,
-  WorkflowTestMessageResponse,
-  WorkflowTriggerDefinition,
 } from '@/lib/api'
+import {NodeConfigPanel} from '@/components/workflows/NodeConfigPanel'
+import {NodePalette} from '@/components/workflows/NodePalette'
+import {WorkflowCanvas} from '@/components/workflows/WorkflowCanvas'
+import {
+  PublishToggle,
+  RunDebugDrawer,
+  ValidationPanel,
+} from '@/components/workflows/WorkflowPanels'
+import {
+  addGraphNode,
+  draftFromWorkflow,
+  draftToRequest,
+  emptyWorkflowDraft,
+  formatDate,
+  nextNodeId,
+  removeGraphNode,
+  statusClass,
+  triggerNodeId,
+  updateGraphNode,
+  validateDraft,
+  type WorkflowDraft,
+} from '@/components/workflows/workflowGraph'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {
@@ -67,9 +62,6 @@ import {Input} from '@/components/ui/input'
 import {Label} from '@/components/ui/label'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
 import {Switch} from '@/components/ui/switch'
-import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
-import {Textarea} from '@/components/ui/textarea'
-import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip'
 import {useToast} from '@/hooks/useToast'
 import {cn} from '@/lib/utils'
 
@@ -82,203 +74,23 @@ export const Route = createFileRoute('/workflows')({
   component: WorkflowsPage,
 })
 
-interface WorkflowFormState {
-  name: string
-  triggerName: string
-  enabled: boolean
-  conditions: WorkflowConditionConfig[]
-  steps: WorkflowStepConfig[]
-  onceForTemplate: string
-}
-
-type WorkflowEditorPanel = 'trigger' | 'conditions' | 'delay' | `step:${number}`
-
-function isDefaultWorkflow(workflow: WorkflowResponse): boolean {
-  return Boolean(workflow.system_key)
-}
-
-const defaultMessage = [
-  '{{alert.title}}',
-  '',
-  'Priority: {{alert.priority}}',
-  'Source: {{alert.source}}',
-  'View: {{alert.url}}',
-].join('\n')
-
-function emptyForm(catalog?: WorkflowCatalogResponse): WorkflowFormState {
-  const triggerName = catalog?.triggers[0]?.name ?? 'alert.triggered'
-  const onceForTemplate = catalog?.triggers[0]?.default_once_for_template.join(', ') ?? 'alert.deduplication_key'
-  return {
-    name: '',
-    triggerName,
-    enabled: true,
-    conditions: [],
-    steps: [],
-    onceForTemplate,
-  }
-}
-
-function workflowToForm(workflow: WorkflowResponse): WorkflowFormState {
-  return {
-    name: workflow.name,
-    triggerName: workflow.trigger_name,
-    enabled: workflow.enabled,
-    conditions: workflow.conditions,
-    steps: workflow.steps,
-    onceForTemplate: workflow.once_for_template.join(', '),
-  }
-}
-
-function formToRequest(form: WorkflowFormState): WorkflowRequest {
-  return {
-    name: form.name.trim(),
-    trigger_name: form.triggerName,
-    enabled: form.enabled,
-    conditions: form.conditions,
-    steps: form.steps,
-    once_for_template: splitReferences(form.onceForTemplate),
-  }
-}
-
-function formToPreviewRequest(form: WorkflowFormState) {
-  return {
-    trigger_name: form.triggerName,
-    steps: form.steps,
-  }
-}
-
-function formToStepPreviewRequest(form: WorkflowFormState, step: WorkflowStepConfig) {
-  return {
-    trigger_name: form.triggerName,
-    steps: [step],
-  }
-}
-
-function workflowTestMessageSummary(response: WorkflowTestMessageResponse): string {
-  const sentCount = response.results.filter((result) => result.status === 'sent').length
-  const skippedCount = response.results.filter((result) => result.status === 'skipped').length
-  const failed = response.results.filter((result) => result.status === 'failed')
-  if (failed.length > 0) {
-    return failed
-      .map((result) => `${previewChannelLabel(result.channel)}: ${result.error_message ?? 'not sent'}`)
-      .join('; ')
-  }
-  const parts = [`${sentCount} sent`]
-  if (skippedCount > 0) parts.push(`${skippedCount} skipped`)
-  return parts.join(', ')
-}
-
-function splitReferences(value: string): string[] {
-  return value
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean)
-}
-
-function triggerByName(
-  catalog: WorkflowCatalogResponse | undefined,
-  triggerName: string
-): WorkflowTriggerDefinition | undefined {
-  return catalog?.triggers.find((trigger) => trigger.name === triggerName)
-}
-
-function stepByName(
-  catalog: WorkflowCatalogResponse | undefined,
-  stepName: string
-): WorkflowStepDefinition | undefined {
-  return catalog?.steps.find((step) => step.name === stepName)
-}
-
-function referenceByName(
-  trigger: WorkflowTriggerDefinition | undefined,
-  reference: string
-): WorkflowScopeReferenceDefinition | undefined {
-  return trigger?.scope.find((item) => item.name === reference)
-}
-
-function operationsForReference(
-  catalog: WorkflowCatalogResponse | undefined,
-  reference: WorkflowScopeReferenceDefinition | undefined
-): WorkflowOperationDefinition[] {
-  const resource = catalog?.resources.find((item) => item.type === reference?.type)
-  return resource?.operations ?? []
-}
-
-function operationRequiresValue(operation: string): boolean {
-  return operation !== 'is_set' && operation !== 'is_not_set'
-}
-
-function defaultStepParams(step: WorkflowStepDefinition): Record<string, string> {
-  return Object.fromEntries(
-    step.params.map((param) => {
-      if (param.name === 'subject') return [param.name, 'Moneat workflow: {{alert.title}}']
-      if (param.name === 'title') return [param.name, 'Moneat workflow']
-      return [param.name, defaultMessage]
-    })
-  )
-}
-
-function runStatusClasses(status: string): string {
-  if (status === 'complete') return 'bg-emerald-500/15 text-emerald-500 border-emerald-500/30'
-  if (status === 'failed') return 'bg-red-500/15 text-red-500 border-red-500/30'
-  return 'bg-amber-500/15 text-amber-500 border-amber-500/30'
-}
-
-function StepIconGlyph({stepName, className}: {stepName: string; className?: string}) {
-  if (stepName.includes('email')) return <Mail className={className} />
-  if (stepName.includes('slack')) return <MessageSquare className={className} />
-  if (stepName.includes('discord')) return <Bell className={className} />
-  return <Code2 className={className} />
-}
-
-function formatDate(value?: string | null): string {
-  if (!value) return 'Never'
-  return new Date(value).toLocaleString()
-}
-
-function conditionLabel(
-  condition: WorkflowConditionConfig,
-  catalog?: WorkflowCatalogResponse,
-  trigger?: WorkflowTriggerDefinition
-): string {
-  const reference = referenceByName(trigger, condition.reference)
-  const operation = operationsForReference(catalog, reference)
-    .find((item) => item.name === condition.operation)
-  const base = `${reference?.label ?? condition.reference} ${operation?.label ?? condition.operation}`
-  if (!operationRequiresValue(condition.operation)) return base
-  return condition.value ? `${base} ${condition.value}` : `${base}...`
-}
-
-function conditionsSummary(
-  conditions: WorkflowConditionConfig[],
-  catalog?: WorkflowCatalogResponse,
-  trigger?: WorkflowTriggerDefinition
-): string {
-  if (conditions.length === 0) return 'Then applies to all alerts'
-  if (conditions.length === 1) return `Then applies when ${conditionLabel(conditions[0], catalog, trigger)}`
-  return `Then applies when ${conditions.length} conditions match`
-}
-
 function WorkflowsPage() {
   const {toast} = useToast()
   const queryClient = useQueryClient()
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<number | null>(null)
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingWorkflow, setEditingWorkflow] = useState<WorkflowResponse | null>(null)
-  const [form, setForm] = useState<WorkflowFormState>(() => emptyForm())
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [draft, setDraft] = useState<WorkflowDraft>(() => emptyWorkflowDraft())
+  const [debugRun, setDebugRun] = useState<WorkflowRunResponse | null>(null)
 
   const {data: catalog, isLoading: catalogLoading} = useQuery({
     queryKey: ['workflow-catalog'],
     queryFn: () => api.getWorkflowCatalog(),
   })
-
   const {data: workflows = [], isLoading: workflowsLoading} = useQuery({
     queryKey: ['workflows'],
     queryFn: () => api.getWorkflows(),
   })
-
   const selectedWorkflow = workflows.find((workflow) => workflow.id === selectedWorkflowId) ?? workflows[0] ?? null
-
   const {data: runs = [], isLoading: runsLoading} = useQuery({
     queryKey: ['workflow-runs', selectedWorkflow?.id],
     queryFn: () => api.getWorkflowRuns(selectedWorkflow?.id ?? 0),
@@ -287,33 +99,31 @@ function WorkflowsPage() {
   })
 
   const createMutation = useMutation({
-    mutationFn: (request: WorkflowRequest) => api.createWorkflow(request),
+    mutationFn: (request: ReturnType<typeof draftToRequest>) => api.createWorkflow(request),
     onSuccess: (workflow) => {
       queryClient.invalidateQueries({queryKey: ['workflows']})
       setSelectedWorkflowId(workflow.id)
-      setDialogOpen(false)
-      toast({title: 'Workflow created'})
+      setEditorOpen(false)
+      toast({title: 'Workflow saved'})
     },
     onError: (error: Error) => {
-      toast({title: 'Failed to create workflow', description: error.message, variant: 'destructive'})
+      toast({title: 'Failed to save workflow', description: error.message, variant: 'destructive'})
     },
   })
-
   const updateMutation = useMutation({
-    mutationFn: ({id, request}: {id: number; request: WorkflowRequest}) => api.updateWorkflow(id, request),
+    mutationFn: ({id, request}: {id: number; request: ReturnType<typeof draftToRequest>}) =>
+      api.updateWorkflow(id, request),
     onSuccess: (workflow) => {
       queryClient.invalidateQueries({queryKey: ['workflows']})
       queryClient.invalidateQueries({queryKey: ['workflow-runs', workflow.id]})
       setSelectedWorkflowId(workflow.id)
-      setDialogOpen(false)
-      setEditingWorkflow(null)
-      toast({title: 'Workflow updated'})
+      setEditorOpen(false)
+      toast({title: 'Workflow saved'})
     },
     onError: (error: Error) => {
-      toast({title: 'Failed to update workflow', description: error.message, variant: 'destructive'})
+      toast({title: 'Failed to save workflow', description: error.message, variant: 'destructive'})
     },
   })
-
   const deleteMutation = useMutation({
     mutationFn: (id: number) => api.deleteWorkflow(id),
     onSuccess: () => {
@@ -321,201 +131,174 @@ function WorkflowsPage() {
       setSelectedWorkflowId(null)
       toast({title: 'Workflow deleted'})
     },
+  })
+  const publishMutation = useMutation({
+    mutationFn: ({id, published}: {id: number; published: boolean}) =>
+      published ? api.unpublishWorkflow(id) : api.publishWorkflow(id),
+    onSuccess: (workflow) => {
+      queryClient.invalidateQueries({queryKey: ['workflows']})
+      setSelectedWorkflowId(workflow.id)
+      toast({title: workflow.published ? 'Workflow published' : 'Workflow unpublished'})
+    },
     onError: (error: Error) => {
-      toast({title: 'Failed to delete workflow', description: error.message, variant: 'destructive'})
+      toast({title: 'Publish change failed', description: error.message, variant: 'destructive'})
+    },
+  })
+  const runMutation = useMutation({
+    mutationFn: (id: number) => api.runWorkflow(id),
+    onSuccess: (run) => {
+      queryClient.invalidateQueries({queryKey: ['workflow-runs', run.workflow_id]})
+      setDebugRun(run)
+      toast({title: 'Manual run started'})
+    },
+    onError: (error: Error) => {
+      toast({title: 'Manual run failed', description: error.message, variant: 'destructive'})
     },
   })
 
-  const activeTrigger = useMemo(
-    () => triggerByName(catalog, form.triggerName),
-    [catalog, form.triggerName]
-  )
-
-  const openCreateDialog = () => {
-    setEditingWorkflow(null)
-    setForm(emptyForm(catalog))
-    setDialogOpen(true)
+  const openCreate = () => {
+    setDraft(emptyWorkflowDraft(catalog))
+    setEditorOpen(true)
   }
-
-  const openEditDialog = (workflow: WorkflowResponse) => {
-    setEditingWorkflow(workflow)
-    setForm(workflowToForm(workflow))
-    setDialogOpen(true)
+  const openEdit = (workflow: WorkflowResponse) => {
+    setDraft(draftFromWorkflow(workflow))
+    setEditorOpen(true)
   }
-
-  const submitForm = () => {
-    const request = formToRequest(form)
-    if (request.name.length === 0) {
-      toast({title: 'Workflow name is required', variant: 'destructive'})
+  const saveDraft = () => {
+    const issues = validateDraft(draft, catalog)
+    if (issues.some((issue) => issue.level === 'error')) {
+      toast({title: 'Resolve validation errors before saving', variant: 'destructive'})
       return
     }
-    if (request.steps.length === 0) {
-      toast({title: 'Add at least one workflow step', variant: 'destructive'})
-      return
-    }
-    if (editingWorkflow) {
-      updateMutation.mutate({id: editingWorkflow.id, request})
+    const request = draftToRequest(draft)
+    if (draft.id) {
+      updateMutation.mutate({id: draft.id, request})
     } else {
       createMutation.mutate(request)
     }
   }
 
-  const isLoading = catalogLoading || workflowsLoading
-
   return (
     <div className="workflows-page">
-      <div className="border-b bg-card/50">
-        <div className="px-4 py-3 lg:px-6">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex min-w-0 items-center gap-2">
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <Workflow className="h-4 w-4" />
-              </div>
-              <div className="min-w-0">
-                <h1 className="text-lg font-bold tracking-tight">Workflows</h1>
-                <p className="text-xs text-muted-foreground">Automate alert routing and notifications</p>
-              </div>
-            </div>
-            <Button onClick={openCreateDialog} size="sm" className="h-8 gap-1.5">
-              <Plus className="h-3.5 w-3.5" />
-              New Workflow
-            </Button>
-          </div>
-        </div>
+      <PageHeader onCreate={openCreate} />
+      <div className="grid gap-4 px-4 py-4 lg:grid-cols-[320px_minmax(0,1fr)] lg:px-6">
+        <WorkflowList
+          workflows={workflows}
+          catalog={catalog}
+          selectedWorkflowId={selectedWorkflow?.id ?? null}
+          loading={catalogLoading || workflowsLoading}
+          onSelect={setSelectedWorkflowId}
+        />
+        <WorkflowDetail
+          workflow={selectedWorkflow}
+          catalog={catalog}
+          runs={runs}
+          runsLoading={runsLoading}
+          publishPending={publishMutation.isPending}
+          runPending={runMutation.isPending}
+          deletePending={deleteMutation.isPending}
+          onEdit={openEdit}
+          onDelete={(workflow) => deleteMutation.mutate(workflow.id)}
+          onPublishToggle={(workflow) => publishMutation.mutate({id: workflow.id, published: workflow.published})}
+          onRun={(workflow) => runMutation.mutate(workflow.id)}
+          onDebugRun={setDebugRun}
+        />
       </div>
-
-      <div className="space-y-4 px-4 py-4 lg:px-6">
-        <WorkflowStats workflows={workflows} catalog={catalog} />
-
-        {isLoading ? (
-          <div className="flex h-48 items-center justify-center">
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-          </div>
-        ) : workflows.length === 0 ? (
-          <EmptyWorkflows onCreate={openCreateDialog} />
-        ) : (
-          <div className="grid gap-4 xl:grid-cols-[minmax(280px,380px)_1fr]">
-            <WorkflowList
-              workflows={workflows}
-              selectedWorkflowId={selectedWorkflow?.id ?? null}
-              catalog={catalog}
-              onSelect={setSelectedWorkflowId}
-            />
-            <WorkflowDetail
-              workflow={selectedWorkflow}
-              catalog={catalog}
-              runs={runs}
-              runsLoading={runsLoading}
-              onEdit={openEditDialog}
-              onDelete={(workflow) => deleteMutation.mutate(workflow.id)}
-              deletePending={deleteMutation.isPending}
-            />
-          </div>
-        )}
-      </div>
-
-      <WorkflowDialog
-        open={dialogOpen}
+      <WorkflowEditorDialog
+        open={editorOpen}
+        draft={draft}
         catalog={catalog}
-        form={form}
-        editingWorkflow={editingWorkflow}
-        activeTrigger={activeTrigger}
         pending={createMutation.isPending || updateMutation.isPending}
-        onOpenChange={setDialogOpen}
-        onFormChange={setForm}
-        onSubmit={submitForm}
+        onDraftChange={setDraft}
+        onOpenChange={setEditorOpen}
+        onSave={saveDraft}
+      />
+      <RunDebugDrawer
+        run={debugRun}
+        open={debugRun !== null}
+        showTemporalLink={false}
+        onOpenChange={(open) => {
+          if (!open) setDebugRun(null)
+        }}
       />
     </div>
   )
 }
 
-function WorkflowStats({
-  workflows,
-  catalog,
-}: {
-  workflows: WorkflowResponse[]
-  catalog?: WorkflowCatalogResponse
-}) {
-  const enabledCount = workflows.filter((workflow) => workflow.enabled).length
-  const runCount = workflows.reduce((total, workflow) => total + workflow.run_count, 0)
+function PageHeader({onCreate}: {onCreate: () => void}) {
   return (
-    <div className="grid gap-2 sm:grid-cols-3">
-      <div className="rounded-md border bg-background px-3 py-2">
-        <p className="text-[11px] text-muted-foreground">Enabled</p>
-        <p className="text-lg font-semibold">{enabledCount}</p>
+    <div className="border-b bg-card/50">
+      <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between lg:px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <WorkflowIcon className="h-4 w-4" />
+          </div>
+          <div>
+            <h1 className="text-lg font-bold tracking-tight">Workflows</h1>
+            <p className="text-xs text-muted-foreground">Build automation graphs for telemetry-driven response.</p>
+          </div>
+        </div>
+        <Button size="sm" onClick={onCreate} className="gap-1.5">
+          <Plus className="h-3.5 w-3.5" />
+          New Workflow
+        </Button>
       </div>
-      <div className="rounded-md border bg-background px-3 py-2">
-        <p className="text-[11px] text-muted-foreground">Runs</p>
-        <p className="text-lg font-semibold">{runCount}</p>
-      </div>
-      <div className="rounded-md border bg-background px-3 py-2">
-        <p className="text-[11px] text-muted-foreground">Catalog</p>
-        <p className="text-lg font-semibold">
-          {(catalog?.triggers.length ?? 0) + (catalog?.steps.length ?? 0)}
-        </p>
-      </div>
-    </div>
-  )
-}
-
-function EmptyWorkflows({onCreate}: {onCreate: () => void}) {
-  return (
-    <div className="rounded-lg border border-dashed bg-background p-8 text-center">
-      <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-        <Workflow className="h-5 w-5" />
-      </div>
-      <h2 className="text-base font-semibold">Create your first workflow</h2>
-      <p className="mx-auto mt-1 max-w-lg text-sm text-muted-foreground">
-        Start with alert-triggered automations that can evaluate conditions and send notifications.
-      </p>
-      <Button onClick={onCreate} size="sm" className="mt-4 gap-1.5">
-        <Plus className="h-3.5 w-3.5" />
-        New Workflow
-      </Button>
     </div>
   )
 }
 
 function WorkflowList({
   workflows,
-  selectedWorkflowId,
   catalog,
+  selectedWorkflowId,
+  loading,
   onSelect,
 }: {
   workflows: WorkflowResponse[]
-  selectedWorkflowId: number | null
   catalog?: WorkflowCatalogResponse
+  selectedWorkflowId: number | null
+  loading: boolean
   onSelect: (workflowId: number) => void
 }) {
+  if (loading) {
+    return <div className="flex h-40 items-center justify-center rounded-md border"><Loader2 className="h-5 w-5 animate-spin" /></div>
+  }
+  if (workflows.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed bg-background p-6 text-sm text-muted-foreground">
+        No workflows yet.
+      </div>
+    )
+  }
   return (
     <div className="space-y-2">
       {workflows.map((workflow) => {
-        const trigger = triggerByName(catalog, workflow.trigger_name)
+        const trigger = catalog?.triggers.find((item) => item.name === workflow.trigger_name)
         return (
           <button
             key={workflow.id}
             type="button"
             onClick={() => onSelect(workflow.id)}
             className={cn(
-              'w-full rounded-md border bg-background p-3 text-left transition-colors hover:bg-muted/50',
+              'w-full rounded-md border bg-background p-3 text-left transition-colors hover:bg-muted/40',
               selectedWorkflowId === workflow.id && 'border-primary/50 bg-primary/5'
             )}
           >
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <p className="truncate text-sm font-semibold">{workflow.name}</p>
-                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                <p className="mt-1 truncate text-xs text-muted-foreground">
                   {trigger?.label ?? workflow.trigger_name}
                 </p>
               </div>
-              <Badge variant={workflow.enabled ? 'default' : 'secondary'} className="shrink-0 text-[10px]">
-                {workflow.enabled ? 'Enabled' : 'Paused'}
+              <Badge variant={workflow.published ? 'default' : 'secondary'} className="shrink-0">
+                {workflow.published ? 'Published' : 'Draft'}
               </Badge>
             </div>
-            <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+            <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
               <span>v{workflow.version}</span>
-              <span>{workflow.steps.length} step{workflow.steps.length === 1 ? '' : 's'}</span>
-              <span>{workflow.run_count} run{workflow.run_count === 1 ? '' : 's'}</span>
+              <span>{workflow.graph.nodes.length} nodes</span>
+              <span>{workflow.run_count} runs</span>
             </div>
           </button>
         )
@@ -529,43 +312,60 @@ function WorkflowDetail({
   catalog,
   runs,
   runsLoading,
+  publishPending,
+  runPending,
+  deletePending,
   onEdit,
   onDelete,
-  deletePending,
+  onPublishToggle,
+  onRun,
+  onDebugRun,
 }: {
   workflow: WorkflowResponse | null
   catalog?: WorkflowCatalogResponse
   runs: WorkflowRunResponse[]
   runsLoading: boolean
+  publishPending: boolean
+  runPending: boolean
+  deletePending: boolean
   onEdit: (workflow: WorkflowResponse) => void
   onDelete: (workflow: WorkflowResponse) => void
-  deletePending: boolean
+  onPublishToggle: (workflow: WorkflowResponse) => void
+  onRun: (workflow: WorkflowResponse) => void
+  onDebugRun: (run: WorkflowRunResponse) => void
 }) {
-  if (!workflow) return null
-  const trigger = triggerByName(catalog, workflow.trigger_name)
-  const defaultWorkflow = isDefaultWorkflow(workflow)
+  if (!workflow) {
+    return <div className="rounded-md border bg-background p-6 text-sm text-muted-foreground">Select a workflow.</div>
+  }
+  const trigger = catalog?.triggers.find((item) => item.name === workflow.trigger_name)
   return (
     <div className="space-y-3">
-      <div className="rounded-lg border bg-background">
-        <div className="flex flex-col gap-3 border-b p-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="rounded-md border bg-background">
+        <div className="flex flex-col gap-3 border-b p-4 xl:flex-row xl:items-start xl:justify-between">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
               <h2 className="text-base font-semibold">{workflow.name}</h2>
-              <Badge variant={workflow.enabled ? 'default' : 'secondary'}>
-                {workflow.enabled ? 'Enabled' : 'Paused'}
-              </Badge>
-              {defaultWorkflow && <Badge variant="outline">Default</Badge>}
+              <Badge variant={workflow.enabled ? 'default' : 'secondary'}>{workflow.enabled ? 'Enabled' : 'Paused'}</Badge>
+              {workflow.system_key && <Badge variant="outline">Default</Badge>}
             </div>
             <p className="mt-1 text-sm text-muted-foreground">{trigger?.description ?? workflow.trigger_name}</p>
           </div>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={() => onEdit(workflow)}>
-              Edit
+          <div className="flex flex-wrap gap-2">
+            <PublishToggle
+              published={workflow.published}
+              pending={publishPending}
+              onPublish={() => onPublishToggle(workflow)}
+              onUnpublish={() => onPublishToggle(workflow)}
+            />
+            <Button size="sm" variant="outline" disabled={runPending} onClick={() => onRun(workflow)} className="gap-1.5">
+              {runPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <PlayCircle className="h-3.5 w-3.5" />}
+              Run
             </Button>
-            {!defaultWorkflow && (
+            <Button size="sm" variant="outline" onClick={() => onEdit(workflow)}>Edit</Button>
+            {!workflow.system_key && (
               <Button
-                variant="outline"
                 size="sm"
+                variant="outline"
                 disabled={deletePending}
                 onClick={() => onDelete(workflow)}
                 className="gap-1.5 text-destructive hover:text-destructive"
@@ -576,1211 +376,195 @@ function WorkflowDetail({
             )}
           </div>
         </div>
-
-        <div className="grid gap-4 p-4 lg:grid-cols-2">
-          <WorkflowConfigSummary workflow={workflow} catalog={catalog} trigger={trigger} />
-          <WorkflowRuns runs={runs} loading={runsLoading} />
+        <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <WorkflowCanvas
+            graph={workflow.graph}
+            catalog={catalog}
+            selectedNodeId={null}
+            onSelectNode={() => undefined}
+            onGraphChange={() => undefined}
+          />
+          <RunsPanel runs={runs} loading={runsLoading} onDebugRun={onDebugRun} />
         </div>
       </div>
     </div>
   )
 }
 
-function WorkflowConfigSummary({
-  workflow,
-  catalog,
-  trigger,
-}: {
-  workflow: WorkflowResponse
-  catalog?: WorkflowCatalogResponse
-  trigger?: WorkflowTriggerDefinition
-}) {
-  return (
-    <div className="space-y-3">
-      <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase text-muted-foreground">Conditions</h3>
-        {workflow.conditions.length === 0 ? (
-          <p className="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-            Runs whenever the trigger fires.
-          </p>
-        ) : (
-          <div className="space-y-2">
-            {workflow.conditions.map((condition, index) => {
-              const reference = referenceByName(trigger, condition.reference)
-              const operation = operationsForReference(catalog, reference)
-                .find((item) => item.name === condition.operation)
-              return (
-                <div key={`${condition.reference}-${index}`} className="rounded-md border px-3 py-2 text-sm">
-                  <span className="font-medium">{reference?.label ?? condition.reference}</span>{' '}
-                  <span className="text-muted-foreground">{operation?.label ?? condition.operation}</span>{' '}
-                  {condition.value && <code className="text-xs">{condition.value}</code>}
-                </div>
-              )
-            })}
-          </div>
-        )}
-      </div>
-
-      <div>
-        <h3 className="mb-2 text-xs font-semibold uppercase text-muted-foreground">Steps</h3>
-        <div className="space-y-2">
-          {workflow.steps.map((step, index) => {
-            const definition = stepByName(catalog, step.name)
-            return (
-              <div key={`${step.name}-${index}`} className="rounded-md border px-3 py-2 text-sm">
-                <div className="flex items-center gap-2">
-                  <StepIconGlyph stepName={step.name} className="h-3.5 w-3.5 text-muted-foreground" />
-                  <span className="font-medium">{definition?.label ?? step.name}</span>
-                </div>
-                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-                  {definition?.description ?? Object.values(step.params).join(' ')}
-                </p>
-              </div>
-            )
-          })}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function WorkflowRuns({
+function RunsPanel({
   runs,
   loading,
+  onDebugRun,
 }: {
   runs: WorkflowRunResponse[]
   loading: boolean
+  onDebugRun: (run: WorkflowRunResponse) => void
 }) {
+  if (loading) {
+    return <div className="flex h-40 items-center justify-center rounded-md border"><Loader2 className="h-5 w-5 animate-spin" /></div>
+  }
   return (
-    <div>
-      <h3 className="mb-2 text-xs font-semibold uppercase text-muted-foreground">Recent Runs</h3>
-      {loading ? (
-        <div className="flex h-28 items-center justify-center rounded-md border">
-          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-        </div>
-      ) : runs.length === 0 ? (
-        <p className="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-          No runs have matched this workflow yet.
-        </p>
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold">Recent runs</h3>
+      {runs.length === 0 ? (
+        <p className="rounded-md border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">No runs recorded.</p>
       ) : (
-        <div className="space-y-2">
-          {runs.map((run) => (
-            <div key={run.id} className="rounded-md border px-3 py-2">
-              <div className="flex items-center justify-between gap-2">
-                <Badge variant="outline" className={runStatusClasses(run.status)}>
-                  {run.status}
-                </Badge>
-                <span className="text-xs text-muted-foreground">{formatDate(run.created_at)}</span>
-              </div>
-              <p className="mt-1 truncate text-xs text-muted-foreground">{run.once_for}</p>
-              {run.error_message && <p className="mt-1 text-xs text-destructive">{run.error_message}</p>}
+        runs.map((run) => (
+          <button
+            key={run.id}
+            type="button"
+            onClick={() => onDebugRun(run)}
+            className="w-full rounded-md border bg-background p-3 text-left hover:bg-muted/40"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <Badge variant="outline" className={statusClass(run.status)}>{run.status}</Badge>
+              <Bug className="h-4 w-4 text-muted-foreground" />
             </div>
-          ))}
-        </div>
+            <p className="mt-2 truncate text-xs text-muted-foreground">{run.once_for}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{formatDate(run.created_at)}</p>
+          </button>
+        ))
       )}
     </div>
   )
 }
 
-function WorkflowDialog({
+function WorkflowEditorDialog({
   open,
+  draft,
   catalog,
-  form,
-  editingWorkflow,
-  activeTrigger,
   pending,
+  onDraftChange,
   onOpenChange,
-  onFormChange,
-  onSubmit,
+  onSave,
 }: {
   open: boolean
+  draft: WorkflowDraft
   catalog?: WorkflowCatalogResponse
-  form: WorkflowFormState
-  editingWorkflow: WorkflowResponse | null
-  activeTrigger?: WorkflowTriggerDefinition
   pending: boolean
+  onDraftChange: (draft: WorkflowDraft) => void
   onOpenChange: (open: boolean) => void
-  onFormChange: (form: WorkflowFormState) => void
-  onSubmit: () => void
+  onSave: () => void
 }) {
-  const {toast} = useToast()
-  const [selectedPanel, setSelectedPanel] = useState<WorkflowEditorPanel>('trigger')
-  const [preview, setPreview] = useState<WorkflowPreviewResponse | null>(null)
-  const selectedStepIndex = selectedPanel.startsWith('step:') ? Number(selectedPanel.slice(5)) : null
-  const activePanel: WorkflowEditorPanel = selectedStepIndex !== null && !form.steps[selectedStepIndex]
-    ? 'trigger'
-    : selectedPanel
-  const previewMutation = useMutation({
-    mutationFn: () => api.previewWorkflow(formToPreviewRequest(form)),
-    onSuccess: (response) => {
-      setPreview(response)
-    },
-    onError: (error: Error) => {
-      toast({title: 'Failed to preview workflow', description: error.message, variant: 'destructive'})
-    },
-  })
-  const testMessageMutation = useMutation({
-    mutationFn: ({step}: {step: WorkflowStepConfig; index: number}) =>
-      api.testWorkflowMessage(formToStepPreviewRequest(form, step)),
-    onSuccess: (response) => {
-      const failedCount = response.results.filter((result) => result.status === 'failed').length
-      toast({
-        title: failedCount > 0 ? 'Test message failed' : 'Test message sent',
-        description: workflowTestMessageSummary(response),
-        variant: failedCount > 0 ? 'destructive' : undefined,
-      })
-    },
-    onError: (error: Error) => {
-      toast({title: 'Failed to send test message', description: error.message, variant: 'destructive'})
-    },
-  })
-
-  const handleFormChange = (nextForm: WorkflowFormState) => {
-    setPreview(null)
-    onFormChange(nextForm)
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(triggerNodeId)
+  const issues = useMemo(() => validateDraft(draft, catalog), [catalog, draft])
+  const selectedNode = draft.graph.nodes.find((node) => node.id === selectedNodeId)
+  const updateGraph = (graph: WorkflowGraphConfig) => onDraftChange({...draft, graph})
+  const addNode = (node: Omit<WorkflowGraphNode, 'id'>, prefix: string) => {
+    const nextNode = {...node, id: nextNodeId(draft.graph, prefix)}
+    updateGraph(addGraphNode(draft.graph, nextNode))
+    setSelectedNodeId(nextNode.id)
   }
-
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      setPreview(null)
-    }
-    onOpenChange(nextOpen)
-  }
-
-  const addCondition = () => {
-    const firstReference = activeTrigger?.scope[0]
-    const operation = operationsForReference(catalog, firstReference)[0]
-    if (!firstReference || !operation) return
-    handleFormChange({
-      ...form,
-      conditions: [...form.conditions, {reference: firstReference.name, operation: operation.name, value: ''}],
+  const changeTrigger = (triggerName: string) => {
+    const graph = updateGraphTrigger(draft.graph, triggerName)
+    const trigger = catalog?.triggers.find((item) => item.name === triggerName)
+    onDraftChange({
+      ...draft,
+      triggerName,
+      graph,
+      onceForTemplate: trigger?.default_once_for_template.join(', ') ?? draft.onceForTemplate,
     })
-    setSelectedPanel('conditions')
   }
-
-  const addStep = () => {
-    const step = catalog?.steps[0]
-    if (!step) return
-    handleFormChange({
-      ...form,
-      steps: [...form.steps, {name: step.name, params: defaultStepParams(step)}],
-    })
-    setSelectedPanel(`step:${form.steps.length}`)
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent className="workflow-editor-dialog max-h-[92vh] max-w-6xl overflow-y-auto shadow-none">
-          <DialogHeader>
-            <DialogTitle>{editingWorkflow ? 'Edit Workflow' : 'New Workflow'}</DialogTitle>
-            <DialogDescription className="sr-only">
-              Configure trigger conditions, idempotency, and notification steps for alert automation.
-            </DialogDescription>
-          </DialogHeader>
-
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
-          <div className="mx-auto w-full max-w-3xl">
-            <TriggerNode
-              trigger={activeTrigger}
-              form={form}
-              selected={activePanel === 'trigger'}
-              onSelect={() => setSelectedPanel('trigger')}
-            />
-            <FlowConnector />
-            <ConditionNode
-              catalog={catalog}
-              trigger={activeTrigger}
-              conditions={form.conditions}
-              selected={activePanel === 'conditions'}
-              onSelect={() => setSelectedPanel('conditions')}
-              onAddCondition={addCondition}
-            />
-            <FlowConnector />
-            <DelayNode selected={activePanel === 'delay'} onSelect={() => setSelectedPanel('delay')} />
-            <FlowConnector />
-            <StepEditor
-              catalog={catalog}
-              steps={form.steps}
-              selectedStepIndex={activePanel.startsWith('step:') ? Number(activePanel.slice(5)) : null}
-              testMessageStepIndex={testMessageMutation.variables?.index ?? null}
-              testMessagePending={testMessageMutation.isPending}
-              testMessageDisabled={testMessageMutation.isPending}
-              onSelectStep={(index) => setSelectedPanel(`step:${index}`)}
-              onTestStep={(step, index) => testMessageMutation.mutate({step, index})}
-              onAddStep={addStep}
-              onRemoveStep={(index) => {
-                handleFormChange({...form, steps: form.steps.filter((_, itemIndex) => itemIndex !== index)})
-                setSelectedPanel('trigger')
-              }}
-            />
-          </div>
-
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[92vh] max-w-[1400px] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{draft.id ? 'Edit workflow' : 'New workflow'}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Configure a workflow automation graph with triggers, conditions, controls, and actions.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 xl:grid-cols-[240px_minmax(0,1fr)_360px]">
           <div className="space-y-3">
-            <WorkflowInspector
-              panel={activePanel}
-              catalog={catalog}
-              trigger={activeTrigger}
-              form={form}
-              editingWorkflow={editingWorkflow}
-              onFormChange={handleFormChange}
-              onSelectPanel={setSelectedPanel}
-            />
-            <WorkflowPreviewPanel
-              preview={preview}
-              pending={previewMutation.isPending}
-              canPreview={form.steps.length > 0}
-              onPreview={() => previewMutation.mutate()}
-            />
-            <CatalogPanel catalog={catalog} trigger={activeTrigger} />
+            <WorkflowDraftFields draft={draft} catalog={catalog} onDraftChange={onDraftChange} onTriggerChange={changeTrigger} />
+            <NodePalette catalog={catalog} onAddNode={addNode} />
+            <ValidationPanel issues={issues} />
           </div>
+          <WorkflowCanvas
+            graph={draft.graph}
+            catalog={catalog}
+            selectedNodeId={selectedNodeId}
+            onSelectNode={setSelectedNodeId}
+            onGraphChange={updateGraph}
+          />
+          <NodeConfigPanel
+            node={selectedNode}
+            catalog={catalog}
+            triggerName={draft.triggerName}
+            onChange={(node) => updateGraph(updateGraphNode(draft.graph, node))}
+            onRemove={(nodeId) => {
+              updateGraph(removeGraphNode(draft.graph, nodeId))
+              setSelectedNodeId(triggerNodeId)
+            }}
+          />
         </div>
-
-        <DialogFooter className="mt-2 gap-2 sm:space-x-0">
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
-            <X className="mr-1.5 h-3.5 w-3.5" />
-            Cancel
-          </Button>
-          <Button onClick={onSubmit} disabled={pending} className="gap-1.5">
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button type="button" onClick={onSave} disabled={pending} className="gap-1.5">
             {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
-            Save Workflow
+            Save
           </Button>
         </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+      </DialogContent>
+    </Dialog>
   )
 }
 
-function TriggerNode({
-  trigger,
-  form,
-  selected,
-  onSelect,
-}: {
-  trigger?: WorkflowTriggerDefinition
-  form: WorkflowFormState
-  selected: boolean
-  onSelect: () => void
-}) {
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onSelect()
-        }
-      }}
-      className={cn(
-        'w-full rounded-lg border bg-background p-4 text-left transition-colors hover:bg-muted/30',
-        selected && 'border-primary/60 ring-2 ring-primary/15'
-      )}
-    >
-      <h3 className="mb-3 text-base font-semibold">Workflow is triggered when...</h3>
-      <div className="rounded-lg bg-muted/30 px-4 py-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-primary/20 bg-primary/10 text-primary">
-            <Hash className="h-5 w-5" />
-          </div>
-          <div className="min-w-0">
-            <p className="truncate font-semibold">{trigger?.label ?? form.triggerName}</p>
-            <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-              {trigger?.description ?? 'Select a workflow trigger'}
-            </p>
-          </div>
-        </div>
-      </div>
-      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-        <Badge variant={form.enabled ? 'default' : 'secondary'}>{form.enabled ? 'Enabled' : 'Paused'}</Badge>
-        {form.onceForTemplate && <span className="truncate">Once per {form.onceForTemplate}</span>}
-      </div>
-    </div>
-  )
-}
-
-function TriggerInspector({
+function WorkflowDraftFields({
+  draft,
   catalog,
-  trigger,
-  form,
-  editingWorkflow,
-  onFormChange,
+  onDraftChange,
+  onTriggerChange,
 }: {
+  draft: WorkflowDraft
   catalog?: WorkflowCatalogResponse
-  trigger?: WorkflowTriggerDefinition
-  form: WorkflowFormState
-  editingWorkflow: WorkflowResponse | null
-  onFormChange: (form: WorkflowFormState) => void
+  onDraftChange: (draft: WorkflowDraft) => void
+  onTriggerChange: (triggerName: string) => void
 }) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-3 rounded-md border bg-muted/20 p-3">
+      <div className="space-y-1.5">
+        <Label>Name</Label>
+        <Input value={draft.name} onChange={(event) => onDraftChange({...draft, name: event.target.value})} />
+      </div>
       <div className="space-y-1.5">
         <Label>Trigger</Label>
-        <Select
-          value={form.triggerName}
-          disabled={editingWorkflow !== null}
-          onValueChange={(triggerName) => {
-            const nextTrigger = triggerByName(catalog, triggerName)
-            onFormChange({
-              ...form,
-              triggerName,
-              conditions: [],
-              onceForTemplate: nextTrigger?.default_once_for_template.join(', ') ?? '',
-            })
-          }}
-        >
-          <SelectTrigger
-            aria-label="Trigger"
-            className="h-auto min-h-14 gap-3 rounded-lg bg-background px-3 py-2 text-left [&>span]:line-clamp-none"
-          >
-          <div className="flex min-w-0 items-center gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-primary/20 bg-primary/10 text-primary">
-              <Hash className="h-4 w-4" />
-            </div>
-            <div className="min-w-0">
-              <p className="truncate font-semibold">{trigger?.label ?? form.triggerName}</p>
-              <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-                {trigger?.description ?? 'Select a workflow trigger'}
-              </p>
-            </div>
-          </div>
-        </SelectTrigger>
-        <SelectContent>
-          {catalog?.triggers.map((catalogTrigger) => (
-            <SelectItem key={catalogTrigger.name} value={catalogTrigger.name}>
-              {catalogTrigger.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      </div>
-
-      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
-        <div className="space-y-1.5">
-          <Label>Name</Label>
-          <Input
-            value={form.name}
-            onChange={(event) => onFormChange({...form, name: event.target.value})}
-            placeholder="Escalate critical uptime alerts"
-          />
-        </div>
-        <div className="flex items-end gap-2 pb-2">
-          <Switch
-            checked={form.enabled}
-            onCheckedChange={(enabled) => onFormChange({...form, enabled})}
-          />
-          <Label>{form.enabled ? 'Enabled' : 'Paused'}</Label>
-        </div>
-      </div>
-
-      <div className="space-y-1.5">
-        <Label>Run once per</Label>
-        <Input
-          value={form.onceForTemplate}
-          onChange={(event) => onFormChange({...form, onceForTemplate: event.target.value})}
-          placeholder="alert.deduplication_key"
-        />
-      </div>
-    </div>
-  )
-}
-
-function FlowConnector() {
-  return <div className="mx-auto h-8 w-px bg-border" />
-}
-
-function DelayNode({
-  selected,
-  onSelect,
-}: {
-  selected: boolean
-  onSelect: () => void
-}) {
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onSelect()
-        }
-      }}
-      className={cn(
-        'flex w-full items-center justify-between gap-3 rounded-lg border bg-background px-4 py-3 text-left transition-colors hover:bg-muted/30',
-        selected && 'border-primary/60 ring-2 ring-primary/15'
-      )}
-    >
-      <div className="flex min-w-0 items-center gap-3">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
-          <Clock3 className="h-4 w-4" />
-        </div>
-        <p className="truncate font-medium">And runs immediately</p>
-      </div>
-      <Button type="button" variant="ghost" size="sm" disabled onClick={(event) => event.stopPropagation()}>
-        Edit delay
-      </Button>
-    </div>
-  )
-}
-
-function ConditionNode({
-  catalog,
-  trigger,
-  conditions,
-  selected,
-  onSelect,
-  onAddCondition,
-}: {
-  catalog?: WorkflowCatalogResponse
-  trigger?: WorkflowTriggerDefinition
-  conditions: WorkflowConditionConfig[]
-  selected: boolean
-  onSelect: () => void
-  onAddCondition: () => void
-}) {
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onSelect()
-        }
-      }}
-      className={cn(
-        'overflow-hidden rounded-lg border bg-background text-left transition-colors hover:bg-muted/30',
-        selected && 'border-primary/60 ring-2 ring-primary/15'
-      )}
-    >
-      <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
-            <Filter className="h-4 w-4" />
-          </div>
-          <p className="min-w-0 break-words font-medium">
-            {conditionsSummary(conditions, catalog, trigger)}
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={(event) => {
-            event.stopPropagation()
-            onAddCondition()
-          }}
-          className="gap-1.5"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          Add condition
-        </Button>
-      </div>
-
-      {conditions.length > 0 && (
-        <div className="flex flex-wrap gap-2 border-t bg-muted/20 p-3">
-          {conditions.map((condition, index) => (
-            <Badge
-              key={`${condition.reference}-${index}`}
-              variant="secondary"
-              className="max-w-full gap-1.5 rounded-md px-2.5 py-1.5 text-xs"
-            >
-              <Filter className="h-3 w-3 shrink-0" />
-              <span className="truncate">{conditionLabel(condition, catalog, trigger)}</span>
-            </Badge>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function ConditionRow({
-  catalog,
-  trigger,
-  condition,
-  onChange,
-  onRemove,
-}: {
-  catalog?: WorkflowCatalogResponse
-  trigger?: WorkflowTriggerDefinition
-  condition: WorkflowConditionConfig
-  onChange: (condition: WorkflowConditionConfig) => void
-  onRemove: () => void
-}) {
-  const reference = referenceByName(trigger, condition.reference)
-  const operations = operationsForReference(catalog, reference)
-  return (
-    <div className="grid gap-2 rounded-md border p-2 sm:grid-cols-[1.2fr_1fr_1fr_auto]">
-      <Select
-        value={condition.reference}
-        onValueChange={(referenceName) => {
-          const nextReference = referenceByName(trigger, referenceName)
-          const nextOperation = operationsForReference(catalog, nextReference)[0]
-          onChange({reference: referenceName, operation: nextOperation?.name ?? 'eq', value: ''})
-        }}
-      >
-        <SelectTrigger>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {trigger?.scope.map((scopeReference) => (
-            <SelectItem key={scopeReference.name} value={scopeReference.name}>
-              {scopeReference.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      <Select
-        value={condition.operation}
-        onValueChange={(operation) => onChange({...condition, operation})}
-      >
-        <SelectTrigger>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {operations.map((operation) => (
-            <SelectItem key={operation.name} value={operation.name}>
-              {operation.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      {operationRequiresValue(condition.operation) ? (
-        <Input
-          value={condition.value ?? ''}
-          onChange={(event) => onChange({...condition, value: event.target.value})}
-          placeholder="Value"
-        />
-      ) : (
-        <div className="flex h-9 items-center rounded-md border px-3 text-xs text-muted-foreground">No value</div>
-      )}
-
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button type="button" variant="ghost" size="icon" onClick={onRemove}>
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Remove condition</TooltipContent>
-      </Tooltip>
-    </div>
-  )
-}
-
-function StepEditor({
-  catalog,
-  steps,
-  selectedStepIndex,
-  testMessageStepIndex,
-  testMessagePending,
-  testMessageDisabled,
-  onSelectStep,
-  onTestStep,
-  onAddStep,
-  onRemoveStep,
-}: {
-  catalog?: WorkflowCatalogResponse
-  steps: WorkflowStepConfig[]
-  selectedStepIndex: number | null
-  testMessageStepIndex: number | null
-  testMessagePending: boolean
-  testMessageDisabled: boolean
-  onSelectStep: (index: number) => void
-  onTestStep: (step: WorkflowStepConfig, index: number) => void
-  onAddStep: () => void
-  onRemoveStep: (index: number) => void
-}) {
-  return (
-    <div>
-      <div className="space-y-0">
-        {steps.map((step, index) => (
-          <div key={`${step.name}-${index}`}>
-            <StepNode
-              definition={stepByName(catalog, step.name)}
-              step={step}
-              index={index}
-              selected={selectedStepIndex === index}
-              testMessagePending={testMessagePending && testMessageStepIndex === index}
-              testMessageDisabled={testMessageDisabled}
-              onSelect={() => onSelectStep(index)}
-              onTest={() => onTestStep(step, index)}
-              onRemove={() => onRemoveStep(index)}
-            />
-            <FlowConnector />
-          </div>
-        ))}
-      </div>
-      <div className="flex justify-center">
-        <Button type="button" variant="outline" size="sm" onClick={onAddStep} className="gap-1.5 rounded-lg">
-          <Plus className="h-3.5 w-3.5" />
-          Add step
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-function StepNode({
-  definition,
-  step,
-  index,
-  selected,
-  testMessagePending,
-  testMessageDisabled,
-  onSelect,
-  onTest,
-  onRemove,
-}: {
-  definition?: WorkflowStepDefinition
-  step: WorkflowStepConfig
-  index: number
-  selected: boolean
-  testMessagePending: boolean
-  testMessageDisabled: boolean
-  onSelect: () => void
-  onTest: () => void
-  onRemove: () => void
-}) {
-  const firstParam = definition?.params[0]
-  const firstValue = firstParam ? step.params[firstParam.name] : undefined
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onSelect()
-        }
-      }}
-      className={cn(
-        'overflow-hidden rounded-lg border bg-background text-left transition-colors hover:bg-muted/30',
-        selected && 'border-primary/60 ring-2 ring-primary/15'
-      )}
-    >
-      <div className="flex items-center gap-3 bg-muted/20 p-3">
-        <Badge variant="secondary" className="w-fit shrink-0">Step {index + 1}</Badge>
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background text-muted-foreground">
-          <StepIconGlyph stepName={step.name} className="h-4 w-4" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-semibold">{definition?.label ?? step.name}</p>
-          {firstValue && <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{firstValue}</p>}
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label={`Send test message for ${definition?.label ?? step.name}`}
-                disabled={testMessageDisabled}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onTest()
-                }}
-                className="h-8 w-8"
-              >
-                {testMessagePending ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Send className="h-3.5 w-3.5" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Send test message</TooltipContent>
-          </Tooltip>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={(event) => {
-              event.stopPropagation()
-              onRemove()
-            }}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function StepConfigurator({
-  catalog,
-  step,
-  index,
-  onChange,
-  onRemove,
-}: {
-  catalog?: WorkflowCatalogResponse
-  step: WorkflowStepConfig
-  index: number
-  onChange: (step: WorkflowStepConfig) => void
-  onRemove: () => void
-}) {
-  const definition = stepByName(catalog, step.name)
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-3">
-        <Badge variant="secondary" className="w-fit">Step {index + 1}</Badge>
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background text-muted-foreground">
-          <StepIconGlyph stepName={step.name} className="h-4 w-4" />
-        </div>
-        <Button type="button" variant="ghost" size="icon" onClick={onRemove} className="ml-auto">
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      </div>
-
-      <div className="space-y-1.5">
-        <Label>Step</Label>
-        <Select
-          value={step.name}
-          onValueChange={(stepName) => {
-            const nextDefinition = stepByName(catalog, stepName)
-            onChange({
-              name: stepName,
-              params: nextDefinition ? defaultStepParams(nextDefinition) : {},
-            })
-          }}
-        >
-          <SelectTrigger className="min-h-10 bg-background">
+        <Select value={draft.triggerName} onValueChange={onTriggerChange}>
+          <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {catalog?.steps.map((catalogStep) => (
-              <SelectItem key={catalogStep.name} value={catalogStep.name}>
-                {catalogStep.label}
+            {catalog?.triggers.map((trigger) => (
+              <SelectItem key={trigger.name} value={trigger.name}>
+                {trigger.label}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </div>
-
-      <div className="space-y-3 p-4">
-        {definition?.params.map((param) => (
-          <div key={param.name} className="space-y-1.5">
-            <Label>{param.label}</Label>
-            {param.type === 'Text' ? (
-              <Textarea
-                value={step.params[param.name] ?? ''}
-                onChange={(event) => onChange({
-                  ...step,
-                  params: {...step.params, [param.name]: event.target.value},
-                })}
-                className="min-h-28"
-              />
-            ) : (
-              <Input
-                value={step.params[param.name] ?? ''}
-                onChange={(event) => onChange({
-                  ...step,
-                  params: {...step.params, [param.name]: event.target.value},
-                })}
-              />
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-function WorkflowInspector({
-  panel,
-  catalog,
-  trigger,
-  form,
-  editingWorkflow,
-  onFormChange,
-  onSelectPanel,
-}: {
-  panel: WorkflowEditorPanel
-  catalog?: WorkflowCatalogResponse
-  trigger?: WorkflowTriggerDefinition
-  form: WorkflowFormState
-  editingWorkflow: WorkflowResponse | null
-  onFormChange: (form: WorkflowFormState) => void
-  onSelectPanel: (panel: WorkflowEditorPanel) => void
-}) {
-  const selectedStepIndex = panel.startsWith('step:') ? Number(panel.slice(5)) : null
-  const selectedStep = selectedStepIndex !== null ? form.steps[selectedStepIndex] : undefined
-
-  return (
-    <div className="rounded-lg border bg-muted/20 p-3">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div>
-          <h3 className="text-sm font-semibold">{inspectorTitle(panel)}</h3>
-          <p className="text-xs text-muted-foreground">{inspectorSubtitle(panel)}</p>
-        </div>
-      </div>
-
-      {panel === 'trigger' && (
-        <TriggerInspector
-          catalog={catalog}
-          trigger={trigger}
-          form={form}
-          editingWorkflow={editingWorkflow}
-          onFormChange={onFormChange}
+      <div className="space-y-1.5">
+        <Label>Run once per</Label>
+        <Input
+          value={draft.onceForTemplate}
+          onChange={(event) => onDraftChange({...draft, onceForTemplate: event.target.value})}
         />
-      )}
-
-      {panel === 'conditions' && (
-        <div className="space-y-3">
-          {form.conditions.length === 0 ? (
-            <p className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
-              This workflow currently applies whenever the trigger fires.
-            </p>
-          ) : (
-            form.conditions.map((condition, index) => (
-              <ConditionRow
-                key={`${condition.reference}-${index}`}
-                catalog={catalog}
-                trigger={trigger}
-                condition={condition}
-                onChange={(next) => {
-                  onFormChange({
-                    ...form,
-                    conditions: form.conditions.map((item, itemIndex) => (itemIndex === index ? next : item)),
-                  })
-                }}
-                onRemove={() => onFormChange({
-                  ...form,
-                  conditions: form.conditions.filter((_, itemIndex) => itemIndex !== index),
-                })}
-              />
-            ))
-          )}
-        </div>
-      )}
-
-      {panel === 'delay' && (
-        <div className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
-          Workflows run as soon as their trigger and conditions match. Delayed execution is shown in the canvas
-          but is not available yet.
-        </div>
-      )}
-
-      {selectedStepIndex !== null && selectedStep && (
-        <StepConfigurator
-          catalog={catalog}
-          step={selectedStep}
-          index={selectedStepIndex}
-          onChange={(next) => {
-            onFormChange({
-              ...form,
-              steps: form.steps.map((item, itemIndex) => (itemIndex === selectedStepIndex ? next : item)),
-            })
-          }}
-          onRemove={() => {
-            onFormChange({
-              ...form,
-              steps: form.steps.filter((_, itemIndex) => itemIndex !== selectedStepIndex),
-            })
-            onSelectPanel('trigger')
-          }}
-        />
-      )}
-    </div>
-  )
-}
-
-function inspectorTitle(panel: WorkflowEditorPanel): string {
-  if (panel === 'trigger') return 'Trigger settings'
-  if (panel === 'conditions') return 'Condition builder'
-  if (panel === 'delay') return 'Delay'
-  return 'Step configuration'
-}
-
-function inspectorSubtitle(panel: WorkflowEditorPanel): string {
-  if (panel === 'trigger') return 'Choose the event, name, and run identity.'
-  if (panel === 'conditions') return 'Filter when this workflow should apply.'
-  if (panel === 'delay') return 'Timing for execution after a match.'
-  return 'Choose the action and fill in its parameters.'
-}
-
-function WorkflowPreviewPanel({
-  preview,
-  pending,
-  canPreview,
-  onPreview,
-}: {
-  preview: WorkflowPreviewResponse | null
-  pending: boolean
-  canPreview: boolean
-  onPreview: () => void
-}) {
-  const previewItems = preview?.previews ?? []
-  const hasPreview = previewItems.length > 0
-  const firstTab = hasPreview ? previewTabValue(previewItems[0], 0) : ''
-  return (
-    <div className="rounded-lg border bg-muted/20 p-3">
-      <div className="mb-3 flex flex-col gap-3">
-        <div>
-          <h3 className="text-sm font-semibold">Message preview</h3>
-          <p className="text-xs text-muted-foreground">Representative alert sample</p>
-        </div>
-        <div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onPreview}
-            disabled={!canPreview || pending}
-            className="h-8 justify-center gap-1.5"
-          >
-            {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Eye className="h-3.5 w-3.5" />}
-            Preview
-          </Button>
-        </div>
       </div>
-
-      {pending ? (
-        <div className="flex items-center gap-2 rounded-md border bg-background px-3 py-4 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Rendering preview
-        </div>
-      ) : hasPreview ? (
-        <Tabs defaultValue={firstTab} className="w-full">
-          <TabsList className="grid h-auto w-full auto-cols-fr grid-flow-col">
-            {previewItems.map((item, index) => (
-              <TabsTrigger key={previewTabValue(item, index)} value={previewTabValue(item, index)}>
-                {previewChannelLabel(item.channel)}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-          {previewItems.map((item, index) => (
-            <TabsContent key={previewTabValue(item, index)} value={previewTabValue(item, index)} className="mt-3">
-              <WorkflowPreviewCard item={item} />
-            </TabsContent>
-          ))}
-        </Tabs>
-      ) : (
-        <div className="rounded-md border border-dashed bg-background px-3 py-4 text-sm text-muted-foreground">
-          Not rendered yet.
-        </div>
-      )}
-    </div>
-  )
-}
-
-function WorkflowPreviewCard({item}: {item: WorkflowStepPreview}) {
-  if (item.channel === 'email') return <EmailPreview item={item} />
-  if (item.channel === 'discord') return <DiscordPreview item={item} />
-  return <SlackPreview item={item} />
-}
-
-function EmailPreview({item}: {item: WorkflowStepPreview}) {
-  return (
-    <div className="overflow-hidden rounded-md border bg-background">
-      <div className="border-b px-3 py-2 text-xs text-muted-foreground">
-        <span className="font-medium text-foreground">Subject:</span> {item.subject ?? item.title}
-      </div>
-      <div className="bg-muted/20 p-4">
-        <div className="rounded-md border bg-card p-4 text-card-foreground">
-          <div className="flex items-start gap-3">
-            <MoneatMessageAvatar />
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-semibold">Moneat</p>
-              <h4 className="mt-3 flex items-start gap-2 text-base font-semibold leading-snug">
-                <span aria-hidden="true">{previewStatusEmoji(item)}</span>
-                <span>{previewHeaderText(item)}</span>
-              </h4>
-              <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">{item.body}</p>
-              <EmailFieldGrid fields={item.fields} />
-              <PreviewCta item={item} />
-              {item.footer && <p className="mt-4 text-xs text-muted-foreground">Added by Moneat</p>}
-            </div>
-          </div>
-        </div>
+      <div className="flex items-center gap-2">
+        <Switch checked={draft.enabled} onCheckedChange={(enabled) => onDraftChange({...draft, enabled})} />
+        <Label>{draft.enabled ? 'Enabled' : 'Paused'}</Label>
       </div>
     </div>
   )
 }
 
-function SlackPreview({item}: {item: WorkflowStepPreview}) {
-  return <AlertMessagePreview item={item} />
-}
-
-function DiscordPreview({item}: {item: WorkflowStepPreview}) {
-  return <AlertMessagePreview item={item} />
-}
-
-function AlertMessagePreview({item}: {item: WorkflowStepPreview}) {
-  return (
-    <div className="rounded-md border bg-[#1f2227] p-3 text-[#d1d2d3]">
-      <div className="flex items-start gap-3">
-        <MoneatMessageAvatar />
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5 text-sm leading-none">
-            <span className="font-bold text-[#f2f3f5]">Moneat</span>
-            <span className="rounded bg-[#34373c] px-1 py-0.5 text-[10px] font-bold text-[#c9cbd0]">APP</span>
-            <span className="text-[#a5a7aa]">now</span>
-          </div>
-          <div className="mt-3 flex items-center gap-2 text-sm font-bold text-[#f2f3f5]">
-            <span>{previewStatusEmoji(item)}</span>
-            <span>{previewHeaderText(item)}</span>
-          </div>
-          <div className="mt-3 border-l-4 py-1 pl-4" style={{borderLeftColor: item.color}}>
-            <p className="mb-3 whitespace-pre-wrap text-sm text-[#d1d2d3]">{item.body}</p>
-            <AlertFieldGrid fields={item.fields} />
-            <PreviewCta item={item} dark />
-            {item.footer && <p className="mt-3 text-xs text-[#a5a7aa]">Added by Moneat</p>}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function MoneatMessageAvatar() {
-  return (
-    <div
-      aria-hidden="true"
-      className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white"
-    >
-      <img src="/favicon.svg" alt="" className="h-8 w-8" />
-    </div>
-  )
-}
-
-function EmailFieldGrid({fields}: {fields: WorkflowStepPreview['fields']}) {
-  if (fields.length === 0) return null
-  return (
-    <div className="mt-4 grid gap-x-6 gap-y-3 sm:grid-cols-2">
-      {fields.map((field) => (
-        <div key={field.label} className="min-w-0">
-          <p className="text-sm font-semibold text-foreground">{field.label}:</p>
-          <p className="break-words text-sm text-muted-foreground">{field.value}</p>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function AlertFieldGrid({fields}: {fields: WorkflowStepPreview['fields']}) {
-  if (fields.length === 0) return null
-  return (
-    <div className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
-      {fields.map((field) => (
-        <div key={field.label} className="min-w-0">
-          <p className="text-sm font-bold text-[#d1d2d3]">{field.label}:</p>
-          <p className="break-words text-sm text-[#d1d2d3]">{field.value}</p>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function PreviewCta({
-  item,
-  dark = false,
-}: {
-  item: WorkflowStepPreview
-  dark?: boolean
-}) {
-  if (!item.cta_label || !item.cta_url) return null
-  return (
-    <div className="mt-3">
-      <Button type="button" variant={dark ? 'secondary' : 'outline'} size="sm" className="h-8 px-3">
-        {item.cta_label}
-      </Button>
-    </div>
-  )
-}
-
-function previewStatusEmoji(item: WorkflowStepPreview): string {
-  const status = previewFieldValue(item, 'Status')
-  if (status.toLowerCase() === 'resolved') return '✅'
-  return item.color.toLowerCase() === '#e01e5a' ? '🔴' : '⚠️'
-}
-
-function previewHeaderText(item: WorkflowStepPreview): string {
-  return item.title
-}
-
-function previewFieldValue(
-  item: WorkflowStepPreview,
-  label: string
-): string {
-  return item.fields.find((field) => field.label.toLowerCase() === label.toLowerCase())?.value ?? ''
-}
-
-function previewTabValue(
-  item: WorkflowStepPreview,
-  index: number
-): string {
-  return item.channel + '-' + index
-}
-
-function previewChannelLabel(channel: string): string {
-  if (channel === 'email') return 'Email'
-  if (channel === 'discord') return 'Discord'
-  if (channel === 'slack') return 'Slack'
-  return channel
-}
-
-function CatalogPanel({
-  catalog,
-  trigger,
-}: {
-  catalog?: WorkflowCatalogResponse
-  trigger?: WorkflowTriggerDefinition
-}) {
-  return (
-    <div className="space-y-3">
-      <div className="rounded-md border bg-muted/20 p-3">
-        <div className="mb-2 flex items-center gap-2">
-          <GitBranch className="h-4 w-4 text-muted-foreground" />
-          <h3 className="text-sm font-semibold">Trigger Scope</h3>
-        </div>
-        <div className="space-y-1.5">
-          {trigger?.scope.map((reference) => (
-            <div key={reference.name} className="rounded border bg-background px-2 py-1.5">
-              <p className="text-xs font-medium">{reference.label}</p>
-              <p className="font-mono text-[11px] text-muted-foreground">{reference.name}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="rounded-md border bg-muted/20 p-3">
-        <div className="mb-2 flex items-center gap-2">
-          <Activity className="h-4 w-4 text-muted-foreground" />
-          <h3 className="text-sm font-semibold">Available Steps</h3>
-        </div>
-        <div className="space-y-1.5">
-          {catalog?.steps.map((step) => (
-            <div key={step.name} className="rounded border bg-background px-2 py-1.5">
-              <div className="flex items-center gap-2">
-                <StepIconGlyph stepName={step.name} className="h-3.5 w-3.5 text-muted-foreground" />
-                <p className="text-xs font-medium">{step.label}</p>
-              </div>
-              <p className="mt-1 text-[11px] text-muted-foreground">{step.description}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="rounded-md border bg-muted/20 p-3">
-        <div className="mb-2 flex items-center gap-2">
-          <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
-          <h3 className="text-sm font-semibold">Interpolation</h3>
-        </div>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          Use scoped values in messages with double braces, for example {'{{alert.title}}'} or {'{{alert.url}}'}.
-        </p>
-      </div>
-    </div>
-  )
+function updateGraphTrigger(
+  graph: WorkflowGraphConfig,
+  triggerName: string
+): WorkflowGraphConfig {
+  return {
+    ...graph,
+    nodes: graph.nodes.map((node) => (
+      node.id === triggerNodeId ? {...node, trigger: triggerName} : node
+    )),
+  }
 }


### PR DESCRIPTION
## Summary
- Add workflow graph persistence, published version state, typed scope compatibility, and run-step progress storage.
- Add graph validation, node catalog definitions, legacy workflow graph adaptation, and execution primitives for branches, waits, loops, error edges, retries, and step outputs.
- Add the Workflows canvas/editor/debug surfaces with publish, unpublish, and manual run controls.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `cd backend && ./gradlew --no-daemon :compileKotlin :compileTestKotlin detekt :test --tests com.moneat.workflows.WorkflowServiceTest --tests com.moneat.workflows.routes.WorkflowRoutesTest --tests com.moneat.workflows.services.WorkflowGraphValidatorTest --tests com.moneat.workflows.engine.temporal.WorkflowInterpreterWorkflowTest`
- `cd dashboard && npm run lint`
- `cd dashboard && npm run typecheck`
- `cd dashboard && npm run build`
- Local browser smoke on `http://localhost:3003/workflows`: opened the Workflows app and editor, verified graph nodes/edges/handles render, validation is visible, and no React Flow handle warnings were emitted.

Existing dashboard build warnings remain from route files under `src/routes/__tests__`, the monitoring context route helper, rrweb `worker_threads`, and the current bundle-size warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph-based workflow editor with canvas, node palette and node config panels for visual creation and editing.
  * Publish/unpublish controls and manual run (trigger) with on-demand execution.
  * Typed JSON scopes and richer step outputs for more expressive parameters and results.
  * Enhanced validation panel with actionable issues and safe save blocking.
  * Run debug drawer showing per-step execution details and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->