### PR TITLE
feat(workflows): expand safe triggers and trusted actions

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
@@ -20,6 +20,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
+import com.moneat.workflows.services.WorkflowService
 import io.lettuce.core.RedisException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -42,6 +43,7 @@ class SecurityIngestionWorker(
     private val queueKey: String = "moneat:dd:security:queue",
     private val dlqKey: String = "moneat:dd:security:dlq",
     private val workerCount: Int = 1,
+    private val workflowService: WorkflowService = WorkflowService()
 ) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var jobs: List<Job> = emptyList()
@@ -104,6 +106,7 @@ class SecurityIngestionWorker(
         suspendRunCatching {
             val batch = SecurityIngestionService.decodeBatch(payload)
             SecurityIngestionService.insertBatch(batch)
+            workflowService.publishSecuritySignals(batch)
             logger.debug {
                 "Security worker $workerId processed batch: " +
                     "type=${batch.batchType}"

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -113,6 +113,7 @@ import com.moneat.workflows.engine.temporal.WorkflowExecutionEngine
 import com.moneat.workflows.services.WorkflowActionExecutor
 import com.moneat.workflows.services.WorkflowService
 import com.moneat.workflows.services.WorkflowStepRenderer
+import com.moneat.workflows.services.WorkflowTrustedActionExecutor
 import org.koin.dsl.module
 
 /** Shared cross-domain singletons: notification channels, pricing, retention, shared repositories. */
@@ -125,7 +126,16 @@ val sharedModule = module {
     single { DiscordService() }
     single { AlertNotificationPreferencesService() }
     single { WorkflowStepRenderer() }
-    single { WorkflowActionExecutor(get(), get(), get(), get()) }
+    single {
+        WorkflowTrustedActionExecutor(
+            logService = get(),
+            dashboardService = get(),
+            monitorService = get(),
+            monitorAlertServiceProvider = { get<MonitorAlertService>() },
+            statusPageService = get(),
+        )
+    }
+    single { WorkflowActionExecutor(get(), get(), get(), get(), get()) }
     single { PersistRunActivityImpl() }
     single { ExecuteActionActivityImpl(get()) }
     single { TemporalClientProvider() }

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
@@ -85,9 +85,13 @@ class IncidentService(
         if (publishWorkflow) {
             suspendRunCatching {
                 workflowService.publishAlertTriggered(event)
+            }.getOrElse { e ->
+                logger.error("Error publishing alert-triggered workflow", e)
+            }
+            suspendRunCatching {
                 workflowService.publishIncidentCreated(event)
             }.getOrElse { e ->
-                logger.error("Error publishing alert workflow", e)
+                logger.error("Error publishing incident-created workflow", e)
             }
         }
 
@@ -160,13 +164,17 @@ class IncidentService(
                     description = description,
                     moneatUrl = moneatUrl
                 )
+            }.getOrElse { e ->
+                logger.error("Error publishing alert-resolved workflow", e)
+            }
+            suspendRunCatching {
                 workflowService.publishIncidentResolved(
                     organizationId = organizationId,
                     deduplicationKey = deduplicationKey,
                     title = title
                 )
             }.getOrElse { e ->
-                logger.error("Error publishing resolved alert workflow", e)
+                logger.error("Error publishing incident-resolved workflow", e)
             }
         }
 

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
@@ -85,6 +85,7 @@ class IncidentService(
         if (publishWorkflow) {
             suspendRunCatching {
                 workflowService.publishAlertTriggered(event)
+                workflowService.publishIncidentCreated(event)
             }.getOrElse { e ->
                 logger.error("Error publishing alert workflow", e)
             }
@@ -158,6 +159,11 @@ class IncidentService(
                     title = title,
                     description = description,
                     moneatUrl = moneatUrl
+                )
+                workflowService.publishIncidentResolved(
+                    organizationId = organizationId,
+                    deduplicationKey = deduplicationKey,
+                    title = title
                 )
             }.getOrElse { e ->
                 logger.error("Error publishing resolved alert workflow", e)

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -33,6 +33,20 @@ private const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
 private const val ALERT_CONDITION_REFERENCE = "alert.condition"
 private const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
 private const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
+private const val ORGANIZATION_ID_REFERENCE = "organization.id"
+private const val WORKFLOW_INPUT_REFERENCE = "workflow.input"
+private const val WORKFLOW_ACTOR_ID_REFERENCE = "workflow.actor_id"
+private const val WORKFLOW_CALLER_REFERENCE = "workflow.caller"
+private const val WEBHOOK_PAYLOAD_REFERENCE = "webhook.payload"
+private const val WEBHOOK_EVENT_ID_REFERENCE = "webhook.event_id"
+private const val INCIDENT_ID_REFERENCE = "incident.id"
+private const val INCIDENT_TITLE_REFERENCE = "incident.title"
+private const val INCIDENT_STATUS_REFERENCE = "incident.status"
+private const val INCIDENT_SEVERITY_REFERENCE = "incident.severity"
+private const val SECURITY_RULE_ID_REFERENCE = "security.rule_id"
+private const val SECURITY_RULE_NAME_REFERENCE = "security.rule_name"
+private const val SECURITY_SEVERITY_REFERENCE = "security.severity"
+private const val SECURITY_RESOURCE_REFERENCE = "security.resource"
 
 @Serializable
 data class WorkflowFieldConfig(
@@ -184,6 +198,25 @@ object WorkflowCatalog {
                 WorkflowOperationDefinition("eq", EQUALS_LABEL, "AlertStatus"),
                 WorkflowOperationDefinition("neq", NOT_EQUALS_LABEL, "AlertStatus")
             )
+        ),
+        WorkflowResourceDefinition(
+            type = "IncidentStatus",
+            label = "Incident Status",
+            fieldConfig = WorkflowFieldConfig(type = "select", placeholder = "created, updated, resolved"),
+            operations = listOf(
+                WorkflowOperationDefinition("eq", EQUALS_LABEL, "IncidentStatus"),
+                WorkflowOperationDefinition("neq", NOT_EQUALS_LABEL, "IncidentStatus")
+            )
+        ),
+        WorkflowResourceDefinition(
+            type = "SecuritySeverity",
+            label = "Security Severity",
+            fieldConfig = WorkflowFieldConfig(type = "select", placeholder = "critical, high, medium, low, info"),
+            operations = listOf(
+                WorkflowOperationDefinition("eq", EQUALS_LABEL, "SecuritySeverity"),
+                WorkflowOperationDefinition("neq", NOT_EQUALS_LABEL, "SecuritySeverity"),
+                WorkflowOperationDefinition("at_least", "is at least", "SecuritySeverity")
+            )
         )
     )
 
@@ -205,7 +238,42 @@ object WorkflowCatalog {
         WorkflowScopeReferenceDefinition(ALERT_CHANNEL_EMAIL_REFERENCE, "Email channel", "Boolean"),
         WorkflowScopeReferenceDefinition(ALERT_CHANNEL_SLACK_REFERENCE, "Slack channel", "Boolean"),
         WorkflowScopeReferenceDefinition(ALERT_CHANNEL_DISCORD_REFERENCE, "Discord channel", "Boolean"),
-        WorkflowScopeReferenceDefinition("organization.id", "Organization ID", "String")
+        WorkflowScopeReferenceDefinition(ORGANIZATION_ID_REFERENCE, "Organization ID", "String")
+    )
+
+    private val manualScope = listOf(
+        WorkflowScopeReferenceDefinition(WORKFLOW_ACTOR_ID_REFERENCE, "Actor user ID", "String"),
+        WorkflowScopeReferenceDefinition(WORKFLOW_INPUT_REFERENCE, "Run input", "Text"),
+        WorkflowScopeReferenceDefinition(ORGANIZATION_ID_REFERENCE, "Organization ID", "String")
+    )
+
+    private val apiScope = listOf(
+        WorkflowScopeReferenceDefinition(WORKFLOW_CALLER_REFERENCE, "Caller", "String"),
+        WorkflowScopeReferenceDefinition(WORKFLOW_INPUT_REFERENCE, "API input", "Text"),
+        WorkflowScopeReferenceDefinition(ORGANIZATION_ID_REFERENCE, "Organization ID", "String")
+    )
+
+    private val webhookScope = listOf(
+        WorkflowScopeReferenceDefinition(WEBHOOK_PAYLOAD_REFERENCE, "Webhook payload", "Text"),
+        WorkflowScopeReferenceDefinition(WEBHOOK_EVENT_ID_REFERENCE, "Webhook event ID", "String"),
+        WorkflowScopeReferenceDefinition(ORGANIZATION_ID_REFERENCE, "Organization ID", "String")
+    )
+
+    private val incidentScope = listOf(
+        WorkflowScopeReferenceDefinition(INCIDENT_ID_REFERENCE, "Incident ID", "String"),
+        WorkflowScopeReferenceDefinition(INCIDENT_TITLE_REFERENCE, "Incident title", "String"),
+        WorkflowScopeReferenceDefinition(INCIDENT_STATUS_REFERENCE, "Incident status", "IncidentStatus"),
+        WorkflowScopeReferenceDefinition(INCIDENT_SEVERITY_REFERENCE, "Incident severity", "AlertSeverity"),
+        WorkflowScopeReferenceDefinition(ALERT_DEDUPLICATION_KEY_REFERENCE, "Deduplication key", "String"),
+        WorkflowScopeReferenceDefinition(ORGANIZATION_ID_REFERENCE, "Organization ID", "String")
+    )
+
+    private val securityScope = listOf(
+        WorkflowScopeReferenceDefinition(SECURITY_RULE_ID_REFERENCE, "Rule ID", "String"),
+        WorkflowScopeReferenceDefinition(SECURITY_RULE_NAME_REFERENCE, "Rule name", "String"),
+        WorkflowScopeReferenceDefinition(SECURITY_SEVERITY_REFERENCE, "Severity", "SecuritySeverity"),
+        WorkflowScopeReferenceDefinition(SECURITY_RESOURCE_REFERENCE, "Resource", "String"),
+        WorkflowScopeReferenceDefinition(ORGANIZATION_ID_REFERENCE, "Organization ID", "String")
     )
 
     val triggers = listOf(
@@ -222,6 +290,90 @@ object WorkflowCatalog {
             description = "Runs when Moneat resolves an alert by deduplication key.",
             scope = alertScope,
             defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "monitor.alerted",
+            label = "When a monitor alerts",
+            description = "Runs when a host or dashboard monitor fires.",
+            scope = alertScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "monitor.recovered",
+            label = "When a monitor recovers",
+            description = "Runs when a host or dashboard monitor recovers.",
+            scope = alertScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "uptime.down",
+            label = "When uptime monitor is down",
+            description = "Runs when an uptime monitor reports an outage.",
+            scope = alertScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "uptime.up",
+            label = "When uptime monitor recovers",
+            description = "Runs when an uptime monitor returns to service.",
+            scope = alertScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "synthetic.failed",
+            label = "When a synthetic test fails",
+            description = "Runs when a synthetic test reports a failed run.",
+            scope = alertScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "synthetic.passed",
+            label = "When a synthetic test passes",
+            description = "Runs when a synthetic test recovers after failures.",
+            scope = alertScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "incident.created",
+            label = "When an incident is created",
+            description = "Runs when incident routing creates or pages a response event.",
+            scope = incidentScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "incident.resolved",
+            label = "When an incident resolves",
+            description = "Runs when incident routing resolves a response event.",
+            scope = incidentScope,
+            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, INCIDENT_STATUS_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "security.signal",
+            label = "When a security signal arrives",
+            description = "Runs when runtime or compliance security telemetry is ingested.",
+            scope = securityScope,
+            defaultOnceForTemplate = listOf(SECURITY_RULE_ID_REFERENCE, SECURITY_RESOURCE_REFERENCE)
+        ),
+        WorkflowTriggerDefinition(
+            name = "manual",
+            label = "Run manually",
+            description = "Runs when an administrator starts the workflow from the dashboard.",
+            scope = manualScope,
+            defaultOnceForTemplate = emptyList()
+        ),
+        WorkflowTriggerDefinition(
+            name = "api",
+            label = "Run from API",
+            description = "Runs when an authenticated API caller starts a workflow instance.",
+            scope = apiScope,
+            defaultOnceForTemplate = emptyList()
+        ),
+        WorkflowTriggerDefinition(
+            name = "webhook",
+            label = "Run from signed webhook",
+            description = "Runs when Moneat receives a valid signed inbound webhook.",
+            scope = webhookScope,
+            defaultOnceForTemplate = listOf(WEBHOOK_EVENT_ID_REFERENCE)
         )
     )
 
@@ -250,6 +402,128 @@ object WorkflowCatalog {
             params = listOf(
                 WorkflowStepParamDefinition("title", "Title", "String", required = false),
                 WorkflowStepParamDefinition("message", "Message", "Text")
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "moneat.logs.search",
+            label = "Search logs",
+            description = "Search organization logs with the same query path used by Moneat log management.",
+            params = listOf(
+                WorkflowStepParamDefinition("query", "Query", "String", required = false),
+                WorkflowStepParamDefinition("levels", "Levels", "String", "Comma-separated log levels", false),
+                WorkflowStepParamDefinition("service", "Service", "String", required = false),
+                WorkflowStepParamDefinition("environment", "Environment", "String", required = false),
+                WorkflowStepParamDefinition("from", "From", "String", "ISO-8601 start time", false),
+                WorkflowStepParamDefinition("to", "To", "String", "ISO-8601 end time", false),
+                WorkflowStepParamDefinition("limit", "Limit", "Number", required = false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "moneat.logs.aggregate",
+            label = "Aggregate logs",
+            description = "Aggregate log volume by interval and optional group.",
+            params = listOf(
+                WorkflowStepParamDefinition("query", "Query", "String", required = false),
+                WorkflowStepParamDefinition("levels", "Levels", "String", "Comma-separated log levels", false),
+                WorkflowStepParamDefinition("service", "Service", "String", required = false),
+                WorkflowStepParamDefinition("from", "From", "String", "ISO-8601 start time", false),
+                WorkflowStepParamDefinition("to", "To", "String", "ISO-8601 end time", false),
+                WorkflowStepParamDefinition("interval", "Interval", "String", "1m, 5m, 15m, 1h, or 1d", false),
+                WorkflowStepParamDefinition("group_by", "Group by", "String", required = false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "moneat.metrics.query",
+            label = "Query host metrics",
+            description = "Read historical host metrics for enrichment.",
+            params = listOf(
+                WorkflowStepParamDefinition("host_id", "Host ID", "Number"),
+                WorkflowStepParamDefinition("hours", "Hours", "Number", required = false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "moneat.traces.search",
+            label = "Search traces",
+            description = "Read recent transaction and trace summaries for a project.",
+            params = listOf(
+                WorkflowStepParamDefinition("project_id", "Project ID", "Number"),
+                WorkflowStepParamDefinition("period", "Period", "String", "1h, 6h, 24h, 7d, or 30d", false),
+                WorkflowStepParamDefinition("environment", "Environment", "String", required = false),
+                WorkflowStepParamDefinition("operation", "Operation", "String", required = false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "moneat.span.get",
+            label = "Get span",
+            description = "Read details for a single span in an organization project.",
+            params = listOf(
+                WorkflowStepParamDefinition("project_id", "Project ID", "Number"),
+                WorkflowStepParamDefinition("span_id", "Span ID", "String")
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "moneat.issues.list",
+            label = "List issues",
+            description = "List issues in an organization project.",
+            params = listOf(
+                WorkflowStepParamDefinition("project_id", "Project ID", "Number"),
+                WorkflowStepParamDefinition("status", "Status", "String", required = false),
+                WorkflowStepParamDefinition("page", "Page", "Number", required = false),
+                WorkflowStepParamDefinition("limit", "Limit", "Number", required = false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "moneat.issues.get",
+            label = "Get issue",
+            description = "Read issue details in an organization project.",
+            params = listOf(
+                WorkflowStepParamDefinition("project_id", "Project ID", "Number"),
+                WorkflowStepParamDefinition("issue_id", "Issue ID", "String")
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "statuspage.update",
+            label = "Update status page",
+            description = "Update safe status page fields.",
+            params = listOf(
+                WorkflowStepParamDefinition("status_page_id", "Status page ID", "String"),
+                WorkflowStepParamDefinition("name", "Name", "String", required = false),
+                WorkflowStepParamDefinition("description", "Description", "Text", required = false),
+                WorkflowStepParamDefinition("is_public", "Public", "Boolean", required = false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "statuspage.incident.create",
+            label = "Create status incident",
+            description = "Create a status page incident update for customer communication.",
+            params = listOf(
+                WorkflowStepParamDefinition("status_page_id", "Status page ID", "String"),
+                WorkflowStepParamDefinition("title", "Title", "String"),
+                WorkflowStepParamDefinition("message", "Message", "Text"),
+                WorkflowStepParamDefinition("status", "Status", "String", required = false),
+                WorkflowStepParamDefinition("impact", "Impact", "String", required = false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "alert.silence",
+            label = "Silence alerts",
+            description = "Create an organization alert silence period.",
+            params = listOf(
+                WorkflowStepParamDefinition("reason", "Reason", "String", required = false),
+                WorkflowStepParamDefinition("starts_at", "Starts at", "Number", "Epoch milliseconds", false),
+                WorkflowStepParamDefinition("ends_at", "Ends at", "Number", "Epoch milliseconds", false)
+            )
+        ),
+        WorkflowStepDefinition(
+            name = "oncall.page",
+            label = "Page on-call",
+            description = "Page responders through the on-call bridge when Enterprise on-call is enabled.",
+            params = listOf(
+                WorkflowStepParamDefinition("escalation_policy_id", "Escalation policy ID", "Number"),
+                WorkflowStepParamDefinition("title", "Title", "String"),
+                WorkflowStepParamDefinition("description", "Description", "Text", required = false),
+                WorkflowStepParamDefinition("priority_level", "Priority", "String", required = false),
+                WorkflowStepParamDefinition("deduplication_key", "Deduplication key", "String", required = false)
             )
         )
     )

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowConditionEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowConditionEvaluator.kt
@@ -21,10 +21,11 @@ import com.moneat.workflows.models.workflowStringValue
 import com.moneat.workflows.models.workflowValue
 import kotlinx.serialization.json.JsonElement
 
-private const val SEVERITY_CRITICAL_RANK = 4
-private const val SEVERITY_HIGH_RANK = 3
-private const val SEVERITY_MEDIUM_RANK = 2
-private const val SEVERITY_LOW_RANK = 1
+private const val SEVERITY_CRITICAL_RANK = 5
+private const val SEVERITY_HIGH_RANK = 4
+private const val SEVERITY_MEDIUM_RANK = 3
+private const val SEVERITY_LOW_RANK = 2
+private const val SEVERITY_INFO_RANK = 1
 private const val SEVERITY_UNKNOWN_RANK = 0
 private val SEVERITY_RESOURCE_TYPES = setOf("AlertSeverity", "SecuritySeverity")
 
@@ -102,6 +103,7 @@ object WorkflowConditionEvaluator {
             "HIGH" -> SEVERITY_HIGH_RANK
             "MEDIUM" -> SEVERITY_MEDIUM_RANK
             "LOW" -> SEVERITY_LOW_RANK
+            "INFO" -> SEVERITY_INFO_RANK
             else -> SEVERITY_UNKNOWN_RANK
         }
 }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowConditionEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowConditionEvaluator.kt
@@ -26,6 +26,7 @@ private const val SEVERITY_HIGH_RANK = 3
 private const val SEVERITY_MEDIUM_RANK = 2
 private const val SEVERITY_LOW_RANK = 1
 private const val SEVERITY_UNKNOWN_RANK = 0
+private val SEVERITY_RESOURCE_TYPES = setOf("AlertSeverity", "SecuritySeverity")
 
 object WorkflowConditionEvaluator {
     fun matchesAll(
@@ -66,7 +67,9 @@ object WorkflowConditionEvaluator {
             "gt", "gte", "lt", "lte" -> compareNumbers(actual, expected, operation)
             "at_least" -> {
                 val expectedRank = severityRank(expected)
-                resourceType == "AlertSeverity" && expectedRank > 0 && severityRank(actual) >= expectedRank
+                resourceType in SEVERITY_RESOURCE_TYPES &&
+                    expectedRank > 0 &&
+                    severityRank(actual) >= expectedRank
             }
             else -> false
         }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/TemporalWorkflowExecutionEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/TemporalWorkflowExecutionEngine.kt
@@ -45,6 +45,10 @@ class TemporalWorkflowExecutionEngine(
         return WorkflowStartResult(execution.workflowId, execution.runId)
     }
 
+    override suspend fun cancel(temporalWorkflowId: String) {
+        clientProvider.client.newUntypedWorkflowStub(temporalWorkflowId).cancel()
+    }
+
     private fun workflowOptions(request: WorkflowStartRequest): WorkflowOptions =
         WorkflowOptions
             .newBuilder()

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowExecutionEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowExecutionEngine.kt
@@ -18,4 +18,6 @@ package com.moneat.workflows.engine.temporal
 
 interface WorkflowExecutionEngine {
     suspend fun start(request: WorkflowStartRequest): WorkflowStartResult
+
+    suspend fun cancel(temporalWorkflowId: String)
 }

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
@@ -227,6 +227,26 @@ data class ManualWorkflowRunRequest(
 )
 
 @Serializable
+data class WorkflowRunInstanceRequest(
+    val scope: Map<String, JsonElement> = emptyMap()
+)
+
+@Serializable
+data class WorkflowRunCancelResponse(
+    val id: Int,
+    val status: String
+)
+
+@Serializable
+data class WorkflowWebhookSigningResponse(
+    @SerialName("workflow_id") val workflowId: Int,
+    @SerialName("webhook_url") val webhookUrl: String,
+    @SerialName("signing_secret") val signingSecret: String,
+    @SerialName("signature_header") val signatureHeader: String,
+    @SerialName("signature_format") val signatureFormat: String
+)
+
+@Serializable
 data class WorkflowResponse(
     val id: Int,
     val name: String,
@@ -271,6 +291,8 @@ data class WorkflowRunResponse(
     val progress: List<WorkflowRunStepProgress>,
     val steps: List<WorkflowRunStepResponse> = emptyList(),
     @SerialName("error_message") val errorMessage: String? = null,
+    @SerialName("temporal_workflow_id") val temporalWorkflowId: String? = null,
+    @SerialName("temporal_run_id") val temporalRunId: String? = null,
     @SerialName("created_at") val createdAt: String,
     @SerialName("completed_at") val completedAt: String? = null,
     @SerialName("failed_at") val failedAt: String? = null

--- a/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
@@ -24,12 +24,14 @@ import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.ManualWorkflowRunRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowPreviewRequest
+import com.moneat.workflows.models.WorkflowRunInstanceRequest
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
+import io.ktor.server.request.receiveText
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.RoutingContext
@@ -44,9 +46,15 @@ private const val MIN_WORKFLOW_RUN_LIMIT = 1
 private const val MAX_WORKFLOW_RUN_LIMIT = 100
 private const val DEFAULT_WORKFLOW_RUN_LIMIT = 50
 private const val WORKFLOW_ID_ROUTE = "/{workflowId}"
+private const val INSTANCE_ID_ROUTE = "{instanceId}"
+private const val WEBHOOK_SIGNATURE_HEADER = "X-Moneat-Workflow-Signature"
+private const val WEBHOOK_EVENT_ID_HEADER = "X-Moneat-Webhook-Event"
 private const val INVALID_WORKFLOW_ID_MESSAGE = "Invalid workflow ID"
+private const val INVALID_INSTANCE_ID_MESSAGE = "Invalid workflow instance ID"
 private const val WORKFLOW_NOT_FOUND_MESSAGE = "Workflow not found"
+private const val WORKFLOW_INSTANCE_NOT_FOUND_MESSAGE = "Workflow instance not found"
 private const val FORBIDDEN_MESSAGE = "Insufficient permissions"
+private const val INVALID_WEBHOOK_SIGNATURE_MESSAGE = "Invalid workflow webhook signature"
 
 fun Route.workflowRoutes() {
     val koin = GlobalContext.get()
@@ -54,6 +62,24 @@ fun Route.workflowRoutes() {
     val membershipService = koin.get<OrgMembershipService>()
 
     route("/v1/workflows") {
+        post("$WORKFLOW_ID_ROUTE/webhook") {
+            val workflowId = workflowIdFromPath() ?: return@post call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+            )
+            val payload = call.receiveText()
+            val signature = call.request.headers[WEBHOOK_SIGNATURE_HEADER]
+            if (!workflowService.verifyWebhookSignature(workflowId, payload, signature)) {
+                return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_WEBHOOK_SIGNATURE_MESSAGE))
+            }
+            val run = workflowService.createWebhookRun(
+                workflowId = workflowId,
+                payload = payload,
+                eventId = call.request.headers[WEBHOOK_EVENT_ID_HEADER]
+            ) ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse(WORKFLOW_NOT_FOUND_MESSAGE))
+            call.respond(HttpStatusCode.Accepted, run)
+        }
+
         authenticate("auth-jwt") {
             get("/catalog") {
                 call.respond(workflowService.catalog())
@@ -166,6 +192,57 @@ fun Route.workflowRoutes() {
                 call.respond(workflowService.listRuns(organizationId, workflowId, limit))
             }
 
+            get("$WORKFLOW_ID_ROUTE/instances") {
+                val organizationId = currentOrganizationId() ?: return@get call.respond(HttpStatusCode.Forbidden)
+                val workflowId = workflowIdFromPath() ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val limit =
+                    call.request.queryParameters["limit"]
+                        ?.toIntOrNull()
+                        ?.coerceIn(MIN_WORKFLOW_RUN_LIMIT, MAX_WORKFLOW_RUN_LIMIT)
+                        ?: DEFAULT_WORKFLOW_RUN_LIMIT
+                call.respond(workflowService.listRuns(organizationId, workflowId, limit))
+            }
+
+            get("$WORKFLOW_ID_ROUTE/instances/$INSTANCE_ID_ROUTE") {
+                val organizationId = currentOrganizationId() ?: return@get call.respond(HttpStatusCode.Forbidden)
+                val workflowId = workflowIdFromPath() ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val instanceId = instanceIdFromPath() ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_INSTANCE_ID_MESSAGE)
+                )
+                val run = workflowService.getRun(organizationId, workflowId, instanceId)
+                    ?: return@get call.respond(
+                        HttpStatusCode.NotFound,
+                        ErrorResponse(WORKFLOW_INSTANCE_NOT_FOUND_MESSAGE)
+                    )
+                call.respond(run)
+            }
+
+            put("$WORKFLOW_ID_ROUTE/instances/$INSTANCE_ID_ROUTE/cancel") {
+                val organizationId = currentOrganizationId() ?: return@put call.respond(HttpStatusCode.Forbidden)
+                ensureWorkflowAdmin(membershipService, organizationId) ?: return@put
+                val workflowId = workflowIdFromPath() ?: return@put call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val instanceId = instanceIdFromPath() ?: return@put call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_INSTANCE_ID_MESSAGE)
+                )
+                val canceled = workflowService.cancelRun(organizationId, workflowId, instanceId)
+                    ?: return@put call.respond(
+                        HttpStatusCode.NotFound,
+                        ErrorResponse(WORKFLOW_INSTANCE_NOT_FOUND_MESSAGE)
+                    )
+                call.respond(canceled)
+            }
+
             post("$WORKFLOW_ID_ROUTE/publish") {
                 val organizationId = currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
                 ensureWorkflowAdmin(membershipService, organizationId) ?: return@post
@@ -190,6 +267,18 @@ fun Route.workflowRoutes() {
                 call.respond(workflow)
             }
 
+            get("$WORKFLOW_ID_ROUTE/webhook-signing") {
+                val organizationId = currentOrganizationId() ?: return@get call.respond(HttpStatusCode.Forbidden)
+                ensureWorkflowAdmin(membershipService, organizationId) ?: return@get
+                val workflowId = workflowIdFromPath() ?: return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val signing = workflowService.webhookSigningInfo(organizationId, workflowId)
+                    ?: return@get call.respond(HttpStatusCode.NotFound, ErrorResponse(WORKFLOW_NOT_FOUND_MESSAGE))
+                call.respond(signing)
+            }
+
             post("$WORKFLOW_ID_ROUTE/run") {
                 val organizationId = currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
                 ensureWorkflowAdmin(membershipService, organizationId) ?: return@post
@@ -198,9 +287,32 @@ fun Route.workflowRoutes() {
                     ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
                 )
                 val request = call.receive<ManualWorkflowRunRequest>()
-                val run = workflowService.runWorkflow(organizationId, workflowId, request)
+                val run = workflowService.runWorkflow(organizationId, workflowId, request, currentUserId())
                     ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse(WORKFLOW_NOT_FOUND_MESSAGE))
                 call.respond(HttpStatusCode.Accepted, run)
+            }
+
+            post("$WORKFLOW_ID_ROUTE/instances") {
+                val organizationId = currentOrganizationId() ?: return@post call.respond(HttpStatusCode.Forbidden)
+                ensureWorkflowAdmin(membershipService, organizationId) ?: return@post
+                val userId = currentUserId() ?: return@post call.respond(HttpStatusCode.Forbidden)
+                val workflowId = workflowIdFromPath() ?: return@post call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(INVALID_WORKFLOW_ID_MESSAGE)
+                )
+                val request = call.receive<WorkflowRunInstanceRequest>()
+                suspendRunCatching {
+                    workflowService.createWorkflowInstance(organizationId, workflowId, request, userId)
+                }.fold(
+                    onSuccess = { run ->
+                        if (run == null) {
+                            call.respond(HttpStatusCode.NotFound, ErrorResponse(WORKFLOW_NOT_FOUND_MESSAGE))
+                        } else {
+                            call.respond(HttpStatusCode.Accepted, run)
+                        }
+                    },
+                    onFailure = { error -> respondWorkflowError(error) }
+                )
             }
         }
     }
@@ -233,6 +345,9 @@ private suspend fun RoutingContext.ensureWorkflowAdmin(
 
 private fun RoutingContext.workflowIdFromPath(): Int? =
     call.parameters["workflowId"]?.toIntOrNull()
+
+private fun RoutingContext.instanceIdFromPath(): Int? =
+    call.parameters["instanceId"]?.toIntOrNull()
 
 private fun RoutingContext.currentOrganizationId(): Int? {
     val principal = call.principal<JWTPrincipal>() ?: return null

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowActionExecutor.kt
@@ -31,6 +31,9 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
+private const val WORKFLOW_ACTOR_ID_SCOPE = "workflow.actor_id"
+private const val WORKFLOW_CALLER_SCOPE = "workflow.caller"
+
 class WorkflowActionExecutor(
     private val emailService: EmailService,
     private val slackService: SlackService,
@@ -61,12 +64,20 @@ class WorkflowActionExecutor(
             SLACK_STEP -> executeSlackStep(organizationId, step, stringScope)
             DISCORD_STEP -> executeDiscordStep(organizationId, step, stringScope)
             else -> if (trustedActions?.supports(step.name) == true) {
-                trustedActions.execute(organizationId, step.name, step.params)
+                trustedActions.execute(
+                    organizationId = organizationId,
+                    stepName = step.name,
+                    params = step.params.mapValues { (_, value) -> interpolate(value, stringScope) },
+                    actorUserId = callerUserIdFromScope(stringScope)
+                )
             } else {
                 throw IllegalArgumentException("Unknown workflow step ${step.name}")
             }
         }
     }
+
+    private fun callerUserIdFromScope(scope: Map<String, String>): Int? =
+        scope[WORKFLOW_ACTOR_ID_SCOPE]?.toIntOrNull() ?: scope[WORKFLOW_CALLER_SCOPE]?.toIntOrNull()
 
     suspend fun sendTestMessageStep(
         organizationId: Int,

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowActionExecutor.kt
@@ -35,7 +35,8 @@ class WorkflowActionExecutor(
     private val emailService: EmailService,
     private val slackService: SlackService,
     private val discordService: DiscordService,
-    private val renderer: WorkflowStepRenderer
+    private val renderer: WorkflowStepRenderer,
+    private val trustedActions: WorkflowTrustedActionExecutor? = null
 ) {
     suspend fun executeStep(
         organizationId: Int,
@@ -59,7 +60,11 @@ class WorkflowActionExecutor(
             )
             SLACK_STEP -> executeSlackStep(organizationId, step, stringScope)
             DISCORD_STEP -> executeDiscordStep(organizationId, step, stringScope)
-            else -> throw IllegalArgumentException("Unknown workflow step ${step.name}")
+            else -> if (trustedActions?.supports(step.name) == true) {
+                trustedActions.execute(organizationId, step.name, step.params)
+            } else {
+                throw IllegalArgumentException("Unknown workflow step ${step.name}")
+            }
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -75,6 +75,7 @@ import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
 import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
@@ -417,7 +418,7 @@ class WorkflowService(
         val run = createRunForWorkflow(
             organizationId = organizationId,
             workflowId = workflowId,
-            scope = manualScope + request.scope,
+            scope = manualScope + (request.scope - manualScope.keys),
             onceFor = manualOnceFor(),
             force = true
         ) ?: return null
@@ -440,10 +441,11 @@ class WorkflowService(
         val run = createRunForWorkflow(
             organizationId = organizationId,
             workflowId = workflowId,
-            scope = apiScope + request.scope,
+            scope = apiScope + (request.scope - apiScope.keys),
             onceFor = apiOnceFor(),
             force = true,
-            requiredTriggerName = API_TRIGGER
+            requiredTriggerName = API_TRIGGER,
+            applyConditions = true
         ) ?: return null
         startTemporalExecution(run)
         return getRun(organizationId, workflowId, run.runId)
@@ -469,7 +471,8 @@ class WorkflowService(
             onceFor = webhookScope[WEBHOOK_EVENT_ID_REFERENCE]?.workflowStringValue().orEmpty(),
             force = false,
             requiredTriggerName = WEBHOOK_TRIGGER,
-            requirePublished = true
+            requirePublished = true,
+            applyConditions = true
         ) ?: return null
         startTemporalExecution(run)
         return getRun(workflowRef.organizationId, workflowId, run.runId)
@@ -519,14 +522,31 @@ class WorkflowService(
                 logger.warn(error) { "Failed to cancel Temporal workflow $temporalWorkflowId" }
             }
         }
-        transaction {
-            WorkflowRuns.update({ WorkflowRuns.id eq runId }) {
-                it[status] = STATUS_CANCELED
-                it[completedAt] = Clock.System.now()
-                it[errorMessage] = null
+        val updated =
+            transaction {
+                WorkflowRuns.update(
+                    {
+                        (WorkflowRuns.id eq runId) and (WorkflowRuns.status notInList TERMINAL_RUN_STATUSES)
+                    }
+                ) {
+                    it[status] = STATUS_CANCELED
+                    it[completedAt] = Clock.System.now()
+                    it[errorMessage] = null
+                }
             }
+        if (updated > 0) {
+            return WorkflowRunCancelResponse(runId, STATUS_CANCELED)
         }
-        return WorkflowRunCancelResponse(runId, STATUS_CANCELED)
+        // The run reached a terminal state between the initial read and this write; report its real status.
+        val currentStatus =
+            transaction {
+                WorkflowRuns
+                    .selectAll()
+                    .where { WorkflowRuns.id eq runId }
+                    .firstOrNull()
+                    ?.get(WorkflowRuns.status)
+            }
+        return WorkflowRunCancelResponse(runId, currentStatus ?: STATUS_CANCELED)
     }
 
     fun listRuns(
@@ -750,7 +770,8 @@ class WorkflowService(
         onceFor: String,
         force: Boolean,
         requiredTriggerName: String? = null,
-        requirePublished: Boolean = false
+        requirePublished: Boolean = false,
+        applyConditions: Boolean = false
     ): WorkflowStartRequest? =
         transaction {
             val workflowRow =
@@ -771,6 +792,11 @@ class WorkflowService(
                     organizationId = organizationId,
                     scope = triggerScope + scope
                 )
+            // Manual runs intentionally bypass conditions (they run against synthetic sample
+            // scope); API and signed-webhook runs carry real input and honor configured conditions.
+            if (applyConditions && !conditionsMatch(event.triggerName, version.conditions, event.scope)) {
+                return@transaction null
+            }
             createRun(event, WorkflowCandidate(workflowId, version), onceFor, force)
         }
 

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -18,7 +18,11 @@ package com.moneat.workflows.services
 
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSeverity
+import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.config.EnvConfig
+import com.moneat.datadog.security.QueuedSecurityBatch
+import com.moneat.datadog.security.QueuedSecurityEventEntry
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
@@ -43,6 +47,8 @@ import com.moneat.workflows.models.WorkflowGraphConfig
 import com.moneat.workflows.models.WorkflowPreviewRequest
 import com.moneat.workflows.models.WorkflowPreviewResponse
 import com.moneat.workflows.models.WorkflowResponse
+import com.moneat.workflows.models.WorkflowRunCancelResponse
+import com.moneat.workflows.models.WorkflowRunInstanceRequest
 import com.moneat.workflows.models.WorkflowRunResponse
 import com.moneat.workflows.models.WorkflowRunStepResponse
 import com.moneat.workflows.models.WorkflowRunStepProgress
@@ -52,6 +58,7 @@ import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowTestMessageResponse
 import com.moneat.workflows.models.WorkflowTriggerEvent
 import com.moneat.workflows.models.WorkflowVersions
+import com.moneat.workflows.models.WorkflowWebhookSigningResponse
 import com.moneat.workflows.models.Workflows
 import com.moneat.workflows.models.typedWorkflowScope
 import com.moneat.workflows.models.workflowJson
@@ -76,6 +83,8 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 import java.util.UUID
 import kotlin.time.Clock
 
@@ -83,6 +92,24 @@ private val logger = KotlinLogging.logger {}
 private const val UNIQUE_VIOLATION_SQL_STATE = "23505"
 private const val TEMPORAL_WORKFLOW_ID_HASH_LENGTH = 32
 private const val UNSIGNED_BYTE_MASK = 0xff
+private const val HMAC_ALGORITHM = "HmacSHA256"
+private const val WORKFLOW_WEBHOOK_SECRET_CONTEXT = "workflow-webhook"
+private const val WORKFLOW_WEBHOOK_SIGNATURE_HEADER = "X-Moneat-Workflow-Signature"
+private const val WEBHOOK_SIGNATURE_PREFIX = "sha256="
+private const val WEBHOOK_PAYLOAD_MAX_CHARS = 32_000
+private const val WORKFLOW_INPUT_REFERENCE = "workflow.input"
+private const val WORKFLOW_ACTOR_ID_REFERENCE = "workflow.actor_id"
+private const val WORKFLOW_CALLER_REFERENCE = "workflow.caller"
+private const val WEBHOOK_PAYLOAD_REFERENCE = "webhook.payload"
+private const val WEBHOOK_EVENT_ID_REFERENCE = "webhook.event_id"
+private const val INCIDENT_ID_REFERENCE = "incident.id"
+private const val INCIDENT_TITLE_REFERENCE = "incident.title"
+private const val INCIDENT_STATUS_REFERENCE = "incident.status"
+private const val INCIDENT_SEVERITY_REFERENCE = "incident.severity"
+private const val SECURITY_RULE_ID_REFERENCE = "security.rule_id"
+private const val SECURITY_RULE_NAME_REFERENCE = "security.rule_name"
+private const val SECURITY_SEVERITY_REFERENCE = "security.severity"
+private const val SECURITY_RESOURCE_REFERENCE = "security.resource"
 private const val DEFAULT_WORKFLOW_READ_ONLY_MESSAGE = "Default workflows cannot be modified"
 private val ALERT_CHANNEL_REFERENCES =
     setOf(ALERT_CHANNEL_EMAIL_REFERENCE, ALERT_CHANNEL_SLACK_REFERENCE, ALERT_CHANNEL_DISCORD_REFERENCE)
@@ -378,31 +405,77 @@ class WorkflowService(
     suspend fun runWorkflow(
         organizationId: Int,
         workflowId: Int,
-        request: ManualWorkflowRunRequest = ManualWorkflowRunRequest()
+        request: ManualWorkflowRunRequest = ManualWorkflowRunRequest(),
+        actorUserId: Int? = null
     ): WorkflowRunResponse? {
-        val run =
-            transaction {
-                val workflowRow =
-                    Workflows
-                        .selectAll()
-                        .where { (Workflows.id eq workflowId) and (Workflows.organizationId eq organizationId) }
-                        .firstOrNull() ?: return@transaction null
-                val version = latestVersion(workflowId) ?: return@transaction null
-                val triggerScope = stepRenderer.sampleScopeForTrigger(workflowRow[Workflows.triggerName])
-                    .typedWorkflowScope()
-                val event =
-                    WorkflowTriggerEvent(
-                        triggerName = workflowRow[Workflows.triggerName],
-                        organizationId = organizationId,
-                        scope = triggerScope + request.scope
-                    )
-                createRun(event, WorkflowCandidate(workflowId, version), manualOnceFor(), force = true)
-            } ?: return null
+        val manualScope =
+            mapOf(
+                WORKFLOW_INPUT_REFERENCE to json.encodeToString(request.scope),
+                WORKFLOW_ACTOR_ID_REFERENCE to actorUserId?.toString().orEmpty(),
+                ORGANIZATION_ID_REFERENCE to organizationId.toString()
+            ).typedWorkflowScope()
+        val run = createRunForWorkflow(
+            organizationId = organizationId,
+            workflowId = workflowId,
+            scope = manualScope + request.scope,
+            onceFor = manualOnceFor(),
+            force = true
+        ) ?: return null
         startTemporalExecution(run)
         return getRun(organizationId, workflowId, run.runId)
     }
 
-    private fun getRun(
+    suspend fun createWorkflowInstance(
+        organizationId: Int,
+        workflowId: Int,
+        request: WorkflowRunInstanceRequest,
+        callerUserId: Int
+    ): WorkflowRunResponse? {
+        val apiScope =
+            mapOf(
+                WORKFLOW_INPUT_REFERENCE to json.encodeToString(request.scope),
+                WORKFLOW_CALLER_REFERENCE to callerUserId.toString(),
+                ORGANIZATION_ID_REFERENCE to organizationId.toString()
+            ).typedWorkflowScope()
+        val run = createRunForWorkflow(
+            organizationId = organizationId,
+            workflowId = workflowId,
+            scope = apiScope + request.scope,
+            onceFor = apiOnceFor(),
+            force = true,
+            requiredTriggerName = API_TRIGGER
+        ) ?: return null
+        startTemporalExecution(run)
+        return getRun(organizationId, workflowId, run.runId)
+    }
+
+    suspend fun createWebhookRun(
+        workflowId: Int,
+        payload: String,
+        eventId: String?
+    ): WorkflowRunResponse? {
+        val sanitizedPayload = payload.take(WEBHOOK_PAYLOAD_MAX_CHARS)
+        val workflowRef = workflowReference(workflowId) ?: return null
+        val webhookScope =
+            mapOf(
+                WEBHOOK_PAYLOAD_REFERENCE to sanitizedPayload,
+                WEBHOOK_EVENT_ID_REFERENCE to (eventId ?: webhookOnceFor()),
+                ORGANIZATION_ID_REFERENCE to workflowRef.organizationId.toString()
+            ).typedWorkflowScope()
+        val run = createRunForWorkflow(
+            organizationId = workflowRef.organizationId,
+            workflowId = workflowId,
+            scope = webhookScope,
+            onceFor = webhookScope[WEBHOOK_EVENT_ID_REFERENCE]?.workflowStringValue().orEmpty(),
+            force = false,
+            requiredTriggerName = WEBHOOK_TRIGGER,
+            requirePublished = true
+        ) ?: return null
+        startTemporalExecution(run)
+        return getRun(workflowRef.organizationId, workflowId, run.runId)
+    }
+
+    fun getRun(
         organizationId: Int,
         workflowId: Int,
         runId: Int
@@ -417,6 +490,44 @@ class WorkflowService(
                 }.firstOrNull()
                 ?.let { row -> runResponse(row) }
         }
+
+    suspend fun cancelRun(
+        organizationId: Int,
+        workflowId: Int,
+        runId: Int
+    ): WorkflowRunCancelResponse? {
+        val candidate =
+            transaction {
+                val row =
+                    WorkflowRuns
+                        .selectAll()
+                        .where {
+                            (WorkflowRuns.id eq runId) and
+                                (WorkflowRuns.workflowId eq workflowId) and
+                                (WorkflowRuns.organizationId eq organizationId)
+                        }.firstOrNull() ?: return@transaction null
+                WorkflowRunCancelCandidate(row[WorkflowRuns.status], row[WorkflowRuns.temporalWorkflowId].orEmpty())
+            } ?: return null
+        if (candidate.status in TERMINAL_RUN_STATUSES) {
+            return WorkflowRunCancelResponse(runId, candidate.status)
+        }
+        val temporalWorkflowId = candidate.temporalWorkflowId
+        if (temporalWorkflowId.isNotBlank()) {
+            suspendRunCatching {
+                executionEngine.cancel(temporalWorkflowId)
+            }.onFailure { error ->
+                logger.warn(error) { "Failed to cancel Temporal workflow $temporalWorkflowId" }
+            }
+        }
+        transaction {
+            WorkflowRuns.update({ WorkflowRuns.id eq runId }) {
+                it[status] = STATUS_CANCELED
+                it[completedAt] = Clock.System.now()
+                it[errorMessage] = null
+            }
+        }
+        return WorkflowRunCancelResponse(runId, STATUS_CANCELED)
+    }
 
     fun listRuns(
         organizationId: Int,
@@ -440,6 +551,36 @@ class WorkflowService(
                 .map { runResponse(it) }
         }
 
+    fun webhookSigningInfo(
+        organizationId: Int,
+        workflowId: Int
+    ): WorkflowWebhookSigningResponse? {
+        workflowReference(workflowId)
+            ?.takeIf { it.organizationId == organizationId && it.triggerName == WEBHOOK_TRIGGER }
+            ?: return null
+        val backendUrl = EnvConfig.get("BACKEND_URL", "https://api.moneat.io").trimEnd('/')
+        return WorkflowWebhookSigningResponse(
+            workflowId = workflowId,
+            webhookUrl = "$backendUrl/v1/workflows/$workflowId/webhook",
+            signingSecret = webhookSecret(workflowId),
+            signatureHeader = WORKFLOW_WEBHOOK_SIGNATURE_HEADER,
+            signatureFormat = "$WEBHOOK_SIGNATURE_PREFIX<hex HMAC-SHA256 of raw body>"
+        )
+    }
+
+    fun verifyWebhookSignature(
+        workflowId: Int,
+        payload: String,
+        signatureHeader: String?
+    ): Boolean {
+        workflowReference(workflowId)
+            ?.takeIf { it.triggerName == WEBHOOK_TRIGGER }
+            ?: return false
+        val provided = signatureHeader?.trim()?.removePrefix(WEBHOOK_SIGNATURE_PREFIX) ?: return false
+        val expected = hmacSha256(webhookSecret(workflowId), payload)
+        return MessageDigest.isEqual(provided.encodeToByteArray(), expected.encodeToByteArray())
+    }
+
     suspend fun publishAlertTriggered(event: AlertLifecycleEvent) {
         val triggerName =
             if (event.status == AlertStatus.RESOLVED) {
@@ -447,13 +588,17 @@ class WorkflowService(
             } else {
                 ALERT_TRIGGERED_TRIGGER
             }
-        publishTrigger(
-            WorkflowTriggerEvent(
-                triggerName = triggerName,
-                organizationId = event.organizationId,
-                scope = alertScope(event)
+        val scope = alertScope(event)
+        publishTrigger(WorkflowTriggerEvent(triggerName, event.organizationId, scope))
+        sourceSpecificAlertTrigger(event)?.let { specificTriggerName ->
+            publishTrigger(
+                WorkflowTriggerEvent(
+                    triggerName = specificTriggerName,
+                    organizationId = event.organizationId,
+                    scope = scope
+                )
             )
-        )
+        }
     }
 
     suspend fun publishAlertResolved(
@@ -465,23 +610,102 @@ class WorkflowService(
         moneatUrl: String = "",
         severity: AlertSeverity? = null
     ) {
+        val scope =
+            mapOf(
+                ALERT_TITLE_REFERENCE to title,
+                ALERT_DESCRIPTION_REFERENCE to description,
+                ALERT_SEVERITY_REFERENCE to severity?.name.orEmpty(),
+                ALERT_PRIORITY_REFERENCE to stepRenderer.priorityLabelForSeverity(severity?.name),
+                ALERT_STATUS_REFERENCE to AlertStatus.RESOLVED.name,
+                ALERT_SOURCE_REFERENCE to source,
+                ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
+                ALERT_URL_REFERENCE to moneatUrl,
+                ORGANIZATION_ID_REFERENCE to organizationId.toString()
+            ).typedWorkflowScope()
         publishTrigger(
             WorkflowTriggerEvent(
                 triggerName = ALERT_RESOLVED_TRIGGER,
                 organizationId = organizationId,
-                scope = mapOf(
-                    ALERT_TITLE_REFERENCE to title,
-                    ALERT_DESCRIPTION_REFERENCE to description,
-                    ALERT_SEVERITY_REFERENCE to severity?.name.orEmpty(),
-                    ALERT_PRIORITY_REFERENCE to stepRenderer.priorityLabelForSeverity(severity?.name),
-                    ALERT_STATUS_REFERENCE to AlertStatus.RESOLVED.name,
-                    ALERT_SOURCE_REFERENCE to source,
-                    ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
-                    ALERT_URL_REFERENCE to moneatUrl,
-                    ORGANIZATION_ID_REFERENCE to organizationId.toString()
-                ).typedWorkflowScope()
+                scope = scope
             )
         )
+        AlertSource.entries.firstOrNull { it.name == source }?.let { alertSource ->
+            specificResolvedAlertTrigger(alertSource)?.let { triggerName ->
+                publishTrigger(
+                    WorkflowTriggerEvent(
+                        triggerName = triggerName,
+                        organizationId = organizationId,
+                        scope = scope
+                    )
+                )
+            }
+        }
+    }
+
+    suspend fun publishIncidentCreated(event: AlertLifecycleEvent) {
+        publishTrigger(
+            WorkflowTriggerEvent(
+                triggerName = INCIDENT_CREATED_TRIGGER,
+                organizationId = event.organizationId,
+                scope = incidentScope(
+                    organizationId = event.organizationId,
+                    status = INCIDENT_STATUS_CREATED,
+                    title = event.title,
+                    severity = event.severity.name,
+                    deduplicationKey = event.deduplicationKey
+                )
+            )
+        )
+    }
+
+    suspend fun publishIncidentResolved(
+        organizationId: Int,
+        deduplicationKey: String,
+        title: String,
+        severity: AlertSeverity? = null
+    ) {
+        publishTrigger(
+            WorkflowTriggerEvent(
+                triggerName = INCIDENT_RESOLVED_TRIGGER,
+                organizationId = organizationId,
+                scope = incidentScope(
+                    organizationId = organizationId,
+                    status = INCIDENT_STATUS_RESOLVED,
+                    title = title,
+                    severity = severity?.name.orEmpty(),
+                    deduplicationKey = deduplicationKey
+                )
+            )
+        )
+    }
+
+    suspend fun publishSecuritySignals(batch: QueuedSecurityBatch) {
+        batch.events.forEach { event ->
+            publishTrigger(
+                WorkflowTriggerEvent(
+                    triggerName = SECURITY_SIGNAL_TRIGGER,
+                    organizationId = batch.organizationId,
+                    scope = securityEventScope(batch.organizationId, event)
+                )
+            )
+        }
+        batch.findings
+            .filter { finding -> finding.status != "passed" }
+            .forEach { finding ->
+                publishTrigger(
+                    WorkflowTriggerEvent(
+                        triggerName = SECURITY_SIGNAL_TRIGGER,
+                        organizationId = batch.organizationId,
+                        scope = mapOf(
+                            SECURITY_RULE_ID_REFERENCE to finding.ruleId,
+                            SECURITY_RULE_NAME_REFERENCE to finding.ruleName,
+                            SECURITY_SEVERITY_REFERENCE to finding.status,
+                            SECURITY_RESOURCE_REFERENCE to finding.resourceName.ifBlank { finding.resourceId },
+                            ORGANIZATION_ID_REFERENCE to batch.organizationId.toString()
+                        ).typedWorkflowScope()
+                    )
+                )
+            }
     }
 
     suspend fun publishTrigger(event: WorkflowTriggerEvent) {
@@ -518,6 +742,37 @@ class WorkflowService(
     suspend fun executeRun(runId: Int) {
         directRunExecutor.executeRun(runId)
     }
+
+    private fun createRunForWorkflow(
+        organizationId: Int,
+        workflowId: Int,
+        scope: Map<String, JsonElement>,
+        onceFor: String,
+        force: Boolean,
+        requiredTriggerName: String? = null,
+        requirePublished: Boolean = false
+    ): WorkflowStartRequest? =
+        transaction {
+            val workflowRow =
+                Workflows
+                    .selectAll()
+                    .where { (Workflows.id eq workflowId) and (Workflows.organizationId eq organizationId) }
+                    .firstOrNull() ?: return@transaction null
+            if (requiredTriggerName != null && workflowRow[Workflows.triggerName] != requiredTriggerName) {
+                return@transaction null
+            }
+            val version = latestVersion(workflowId) ?: return@transaction null
+            if (requirePublished && !version.published) return@transaction null
+            val triggerScope = stepRenderer.sampleScopeForTrigger(workflowRow[Workflows.triggerName])
+                .typedWorkflowScope()
+            val event =
+                WorkflowTriggerEvent(
+                    triggerName = workflowRow[Workflows.triggerName],
+                    organizationId = organizationId,
+                    scope = triggerScope + scope
+                )
+            createRun(event, WorkflowCandidate(workflowId, version), onceFor, force)
+        }
 
     private fun createRun(
         event: WorkflowTriggerEvent,
@@ -595,6 +850,12 @@ class WorkflowService(
     private fun manualOnceFor(): String =
         "manual:${UUID.randomUUID()}"
 
+    private fun apiOnceFor(): String =
+        "api:${UUID.randomUUID()}"
+
+    private fun webhookOnceFor(): String =
+        "webhook:${UUID.randomUUID()}"
+
     private suspend fun startTemporalExecution(request: WorkflowStartRequest) {
         suspendRunCatching {
             executionEngine.start(request)
@@ -621,6 +882,40 @@ class WorkflowService(
             .getInstance("SHA-256")
             .digest(value.toByteArray())
             .joinToString("") { byte -> "%02x".format(byte.toInt() and UNSIGNED_BYTE_MASK) }
+
+    private fun webhookSecret(workflowId: Int): String =
+        hmacSha256(workflowSigningKey(), "$WORKFLOW_WEBHOOK_SECRET_CONTEXT:$workflowId")
+
+    private fun workflowSigningKey(): String =
+        EnvConfig.get("WORKFLOWS_SIGNING_KEY")
+            ?: System.getProperty("WORKFLOWS_SIGNING_KEY")
+            ?: throw IllegalStateException("WORKFLOWS_SIGNING_KEY is required for workflow webhook signing")
+
+    private fun hmacSha256(
+        key: String,
+        value: String
+    ): String {
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(SecretKeySpec(key.encodeToByteArray(), HMAC_ALGORITHM))
+        return mac
+            .doFinal(value.encodeToByteArray())
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and UNSIGNED_BYTE_MASK) }
+    }
+
+    private fun workflowReference(workflowId: Int): WorkflowReference? =
+        transaction {
+            Workflows
+                .selectAll()
+                .where { Workflows.id eq workflowId }
+                .firstOrNull()
+                ?.let { row ->
+                    WorkflowReference(
+                        id = row[Workflows.id].value,
+                        organizationId = row[Workflows.organizationId],
+                        triggerName = row[Workflows.triggerName]
+                    )
+                }
+        }
 
     private fun latestVersion(workflowId: Int): WorkflowVersionRecord? =
         WorkflowVersions
@@ -736,6 +1031,8 @@ class WorkflowService(
             progress = decodeProgress(row[WorkflowRuns.progress]),
             steps = runSteps(row[WorkflowRuns.id].value),
             errorMessage = row[WorkflowRuns.errorMessage],
+            temporalWorkflowId = row[WorkflowRuns.temporalWorkflowId],
+            temporalRunId = row[WorkflowRuns.temporalRunId],
             createdAt = row[WorkflowRuns.createdAt].toString(),
             completedAt = row[WorkflowRuns.completedAt]?.toString(),
             failedAt = row[WorkflowRuns.failedAt]?.toString()
@@ -810,7 +1107,7 @@ class WorkflowService(
                 steps.flatMap { it.params.values } +
                 graph.nodes.flatMap { node -> node.params.values.map { value -> value.workflowStringValue() } }
             )
-            .filter { it.startsWith("alert.") || it.startsWith("organization.") }
+            .filter { reference -> WORKFLOW_ENGINE_CONFIG_PREFIXES.any { prefix -> reference.startsWith(prefix) } }
             .distinct()
 
     private fun alertScope(event: AlertLifecycleEvent): Map<String, JsonElement> {
@@ -836,6 +1133,61 @@ class WorkflowService(
                 value.workflowScopeValue()?.let { reference to JsonPrimitive(it) }
             }.toMap()
 
+    private fun incidentScope(
+        organizationId: Int,
+        status: String,
+        title: String,
+        severity: String,
+        deduplicationKey: String
+    ): Map<String, JsonElement> =
+        mapOf(
+            INCIDENT_ID_REFERENCE to deduplicationKey,
+            INCIDENT_TITLE_REFERENCE to title,
+            INCIDENT_STATUS_REFERENCE to status,
+            INCIDENT_SEVERITY_REFERENCE to severity,
+            ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
+            ORGANIZATION_ID_REFERENCE to organizationId.toString()
+        ).typedWorkflowScope()
+
+    private fun securityEventScope(
+        organizationId: Int,
+        event: QueuedSecurityEventEntry
+    ): Map<String, JsonElement> =
+        mapOf(
+            SECURITY_RULE_ID_REFERENCE to event.ruleId,
+            SECURITY_RULE_NAME_REFERENCE to event.ruleName,
+            SECURITY_SEVERITY_REFERENCE to event.severity,
+            SECURITY_RESOURCE_REFERENCE to event.filePath.ifBlank { event.processName.ifBlank { event.host } },
+            ORGANIZATION_ID_REFERENCE to organizationId.toString()
+        ).typedWorkflowScope()
+
+    private fun sourceSpecificAlertTrigger(event: AlertLifecycleEvent): String? =
+        if (event.status == AlertStatus.RESOLVED) {
+            specificResolvedAlertTrigger(event.source)
+        } else {
+            specificFiringAlertTrigger(event.source)
+        }
+
+    private fun specificFiringAlertTrigger(source: AlertSource): String? =
+        when (source) {
+            AlertSource.HOST_ALERT,
+            AlertSource.HOST_DOWN,
+            AlertSource.DASHBOARD_ALERT -> MONITOR_ALERTED_TRIGGER
+            AlertSource.UPTIME_MONITOR -> UPTIME_DOWN_TRIGGER
+            AlertSource.SYNTHETIC_TEST -> SYNTHETIC_FAILED_TRIGGER
+            AlertSource.ERROR_ALERT -> null
+        }
+
+    private fun specificResolvedAlertTrigger(source: AlertSource): String? =
+        when (source) {
+            AlertSource.HOST_ALERT,
+            AlertSource.HOST_DOWN,
+            AlertSource.DASHBOARD_ALERT -> MONITOR_RECOVERED_TRIGGER
+            AlertSource.UPTIME_MONITOR -> UPTIME_UP_TRIGGER
+            AlertSource.SYNTHETIC_TEST -> SYNTHETIC_PASSED_TRIGGER
+            AlertSource.ERROR_ALERT -> null
+        }
+
     private fun JsonElement.workflowScopeValue(): String? {
         val primitive = this as? JsonPrimitive ?: return null
         return primitive.booleanOrNull?.toString() ?: primitive.contentOrNull
@@ -844,6 +1196,33 @@ class WorkflowService(
     companion object {
         private const val ALERT_TRIGGERED_TRIGGER = "alert.triggered"
         private const val ALERT_RESOLVED_TRIGGER = "alert.resolved"
+        private const val MONITOR_ALERTED_TRIGGER = "monitor.alerted"
+        private const val MONITOR_RECOVERED_TRIGGER = "monitor.recovered"
+        private const val UPTIME_DOWN_TRIGGER = "uptime.down"
+        private const val UPTIME_UP_TRIGGER = "uptime.up"
+        private const val SYNTHETIC_FAILED_TRIGGER = "synthetic.failed"
+        private const val SYNTHETIC_PASSED_TRIGGER = "synthetic.passed"
+        private const val INCIDENT_CREATED_TRIGGER = "incident.created"
+        private const val INCIDENT_RESOLVED_TRIGGER = "incident.resolved"
+        private const val SECURITY_SIGNAL_TRIGGER = "security.signal"
+        private const val API_TRIGGER = "api"
+        private const val WEBHOOK_TRIGGER = "webhook"
+        private const val STATUS_CANCELED = "canceled"
+        private const val INCIDENT_STATUS_CREATED = "created"
+        private const val INCIDENT_STATUS_RESOLVED = "resolved"
+        private val TERMINAL_RUN_STATUSES = setOf("complete", "failed", STATUS_CANCELED)
+        private val WORKFLOW_ENGINE_CONFIG_PREFIXES =
+            listOf(
+                "alert.",
+                "organization.",
+                "workflow.",
+                "webhook.",
+                "schedule.",
+                "incident.",
+                "security.",
+                "oncall.",
+                "steps."
+            )
         private val DEFAULT_WORKFLOWS =
             listOf(
                 DefaultWorkflowDefinition(
@@ -962,6 +1341,17 @@ private data class WorkflowVersionRecord(
 private data class WorkflowCandidate(
     val workflowId: Int,
     val version: WorkflowVersionRecord
+)
+
+private data class WorkflowReference(
+    val id: Int,
+    val organizationId: Int,
+    val triggerName: String
+)
+
+private data class WorkflowRunCancelCandidate(
+    val status: String,
+    val temporalWorkflowId: String
 )
 
 private data class WorkflowRunStats(

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
@@ -47,6 +47,12 @@ internal const val ALERT_LIFECYCLE_FORMAT = "alert_lifecycle"
 internal const val DEFAULT_WORKFLOW_TITLE = "Moneat workflow"
 internal const val ALERT_TRIGGERED_TRIGGER = "alert.triggered"
 internal const val ALERT_RESOLVED_TRIGGER = "alert.resolved"
+internal const val MANUAL_TRIGGER = "manual"
+internal const val API_TRIGGER = "api"
+internal const val WEBHOOK_TRIGGER = "webhook"
+internal const val INCIDENT_CREATED_TRIGGER = "incident.created"
+internal const val INCIDENT_RESOLVED_TRIGGER = "incident.resolved"
+internal const val SECURITY_SIGNAL_TRIGGER = "security.signal"
 internal const val ALERT_DESCRIPTION_TEMPLATE_BLOCK = "{{alert.description}}\n\n"
 internal const val ALERT_PRIORITY_TEMPLATE_LINE = "Priority: {{alert.priority}}\n"
 internal const val ALERT_SOURCE_TEMPLATE_LINE = "Source: {{alert.source}}\n"
@@ -63,10 +69,23 @@ private const val ALERT_COLOR_RED = "#E01E5A"
 private const val ALERT_COLOR_GREEN = "#2EB67D"
 private const val ALERT_COLOR_YELLOW = "#ECB22E"
 private const val ALERT_COLOR_PURPLE = "#6366F1"
+private val RESOLVED_ALERT_TRIGGERS =
+    setOf(ALERT_RESOLVED_TRIGGER, "monitor.recovered", "uptime.up", "synthetic.passed")
 
 class WorkflowStepRenderer {
-    fun sampleScopeForTrigger(triggerName: String): Map<String, String> {
-        val resolved = triggerName == ALERT_RESOLVED_TRIGGER
+    fun sampleScopeForTrigger(triggerName: String): Map<String, String> =
+        when (triggerName) {
+            MANUAL_TRIGGER -> manualSampleScope()
+            API_TRIGGER -> apiSampleScope()
+            WEBHOOK_TRIGGER -> webhookSampleScope()
+            INCIDENT_CREATED_TRIGGER,
+            INCIDENT_RESOLVED_TRIGGER -> incidentSampleScope(triggerName)
+            SECURITY_SIGNAL_TRIGGER -> securitySampleScope()
+            else -> alertSampleScope(triggerName)
+        }
+
+    private fun alertSampleScope(triggerName: String): Map<String, String> {
+        val resolved = triggerName in RESOLVED_ALERT_TRIGGERS
         val status = if (resolved) AlertStatus.RESOLVED.name else AlertStatus.FIRING.name
         val severity = if (resolved) AlertSeverity.LOW.name else AlertSeverity.HIGH.name
         val title = if (resolved) {
@@ -102,6 +121,51 @@ class WorkflowStepRenderer {
         )
     }
 
+    private fun manualSampleScope(): Map<String, String> =
+        mapOf(
+            "workflow.actor_id" to "1",
+            "workflow.input" to """{"reason":"Preview run"}""",
+            ORGANIZATION_ID_REFERENCE to "1"
+        )
+
+    private fun apiSampleScope(): Map<String, String> =
+        mapOf(
+            "workflow.caller" to "1",
+            "workflow.input" to """{"service":"checkout"}""",
+            ORGANIZATION_ID_REFERENCE to "1"
+        )
+
+    private fun webhookSampleScope(): Map<String, String> =
+        mapOf(
+            "webhook.payload" to """{"event":"deploy.finished","service":"checkout"}""",
+            "webhook.event_id" to "deploy-evt-123",
+            ORGANIZATION_ID_REFERENCE to "1"
+        )
+
+    private fun incidentSampleScope(triggerName: String): Map<String, String> {
+        val status = when (triggerName) {
+            INCIDENT_RESOLVED_TRIGGER -> "resolved"
+            else -> "created"
+        }
+        return mapOf(
+            "incident.id" to "incident-123",
+            "incident.title" to "Checkout latency incident",
+            "incident.status" to status,
+            "incident.severity" to AlertSeverity.HIGH.name,
+            ALERT_DEDUPLICATION_KEY_REFERENCE to "incident-checkout-latency",
+            ORGANIZATION_ID_REFERENCE to "1"
+        )
+    }
+
+    private fun securitySampleScope(): Map<String, String> =
+        mapOf(
+            "security.rule_id" to "runtime.file.modified",
+            "security.rule_name" to "Sensitive file modified",
+            "security.severity" to "high",
+            "security.resource" to "/etc/app/config.yml",
+            ORGANIZATION_ID_REFERENCE to "1"
+        )
+
     fun renderStepPreview(
         step: WorkflowStepConfig,
         scope: Map<String, String>
@@ -117,7 +181,7 @@ class WorkflowStepRenderer {
             EMAIL_ORG_STEP -> EMAIL_CHANNEL
             SLACK_STEP -> SLACK_CHANNEL
             DISCORD_STEP -> DISCORD_CHANNEL
-            else -> throw IllegalArgumentException("Unknown workflow step $stepName")
+            else -> "workflow"
         }
 
     fun priorityLabelForSeverity(severity: String?): String =
@@ -175,7 +239,15 @@ class WorkflowStepRenderer {
                     fallbackText = "$title: $body"
                 )
             }
-            else -> throw IllegalArgumentException("Unknown workflow step ${step.name}")
+            else -> WorkflowStepPreview(
+                step = step.name,
+                channel = "workflow",
+                title = step.name,
+                body = "This action reads or updates Moneat data when the workflow runs.",
+                textBody = "This action reads or updates Moneat data when the workflow runs.",
+                color = ALERT_COLOR_PURPLE,
+                fallbackText = step.name
+            )
         }
 
     private fun renderAlertLifecyclePreview(

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
@@ -68,7 +68,8 @@ class WorkflowTrustedActionExecutor(
     suspend fun execute(
         organizationId: Int,
         stepName: String,
-        params: Map<String, String>
+        params: Map<String, String>,
+        actorUserId: Int? = null
     ): Map<String, JsonElement> =
         when (stepName) {
             LOGS_SEARCH_STEP -> executeLogSearch(organizationId, params)
@@ -80,7 +81,7 @@ class WorkflowTrustedActionExecutor(
             ISSUES_GET_STEP -> executeIssueGet(organizationId, params)
             STATUS_PAGE_UPDATE_STEP -> executeStatusPageUpdate(organizationId, params)
             STATUS_PAGE_INCIDENT_CREATE_STEP -> executeStatusPageIncidentCreate(organizationId, params)
-            ALERT_SILENCE_STEP -> executeAlertSilence(organizationId, params)
+            ALERT_SILENCE_STEP -> executeAlertSilence(organizationId, params, actorUserId)
             ON_CALL_PAGE_STEP -> executeOnCallPage(organizationId, params)
             else -> throw IllegalArgumentException("Unknown workflow step $stepName")
         }
@@ -235,7 +236,8 @@ class WorkflowTrustedActionExecutor(
 
     private fun executeAlertSilence(
         organizationId: Int,
-        params: Map<String, String>
+        params: Map<String, String>,
+        actorUserId: Int?
     ): Map<String, JsonElement> {
         val now = System.currentTimeMillis()
         val startsAt = params.optional("starts_at")?.toLongOrNull() ?: now
@@ -245,7 +247,7 @@ class WorkflowTrustedActionExecutor(
         val period =
             monitorAlertServiceProvider().createSilencePeriod(
                 organizationId = organizationId,
-                userId = workflowActorUserId(organizationId),
+                userId = actorUserId ?: workflowActorUserId(organizationId),
                 request = CreateSilencePeriodRequest(
                     reason = params.optional("reason") ?: "Workflow automation",
                     startsAt = startsAt,
@@ -293,6 +295,8 @@ class WorkflowTrustedActionExecutor(
         require(hasAccess) { "Project not found for organization" }
     }
 
+    // Deterministic fallback for event-driven runs (alert/incident/security) that have no
+    // human actor. Manual and API runs thread their real caller id in via [execute].
     private fun workflowActorUserId(organizationId: Int): Int =
         transaction {
             Memberships

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
@@ -208,7 +208,7 @@ class WorkflowTrustedActionExecutor(
                 request = UpdateStatusPageRequest(
                     name = params.optional("name"),
                     description = params.optional("description"),
-                    isPublic = params.optional("is_public")?.toBooleanStrictOrNull()
+                    isPublic = params.optionalBoolean("is_public")
                 )
             ) ?: throw IllegalArgumentException("Status page not found")
         return result("status_page", response)
@@ -240,8 +240,8 @@ class WorkflowTrustedActionExecutor(
         actorUserId: Int?
     ): Map<String, JsonElement> {
         val now = System.currentTimeMillis()
-        val startsAt = params.optional("starts_at")?.toLongOrNull() ?: now
-        val endsAt = params.optional("ends_at")?.toLongOrNull()
+        val startsAt = params.optionalLong("starts_at") ?: now
+        val endsAt = params.optionalLong("ends_at")
             ?: now + DEFAULT_SILENCE_MINUTES * MILLIS_PER_MINUTE
         require(startsAt < endsAt) { "Silence starts_at must be before ends_at" }
         val period =
@@ -325,6 +325,16 @@ class WorkflowTrustedActionExecutor(
     private fun Map<String, String>.optional(name: String): String? =
         this[name]?.trim()?.takeIf { it.isNotEmpty() }
 
+    private fun Map<String, String>.optionalBoolean(name: String): Boolean? =
+        optional(name)?.let {
+            it.toBooleanStrictOrNull() ?: throw IllegalArgumentException("Parameter $name must be true or false")
+        }
+
+    private fun Map<String, String>.optionalLong(name: String): Long? =
+        optional(name)?.let {
+            it.toLongOrNull() ?: throw IllegalArgumentException("Parameter $name must be a number")
+        }
+
     private fun intParam(
         params: Map<String, String>,
         name: String,
@@ -332,7 +342,12 @@ class WorkflowTrustedActionExecutor(
         min: Int,
         max: Int
     ): Int =
-        params.optional(name)?.toIntOrNull()?.coerceIn(min, max) ?: defaultValue
+        params.optional(name)
+            ?.let { value ->
+                (value.toIntOrNull() ?: throw IllegalArgumentException("Parameter $name must be an integer"))
+                    .coerceIn(min, max)
+            }
+            ?: defaultValue
 
     private fun csvParam(
         params: Map<String, String>,

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
@@ -1,0 +1,371 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.services
+
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.events.services.DashboardService
+import com.moneat.logs.models.LogQueryRequest
+import com.moneat.logs.repositories.LogRepositoryImpl
+import com.moneat.logs.services.LogService
+import com.moneat.monitor.models.CreateSilencePeriodRequest
+import com.moneat.monitor.repositories.HostAlertRepositoryImpl
+import com.moneat.monitor.repositories.HostRepositoryImpl
+import com.moneat.monitor.services.MonitorAlertService
+import com.moneat.monitor.services.MonitorService
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.Projects
+import com.moneat.statuspage.models.CreateIncidentRequest
+import com.moneat.statuspage.models.UpdateStatusPageRequest
+import com.moneat.statuspage.services.StatusPageService
+import com.moneat.workflows.models.workflowJson
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+private const val DEFAULT_LOG_LIMIT = 100
+private const val MAX_LOG_LIMIT = 1_000
+private const val DEFAULT_LOOKBACK_HOURS = 24L
+private const val DEFAULT_ISSUE_PAGE = 1
+private const val DEFAULT_ISSUE_LIMIT = 25
+private const val MAX_ISSUE_LIMIT = 250
+private const val DEFAULT_METRIC_HOURS = 24
+private const val MAX_METRIC_HOURS = 168
+private const val MILLIS_PER_HOUR = 3_600_000L
+private const val DEFAULT_SILENCE_MINUTES = 60L
+private const val MILLIS_PER_MINUTE = 60_000L
+
+class WorkflowTrustedActionExecutor(
+    private val logService: LogService = LogService(LogRepositoryImpl()),
+    private val dashboardService: DashboardService = DashboardService.create(),
+    private val monitorService: MonitorService = MonitorService(HostRepositoryImpl(), HostAlertRepositoryImpl()),
+    private val monitorAlertServiceProvider: () -> MonitorAlertService = { MonitorAlertService() },
+    private val statusPageService: StatusPageService = StatusPageService()
+) {
+    private val json = workflowJson
+
+    suspend fun execute(
+        organizationId: Int,
+        stepName: String,
+        params: Map<String, String>
+    ): Map<String, JsonElement> =
+        when (stepName) {
+            LOGS_SEARCH_STEP -> executeLogSearch(organizationId, params)
+            LOGS_AGGREGATE_STEP -> executeLogAggregate(organizationId, params)
+            METRICS_QUERY_STEP -> executeMetricsQuery(organizationId, params)
+            TRACES_SEARCH_STEP -> executeTraceSearch(organizationId, params)
+            SPAN_GET_STEP -> executeSpanGet(organizationId, params)
+            ISSUES_LIST_STEP -> executeIssuesList(organizationId, params)
+            ISSUES_GET_STEP -> executeIssueGet(organizationId, params)
+            STATUS_PAGE_UPDATE_STEP -> executeStatusPageUpdate(organizationId, params)
+            STATUS_PAGE_INCIDENT_CREATE_STEP -> executeStatusPageIncidentCreate(organizationId, params)
+            ALERT_SILENCE_STEP -> executeAlertSilence(organizationId, params)
+            ON_CALL_PAGE_STEP -> executeOnCallPage(organizationId, params)
+            else -> throw IllegalArgumentException("Unknown workflow step $stepName")
+        }
+
+    fun supports(stepName: String): Boolean =
+        stepName in SUPPORTED_ACTIONS
+
+    private suspend fun executeLogSearch(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val now = Instant.now()
+        val request =
+            LogQueryRequest(
+                limit = intParam(params, "limit", DEFAULT_LOG_LIMIT, 1, MAX_LOG_LIMIT),
+                query = params.optional("query"),
+                levels = csvParam(params, "levels"),
+                service = params.optional("service"),
+                environment = params.optional("environment"),
+                from = params.optional("from") ?: now.minus(DEFAULT_LOOKBACK_HOURS, ChronoUnit.HOURS).toString(),
+                to = params.optional("to") ?: now.toString(),
+                traceId = params.optional("trace_id"),
+                systemId = params.optional("system_id"),
+                containerName = params.optional("container_name")
+            )
+        return result("logs", logService.queryLogs(organizationId.toLong(), request))
+    }
+
+    private suspend fun executeLogAggregate(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> =
+        result(
+            "aggregate",
+            logService.aggregateLogs(
+                organizationId = organizationId.toLong(),
+                from = params.optional("from"),
+                to = params.optional("to"),
+                interval = params.optional("interval"),
+                query = params.optional("query"),
+                levels = csvParam(params, "levels"),
+                service = params.optional("service"),
+                environment = params.optional("environment"),
+                tags = emptyMap(),
+                excludeService = null,
+                excludeEnvironment = null,
+                excludeContainerName = null,
+                excludeTags = emptyMap(),
+                groupBy = params.optional("group_by")
+            )
+        )
+
+    private suspend fun executeMetricsQuery(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val hostId = params.requiredInt("host_id")
+        val host = monitorService.getHostById(hostId)
+        require(host?.organizationId == organizationId) { "Host not found for organization" }
+        val hours = intParam(params, "hours", DEFAULT_METRIC_HOURS, 1, MAX_METRIC_HOURS)
+        val now = System.currentTimeMillis()
+        return result(
+            "metrics",
+            monitorService.getHistoricalMetrics(hostId, now - hours * MILLIS_PER_HOUR, now, intervalSeconds = null)
+        )
+    }
+
+    private suspend fun executeTraceSearch(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val projectId = params.requiredLong("project_id")
+        requireProjectAccess(organizationId, projectId)
+        return result(
+            "traces",
+            dashboardService.getTransactions(
+                projectId = projectId,
+                period = params.optional("period") ?: "24h",
+                environment = params.optional("environment"),
+                operation = params.optional("operation")
+            )
+        )
+    }
+
+    private suspend fun executeSpanGet(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val projectId = params.requiredLong("project_id")
+        requireProjectAccess(organizationId, projectId)
+        val spanId = params.required("span_id")
+        return result("span", dashboardService.getSpanDetails(projectId, spanId))
+    }
+
+    private suspend fun executeIssuesList(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val projectId = params.requiredLong("project_id")
+        requireProjectAccess(organizationId, projectId)
+        val page = intParam(params, "page", DEFAULT_ISSUE_PAGE, 1, Int.MAX_VALUE)
+        val limit = intParam(params, "limit", DEFAULT_ISSUE_LIMIT, 1, MAX_ISSUE_LIMIT)
+        return result("issues", dashboardService.getIssues(projectId, page, limit, params.optional("status")))
+    }
+
+    private suspend fun executeIssueGet(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val projectId = params.requiredLong("project_id")
+        requireProjectAccess(organizationId, projectId)
+        return result("issue", dashboardService.getIssue(params.required("issue_id"), projectId = projectId))
+    }
+
+    private fun executeStatusPageUpdate(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val pageId = UUID.fromString(params.required("status_page_id"))
+        val response =
+            statusPageService.updateStatusPage(
+                pageId = pageId,
+                organizationId = organizationId,
+                request = UpdateStatusPageRequest(
+                    name = params.optional("name"),
+                    description = params.optional("description"),
+                    isPublic = params.optional("is_public")?.toBooleanStrictOrNull()
+                )
+            ) ?: throw IllegalArgumentException("Status page not found")
+        return result("status_page", response)
+    }
+
+    private fun executeStatusPageIncidentCreate(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val pageId = UUID.fromString(params.required("status_page_id"))
+        val response =
+            statusPageService.createIncident(
+                pageId = pageId,
+                organizationId = organizationId,
+                request = CreateIncidentRequest(
+                    title = params.required("title"),
+                    status = params.optional("status") ?: "investigating",
+                    type = params.optional("type") ?: "incident",
+                    impact = params.optional("impact") ?: "minor",
+                    message = params.required("message")
+                )
+            )
+        return result("incident", response)
+    }
+
+    private fun executeAlertSilence(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val now = System.currentTimeMillis()
+        val startsAt = params.optional("starts_at")?.toLongOrNull() ?: now
+        val endsAt = params.optional("ends_at")?.toLongOrNull()
+            ?: now + DEFAULT_SILENCE_MINUTES * MILLIS_PER_MINUTE
+        require(startsAt < endsAt) { "Silence starts_at must be before ends_at" }
+        val period =
+            monitorAlertServiceProvider().createSilencePeriod(
+                organizationId = organizationId,
+                userId = workflowActorUserId(organizationId),
+                request = CreateSilencePeriodRequest(
+                    reason = params.optional("reason") ?: "Workflow automation",
+                    startsAt = startsAt,
+                    endsAt = endsAt
+                )
+            )
+        return result("silence", period)
+    }
+
+    private suspend fun executeOnCallPage(
+        organizationId: Int,
+        params: Map<String, String>
+    ): Map<String, JsonElement> {
+        val bridge = FeatureRegistry.getOnCallBridge()
+            ?: return mapOf(
+                "requires_enterprise" to JsonPrimitive(true),
+                "message" to JsonPrimitive("On-call paging requires an enabled on-call bridge")
+            )
+        val incidentId =
+            bridge.triggerEscalation(
+                organizationId = organizationId,
+                escalationPolicyId = params.requiredInt("escalation_policy_id"),
+                title = params.required("title"),
+                description = params.optional("description"),
+                priorityLevel = params.optional("priority_level") ?: "P2",
+                alertSource = params.optional("alert_source") ?: "WORKFLOW",
+                deduplicationKey = params.optional("deduplication_key"),
+                metadata = params.optional("metadata")
+            )
+        return mapOf("incident_id" to JsonPrimitive(incidentId))
+    }
+
+    private fun requireProjectAccess(
+        organizationId: Int,
+        projectId: Long
+    ) {
+        val hasAccess =
+            transaction {
+                Projects
+                    .selectAll()
+                    .where {
+                        (Projects.id eq projectId) and (Projects.organization_id eq organizationId)
+                    }.count() > 0
+            }
+        require(hasAccess) { "Project not found for organization" }
+    }
+
+    private fun workflowActorUserId(organizationId: Int): Int =
+        transaction {
+            Memberships
+                .selectAll()
+                .where { Memberships.organization_id eq organizationId }
+                .orderBy(Memberships.id to SortOrder.ASC)
+                .firstOrNull()
+                ?.get(Memberships.user_id)
+        } ?: throw IllegalArgumentException("Organization has no members for workflow audit attribution")
+
+    private inline fun <reified T> result(
+        key: String,
+        value: T
+    ): Map<String, JsonElement> =
+        mapOf(key to json.encodeToJsonElement(value))
+
+    private fun Map<String, String>.required(name: String): String =
+        optional(name) ?: throw IllegalArgumentException("Missing required parameter $name")
+
+    private fun Map<String, String>.requiredInt(name: String): Int =
+        required(name).toIntOrNull() ?: throw IllegalArgumentException("Parameter $name must be an integer")
+
+    private fun Map<String, String>.requiredLong(name: String): Long =
+        required(name).toLongOrNull() ?: throw IllegalArgumentException("Parameter $name must be a number")
+
+    private fun Map<String, String>.optional(name: String): String? =
+        this[name]?.trim()?.takeIf { it.isNotEmpty() }
+
+    private fun intParam(
+        params: Map<String, String>,
+        name: String,
+        defaultValue: Int,
+        min: Int,
+        max: Int
+    ): Int =
+        params.optional(name)?.toIntOrNull()?.coerceIn(min, max) ?: defaultValue
+
+    private fun csvParam(
+        params: Map<String, String>,
+        name: String
+    ): List<String> =
+        params.optional(name)
+            ?.split(",")
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            ?: emptyList()
+
+    companion object {
+        const val LOGS_SEARCH_STEP = "moneat.logs.search"
+        const val LOGS_AGGREGATE_STEP = "moneat.logs.aggregate"
+        const val METRICS_QUERY_STEP = "moneat.metrics.query"
+        const val TRACES_SEARCH_STEP = "moneat.traces.search"
+        const val SPAN_GET_STEP = "moneat.span.get"
+        const val ISSUES_LIST_STEP = "moneat.issues.list"
+        const val ISSUES_GET_STEP = "moneat.issues.get"
+        const val STATUS_PAGE_UPDATE_STEP = "statuspage.update"
+        const val STATUS_PAGE_INCIDENT_CREATE_STEP = "statuspage.incident.create"
+        const val ALERT_SILENCE_STEP = "alert.silence"
+        const val ON_CALL_PAGE_STEP = "oncall.page"
+
+        private val SUPPORTED_ACTIONS =
+            setOf(
+                LOGS_SEARCH_STEP,
+                LOGS_AGGREGATE_STEP,
+                METRICS_QUERY_STEP,
+                TRACES_SEARCH_STEP,
+                SPAN_GET_STEP,
+                ISSUES_LIST_STEP,
+                ISSUES_GET_STEP,
+                STATUS_PAGE_UPDATE_STEP,
+                STATUS_PAGE_INCIDENT_CREATE_STEP,
+                ALERT_SILENCE_STEP,
+                ON_CALL_PAGE_STEP
+            )
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -20,6 +20,8 @@ import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.datadog.security.QueuedSecurityBatch
+import com.moneat.datadog.security.QueuedSecurityEventEntry
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
@@ -35,6 +37,7 @@ import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
 import com.moneat.workflows.models.WorkflowConditionConfig
 import com.moneat.workflows.models.WorkflowPreviewRequest
+import com.moneat.workflows.models.WorkflowRunInstanceRequest
 import com.moneat.workflows.models.WorkflowRuns
 import com.moneat.workflows.models.WorkflowRunSteps
 import com.moneat.workflows.models.WorkflowStepConfig
@@ -59,6 +62,8 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -210,10 +215,11 @@ class WorkflowServiceTest {
     fun `catalog exposes alert triggers resources steps and lookup helpers`() {
         val response = service.catalog()
 
-        assertEquals(7, response.resources.size)
+        assertEquals(9, response.resources.size)
         assertTrue(response.resources.any { it.type == "Boolean" })
         assertTrue(response.resources.any { it.type == "AlertSeverity" })
         assertTrue(response.resources.any { it.type == "AlertStatus" })
+        assertTrue(response.resources.any { it.type == "SecuritySeverity" })
         assertTrue(
             response.resources
                 .first { it.type == "String" }
@@ -222,11 +228,18 @@ class WorkflowServiceTest {
         )
         assertEquals("alert.triggered", response.triggers.first().name)
         assertEquals(listOf("alert.deduplication_key"), response.triggers.first().defaultOnceForTemplate)
-        assertEquals("alert.resolved", response.triggers.last().name)
+        val resolvedTrigger = response.triggers.first { it.name == "alert.resolved" }
         assertEquals(
             listOf("alert.deduplication_key", "alert.status"),
-            response.triggers.last().defaultOnceForTemplate
+            resolvedTrigger.defaultOnceForTemplate
         )
+        assertTrue(response.triggers.any { it.name == "api" })
+        assertTrue(response.triggers.any { it.name == "webhook" })
+        assertTrue(response.triggers.any { it.name == "security.signal" })
+        assertTrue(response.steps.any { it.name == "moneat.logs.search" })
+        assertTrue(response.steps.any { it.name == "statuspage.incident.create" })
+        assertFalse(response.steps.any { it.name == "http.request" })
+        assertFalse(response.steps.any { it.name == "transform.graaljs" })
         assertEquals("Email organization members", WorkflowCatalog.step("notification.email_org")?.label)
         assertEquals("AlertSeverity", WorkflowCatalog.scopeType("alert.triggered", "alert.severity"))
         assertEquals("String", WorkflowCatalog.scopeType("alert.triggered", "alert.priority"))
@@ -721,6 +734,151 @@ class WorkflowServiceTest {
         }
 
     @Test
+    fun `source specific alert triggers preserve legacy alert workflow behavior`() =
+        runBlocking {
+            val alertWorkflow =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "Legacy alert trigger",
+                        triggerName = "alert.triggered",
+                        steps = emptyList()
+                    )
+                )
+            val uptimeWorkflow =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "Uptime down trigger",
+                        triggerName = "uptime.down",
+                        steps = emptyList()
+                    )
+                )
+            publish(alertWorkflow.id)
+            publish(uptimeWorkflow.id)
+
+            service.publishAlertTriggered(
+                alertEvent().copy(
+                    source = AlertSource.UPTIME_MONITOR,
+                    deduplicationKey = "uptime-1"
+                )
+            )
+
+            assertEquals("alert.triggered", service.listRuns(orgId, alertWorkflow.id).single().triggerName)
+            assertEquals("uptime.down", service.listRuns(orgId, uptimeWorkflow.id).single().triggerName)
+            assertEquals(listOf("alert.triggered", "uptime.down"), workflowEngine.requests.map { it.triggerName })
+        }
+
+    @Test
+    fun `security signal trigger supports severity conditions`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "Security enrichment",
+                        triggerName = "security.signal",
+                        conditions = listOf(WorkflowConditionConfig("security.severity", "at_least", "high")),
+                        steps = emptyList(),
+                        onceForTemplate = listOf("security.rule_id", "security.resource")
+                    )
+                )
+            publish(workflow.id)
+
+            service.publishSecuritySignals(
+                QueuedSecurityBatch(
+                    organizationId = orgId,
+                    batchType = "runtime",
+                    events = listOf(
+                        securityEvent("rule-low", "low"),
+                        securityEvent("rule-high", "high")
+                    )
+                )
+            )
+
+            val run = service.listRuns(orgId, workflow.id).single()
+            assertEquals("security.signal", run.triggerName)
+            assertEquals("security.rule_id=rule-high|security.resource=/tmp/high", run.onceFor)
+        }
+
+    @Test
+    fun `API workflow instances and cancellation record Temporal identifiers`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "API trigger",
+                        triggerName = "api",
+                        steps = emptyList(),
+                        onceForTemplate = emptyList()
+                    )
+                )
+
+            val run =
+                service.createWorkflowInstance(
+                    organizationId = orgId,
+                    workflowId = workflow.id,
+                    request = WorkflowRunInstanceRequest(
+                        scope = mapOf("workflow.input.reason" to JsonPrimitive("operator"))
+                    ),
+                    callerUserId = 99
+                )
+
+            assertNotNull(run)
+            assertEquals("api", run.triggerName)
+            assertEquals("pending", run.status)
+            assertEquals(workflowEngine.requests.single().temporalWorkflowId, run.temporalWorkflowId)
+            assertEquals("temporal-run-${run.id}", run.temporalRunId)
+            assertNotNull(service.getRun(orgId, workflow.id, run.id))
+
+            val canceled = service.cancelRun(orgId, workflow.id, run.id)
+
+            assertEquals("canceled", canceled?.status)
+            assertEquals(listOf(run.temporalWorkflowId), workflowEngine.canceledWorkflowIds)
+            assertEquals("canceled", service.getRun(orgId, workflow.id, run.id)?.status)
+        }
+
+    @Test
+    fun `signed webhook trigger requires valid signature and published webhook workflow`() =
+        runBlocking {
+            System.setProperty("WORKFLOWS_SIGNING_KEY", "test-workflow-signing-key")
+            try {
+                val workflow =
+                    service.createWorkflow(
+                        orgId,
+                        validRequest(
+                            name = "Webhook trigger",
+                            triggerName = "webhook",
+                            steps = emptyList(),
+                            onceForTemplate = listOf("webhook.event_id")
+                        )
+                    )
+                publish(workflow.id)
+                val payload = """{"event":"deploy"}"""
+                val signing = service.webhookSigningInfo(orgId, workflow.id)
+                val signature = "sha256=${hmacSha256(signing?.signingSecret.orEmpty(), payload)}"
+
+                assertTrue(service.verifyWebhookSignature(workflow.id, payload, signature))
+                assertFalse(service.verifyWebhookSignature(workflow.id, payload, "sha256=invalid"))
+
+                val run =
+                    service.createWebhookRun(
+                        workflowId = workflow.id,
+                        payload = payload,
+                        eventId = "deploy-1"
+                    )
+
+                assertNotNull(run)
+                assertEquals("webhook", run.triggerName)
+                assertEquals("deploy-1", run.onceFor)
+                assertEquals(1, workflowEngine.requests.size)
+            } finally {
+                System.clearProperty("WORKFLOWS_SIGNING_KEY")
+            }
+        }
+
+    @Test
     fun `dashboard alert channel metadata skips disabled notification steps`() =
         runBlocking {
             val workflow =
@@ -997,6 +1155,18 @@ class WorkflowServiceTest {
             moneatUrl = "https://moneat.io/hosts/1"
         )
 
+    private fun securityEvent(
+        ruleId: String,
+        severity: String
+    ): QueuedSecurityEventEntry =
+        QueuedSecurityEventEntry(
+            ruleId = ruleId,
+            ruleName = "Rule $ruleId",
+            severity = severity,
+            filePath = "/tmp/$severity",
+            timestampMs = 1_700_000_000_000
+        )
+
     private fun persistedTemporalIds(runId: Int): PersistedTemporalIds =
         transaction {
             val run = WorkflowRuns.selectAll().where { WorkflowRuns.id eq runId }.single()
@@ -1007,6 +1177,17 @@ class WorkflowServiceTest {
         }
 }
 
+private fun hmacSha256(
+    key: String,
+    value: String
+): String {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(key.encodeToByteArray(), "HmacSHA256"))
+    return mac.doFinal(value.encodeToByteArray()).joinToString("") { byte ->
+        "%02x".format(byte.toInt() and 0xff)
+    }
+}
+
 private data class PersistedTemporalIds(
     val workflowId: String?,
     val runId: String?
@@ -1014,6 +1195,7 @@ private data class PersistedTemporalIds(
 
 private class FakeWorkflowExecutionEngine : WorkflowExecutionEngine {
     val requests = mutableListOf<WorkflowStartRequest>()
+    val canceledWorkflowIds = mutableListOf<String?>()
     var error: Throwable? = null
 
     override suspend fun start(request: WorkflowStartRequest): WorkflowStartResult {
@@ -1023,5 +1205,9 @@ private class FakeWorkflowExecutionEngine : WorkflowExecutionEngine {
             temporalWorkflowId = request.temporalWorkflowId,
             temporalRunId = "temporal-run-${request.runId}"
         )
+    }
+
+    override suspend fun cancel(temporalWorkflowId: String) {
+        canceledWorkflowIds += temporalWorkflowId
     }
 }

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -840,8 +840,60 @@ class WorkflowServiceTest {
         }
 
     @Test
+    fun `API workflow instances honor configured conditions`() =
+        runBlocking {
+            val request = WorkflowRunInstanceRequest(scope = mapOf("service" to JsonPrimitive("checkout")))
+            val matching =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "Conditional API trigger",
+                        triggerName = "api",
+                        conditions = listOf(WorkflowConditionConfig("workflow.input", "contains", "checkout")),
+                        steps = emptyList(),
+                        onceForTemplate = emptyList()
+                    )
+                )
+
+            val matched =
+                service.createWorkflowInstance(
+                    organizationId = orgId,
+                    workflowId = matching.id,
+                    request = request,
+                    callerUserId = 7
+                )
+
+            assertNotNull(matched)
+            assertEquals(1, workflowEngine.requests.size)
+
+            val mismatch =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "Non-matching API trigger",
+                        triggerName = "api",
+                        conditions = listOf(WorkflowConditionConfig("workflow.input", "contains", "database")),
+                        steps = emptyList(),
+                        onceForTemplate = emptyList()
+                    )
+                )
+            val skipped =
+                service.createWorkflowInstance(
+                    organizationId = orgId,
+                    workflowId = mismatch.id,
+                    request = request,
+                    callerUserId = 7
+                )
+
+            assertNull(skipped)
+            assertEquals(1, workflowEngine.requests.size)
+            assertTrue(service.listRuns(orgId, mismatch.id).isEmpty())
+        }
+
+    @Test
     fun `signed webhook trigger requires valid signature and published webhook workflow`() =
         runBlocking {
+            val previousSigningKey = System.getProperty("WORKFLOWS_SIGNING_KEY")
             System.setProperty("WORKFLOWS_SIGNING_KEY", "test-workflow-signing-key")
             try {
                 val workflow =
@@ -874,7 +926,11 @@ class WorkflowServiceTest {
                 assertEquals("deploy-1", run.onceFor)
                 assertEquals(1, workflowEngine.requests.size)
             } finally {
-                System.clearProperty("WORKFLOWS_SIGNING_KEY")
+                if (previousSigningKey == null) {
+                    System.clearProperty("WORKFLOWS_SIGNING_KEY")
+                } else {
+                    System.setProperty("WORKFLOWS_SIGNING_KEY", previousSigningKey)
+                }
             }
         }
 

--- a/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
@@ -35,14 +35,18 @@ import com.moneat.workflows.models.WorkflowConditionConfig
 import com.moneat.workflows.models.WorkflowPreviewRequest
 import com.moneat.workflows.models.WorkflowPreviewResponse
 import com.moneat.workflows.models.WorkflowResponse
+import com.moneat.workflows.models.WorkflowRunCancelResponse
+import com.moneat.workflows.models.WorkflowRunInstanceRequest
 import com.moneat.workflows.models.WorkflowRunResponse
 import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowStepPreview
 import com.moneat.workflows.models.WorkflowTestMessageResponse
 import com.moneat.workflows.models.WorkflowTestMessageResult
+import com.moneat.workflows.models.WorkflowWebhookSigningResponse
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -437,6 +441,127 @@ class WorkflowRoutesTest {
             assertTrue(defaultLimit.bodyAsText().contains("pending"))
             assertEquals(HttpStatusCode.OK, upperBound.status)
             assertTrue(upperBound.bodyAsText().contains("failed"))
+        }
+
+    @Test
+    fun `instance routes create list get and cancel workflow runs`() =
+        testApplication {
+            setupApp()
+            val request = WorkflowRunInstanceRequest()
+            every { workflowService.listRuns(organizationId, WORKFLOW_ID, 50) } returns listOf(runResponse())
+            every { workflowService.getRun(organizationId, WORKFLOW_ID, 7) } returns runResponse()
+            coEvery {
+                workflowService.createWorkflowInstance(organizationId, WORKFLOW_ID, request, userId)
+            } returns runResponse(status = "pending")
+            coEvery {
+                workflowService.cancelRun(organizationId, WORKFLOW_ID, 7)
+            } returns WorkflowRunCancelResponse(7, "canceled")
+
+            val list = client.get("/v1/workflows/$WORKFLOW_ID/instances") {
+                withAuth(token())
+            }
+            val detail = client.get("/v1/workflows/$WORKFLOW_ID/instances/7") {
+                withAuth(token())
+            }
+            val created = client.post("/v1/workflows/$WORKFLOW_ID/instances") {
+                withAuth(token())
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(request))
+            }
+            val canceled = client.put("/v1/workflows/$WORKFLOW_ID/instances/7/cancel") {
+                withAuth(token())
+            }
+
+            assertEquals(HttpStatusCode.OK, list.status)
+            assertTrue(list.bodyAsText().contains("complete"))
+            assertEquals(HttpStatusCode.OK, detail.status)
+            assertTrue(detail.bodyAsText().contains("host-1"))
+            assertEquals(HttpStatusCode.Accepted, created.status)
+            assertTrue(created.bodyAsText().contains("pending"))
+            assertEquals(HttpStatusCode.OK, canceled.status)
+            assertTrue(canceled.bodyAsText().contains("canceled"))
+        }
+
+    @Test
+    fun `instance routes validate identifiers and map missing runs`() =
+        testApplication {
+            setupApp()
+            every { workflowService.getRun(organizationId, WORKFLOW_ID, 8) } returns null
+            coEvery { workflowService.cancelRun(organizationId, WORKFLOW_ID, 8) } returns null
+
+            val invalidWorkflow = client.get("/v1/workflows/nope/instances/7") {
+                withAuth(token())
+            }
+            val invalidInstance = client.get("/v1/workflows/$WORKFLOW_ID/instances/nope") {
+                withAuth(token())
+            }
+            val missingDetail = client.get("/v1/workflows/$WORKFLOW_ID/instances/8") {
+                withAuth(token())
+            }
+            val missingCancel = client.put("/v1/workflows/$WORKFLOW_ID/instances/8/cancel") {
+                withAuth(token())
+            }
+
+            assertEquals(HttpStatusCode.BadRequest, invalidWorkflow.status)
+            assertEquals(HttpStatusCode.BadRequest, invalidInstance.status)
+            assertEquals(HttpStatusCode.NotFound, missingDetail.status)
+            assertEquals(HttpStatusCode.NotFound, missingCancel.status)
+        }
+
+    @Test
+    fun `webhook signing route requires admin role and returns signing metadata`() =
+        testApplication {
+            setupApp()
+            val memberToken = RouteTestSupport.createToken(userId = memberUserId, orgId = organizationId)
+            every {
+                workflowService.webhookSigningInfo(organizationId, WORKFLOW_ID)
+            } returns WorkflowWebhookSigningResponse(
+                workflowId = WORKFLOW_ID,
+                webhookUrl = "https://api.moneat.io/v1/workflows/$WORKFLOW_ID/webhook",
+                signingSecret = "secret",
+                signatureHeader = "X-Moneat-Workflow-Signature",
+                signatureFormat = "sha256=<hex HMAC-SHA256 of raw body>"
+            )
+
+            val forbidden = client.get("/v1/workflows/$WORKFLOW_ID/webhook-signing") {
+                withAuth(memberToken)
+            }
+            val response = client.get("/v1/workflows/$WORKFLOW_ID/webhook-signing") {
+                withAuth(token())
+            }
+
+            assertEquals(HttpStatusCode.Forbidden, forbidden.status)
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("X-Moneat-Workflow-Signature"))
+        }
+
+    @Test
+    fun `signed webhook route validates signature before creating a run`() =
+        testApplication {
+            setupApp()
+            every { workflowService.verifyWebhookSignature(WORKFLOW_ID, "{}", null) } returns false
+            every {
+                workflowService.verifyWebhookSignature(WORKFLOW_ID, "{}", "sha256=valid")
+            } returns true
+            coEvery {
+                workflowService.createWebhookRun(WORKFLOW_ID, "{}", "event-1")
+            } returns runResponse(status = "pending")
+
+            val unsigned = client.post("/v1/workflows/$WORKFLOW_ID/webhook") {
+                contentType(ContentType.Application.Json)
+                setBody("{}")
+            }
+            val signed = client.post("/v1/workflows/$WORKFLOW_ID/webhook") {
+                header("X-Moneat-Workflow-Signature", "sha256=valid")
+                header("X-Moneat-Webhook-Event", "event-1")
+                contentType(ContentType.Application.Json)
+                setBody("{}")
+            }
+
+            assertEquals(HttpStatusCode.Unauthorized, unsigned.status)
+            assertEquals(HttpStatusCode.Accepted, signed.status)
+            assertTrue(signed.bodyAsText().contains("pending"))
+            coVerify { workflowService.createWebhookRun(WORKFLOW_ID, "{}", "event-1") }
         }
 
     private fun ApplicationTestBuilder.setupApp() {

--- a/dashboard/src/components/workflows/NodeConfigPanel.tsx
+++ b/dashboard/src/components/workflows/NodeConfigPanel.tsx
@@ -21,6 +21,7 @@ import type {
   WorkflowGraphNode,
   WorkflowOperationDefinition,
   WorkflowScopeReferenceDefinition,
+  WorkflowStepParamDefinition,
   WorkflowSwitchCaseConfig,
 } from '@/lib/api'
 import {Button} from '@/components/ui/button'
@@ -137,21 +138,7 @@ function ActionFields({
         </Select>
       </div>
       {definition?.params.map((param) => (
-        <div key={param.name} className="space-y-1.5">
-          <Label>{param.label}</Label>
-          {param.type === 'Text' ? (
-            <Textarea
-              value={String(node.params?.[param.name] ?? '')}
-              onChange={(event) => updateParam(node, param.name, event.target.value, onChange)}
-              className="min-h-24"
-            />
-          ) : (
-            <Input
-              value={String(node.params?.[param.name] ?? '')}
-              onChange={(event) => updateParam(node, param.name, event.target.value, onChange)}
-            />
-          )}
-        </div>
+        <ParamField key={param.name} node={node} param={param} onChange={onChange} />
       ))}
       <div className="flex items-center gap-2">
         <Switch
@@ -161,6 +148,52 @@ function ActionFields({
         <Label>Continue on error</Label>
       </div>
       <RetryFields node={node} onChange={onChange} />
+    </div>
+  )
+}
+
+function ParamField({
+  node,
+  param,
+  onChange,
+}: {
+  node: WorkflowGraphNode
+  param: WorkflowStepParamDefinition
+  onChange: (node: WorkflowGraphNode) => void
+}) {
+  const value = node.params?.[param.name]
+  return (
+    <div className="space-y-1.5">
+      <Label>{param.label}</Label>
+      {param.type === 'Text' && (
+        <Textarea
+          value={String(value ?? '')}
+          onChange={(event) => updateParam(node, param.name, event.target.value, onChange)}
+          className="min-h-24"
+        />
+      )}
+      {param.type === 'Number' && (
+        <Input
+          type="number"
+          value={String(value ?? '')}
+          onChange={(event) => updateNumberParam(node, param.name, event.target.value, onChange)}
+        />
+      )}
+      {param.type === 'Boolean' && (
+        <div className="flex h-10 items-center gap-2">
+          <Switch
+            checked={booleanParamChecked(value)}
+            onCheckedChange={(checked) => updateParamValue(node, param.name, checked, onChange)}
+          />
+          <span className="text-sm text-muted-foreground">{booleanParamChecked(value) ? 'True' : 'False'}</span>
+        </div>
+      )}
+      {param.type !== 'Text' && param.type !== 'Number' && param.type !== 'Boolean' && (
+        <Input
+          value={String(value ?? '')}
+          onChange={(event) => updateParam(node, param.name, event.target.value, onChange)}
+        />
+      )}
     </div>
   )
 }
@@ -508,7 +541,29 @@ function updateParam(
   value: string,
   onChange: (node: WorkflowGraphNode) => void
 ) {
+  updateParamValue(node, name, value, onChange)
+}
+
+function updateNumberParam(
+  node: WorkflowGraphNode,
+  name: string,
+  value: string,
+  onChange: (node: WorkflowGraphNode) => void
+) {
+  updateParamValue(node, name, value === '' ? '' : Number(value), onChange)
+}
+
+function updateParamValue(
+  node: WorkflowGraphNode,
+  name: string,
+  value: string | number | boolean,
+  onChange: (node: WorkflowGraphNode) => void
+) {
   onChange({...node, params: {...node.params, [name]: value}})
+}
+
+function booleanParamChecked(value: unknown): boolean {
+  return value === true || value === 'true'
 }
 
 function nodeForConditionKind(

--- a/dashboard/src/components/workflows/NodeConfigPanel.tsx
+++ b/dashboard/src/components/workflows/NodeConfigPanel.tsx
@@ -176,7 +176,8 @@ function ParamField({
         <Input
           type="number"
           value={String(value ?? '')}
-          onChange={(event) => updateNumberParam(node, param.name, event.target.value, onChange)}
+          onChange={(event) => updateParamValue(node, param.name, event.target.value, onChange)}
+          onBlur={(event) => commitNumberParam(node, param.name, event.target.value, onChange)}
         />
       )}
       {param.type === 'Boolean' && (
@@ -544,13 +545,19 @@ function updateParam(
   updateParamValue(node, name, value, onChange)
 }
 
-function updateNumberParam(
+function commitNumberParam(
   node: WorkflowGraphNode,
   name: string,
   value: string,
   onChange: (node: WorkflowGraphNode) => void
 ) {
-  updateParamValue(node, name, value === '' ? '' : Number(value), onChange)
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    updateParamValue(node, name, '', onChange)
+    return
+  }
+  const parsed = Number(trimmed)
+  updateParamValue(node, name, Number.isFinite(parsed) ? parsed : trimmed, onChange)
 }
 
 function updateParamValue(

--- a/dashboard/src/components/workflows/NodePalette.tsx
+++ b/dashboard/src/components/workflows/NodePalette.tsx
@@ -32,7 +32,7 @@ export function NodePalette({catalog, onAddNode}: NodePaletteProps) {
     <div className="space-y-3 rounded-md border bg-muted/20 p-3">
       <div>
         <h3 className="text-sm font-semibold">Node palette</h3>
-        <p className="text-xs text-muted-foreground">Add branches, waits, and notification actions.</p>
+        <p className="text-xs text-muted-foreground">Add branches, waits, and workflow actions.</p>
       </div>
       <div className="grid gap-2">
         <PaletteButton

--- a/dashboard/src/components/workflows/workflowGraph.ts
+++ b/dashboard/src/components/workflows/workflowGraph.ts
@@ -20,6 +20,7 @@ import type {
   WorkflowGraphConfig,
   WorkflowGraphEdge,
   WorkflowGraphNode,
+  WorkflowJsonValue,
   WorkflowRequest,
   WorkflowResponse,
   WorkflowStepConfig,
@@ -234,7 +235,7 @@ export function statusClass(status: string): string {
   return 'border-amber-500/30 bg-amber-500/10 text-amber-600'
 }
 
-export function defaultParamsForStep(step: WorkflowStepDefinition): Record<string, string> {
+export function defaultParamsForStep(step: WorkflowStepDefinition): Record<string, WorkflowJsonValue> {
   return Object.fromEntries(step.params.map((param) => [param.name, defaultParamValue(param.name, param.type)]))
 }
 
@@ -292,10 +293,11 @@ function withNodeDefaults(node: WorkflowGraphNode): WorkflowGraphNode {
 function defaultParamValue(
   name: string,
   type: string
-): string {
+): WorkflowJsonValue {
   if (name === 'subject') return 'Moneat workflow: {{alert.title}}'
   if (name === 'title') return 'Moneat workflow'
-  if (type === 'Number') return '100'
+  if (type === 'Number') return 100
+  if (type === 'Boolean') return false
   return [
     '{{alert.display_title}}',
     '',

--- a/dashboard/src/lib/api/modules/workflows.ts
+++ b/dashboard/src/lib/api/modules/workflows.ts
@@ -21,10 +21,13 @@ import type {
   WorkflowPreviewRequest,
   WorkflowPreviewResponse,
   WorkflowRequest,
+  WorkflowRunCancelResponse,
+  WorkflowRunInstanceRequest,
   WorkflowResponse,
   WorkflowRunResponse,
   WorkflowTestMessageResponse,
   WorkflowUpdateRequest,
+  WorkflowWebhookSigningResponse,
 } from '../types'
 
 export function workflowsMethods(core: ApiClientCore) {
@@ -84,5 +87,28 @@ export function workflowsMethods(core: ApiClientCore) {
 
     getWorkflowRuns: (id: number) =>
       core.request<WorkflowRunResponse[]>(`${base}/workflows/${id}/runs`),
+
+    getWorkflowInstances: (id: number) =>
+      core.request<WorkflowRunResponse[]>(`${base}/workflows/${id}/instances`),
+
+    getWorkflowRun: (id: number, runId: number) =>
+      core.request<WorkflowRunResponse>(`${base}/workflows/${id}/instances/${runId}`),
+
+    createWorkflowInstance: (
+      id: number,
+      request: WorkflowRunInstanceRequest = {scope: {}}
+    ) =>
+      core.request<WorkflowRunResponse>(`${base}/workflows/${id}/instances`, {
+        method: 'POST',
+        body: JSON.stringify(request),
+      }),
+
+    cancelWorkflowRun: (id: number, runId: number) =>
+      core.request<WorkflowRunCancelResponse>(`${base}/workflows/${id}/instances/${runId}/cancel`, {
+        method: 'PUT',
+      }),
+
+    getWorkflowWebhookSigning: (id: number) =>
+      core.request<WorkflowWebhookSigningResponse>(`${base}/workflows/${id}/webhook-signing`),
   }
 }

--- a/dashboard/src/lib/api/types/workflows.ts
+++ b/dashboard/src/lib/api/types/workflows.ts
@@ -182,9 +182,28 @@ export interface WorkflowRunResponse {
   progress: WorkflowRunStepProgress[]
   steps: WorkflowRunStepResponse[]
   error_message?: string | null
+  temporal_workflow_id?: string | null
+  temporal_run_id?: string | null
   created_at: string
   completed_at?: string | null
   failed_at?: string | null
+}
+
+export interface WorkflowRunInstanceRequest {
+  scope: Record<string, WorkflowJsonValue>
+}
+
+export interface WorkflowRunCancelResponse {
+  id: number
+  status: string
+}
+
+export interface WorkflowWebhookSigningResponse {
+  workflow_id: number
+  webhook_url: string
+  signing_secret: string
+  signature_header: string
+  signature_format: string
 }
 
 export interface WorkflowFieldConfig {


### PR DESCRIPTION
## Summary

Extends the workflow engine (built on the Temporal execution engine and graph canvas from #482 and #485) with safe triggers, trusted Moneat-native actions, and run-instance management.

## Triggers
- **Manual / API / signed webhook** — inbound webhooks use HMAC-SHA256 with a per-workflow derived secret, constant-time signature verification, and are accepted only for workflows whose trigger is `webhook`.
- **Source-specific alert triggers** — `monitor.alerted/recovered`, `uptime.down/up`, `synthetic.failed/passed`, published alongside the existing `alert.triggered/resolved` (legacy alert behavior preserved).
- **Incident created/resolved** and **security signal** (runtime + compliance telemetry).

## Trusted actions
Read paths reuse existing services: logs search/aggregate, host metrics, traces search, span get, issues list/get. Write paths: status page update, status page incident create, and alert silence. On-call paging routes through the Enterprise on-call bridge and returns a clear "requires enterprise" result when the bridge is not enabled. All action parameters are typed and validated, and project/host access is scoped to the workflow's organization.

## Run instances
List, detail, create, and cancel run instances. Cancellation propagates to Temporal and records terminal state. Run responses now expose Temporal workflow/run identifiers.

## Frontend
- Typed parameter inputs (number / boolean / text) in the node config panel.
- API client methods for run instances and webhook signing metadata.

## Intentionally not shipped
`http.request` and `transform.graaljs` are not exposed in the catalog and are not runnable. Schedule lifecycle and on-call trigger emitters remain gated.

## Testing
- `./gradlew detekt compileKotlin compileTestKotlin` — passing
- `./gradlew :test --tests WorkflowServiceTest --tests WorkflowRoutesTest --tests SecurityIngestionWorkerTest` — passing (genuine run, cache bypassed)
- `npm run lint && npm run typecheck && npm run build` — passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel in-progress workflow runs and view cancellation status; run responses include Temporal IDs.
  * Webhook signing/verification with admin endpoint to fetch signing info.
  * Workflow instances: list, create, fetch, and cancel run instances via API and UI.
  * New triggers (incident, security) and many new workflow steps (logs, metrics, traces, issues, status page, incident creation, silences, on-call).
  * Security signal publishing so ingested security batches can trigger workflows.
  * Trusted/enterprise actions support for additional secure workflow steps.

* **UI**
  * Node palette subtitle updated; node config uses improved parameter inputs (numbers, booleans, text).

* **Tests**
  * Expanded coverage for webhook signing, instance lifecycle, cancellation, and security signal workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moneat-io/moneat/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->