### PR TITLE
fix: SEO prerender sitemap coverage

### DIFF
--- a/dashboard/public/robots.txt
+++ b/dashboard/public/robots.txt
@@ -21,4 +21,3 @@ Disallow: /impersonate-callback
 Disallow: /auth
 
 Sitemap: https://moneat.io/sitemap.xml
-Sitemap: https://moneat.io/docs/sitemap.xml

--- a/dashboard/public/robots.txt
+++ b/dashboard/public/robots.txt
@@ -21,3 +21,4 @@ Disallow: /impersonate-callback
 Disallow: /auth
 
 Sitemap: https://moneat.io/sitemap.xml
+Sitemap: https://moneat.io/docs/sitemap.xml

--- a/dashboard/src/lib/seo/__tests__/routes.test.ts
+++ b/dashboard/src/lib/seo/__tests__/routes.test.ts
@@ -21,17 +21,19 @@ import {
   blogPostSeo,
   buildSitemapEntries,
   compareHubSeo,
+  docsIndexSeo,
   competitorPageSeo,
   featurePageSeo,
   homeSeo,
 } from '../routes'
 
 describe('static route descriptors', () => {
-  it('home/blog/compare descriptors have required fields', () => {
+  it('home/blog/docs/compare descriptors have required fields', () => {
     expect(homeSeo.path).toBe('/')
     expect(homeSeo.jsonLd?.length).toBeGreaterThan(0)
     expect(homeSeo.socialTitle).toBeTruthy()
     expect(blogIndexSeo.path).toBe('/blog')
+    expect(docsIndexSeo.path).toBe('/docs')
     expect(compareHubSeo.path).toBe('/compare')
     expect(compareHubSeo.image).toContain('/marketing/')
   })
@@ -98,7 +100,7 @@ describe('buildSitemapEntries', () => {
   })
 
   it('keeps noindex and docs-only routes out of the root sitemap', () => {
-    // Docs detail pages are advertised by /docs/sitemap.xml, not the root app sitemap.
+    // Docs detail pages do not have prerendered app SEO output, so the root sitemap lists only /docs.
     expect(paths).not.toContain('/docs/getting-started')
     expect(paths).not.toContain('/docs/')
     expect(paths.filter((p) => p === '/docs')).toHaveLength(1)

--- a/dashboard/src/lib/seo/__tests__/routes.test.ts
+++ b/dashboard/src/lib/seo/__tests__/routes.test.ts
@@ -16,7 +16,7 @@
 
 import {describe, it, expect} from 'vitest'
 import {
-  FEATURE_PAGE_SLUGS,
+  FEATURE_PAGE_SEO_INPUTS,
   blogIndexSeo,
   blogPostSeo,
   buildSitemapEntries,
@@ -77,32 +77,35 @@ describe('competitorPageSeo / featurePageSeo', () => {
 describe('buildSitemapEntries', () => {
   const entries = buildSitemapEntries({
     posts: [{slug: 'a', date: '2026-01-01'}, {slug: 'b'}],
-    docs: [{slug: 'getting-started'}, {slug: ''}],
     competitors: [{route: '/datadog-alternative'}, {route: '/sentry-alternative'}],
     buildDate: '2026-05-30',
   })
   const paths = entries.map((e) => e.path)
 
-  it('includes core, competitor, feature, blog, doc and legal routes', () => {
+  it('includes core, competitor, feature, blog and legal routes', () => {
     expect(paths).toContain('/')
     expect(paths).toContain('/blog')
     expect(paths).toContain('/datadog-alternative')
     expect(paths).toContain('/sentry-alternative')
     expect(paths).toContain('/blog/a')
     expect(paths).toContain('/blog/b')
-    expect(paths).toContain('/docs/getting-started')
+    expect(paths).toContain('/docs')
     expect(paths).toContain('/legal/terms')
     expect(paths).toContain('/legal/privacy')
-    for (const slug of FEATURE_PAGE_SLUGS) {
-      expect(paths).toContain(`/${slug}`)
+    for (const page of FEATURE_PAGE_SEO_INPUTS) {
+      expect(paths).toContain(`/${page.slug}`)
     }
   })
 
-  it('skips docs with an empty slug and carries post lastmod', () => {
-    // The empty-slug doc must not produce a "/docs/" entry...
+  it('keeps noindex and docs-only routes out of the root sitemap', () => {
+    // Docs detail pages are advertised by /docs/sitemap.xml, not the root app sitemap.
+    expect(paths).not.toContain('/docs/getting-started')
     expect(paths).not.toContain('/docs/')
-    // ...and "/docs" appears exactly once (the index added separately, not from the docs loop).
     expect(paths.filter((p) => p === '/docs')).toHaveLength(1)
+    expect(paths).not.toContain('/signup')
+  })
+
+  it('carries post lastmod and core priority metadata', () => {
     expect(entries.find((e) => e.path === '/blog/a')?.lastmod).toBe('2026-01-01')
     expect(entries.find((e) => e.path === '/blog/b')?.lastmod).toBeUndefined()
     expect(entries.find((e) => e.path === '/')?.priority).toBe(1.0)

--- a/dashboard/src/lib/seo/routes.ts
+++ b/dashboard/src/lib/seo/routes.ts
@@ -7,7 +7,7 @@ export interface FeatureSeoInput {
   readonly slug: string
   readonly title: string
   readonly metaDescription: string
-  readonly image?: string
+  readonly image: string
 }
 
 /** Product feature/marketing pages rendered via FeaturePageTemplate (slug === path). */
@@ -126,6 +126,17 @@ export const FEATURE_PAGE_SEO_INPUTS = [
   },
 ] as const satisfies readonly FeatureSeoInput[]
 
+export type FeaturePageSlug = (typeof FEATURE_PAGE_SEO_INPUTS)[number]['slug']
+
+/** Return the shared SEO data for a feature route so runtime pages and prerender stay aligned. */
+export function getFeaturePageSeoInput(slug: FeaturePageSlug): FeatureSeoInput {
+  const page = FEATURE_PAGE_SEO_INPUTS.find((candidate) => candidate.slug === slug)
+  if (!page) {
+    throw new Error(`Missing feature SEO input for ${slug}`)
+  }
+  return page
+}
+
 export const homeSeo: PageSeo = {
   path: '/',
   title: 'Moneat | Open-Source Observability for Sentry and Datadog Teams',
@@ -149,6 +160,13 @@ export const blogIndexSeo: PageSeo = {
   path: '/blog',
   title: 'Blog — Moneat',
   description: 'Engineering deep-dives, observability best practices, and product updates.',
+}
+
+export const docsIndexSeo: PageSeo = {
+  path: '/docs',
+  title: 'Documentation — Moneat',
+  description:
+    'Moneat documentation — error monitoring, incident management, uptime tracking, and structured logging.',
 }
 
 export const compareHubSeo: PageSeo = {
@@ -185,6 +203,7 @@ export const privacySeo: PageSeo = {
 export const STATIC_SEO_PAGES = [
   homeSeo,
   blogIndexSeo,
+  docsIndexSeo,
   compareHubSeo,
   pricingSeo,
   termsSeo,

--- a/dashboard/src/lib/seo/routes.ts
+++ b/dashboard/src/lib/seo/routes.ts
@@ -3,23 +3,128 @@ import type {PageSeo, SitemapEntry} from './types'
 
 const COMPARISON_OG_IMAGE = '/marketing/observability-comparison-hero-a.webp'
 
+export interface FeatureSeoInput {
+  readonly slug: string
+  readonly title: string
+  readonly metaDescription: string
+  readonly image?: string
+}
+
 /** Product feature/marketing pages rendered via FeaturePageTemplate (slug === path). */
-export const FEATURE_PAGE_SLUGS = [
-  'error-tracking',
-  'log-management',
-  'infrastructure-monitoring',
-  'uptime-monitoring',
-  'session-replay',
-  'performance-monitoring',
-  'profiling',
-  'on-call-management',
-  'public-status-pages',
-  'alerting',
-  'ai-observability',
-  'mcp-server',
-  'custom-dashboards',
-  'security-sbom',
-] as const
+export const FEATURE_PAGE_SEO_INPUTS = [
+  {
+    slug: 'error-tracking',
+    title: 'Error Tracking',
+    metaDescription:
+      'Error tracking with smart fingerprinting, stack traces, and breadcrumbs. Compatible with Sentry SDKs. ' +
+      'Start free with Moneat.',
+    image: '/screenshots/error-tracking.png',
+  },
+  {
+    slug: 'log-management',
+    title: 'Log Management',
+    metaDescription:
+      'Log management with structured JSON, full-text search, real-time streaming, and powerful filtering. ' +
+      'Start free with Moneat.',
+    image: '/screenshots/log-management.png',
+  },
+  {
+    slug: 'infrastructure-monitoring',
+    title: 'Infrastructure Monitoring',
+    metaDescription:
+      'Infrastructure monitoring for hosts, containers, Kubernetes, and databases. Compatible with the Datadog ' +
+      'Agent. Start free with Moneat.',
+    image: '/screenshots/containers.png',
+  },
+  {
+    slug: 'uptime-monitoring',
+    title: 'Uptime Monitoring',
+    metaDescription:
+      'Uptime monitoring with instant alerts via phone, SMS, Slack. Public status pages included. Start free ' +
+      'with Moneat.',
+    image: '/screenshots/uptime.png',
+  },
+  {
+    slug: 'session-replay',
+    title: 'Session Replay',
+    metaDescription:
+      'Session replay with click tracking, console output, and error correlation. Replay user sessions to debug ' +
+      'issues faster. Start free with Moneat.',
+    image: '/screenshots/session-replay.png',
+  },
+  {
+    slug: 'performance-monitoring',
+    title: 'APM & Traces',
+    metaDescription:
+      'Application performance monitoring with distributed tracing, transaction tracking, and span analysis. ' +
+      'Start free with Moneat.',
+    image: '/screenshots/performance.png',
+  },
+  {
+    slug: 'profiling',
+    title: 'Continuous Profiling',
+    metaDescription:
+      'Continuous profiling with CPU, heap, and wall-time flamegraphs. Pinpoint performance bottlenecks in ' +
+      'production. Start free with Moneat.',
+    image: '/screenshots/profiles.png',
+  },
+  {
+    slug: 'on-call-management',
+    title: 'On-Call & Incidents',
+    metaDescription:
+      'On-call scheduling with phone, SMS, and Slack alerts. Escalation policies and rotation management. ' +
+      'Start free with Moneat.',
+    image: '/screenshots/escalation-policies.png',
+  },
+  {
+    slug: 'public-status-pages',
+    title: 'Status Pages',
+    metaDescription:
+      'Public status pages with custom domains, automated from uptime monitors. Free on all plans. Start free ' +
+      'with Moneat.',
+    image: '/screenshots/status-page-public.png',
+  },
+  {
+    slug: 'alerting',
+    title: 'Alerting & Integrations',
+    metaDescription:
+      'Alerting with Slack, Discord, email, phone, and SMS. Flexible routing rules and escalation policies. ' +
+      'Start free with Moneat.',
+    image: '/screenshots/alerting.png',
+  },
+  {
+    slug: 'ai-observability',
+    title: 'AI & LLM Observability',
+    metaDescription:
+      'AI and LLM observability with token tracking, cost analysis, and prompt monitoring across providers. ' +
+      'Start free with Moneat.',
+    image: '/screenshots/ai.png',
+  },
+  {
+    slug: 'mcp-server',
+    title: 'MCP Server',
+    metaDescription:
+      'MCP server for AI-powered observability. Query issues, logs, and traces from Cursor, GitHub Copilot, ' +
+      'or any MCP client. Start free with Moneat.',
+    image: '/screenshots/dashboard.png',
+  },
+  {
+    slug: 'custom-dashboards',
+    title: 'Dashboards',
+    metaDescription:
+      'Custom dashboards with drag-and-drop widgets. Connect any data source — PostgreSQL, ClickHouse, BigQuery, ' +
+      'and more. Start free with Moneat.',
+    image: '/screenshots/dashboard.png',
+  },
+  {
+    slug: 'security-sbom',
+    title: 'Security & SBOM',
+    metaDescription:
+      'Security monitoring with SBOM inventory and CVE tracking. Know which vulnerabilities affect your services. ' +
+      'Start free with Moneat.',
+    image: '/screenshots/security.png',
+  },
+] as const satisfies readonly FeatureSeoInput[]
 
 export const homeSeo: PageSeo = {
   path: '/',
@@ -34,7 +139,8 @@ export const homeSeo: PageSeo = {
     'both. Use your existing SDKs and agents — zero code changes.',
   keywords:
     'Sentry alternative, Datadog alternative, open source Sentry alternative, self-hosted Datadog replacement, ' +
-    'drop-in Datadog replacement, error monitoring, log management, APM, infrastructure monitoring, observability platform',
+    'drop-in Datadog replacement, error monitoring, log management, APM, infrastructure monitoring, ' +
+    'observability platform',
   image: '/screenshots/dashboard.png',
   jsonLd: [softwareApplicationLd(), organizationLd(), webSiteLd()],
 }
@@ -56,6 +162,35 @@ export const compareHubSeo: PageSeo = {
   image: COMPARISON_OG_IMAGE,
 }
 
+export const pricingSeo: PageSeo = {
+  path: '/pricing',
+  title: 'Pricing | Moneat',
+  description:
+    'Simple, transparent pricing for Moneat. Per-type limits so you only pay for what you use. Unlimited team ' +
+    'members on every plan. Start free.',
+}
+
+export const termsSeo: PageSeo = {
+  path: '/legal/terms',
+  title: 'Terms of Use | Moneat',
+  description: 'Terms of Use for Moneat monitoring service.',
+}
+
+export const privacySeo: PageSeo = {
+  path: '/legal/privacy',
+  title: 'Privacy Policy | Moneat',
+  description: 'Privacy Policy for Moneat monitoring service.',
+}
+
+export const STATIC_SEO_PAGES = [
+  homeSeo,
+  blogIndexSeo,
+  compareHubSeo,
+  pricingSeo,
+  termsSeo,
+  privacySeo,
+] as const
+
 export interface CompetitorSeoInput {
   title: string
   route: string
@@ -70,13 +205,6 @@ export function competitorPageSeo(page: CompetitorSeoInput): PageSeo {
     description: page.metaDescription,
     image: COMPARISON_OG_IMAGE,
   }
-}
-
-export interface FeatureSeoInput {
-  slug: string
-  title: string
-  metaDescription: string
-  image?: string
 }
 
 /** PageSeo for a product feature page (slug === path, e.g. /error-tracking). */
@@ -128,7 +256,6 @@ export function blogPostSeo(post: BlogPostSeoInput): PageSeo {
 
 export interface SitemapInput {
   posts: {slug: string; date?: string}[]
-  docs: {slug: string}[]
   competitors: {route: string}[]
   /** YYYY-MM-DD used for routes without their own modification date. */
   buildDate: string
@@ -136,7 +263,7 @@ export interface SitemapInput {
 
 /** Assemble the full list of indexable marketing/content routes for sitemap.xml. */
 export function buildSitemapEntries(input: SitemapInput): SitemapEntry[] {
-  const {posts, docs, competitors, buildDate} = input
+  const {posts, competitors, buildDate} = input
   const entries: SitemapEntry[] = [
     {path: '/', changefreq: 'weekly', priority: 1.0, lastmod: buildDate},
     {path: '/blog', changefreq: 'weekly', priority: 0.8, lastmod: buildDate},
@@ -147,18 +274,13 @@ export function buildSitemapEntries(input: SitemapInput): SitemapEntry[] {
   for (const competitor of competitors) {
     entries.push({path: competitor.route, changefreq: 'monthly', priority: 0.8})
   }
-  for (const slug of FEATURE_PAGE_SLUGS) {
-    entries.push({path: `/${slug}`, changefreq: 'monthly', priority: 0.6})
+  for (const page of FEATURE_PAGE_SEO_INPUTS) {
+    entries.push({path: `/${page.slug}`, changefreq: 'monthly', priority: 0.6})
   }
   for (const post of posts) {
     entries.push({path: `/blog/${post.slug}`, changefreq: 'monthly', priority: 0.7, lastmod: post.date})
   }
-  for (const doc of docs) {
-    if (!doc.slug) continue
-    entries.push({path: `/docs/${doc.slug}`, changefreq: 'monthly', priority: 0.5})
-  }
   entries.push(
-    {path: '/signup', changefreq: 'monthly', priority: 0.5},
     {path: '/legal/terms', changefreq: 'yearly', priority: 0.2},
     {path: '/legal/privacy', changefreq: 'yearly', priority: 0.2},
   )

--- a/dashboard/src/prerender/render.tsx
+++ b/dashboard/src/prerender/render.tsx
@@ -11,17 +11,16 @@
 // excluded from vitest coverage. The pure logic it composes lives in src/lib/seo (fully tested).
 import {renderToStaticMarkup} from 'react-dom/server'
 import {allPosts, type Post} from '@/blog/loader'
-import {allDocs} from '@/docs/loader'
 import {competitorPages} from '@/components/landing/competitorComparisonData'
 import {renderHeadTags} from '@/lib/seo/headTags'
 import {buildSitemapXml} from '@/lib/seo/sitemap'
 import {
-  blogIndexSeo,
   blogPostSeo,
   buildSitemapEntries,
-  compareHubSeo,
   competitorPageSeo,
-  homeSeo,
+  FEATURE_PAGE_SEO_INPUTS,
+  featurePageSeo,
+  STATIC_SEO_PAGES,
 } from '@/lib/seo/routes'
 
 export interface PrerenderedRoute {
@@ -74,11 +73,13 @@ function BlogArticleBody({post}: {readonly post: Post}) {
 
 /** Routes that get static SEO <head> (and, for blog posts, prerendered body HTML). */
 export function getPrerenderRoutes(): PrerenderedRoute[] {
-  const routes: PrerenderedRoute[] = [
-    {path: '/', head: renderHeadTags(homeSeo)},
-    {path: '/blog', head: renderHeadTags(blogIndexSeo)},
-    {path: '/compare', head: renderHeadTags(compareHubSeo)},
-  ]
+  const routes: PrerenderedRoute[] = STATIC_SEO_PAGES.map((seo) => ({
+    path: seo.path,
+    head: renderHeadTags(seo),
+  }))
+  for (const page of FEATURE_PAGE_SEO_INPUTS) {
+    routes.push({path: `/${page.slug}`, head: renderHeadTags(featurePageSeo(page))})
+  }
   for (const page of competitorPages) {
     routes.push({path: page.route, head: renderHeadTags(competitorPageSeo(page))})
   }
@@ -97,7 +98,6 @@ export function getSitemapXml(buildDate: string = new Date().toISOString().slice
   return buildSitemapXml(
     buildSitemapEntries({
       posts: allPosts.map((post) => ({slug: post.slug, date: post.date})),
-      docs: allDocs.map((doc) => ({slug: doc.slug})),
       competitors: competitorPages.map((page) => ({route: page.route})),
       buildDate,
     }),

--- a/dashboard/src/routes/ai-observability.tsx
+++ b/dashboard/src/routes/ai-observability.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Brain, DollarSign, Clock, Layers, BarChart3, Zap} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('ai-observability')
 
 const config: FeaturePageConfig = {
-  slug: 'ai-observability',
-  title: 'AI & LLM Observability',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Monitor your AI in production',
   description: 'Monitor LLM calls, token usage, latency, and costs across providers. Track prompts, completions, and model performance to optimize your AI workflows and control spending.',
-  metaDescription: 'AI and LLM observability with token tracking, cost analysis, and prompt monitoring across providers. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Brain,
   iconColor: 'text-fuchsia-400',
   iconBg: 'bg-fuchsia-500/10',
   gradient: 'from-fuchsia-500 to-pink-400',
   accentColor: 'text-fuchsia-400',
-  screenshot: '/screenshots/ai.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'AI observability dashboard showing LLM metrics and token usage',
   subFeatures: [
     {icon: Layers, title: 'Multi-Provider', description: 'Track OpenAI, Anthropic, Google, and any provider in a single unified view.', iconColor: 'text-fuchsia-400'},

--- a/dashboard/src/routes/alerting.tsx
+++ b/dashboard/src/routes/alerting.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Bell, MessageSquare, Mail, Filter, Workflow, Phone} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('alerting')
 
 const config: FeaturePageConfig = {
-  slug: 'alerting',
-  title: 'Alerting & Integrations',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Never miss what matters',
   description: 'Multi-channel alerts with Slack, Discord, email, phone, and SMS integrations. Route alerts to the right teams instantly with flexible rules and escalation policies.',
-  metaDescription: 'Alerting with Slack, Discord, email, phone, and SMS. Flexible routing rules and escalation policies. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Bell,
   iconColor: 'text-rose-400',
   iconBg: 'bg-rose-500/10',
   gradient: 'from-rose-500 to-pink-400',
   accentColor: 'text-rose-400',
-  screenshot: '/screenshots/alerting.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Alerting configuration with multi-channel notification settings',
   subFeatures: [
     {icon: MessageSquare, title: 'Slack & Discord', description: 'Rich alert notifications in Slack and Discord with actionable buttons to acknowledge or resolve.', iconColor: 'text-rose-400'},

--- a/dashboard/src/routes/custom-dashboards.tsx
+++ b/dashboard/src/routes/custom-dashboards.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {LayoutDashboard, Database, LineChart, Grid3x3, Share2, Palette} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('custom-dashboards')
 
 const config: FeaturePageConfig = {
-  slug: 'custom-dashboards',
-  title: 'Dashboards',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Visualize anything',
   description: 'Build custom dashboards with drag-and-drop widgets powered by any data source. Connect PostgreSQL, ClickHouse, BigQuery, or use built-in Moneat metrics to create the views your team needs.',
-  metaDescription: 'Custom dashboards with drag-and-drop widgets. Connect any data source — PostgreSQL, ClickHouse, BigQuery, and more. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: LayoutDashboard,
   iconColor: 'text-sky-400',
   iconBg: 'bg-sky-500/10',
   gradient: 'from-sky-500 to-blue-400',
   accentColor: 'text-sky-400',
-  screenshot: '/screenshots/dashboard.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Custom dashboard with multiple widgets showing metrics and charts',
   subFeatures: [
     {icon: Grid3x3, title: 'Drag & Drop', description: 'Arrange widgets on a flexible grid. Resize, reorder, and organize your dashboard layout visually.', iconColor: 'text-sky-400'},

--- a/dashboard/src/routes/docs.index.tsx
+++ b/dashboard/src/routes/docs.index.tsx
@@ -1,8 +1,9 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {getDoc} from '@/docs/loader'
-import {Helmet} from 'react-helmet-async'
 import {mdxComponents} from '@/docs/mdx-components'
 import {DocsFeedback} from '@/docs/components/DocsFeedback'
+import {SeoHead} from '@/components/SeoHead'
+import {docsIndexSeo} from '@/lib/seo/routes'
 
 export const Route = createFileRoute('/docs/')({
   component: DocsIndex,
@@ -23,10 +24,7 @@ function DocsIndex() {
 
   return (
     <>
-      <Helmet>
-        <title>Documentation — Moneat</title>
-        <meta name="description" content="Moneat documentation — error monitoring, incident management, uptime tracking, and structured logging." />
-      </Helmet>
+      <SeoHead seo={docsIndexSeo} />
       <article className="px-4 py-12 sm:px-8 lg:px-12">
         <div className="prose prose-slate max-w-none prose-headings:text-slate-950 prose-p:text-slate-700 prose-li:text-slate-700 prose-strong:text-slate-950 prose-a:text-sky-700 hover:prose-a:text-sky-900 [&_code]:before:content-none [&_code]:after:content-none">
           <Component components={mdxComponents} />

--- a/dashboard/src/routes/error-tracking.tsx
+++ b/dashboard/src/routes/error-tracking.tsx
@@ -17,21 +17,24 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Activity, Fingerprint, Layers, Search, Tag, Workflow} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('error-tracking')
 
 const config: FeaturePageConfig = {
-  slug: 'error-tracking',
-  title: 'Error Tracking',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Triage production exceptions',
   description:
     'Catch, group, and triage errors with smart fingerprinting. See full stack traces, breadcrumbs, and user ' +
     'context for every exception across all your projects. Works with Sentry-compatible SDKs.',
-  metaDescription: 'Error tracking with smart fingerprinting, stack traces, and breadcrumbs. Compatible with Sentry SDKs. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Activity,
   iconColor: 'text-sky-400',
   iconBg: 'bg-sky-500/10',
   gradient: 'from-sky-500 to-cyan-400',
   accentColor: 'text-sky-400',
-  screenshot: '/screenshots/error-tracking.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Error tracking dashboard showing issues list with stack traces and context',
   subFeatures: [
     {icon: Fingerprint, title: 'Smart Fingerprinting', description: 'Automatically group similar errors together with intelligent fingerprinting that understands your stack.', iconColor: 'text-sky-400'},

--- a/dashboard/src/routes/infrastructure-monitoring.tsx
+++ b/dashboard/src/routes/infrastructure-monitoring.tsx
@@ -17,21 +17,24 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Server, Cpu, HardDrive, Box, Network, Database} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('infrastructure-monitoring')
 
 const config: FeaturePageConfig = {
-  slug: 'infrastructure-monitoring',
-  title: 'Infrastructure Monitoring',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Infrastructure telemetry',
   description:
     'Monitor hosts, containers, Kubernetes clusters, and databases with real-time infrastructure telemetry. ' +
     'Point compatible agents at Moneat and get full visibility without changing your applications.',
-  metaDescription: 'Infrastructure monitoring for hosts, containers, Kubernetes, and databases. Compatible with the Datadog Agent. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Server,
   iconColor: 'text-orange-400',
   iconBg: 'bg-orange-500/10',
   gradient: 'from-orange-500 to-amber-400',
   accentColor: 'text-orange-400',
-  screenshot: '/screenshots/containers.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Infrastructure monitoring showing host and container metrics',
   subFeatures: [
     {icon: Cpu, title: 'Host Metrics', description: 'CPU, memory, disk, network, and load metrics from every host in your fleet.', iconColor: 'text-orange-400'},

--- a/dashboard/src/routes/legal.privacy.tsx
+++ b/dashboard/src/routes/legal.privacy.tsx
@@ -16,7 +16,8 @@
 
 import {createFileRoute, Link} from '@tanstack/react-router'
 import {LEGAL_PRIVACY_VERSION} from '@/lib/legal'
-import {Helmet} from 'react-helmet-async'
+import {SeoHead} from '@/components/SeoHead'
+import {privacySeo} from '@/lib/seo/routes'
 
 export const Route = createFileRoute('/legal/privacy')({
   component: PrivacyPolicyPage,
@@ -25,11 +26,7 @@ export const Route = createFileRoute('/legal/privacy')({
 function PrivacyPolicyPage() {
   return (
     <main>
-      <Helmet>
-        <title>Privacy Policy | Moneat</title>
-        <meta name="description" content="Privacy Policy for Moneat monitoring service." />
-        <link rel="canonical" href="https://moneat.io/legal/privacy" />
-      </Helmet>
+      <SeoHead seo={privacySeo} />
       <div className="mx-auto max-w-4xl px-6 py-12 md:py-16">
         <div className="mb-10 space-y-3">
           <h1 className="text-3xl font-bold tracking-tight">Privacy Policy</h1>

--- a/dashboard/src/routes/legal.terms.tsx
+++ b/dashboard/src/routes/legal.terms.tsx
@@ -16,7 +16,8 @@
 
 import {createFileRoute, Link} from '@tanstack/react-router'
 import {LEGAL_TERMS_VERSION} from '@/lib/legal'
-import {Helmet} from 'react-helmet-async'
+import {SeoHead} from '@/components/SeoHead'
+import {termsSeo} from '@/lib/seo/routes'
 
 export const Route = createFileRoute('/legal/terms')({
   component: TermsOfUsePage,
@@ -25,11 +26,7 @@ export const Route = createFileRoute('/legal/terms')({
 function TermsOfUsePage() {
   return (
     <main>
-      <Helmet>
-        <title>Terms of Use | Moneat</title>
-        <meta name="description" content="Terms of Use for Moneat monitoring service." />
-        <link rel="canonical" href="https://moneat.io/legal/terms" />
-      </Helmet>
+      <SeoHead seo={termsSeo} />
       <div className="mx-auto max-w-4xl px-6 py-12 md:py-16">
         <div className="mb-10 space-y-3">
           <h1 className="text-3xl font-bold tracking-tight">Terms of Use</h1>

--- a/dashboard/src/routes/log-management.tsx
+++ b/dashboard/src/routes/log-management.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {FileText, Filter, RefreshCw, Search, Braces, Link2} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('log-management')
 
 const config: FeaturePageConfig = {
-  slug: 'log-management',
-  title: 'Log Management',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Structured logging at scale',
   description: 'Structured JSON logs with auto-refresh, full-text search, and powerful filtering. Unified with your errors and traces for faster root-cause analysis.',
-  metaDescription: 'Log management with structured JSON, full-text search, real-time streaming, and powerful filtering. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: FileText,
   iconColor: 'text-blue-400',
   iconBg: 'bg-blue-500/10',
   gradient: 'from-blue-500 to-indigo-400',
   accentColor: 'text-blue-400',
-  screenshot: '/screenshots/log-management.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Log management interface with real-time log viewer and filtering',
   subFeatures: [
     {icon: Search, title: 'Full-Text Search', description: 'Search across billions of log entries with sub-second response times.', iconColor: 'text-blue-400'},

--- a/dashboard/src/routes/mcp-server.tsx
+++ b/dashboard/src/routes/mcp-server.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Bot, Code2, Search, BarChart3, Bug, Terminal} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('mcp-server')
 
 const config: FeaturePageConfig = {
-  slug: 'mcp-server',
-  title: 'MCP Server',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Observability in your IDE',
   description: 'Connect Cursor, GitHub Copilot, Claude Code, or your own agents to Moneat via the Model Context Protocol. Query issues, logs, traces, and metrics from your AI workflows without leaving your editor.',
-  metaDescription: 'MCP server for AI-powered observability. Query issues, logs, and traces from Cursor, GitHub Copilot, or any MCP client. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Bot,
   iconColor: 'text-violet-400',
   iconBg: 'bg-violet-500/10',
   gradient: 'from-violet-500 to-purple-400',
   accentColor: 'text-violet-400',
-  screenshot: '/screenshots/dashboard.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Moneat dashboard showing observability data accessible via MCP',
   subFeatures: [
     {icon: Terminal, title: '30+ Tools', description: 'List issues, query logs, get traces, search hosts, create dashboards, and more — all via MCP.', iconColor: 'text-violet-400'},

--- a/dashboard/src/routes/on-call-management.tsx
+++ b/dashboard/src/routes/on-call-management.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Phone, Calendar, ArrowUpRight, MessageSquare, Clock, Users} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('on-call-management')
 
 const config: FeaturePageConfig = {
-  slug: 'on-call-management',
-  title: 'On-Call & Incidents',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'The right person, every time',
   description: 'Manage on-call rotations and escalation policies. When things break, Moneat notifies the right person via phone call, SMS, Slack, or email — with automatic escalation if they don\'t respond.',
-  metaDescription: 'On-call scheduling with phone, SMS, and Slack alerts. Escalation policies and rotation management. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Phone,
   iconColor: 'text-orange-400',
   iconBg: 'bg-orange-500/10',
   gradient: 'from-orange-500 to-amber-400',
   accentColor: 'text-orange-400',
-  screenshot: '/screenshots/escalation-policies.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'On-call escalation policies with rotation schedules',
   subFeatures: [
     {icon: Calendar, title: 'On-Call Schedules', description: 'Create rotating schedules with daily, weekly, or custom rotation patterns for your team.', iconColor: 'text-orange-400'},

--- a/dashboard/src/routes/performance-monitoring.tsx
+++ b/dashboard/src/routes/performance-monitoring.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Zap, Activity, Timer, GitBranch, BarChart3, Search} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('performance-monitoring')
 
 const config: FeaturePageConfig = {
-  slug: 'performance-monitoring',
-  title: 'APM & Traces',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Find slow endpoints fast',
   description: 'Track transactions and spans across your services. Find slow endpoints, database queries, and external calls before your users notice. Distributed tracing with full context.',
-  metaDescription: 'Application performance monitoring with distributed tracing, transaction tracking, and span analysis. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Zap,
   iconColor: 'text-amber-400',
   iconBg: 'bg-amber-500/10',
   gradient: 'from-amber-500 to-orange-400',
   accentColor: 'text-amber-400',
-  screenshot: '/screenshots/performance.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Performance monitoring dashboard with transaction timings and span waterfall',
   subFeatures: [
     {icon: Activity, title: 'Transaction Tracking', description: 'Automatically capture every HTTP request, background job, and queue consumer as a transaction.', iconColor: 'text-amber-400'},

--- a/dashboard/src/routes/pricing.tsx
+++ b/dashboard/src/routes/pricing.tsx
@@ -18,7 +18,8 @@ import {createFileRoute} from '@tanstack/react-router'
 import {PricingSection} from '@/components/landing/PricingSection'
 import {PricingCalculatorSection} from '@/components/landing/PricingCalculatorSection'
 import {LandingNavbar, LandingFooter} from '@/components/landing/LandingNavbar'
-import {Helmet} from 'react-helmet-async'
+import {SeoHead} from '@/components/SeoHead'
+import {pricingSeo} from '@/lib/seo/routes'
 
 export const Route = createFileRoute('/pricing')({
   component: PricingPage,
@@ -27,14 +28,7 @@ export const Route = createFileRoute('/pricing')({
 function PricingPage() {
   return (
     <article className="min-h-screen bg-white text-slate-950">
-      <Helmet>
-        <title>Pricing | Moneat</title>
-        <meta
-          name="description"
-          content="Simple, transparent pricing for Moneat. Per-type limits so you only pay for what you use. Unlimited team members on every plan. Start free."
-        />
-        <link rel="canonical" href="https://moneat.io/pricing" />
-      </Helmet>
+      <SeoHead seo={pricingSeo} />
 
       <LandingNavbar tone="light" />
 

--- a/dashboard/src/routes/profiling.tsx
+++ b/dashboard/src/routes/profiling.tsx
@@ -17,21 +17,24 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Flame, Cpu, HardDrive, Clock, Layers, Search} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('profiling')
 
 const config: FeaturePageConfig = {
-  slug: 'profiling',
-  title: 'Continuous Profiling',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Pinpoint hot paths in production',
   description:
     'CPU, heap, and wall-time profiles from production telemetry. Identify hot functions, memory leaks, ' +
     'and resource bottlenecks without adding application overhead.',
-  metaDescription: 'Continuous profiling with CPU, heap, and wall-time flamegraphs. Pinpoint performance bottlenecks in production. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Flame,
   iconColor: 'text-red-400',
   iconBg: 'bg-red-500/10',
   gradient: 'from-red-500 to-orange-400',
   accentColor: 'text-red-400',
-  screenshot: '/screenshots/profiles.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Continuous profiling flamegraph showing CPU and memory hotspots',
   subFeatures: [
     {icon: Flame, title: 'Flamegraphs', description: 'Interactive flamegraphs that visualize exactly where your application spends its time.', iconColor: 'text-red-400'},

--- a/dashboard/src/routes/public-status-pages.tsx
+++ b/dashboard/src/routes/public-status-pages.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {GitBranch, Globe, Palette, RefreshCw, Bell, Shield} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('public-status-pages')
 
 const config: FeaturePageConfig = {
-  slug: 'public-status-pages',
-  title: 'Status Pages',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Keep your users informed',
   description: 'Beautiful public status pages with custom domains, automated from your monitors. Show your customers real-time service health with zero manual effort. Free on all plans.',
-  metaDescription: 'Public status pages with custom domains, automated from uptime monitors. Free on all plans. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: GitBranch,
   iconColor: 'text-cyan-400',
   iconBg: 'bg-cyan-500/10',
   gradient: 'from-cyan-500 to-teal-400',
   accentColor: 'text-cyan-400',
-  screenshot: '/screenshots/status-page-public.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Public status page showing service health and uptime history',
   subFeatures: [
     {icon: Globe, title: 'Custom Domains', description: 'Host your status page on your own domain like status.yourapp.com with automatic SSL.', iconColor: 'text-cyan-400'},

--- a/dashboard/src/routes/security-sbom.tsx
+++ b/dashboard/src/routes/security-sbom.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {ShieldCheck, Package, AlertTriangle, Search, FileText, Shield} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('security-sbom')
 
 const config: FeaturePageConfig = {
-  slug: 'security-sbom',
-  title: 'Security & SBOM',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Know what you\'re running',
   description: 'Software bill of materials with CVE tracking across all your services. Know exactly what packages are deployed, which versions have known vulnerabilities, and what needs patching.',
-  metaDescription: 'Security monitoring with SBOM inventory and CVE tracking. Know which vulnerabilities affect your services. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: ShieldCheck,
   iconColor: 'text-emerald-400',
   iconBg: 'bg-emerald-500/10',
   gradient: 'from-emerald-500 to-green-400',
   accentColor: 'text-emerald-400',
-  screenshot: '/screenshots/security.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Security dashboard showing SBOM inventory and CVE tracking',
   subFeatures: [
     {icon: Package, title: 'Package Inventory', description: 'Full inventory of every package and version running across all your services and hosts.', iconColor: 'text-emerald-400'},

--- a/dashboard/src/routes/session-replay.tsx
+++ b/dashboard/src/routes/session-replay.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Play, MousePointerClick, Monitor, Bug, Clock, Layers} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('session-replay')
 
 const config: FeaturePageConfig = {
-  slug: 'session-replay',
-  title: 'Session Replay',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'See what your users see',
   description: 'Watch exactly what users did before an error. See clicks, navigation, and console output reconstructed in real-time. No more guessing — replay the exact session that triggered the bug.',
-  metaDescription: 'Session replay with click tracking, console output, and error correlation. Replay user sessions to debug issues faster. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Play,
   iconColor: 'text-violet-400',
   iconBg: 'bg-violet-500/10',
   gradient: 'from-violet-500 to-purple-400',
   accentColor: 'text-violet-400',
-  screenshot: '/screenshots/session-replay.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Session replay showing user interactions before errors occurred',
   subFeatures: [
     {icon: MousePointerClick, title: 'Click & Scroll Tracking', description: 'See every click, scroll, and navigation event in the exact order the user performed them.', iconColor: 'text-violet-400'},

--- a/dashboard/src/routes/uptime-monitoring.tsx
+++ b/dashboard/src/routes/uptime-monitoring.tsx
@@ -17,19 +17,22 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {Globe, Clock, Bell, BarChart3, GitBranch, Phone} from 'lucide-react'
 import {FeaturePageTemplate, type FeaturePageConfig} from '@/components/landing/FeaturePageTemplate'
+import {getFeaturePageSeoInput} from '@/lib/seo/routes'
+
+const pageSeo = getFeaturePageSeoInput('uptime-monitoring')
 
 const config: FeaturePageConfig = {
-  slug: 'uptime-monitoring',
-  title: 'Uptime Monitoring',
+  slug: pageSeo.slug,
+  title: pageSeo.title,
   tagline: 'Never miss downtime',
   description: 'Monitor your services 24/7 with customizable check intervals. Get alerted instantly via phone, SMS, Slack, or Discord when something goes down. Automatic public status pages included.',
-  metaDescription: 'Uptime monitoring with instant alerts via phone, SMS, Slack. Public status pages included. Start free with Moneat.',
+  metaDescription: pageSeo.metaDescription,
   icon: Globe,
   iconColor: 'text-green-400',
   iconBg: 'bg-green-500/10',
   gradient: 'from-green-500 to-emerald-400',
   accentColor: 'text-green-400',
-  screenshot: '/screenshots/uptime.png',
+  screenshot: pageSeo.image,
   screenshotAlt: 'Uptime monitoring dashboard with status checks and availability metrics',
   subFeatures: [
     {icon: Clock, title: 'Configurable Intervals', description: 'Check every 30 seconds to every 30 minutes. Choose the cadence that matches your SLA.', iconColor: 'text-green-400'},


### PR DESCRIPTION
## Summary

Fixes the SEO regression in the recently landed prerender changes by making the generated sitemap match routes that have usable static SEO output.

## Changes

- Prerender static SEO head files for feature pages, pricing, legal pages, and the `/docs` index so sitemap-listed app routes do not fall back to the homepage metadata shell.
- Remove `signup` and JS-only docs detail routes from the root sitemap; `signup` remains `noindex`, and no phantom docs sitemap is advertised from `robots.txt`.
- Centralize pricing/legal/docs metadata through `SeoHead` so runtime and prerendered tags stay aligned.
- Have feature route configs consume the central feature SEO data for slug/title/meta/image so runtime and prerender cannot drift silently.
- Extend sitemap tests for noindex/docs exclusions and feature-page coverage.

## Validation

- `npm run test -- src/lib/seo src/components/__tests__/SeoHead.test.tsx`
- `npm run build`
- `git diff --check`
- Spot-checked `dist/performance-monitoring/index.html`, `dist/pricing/index.html`, `dist/docs/index.html`, and legal route output after prerender.
- Confirmed `dashboard/public/docs/` and `docs/build/` ignored local artifacts are absent, and the clean build does not create `/docs/sitemap.xml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated robots.txt to point to the sitemap URL and adjusted sitemap generation to include feature and competitor routes while removing per-doc entries and signup.
  * Centralized SEO metadata across feature, pricing, legal, and docs index pages so pages use shared SEO definitions.

* **Tests**
  * Updated sitemap tests to validate feature, competitor, blog, docs-index inclusion and exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->