### PR TITLE
Security signals: model, triage API, derivation from passthrough

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
@@ -21,6 +21,9 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdActivityDumpPayload
 import com.moneat.datadog.models.DdCompliancePayload
 import com.moneat.datadog.models.DdSecurityEventPayload
+import com.moneat.security.signals.SignalDerivation
+import com.moneat.security.signals.SignalOutcome
+import com.moneat.security.signals.SignalWriter
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
@@ -152,13 +155,33 @@ object SecurityIngestionService {
         return entries.size
     }
 
-    suspend fun insertBatch(batch: QueuedSecurityBatch) {
+    /**
+     * Inserts the batch into ClickHouse, then derives security signals from it via [SignalWriter]
+     * (open-signal dedup). Returns the resulting signal outcomes so the caller can drive the
+     * `security.signal` workflow trigger off signal lifecycle rather than per raw event. Both the
+     * ingestion worker and the demo reseed call this, so both populate the triage surface.
+     */
+    suspend fun insertBatch(batch: QueuedSecurityBatch): List<SignalOutcome> {
         when (batch.batchType) {
             "events" -> insertSecurityEvents(batch)
             "dumps" -> insertActivityDumps(batch)
             "findings" -> insertComplianceFindings(batch)
         }
+        return deriveSignals(batch)
     }
+
+    /**
+     * Derives signals best-effort: the ClickHouse insert is already durable by this point, so a
+     * problem persisting signals (e.g. a transient Postgres issue) is logged and degrades to "no
+     * signals for this batch" rather than failing the ingest or crashing the worker. Each spec is
+     * upserted independently so one bad row cannot drop the rest.
+     */
+    private fun deriveSignals(batch: QueuedSecurityBatch): List<SignalOutcome> =
+        SignalDerivation.fromBatch(batch).mapNotNull { spec ->
+            runCatching { SignalWriter.upsert(batch.organizationId, spec) }
+                .onFailure { logger.warn { "Signal derivation failed for rule ${spec.ruleId}: ${it.message}" } }
+                .getOrNull()
+        }
 
     @Suppress("LongMethod")
     private suspend fun insertSecurityEvents(batch: QueuedSecurityBatch) {

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
@@ -105,8 +105,8 @@ class SecurityIngestionWorker(
     ) {
         suspendRunCatching {
             val batch = SecurityIngestionService.decodeBatch(payload)
-            SecurityIngestionService.insertBatch(batch)
-            workflowService.publishSecuritySignals(batch)
+            val signals = SecurityIngestionService.insertBatch(batch)
+            workflowService.publishSecuritySignals(batch.organizationId, signals)
             logger.debug {
                 "Security worker $workerId processed batch: " +
                     "type=${batch.batchType}"

--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -43,6 +43,7 @@ import com.moneat.org.routes.adminRoutes
 import com.moneat.org.routes.orgManagementRoutes
 import com.moneat.otlp.routes.otlpMetricsRoutes
 import com.moneat.otlp.routes.otlpTraceRoutes
+import com.moneat.security.signals.signalRoutes
 import com.moneat.statuspage.routes.statusPageRoutes
 import com.moneat.summary.routes.summaryRoutes
 import com.moneat.uptime.routes.uptimeRoutes
@@ -264,6 +265,11 @@ fun Application.configureRouting() {
         // Workflow automation endpoints
         rateLimit(RateLimitName("api")) {
             workflowRoutes()
+        }
+
+        // Security signals triage surface (OSS core)
+        rateLimit(RateLimitName("api")) {
+            signalRoutes()
         }
 
         routingLogger.info { "Registering enterprise routes..." }

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalDerivation.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalDerivation.kt
@@ -1,0 +1,105 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.datadog.security.QueuedComplianceEntry
+import com.moneat.datadog.security.QueuedSecurityBatch
+import com.moneat.datadog.security.QueuedSecurityEventEntry
+
+private const val COMPLIANCE_STATUS_FAILED = "failed"
+private const val COMPLIANCE_STATUS_ERROR = "error"
+private const val EVIDENCE_TYPE = "clickhouse_query"
+private const val EVENTS_TABLE = "security_events"
+private const val COMPLIANCE_TABLE = "compliance_findings"
+
+/**
+ * Turns an ingested agent batch into the signal specs the agent passthrough produces. A CWS runtime
+ * event yields one `agent_runtime` spec (dedup by rule + host + process); a **failed** compliance
+ * finding yields one `agent_compliance` spec (dedup by rule + resource). Passed/skipped findings and
+ * activity dumps produce nothing. Evidence is a ClickHouse query descriptor — never the rows.
+ */
+object SignalDerivation {
+
+    fun fromBatch(batch: QueuedSecurityBatch): List<SignalSpec> =
+        when (batch.batchType) {
+            "events" -> batch.events.map { runtimeSpec(it) }
+            "findings" -> batch.findings.mapNotNull { complianceSpec(it) }
+            else -> emptyList()
+        }
+
+    private fun runtimeSpec(event: QueuedSecurityEventEntry): SignalSpec {
+        val host = event.host
+        val process = event.processName
+        val resource = event.filePath.ifBlank { process.ifBlank { host } }
+        val entities = buildMap {
+            if (host.isNotBlank()) put("host", host)
+            if (process.isNotBlank()) put("process", process)
+            if (resource.isNotBlank()) put("resource", resource)
+        }
+        val dedupKey = "${event.ruleId}|$host|$process"
+        return SignalSpec(
+            source = SignalSource.AGENT_RUNTIME,
+            ruleId = event.ruleId,
+            ruleName = event.ruleName.ifBlank { event.ruleId },
+            severity = SignalSeverity.fromWire(event.severity),
+            dedupKey = dedupKey,
+            entities = entities,
+            evidenceType = EVIDENCE_TYPE,
+            evidenceReference = runtimeEvidence(event, dedupKey),
+            occurredAtMs = event.timestampMs,
+        )
+    }
+
+    private fun complianceSpec(finding: QueuedComplianceEntry): SignalSpec? {
+        val severity = complianceSeverity(finding.status) ?: return null
+        val resourceId = finding.resourceId
+        val resourceName = finding.resourceName.ifBlank { resourceId }
+        val entities = buildMap {
+            if (resourceName.isNotBlank()) put("resource", resourceName)
+            if (resourceId.isNotBlank()) put("resource_id", resourceId)
+            if (finding.framework.isNotBlank()) put("framework", finding.framework)
+        }
+        val dedupKey = "${finding.ruleId}|$resourceId"
+        return SignalSpec(
+            source = SignalSource.AGENT_COMPLIANCE,
+            ruleId = finding.ruleId,
+            ruleName = finding.ruleName.ifBlank { finding.ruleId },
+            severity = severity,
+            dedupKey = dedupKey,
+            entities = entities,
+            evidenceType = EVIDENCE_TYPE,
+            evidenceReference = complianceEvidence(finding, dedupKey),
+            occurredAtMs = finding.timestampMs,
+        )
+    }
+
+    /** Compliance status → signal severity. Only failing states become signals. */
+    private fun complianceSeverity(status: String): SignalSeverity? =
+        when (status) {
+            COMPLIANCE_STATUS_FAILED -> SignalSeverity.HIGH
+            COMPLIANCE_STATUS_ERROR -> SignalSeverity.MEDIUM
+            else -> null
+        }
+
+    private fun runtimeEvidence(event: QueuedSecurityEventEntry, dedupKey: String): String =
+        "table=$EVENTS_TABLE dedup=$dedupKey rule_id=${event.ruleId} " +
+            "host=${event.host} process=${event.processName} occurred_at_ms=${event.timestampMs}"
+
+    private fun complianceEvidence(finding: QueuedComplianceEntry, dedupKey: String): String =
+        "table=$COMPLIANCE_TABLE dedup=$dedupKey rule_id=${finding.ruleId} " +
+            "resource_id=${finding.resourceId} occurred_at_ms=${finding.timestampMs}"
+}

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
@@ -1,0 +1,256 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.jsonb
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+
+/**
+ * Security signals — the deduplicated, scored, triageable finding model that is the single
+ * triage surface. State (status/assignee/notes) lives here in Postgres; the matched evidence
+ * (CWS events, compliance findings) stays in ClickHouse and is referenced by a query descriptor,
+ * never copied row-for-row.
+ */
+object SecuritySignals : IntIdTable("security_signals") {
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val signalSource = varchar("source", 32)
+    val ruleId = varchar("rule_id", 255)
+    val ruleName = varchar("rule_name", 255)
+    val severity = varchar("severity", 16)
+    val status = varchar("status", 16).default(SignalStatus.OPEN.wire)
+    val archiveReason = varchar("archive_reason", 16).nullable()
+    val dedupKey = text("dedup_key")
+    val entities = jsonb("entities").default("{}")
+    val sampleCount = integer("sample_count").default(1)
+    val assigneeUserId = integer("assignee_user_id").nullable()
+    val tags = jsonb("tags").default("[]")
+    val firstSeen = timestamp("first_seen")
+    val lastSeen = timestamp("last_seen")
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+}
+
+/** ClickHouse evidence references for a signal — a descriptor that can re-query the source table. */
+object SecuritySignalEvidence : IntIdTable("security_signal_evidence") {
+    val signalId = integer("signal_id").references(SecuritySignals.id, onDelete = ReferenceOption.CASCADE)
+    val evidenceType = varchar("evidence_type", 32)
+    val reference = text("reference")
+    val createdAt = timestamp("created_at")
+}
+
+/** Audit trail for triage transitions — every status change / assignment / note is attributable. */
+object SecuritySignalAudit : IntIdTable("security_signal_audit") {
+    val signalId = integer("signal_id").references(SecuritySignals.id, onDelete = ReferenceOption.CASCADE)
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val actorUserId = integer("actor_user_id").nullable()
+    val action = varchar("action", 32)
+    val fromStatus = varchar("from_status", 16).nullable()
+    val toStatus = varchar("to_status", 16).nullable()
+    val reason = varchar("reason", 16).nullable()
+    val note = text("note").nullable()
+    val createdAt = timestamp("created_at")
+}
+
+/** Lifecycle status of a signal. Wire values are the strings persisted in Postgres and returned in the API. */
+enum class SignalStatus(val wire: String) {
+    OPEN("open"),
+    UNDER_REVIEW("under_review"),
+    ARCHIVED("archived");
+
+    companion object {
+        fun fromWire(value: String?): SignalStatus? = entries.firstOrNull { it.wire == value }
+    }
+}
+
+/** Reason recorded when a signal is archived; required only for the archive transition. */
+enum class ArchiveReason(val wire: String) {
+    TRUE_POSITIVE("true_positive"),
+    FALSE_POSITIVE("false_positive"),
+    BENIGN("benign");
+
+    companion object {
+        fun fromWire(value: String?): ArchiveReason? = entries.firstOrNull { it.wire == value }
+    }
+}
+
+/** Severity ordered low→high so escalation can compare and pick the maximum. */
+enum class SignalSeverity(val wire: String, val rank: Int) {
+    INFO("info", 0),
+    LOW("low", 1),
+    MEDIUM("medium", 2),
+    HIGH("high", 3),
+    CRITICAL("critical", 4);
+
+    companion object {
+        fun fromWire(value: String?): SignalSeverity =
+            entries.firstOrNull { it.wire == value } ?: INFO
+    }
+}
+
+/** Producer that emitted a signal. */
+enum class SignalSource(val wire: String) {
+    AGENT_RUNTIME("agent_runtime"),
+    AGENT_COMPLIANCE("agent_compliance"),
+}
+
+/** Audit action kinds. */
+enum class SignalAuditAction(val wire: String) {
+    STATUS_CHANGE("status_change"),
+    ASSIGN("assign"),
+    NOTE("note"),
+}
+
+/**
+ * A request to upsert a signal from a producer. Identity for open-signal dedup is
+ * `(organizationId, ruleId, dedupKey)`. [evidenceReference] is a descriptor — source table plus
+ * dedup fields plus the time window — sufficient to re-query ClickHouse, never the rows themselves.
+ */
+data class SignalSpec(
+    val source: SignalSource,
+    val ruleId: String,
+    val ruleName: String,
+    val severity: SignalSeverity,
+    val dedupKey: String,
+    val entities: Map<String, String>,
+    val evidenceType: String,
+    val evidenceReference: String,
+    val occurredAtMs: Long,
+)
+
+/** Result of [SignalWriter.upsert]; drives whether the workflow trigger fires (Created/Escalated only). */
+sealed interface SignalOutcome {
+    val signalId: Int
+    val organizationId: Int
+    val source: SignalSource
+    val ruleId: String
+    val ruleName: String
+    val severity: SignalSeverity
+    val dedupKey: String
+    val entities: Map<String, String>
+
+    data class Created(
+        override val signalId: Int,
+        override val organizationId: Int,
+        override val source: SignalSource,
+        override val ruleId: String,
+        override val ruleName: String,
+        override val severity: SignalSeverity,
+        override val dedupKey: String,
+        override val entities: Map<String, String>,
+    ) : SignalOutcome
+
+    data class Escalated(
+        override val signalId: Int,
+        override val organizationId: Int,
+        override val source: SignalSource,
+        override val ruleId: String,
+        override val ruleName: String,
+        override val severity: SignalSeverity,
+        override val dedupKey: String,
+        override val entities: Map<String, String>,
+    ) : SignalOutcome
+
+    data class Updated(
+        override val signalId: Int,
+        override val organizationId: Int,
+        override val source: SignalSource,
+        override val ruleId: String,
+        override val ruleName: String,
+        override val severity: SignalSeverity,
+        override val dedupKey: String,
+        override val entities: Map<String, String>,
+    ) : SignalOutcome
+}
+
+@Serializable
+data class SignalEvidenceResponse(
+    val id: Int,
+    @SerialName("evidence_type") val evidenceType: String,
+    val reference: String,
+    @SerialName("created_at") val createdAt: String,
+)
+
+@Serializable
+data class SignalAuditResponse(
+    val id: Int,
+    @SerialName("actor_user_id") val actorUserId: Int? = null,
+    val action: String,
+    @SerialName("from_status") val fromStatus: String? = null,
+    @SerialName("to_status") val toStatus: String? = null,
+    val reason: String? = null,
+    val note: String? = null,
+    @SerialName("created_at") val createdAt: String,
+)
+
+@Serializable
+data class SignalResponse(
+    val id: Int,
+    val source: String,
+    @SerialName("rule_id") val ruleId: String,
+    @SerialName("rule_name") val ruleName: String,
+    val severity: String,
+    val status: String,
+    @SerialName("archive_reason") val archiveReason: String? = null,
+    @SerialName("dedup_key") val dedupKey: String,
+    val entities: Map<String, String> = emptyMap(),
+    @SerialName("sample_count") val sampleCount: Int,
+    @SerialName("assignee_user_id") val assigneeUserId: Int? = null,
+    val tags: List<String> = emptyList(),
+    @SerialName("first_seen") val firstSeen: String,
+    @SerialName("last_seen") val lastSeen: String,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+)
+
+@Serializable
+data class SignalListResponse(
+    val signals: List<SignalResponse>,
+    @SerialName("total_count") val totalCount: Long,
+)
+
+@Serializable
+data class SignalDetailResponse(
+    val signal: SignalResponse,
+    val evidence: List<SignalEvidenceResponse>,
+    val audit: List<SignalAuditResponse>,
+    @SerialName("sample_events") val sampleEvents: List<JsonElement>,
+)
+
+@Serializable
+data class TriageRequest(
+    val status: String? = null,
+    val reason: String? = null,
+    @SerialName("assignee_user_id") val assigneeUserId: Int? = null,
+    @SerialName("clear_assignee") val clearAssignee: Boolean = false,
+    val note: String? = null,
+)
+
+/** A validated triage transition, or the reason it was rejected. */
+sealed interface TransitionResult {
+    /**
+     * [status] is null when the request changes only assignee/note (no status move); when non-null
+     * it is the new status, with [archiveReason] set iff the target is [SignalStatus.ARCHIVED].
+     */
+    data class Valid(val status: SignalStatus?, val archiveReason: ArchiveReason?) : TransitionResult
+    data class Invalid(val message: String) : TransitionResult
+}

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalRoutes.kt
@@ -58,7 +58,6 @@ private suspend fun RoutingContext.handleList(service: SignalService) {
         status = call.parameters["status"],
         severity = call.parameters["severity"],
         source = call.parameters["source"],
-        entity = call.parameters["entity"],
         from = call.parameters["from"],
         to = call.parameters["to"],
     )

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalRoutes.kt
@@ -1,0 +1,103 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.utils.ErrorResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.route
+
+private const val DEFAULT_LIMIT = 50
+private const val MAX_LIMIT = 200
+private const val SIGNAL_ID_ROUTE = "/{signalId}"
+private const val INVALID_SIGNAL_ID_MESSAGE = "Invalid signal ID"
+private const val SIGNAL_NOT_FOUND_MESSAGE = "Signal not found"
+private const val MISSING_ORG_MESSAGE = "No active organization"
+
+/**
+ * OSS core signal triage API. Tenant isolation is enforced by the signed `orgId` JWT claim combined
+ * with org-scoping in [SignalService] on every query, matching the sibling security read routes; the
+ * `userId` claim attributes triage actions in the audit trail.
+ */
+fun Route.signalRoutes(service: SignalService = SignalService()) {
+    route("/v1/security/signals") {
+        authenticate("auth-jwt") {
+            get { handleList(service) }
+            get(SIGNAL_ID_ROUTE) { handleDetail(service) }
+            patch(SIGNAL_ID_ROUTE) { handleTriage(service) }
+        }
+    }
+}
+
+private suspend fun RoutingContext.handleList(service: SignalService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    val filters = SignalFilters(
+        status = call.parameters["status"],
+        severity = call.parameters["severity"],
+        source = call.parameters["source"],
+        entity = call.parameters["entity"],
+        from = call.parameters["from"],
+        to = call.parameters["to"],
+    )
+    call.respond(service.list(orgId, filters, paramLimit(), paramOffset()))
+}
+
+private suspend fun RoutingContext.handleDetail(service: SignalService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    val signalId = signalIdFromPath()
+        ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_SIGNAL_ID_MESSAGE))
+    val detail = service.get(orgId, signalId)
+        ?: return call.respond(HttpStatusCode.NotFound, ErrorResponse(SIGNAL_NOT_FOUND_MESSAGE))
+    call.respond(detail)
+}
+
+private suspend fun RoutingContext.handleTriage(service: SignalService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    val signalId = signalIdFromPath()
+        ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_SIGNAL_ID_MESSAGE))
+    val request = call.receive<TriageRequest>()
+    when (val result = service.triage(orgId, signalId, currentUserId(), request)) {
+        is TriageResult.Ok -> call.respond(result.signal)
+        is TriageResult.NotFound -> call.respond(HttpStatusCode.NotFound, ErrorResponse(SIGNAL_NOT_FOUND_MESSAGE))
+        is TriageResult.Invalid -> call.respond(HttpStatusCode.BadRequest, ErrorResponse(result.message))
+    }
+}
+
+private fun RoutingContext.signalIdFromPath(): Int? = call.parameters["signalId"]?.toIntOrNull()
+
+private fun RoutingContext.currentOrganizationId(): Int? =
+    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+
+private fun RoutingContext.currentUserId(): Int? =
+    call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()
+
+private fun RoutingContext.paramLimit(): Int =
+    (call.parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceIn(0, MAX_LIMIT)
+
+private fun RoutingContext.paramOffset(): Int =
+    (call.parameters["offset"]?.toIntOrNull() ?: 0).coerceAtLeast(0)

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
@@ -49,7 +49,6 @@ data class SignalFilters(
     val status: String? = null,
     val severity: String? = null,
     val source: String? = null,
-    val entity: String? = null,
     val from: String? = null,
     val to: String? = null,
 )

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
@@ -1,0 +1,383 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.config.ClickHouseQueryException
+import com.moneat.config.isClickHouseError
+import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import mu.KotlinLogging
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+
+private val logger = KotlinLogging.logger {}
+
+/** Filters accepted by [SignalService.list]. All are optional and AND together. */
+data class SignalFilters(
+    val status: String? = null,
+    val severity: String? = null,
+    val source: String? = null,
+    val entity: String? = null,
+    val from: String? = null,
+    val to: String? = null,
+)
+
+/** Outcome of a triage attempt so the route can map it to the right HTTP status. */
+sealed interface TriageResult {
+    data class Ok(val signal: SignalResponse) : TriageResult
+    data object NotFound : TriageResult
+    data class Invalid(val message: String) : TriageResult
+}
+
+/**
+ * Read/triage surface for security signals. Every method is org-scoped: a caller can only ever read
+ * or mutate signals their organization owns. Sample evidence is pulled from ClickHouse on demand and
+ * its errors are sanitized via [ClickHouseQueryException] so no query text or schema leaks.
+ */
+class SignalService {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun list(orgId: Int, filters: SignalFilters, limit: Int, offset: Int): SignalListResponse =
+        transaction {
+            val predicate = buildPredicate(orgId, filters)
+            val total = SecuritySignals.selectAll().where(predicate).count()
+            val rows = SecuritySignals
+                .selectAll()
+                .where(predicate)
+                .orderBy(SecuritySignals.lastSeen to SortOrder.DESC, SecuritySignals.id to SortOrder.DESC)
+                .limit(limit).offset(offset.toLong())
+                .map { it.toSignalResponse() }
+            SignalListResponse(signals = rows, totalCount = total)
+        }
+
+    /** Returns the signal with its evidence refs, audit trail, and a bounded sample of CH events. */
+    suspend fun get(orgId: Int, signalId: Int): SignalDetailResponse? {
+        val detail = transaction {
+            val row = SecuritySignals
+                .selectAll()
+                .where { (SecuritySignals.id eq signalId) and (SecuritySignals.organizationId eq orgId) }
+                .firstOrNull() ?: return@transaction null
+            val signal = row.toSignalResponse()
+            val evidence = SecuritySignalEvidence
+                .selectAll()
+                .where { SecuritySignalEvidence.signalId eq signalId }
+                .orderBy(SecuritySignalEvidence.id to SortOrder.ASC)
+                .map {
+                    SignalEvidenceResponse(
+                        id = it[SecuritySignalEvidence.id].value,
+                        evidenceType = it[SecuritySignalEvidence.evidenceType],
+                        reference = it[SecuritySignalEvidence.reference],
+                        createdAt = it[SecuritySignalEvidence.createdAt].toString(),
+                    )
+                }
+            val audit = SecuritySignalAudit
+                .selectAll()
+                .where { SecuritySignalAudit.signalId eq signalId }
+                .orderBy(SecuritySignalAudit.id to SortOrder.DESC)
+                .map {
+                    SignalAuditResponse(
+                        id = it[SecuritySignalAudit.id].value,
+                        actorUserId = it[SecuritySignalAudit.actorUserId],
+                        action = it[SecuritySignalAudit.action],
+                        fromStatus = it[SecuritySignalAudit.fromStatus],
+                        toStatus = it[SecuritySignalAudit.toStatus],
+                        reason = it[SecuritySignalAudit.reason],
+                        note = it[SecuritySignalAudit.note],
+                        createdAt = it[SecuritySignalAudit.createdAt].toString(),
+                    )
+                }
+            Triple(signal, evidence, audit)
+        } ?: return null
+
+        val (signal, evidence, audit) = detail
+        val sampleEvents = fetchSampleEvents(orgId, signal)
+        return SignalDetailResponse(signal = signal, evidence = evidence, audit = audit, sampleEvents = sampleEvents)
+    }
+
+    /**
+     * Applies a triage action under the state machine `open → under_review → archived{reason}` with
+     * a permitted `archived → open` reopen. Persists the new state, optional assignee/note, and one
+     * audit row per change with the acting user for attribution.
+     */
+    fun triage(orgId: Int, signalId: Int, actorUserId: Int?, request: TriageRequest): TriageResult =
+        transaction {
+            val row = SecuritySignals
+                .selectAll()
+                .where { (SecuritySignals.id eq signalId) and (SecuritySignals.organizationId eq orgId) }
+                .forUpdate()
+                .firstOrNull() ?: return@transaction TriageResult.NotFound
+
+            val current = SignalStatus.fromWire(row[SecuritySignals.status]) ?: SignalStatus.OPEN
+            val transition = resolveTransition(current, request)
+            if (transition is TransitionResult.Invalid) {
+                return@transaction TriageResult.Invalid(transition.message)
+            }
+            val target = (transition as TransitionResult.Valid)
+
+            val now = Clock.System.now()
+            SecuritySignals.update({ SecuritySignals.id eq signalId }) {
+                if (target.status != null) {
+                    it[status] = target.status.wire
+                    it[archiveReason] = target.archiveReason?.wire
+                }
+                if (request.clearAssignee) {
+                    it[assigneeUserId] = null
+                } else if (request.assigneeUserId != null) {
+                    it[assigneeUserId] = request.assigneeUserId
+                }
+                it[updatedAt] = now
+            }
+
+            val audit = AuditContext(signalId, orgId, actorUserId, now)
+            if (target.status != null && target.status != current) {
+                audit.write(
+                    SignalAuditAction.STATUS_CHANGE,
+                    from = current,
+                    to = target.status,
+                    archiveReason = target.archiveReason,
+                )
+            }
+            if (request.clearAssignee || request.assigneeUserId != null) {
+                audit.write(SignalAuditAction.ASSIGN)
+            }
+            if (!request.note.isNullOrBlank()) {
+                audit.write(SignalAuditAction.NOTE, auditNote = request.note)
+            }
+
+            val updated = SecuritySignals
+                .selectAll()
+                .where { SecuritySignals.id eq signalId }
+                .first()
+                .toSignalResponse()
+            TriageResult.Ok(updated)
+        }
+
+    private fun buildPredicate(
+        orgId: Int,
+        filters: SignalFilters,
+    ): Op<Boolean> {
+        var predicate: Op<Boolean> = SecuritySignals.organizationId eq orgId
+        SignalStatus.fromWire(filters.status)?.let { predicate = predicate and (SecuritySignals.status eq it.wire) }
+        filters.severity?.let { predicate = predicate and (SecuritySignals.severity eq it) }
+        filters.source?.let { predicate = predicate and (SecuritySignals.signalSource eq it) }
+        parseInstant(filters.from)?.let { predicate = predicate and (SecuritySignals.lastSeen greaterEq it) }
+        parseInstant(filters.to)?.let { predicate = predicate and (SecuritySignals.lastSeen lessEq it) }
+        return predicate
+    }
+
+    /** Captures the fields common to every audit row of one triage so each write stays terse. */
+    private inner class AuditContext(
+        private val auditSignalId: Int,
+        private val auditOrgId: Int,
+        private val auditActorUserId: Int?,
+        private val auditNow: kotlin.time.Instant,
+    ) {
+        fun write(
+            auditAction: SignalAuditAction,
+            from: SignalStatus? = null,
+            to: SignalStatus? = null,
+            archiveReason: ArchiveReason? = null,
+            auditNote: String? = null,
+        ) {
+            SecuritySignalAudit.insert {
+                it[signalId] = auditSignalId
+                it[organizationId] = auditOrgId
+                it[actorUserId] = auditActorUserId
+                it[action] = auditAction.wire
+                it[fromStatus] = from?.wire
+                it[toStatus] = to?.wire
+                it[reason] = archiveReason?.wire
+                it[note] = auditNote
+                it[createdAt] = auditNow
+            }
+        }
+    }
+
+    private fun ResultRow.toSignalResponse(): SignalResponse =
+        SignalResponse(
+            id = this[SecuritySignals.id].value,
+            source = this[SecuritySignals.signalSource],
+            ruleId = this[SecuritySignals.ruleId],
+            ruleName = this[SecuritySignals.ruleName],
+            severity = this[SecuritySignals.severity],
+            status = this[SecuritySignals.status],
+            archiveReason = this[SecuritySignals.archiveReason],
+            dedupKey = this[SecuritySignals.dedupKey],
+            entities = decodeStringMap(this[SecuritySignals.entities]),
+            sampleCount = this[SecuritySignals.sampleCount],
+            assigneeUserId = this[SecuritySignals.assigneeUserId],
+            tags = decodeStringList(this[SecuritySignals.tags]),
+            firstSeen = this[SecuritySignals.firstSeen].toString(),
+            lastSeen = this[SecuritySignals.lastSeen].toString(),
+            createdAt = this[SecuritySignals.createdAt].toString(),
+            updatedAt = this[SecuritySignals.updatedAt].toString(),
+        )
+
+    private fun decodeStringMap(raw: String): Map<String, String> =
+        runCatching {
+            json.parseToJsonElement(raw).jsonObject.mapValues { (_, v) -> v.jsonPrimitiveContent() }
+        }.getOrDefault(emptyMap())
+
+    private fun decodeStringList(raw: String): List<String> =
+        runCatching {
+            json.parseToJsonElement(raw).let { el ->
+                (el as? kotlinx.serialization.json.JsonArray)?.map { it.jsonPrimitiveContent() } ?: emptyList()
+            }
+        }.getOrDefault(emptyList())
+
+    private fun JsonElement.jsonPrimitiveContent(): String =
+        (this as? kotlinx.serialization.json.JsonPrimitive)?.content ?: toString()
+
+    private suspend fun fetchSampleEvents(orgId: Int, signal: SignalResponse): List<JsonElement> =
+        when (SignalSource.entries.firstOrNull { it.wire == signal.source }) {
+            SignalSource.AGENT_RUNTIME -> fetchRuntimeSamples(orgId, signal)
+            SignalSource.AGENT_COMPLIANCE -> fetchComplianceSamples(orgId, signal)
+            null -> emptyList()
+        }
+
+    private suspend fun fetchRuntimeSamples(orgId: Int, signal: SignalResponse): List<JsonElement> {
+        val db = ClickHouseClient.getDatabase()
+        val conditions = mutableListOf(
+            ClickHouseQueryUtils.orgIdClause(orgId.toLong()),
+            "rule_id = '${escapeSql(signal.ruleId)}'",
+        )
+        signal.entities["host"]?.takeIf { it.isNotBlank() }?.let {
+            conditions.add("host = '${escapeSql(it)}'")
+        }
+        signal.entities["process"]?.takeIf { it.isNotBlank() }?.let {
+            conditions.add("process_name = '${escapeSql(it)}'")
+        }
+        val where = conditions.joinToString(" AND ")
+        return executeSamples(
+            """SELECT event_id, rule_id, rule_name, severity, event_type, process_name,
+                file_path, host, env,
+                formatDateTime(timestamp, '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as ts
+            FROM `$db`.security_events WHERE $where
+            ORDER BY timestamp DESC LIMIT $SAMPLE_EVENT_LIMIT FORMAT JSONEachRow""",
+        ) { obj ->
+            buildJsonObject {
+                put("eventId", obj.s("event_id"))
+                put("ruleId", obj.s("rule_id"))
+                put("ruleName", obj.s("rule_name"))
+                put("severity", obj.s("severity"))
+                put("eventType", obj.s("event_type"))
+                put("processName", obj.s("process_name"))
+                put("filePath", obj.s("file_path"))
+                put("host", obj.s("host"))
+                put("env", obj.s("env"))
+                put("timestamp", obj.s("ts"))
+            }
+        }
+    }
+
+    private suspend fun fetchComplianceSamples(orgId: Int, signal: SignalResponse): List<JsonElement> {
+        val db = ClickHouseClient.getDatabase()
+        val conditions = mutableListOf(
+            ClickHouseQueryUtils.orgIdClause(orgId.toLong()),
+            "rule_id = '${escapeSql(signal.ruleId)}'",
+        )
+        signal.entities["resource"]?.takeIf { it.isNotBlank() }?.let {
+            conditions.add("resource_id = '${escapeSql(it)}'")
+        }
+        val where = conditions.joinToString(" AND ")
+        return executeSamples(
+            """SELECT finding_id, framework, rule_id, rule_name, status, resource_type,
+                resource_id, resource_name,
+                formatDateTime(evaluated_at, '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as ts
+            FROM `$db`.compliance_findings WHERE $where
+            ORDER BY evaluated_at DESC LIMIT $SAMPLE_EVENT_LIMIT FORMAT JSONEachRow""",
+        ) { obj ->
+            buildJsonObject {
+                put("findingId", obj.s("finding_id"))
+                put("framework", obj.s("framework"))
+                put("ruleId", obj.s("rule_id"))
+                put("ruleName", obj.s("rule_name"))
+                put("status", obj.s("status"))
+                put("resourceType", obj.s("resource_type"))
+                put("resourceId", obj.s("resource_id"))
+                put("resourceName", obj.s("resource_name"))
+                put("evaluatedAt", obj.s("ts"))
+            }
+        }
+    }
+
+    private suspend fun executeSamples(
+        sql: String,
+        mapper: (JsonObject) -> JsonObject,
+    ): List<JsonElement> {
+        val resp = ClickHouseClient.execute(sql)
+        val body = resp.bodyAsText()
+        if (resp.isClickHouseError(body)) {
+            throw sampleQueryError(sql, body)
+        }
+        return body.trim().lines()
+            .filter { it.isNotBlank() }
+            .mapNotNull { line -> runCatching { json.parseToJsonElement(line).jsonObject }.getOrNull() }
+            .map { mapper(it) }
+    }
+
+    /**
+     * Logs the query and ClickHouse body server-side and returns a [ClickHouseQueryException]; the
+     * status-pages plugin maps it to a generic client response so no SQL/schema text ever leaks.
+     */
+    private fun sampleQueryError(sql: String, body: String): ClickHouseQueryException {
+        logger.error {
+            "ClickHouse error in signal sample fetch. " +
+                "SQL: ${sql.take(LOG_SQL_MAX_LEN)} Body: ${body.take(LOG_BODY_MAX_LEN)}"
+        }
+        return ClickHouseQueryException(
+            isTimeout = false,
+            internalDetail = "Signal sample query failed: ${body.take(LOG_BODY_MAX_LEN)}",
+        )
+    }
+
+    private fun parseInstant(value: String?): kotlin.time.Instant? =
+        value?.let { runCatching { kotlin.time.Instant.parse(it) }.getOrNull() }
+
+    private fun JsonObject.s(key: String): String {
+        val el = this[key] ?: return ""
+        return (el as? kotlinx.serialization.json.JsonPrimitive)?.content ?: el.toString()
+    }
+
+    companion object {
+        private const val SAMPLE_EVENT_LIMIT = 25
+        private const val LOG_SQL_MAX_LEN = 200
+        private const val LOG_BODY_MAX_LEN = 300
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalTriageStateMachine.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalTriageStateMachine.kt
@@ -1,0 +1,92 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+internal const val INVALID_STATUS_MESSAGE = "Unknown status"
+internal const val INVALID_REASON_MESSAGE =
+    "archive_reason must be one of true_positive, false_positive, benign"
+internal const val ARCHIVE_REQUIRES_REASON_MESSAGE = "Archiving a signal requires an archive_reason"
+
+/**
+ * The triage state machine. Allowed status moves:
+ * - `open → under_review`
+ * - `under_review → archived{reason}` (reason mandatory)
+ * - `open → archived{reason}` (skip review; reason mandatory)
+ * - `archived → open` (reopen; clears the archive reason)
+ * - any status → itself (idempotent no-op move)
+ *
+ * A request with no `status` is valid and changes only assignee/note. Pure so it is unit-testable in
+ * isolation from the database.
+ */
+fun resolveTransition(current: SignalStatus, request: TriageRequest): TransitionResult {
+    if (request.status == null) {
+        return TransitionResult.Valid(status = null, archiveReason = null)
+    }
+    val target = SignalStatus.fromWire(request.status)
+        ?: return TransitionResult.Invalid(INVALID_STATUS_MESSAGE)
+
+    if (target == current) {
+        return idempotentMove(current, request)
+    }
+
+    return when (target) {
+        SignalStatus.UNDER_REVIEW -> reviewTransition(current)
+        SignalStatus.ARCHIVED -> archiveTransition(current, request)
+        SignalStatus.OPEN -> reopenTransition(current)
+    }
+}
+
+private fun idempotentMove(current: SignalStatus, request: TriageRequest): TransitionResult =
+    if (current == SignalStatus.ARCHIVED) {
+        // Re-archiving may update the reason; still require a valid one.
+        archiveReasonOrInvalid(request) { reason -> TransitionResult.Valid(SignalStatus.ARCHIVED, reason) }
+    } else {
+        TransitionResult.Valid(status = null, archiveReason = null)
+    }
+
+private fun reviewTransition(current: SignalStatus): TransitionResult =
+    if (current == SignalStatus.OPEN) {
+        TransitionResult.Valid(SignalStatus.UNDER_REVIEW, archiveReason = null)
+    } else {
+        invalidMove(current, SignalStatus.UNDER_REVIEW)
+    }
+
+private fun archiveTransition(current: SignalStatus, request: TriageRequest): TransitionResult =
+    if (current == SignalStatus.OPEN || current == SignalStatus.UNDER_REVIEW) {
+        archiveReasonOrInvalid(request) { reason -> TransitionResult.Valid(SignalStatus.ARCHIVED, reason) }
+    } else {
+        invalidMove(current, SignalStatus.ARCHIVED)
+    }
+
+private fun reopenTransition(current: SignalStatus): TransitionResult =
+    if (current == SignalStatus.ARCHIVED) {
+        TransitionResult.Valid(SignalStatus.OPEN, archiveReason = null)
+    } else {
+        invalidMove(current, SignalStatus.OPEN)
+    }
+
+private fun archiveReasonOrInvalid(
+    request: TriageRequest,
+    onValid: (ArchiveReason) -> TransitionResult,
+): TransitionResult {
+    val raw = request.reason ?: return TransitionResult.Invalid(ARCHIVE_REQUIRES_REASON_MESSAGE)
+    val reason = ArchiveReason.fromWire(raw) ?: return TransitionResult.Invalid(INVALID_REASON_MESSAGE)
+    return onValid(reason)
+}
+
+private fun invalidMove(from: SignalStatus, to: SignalStatus): TransitionResult =
+    TransitionResult.Invalid("Cannot move signal from ${from.wire} to ${to.wire}")

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
@@ -1,0 +1,192 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+
+private const val UNIQUE_VIOLATION_SQL_STATE = "23505"
+private const val UPSERT_MAX_ATTEMPTS = 3
+
+private val signalJson = Json { encodeDefaults = true }
+
+/**
+ * Writes signals with **open-signal dedup**: while a signal is `open`, a repeat for the same
+ * `(organizationId, ruleId, dedupKey)` folds into it — incrementing the sample count, raising
+ * severity to the max seen, bumping `last_seen`, and appending an evidence reference. Once a
+ * signal is archived a fresh occurrence opens a new signal.
+ *
+ * Race-safety: the fold is decided inside a single transaction against the live row. On Postgres a
+ * partial unique index `(organization_id, rule_id, dedup_key) WHERE status = 'open'` makes two
+ * concurrent inserts collide; the loser catches the unique violation and retries, on which pass it
+ * now sees the winner's open row and folds. H2 (tests) has no partial index, so dedup there rests on
+ * the in-transaction lookup, which is sufficient for the single-writer test path.
+ */
+object SignalWriter {
+
+    fun upsert(organizationId: Int, spec: SignalSpec): SignalOutcome {
+        repeat(UPSERT_MAX_ATTEMPTS) { attempt ->
+            val outcome = attemptUpsert(organizationId, spec, lastAttempt = attempt == UPSERT_MAX_ATTEMPTS - 1)
+            if (outcome != null) return outcome
+        }
+        // Unreachable: the final attempt never swallows the unique violation. Fold as a last resort.
+        return foldOrThrow(organizationId, spec)
+    }
+
+    /**
+     * One upsert pass. Returns null only when an insert lost the open-dedup race and a retry is
+     * warranted; on the final attempt the violation is rethrown so the caller never silently drops.
+     */
+    private fun attemptUpsert(organizationId: Int, spec: SignalSpec, lastAttempt: Boolean): SignalOutcome? =
+        transaction {
+            val existing = findOpenSignal(organizationId, spec)
+            if (existing != null) {
+                return@transaction foldIntoExisting(existing, spec)
+            }
+            try {
+                createNewSignal(organizationId, spec)
+            } catch (e: ExposedSQLException) {
+                if (e.sqlState == UNIQUE_VIOLATION_SQL_STATE && !lastAttempt) {
+                    null
+                } else {
+                    throw e
+                }
+            }
+        }
+
+    private fun foldOrThrow(organizationId: Int, spec: SignalSpec): SignalOutcome =
+        transaction {
+            val existing = findOpenSignal(organizationId, spec)
+                ?: error("Open signal dedup race did not resolve for rule ${spec.ruleId}")
+            foldIntoExisting(existing, spec)
+        }
+
+    private fun findOpenSignal(organizationId: Int, spec: SignalSpec): OpenSignalRow? =
+        SecuritySignals
+            .selectAll()
+            .where {
+                (SecuritySignals.organizationId eq organizationId) and
+                    (SecuritySignals.ruleId eq spec.ruleId) and
+                    (SecuritySignals.dedupKey eq spec.dedupKey) and
+                    (SecuritySignals.status eq SignalStatus.OPEN.wire)
+            }
+            .forUpdate()
+            .limit(1)
+            .firstOrNull()
+            ?.let { row ->
+                OpenSignalRow(
+                    id = row[SecuritySignals.id].value,
+                    organizationId = row[SecuritySignals.organizationId],
+                    severity = SignalSeverity.fromWire(row[SecuritySignals.severity]),
+                    sampleCount = row[SecuritySignals.sampleCount],
+                )
+            }
+
+    private fun foldIntoExisting(existing: OpenSignalRow, spec: SignalSpec): SignalOutcome {
+        val now = Clock.System.now()
+        val escalated = spec.severity.rank > existing.severity.rank
+        val newSeverity = if (escalated) spec.severity else existing.severity
+        SecuritySignals.update({ SecuritySignals.id eq existing.id }) {
+            it[sampleCount] = existing.sampleCount + 1
+            it[severity] = newSeverity.wire
+            it[lastSeen] = occurrenceTime(spec.occurredAtMs, now)
+            it[updatedAt] = now
+        }
+        insertEvidence(existing.id, spec, now)
+        return if (escalated) {
+            outcome(SignalOutcome::Escalated, existing.id, existing.organizationId, spec, newSeverity)
+        } else {
+            outcome(SignalOutcome::Updated, existing.id, existing.organizationId, spec, newSeverity)
+        }
+    }
+
+    private fun createNewSignal(organizationId: Int, spec: SignalSpec): SignalOutcome {
+        val now = Clock.System.now()
+        val occurred = occurrenceTime(spec.occurredAtMs, now)
+        val signalId = SecuritySignals.insertAndGetId {
+            it[SecuritySignals.organizationId] = organizationId
+            it[signalSource] = spec.source.wire
+            it[ruleId] = spec.ruleId
+            it[ruleName] = spec.ruleName
+            it[severity] = spec.severity.wire
+            it[status] = SignalStatus.OPEN.wire
+            it[dedupKey] = spec.dedupKey
+            it[entities] = signalJson.encodeToString(spec.entities)
+            it[sampleCount] = 1
+            it[tags] = "[]"
+            it[firstSeen] = occurred
+            it[lastSeen] = occurred
+            it[createdAt] = now
+            it[updatedAt] = now
+        }.value
+        insertEvidence(signalId, spec, now)
+        return outcome(SignalOutcome::Created, signalId, organizationId, spec, spec.severity)
+    }
+
+    private fun insertEvidence(signalId: Int, spec: SignalSpec, now: kotlin.time.Instant) {
+        SecuritySignalEvidence.insert {
+            it[SecuritySignalEvidence.signalId] = signalId
+            it[evidenceType] = spec.evidenceType
+            it[reference] = spec.evidenceReference
+            it[createdAt] = now
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun outcome(
+        factory: (Int, Int, SignalSource, String, String, SignalSeverity, String, Map<String, String>) -> SignalOutcome,
+        signalId: Int,
+        organizationId: Int,
+        spec: SignalSpec,
+        severity: SignalSeverity,
+    ): SignalOutcome =
+        factory(
+            signalId,
+            organizationId,
+            spec.source,
+            spec.ruleId,
+            spec.ruleName,
+            severity,
+            spec.dedupKey,
+            spec.entities,
+        )
+
+    /**
+     * The occurrence time clamped so a bad future timestamp from a producer cannot push `last_seen`
+     * ahead of wall-clock now.
+     */
+    private fun occurrenceTime(occurredAtMs: Long, now: kotlin.time.Instant): kotlin.time.Instant {
+        val occurred = kotlin.time.Instant.fromEpochMilliseconds(occurredAtMs)
+        return if (occurred > now) now else occurred
+    }
+
+    private data class OpenSignalRow(
+        val id: Int,
+        val organizationId: Int,
+        val severity: SignalSeverity,
+        val sampleCount: Int,
+    )
+}

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
@@ -102,17 +102,24 @@ object SignalWriter {
                     organizationId = row[SecuritySignals.organizationId],
                     severity = SignalSeverity.fromWire(row[SecuritySignals.severity]),
                     sampleCount = row[SecuritySignals.sampleCount],
+                    firstSeen = row[SecuritySignals.firstSeen],
+                    lastSeen = row[SecuritySignals.lastSeen],
                 )
             }
 
     private fun foldIntoExisting(existing: OpenSignalRow, spec: SignalSpec): SignalOutcome {
         val now = Clock.System.now()
+        val occurred = occurrenceTime(spec.occurredAtMs, now)
         val escalated = spec.severity.rank > existing.severity.rank
         val newSeverity = if (escalated) spec.severity else existing.severity
         SecuritySignals.update({ SecuritySignals.id eq existing.id }) {
             it[sampleCount] = existing.sampleCount + 1
             it[severity] = newSeverity.wire
-            it[lastSeen] = occurrenceTime(spec.occurredAtMs, now)
+            // Agent events can arrive out of order, so clamp the window monotonically: never move
+            // last_seen backwards (it is the list sort key and time-filter bound) and lower first_seen
+            // only when an earlier occurrence folds in.
+            it[firstSeen] = minOf(existing.firstSeen, occurred)
+            it[lastSeen] = maxOf(existing.lastSeen, occurred)
             it[updatedAt] = now
         }
         insertEvidence(existing.id, spec, now)
@@ -188,5 +195,7 @@ object SignalWriter {
         val organizationId: Int,
         val severity: SignalSeverity,
         val sampleCount: Int,
+        val firstSeen: kotlin.time.Instant,
+        val lastSeen: kotlin.time.Instant,
     )
 }

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -21,9 +21,8 @@ import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
 import com.moneat.config.EnvConfig
-import com.moneat.datadog.security.QueuedSecurityBatch
-import com.moneat.datadog.security.QueuedSecurityEventEntry
 import com.moneat.monitoring.OperationalMetrics
+import com.moneat.security.signals.SignalOutcome
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
@@ -723,30 +722,20 @@ class WorkflowService(
         )
     }
 
-    suspend fun publishSecuritySignals(batch: QueuedSecurityBatch) {
-        batch.events.forEach { event ->
-            publishTrigger(
-                WorkflowTriggerEvent(
-                    triggerName = SECURITY_SIGNAL_TRIGGER,
-                    organizationId = batch.organizationId,
-                    scope = securityEventScope(batch.organizationId, event)
-                )
-            )
-        }
-        batch.findings
-            .filter { finding -> finding.status != "passed" }
-            .forEach { finding ->
+    /**
+     * Fires the `security.signal` workflow trigger once per **newly created or escalated** signal,
+     * not once per raw agent event — eliminating the previous per-event fan-out. Repeats that merely
+     * fold into an existing open signal (`Updated`) intentionally do not re-trigger.
+     */
+    suspend fun publishSecuritySignals(organizationId: Int, signals: List<SignalOutcome>) {
+        signals
+            .filter { it is SignalOutcome.Created || it is SignalOutcome.Escalated }
+            .forEach { signal ->
                 publishTrigger(
                     WorkflowTriggerEvent(
                         triggerName = SECURITY_SIGNAL_TRIGGER,
-                        organizationId = batch.organizationId,
-                        scope = mapOf(
-                            SECURITY_RULE_ID_REFERENCE to finding.ruleId,
-                            SECURITY_RULE_NAME_REFERENCE to finding.ruleName,
-                            SECURITY_SEVERITY_REFERENCE to finding.status,
-                            SECURITY_RESOURCE_REFERENCE to finding.resourceName.ifBlank { finding.resourceId },
-                            ORGANIZATION_ID_REFERENCE to batch.organizationId.toString()
-                        ).typedWorkflowScope()
+                        organizationId = organizationId,
+                        scope = securitySignalScope(organizationId, signal)
                     )
                 )
             }
@@ -1231,17 +1220,23 @@ class WorkflowService(
             ORGANIZATION_ID_REFERENCE to organizationId.toString()
         ).typedWorkflowScope()
 
-    private fun securityEventScope(
+    private fun securitySignalScope(
         organizationId: Int,
-        event: QueuedSecurityEventEntry
+        signal: SignalOutcome
     ): Map<String, JsonElement> =
         mapOf(
-            SECURITY_RULE_ID_REFERENCE to event.ruleId,
-            SECURITY_RULE_NAME_REFERENCE to event.ruleName,
-            SECURITY_SEVERITY_REFERENCE to event.severity,
-            SECURITY_RESOURCE_REFERENCE to event.filePath.ifBlank { event.processName.ifBlank { event.host } },
+            SECURITY_RULE_ID_REFERENCE to signal.ruleId,
+            SECURITY_RULE_NAME_REFERENCE to signal.ruleName,
+            SECURITY_SEVERITY_REFERENCE to signal.severity.wire,
+            SECURITY_RESOURCE_REFERENCE to signalResource(signal),
             ORGANIZATION_ID_REFERENCE to organizationId.toString()
         ).typedWorkflowScope()
+
+    private fun signalResource(signal: SignalOutcome): String =
+        signal.entities["resource"]
+            ?: signal.entities["process"]
+            ?: signal.entities["host"]
+            ?: ""
 
     private fun sourceSpecificAlertTrigger(event: AlertLifecycleEvent): String? =
         if (event.status == AlertStatus.RESOLVED) {

--- a/backend/src/main/resources/db/migration/V119__security_signals.sql
+++ b/backend/src/main/resources/db/migration/V119__security_signals.sql
@@ -1,0 +1,59 @@
+-- Security signals: the deduplicated, scored, triageable finding model — the single triage surface.
+-- State lives here in Postgres; matched evidence stays in ClickHouse, referenced by a query descriptor.
+
+CREATE TABLE security_signals (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    source VARCHAR(32) NOT NULL,
+    rule_id VARCHAR(255) NOT NULL,
+    rule_name VARCHAR(255) NOT NULL,
+    severity VARCHAR(16) NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'open',
+    archive_reason VARCHAR(16),
+    dedup_key TEXT NOT NULL,
+    entities JSONB NOT NULL DEFAULT '{}'::JSONB,
+    sample_count INTEGER NOT NULL DEFAULT 1,
+    assignee_user_id INTEGER,
+    tags JSONB NOT NULL DEFAULT '[]'::JSONB,
+    first_seen TIMESTAMPTZ NOT NULL,
+    last_seen TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+-- Primary triage list ordering: scope by org + status + severity, most-recent first.
+CREATE INDEX idx_security_signals_triage
+    ON security_signals (organization_id, status, severity, last_seen);
+
+-- Open-signal dedup: while a signal is open, repeats fold into it. Once archived, a new
+-- occurrence forms a fresh signal — so the uniqueness only applies to open rows.
+CREATE UNIQUE INDEX idx_security_signals_open_dedup
+    ON security_signals (organization_id, rule_id, dedup_key)
+    WHERE status = 'open';
+
+CREATE TABLE security_signal_evidence (
+    id SERIAL PRIMARY KEY,
+    signal_id INTEGER NOT NULL REFERENCES security_signals(id) ON DELETE CASCADE,
+    evidence_type VARCHAR(32) NOT NULL,
+    reference TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_security_signal_evidence_signal
+    ON security_signal_evidence (signal_id, id);
+
+CREATE TABLE security_signal_audit (
+    id SERIAL PRIMARY KEY,
+    signal_id INTEGER NOT NULL REFERENCES security_signals(id) ON DELETE CASCADE,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    actor_user_id INTEGER,
+    action VARCHAR(32) NOT NULL,
+    from_status VARCHAR(16),
+    to_status VARCHAR(16),
+    reason VARCHAR(16),
+    note TEXT,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_security_signal_audit_signal
+    ON security_signal_audit (signal_id, id);

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalDerivationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalDerivationTest.kt
@@ -1,0 +1,123 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.datadog.security.QueuedComplianceEntry
+import com.moneat.datadog.security.QueuedSecurityBatch
+import com.moneat.datadog.security.QueuedSecurityEventEntry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SignalDerivationTest {
+
+    @Test
+    fun `runtime event derives a single agent_runtime spec keyed by rule host process`() {
+        val batch = QueuedSecurityBatch(
+            organizationId = 1,
+            batchType = "events",
+            events = listOf(
+                QueuedSecurityEventEntry(
+                    ruleId = "cws-1",
+                    ruleName = "Suspicious exec",
+                    severity = "high",
+                    processName = "bash",
+                    filePath = "/etc/shadow",
+                    host = "web-01",
+                    timestampMs = 1_700_000_000_000
+                )
+            )
+        )
+
+        val specs = SignalDerivation.fromBatch(batch)
+
+        assertEquals(1, specs.size)
+        val spec = specs.single()
+        assertEquals(SignalSource.AGENT_RUNTIME, spec.source)
+        assertEquals("cws-1|web-01|bash", spec.dedupKey)
+        assertEquals(SignalSeverity.HIGH, spec.severity)
+        assertEquals("web-01", spec.entities["host"])
+        assertEquals("bash", spec.entities["process"])
+        assertEquals("/etc/shadow", spec.entities["resource"])
+        assertTrue(spec.evidenceReference.contains("table=security_events"))
+        assertTrue(spec.evidenceReference.contains("cws-1"))
+    }
+
+    @Test
+    fun `failed compliance finding derives an agent_compliance spec keyed by rule resource`() {
+        val batch = QueuedSecurityBatch(
+            organizationId = 1,
+            batchType = "findings",
+            findings = listOf(
+                QueuedComplianceEntry(
+                    framework = "cis-aws",
+                    ruleId = "cis-1.1",
+                    ruleName = "Root MFA",
+                    status = "failed",
+                    resourceType = "aws_account",
+                    resourceId = "acct-123",
+                    resourceName = "prod",
+                    timestampMs = 1_700_000_000_000
+                )
+            )
+        )
+
+        val specs = SignalDerivation.fromBatch(batch)
+
+        assertEquals(1, specs.size)
+        val spec = specs.single()
+        assertEquals(SignalSource.AGENT_COMPLIANCE, spec.source)
+        assertEquals("cis-1.1|acct-123", spec.dedupKey)
+        assertEquals(SignalSeverity.HIGH, spec.severity)
+        assertEquals("prod", spec.entities["resource"])
+        assertEquals("acct-123", spec.entities["resource_id"])
+        assertTrue(spec.evidenceReference.contains("table=compliance_findings"))
+    }
+
+    @Test
+    fun `passed and skipped compliance findings derive no signals`() {
+        val batch = QueuedSecurityBatch(
+            organizationId = 1,
+            batchType = "findings",
+            findings = listOf(
+                QueuedComplianceEntry(ruleId = "r1", status = "passed", timestampMs = 1),
+                QueuedComplianceEntry(ruleId = "r2", status = "skipped", timestampMs = 1)
+            )
+        )
+
+        assertTrue(SignalDerivation.fromBatch(batch).isEmpty())
+    }
+
+    @Test
+    fun `error compliance finding maps to medium severity`() {
+        val batch = QueuedSecurityBatch(
+            organizationId = 1,
+            batchType = "findings",
+            findings = listOf(
+                QueuedComplianceEntry(ruleId = "r3", status = "error", resourceId = "x", timestampMs = 1)
+            )
+        )
+
+        assertEquals(SignalSeverity.MEDIUM, SignalDerivation.fromBatch(batch).single().severity)
+    }
+
+    @Test
+    fun `activity dump batches derive no signals`() {
+        val batch = QueuedSecurityBatch(organizationId = 1, batchType = "dumps")
+        assertTrue(SignalDerivation.fromBatch(batch).isEmpty())
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalRoutesTest.kt
@@ -1,0 +1,171 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.shared.models.Organizations
+import com.moneat.testsupport.RouteTestSupport.createToken
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.patch
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SignalRoutesTest {
+    companion object {
+        private var db: Database? = null
+        private const val USER_ID = 11
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+    private var orgId: Int = 0
+    private var otherOrgId: Int = 0
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_signal_routes;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        SignalSchemaTestSupport.reset()
+        orgId = seedOrg("acme")
+        otherOrgId = seedOrg("globex")
+    }
+
+    @Test
+    fun `list requires authentication`() = testApplication {
+        setupApp()
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/security/signals").status)
+    }
+
+    @Test
+    fun `list returns the calling org's signals`() = testApplication {
+        setupApp()
+        SignalWriter.upsert(orgId, spec("a"))
+        SignalWriter.upsert(otherOrgId, spec("b"))
+
+        val response = client.get("/v1/security/signals") { withAuth(token(orgId)) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"rule_id\":\"a\""))
+        assertTrue(!body.contains("\"rule_id\":\"b\""))
+    }
+
+    @Test
+    fun `detail returns not found for another org's signal`() = testApplication {
+        setupApp()
+        val created = SignalWriter.upsert(otherOrgId, spec("a"))
+
+        val response = client.get("/v1/security/signals/${created.signalId}") { withAuth(token(orgId)) }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `patch triages a signal owned by the caller`() = testApplication {
+        setupApp()
+        val created = SignalWriter.upsert(orgId, spec("a"))
+
+        val response = client.patch("/v1/security/signals/${created.signalId}") {
+            withAuth(token(orgId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(TriageRequest(status = "under_review")))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"status\":\"under_review\""))
+    }
+
+    @Test
+    fun `patch cannot triage another org's signal`() = testApplication {
+        setupApp()
+        val created = SignalWriter.upsert(otherOrgId, spec("a"))
+
+        val response = client.patch("/v1/security/signals/${created.signalId}") {
+            withAuth(token(orgId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(TriageRequest(status = "under_review")))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `patch rejects an invalid transition`() = testApplication {
+        setupApp()
+        val created = SignalWriter.upsert(orgId, spec("a"))
+
+        val response = client.patch("/v1/security/signals/${created.signalId}") {
+            withAuth(token(orgId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(TriageRequest(status = "archived")))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    private fun ApplicationTestBuilder.setupApp() {
+        application {
+            installJwtAuth()
+            routing { signalRoutes() }
+        }
+    }
+
+    private fun token(org: Int): String = createToken(userId = USER_ID, orgId = org)
+
+    private fun spec(ruleId: String) = SignalSpec(
+        source = SignalSource.AGENT_RUNTIME,
+        ruleId = ruleId,
+        ruleName = "Rule $ruleId",
+        severity = SignalSeverity.HIGH,
+        dedupKey = "$ruleId|host|proc",
+        entities = mapOf("host" to "web-01"),
+        evidenceType = "clickhouse_query",
+        evidenceReference = "table=security_events dedup=$ruleId",
+        occurredAtMs = 1_700_000_000_000
+    )
+
+    private fun seedOrg(name: String): Int =
+        transaction {
+            Organizations.insert {
+                it[Organizations.name] = name
+                it[slug] = name
+            } get Organizations.id
+        }
+}

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalSchemaTestSupport.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalSchemaTestSupport.kt
@@ -68,6 +68,12 @@ object SignalSchemaTestSupport {
                 "CREATE INDEX idx_security_signals_triage " +
                     "ON security_signals (organization_id, status, severity, last_seen)"
             )
+            // V119's partial unique index idx_security_signals_open_dedup on
+            // (organization_id, rule_id, dedup_key) WHERE status = 'open' is Postgres-only: H2
+            // cannot express a filtered unique index, and a plain unique index would wrongly
+            // forbid opening a fresh signal after the prior one is archived. Open-signal dedup is
+            // enforced in the SignalWriter transaction (SELECT ... FOR UPDATE), which these tests
+            // exercise; the production index is the concurrency backstop, verified on Postgres.
             exec(
                 """
                 CREATE TABLE security_signal_evidence (
@@ -80,6 +86,10 @@ object SignalSchemaTestSupport {
                         FOREIGN KEY (signal_id) REFERENCES security_signals(id) ON DELETE CASCADE
                 )
                 """.trimIndent()
+            )
+            exec(
+                "CREATE INDEX idx_security_signal_evidence_signal " +
+                    "ON security_signal_evidence (signal_id, id)"
             )
             exec(
                 """
@@ -100,6 +110,10 @@ object SignalSchemaTestSupport {
                         FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE
                 )
                 """.trimIndent()
+            )
+            exec(
+                "CREATE INDEX idx_security_signal_audit_signal " +
+                    "ON security_signal_audit (signal_id, id)"
             )
         }
     }

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalSchemaTestSupport.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalSchemaTestSupport.kt
@@ -1,0 +1,106 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.shared.models.Organizations
+import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/**
+ * Manual H2 DDL for the signals tables. SchemaUtils cannot create them directly because Exposed
+ * emits the JSONB column defaults (`{}` / `[]`) unquoted, which H2 rejects — the same reason the
+ * workflow tables use hand-written DDL in their service test. The columns mirror
+ * `V119__security_signals.sql` with JSONB → TEXT for H2. The partial unique index is Postgres-only;
+ * dedup correctness in tests rests on SignalWriter's in-transaction lookup.
+ */
+object SignalSchemaTestSupport {
+
+    fun reset() {
+        TestDatabaseHelper.dropAndPatchJsonb(
+            Organizations,
+            SecuritySignals,
+            SecuritySignalEvidence,
+            SecuritySignalAudit
+        )
+        transaction {
+            SchemaUtils.create(Organizations)
+            exec(
+                """
+                CREATE TABLE security_signals (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    organization_id INT NOT NULL,
+                    source VARCHAR(32) NOT NULL,
+                    rule_id VARCHAR(255) NOT NULL,
+                    rule_name VARCHAR(255) NOT NULL,
+                    severity VARCHAR(16) NOT NULL,
+                    status VARCHAR(16) NOT NULL DEFAULT 'open',
+                    archive_reason VARCHAR(16),
+                    dedup_key TEXT NOT NULL,
+                    entities TEXT NOT NULL DEFAULT '{}',
+                    sample_count INT NOT NULL DEFAULT 1,
+                    assignee_user_id INT,
+                    tags TEXT NOT NULL DEFAULT '[]',
+                    first_seen TIMESTAMP NOT NULL,
+                    last_seen TIMESTAMP NOT NULL,
+                    created_at TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP NOT NULL,
+                    CONSTRAINT fk_security_signals_organization_id
+                        FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            exec(
+                "CREATE INDEX idx_security_signals_triage " +
+                    "ON security_signals (organization_id, status, severity, last_seen)"
+            )
+            exec(
+                """
+                CREATE TABLE security_signal_evidence (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    signal_id INT NOT NULL,
+                    evidence_type VARCHAR(32) NOT NULL,
+                    reference TEXT NOT NULL,
+                    created_at TIMESTAMP NOT NULL,
+                    CONSTRAINT fk_security_signal_evidence_signal
+                        FOREIGN KEY (signal_id) REFERENCES security_signals(id) ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE security_signal_audit (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    signal_id INT NOT NULL,
+                    organization_id INT NOT NULL,
+                    actor_user_id INT,
+                    action VARCHAR(32) NOT NULL,
+                    from_status VARCHAR(16),
+                    to_status VARCHAR(16),
+                    reason VARCHAR(16),
+                    note TEXT,
+                    created_at TIMESTAMP NOT NULL,
+                    CONSTRAINT fk_security_signal_audit_signal
+                        FOREIGN KEY (signal_id) REFERENCES security_signals(id) ON DELETE CASCADE,
+                    CONSTRAINT fk_security_signal_audit_organization_id
+                        FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalServiceTest.kt
@@ -1,0 +1,217 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.shared.models.Organizations
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SignalServiceTest {
+    companion object {
+        private var db: Database? = null
+        private const val ACTOR = 7
+    }
+
+    private val service = SignalService()
+    private var orgId: Int = 0
+    private var otherOrgId: Int = 0
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_signal_service;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        SignalSchemaTestSupport.reset()
+        orgId = seedOrg("acme")
+        otherOrgId = seedOrg("globex")
+    }
+
+    @Test
+    fun `list returns only the calling org's signals filtered and paged`() {
+        SignalWriter.upsert(orgId, spec(ruleId = "a", severity = SignalSeverity.HIGH))
+        SignalWriter.upsert(orgId, spec(ruleId = "b", severity = SignalSeverity.LOW))
+        SignalWriter.upsert(otherOrgId, spec(ruleId = "c", severity = SignalSeverity.CRITICAL))
+
+        val all = service.list(orgId, SignalFilters(), limit = 50, offset = 0)
+        assertEquals(2, all.totalCount)
+        assertTrue(all.signals.all { it.severity != "critical" })
+
+        val highOnly = service.list(orgId, SignalFilters(severity = "high"), limit = 50, offset = 0)
+        assertEquals(1, highOnly.totalCount)
+        assertEquals("a", highOnly.signals.single().ruleId)
+    }
+
+    @Test
+    fun `triage advances status and records an audit row with the actor`() {
+        val created = SignalWriter.upsert(orgId, spec(ruleId = "a", severity = SignalSeverity.HIGH))
+
+        val result = service.triage(orgId, created.signalId, ACTOR, TriageRequest(status = "under_review"))
+
+        val ok = assertIs<TriageResult.Ok>(result)
+        assertEquals("under_review", ok.signal.status)
+        val audit = latestAudit(created.signalId)
+        assertEquals(SignalAuditAction.STATUS_CHANGE.wire, audit.action)
+        assertEquals(SignalStatus.OPEN.wire, audit.fromStatus)
+        assertEquals(SignalStatus.UNDER_REVIEW.wire, audit.toStatus)
+        assertEquals(ACTOR, audit.actorUserId)
+    }
+
+    @Test
+    fun `archiving persists the reason and audits it`() {
+        val created = SignalWriter.upsert(orgId, spec(ruleId = "a", severity = SignalSeverity.HIGH))
+        service.triage(orgId, created.signalId, ACTOR, TriageRequest(status = "under_review"))
+
+        val result = service.triage(
+            orgId,
+            created.signalId,
+            ACTOR,
+            TriageRequest(status = "archived", reason = "false_positive")
+        )
+
+        val ok = assertIs<TriageResult.Ok>(result)
+        assertEquals("archived", ok.signal.status)
+        assertEquals("false_positive", ok.signal.archiveReason)
+        val audit = latestAudit(created.signalId)
+        assertEquals("false_positive", audit.reason)
+        assertEquals(SignalStatus.ARCHIVED.wire, audit.toStatus)
+    }
+
+    @Test
+    fun `an invalid transition is rejected and leaves status unchanged`() {
+        val created = SignalWriter.upsert(orgId, spec(ruleId = "a", severity = SignalSeverity.HIGH))
+
+        val result = service.triage(orgId, created.signalId, ACTOR, TriageRequest(status = "archived"))
+
+        assertIs<TriageResult.Invalid>(result)
+        transaction {
+            assertEquals(
+                SignalStatus.OPEN.wire,
+                SecuritySignals.selectAll().where { SecuritySignals.id eq created.signalId }
+                    .single()[SecuritySignals.status]
+            )
+        }
+    }
+
+    @Test
+    fun `assignment and notes are recorded without a status move`() {
+        val created = SignalWriter.upsert(orgId, spec(ruleId = "a", severity = SignalSeverity.HIGH))
+
+        val result = service.triage(
+            orgId,
+            created.signalId,
+            ACTOR,
+            TriageRequest(assigneeUserId = 42, note = "mine")
+        )
+
+        val ok = assertIs<TriageResult.Ok>(result)
+        assertEquals(42, ok.signal.assigneeUserId)
+        assertEquals("open", ok.signal.status)
+        val actions = allAuditActions(created.signalId)
+        assertTrue(actions.contains(SignalAuditAction.ASSIGN.wire))
+        assertTrue(actions.contains(SignalAuditAction.NOTE.wire))
+        assertTrue(actions.none { it == SignalAuditAction.STATUS_CHANGE.wire })
+    }
+
+    @Test
+    fun `clear_assignee removes the assignee`() {
+        val created = SignalWriter.upsert(orgId, spec(ruleId = "a", severity = SignalSeverity.HIGH))
+        service.triage(orgId, created.signalId, ACTOR, TriageRequest(assigneeUserId = 42))
+
+        val result = service.triage(orgId, created.signalId, ACTOR, TriageRequest(clearAssignee = true))
+
+        assertNull(assertIs<TriageResult.Ok>(result).signal.assigneeUserId)
+    }
+
+    @Test
+    fun `a caller cannot triage another org's signal`() {
+        val created = SignalWriter.upsert(orgId, spec(ruleId = "a", severity = SignalSeverity.HIGH))
+
+        val result = service.triage(otherOrgId, created.signalId, ACTOR, TriageRequest(status = "under_review"))
+
+        assertIs<TriageResult.NotFound>(result)
+        // The original org's signal is untouched.
+        transaction {
+            assertEquals(
+                SignalStatus.OPEN.wire,
+                SecuritySignals.selectAll().where { SecuritySignals.id eq created.signalId }
+                    .single()[SecuritySignals.status]
+            )
+        }
+    }
+
+    private fun latestAudit(signalId: Int): SignalAuditResponse =
+        transaction {
+            SecuritySignalAudit.selectAll()
+                .where { SecuritySignalAudit.signalId eq signalId }
+                .orderBy(SecuritySignalAudit.id to SortOrder.DESC)
+                .first()
+                .let {
+                    SignalAuditResponse(
+                        id = it[SecuritySignalAudit.id].value,
+                        actorUserId = it[SecuritySignalAudit.actorUserId],
+                        action = it[SecuritySignalAudit.action],
+                        fromStatus = it[SecuritySignalAudit.fromStatus],
+                        toStatus = it[SecuritySignalAudit.toStatus],
+                        reason = it[SecuritySignalAudit.reason],
+                        note = it[SecuritySignalAudit.note],
+                        createdAt = it[SecuritySignalAudit.createdAt].toString()
+                    )
+                }
+        }
+
+    private fun allAuditActions(signalId: Int): List<String> =
+        transaction {
+            SecuritySignalAudit.selectAll()
+                .where { SecuritySignalAudit.signalId eq signalId }
+                .map { it[SecuritySignalAudit.action] }
+        }
+
+    private fun spec(ruleId: String, severity: SignalSeverity) = SignalSpec(
+        source = SignalSource.AGENT_RUNTIME,
+        ruleId = ruleId,
+        ruleName = "Rule $ruleId",
+        severity = severity,
+        dedupKey = "$ruleId|host|proc",
+        entities = mapOf("host" to "web-01", "process" to "bash"),
+        evidenceType = "clickhouse_query",
+        evidenceReference = "table=security_events dedup=$ruleId",
+        occurredAtMs = 1_700_000_000_000
+    )
+
+    private fun seedOrg(name: String): Int =
+        transaction {
+            Organizations.insert {
+                it[Organizations.name] = name
+                it[slug] = name
+            } get Organizations.id
+        }
+}

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalTriageStateMachineTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalTriageStateMachineTest.kt
@@ -1,0 +1,117 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class SignalTriageStateMachineTest {
+
+    @Test
+    fun `open advances to under_review`() {
+        val result = resolveTransition(SignalStatus.OPEN, TriageRequest(status = "under_review"))
+        val valid = assertIs<TransitionResult.Valid>(result)
+        assertEquals(SignalStatus.UNDER_REVIEW, valid.status)
+        assertNull(valid.archiveReason)
+    }
+
+    @Test
+    fun `under_review archives with a reason`() {
+        val result = resolveTransition(
+            SignalStatus.UNDER_REVIEW,
+            TriageRequest(status = "archived", reason = "false_positive")
+        )
+        val valid = assertIs<TransitionResult.Valid>(result)
+        assertEquals(SignalStatus.ARCHIVED, valid.status)
+        assertEquals(ArchiveReason.FALSE_POSITIVE, valid.archiveReason)
+    }
+
+    @Test
+    fun `open may archive directly with a reason`() {
+        val result = resolveTransition(
+            SignalStatus.OPEN,
+            TriageRequest(status = "archived", reason = "true_positive")
+        )
+        val valid = assertIs<TransitionResult.Valid>(result)
+        assertEquals(SignalStatus.ARCHIVED, valid.status)
+        assertEquals(ArchiveReason.TRUE_POSITIVE, valid.archiveReason)
+    }
+
+    @Test
+    fun `archiving without a reason is rejected`() {
+        val result = resolveTransition(SignalStatus.OPEN, TriageRequest(status = "archived"))
+        val invalid = assertIs<TransitionResult.Invalid>(result)
+        assertEquals(ARCHIVE_REQUIRES_REASON_MESSAGE, invalid.message)
+    }
+
+    @Test
+    fun `archiving with an unknown reason is rejected`() {
+        val result = resolveTransition(
+            SignalStatus.OPEN,
+            TriageRequest(status = "archived", reason = "not_a_reason")
+        )
+        val invalid = assertIs<TransitionResult.Invalid>(result)
+        assertEquals(INVALID_REASON_MESSAGE, invalid.message)
+    }
+
+    @Test
+    fun `archived reopens to open and clears reason`() {
+        val result = resolveTransition(SignalStatus.ARCHIVED, TriageRequest(status = "open"))
+        val valid = assertIs<TransitionResult.Valid>(result)
+        assertEquals(SignalStatus.OPEN, valid.status)
+        assertNull(valid.archiveReason)
+    }
+
+    @Test
+    fun `under_review cannot jump back to open`() {
+        val result = resolveTransition(SignalStatus.UNDER_REVIEW, TriageRequest(status = "open"))
+        assertIs<TransitionResult.Invalid>(result)
+    }
+
+    @Test
+    fun `archived cannot move straight to under_review`() {
+        val result = resolveTransition(SignalStatus.ARCHIVED, TriageRequest(status = "under_review"))
+        assertIs<TransitionResult.Invalid>(result)
+    }
+
+    @Test
+    fun `unknown status is rejected`() {
+        val result = resolveTransition(SignalStatus.OPEN, TriageRequest(status = "bogus"))
+        val invalid = assertIs<TransitionResult.Invalid>(result)
+        assertEquals(INVALID_STATUS_MESSAGE, invalid.message)
+    }
+
+    @Test
+    fun `a request with no status is a valid no-op move`() {
+        val result = resolveTransition(SignalStatus.UNDER_REVIEW, TriageRequest(note = "looking into it"))
+        val valid = assertIs<TransitionResult.Valid>(result)
+        assertNull(valid.status)
+    }
+
+    @Test
+    fun `re-archiving updates the reason`() {
+        val result = resolveTransition(
+            SignalStatus.ARCHIVED,
+            TriageRequest(status = "archived", reason = "benign")
+        )
+        val valid = assertIs<TransitionResult.Valid>(result)
+        assertEquals(SignalStatus.ARCHIVED, valid.status)
+        assertEquals(ArchiveReason.BENIGN, valid.archiveReason)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
@@ -1,0 +1,180 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.signals
+
+import com.moneat.shared.models.Organizations
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+
+class SignalWriterTest {
+    companion object {
+        private var db: Database? = null
+    }
+
+    private var orgId: Int = 0
+    private var otherOrgId: Int = 0
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_signal_writer;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        SignalSchemaTestSupport.reset()
+        orgId = seedOrg("acme")
+        otherOrgId = seedOrg("globex")
+    }
+
+    @Test
+    fun `first occurrence creates an open signal with one evidence row`() {
+        val outcome = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM))
+
+        assertIs<SignalOutcome.Created>(outcome)
+        transaction {
+            val row = SecuritySignals.selectAll().where { SecuritySignals.id eq outcome.signalId }.single()
+            assertEquals(SignalStatus.OPEN.wire, row[SecuritySignals.status])
+            assertEquals(1, row[SecuritySignals.sampleCount])
+            assertEquals("medium", row[SecuritySignals.severity])
+            assertEquals(
+                1,
+                SecuritySignalEvidence.selectAll()
+                    .where { SecuritySignalEvidence.signalId eq outcome.signalId }.count()
+            )
+        }
+    }
+
+    @Test
+    fun `repeat within an open signal folds in and increments sample_count`() {
+        val first = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM))
+        val second = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM))
+
+        assertIs<SignalOutcome.Updated>(second)
+        assertEquals(first.signalId, second.signalId)
+        transaction {
+            val row = SecuritySignals.selectAll().where { SecuritySignals.id eq first.signalId }.single()
+            assertEquals(2, row[SecuritySignals.sampleCount])
+            assertEquals(
+                2,
+                SecuritySignalEvidence.selectAll()
+                    .where { SecuritySignalEvidence.signalId eq first.signalId }.count()
+            )
+        }
+        // No new signal was created.
+        transaction { assertEquals(1, SecuritySignals.selectAll().count()) }
+    }
+
+    @Test
+    fun `a higher-severity repeat escalates and raises severity to the max`() {
+        val first = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.LOW))
+        val escalated = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.CRITICAL))
+
+        assertIs<SignalOutcome.Escalated>(escalated)
+        assertEquals(first.signalId, escalated.signalId)
+        assertEquals(SignalSeverity.CRITICAL, escalated.severity)
+        transaction {
+            assertEquals(
+                "critical",
+                SecuritySignals.selectAll().where { SecuritySignals.id eq first.signalId }
+                    .single()[SecuritySignals.severity]
+            )
+        }
+    }
+
+    @Test
+    fun `a lower-severity repeat does not lower severity and is only an update`() {
+        SignalWriter.upsert(orgId, spec(severity = SignalSeverity.HIGH))
+        val outcome = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.LOW))
+
+        assertIs<SignalOutcome.Updated>(outcome)
+        assertEquals(SignalSeverity.HIGH, outcome.severity)
+    }
+
+    @Test
+    fun `once archived a new occurrence forms a fresh signal`() {
+        val first = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM))
+        transaction {
+            SecuritySignals.update({ SecuritySignals.id eq first.signalId }) {
+                it[status] = SignalStatus.ARCHIVED.wire
+                it[archiveReason] = ArchiveReason.FALSE_POSITIVE.wire
+            }
+        }
+
+        val second = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM))
+
+        assertIs<SignalOutcome.Created>(second)
+        assertNotEquals(first.signalId, second.signalId)
+        transaction { assertEquals(2, SecuritySignals.selectAll().count()) }
+    }
+
+    @Test
+    fun `signals are isolated per organization`() {
+        val mine = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM))
+        val theirs = SignalWriter.upsert(otherOrgId, spec(severity = SignalSeverity.MEDIUM))
+
+        // Identical rule + dedup_key in two orgs are two distinct signals, never folded together.
+        assertIs<SignalOutcome.Created>(theirs)
+        assertNotEquals(mine.signalId, theirs.signalId)
+        transaction {
+            assertEquals(
+                1,
+                SecuritySignals.selectAll()
+                    .where { (SecuritySignals.organizationId eq orgId) and (SecuritySignals.ruleId eq "cws-1") }
+                    .count()
+            )
+            assertEquals(
+                1,
+                SecuritySignals.selectAll()
+                    .where { (SecuritySignals.organizationId eq otherOrgId) and (SecuritySignals.ruleId eq "cws-1") }
+                    .count()
+            )
+        }
+    }
+
+    private fun spec(severity: SignalSeverity) = SignalSpec(
+        source = SignalSource.AGENT_RUNTIME,
+        ruleId = "cws-1",
+        ruleName = "Suspicious exec",
+        severity = severity,
+        dedupKey = "cws-1|web-01|bash",
+        entities = mapOf("host" to "web-01", "process" to "bash"),
+        evidenceType = "clickhouse_query",
+        evidenceReference = "table=security_events dedup=cws-1|web-01|bash",
+        occurredAtMs = 1_700_000_000_000
+    )
+
+    private fun seedOrg(name: String): Int =
+        transaction {
+            Organizations.insert {
+                it[Organizations.name] = name
+                it[slug] = name
+            } get Organizations.id
+        }
+}

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
@@ -30,6 +30,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class SignalWriterTest {
     companion object {
@@ -89,6 +91,33 @@ class SignalWriterTest {
         }
         // No new signal was created.
         transaction { assertEquals(1, SecuritySignals.selectAll().count()) }
+    }
+
+    @Test
+    fun `an out-of-order fold never moves last_seen back and lowers first_seen to the earliest`() {
+        // Agent events can arrive out of order (Redis queue, multiple workers, producer retries).
+        val baseMs = 1_700_000_000_000
+        val earlierMs = baseMs - 60_000
+
+        val first = SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM, occurredAtMs = baseMs))
+        val (firstSeenAfterCreate, lastSeenAfterCreate) = transaction {
+            val row = SecuritySignals.selectAll().where { SecuritySignals.id eq first.signalId }.single()
+            row[SecuritySignals.firstSeen] to row[SecuritySignals.lastSeen]
+        }
+
+        // An older occurrence folds into the still-open signal.
+        SignalWriter.upsert(orgId, spec(severity = SignalSeverity.MEDIUM, occurredAtMs = earlierMs))
+
+        transaction {
+            val row = SecuritySignals.selectAll().where { SecuritySignals.id eq first.signalId }.single()
+            val firstSeen = row[SecuritySignals.firstSeen]
+            val lastSeen = row[SecuritySignals.lastSeen]
+            // last_seen is the list sort key and time-filter bound: it must not regress.
+            assertEquals(lastSeenAfterCreate, lastSeen)
+            // first_seen lowers to reflect the earliest occurrence seen.
+            assertEquals(Instant.fromEpochMilliseconds(earlierMs), firstSeen)
+            assertTrue(firstSeen < firstSeenAfterCreate)
+        }
     }
 
     @Test
@@ -158,7 +187,7 @@ class SignalWriterTest {
         }
     }
 
-    private fun spec(severity: SignalSeverity) = SignalSpec(
+    private fun spec(severity: SignalSeverity, occurredAtMs: Long = 1_700_000_000_000) = SignalSpec(
         source = SignalSource.AGENT_RUNTIME,
         ruleId = "cws-1",
         ruleName = "Suspicious exec",
@@ -167,7 +196,7 @@ class SignalWriterTest {
         entities = mapOf("host" to "web-01", "process" to "bash"),
         evidenceType = "clickhouse_query",
         evidenceReference = "table=security_events dedup=cws-1|web-01|bash",
-        occurredAtMs = 1_700_000_000_000
+        occurredAtMs = occurredAtMs
     )
 
     private fun seedOrg(name: String): Int =

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -20,11 +20,12 @@ import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
-import com.moneat.datadog.security.QueuedSecurityBatch
-import com.moneat.datadog.security.QueuedSecurityEventEntry
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
+import com.moneat.security.signals.SignalOutcome
+import com.moneat.security.signals.SignalSeverity
+import com.moneat.security.signals.SignalSource
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Users
@@ -826,19 +827,50 @@ class WorkflowServiceTest {
             publish(workflow.id)
 
             service.publishSecuritySignals(
-                QueuedSecurityBatch(
-                    organizationId = orgId,
-                    batchType = "runtime",
-                    events = listOf(
-                        securityEvent("rule-low", "low"),
-                        securityEvent("rule-high", "high")
-                    )
+                orgId,
+                listOf(
+                    createdSignal("rule-low", "low"),
+                    createdSignal("rule-high", "high")
                 )
             )
 
             val run = service.listRuns(orgId, workflow.id).single()
             assertEquals("security.signal", run.triggerName)
             assertEquals("security.rule_id=rule-high|security.resource=/tmp/high", run.onceFor)
+        }
+
+    @Test
+    fun `security signal trigger fires only for created and escalated signals`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "Security all",
+                        triggerName = "security.signal",
+                        steps = emptyList(),
+                        onceForTemplate = listOf("security.rule_id", "security.resource")
+                    )
+                )
+            publish(workflow.id)
+
+            service.publishSecuritySignals(
+                orgId,
+                listOf(
+                    createdSignal("rule-a", "medium"),
+                    escalatedSignal("rule-b", "high"),
+                    updatedSignal("rule-c", "low")
+                )
+            )
+
+            // The Updated (repeat-fold) signal must not produce a run; only created/escalated do.
+            assertEquals(
+                listOf(
+                    "security.rule_id=rule-a|security.resource=/tmp/medium",
+                    "security.rule_id=rule-b|security.resource=/tmp/high"
+                ).sorted(),
+                service.listRuns(orgId, workflow.id).map { it.onceFor }.sorted()
+            )
         }
 
     @Test
@@ -1251,16 +1283,52 @@ class WorkflowServiceTest {
             moneatUrl = "https://moneat.io/hosts/1"
         )
 
-    private fun securityEvent(
+    private fun createdSignal(
         ruleId: String,
-        severity: String
-    ): QueuedSecurityEventEntry =
-        QueuedSecurityEventEntry(
+        severity: String,
+        resource: String = "/tmp/$severity"
+    ): SignalOutcome.Created =
+        SignalOutcome.Created(
+            signalId = ruleId.hashCode(),
+            organizationId = orgId,
+            source = SignalSource.AGENT_RUNTIME,
             ruleId = ruleId,
             ruleName = "Rule $ruleId",
-            severity = severity,
-            filePath = "/tmp/$severity",
-            timestampMs = 1_700_000_000_000
+            severity = SignalSeverity.fromWire(severity),
+            dedupKey = "$ruleId|host|proc",
+            entities = mapOf("resource" to resource)
+        )
+
+    private fun escalatedSignal(
+        ruleId: String,
+        severity: String,
+        resource: String = "/tmp/$severity"
+    ): SignalOutcome.Escalated =
+        SignalOutcome.Escalated(
+            signalId = ruleId.hashCode(),
+            organizationId = orgId,
+            source = SignalSource.AGENT_RUNTIME,
+            ruleId = ruleId,
+            ruleName = "Rule $ruleId",
+            severity = SignalSeverity.fromWire(severity),
+            dedupKey = "$ruleId|host|proc",
+            entities = mapOf("resource" to resource)
+        )
+
+    private fun updatedSignal(
+        ruleId: String,
+        severity: String,
+        resource: String = "/tmp/$severity"
+    ): SignalOutcome.Updated =
+        SignalOutcome.Updated(
+            signalId = ruleId.hashCode(),
+            organizationId = orgId,
+            source = SignalSource.AGENT_RUNTIME,
+            ruleId = ruleId,
+            ruleName = "Rule $ruleId",
+            severity = SignalSeverity.fromWire(severity),
+            dedupKey = "$ruleId|host|proc",
+            entities = mapOf("resource" to resource)
         )
 
     private fun persistedTemporalIds(runId: Int): PersistedTemporalIds =


### PR DESCRIPTION
- Add the signals model (state in Postgres, evidence referenced in ClickHouse) + migration.
- Signal service + triage state machine with audit trail.
- Signal list / detail / triage API (core).
- Derive signals from agent passthrough; emit one workflow signal per created/escalated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive security signals triage platform with REST API endpoints for listing, retrieving, and triaging signals.
  * Automatic signal derivation from security events and compliance findings with deduplication and severity tracking.
  * Triage workflows support status management (open/under review/archived), assignee management, archival with reasons, and full audit history.
  * Signal details include evidence references and contextual entities for investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->