### PR TITLE
Security detection: Sigma import + starter rule pack

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -146,6 +146,9 @@ dependencies {
     // JSON path query for uptime monitoring
     implementation(libs.jsonpath)
 
+    // YAML parsing for Sigma detection-rule import
+    implementation(libs.snakeyaml)
+
     // Environment variables
     implementation(libs.dotenv.kotlin)
 

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ zstd-jni = { module = "com.github.luben:zstd-jni", version = "1.5.7-9" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version = "4.34.2" }
 opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version = "1.10.0-alpha" }
 jsonpath = { module = "com.jayway.jsonpath:json-path", version = "3.0.0" }
+snakeyaml = { module = "org.yaml:snakeyaml", version = "2.5" }
 
 # Environment
 dotenv-kotlin = { module = "io.github.cdimascio:dotenv-kotlin", version = "6.5.1" }

--- a/backend/src/main/kotlin/com/moneat/config/DemoDataReseeder.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoDataReseeder.kt
@@ -147,6 +147,7 @@ private suspend fun runStaleDemoReseed(snap: ReseedSnapshot) {
     maybeReseedSbom(snap.freshSbomCount)
     maybeReseedDashboards(snap.demoDashboardCount)
     maybeReseedSecurity(snap.freshSecurityCount)
+    seedDemoDetectionRules()
     maybeReseedSynthetics(snap.freshSyntheticsCount)
 
     logger.info { "Demo data reseed complete" }

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedDetections.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedDetections.kt
@@ -20,6 +20,8 @@ import com.moneat.security.detection.DetectionRuleService
 import com.moneat.security.detection.DetectionRules
 import com.moneat.security.detection.DetectionStarterPack
 import com.moneat.utils.suspendRunCatching
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -43,19 +45,25 @@ private const val DEMO_ORG_ID = -1
  * so it never blocks the rest of the demo reseed.
  */
 internal suspend fun seedDemoDetectionRules() {
+    // Detection rules live in Postgres, so this does blocking Exposed transaction work; run it on the
+    // IO dispatcher so it never blocks the calling event-loop thread. Still non-fatal.
     suspendRunCatching {
-        if (demoStarterRulesPresent()) {
-            logger.info { "Demo detection rules already present, skipping detection seed" }
-            return@suspendRunCatching
+        withContext(Dispatchers.IO) {
+            if (demoStarterRulesPresent()) {
+                logger.info { "Demo detection rules already present, skipping detection seed" }
+                return@withContext
+            }
+            val service = DetectionRuleService()
+            var created = 0
+            for (request in DetectionStarterPack.seedRequests()) {
+                suspendRunCatching { service.create(DEMO_ORG_ID, request.copy(enabled = false)) }
+                    .onSuccess { created++ }
+                    .onFailure {
+                        logger.warn { "Demo detection rule '${request.name}' failed (non-fatal): ${it.message}" }
+                    }
+            }
+            logger.info { "Seeded $created demo detection rules (disabled)" }
         }
-        val service = DetectionRuleService()
-        var created = 0
-        for (request in DetectionStarterPack.seedRequests()) {
-            suspendRunCatching { service.create(DEMO_ORG_ID, request.copy(enabled = false)) }
-                .onSuccess { created++ }
-                .onFailure { logger.warn { "Demo detection rule '${request.name}' failed (non-fatal): ${it.message}" } }
-        }
-        logger.info { "Seeded $created demo detection rules (disabled)" }
     }.onFailure {
         logger.warn { "Demo detection rule seed failed (non-fatal): ${it.message}" }
     }

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedDetections.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedDetections.kt
@@ -1,0 +1,71 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.config
+
+import com.moneat.security.detection.DetectionRuleService
+import com.moneat.security.detection.DetectionRules
+import com.moneat.security.detection.DetectionStarterPack
+import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+private val logger = KotlinLogging.logger {}
+
+// ── Detection starter-pack demo seed ───────────────────────────────────
+//
+// Seeds the Moneat starter-pack rules as DISABLED detection rules for the demo org so the demo
+// Detections tab is not empty. Unlike the ClickHouse demo data, detection rules live in Postgres
+// (no TTL), so this is a one-time, idempotent insert rather than a purge-and-reseed: it is skipped
+// once the demo org already owns starter rules. Each rule is created through the compiler-gated
+// DetectionRuleService.create path, so a demo rule is sandboxed exactly like any other.
+
+/** Postgres demo organization id (the single demo org seeded by V50). */
+private const val DEMO_ORG_ID = -1
+
+/**
+ * Idempotently seed the starter pack for the demo org. Non-fatal: any failure is logged and swallowed
+ * so it never blocks the rest of the demo reseed.
+ */
+internal suspend fun seedDemoDetectionRules() {
+    suspendRunCatching {
+        if (demoStarterRulesPresent()) {
+            logger.info { "Demo detection rules already present, skipping detection seed" }
+            return@suspendRunCatching
+        }
+        val service = DetectionRuleService()
+        var created = 0
+        for (request in DetectionStarterPack.seedRequests()) {
+            suspendRunCatching { service.create(DEMO_ORG_ID, request.copy(enabled = false)) }
+                .onSuccess { created++ }
+                .onFailure { logger.warn { "Demo detection rule '${request.name}' failed (non-fatal): ${it.message}" } }
+        }
+        logger.info { "Seeded $created demo detection rules (disabled)" }
+    }.onFailure {
+        logger.warn { "Demo detection rule seed failed (non-fatal): ${it.message}" }
+    }
+}
+
+/** True if the demo org already owns at least one detection rule (the starter pack was seeded before). */
+private fun demoStarterRulesPresent(): Boolean = transaction {
+    DetectionRules
+        .selectAll()
+        .where { DetectionRules.organizationId eq DEMO_ORG_ID }
+        .limit(1)
+        .any()
+}

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionImportService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionImportService.kt
@@ -49,6 +49,11 @@ class DetectionImportService(
             importer.toRuleRequest(document)
         } catch (e: SigmaImportException) {
             return SigmaImportItemResult(index = index, error = e.message ?: "Could not map Sigma rule")
+        } catch (e: StackOverflowError) {
+            // Defence in depth: the compiler caps nesting and rejects oversized conditions before
+            // recursing, but a malformed/over-nested document must still degrade to a per-item error
+            // rather than an uncaught Error that fails the whole batch (500 / fork crash).
+            return SigmaImportItemResult(index = index, error = "Could not map Sigma rule: condition too complex")
         }
         return try {
             // forceDisabled = true so an imported rule can never arrive pre-enabled regardless of mapping.

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionImportService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionImportService.kt
@@ -1,0 +1,76 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+/**
+ * Imports detection rules from **Sigma** YAML and installs **starter-pack** templates. Both paths build
+ * a [CreateDetectionRuleRequest] and hand it to [DetectionRuleService.create], which runs it through
+ * [RuleQueryCompiler] before persisting — so an imported or templated rule is validated and sandboxed
+ * exactly like a hand-authored one (org injection, column whitelist, caps, no raw SQL) and is never a
+ * bypass. A rule that does not compile is rejected, not stored. All created rules are `enabled = false`.
+ */
+class DetectionImportService(
+    private val ruleService: DetectionRuleService = DetectionRuleService(),
+    private val importer: SigmaImporter = SigmaImporter(),
+) {
+
+    /**
+     * Map and create each Sigma document for [organizationId]. Each document is independent: one that
+     * cannot be mapped (unsupported construct) or compiled (whitelist/window failure) yields a per-item
+     * error and never aborts the others. Errors carry only the DSL/import message, never ClickHouse text.
+     */
+    fun importSigma(organizationId: Int, documents: List<String>): SigmaImportResponse {
+        val results = documents.mapIndexed { index, document ->
+            importOne(organizationId, index, document)
+        }
+        return SigmaImportResponse(
+            createdCount = results.count { it.ruleId != null },
+            errorCount = results.count { it.error != null },
+            results = results,
+        )
+    }
+
+    private fun importOne(organizationId: Int, index: Int, document: String): SigmaImportItemResult {
+        val mapped = try {
+            importer.toRuleRequest(document)
+        } catch (e: SigmaImportException) {
+            return SigmaImportItemResult(index = index, error = e.message ?: "Could not map Sigma rule")
+        }
+        return try {
+            // forceDisabled = true so an imported rule can never arrive pre-enabled regardless of mapping.
+            val created = ruleService.create(organizationId, mapped.request.copy(enabled = false))
+            SigmaImportItemResult(index = index, title = mapped.title, ruleId = created.id)
+        } catch (e: DetectionCompileException) {
+            SigmaImportItemResult(index = index, title = mapped.title, error = e.message ?: "Rule did not compile")
+        }
+    }
+
+    /** The installable starter-pack templates (metadata only; no rule is created). */
+    fun listTemplates(): DetectionTemplateListResponse = DetectionStarterPack.list()
+
+    /**
+     * Install one starter template as a new **disabled** rule for [organizationId], via the same
+     * compiler-gated create path. Returns the created rule, or `null` if [templateId] is unknown.
+     *
+     * @throws DetectionCompileException if the (Moneat-authored) template somehow fails to compile — a
+     *   bug we want surfaced loudly rather than a silently-skipped install.
+     */
+    fun installTemplate(organizationId: Int, templateId: String): DetectionRuleResponse? {
+        val template = DetectionStarterPack.find(templateId) ?: return null
+        return ruleService.create(organizationId, template.request.copy(enabled = false))
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionModels.kt
@@ -163,3 +163,26 @@ data class DetectionPreviewResponse(
     val samples: List<DetectionMatchSample>,
     @SerialName("window_seconds") val windowSeconds: Int,
 )
+
+/** Body of a Sigma import: one or more raw Sigma YAML documents to map + create as disabled rules. */
+@Serializable
+data class SigmaImportRequest(
+    /** Each entry is a single Sigma YAML document (split multi-doc YAML on `---` before sending). */
+    val documents: List<String> = emptyList(),
+)
+
+/** A single imported rule's outcome: the created rule, or a schema-free reason it could not be mapped. */
+@Serializable
+data class SigmaImportItemResult(
+    val index: Int,
+    val title: String? = null,
+    @SerialName("rule_id") val ruleId: Int? = null,
+    val error: String? = null,
+)
+
+@Serializable
+data class SigmaImportResponse(
+    @SerialName("created_count") val createdCount: Int,
+    @SerialName("error_count") val errorCount: Int,
+    val results: List<SigmaImportItemResult>,
+)

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
@@ -44,6 +44,12 @@ private const val TEMPLATE_NOT_FOUND_MESSAGE = "Detection template not found"
 private const val NO_DOCUMENTS_MESSAGE = "No Sigma documents supplied"
 private const val MAX_SIGMA_DOCUMENTS = 200
 
+private const val BYTES_PER_MB = 1024 * 1024
+
+/** Aggregate cap on the combined size of all Sigma documents in one request (~8MB), bounding total work. */
+private const val MAX_SIGMA_TOTAL_MB = 8
+private const val MAX_SIGMA_TOTAL_CHARS = MAX_SIGMA_TOTAL_MB.toLong() * BYTES_PER_MB
+
 /**
  * OSS core detection-rule CRUD + preview. Reads require org MEMBER; mutations and preview require org
  * ADMIN via [OrgMembershipService.requireRole] — because a rule executes server-side ClickHouse
@@ -197,6 +203,12 @@ private suspend fun RoutingContext.handleSigmaImport(
         return call.respond(
             HttpStatusCode.BadRequest,
             ErrorResponse("At most $MAX_SIGMA_DOCUMENTS Sigma documents may be imported at once"),
+        )
+    }
+    if (documents.sumOf { it.length.toLong() } > MAX_SIGMA_TOTAL_CHARS) {
+        return call.respond(
+            HttpStatusCode.BadRequest,
+            ErrorResponse("Sigma import payload is too large (limit ${MAX_SIGMA_TOTAL_MB}MB)"),
         )
     }
     // Per-document mapping/compile failures are returned as item errors; only an unexpected (non-DSL)

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
@@ -40,6 +40,9 @@ private const val INVALID_RULE_ID_MESSAGE = "Invalid rule ID"
 private const val RULE_NOT_FOUND_MESSAGE = "Detection rule not found"
 private const val MISSING_ORG_MESSAGE = "No active organization"
 private const val FORBIDDEN_MESSAGE = "Insufficient permissions"
+private const val TEMPLATE_NOT_FOUND_MESSAGE = "Detection template not found"
+private const val NO_DOCUMENTS_MESSAGE = "No Sigma documents supplied"
+private const val MAX_SIGMA_DOCUMENTS = 200
 
 /**
  * OSS core detection-rule CRUD + preview. Reads require org MEMBER; mutations and preview require org
@@ -51,6 +54,7 @@ private const val FORBIDDEN_MESSAGE = "Insufficient permissions"
 fun Route.detectionRuleRoutes(
     service: DetectionRuleService = DetectionRuleService(),
     membershipService: OrgMembershipService = GlobalContext.get().get(),
+    importService: DetectionImportService = DetectionImportService(service),
 ) {
     route("/v1/security/detection/rules") {
         authenticate("auth-jwt") {
@@ -60,6 +64,40 @@ fun Route.detectionRuleRoutes(
             put(RULE_ID_ROUTE) { handleUpdate(service, membershipService) }
             delete(RULE_ID_ROUTE) { handleDelete(service, membershipService) }
             post("$RULE_ID_ROUTE/preview") { handlePreview(service, membershipService) }
+        }
+    }
+    detectionImportRoutes(importService, membershipService)
+    detectionTemplateRoutes(importService, membershipService)
+}
+
+/**
+ * Sigma import (ADMIN). Each mapped rule is created through the compiler-gated path, so an imported rule
+ * gets no more power than a hand-authored one; unmappable/non-compiling documents return a per-item,
+ * DSL-level error rather than aborting the batch. Created rules are always disabled.
+ */
+private fun Route.detectionImportRoutes(
+    importService: DetectionImportService,
+    membershipService: OrgMembershipService,
+) {
+    route("/v1/security/detection/import/sigma") {
+        authenticate("auth-jwt") {
+            post { handleSigmaImport(importService, membershipService) }
+        }
+    }
+}
+
+/**
+ * Starter-pack templates: list (MEMBER) and install (ADMIN). Install creates a disabled rule via the
+ * same compiler-gated path, so a template can never bypass org injection or the column whitelist.
+ */
+private fun Route.detectionTemplateRoutes(
+    importService: DetectionImportService,
+    membershipService: OrgMembershipService,
+) {
+    route("/v1/security/detection/templates") {
+        authenticate("auth-jwt") {
+            get { handleTemplateList(importService) }
+            post("/{templateId}/install") { handleTemplateInstall(importService, membershipService) }
         }
     }
 }
@@ -139,6 +177,54 @@ private suspend fun RoutingContext.handlePreview(
                 call.respond(HttpStatusCode.NotFound, ErrorResponse(RULE_NOT_FOUND_MESSAGE))
             } else {
                 call.respond(preview)
+            }
+        },
+        onFailure = { respondRuleError(it) },
+    )
+}
+
+private suspend fun RoutingContext.handleSigmaImport(
+    importService: DetectionImportService,
+    membershipService: OrgMembershipService,
+) {
+    val orgId = requireAdmin(membershipService) ?: return
+    val request = call.receive<SigmaImportRequest>()
+    val documents = request.documents.filter { it.isNotBlank() }
+    if (documents.isEmpty()) {
+        return call.respond(HttpStatusCode.BadRequest, ErrorResponse(NO_DOCUMENTS_MESSAGE))
+    }
+    if (documents.size > MAX_SIGMA_DOCUMENTS) {
+        return call.respond(
+            HttpStatusCode.BadRequest,
+            ErrorResponse("At most $MAX_SIGMA_DOCUMENTS Sigma documents may be imported at once"),
+        )
+    }
+    // Per-document mapping/compile failures are returned as item errors; only an unexpected (non-DSL)
+    // failure rethrows to the status-pages plugin so no ClickHouse internals leak.
+    suspendRunCatching { importService.importSigma(orgId, documents) }.fold(
+        onSuccess = { call.respond(HttpStatusCode.OK, it) },
+        onFailure = { respondRuleError(it) },
+    )
+}
+
+private suspend fun RoutingContext.handleTemplateList(importService: DetectionImportService) {
+    currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    call.respond(importService.listTemplates())
+}
+
+private suspend fun RoutingContext.handleTemplateInstall(
+    importService: DetectionImportService,
+    membershipService: OrgMembershipService,
+) {
+    val orgId = requireAdmin(membershipService) ?: return
+    val templateId = call.parameters["templateId"].orEmpty()
+    suspendRunCatching { importService.installTemplate(orgId, templateId) }.fold(
+        onSuccess = { created ->
+            if (created == null) {
+                call.respond(HttpStatusCode.NotFound, ErrorResponse(TEMPLATE_NOT_FOUND_MESSAGE))
+            } else {
+                call.respond(HttpStatusCode.Created, created)
             }
         },
         onFailure = { respondRuleError(it) },

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionStarterPack.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionStarterPack.kt
@@ -1,0 +1,215 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Moneat's OSS **starter pack** of detection rules — installable templates that give a fresh tenant a
+ * working baseline without authoring anything. Templates are code resources (no table); installing one
+ * creates a normal, **disabled** detection rule through [DetectionRuleService.create], so every template
+ * is compiled and sandboxed by [RuleQueryCompiler] exactly like a hand-authored or imported rule.
+ *
+ * Each template's [request] is conservative on purpose (tight windows, meaningful thresholds) to keep
+ * day-one noise low; an operator reviews the preview, then enables it.
+ */
+@Serializable
+data class DetectionTemplateSummary(
+    val id: String,
+    val name: String,
+    val description: String,
+    val severity: String,
+    val type: String,
+    val tags: List<String> = emptyList(),
+)
+
+@Serializable
+data class DetectionTemplateListResponse(
+    val templates: List<DetectionTemplateSummary>,
+    @SerialName("total_count") val totalCount: Int,
+)
+
+/** A starter template: a stable [id] plus the request the install path feeds to the compiler. */
+data class StarterTemplate(
+    val id: String,
+    val request: CreateDetectionRuleRequest,
+) {
+    fun summary(): DetectionTemplateSummary = DetectionTemplateSummary(
+        id = id,
+        name = request.name,
+        description = request.description,
+        severity = request.severity,
+        type = request.type,
+        tags = request.tags,
+    )
+}
+
+/**
+ * The bundled starter rules. Filters are written in the
+ * [LogQueryParser][com.moneat.logs.services.LogQueryParser] language and group only on whitelisted
+ * dimensions, so each one compiles cleanly through [RuleQueryCompiler]; a test asserts exactly that.
+ */
+object DetectionStarterPack {
+
+    private const val WINDOW_5M = 300
+    private const val WINDOW_10M = 600
+    private const val WINDOW_15M = 900
+
+    /** All templates, in display order. */
+    val templates: List<StarterTemplate> = listOf(
+        failedAuthBruteForce(),
+        newSourceLogin(),
+        privilegeEscalationSpike(),
+        suspiciousProcessExec(),
+        sensitiveFileAccess(),
+        outboundToSuspicious(),
+    )
+
+    private val byId: Map<String, StarterTemplate> = templates.associateBy { it.id }
+
+    fun list(): DetectionTemplateListResponse =
+        DetectionTemplateListResponse(
+            templates = templates.map { it.summary() },
+            totalCount = templates.size,
+        )
+
+    fun find(id: String): StarterTemplate? = byId[id]
+
+    /** The starter requests to seed (disabled) for a demo/bootstrap org. */
+    fun seedRequests(): List<CreateDetectionRuleRequest> = templates.map { it.request }
+
+    // ── Templates ─────────────────────────────────────────────────────────
+
+    private fun failedAuthBruteForce() = StarterTemplate(
+        id = "failed-auth-brute-force",
+        request = CreateDetectionRuleRequest(
+            name = "Failed authentication brute force",
+            description = "Repeated failed logins from the same host within a short window, indicating " +
+                "password guessing or credential stuffing.",
+            filter = "(*:\"failed password\" OR *:\"authentication failure\" OR *:\"invalid user\")",
+            groupBy = listOf("host"),
+            windowSeconds = WINDOW_5M,
+            type = DetectionRuleType.THRESHOLD.wire,
+            thresholdCount = 8,
+            severity = "high",
+            signalTitle = "Failed-auth brute force on {host}",
+            signalMessage = "{host} saw repeated failed authentications in the last 5 minutes.",
+            enabled = false,
+            tags = listOf("starter-pack", "mitre:T1110", "category:authentication"),
+        ),
+    )
+
+    private fun newSourceLogin() = StarterTemplate(
+        id = "new-source-login",
+        request = CreateDetectionRuleRequest(
+            name = "Login from a new source",
+            description = "A successful login from a source host/user combination not seen before " +
+                "(after a learning window), surfacing new-geo / new-machine access.",
+            filter = "(*:\"accepted password\" OR *:\"session opened\" OR *:\"login successful\")",
+            groupBy = listOf("host", "tags['user']"),
+            windowSeconds = WINDOW_15M,
+            type = DetectionRuleType.NEW_VALUE.wire,
+            thresholdCount = null,
+            severity = "medium",
+            signalTitle = "New login source {host}",
+            signalMessage = "First-seen successful login for {host} / {tags['user']}.",
+            enabled = false,
+            tags = listOf("starter-pack", "mitre:T1078", "category:authentication"),
+        ),
+    )
+
+    private fun privilegeEscalationSpike() = StarterTemplate(
+        id = "privilege-escalation-spike",
+        request = CreateDetectionRuleRequest(
+            name = "Privilege escalation spike",
+            description = "A burst of sudo / su / privilege-escalation activity on a host, which can " +
+                "indicate an attacker elevating access.",
+            filter = "(*:sudo OR *:\"su:\" OR *:\"COMMAND=\" OR *:pkexec) AND -level:debug",
+            groupBy = listOf("host"),
+            windowSeconds = WINDOW_10M,
+            type = DetectionRuleType.THRESHOLD.wire,
+            thresholdCount = 15,
+            severity = "high",
+            signalTitle = "Privilege-escalation spike on {host}",
+            signalMessage = "{host} had an unusual volume of privilege-escalation events.",
+            enabled = false,
+            tags = listOf("starter-pack", "mitre:T1548", "category:privilege_escalation"),
+        ),
+    )
+
+    private fun suspiciousProcessExec() = StarterTemplate(
+        id = "suspicious-process-exec",
+        request = CreateDetectionRuleRequest(
+            name = "Suspicious process execution",
+            description = "Execution of tools commonly abused for download-and-execute or reverse " +
+                "shells (nc, ncat, curl|bash, python -c, base64 -d).",
+            filter = "(*:\"nc -e\" OR *:ncat OR *:\"curl | bash\" OR *:\"python -c\" OR *:\"base64 -d\" " +
+                "OR *:\"/dev/tcp/\")",
+            groupBy = listOf("host", "service"),
+            windowSeconds = WINDOW_10M,
+            type = DetectionRuleType.THRESHOLD.wire,
+            thresholdCount = 1,
+            severity = "critical",
+            signalTitle = "Suspicious process on {host}",
+            signalMessage = "{host} executed a process matching a known download/exec pattern.",
+            enabled = false,
+            tags = listOf("starter-pack", "mitre:T1059", "category:execution"),
+        ),
+    )
+
+    private fun sensitiveFileAccess() = StarterTemplate(
+        id = "sensitive-file-access",
+        request = CreateDetectionRuleRequest(
+            name = "Sensitive / secret file access",
+            description = "Reads of credential and secret material (/etc/shadow, SSH keys, cloud " +
+                "credential files, .env), which can indicate credential theft.",
+            filter = "(*:\"/etc/shadow\" OR *:\"id_rsa\" OR *:\"authorized_keys\" OR *:\".aws/credentials\" " +
+                "OR *:\".env\" OR *:\"private key\")",
+            groupBy = listOf("host"),
+            windowSeconds = WINDOW_15M,
+            type = DetectionRuleType.THRESHOLD.wire,
+            thresholdCount = 1,
+            severity = "high",
+            signalTitle = "Sensitive file access on {host}",
+            signalMessage = "{host} accessed credential or secret material.",
+            enabled = false,
+            tags = listOf("starter-pack", "mitre:T1552", "category:credential_access"),
+        ),
+    )
+
+    private fun outboundToSuspicious() = StarterTemplate(
+        id = "outbound-to-suspicious",
+        request = CreateDetectionRuleRequest(
+            name = "Outbound to suspicious destination",
+            description = "Connections to ports / patterns associated with C2 or data exfiltration " +
+                "(raw IP egress, uncommon high ports, known tooling user-agents). Pairs with threat " +
+                "enrichment when available.",
+            filter = "(*:\"outbound connection\" OR *:\"connect to\" OR *:\"egress\") AND " +
+                "(*:\":4444\" OR *:\":1337\" OR *:\":9001\" OR *:\"user-agent: curl\")",
+            groupBy = listOf("host", "service"),
+            windowSeconds = WINDOW_10M,
+            type = DetectionRuleType.THRESHOLD.wire,
+            thresholdCount = 3,
+            severity = "medium",
+            signalTitle = "Suspicious outbound from {host}",
+            signalMessage = "{host} made repeated connections to a suspicious destination pattern.",
+            enabled = false,
+            tags = listOf("starter-pack", "mitre:T1071", "category:command_and_control"),
+        ),
+    )
+}

--- a/backend/src/main/kotlin/com/moneat/security/detection/SigmaConditionCompiler.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/SigmaConditionCompiler.kt
@@ -1,0 +1,216 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+/**
+ * Compiles a Sigma `condition` expression into a single
+ * [LogQueryParser][com.moneat.logs.services.LogQueryParser] filter string, resolving each selection
+ * identifier to the fragment [SigmaImporter] already mapped for it.
+ *
+ * Supported grammar (precedence `or` < `and` < `not`, with `(` `)` grouping):
+ *
+ * ```
+ * expr      := orExpr
+ * orExpr    := andExpr ( 'or' andExpr )*
+ * andExpr   := notExpr ( 'and' notExpr )*
+ * notExpr   := 'not' notExpr | atom
+ * atom      := '(' expr ')' | quantifier | identifier
+ * quantifier:= ( '1' | 'all' ) 'of' ( identifierPattern | 'them' )
+ * ```
+ *
+ * Anything outside this grammar — aggregation pipes (handled earlier), unknown identifiers, `near`,
+ * dangling operators — raises a [SigmaImportException]. This compiler builds only a boolean combination
+ * of already-safe fragments; it never emits a field/value itself, so it adds no new injection surface
+ * (the eventual query still goes through [RuleQueryCompiler]).
+ */
+internal class SigmaConditionCompiler(
+    /** Selection name → its mapped [LogQueryParser][com.moneat.logs.services.LogQueryParser] fragment. */
+    private val selections: Map<String, String>,
+) {
+
+    private lateinit var tokens: List<String>
+    private var pos: Int = 0
+
+    fun compile(condition: String): String {
+        tokens = tokenize(condition)
+        pos = 0
+        if (tokens.isEmpty()) throw SigmaImportException("Sigma condition is empty")
+        val node = parseOr()
+        if (pos != tokens.size) {
+            throw SigmaImportException("Sigma condition has trailing tokens after '${peekSafe()}'")
+        }
+        return node
+    }
+
+    // ── Recursive-descent parser; each level returns a parser-syntax fragment. ──
+
+    private fun parseOr(): String {
+        var left = parseAnd()
+        while (matchKeyword("or")) {
+            val right = parseAnd()
+            left = "($left OR $right)"
+        }
+        return left
+    }
+
+    private fun parseAnd(): String {
+        var left = parseNot()
+        while (matchKeyword("and")) {
+            val right = parseNot()
+            left = "($left AND $right)"
+        }
+        return left
+    }
+
+    private fun parseNot(): String {
+        if (matchKeyword("not")) {
+            val inner = parseNot()
+            return "NOT ($inner)"
+        }
+        return parseAtom()
+    }
+
+    private fun parseAtom(): String {
+        val token = peek() ?: throw SigmaImportException("Sigma condition ended unexpectedly")
+        if (token == "(") {
+            advance()
+            val inner = parseOr()
+            expect(")")
+            return "($inner)"
+        }
+        if (token == "1" || token.equals("all", ignoreCase = true)) {
+            // Could be a quantifier ("1 of …" / "all of …"); only treat as one when 'of' follows.
+            if (peek(1)?.equals("of", ignoreCase = true) == true) {
+                return parseQuantifier(token)
+            }
+        }
+        return resolveIdentifier(consumeIdentifier())
+    }
+
+    private fun parseQuantifier(quantToken: String): String {
+        advance() // quantifier ('1' or 'all')
+        expectKeyword("of")
+        val target = consumeIdentifier()
+        val matched = if (target.equals("them", ignoreCase = true)) {
+            selections.keys.toList()
+        } else {
+            resolvePattern(target)
+        }
+        if (matched.isEmpty()) {
+            throw SigmaImportException("Sigma condition '… of $target' matches no selections")
+        }
+        val fragments = matched.map { resolveIdentifier(it) }
+        val op = if (quantToken == "1") "OR" else "AND"
+        return "(" + fragments.joinToString(" $op ") + ")"
+    }
+
+    /** Resolves a `prefix*` / `*suffix` / `*sub*` selection pattern to the matching selection names. */
+    private fun resolvePattern(pattern: String): List<String> {
+        if (!pattern.contains("*")) {
+            // A bare identifier after "of" (e.g. "1 of selection") refers to that single selection.
+            return listOf(pattern)
+        }
+        val regex = patternToRegex(pattern)
+        return selections.keys.filter { regex.matches(it) }
+    }
+
+    private fun resolveIdentifier(name: String): String =
+        selections[name]
+            ?: throw SigmaImportException("Sigma condition references unknown selection '${safe(name)}'")
+
+    // ── Token plumbing ────────────────────────────────────────────────────────
+
+    private fun consumeIdentifier(): String {
+        val token = peek() ?: throw SigmaImportException("Sigma condition expected a selection name")
+        if (token in STRUCTURAL || token.lowercase() in KEYWORDS) {
+            throw SigmaImportException("Sigma condition expected a selection name but found '${safe(token)}'")
+        }
+        advance()
+        return token
+    }
+
+    private fun matchKeyword(keyword: String): Boolean {
+        if (peek()?.equals(keyword, ignoreCase = true) == true) {
+            advance()
+            return true
+        }
+        return false
+    }
+
+    private fun expectKeyword(keyword: String) {
+        if (!matchKeyword(keyword)) {
+            throw SigmaImportException("Sigma condition expected '$keyword' but found '${peekSafe()}'")
+        }
+    }
+
+    private fun expect(symbol: String) {
+        if (peek() != symbol) {
+            throw SigmaImportException("Sigma condition expected '$symbol' but found '${peekSafe()}'")
+        }
+        advance()
+    }
+
+    private fun peek(ahead: Int = 0): String? = tokens.getOrNull(pos + ahead)
+
+    private fun peekSafe(): String = safe(peek() ?: "<end>")
+
+    private fun advance() {
+        pos++
+    }
+
+    private fun safe(token: String): String =
+        token.take(IDENT_PREVIEW).filter { it.isLetterOrDigit() || it in "_*()" }
+
+    companion object {
+        private const val IDENT_PREVIEW = 60
+        private val STRUCTURAL = setOf("(", ")")
+        private val KEYWORDS = setOf("and", "or", "not", "of")
+
+        /** Splits a condition into identifier, keyword and parenthesis tokens. */
+        private fun tokenize(condition: String): List<String> {
+            val out = mutableListOf<String>()
+            val sb = StringBuilder()
+            fun flush() {
+                if (sb.isNotEmpty()) {
+                    out += sb.toString()
+                    sb.clear()
+                }
+            }
+            for (ch in condition) {
+                when {
+                    ch.isWhitespace() -> flush()
+                    ch == '(' || ch == ')' -> {
+                        flush()
+                        out += ch.toString()
+                    }
+                    ch.isLetterOrDigit() || ch == '_' || ch == '*' || ch == '-' || ch == '.' -> sb.append(ch)
+                    else -> throw SigmaImportException(
+                        "Sigma condition contains an unsupported character '$ch'"
+                    )
+                }
+            }
+            flush()
+            return out
+        }
+
+        /** Compiles a `*`-only Sigma selection pattern to an anchored regex over selection names. */
+        private fun patternToRegex(pattern: String): Regex {
+            val escaped = pattern.split("*").joinToString(".*") { Regex.escape(it) }
+            return Regex("^$escaped$")
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/detection/SigmaConditionCompiler.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/SigmaConditionCompiler.kt
@@ -45,15 +45,46 @@ internal class SigmaConditionCompiler(
     private lateinit var tokens: List<String>
     private var pos: Int = 0
 
+    /** Current grouping/`not` nesting depth; guards the recursive descent against stack exhaustion. */
+    private var depth: Int = 0
+
     fun compile(condition: String): String {
+        boundRawCondition(condition)
         tokens = tokenize(condition)
         pos = 0
+        depth = 0
         if (tokens.isEmpty()) throw SigmaImportException("Sigma condition is empty")
         val node = parseOr()
         if (pos != tokens.size) {
             throw SigmaImportException("Sigma condition has trailing tokens after '${peekSafe()}'")
         }
         return node
+    }
+
+    /**
+     * Reject an absurdly large or deeply parenthesised raw condition before tokenizing, so a hostile
+     * `((((…))))` cannot drive the recursive-descent parser into a [StackOverflowError]. This is a coarse
+     * pre-filter; [enterDepth] is the precise per-node guard once we are parsing.
+     */
+    private fun boundRawCondition(condition: String) {
+        if (condition.length > MAX_CONDITION_LENGTH) {
+            throw SigmaImportException("Sigma condition is too long (limit $MAX_CONDITION_LENGTH characters)")
+        }
+        val openParens = condition.count { it == '(' }
+        if (openParens > MAX_PARENS) {
+            throw SigmaImportException("Sigma condition nests too many parentheses (limit $MAX_PARENS)")
+        }
+    }
+
+    /** Enters one recursion level, rejecting a condition nested past [MAX_DEPTH] instead of overflowing. */
+    private fun enterDepth() {
+        if (++depth > MAX_DEPTH) {
+            throw SigmaImportException("Sigma condition is nested too deeply (limit $MAX_DEPTH)")
+        }
+    }
+
+    private fun exitDepth() {
+        depth--
     }
 
     // ── Recursive-descent parser; each level returns a parser-syntax fragment. ──
@@ -78,7 +109,9 @@ internal class SigmaConditionCompiler(
 
     private fun parseNot(): String {
         if (matchKeyword("not")) {
+            enterDepth()
             val inner = parseNot()
+            exitDepth()
             return "NOT ($inner)"
         }
         return parseAtom()
@@ -88,7 +121,9 @@ internal class SigmaConditionCompiler(
         val token = peek() ?: throw SigmaImportException("Sigma condition ended unexpectedly")
         if (token == "(") {
             advance()
+            enterDepth()
             val inner = parseOr()
+            exitDepth()
             expect(")")
             return "($inner)"
         }
@@ -177,6 +212,14 @@ internal class SigmaConditionCompiler(
 
     companion object {
         private const val IDENT_PREVIEW = 60
+
+        /** Hard cap on grouping/`not` nesting; well past any real Sigma condition, far below a stack overflow. */
+        private const val MAX_DEPTH = 64
+
+        /** Coarse pre-tokenize bounds so a pathological condition is rejected before any recursion. */
+        private const val MAX_CONDITION_LENGTH = 4_096
+        private const val MAX_PARENS = 128
+
         private val STRUCTURAL = setOf("(", ")")
         private val KEYWORDS = setOf("and", "or", "not", "of")
 

--- a/backend/src/main/kotlin/com/moneat/security/detection/SigmaImporter.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/SigmaImporter.kt
@@ -64,7 +64,7 @@ class SigmaImporter {
         val title: String,
     )
 
-    private val yaml: Yaml = Yaml(SafeConstructor(LoaderOptions().apply { isAllowDuplicateKeys = false }))
+    private val yaml: Yaml = Yaml(SafeConstructor(loaderOptions()))
 
     /**
      * Parse and map a single Sigma YAML document. Multi-document YAML is rejected here so the caller can
@@ -113,6 +113,10 @@ class SigmaImporter {
 
     private fun parseSingleDocument(sigmaYaml: String): Map<String, Any?> {
         if (sigmaYaml.isBlank()) throw SigmaImportException("Sigma document is empty")
+        if (sigmaYaml.length > MAX_DOCUMENT_CHARS) {
+            // Reject before handing to snakeyaml; bounds the aggregate request even at the document cap.
+            throw SigmaImportException("Sigma document is too large (limit ${MAX_DOCUMENT_KB}KB)")
+        }
         val docs = try {
             yaml.loadAll(sigmaYaml).toList()
         } catch (e: org.yaml.snakeyaml.error.YAMLException) {
@@ -250,14 +254,14 @@ class SigmaImporter {
     /**
      * One `field op value` fragment in [LogQueryParser][com.moneat.logs.services.LogQueryParser] syntax.
      * Equality uses a quoted value so separators bind as a literal; the contains/startswith/endswith
-     * modifiers use wildcards, which the parser turns into an `ILIKE` (values are still escaped by the
-     * compiler, so a value can never become SQL structure).
+     * modifiers append the modifier's own wildcard, which the parser turns into an `ILIKE` (values are
+     * still escaped by the compiler, so a value can never become SQL structure).
      */
     private fun fieldValueFragment(field: String, value: String, modifier: String?): String {
         val token = when (modifier) {
-            "contains" -> "*${wildcardEscape(value)}*"
-            "startswith" -> "${wildcardEscape(value)}*"
-            "endswith" -> "*${wildcardEscape(value)}"
+            "contains" -> "*${wildcardValue(value, modifier)}*"
+            "startswith" -> "${wildcardValue(value, modifier)}*"
+            "endswith" -> "*${wildcardValue(value, modifier)}"
             null -> null
             else -> throw SigmaImportException("Unsupported Sigma value modifier '${sanitize(modifier)}'")
         }
@@ -339,13 +343,22 @@ class SigmaImporter {
     }
 
     /**
-     * Escape a value used inside an unquoted wildcard token so only the modifier's own `*`/`?` act as
-     * wildcards: a literal `*`/`?` in the Sigma value is backslash-escaped (the parser unescapes it back
-     * to a literal), and the parser's other control chars cannot appear because they would already have
-     * been rejected by the field/condition handling that routes here.
+     * Prepare a `contains`/`startswith`/`endswith` value for an unquoted wildcard token. A raw `*` or `?`
+     * in such a value is **rejected**, not escaped or passed through: faithfully matching a Sigma literal
+     * `a*b` is ambiguous (Sigma treats it as a literal there, but emitting it would either widen the rule
+     * to an extra wildcard or silently drop the glob), so per the "never silently produce an over-broad
+     * rule" requirement we refuse it rather than guess. The backslash and quote are escaped so the value
+     * still cannot break out of the parser token; the modifier's own surrounding `*` stays a wildcard.
      */
-    private fun wildcardEscape(value: String): String =
-        value.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?").replace("\"", "\\\"")
+    private fun wildcardValue(value: String, modifier: String): String {
+        if (value.contains('*') || value.contains('?')) {
+            throw SigmaImportException(
+                "Sigma '$modifier' value '${sanitize(value)}' contains a literal '*'/'?'; " +
+                    "this cannot be mapped without changing the rule's breadth"
+            )
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"")
+    }
 
     private fun joinAnd(fragments: List<String>): String = combine(fragments, "AND")
 
@@ -370,6 +383,32 @@ class SigmaImporter {
         private const val MSG_PREVIEW = 80
         private const val TOKEN_PREVIEW = 60
         private const val TAG_PREVIEW = 60
+
+        private const val BYTES_PER_KB = 1024
+
+        /** Per-document input cap (~512KB). Bounds parser work and the aggregate request body up front. */
+        private const val MAX_DOCUMENT_KB = 512
+        private const val MAX_DOCUMENT_CHARS = MAX_DOCUMENT_KB * BYTES_PER_KB
+
+        /** snakeyaml DoS limits pinned explicitly so safety does not depend on library defaults. */
+        private const val YAML_NESTING_DEPTH_LIMIT = 50
+        private const val YAML_MAX_ALIASES = 50
+        private const val YAML_CODEPOINT_LIMIT = MAX_DOCUMENT_CHARS
+
+        /**
+         * A [LoaderOptions] with the DoS limits set explicitly (rather than relying on snakeyaml's
+         * defaults, which can shift across upgrades): no duplicate keys, no recursive keys, a bounded
+         * alias count, a bounded nesting depth, and a tight per-document code-point limit. Combined with
+         * [SafeConstructor]/`UnTrustedTagInspector` this keeps untrusted Sigma YAML from exhausting CPU
+         * or memory.
+         */
+        private fun loaderOptions(): LoaderOptions = LoaderOptions().apply {
+            isAllowDuplicateKeys = false
+            allowRecursiveKeys = false
+            maxAliasesForCollections = YAML_MAX_ALIASES
+            nestingDepthLimit = YAML_NESTING_DEPTH_LIMIT
+            codePointLimit = YAML_CODEPOINT_LIMIT
+        }
 
         /** Field name charset: identifier chars plus the dot/dash Sigma uses; nothing the parser treats specially. */
         private val FIELD_NAME_REGEX = Regex("^[A-Za-z0-9_.-]{1,128}$")

--- a/backend/src/main/kotlin/com/moneat/security/detection/SigmaImporter.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/SigmaImporter.kt
@@ -1,0 +1,393 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+
+/**
+ * Raised when a Sigma document cannot be faithfully translated into a [CreateDetectionRuleRequest].
+ * The [message] is a human-readable, schema-free reason; it never carries ClickHouse text (the importer
+ * never reaches ClickHouse — the resulting rule is only ever executed later through [RuleQueryCompiler]).
+ *
+ * Faithfulness is a security property: a Sigma construct that cannot be mapped exactly is **rejected**,
+ * never approximated, so an import can neither silently widen a rule (false negatives) nor mistranslate
+ * it into something broader than the author intended.
+ */
+class SigmaImportException(message: String) : IllegalArgumentException(message)
+
+/**
+ * Translates a community **Sigma** rule (the open YAML detection-rule standard) into a Moneat
+ * [CreateDetectionRuleRequest] whose `filter` is a [LogQueryParser][com.moneat.logs.services.LogQueryParser]
+ * expression. The produced request is created through the **same** path as a hand-authored rule
+ * ([DetectionRuleService.create]), so it is compiled and sandboxed by [RuleQueryCompiler] and gets no
+ * more power than a hand-written one — same org injection, same column whitelist, same caps, no raw SQL.
+ *
+ * ### Supported safe subset
+ * - **logsource**: `category`/`product`/`service` are recorded as `tags[...]` and used to pick a default
+ *   `group_by`; a logsource that is not a log/process/auth-type source we can serve is rejected.
+ * - **detection selections**:
+ *   - field equality (`field: value`) → `@field:"value"`;
+ *   - value modifiers `contains` / `startswith` / `endswith` → wildcard match (`*v*`, `v*`, `*v`);
+ *   - the `all` modifier on a list → AND of the values (default for a list is OR);
+ *   - lists of values (OR), maps of fields (AND);
+ *   - keyword / full-text selections (a bare list) → full-text terms (`*:term`).
+ * - **condition**: `and` / `or` / `not`, `1 of <pattern>` / `all of <pattern>` (and `… of them`),
+ *   and simple parenthesised groups; selection identifiers resolve to the mapped selections above.
+ *
+ * Everything else — regex (`|re`), base64/utf16/wide/cidr/numeric-comparison modifiers, aggregation
+ * conditions (`| count() …`), `near`, timeframes, and any field name that cannot be expressed as a safe
+ * identifier — is rejected with a [SigmaImportException], because translating it could produce a wrong
+ * or over-broad rule. Imported rules are always created `enabled = false`.
+ */
+class SigmaImporter {
+
+    /** One parsed-and-mapped Sigma document, ready for [DetectionRuleService.create]. */
+    data class MappedRule(
+        val request: CreateDetectionRuleRequest,
+        /** The Sigma `title`, surfaced in per-document import results for correlation. */
+        val title: String,
+    )
+
+    private val yaml: Yaml = Yaml(SafeConstructor(LoaderOptions().apply { isAllowDuplicateKeys = false }))
+
+    /**
+     * Parse and map a single Sigma YAML document. Multi-document YAML is rejected here so the caller can
+     * split on `---` and report a per-document result; pass exactly one document.
+     *
+     * @throws SigmaImportException with a schema-free message on any unmappable construct.
+     */
+    fun toRuleRequest(sigmaYaml: String): MappedRule {
+        val root = parseSingleDocument(sigmaYaml)
+        val title = requireText(root["title"], "title")
+        val description = optionalText(root["description"])
+        val severity = mapLevel(optionalText(root["level"]))
+        val logsourceTags = mapLogsource(root["logsource"])
+
+        val detection = asMap(root["detection"])
+            ?: throw SigmaImportException("Sigma rule '$title' has no detection block")
+        val condition = requireText(detection["condition"], "detection.condition")
+        rejectAggregation(condition)
+
+        val selections = buildSelections(detection, title)
+        val filter = SigmaConditionCompiler(selections).compile(condition)
+        if (filter.isBlank()) {
+            throw SigmaImportException("Sigma rule '$title' produced an empty filter")
+        }
+
+        val groupBy = defaultGroupBy(logsourceTags)
+        val request = CreateDetectionRuleRequest(
+            name = title,
+            description = description,
+            source = DetectionSource.LOGS.wire,
+            filter = filter,
+            groupBy = groupBy,
+            windowSeconds = DEFAULT_WINDOW_SECONDS,
+            type = DetectionRuleType.THRESHOLD.wire,
+            thresholdCount = DEFAULT_THRESHOLD,
+            severity = severity,
+            signalTitle = title,
+            signalMessage = description.ifBlank { title },
+            enabled = false,
+            tags = sigmaTags(root, logsourceTags),
+        )
+        return MappedRule(request = request, title = title)
+    }
+
+    // ── Document parsing ────────────────────────────────────────────────────
+
+    private fun parseSingleDocument(sigmaYaml: String): Map<String, Any?> {
+        if (sigmaYaml.isBlank()) throw SigmaImportException("Sigma document is empty")
+        val docs = try {
+            yaml.loadAll(sigmaYaml).toList()
+        } catch (e: org.yaml.snakeyaml.error.YAMLException) {
+            // Surface a generic message; the underlying parser text can include input fragments.
+            throw SigmaImportException("Sigma document is not valid YAML: ${e.message?.take(MSG_PREVIEW) ?: ""}")
+        }
+        val nonNull = docs.filterNotNull()
+        if (nonNull.isEmpty()) throw SigmaImportException("Sigma document is empty")
+        if (nonNull.size > 1) {
+            throw SigmaImportException("Expected a single Sigma document; split multi-document YAML on '---'")
+        }
+        return asMap(nonNull.single())
+            ?: throw SigmaImportException("Sigma document is not a mapping")
+    }
+
+    // ── Metadata mapping ────────────────────────────────────────────────────
+
+    /** Sigma `level` → [com.moneat.security.signals.SignalSeverity] wire value. Unknown/absent → medium. */
+    private fun mapLevel(level: String?): String = when (level?.trim()?.lowercase()) {
+        "informational", "info" -> "info"
+        "low" -> "low"
+        "medium" -> "medium"
+        "high" -> "high"
+        "critical" -> "critical"
+        null, "" -> "medium"
+        else -> throw SigmaImportException("Unsupported Sigma level '${sanitize(level)}'")
+    }
+
+    /**
+     * Validate the `logsource` targets something we can serve from logs, and return its
+     * `category`/`product`/`service` for tagging + default grouping. We do not reject on product/service
+     * (logs come from many products); we reject categories that are clearly non-log telemetry we cannot
+     * evaluate over the `logs` table (e.g. raw network-flow or registry sources with no log representation).
+     */
+    private fun mapLogsource(raw: Any?): LogsourceTags {
+        val map = asMap(raw) ?: return LogsourceTags(null, null, null)
+        val category = optionalText(map["category"]).lowercase().ifBlank { null }
+        val product = optionalText(map["product"]).lowercase().ifBlank { null }
+        val service = optionalText(map["service"]).lowercase().ifBlank { null }
+        if (category != null && category in REJECTED_CATEGORIES) {
+            throw SigmaImportException(
+                "Sigma logsource category '${sanitize(category)}' is not a log source Moneat can evaluate"
+            )
+        }
+        return LogsourceTags(category, product, service)
+    }
+
+    private fun defaultGroupBy(tags: LogsourceTags): List<String> {
+        // Group by host so signals dedup per machine; auth-type sources additionally key on the user
+        // attribute, which the log search routes to tags/resource_attributes. Host is always a real column.
+        val groups = mutableListOf("host")
+        val authy = tags.category in AUTH_CATEGORIES || tags.service in AUTH_SERVICES
+        if (authy) groups += "tags['user']"
+        return groups
+    }
+
+    private fun sigmaTags(root: Map<String, Any?>, logsource: LogsourceTags): List<String> {
+        val tags = mutableListOf("imported:sigma")
+        logsource.category?.let { tags += "sigma.category:$it" }
+        logsource.product?.let { tags += "sigma.product:$it" }
+        logsource.service?.let { tags += "sigma.service:$it" }
+        // Sigma `tags:` (MITRE attack.* etc.) carry over as plain labels when they are simple scalars.
+        (root["tags"] as? List<*>)?.forEach { tag ->
+            (tag as? String)?.let { tags += "sigma:${it.take(TAG_PREVIEW)}" }
+        }
+        return tags
+    }
+
+    // ── Selection mapping ───────────────────────────────────────────────────
+
+    /** Maps every named entry of the detection block (except `condition`) to a filter fragment. */
+    private fun buildSelections(detection: Map<String, Any?>, title: String): Map<String, String> =
+        detection.entries
+            .filter { it.key != "condition" }
+            .associate { (name, value) -> name to mapSelection(name, value, title) }
+
+    private fun mapSelection(name: String, value: Any?, title: String): String = when (value) {
+        is Map<*, *> -> mapFieldMap(value, title)
+        is List<*> -> mapKeywordList(value, title)
+        is String -> fullTextTerm(value)
+        null -> throw SigmaImportException("Sigma rule '$title' selection '${sanitize(name)}' is empty")
+        else -> throw SigmaImportException(
+            "Sigma rule '$title' selection '${sanitize(name)}' has an unsupported shape"
+        )
+    }
+
+    /** A map selection = AND of `field[: modifiers]: value` entries. */
+    private fun mapFieldMap(map: Map<*, *>, title: String): String {
+        if (map.isEmpty()) throw SigmaImportException("Sigma rule '$title' has an empty selection map")
+        val conjuncts = map.entries.map { (rawKey, rawValue) ->
+            val key = (rawKey as? String)
+                ?: throw SigmaImportException("Sigma rule '$title' has a non-string field key")
+            mapFieldCondition(key, rawValue, title)
+        }
+        return joinAnd(conjuncts)
+    }
+
+    /** A bare list selection = OR of full-text keyword terms. */
+    private fun mapKeywordList(list: List<*>, title: String): String {
+        if (list.isEmpty()) throw SigmaImportException("Sigma rule '$title' has an empty keyword list")
+        val terms = list.map { item ->
+            val text = item as? String
+                ?: throw SigmaImportException("Sigma rule '$title' keyword list has a non-string entry")
+            fullTextTerm(text)
+        }
+        return joinOr(terms)
+    }
+
+    /** Maps one `field|modifier...: value-or-list` entry into a parenthesised filter fragment. */
+    private fun mapFieldCondition(rawField: String, rawValue: Any?, title: String): String {
+        val parts = rawField.split("|")
+        val fieldName = parts.first()
+        val modifiers = parts.drop(1).map { it.lowercase() }
+        val safeField = safeFieldName(fieldName, title)
+        rejectUnsupportedModifiers(modifiers, title)
+
+        val combineWithAnd = modifiers.contains("all")
+        val valueModifier = modifiers.firstOrNull { it in VALUE_MODIFIERS }
+
+        val rendered = when (rawValue) {
+            is List<*> -> {
+                val fragments = rawValue.map { v -> fieldValueFragment(safeField, scalar(v, title), valueModifier) }
+                if (combineWithAnd) joinAnd(fragments) else joinOr(fragments)
+            }
+
+            null -> fieldNullFragment(safeField)
+            else -> fieldValueFragment(safeField, scalar(rawValue, title), valueModifier)
+        }
+        return rendered
+    }
+
+    /** `field: null` in Sigma means the field is absent → negated existence. */
+    private fun fieldNullFragment(field: String): String = "-@$field:*"
+
+    /**
+     * One `field op value` fragment in [LogQueryParser][com.moneat.logs.services.LogQueryParser] syntax.
+     * Equality uses a quoted value so separators bind as a literal; the contains/startswith/endswith
+     * modifiers use wildcards, which the parser turns into an `ILIKE` (values are still escaped by the
+     * compiler, so a value can never become SQL structure).
+     */
+    private fun fieldValueFragment(field: String, value: String, modifier: String?): String {
+        val token = when (modifier) {
+            "contains" -> "*${wildcardEscape(value)}*"
+            "startswith" -> "${wildcardEscape(value)}*"
+            "endswith" -> "*${wildcardEscape(value)}"
+            null -> null
+            else -> throw SigmaImportException("Unsupported Sigma value modifier '${sanitize(modifier)}'")
+        }
+        return if (token == null) {
+            "@$field:${quote(value)}"
+        } else {
+            // A wildcard token is unquoted (the parser treats * / ? literally inside quotes).
+            "@$field:$token"
+        }
+    }
+
+    private fun fullTextTerm(term: String): String = "*:${quote(term)}"
+
+    // ── Validation helpers ──────────────────────────────────────────────────
+
+    private fun rejectUnsupportedModifiers(modifiers: List<String>, title: String) {
+        modifiers.forEach { mod ->
+            if (mod !in SUPPORTED_MODIFIERS) {
+                throw SigmaImportException(
+                    "Sigma rule '$title' uses an unsupported field modifier '${sanitize(mod)}'"
+                )
+            }
+        }
+        if (modifiers.count { it in VALUE_MODIFIERS } > 1) {
+            throw SigmaImportException("Sigma rule '$title' combines incompatible value modifiers")
+        }
+    }
+
+    private fun rejectAggregation(condition: String) {
+        if (condition.contains("|")) {
+            throw SigmaImportException("Aggregation conditions (| count/min/max/…) are not supported")
+        }
+    }
+
+    /**
+     * Ensures a Sigma field maps to a [LogQueryParser][com.moneat.logs.services.LogQueryParser] field
+     * name that tokenizes cleanly. Sigma uses dotted/CamelCase names (e.g. `Image`, `process.name`); we
+     * accept an identifier-ish charset only, so a name can never carry the parser's control chars
+     * (`:`, quotes, parentheses, whitespace) that could change how the filter is structured. Unknown but
+     * safe names flow through the parser to `tags[…]`/`resource_attributes[…]`, never to a real column it
+     * does not whitelist, so this is the safe "map unknown fields to tags only if safe, else reject" rule.
+     */
+    private fun safeFieldName(field: String, title: String): String {
+        val trimmed = field.trim()
+        if (trimmed.isEmpty() || !FIELD_NAME_REGEX.matches(trimmed)) {
+            throw SigmaImportException(
+                "Sigma rule '$title' field '${sanitize(field)}' cannot be mapped to a safe attribute name"
+            )
+        }
+        return trimmed
+    }
+
+    private fun scalar(value: Any?, title: String): String = when (value) {
+        is String -> value
+        is Number -> value.toString()
+        is Boolean -> value.toString()
+        null -> throw SigmaImportException("Sigma rule '$title' has a null value where a scalar was expected")
+        else -> throw SigmaImportException("Sigma rule '$title' has a non-scalar value in a field condition")
+    }
+
+    // ── Small text utilities ────────────────────────────────────────────────
+
+    private fun requireText(value: Any?, field: String): String {
+        val text = (value as? String)?.trim().orEmpty()
+        if (text.isEmpty()) throw SigmaImportException("Sigma rule is missing required field '$field'")
+        return text
+    }
+
+    private fun optionalText(value: Any?): String = (value as? String)?.trim().orEmpty()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun asMap(value: Any?): Map<String, Any?>? =
+        (value as? Map<*, *>)?.entries?.associate { (k, v) -> k.toString() to v }
+
+    /** Quote a value for the parser and neutralise the quote/backslash the parser itself unescapes. */
+    private fun quote(value: String): String {
+        val escaped = value.replace("\\", "\\\\").replace("\"", "\\\"")
+        return "\"$escaped\""
+    }
+
+    /**
+     * Escape a value used inside an unquoted wildcard token so only the modifier's own `*`/`?` act as
+     * wildcards: a literal `*`/`?` in the Sigma value is backslash-escaped (the parser unescapes it back
+     * to a literal), and the parser's other control chars cannot appear because they would already have
+     * been rejected by the field/condition handling that routes here.
+     */
+    private fun wildcardEscape(value: String): String =
+        value.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?").replace("\"", "\\\"")
+
+    private fun joinAnd(fragments: List<String>): String = combine(fragments, "AND")
+
+    private fun joinOr(fragments: List<String>): String = combine(fragments, "OR")
+
+    private fun combine(fragments: List<String>, op: String): String {
+        val nonBlank = fragments.filter { it.isNotBlank() }
+        return when (nonBlank.size) {
+            0 -> ""
+            1 -> nonBlank.single()
+            else -> "(" + nonBlank.joinToString(" $op ") + ")"
+        }
+    }
+
+    private fun sanitize(token: String): String =
+        token.take(TOKEN_PREVIEW).filter { it.isLetterOrDigit() || it in "_-. /:|" }
+
+    private data class LogsourceTags(val category: String?, val product: String?, val service: String?)
+
+    companion object {
+        private const val DEFAULT_THRESHOLD = 1
+        private const val MSG_PREVIEW = 80
+        private const val TOKEN_PREVIEW = 60
+        private const val TAG_PREVIEW = 60
+
+        /** Field name charset: identifier chars plus the dot/dash Sigma uses; nothing the parser treats specially. */
+        private val FIELD_NAME_REGEX = Regex("^[A-Za-z0-9_.-]{1,128}$")
+
+        /** Modifiers that change how a single value is matched. At most one may apply to a value. */
+        private val VALUE_MODIFIERS = setOf("contains", "startswith", "endswith")
+
+        /** The full set of field modifiers we can translate faithfully (`all` toggles list AND). */
+        private val SUPPORTED_MODIFIERS = VALUE_MODIFIERS + "all"
+
+        /** Sigma logsource categories with no representation in the `logs` table → reject up front. */
+        private val REJECTED_CATEGORIES = setOf(
+            "registry_event", "registry_set", "registry_add", "registry_delete", "registry_rename",
+            "raw_access_thread", "create_remote_thread", "image_load", "driver_load",
+            "network_connection", "dns_query", "pipe_created", "wmi_event",
+        )
+
+        private val AUTH_CATEGORIES = setOf("authentication")
+        private val AUTH_SERVICES = setOf("auth", "authentication", "sshd", "sudo", "security", "system")
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/detection/SigmaImporter.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/SigmaImporter.kt
@@ -152,7 +152,11 @@ class SigmaImporter {
      * evaluate over the `logs` table (e.g. raw network-flow or registry sources with no log representation).
      */
     private fun mapLogsource(raw: Any?): LogsourceTags {
-        val map = asMap(raw) ?: return LogsourceTags(null, null, null)
+        if (raw == null) return LogsourceTags(null, null, null)
+        // A scalar or sequence logsource is malformed Sigma; reject it rather than treating it as absent
+        // (which would silently fall back to the default grouping for an unintended rule).
+        val map = asMap(raw)
+            ?: throw SigmaImportException("Sigma logsource must be a mapping")
         val category = optionalText(map["category"]).lowercase().ifBlank { null }
         val product = optionalText(map["product"]).lowercase().ifBlank { null }
         val service = optionalText(map["service"]).lowercase().ifBlank { null }
@@ -238,6 +242,11 @@ class SigmaImporter {
 
         val rendered = when (rawValue) {
             is List<*> -> {
+                if (rawValue.isEmpty()) {
+                    throw SigmaImportException(
+                        "Sigma rule '$title' field '${sanitize(rawField)}' has an empty value list"
+                    )
+                }
                 val fragments = rawValue.map { v -> fieldValueFragment(safeField, scalar(v, title), valueModifier) }
                 if (combineWithAnd) joinAnd(fragments) else joinOr(fragments)
             }
@@ -353,8 +362,16 @@ class SigmaImporter {
     private fun wildcardValue(value: String, modifier: String): String {
         if (value.contains('*') || value.contains('?')) {
             throw SigmaImportException(
-                "Sigma '$modifier' value '${sanitize(value)}' contains a literal '*'/'?'; " +
+                "Sigma '${sanitize(modifier)}' value '${sanitize(value)}' contains a literal '*'/'?'; " +
                     "this cannot be mapped without changing the rule's breadth"
+            )
+        }
+        // The wildcard token is emitted unquoted, so a value carrying the parser's control characters
+        // (whitespace, ':' or parentheses) could change the filter's structure. Reject rather than mangle.
+        if (value.any { it.isWhitespace() || it in ":()" }) {
+            throw SigmaImportException(
+                "Sigma '${sanitize(modifier)}' value '${sanitize(value)}' contains parser control characters; " +
+                    "this cannot be mapped safely without quoted wildcard support"
             )
         }
         return value.replace("\\", "\\\\").replace("\"", "\\\"")

--- a/backend/src/test/kotlin/com/moneat/security/detection/DetectionImportRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/DetectionImportRoutesTest.kt
@@ -1,0 +1,266 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import com.moneat.org.repositories.OrgMembershipRepository
+import com.moneat.org.repositories.OrgMembershipRepositoryImpl
+import com.moneat.org.services.OrgMembershipService
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import com.moneat.testsupport.RouteTestSupport
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import com.moneat.testsupport.stopTestKoin
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * AuthZ + behavior for the Sigma import and starter-pack template endpoints. Import + install are
+ * ADMIN; template list is MEMBER. Created rules persist disabled. A real [DetectionRuleService] (with a
+ * faked query runner) is used so the import/install path genuinely runs the compiler before persisting.
+ */
+class DetectionImportRoutesTest {
+    companion object {
+        private var db: Database? = null
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+    private var orgId: Int = 0
+    private var adminUserId: Int = 0
+    private var memberUserId: Int = 0
+
+    private val service = DetectionRuleService(
+        compiler = RuleQueryCompiler({ "moneat" }),
+        runner = DetectionQueryRunner(execute = { _ -> """{"g0":"web-01","match_count":3}""" }),
+    )
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_detection_import;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        DetectionSchemaTestSupport.reset()
+        transaction { SchemaUtils.create(Users, Memberships) }
+        adminUserId = seedUser("admin@import.test")
+        memberUserId = seedUser("member@import.test")
+        orgId = seedOrg("acme")
+        seedMembership(orgId, adminUserId, "admin")
+        seedMembership(orgId, memberUserId, "member")
+
+        stopTestKoin()
+        startKoin {
+            modules(
+                module {
+                    single<OrgMembershipRepository> { OrgMembershipRepositoryImpl() }
+                    single { OrgMembershipService(get()) }
+                }
+            )
+        }
+    }
+
+    @AfterTest
+    fun teardown() = stopTestKoin()
+
+    private val sampleSigma = """
+        title: Suspicious curl download
+        level: high
+        logsource:
+          category: process_creation
+        detection:
+          selection:
+            Image|endswith: /curl
+            CommandLine|contains: http
+          condition: selection
+    """.trimIndent()
+
+    @Test
+    fun `a member cannot import sigma`() = testApplication {
+        setupApp()
+        val response = client.post("/v1/security/detection/import/sigma") {
+            withAuth(token(memberUserId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(SigmaImportRequest(documents = listOf(sampleSigma))))
+        }
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `an admin can import a sigma rule and it persists disabled`() = testApplication {
+        setupApp()
+        val response = client.post("/v1/security/detection/import/sigma") {
+            withAuth(token(adminUserId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(SigmaImportRequest(documents = listOf(sampleSigma))))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"created_count\":1"), body)
+        assertTrue(body.contains("\"error_count\":0"), body)
+        // The created rule exists for the org and is disabled.
+        val list = service.list(orgId)
+        assertEquals(1, list.totalCount)
+        assertFalse(list.rules.single().enabled)
+        assertEquals("Suspicious curl download", list.rules.single().name)
+    }
+
+    @Test
+    fun `a batch reports per-document errors without aborting the good ones`() = testApplication {
+        setupApp()
+        val badSigma = "title: bad\ndetection:\n  s:\n    CommandLine|re: ev[il]+\n  condition: s"
+        val response = client.post("/v1/security/detection/import/sigma") {
+            withAuth(token(adminUserId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(SigmaImportRequest(documents = listOf(sampleSigma, badSigma))))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"created_count\":1"), body)
+        assertTrue(body.contains("\"error_count\":1"), body)
+        // Only the good one persisted.
+        assertEquals(1, service.list(orgId).totalCount)
+        // No ClickHouse internals leak in the per-item error.
+        listOf("Code:", "DB::Exception", "SETTINGS", "FROM `").forEach {
+            assertFalse(body.contains(it), "leaked '$it': $body")
+        }
+    }
+
+    @Test
+    fun `empty document list is a 400`() = testApplication {
+        setupApp()
+        val response = client.post("/v1/security/detection/import/sigma") {
+            withAuth(token(adminUserId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(SigmaImportRequest(documents = emptyList())))
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `a member can list templates`() = testApplication {
+        setupApp()
+        val response = client.get("/v1/security/detection/templates") { withAuth(token(memberUserId)) }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("failed-auth-brute-force"), body)
+        assertTrue(body.contains("\"total_count\":6"), body)
+    }
+
+    @Test
+    fun `template list requires authentication`() = testApplication {
+        setupApp()
+        assertEquals(
+            HttpStatusCode.Unauthorized,
+            client.get("/v1/security/detection/templates").status,
+        )
+    }
+
+    @Test
+    fun `a member cannot install a template`() = testApplication {
+        setupApp()
+        val response = client.post("/v1/security/detection/templates/failed-auth-brute-force/install") {
+            withAuth(token(memberUserId))
+        }
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `an admin can install a template as a disabled rule`() = testApplication {
+        setupApp()
+        val response = client.post("/v1/security/detection/templates/failed-auth-brute-force/install") {
+            withAuth(token(adminUserId))
+        }
+        assertEquals(HttpStatusCode.Created, response.status)
+        val list = service.list(orgId)
+        assertEquals(1, list.totalCount)
+        assertFalse(list.rules.single().enabled)
+        assertEquals("Failed authentication brute force", list.rules.single().name)
+    }
+
+    @Test
+    fun `installing an unknown template is a 404`() = testApplication {
+        setupApp()
+        val response = client.post("/v1/security/detection/templates/does-not-exist/install") {
+            withAuth(token(adminUserId))
+        }
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    private fun ApplicationTestBuilder.setupApp() {
+        application {
+            installJwtAuth()
+            routing { detectionRuleRoutes(service) }
+        }
+    }
+
+    private fun token(userId: Int): String = RouteTestSupport.createToken(userId = userId, orgId = orgId)
+
+    private fun seedUser(email: String): Int = transaction {
+        Users.insert {
+            it[Users.email] = email
+            it[password_hash] = "hash"
+            it[name] = email.substringBefore("@")
+            it[email_verified] = true
+        } get Users.id
+    }
+
+    private fun seedOrg(name: String): Int = transaction {
+        Organizations.insert {
+            it[Organizations.name] = name
+            it[slug] = name
+        } get Organizations.id
+    }
+
+    private fun seedMembership(orgId: Int, userId: Int, role: String) {
+        transaction {
+            Memberships.insert {
+                it[organization_id] = orgId
+                it[user_id] = userId
+                it[Memberships.role] = role
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/detection/DetectionImportRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/DetectionImportRoutesTest.kt
@@ -169,6 +169,24 @@ class DetectionImportRoutesTest {
     }
 
     @Test
+    fun `a pathologically nested condition yields a clean per-item error not a 500`() = testApplication {
+        setupApp()
+        val nested = "(".repeat(20_000) + "s" + ")".repeat(20_000)
+        val evil = "title: nested\ndetection:\n  s:\n    Image: x\n  condition: $nested"
+        val response = client.post("/v1/security/detection/import/sigma") {
+            withAuth(token(adminUserId))
+            contentType(ContentType.Application.Json)
+            setBody(json.encodeToString(SigmaImportRequest(documents = listOf(sampleSigma, evil))))
+        }
+        // The whole batch still returns 200; the hostile document is a per-item error, the good one persists.
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"created_count\":1"), body)
+        assertTrue(body.contains("\"error_count\":1"), body)
+        assertEquals(1, service.list(orgId).totalCount)
+    }
+
+    @Test
     fun `empty document list is a 400`() = testApplication {
         setupApp()
         val response = client.post("/v1/security/detection/import/sigma") {

--- a/backend/src/test/kotlin/com/moneat/security/detection/DetectionStarterPackTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/DetectionStarterPackTest.kt
@@ -1,0 +1,131 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import com.moneat.shared.models.Organizations
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The starter pack as installable templates. Installing each one goes through the same
+ * [DetectionRuleService.create] (compiler-gated) path and persists a disabled rule — proving the pack is
+ * not a bypass and that every Moneat-authored rule actually compiles end-to-end.
+ */
+class DetectionStarterPackTest {
+    companion object {
+        private var db: Database? = null
+    }
+
+    private var orgId: Int = 0
+
+    private val ruleService = DetectionRuleService(
+        compiler = RuleQueryCompiler({ "moneat" }),
+        runner = DetectionQueryRunner(execute = { _ -> """{"g0":"web-01","match_count":1}""" }),
+    )
+    private val importService = DetectionImportService(ruleService)
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_starter_pack;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        DetectionSchemaTestSupport.reset()
+        orgId = seedOrg("acme")
+    }
+
+    @Test
+    fun `the pack lists six templates with stable ids`() {
+        val ids = DetectionStarterPack.templates.map { it.id }
+        assertEquals(6, ids.size)
+        assertEquals(ids.size, ids.toSet().size, "template ids must be unique")
+        assertTrue(ids.contains("failed-auth-brute-force"))
+        assertTrue(ids.contains("new-source-login"))
+        assertTrue(ids.contains("outbound-to-suspicious"))
+    }
+
+    @Test
+    fun `every template is authored disabled`() {
+        DetectionStarterPack.templates.forEach { assertFalse(it.request.enabled, "${it.id} must be disabled") }
+    }
+
+    @Test
+    fun `installing every template through the compiler-gated path persists a disabled rule`() {
+        DetectionStarterPack.templates.forEach { template ->
+            val created = importService.installTemplate(orgId, template.id)
+            requireNotNull(created) { "install returned null for ${template.id}" }
+            assertFalse(created.enabled, "${template.id} installed enabled")
+            assertEquals(template.request.name, created.name)
+        }
+        // All six now exist for the org.
+        assertEquals(6, ruleService.list(orgId).totalCount)
+    }
+
+    @Test
+    fun `installing an unknown template returns null`() {
+        assertNull(importService.installTemplate(orgId, "nope"))
+    }
+
+    @Test
+    fun `the new-value template keeps its type and a user group key`() {
+        val installed = importService.installTemplate(orgId, "new-source-login")
+        requireNotNull(installed)
+        assertEquals(DetectionRuleType.NEW_VALUE.wire, installed.type)
+        assertTrue(installed.groupBy.contains("tags['user']"), installed.groupBy.toString())
+    }
+
+    @Test
+    fun `sigma import goes through the compiler and rejects unmappable docs per item`() {
+        val good = """
+            title: ok
+            logsource:
+              category: process_creation
+            detection:
+              selection:
+                Image: /bin/sh
+              condition: selection
+        """.trimIndent()
+        val unmappable = "title: bad\ndetection:\n  s:\n    Image|re: '.*'\n  condition: s"
+        val result = importService.importSigma(orgId, listOf(good, unmappable))
+        assertEquals(1, result.createdCount)
+        assertEquals(1, result.errorCount)
+        // The created one persisted disabled; the bad one did not.
+        assertEquals(1, ruleService.list(orgId).totalCount)
+        val createdItem = result.results.single { it.ruleId != null }
+        assertEquals("ok", createdItem.title)
+        val errorItem = result.results.single { it.error != null }
+        assertTrue(errorItem.error!!.isNotBlank())
+    }
+
+    private fun seedOrg(name: String): Int = transaction {
+        Organizations.insert {
+            it[Organizations.name] = name
+            it[slug] = name
+        } get Organizations.id
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/detection/SigmaImportGateTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/SigmaImportGateTest.kt
@@ -1,0 +1,138 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The hard gate for imported/template rules: a mapped Sigma rule and every starter-pack template must
+ * compile through the **same** [RuleQueryCompiler] as a hand-authored rule, so they inherit the org
+ * injection, the column whitelist, and the resource caps and gain no extra power. A crafted Sigma rule
+ * cannot escape org scoping or reach a non-whitelisted column.
+ */
+class SigmaImportGateTest {
+
+    private val importer = SigmaImporter()
+    private val compiler = RuleQueryCompiler({ "moneat" })
+
+    private fun compileRequest(orgId: Int, request: CreateDetectionRuleRequest): CompiledRuleQuery {
+        val type = DetectionRuleType.fromWire(request.type)!!
+        return compiler.compile(
+            orgId,
+            RuleQueryCompiler.RuleInput(
+                source = request.source,
+                filter = request.filter,
+                groupBy = request.groupBy,
+                windowSeconds = request.windowSeconds,
+                type = type,
+                thresholdCount = request.thresholdCount,
+            ),
+        )
+    }
+
+    private fun compileSigma(orgId: Int, yaml: String): CompiledRuleQuery =
+        compileRequest(orgId, importer.toRuleRequest(yaml).request)
+
+    @Test
+    fun `a mapped sigma rule compiles and is org-scoped to the context org`() {
+        val sql = compileSigma(
+            orgId = 77,
+            yaml = """
+                title: Suspicious curl
+                logsource:
+                  category: process_creation
+                detection:
+                  selection:
+                    Image|endswith: /curl
+                    CommandLine|contains: http
+                  condition: selection
+            """.trimIndent(),
+        ).sql
+        assertTrue(sql.contains("organization_id = 77"), sql)
+        assertTrue(sql.contains("`moneat`.logs"), sql)
+        assertTrue(sql.contains("SETTINGS"), sql)
+    }
+
+    @Test
+    fun `an imported rule cannot escape org scoping even with an adversarial value`() {
+        // The Sigma value tries to break out of the string and drop the org clause; it must bind as a
+        // value with its quote escaped, so it stays inside the string literal and cannot inject structure.
+        val sql = compileSigma(
+            orgId = 5,
+            yaml = """
+                title: evil
+                detection:
+                  selection:
+                    CommandLine: "x' OR 1=1; DROP TABLE logs; --"
+                  condition: selection
+            """.trimIndent(),
+        ).sql
+        assertTrue(sql.contains("organization_id = 5"), sql)
+        // Exactly one org predicate and it is the context org — the value could not add another.
+        assertEquals(1, Regex("""organization_id""").findAll(sql).count(), sql)
+        // The breakout quote is backslash-escaped, so the malicious tail lives inside the string literal.
+        assertTrue(sql.contains("""x\' OR 1=1; DROP TABLE logs; --"""), sql)
+        // No UNSCAPED quote-then-statement exists: the only `DROP` present sits after an escaped quote.
+        assertFalse(Regex("""[^\\]'\s*;?\s*DROP\s+TABLE""", RegexOption.IGNORE_CASE).containsMatchIn(sql), sql)
+    }
+
+    @Test
+    fun `an imported rule cannot group on a non-whitelisted column`() {
+        // Sigma cannot set group_by directly, but even a crafted logsource maps only to host/tags['user'].
+        val request = importer.toRuleRequest(
+            """
+            title: t
+            logsource:
+              service: sshd
+            detection:
+              keywords:
+                - "Failed password"
+              condition: keywords
+            """.trimIndent()
+        ).request
+        // Every group_by produced is within the compiler whitelist (host + map access only).
+        request.groupBy.forEach { col ->
+            val allowed = col in RuleQueryCompiler.ALLOWED_GROUP_BY_COLUMNS ||
+                Regex("""^[a-z_]+\['?[A-Za-z0-9_.:/-]+'?]$""").matches(col)
+            assertTrue(allowed, "group_by '$col' is outside the whitelist")
+        }
+    }
+
+    @Test
+    fun `every starter-pack rule compiles cleanly through the compiler`() {
+        DetectionStarterPack.templates.forEach { template ->
+            val compiled = compileRequest(orgId = 1, request = template.request)
+            assertTrue(compiled.sql.contains("organization_id = 1"), "${template.id}: ${compiled.sql}")
+            assertTrue(compiled.sql.contains("`moneat`.logs"), template.id)
+            assertTrue(compiled.sql.contains("SETTINGS"), template.id)
+        }
+    }
+
+    @Test
+    fun `starter-pack new-value rule emits no HAVING and threshold rules do`() {
+        val newValue = DetectionStarterPack.find("new-source-login")!!
+        val nvSql = compileRequest(1, newValue.request).sql
+        assertFalse(nvSql.contains("HAVING"), nvSql)
+
+        val threshold = DetectionStarterPack.find("failed-auth-brute-force")!!
+        val tSql = compileRequest(1, threshold.request).sql
+        assertTrue(tSql.contains("HAVING count() >="), tSql)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/detection/SigmaImporterTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/SigmaImporterTest.kt
@@ -34,7 +34,7 @@ class SigmaImporterTest {
 
     private fun map(yaml: String) = importer.toRuleRequest(yaml).request
 
-    // ── Supported subset ───────────────────────────────────────────────────
+    // ──── Supported subset ────
 
     @Test
     fun `title description and level map to name description and severity`() {
@@ -94,8 +94,8 @@ class SigmaImporterTest {
     fun `contains startswith endswith map to wildcard matches`() {
         val contains = map(sel("CommandLine|contains", "mimikatz"))
         assertEquals("@CommandLine:*mimikatz*", contains.filter)
-        val starts = map(sel("Image|startswith", "C:\\Temp"))
-        assertTrue(starts.filter.startsWith("@Image:C:") && starts.filter.endsWith("*"), starts.filter)
+        val starts = map(sel("Image|startswith", "powershell"))
+        assertEquals("@Image:powershell*", starts.filter)
         val ends = map(sel("TargetFilename|endswith", ".lnk"))
         assertEquals("@TargetFilename:*.lnk", ends.filter)
     }
@@ -274,7 +274,7 @@ class SigmaImporterTest {
         assertTrue(rule.tags.any { it.contains("attack.t1059") })
     }
 
-    // ── Rejections (faithfulness: reject rather than mistranslate) ──────────
+    // ──── Rejections (faithfulness: reject rather than mistranslate) ────
 
     @Test
     fun `regex modifier is rejected`() {
@@ -410,6 +410,62 @@ class SigmaImporterTest {
                 }
                 assertTrue(ex.message!!.contains("literal", ignoreCase = true), ex.message)
             }
+    }
+
+    @Test
+    fun `a parser control character in a contains-startswith-endswith value is rejected`() {
+        // The wildcard token is emitted unquoted, so whitespace / ':' / parentheses in the value could
+        // change the filter's structure. These are rejected rather than mangled.
+        listOf("CommandLine|contains" to "foo bar", "Image|startswith" to "C:dir", "Name|endswith" to "a(b)")
+            .forEach { (key, value) ->
+                val ex = assertFailsWith<SigmaImportException>("$key:$value should be rejected") {
+                    map(sel(key, "\"$value\""))
+                }
+                assertTrue(ex.message!!.contains("control characters", ignoreCase = true), ex.message)
+            }
+    }
+
+    @Test
+    fun `an empty field value list is rejected rather than dropped`() {
+        // `field: []` would otherwise compile to a blank fragment that is silently filtered out, dropping
+        // part of the rule. Faithfulness requires rejecting it.
+        val ex = assertFailsWith<SigmaImportException> { map(sel("CommandLine", "[]")) }
+        assertTrue(ex.message!!.contains("empty value list", ignoreCase = true), ex.message)
+    }
+
+    @Test
+    fun `a scalar logsource is rejected rather than treated as missing`() {
+        val ex = assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                logsource: windows
+                detection:
+                  selection:
+                    Image: x
+                  condition: selection
+                """.trimIndent()
+            )
+        }
+        assertTrue(ex.message!!.contains("logsource", ignoreCase = true), ex.message)
+    }
+
+    @Test
+    fun `a sequence logsource is rejected rather than treated as missing`() {
+        val ex = assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                logsource:
+                  - category: process_creation
+                detection:
+                  selection:
+                    Image: x
+                  condition: selection
+                """.trimIndent()
+            )
+        }
+        assertTrue(ex.message!!.contains("logsource", ignoreCase = true), ex.message)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/security/detection/SigmaImporterTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/SigmaImporterTest.kt
@@ -398,6 +398,84 @@ class SigmaImporterTest {
         assertTrue(rule.filter.contains("\\\""), rule.filter)
     }
 
+    @Test
+    fun `a literal wildcard in a contains-startswith-endswith value is rejected not widened`() {
+        // Faithfulness: a raw `*`/`?` inside a value modifier must not silently become a wildcard (a
+        // broader rule than authored), so it is rejected rather than emitted. Values are YAML-quoted so
+        // the glob reaches the importer (an unquoted leading `*` is a YAML alias, a different error).
+        listOf("CommandLine|contains" to "a*b", "Image|startswith" to "C:?x", "TargetFilename|endswith" to "x*.exe")
+            .forEach { (key, value) ->
+                val ex = assertFailsWith<SigmaImportException>("$key:$value should be rejected") {
+                    map(sel(key, "\"$value\""))
+                }
+                assertTrue(ex.message!!.contains("literal", ignoreCase = true), ex.message)
+            }
+    }
+
+    @Test
+    fun `an over-nested condition trips the per-node depth guard not just the size pre-filter`() {
+        // Stays under the coarse length/paren pre-filter (so this exercises the recursive depth() guard
+        // itself) yet nests past the depth cap; it must reject gracefully, never StackOverflowError.
+        val depth = 90
+        val nested = "(".repeat(depth) + "selection" + ")".repeat(depth)
+        val ex = assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                detection:
+                  selection:
+                    Image: x
+                  condition: $nested
+                """.trimIndent()
+            )
+        }
+        assertTrue(ex.message!!.contains("nested too deeply", ignoreCase = true), ex.message)
+    }
+
+    @Test
+    fun `a huge-paren condition is rejected by the coarse pre-filter before recursing`() {
+        // Thousands of parens would otherwise drive the recursive descent into a StackOverflowError; the
+        // pre-tokenize bound rejects it up front as an ordinary import error.
+        val depth = 5_000
+        val nested = "(".repeat(depth) + "selection" + ")".repeat(depth)
+        val ex = assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                detection:
+                  selection:
+                    Image: x
+                  condition: $nested
+                """.trimIndent()
+            )
+        }
+        assertTrue(ex.message!!.contains("too", ignoreCase = true), ex.message)
+    }
+
+    @Test
+    fun `an oversized document is rejected before parsing`() {
+        val huge = "title: t\ndescription: " + "x".repeat(600 * 1024) +
+            "\ndetection:\n  s:\n    Image: x\n  condition: s"
+        val ex = assertFailsWith<SigmaImportException> { map(huge) }
+        assertTrue(ex.message!!.contains("too large", ignoreCase = true), ex.message)
+    }
+
+    @Test
+    fun `a yaml billion-laughs alias bomb is bounded by the alias limit`() {
+        // Explicit alias cap (not the library default) keeps an alias-expansion bomb from exhausting memory.
+        val bomb = buildString {
+            append("title: t\n")
+            append("detection:\n  s:\n    Image: x\n  condition: s\n")
+            append("a: &a [\"x\",\"x\",\"x\",\"x\",\"x\",\"x\",\"x\",\"x\",\"x\",\"x\"]\n")
+            for (i in 0 until 12) {
+                append("b$i: [")
+                append((0 until 10).joinToString(",") { "*a" })
+                append("]\n")
+            }
+        }
+        assertFailsWith<SigmaImportException> { map(bomb) }
+    }
+
     private fun sel(field: String, value: String): String =
         """
         title: t

--- a/backend/src/test/kotlin/com/moneat/security/detection/SigmaImporterTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/SigmaImporterTest.kt
@@ -1,0 +1,409 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Sigma → rule mapping: the supported safe subset is translated into a [LogQueryParser]-compatible
+ * filter, and everything that cannot be translated faithfully is rejected (never approximated). The
+ * companion [SigmaImportGateTest] proves the mapped filter still compiles through [RuleQueryCompiler]
+ * (org-scoped, whitelisted), so an imported rule has no more power than a hand-authored one.
+ */
+class SigmaImporterTest {
+
+    private val importer = SigmaImporter()
+
+    private fun map(yaml: String) = importer.toRuleRequest(yaml).request
+
+    // ── Supported subset ───────────────────────────────────────────────────
+
+    @Test
+    fun `title description and level map to name description and severity`() {
+        val rule = map(
+            """
+            title: Suspicious thing
+            description: it is suspicious
+            level: critical
+            logsource:
+              category: process_creation
+            detection:
+              selection:
+                Image: /usr/bin/curl
+              condition: selection
+            """.trimIndent()
+        )
+        assertEquals("Suspicious thing", rule.name)
+        assertEquals("it is suspicious", rule.description)
+        assertEquals("critical", rule.severity)
+        // Imported rules are always disabled.
+        assertFalse(rule.enabled)
+        // Defaults to a threshold count>=1 rule.
+        assertEquals(DetectionRuleType.THRESHOLD.wire, rule.type)
+        assertEquals(1, rule.thresholdCount)
+    }
+
+    @Test
+    fun `informational level maps to info`() {
+        val rule = map(
+            """
+            title: t
+            level: informational
+            detection:
+              sel:
+                Image: x
+              condition: sel
+            """.trimIndent()
+        )
+        assertEquals("info", rule.severity)
+    }
+
+    @Test
+    fun `field equality maps to a quoted attribute match`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              selection:
+                CommandLine: whoami
+              condition: selection
+            """.trimIndent()
+        )
+        assertEquals("@CommandLine:\"whoami\"", rule.filter)
+    }
+
+    @Test
+    fun `contains startswith endswith map to wildcard matches`() {
+        val contains = map(sel("CommandLine|contains", "mimikatz"))
+        assertEquals("@CommandLine:*mimikatz*", contains.filter)
+        val starts = map(sel("Image|startswith", "C:\\Temp"))
+        assertTrue(starts.filter.startsWith("@Image:C:") && starts.filter.endsWith("*"), starts.filter)
+        val ends = map(sel("TargetFilename|endswith", ".lnk"))
+        assertEquals("@TargetFilename:*.lnk", ends.filter)
+    }
+
+    @Test
+    fun `a list of values becomes an OR`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              selection:
+                Image:
+                  - /bin/nc
+                  - /bin/ncat
+              condition: selection
+            """.trimIndent()
+        )
+        assertEquals("(@Image:\"/bin/nc\" OR @Image:\"/bin/ncat\")", rule.filter)
+    }
+
+    @Test
+    fun `the all modifier turns a list into an AND`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              selection:
+                CommandLine|contains|all:
+                  - -enc
+                  - hidden
+              condition: selection
+            """.trimIndent()
+        )
+        assertEquals("(@CommandLine:*-enc* AND @CommandLine:*hidden*)", rule.filter)
+    }
+
+    @Test
+    fun `a map of fields becomes an AND`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              selection:
+                Image|endswith: \powershell.exe
+                CommandLine|contains: -enc
+              condition: selection
+            """.trimIndent()
+        )
+        // The literal backslash in the value is escaped (`\\`) so the parser unescapes it back to a
+        // single backslash rather than treating it as an escape of the following char.
+        assertEquals("(@Image:*\\\\powershell.exe AND @CommandLine:*-enc*)", rule.filter)
+    }
+
+    @Test
+    fun `keyword list becomes full-text OR`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              keywords:
+                - "failed password"
+                - "invalid user"
+              condition: keywords
+            """.trimIndent()
+        )
+        assertEquals("(*:\"failed password\" OR *:\"invalid user\")", rule.filter)
+    }
+
+    @Test
+    fun `condition and or not compose selection fragments`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              sel_a:
+                Image: a
+              sel_b:
+                Image: b
+              filter_c:
+                User: root
+              condition: (sel_a or sel_b) and not filter_c
+            """.trimIndent()
+        )
+        // Explicit Sigma parentheses are preserved as a nested group (the extra parens are harmless and
+        // the LogQueryParser handles them); the boolean shape is (A or B) and not C.
+        assertEquals(
+            "(((@Image:\"a\" OR @Image:\"b\")) AND NOT (@User:\"root\"))",
+            rule.filter,
+        )
+    }
+
+    @Test
+    fun `1 of selection-star expands to an OR over matching selections`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              selection_curl:
+                Image: curl
+              selection_wget:
+                Image: wget
+              condition: 1 of selection_*
+            """.trimIndent()
+        )
+        // Order follows declaration order in the detection map.
+        assertEquals("(@Image:\"curl\" OR @Image:\"wget\")", rule.filter)
+    }
+
+    @Test
+    fun `all of them expands to an AND over every selection`() {
+        val rule = map(
+            """
+            title: t
+            detection:
+              sel1:
+                Image: a
+              sel2:
+                CommandLine: b
+              condition: all of them
+            """.trimIndent()
+        )
+        assertEquals("(@Image:\"a\" AND @CommandLine:\"b\")", rule.filter)
+    }
+
+    @Test
+    fun `auth logsource adds a user group key`() {
+        val rule = map(
+            """
+            title: t
+            logsource:
+              product: linux
+              service: sshd
+            detection:
+              keywords:
+                - "Failed password"
+              condition: keywords
+            """.trimIndent()
+        )
+        assertEquals(listOf("host", "tags['user']"), rule.groupBy)
+    }
+
+    @Test
+    fun `non-auth logsource groups by host only`() {
+        val rule = map(
+            """
+            title: t
+            logsource:
+              category: process_creation
+            detection:
+              selection:
+                Image: x
+              condition: selection
+            """.trimIndent()
+        )
+        assertEquals(listOf("host"), rule.groupBy)
+    }
+
+    @Test
+    fun `sigma metadata is preserved as tags`() {
+        val rule = map(
+            """
+            title: t
+            logsource:
+              category: process_creation
+            tags:
+              - attack.execution
+              - attack.t1059
+            detection:
+              selection:
+                Image: x
+              condition: selection
+            """.trimIndent()
+        )
+        assertTrue(rule.tags.contains("imported:sigma"), rule.tags.toString())
+        assertTrue(rule.tags.contains("sigma.category:process_creation"))
+        assertTrue(rule.tags.any { it.contains("attack.t1059") })
+    }
+
+    // ── Rejections (faithfulness: reject rather than mistranslate) ──────────
+
+    @Test
+    fun `regex modifier is rejected`() {
+        assertFailsWith<SigmaImportException> { map(sel("CommandLine|re", "ev[il]+")) }
+    }
+
+    @Test
+    fun `base64 and cidr and numeric modifiers are rejected`() {
+        listOf("CommandLine|base64offset|contains", "DestinationIp|cidr", "EventID|gte").forEach { key ->
+            assertFailsWith<SigmaImportException>("$key should be rejected") { map(sel(key, "1")) }
+        }
+    }
+
+    @Test
+    fun `aggregation conditions are rejected`() {
+        val ex = assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                detection:
+                  selection:
+                    Image: x
+                  condition: selection | count() by host > 5
+                """.trimIndent()
+            )
+        }
+        assertTrue(ex.message!!.contains("Aggregation", ignoreCase = true))
+    }
+
+    @Test
+    fun `an unknown selection name in the condition is rejected`() {
+        assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                detection:
+                  selection:
+                    Image: x
+                  condition: selection and missing
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `a field name with unsafe characters is rejected`() {
+        // A field carrying parser control chars (a colon) cannot be expressed as a safe attribute name.
+        assertFailsWith<SigmaImportException> { map(sel("we:ird", "x")) }
+    }
+
+    @Test
+    fun `a missing title is rejected`() {
+        assertFailsWith<SigmaImportException> {
+            map(
+                """
+                detection:
+                  selection:
+                    Image: x
+                  condition: selection
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `a missing detection block is rejected`() {
+        assertFailsWith<SigmaImportException> { map("title: t\nlevel: low") }
+    }
+
+    @Test
+    fun `a non-log logsource category is rejected`() {
+        val ex = assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                logsource:
+                  category: registry_set
+                detection:
+                  selection:
+                    TargetObject: x
+                  condition: selection
+                """.trimIndent()
+            )
+        }
+        assertTrue(ex.message!!.contains("registry_set"))
+    }
+
+    @Test
+    fun `multi-document yaml is rejected so the caller splits first`() {
+        assertFailsWith<SigmaImportException> {
+            map("title: a\ndetection:\n  s:\n    Image: x\n  condition: s\n---\ntitle: b")
+        }
+    }
+
+    @Test
+    fun `invalid yaml is rejected without leaking parser internals to a rule`() {
+        val ex = assertFailsWith<SigmaImportException> { map("title: [unterminated") }
+        assertTrue(ex.message!!.contains("YAML", ignoreCase = true))
+    }
+
+    @Test
+    fun `an unsupported level value is rejected`() {
+        assertFailsWith<SigmaImportException> {
+            map(
+                """
+                title: t
+                level: catastrophic
+                detection:
+                  s:
+                    Image: x
+                  condition: s
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `a quote in a value is neutralised in the produced filter`() {
+        val rule = map(sel("CommandLine", "say \"hi\""))
+        // The embedded quote is backslash-escaped so it cannot terminate the parser's quoted value.
+        assertTrue(rule.filter.contains("\\\""), rule.filter)
+    }
+
+    private fun sel(field: String, value: String): String =
+        """
+        title: t
+        detection:
+          selection:
+            $field: $value
+          condition: selection
+        """.trimIndent()
+}


### PR DESCRIPTION
- Import Sigma rules (compiled through the existing rule gate; created disabled).
- Starter detection-rule templates (list + install).
- Seed disabled starter rules into demo data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Import Sigma detection rules from YAML documents with per-document error reporting
  * Browse and install pre-built detection rule templates from a starter pack
  * New API endpoints for Sigma imports and template management
  * Batch import support without aborting on individual failures

* **Chores**
  * Added dependency for YAML parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->