### PR TITLE
feat(security): add vulnerability sbom ingest

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
@@ -103,7 +103,7 @@ class DatadogModule : EnterpriseModule {
                 dbmIngestRoutes()
                 debuggerIngestRoutes()
                 telemetryProxyRoutes()
-                miscIngestRoutes()
+                miscIngestRoutes(includeSbomRoutes = false)
                 ndmIngestRoutes()
                 securityIngestRoutes()
             }

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
@@ -48,6 +48,7 @@ private val json = Json {
 
 fun Route.miscIngestRoutes(
     quotaService: BillingQuotaService = BillingQuotaService(),
+    includeSbomRoutes: Boolean = true,
 ) {
     route("/dd") {
         // Symbol DB
@@ -70,7 +71,9 @@ fun Route.miscIngestRoutes(
             post("/data_streams") { handleDataStreams(quotaService) }
             post("/synthetics") { handleSynthetics(quotaService) }
             post("/contimage") { handleContainerImage(quotaService) }
-            post("/sbom") { handleSbom(quotaService) }
+            if (includeSbomRoutes) {
+                post("/sbom") { handleSbom(quotaService) }
+            }
         }
     }
 
@@ -79,7 +82,9 @@ fun Route.miscIngestRoutes(
     route("/api/v2") {
         post("/contlcycle") { handleContainerLifecycle() }
         post("/contimage") { handleContainerImage(quotaService) }
-        post("/sbom") { handleSbom(quotaService) }
+        if (includeSbomRoutes) {
+            post("/sbom") { handleSbom(quotaService) }
+        }
         post("/synthetics") { handleSynthetics(quotaService) }
         post("/data_streams_messages") { handleDataStreams(quotaService) }
         post("/events") { handleEventManagement() }

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -73,6 +73,7 @@ import com.moneat.monitor.repositories.HostRepositoryImpl
 import com.moneat.monitor.services.AgentApiKeyService
 import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.security.detection.DetectionScheduler
+import com.moneat.security.vulnerabilities.VulnerabilityAdvisorySyncJob
 import com.moneat.monitor.services.MonitorService
 import com.moneat.notifications.services.AlertNotificationPreferencesService
 import com.moneat.notifications.services.DiscordService
@@ -245,6 +246,7 @@ val monitorModule = module {
     single { AgentApiKeyService() }
     single { SyntheticsService(get(), get()) }
     single { DetectionScheduler() }
+    single { VulnerabilityAdvisorySyncJob() }
 }
 
 /** Log ingestion and querying. */

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -30,6 +30,7 @@ import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.otlp.services.OtlpMetricsIngestionWorker
 import com.moneat.otlp.services.OtlpTraceIngestionWorker
 import com.moneat.security.detection.DetectionScheduler
+import com.moneat.security.vulnerabilities.VulnerabilityAdvisorySyncJob
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.DemoLivenessBackgroundService
 import com.moneat.shared.services.PulseService
@@ -131,6 +132,7 @@ fun Application.configureBackgroundJobs() {
     val artifactCleanupService = koin.get<ArtifactCleanupService>()
     val uptimeScheduler = koin.get<UptimeScheduler>()
     val detectionScheduler = koin.get<DetectionScheduler>()
+    val vulnerabilityAdvisorySyncJob = koin.get<VulnerabilityAdvisorySyncJob>()
     val demoLivenessBackgroundService = koin.get<DemoLivenessBackgroundService>()
     val queueKey = environment.config.property("ingest.queueKey").getString()
     val dlqKey = environment.config.property("ingest.dlqKey").getString()
@@ -233,6 +235,7 @@ fun Application.configureBackgroundJobs() {
     artifactCleanupService.start(jobScope)
     uptimeScheduler.start()
     detectionScheduler.start(jobScope)
+    vulnerabilityAdvisorySyncJob.start(jobScope)
     ingestionWorker.start()
     logIngestionWorker.start()
     llmIngestionWorker.start()
@@ -278,6 +281,7 @@ fun Application.configureBackgroundJobs() {
         artifactCleanupService.stop()
         uptimeScheduler.stop()
         detectionScheduler.stop()
+        vulnerabilityAdvisorySyncJob.stop()
         ingestionWorker.stop()
         logIngestionWorker.stop()
         llmIngestionWorker.stop()

--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -45,6 +45,7 @@ import com.moneat.otlp.routes.otlpMetricsRoutes
 import com.moneat.otlp.routes.otlpTraceRoutes
 import com.moneat.security.detection.detectionRuleRoutes
 import com.moneat.security.signals.signalRoutes
+import com.moneat.security.vulnerabilities.vulnerabilityRoutes
 import com.moneat.statuspage.routes.statusPageRoutes
 import com.moneat.summary.routes.summaryRoutes
 import com.moneat.uptime.routes.uptimeRoutes
@@ -276,6 +277,16 @@ fun Application.configureRouting() {
         // Detection rules: scheduled, declarative rules over logs → signals (OSS core)
         rateLimit(RateLimitName("api")) {
             detectionRuleRoutes()
+        }
+
+        // Vulnerability/SBOM inventory and findings (OSS core)
+        rateLimit(RateLimitName("api")) {
+            vulnerabilityRoutes(includeAgentRoutes = false)
+        }
+
+        // SBOM compatibility ingest is OSS core so direct package inventory works without EE.
+        rateLimit(RateLimitName("datadog-ingestion")) {
+            vulnerabilityRoutes(includeApiRoutes = false)
         }
 
         routingLogger.info { "Registering enterprise routes..." }

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
@@ -112,6 +112,7 @@ enum class SignalSource(val wire: String) {
     AGENT_RUNTIME("agent_runtime"),
     AGENT_COMPLIANCE("agent_compliance"),
     DETECTION("detection"),
+    VULNERABILITY("vulnerability"),
 }
 
 /** Audit action kinds. */
@@ -136,6 +137,7 @@ data class SignalSpec(
     val evidenceType: String,
     val evidenceReference: String,
     val occurredAtMs: Long,
+    val tags: List<String> = emptyList(),
 )
 
 /** Result of [SignalWriter.upsert]; drives whether the workflow trigger fires (Created/Escalated only). */

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
@@ -269,8 +269,16 @@ class SignalService {
             SignalSource.AGENT_RUNTIME -> fetchRuntimeSamples(orgId, signal)
             SignalSource.AGENT_COMPLIANCE -> fetchComplianceSamples(orgId, signal)
             SignalSource.DETECTION -> fetchDetectionSamples(orgId, signal)
+            SignalSource.VULNERABILITY -> vulnerabilitySamples(signal)
             null -> emptyList()
         }
+
+    private fun vulnerabilitySamples(signal: SignalResponse): List<JsonElement> =
+        listOf(
+            buildJsonObject {
+                signal.entities.forEach { (key, value) -> put(key, value) }
+            }
+        )
 
     /**
      * Evidence for a detection-rule signal: recent log rows for the entity this signal fired on, scoped

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
@@ -113,8 +113,11 @@ object SignalWriter {
         val escalated = spec.severity.rank > existing.severity.rank
         val newSeverity = if (escalated) spec.severity else existing.severity
         SecuritySignals.update({ SecuritySignals.id eq existing.id }) {
+            it[ruleName] = spec.ruleName
             it[sampleCount] = existing.sampleCount + 1
             it[severity] = newSeverity.wire
+            it[entities] = signalJson.encodeToString(spec.entities)
+            it[tags] = signalJson.encodeToString(spec.tags)
             // Agent events can arrive out of order, so clamp the window monotonically: never move
             // last_seen backwards (it is the list sort key and time-filter bound) and lower first_seen
             // only when an earlier occurrence folds in.

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalWriter.kt
@@ -143,7 +143,7 @@ object SignalWriter {
             it[dedupKey] = spec.dedupKey
             it[entities] = signalJson.encodeToString(spec.entities)
             it[sampleCount] = 1
-            it[tags] = "[]"
+            it[tags] = signalJson.encodeToString(spec.tags)
             it[firstSeen] = occurred
             it[lastSeen] = occurred
             it[createdAt] = now

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/AdvisoryParser.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/AdvisoryParser.kt
@@ -1,0 +1,216 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlin.time.Instant
+
+object AdvisoryParser {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    fun parseDocument(raw: String): List<AdvisoryRecord> {
+        val trimmed = raw.trim()
+        if (trimmed.isBlank()) return emptyList()
+        return when (val root = json.parseToJsonElement(trimmed)) {
+            is JsonArray -> root.flatMap { parseElement(it) }
+            is JsonObject -> parseElement(root)
+            else -> emptyList()
+        }
+    }
+
+    fun parseNdjson(raw: String): List<AdvisoryRecord> =
+        raw.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .flatMap { parseDocument(it) }
+            .toList()
+
+    private fun parseElement(element: JsonElement): List<AdvisoryRecord> {
+        val obj = element as? JsonObject ?: return emptyList()
+        return when {
+            obj["affected"] != null -> parseOsv(obj)
+            obj["vulnerabilities"] != null || obj["ghsa_id"] != null -> parseGhsa(obj)
+            else -> emptyList()
+        }
+    }
+
+    private fun parseOsv(root: JsonObject): List<AdvisoryRecord> {
+        val advisoryId = root.s("id")
+        if (advisoryId.isBlank()) return emptyList()
+        val cveId = firstCve(root.a("aliases"))
+        val cvssScore = root.obj("database_specific")?.d("cvss_score") ?: root.d("cvss_score")
+        val severity = severityFrom(cvssScore, root.obj("database_specific")?.s("severity"))
+        val link = "https://osv.dev/vulnerability/$advisoryId"
+        val withdrawn = root["withdrawn"] != null
+        return root.a("affected").mapNotNull { affectedElement ->
+            val affected = affectedElement as? JsonObject ?: return@mapNotNull null
+            val pkg = affected.obj("package") ?: return@mapNotNull null
+            val name = SbomParser.clean(pkg.s("name"))
+            if (name.isBlank()) return@mapNotNull null
+            val ecosystem = SbomParser.normalizeEcosystem(pkg.s("ecosystem"))
+            val ranges = parseOsvRanges(affected.a("ranges"))
+            val fixedVersion = ranges.firstOrNull { !it.fixed.isNullOrBlank() }?.fixed
+            AdvisoryRecord(
+                source = "osv",
+                advisoryId = advisoryId,
+                cveId = cveId,
+                packageName = name,
+                ecosystem = ecosystem,
+                packageType = ecosystem,
+                affectedRanges = ranges,
+                affectedVersions = affected.a("versions").mapNotNull { it.stringOrNull() },
+                fixedVersion = fixedVersion,
+                severity = severity,
+                cvssScore = cvssScore,
+                link = link,
+                summary = root.s("summary").ifBlank { root.s("details") }.take(SUMMARY_MAX_LENGTH),
+                rawAdvisory = root.toString(),
+                withdrawn = withdrawn,
+                publishedAt = root.instant("published"),
+                modifiedAt = root.instant("modified"),
+            )
+        }
+    }
+
+    private fun parseOsvRanges(ranges: List<JsonElement>): List<AdvisoryRange> {
+        val parsed = mutableListOf<AdvisoryRange>()
+        ranges.forEach { rangeElement ->
+            val range = rangeElement as? JsonObject ?: return@forEach
+            val events = range.a("events")
+            var introduced: String? = null
+            events.forEach { eventElement ->
+                val event = eventElement as? JsonObject ?: return@forEach
+                val nextIntroduced = event.s("introduced").takeIf { it.isNotBlank() }
+                val fixed = event.s("fixed").takeIf { it.isNotBlank() }
+                if (nextIntroduced != null) introduced = nextIntroduced
+                if (fixed != null) {
+                    parsed.add(AdvisoryRange(introduced = introduced ?: "0", fixed = fixed))
+                    introduced = null
+                }
+            }
+            if (introduced != null) {
+                parsed.add(AdvisoryRange(introduced = introduced))
+            }
+        }
+        return parsed
+    }
+
+    private fun parseGhsa(root: JsonObject): List<AdvisoryRecord> {
+        val advisoryId = root.s("ghsa_id").ifBlank { root.s("id") }
+        if (advisoryId.isBlank()) return emptyList()
+        val cveId = root.s("cve_id").takeIf { it.isNotBlank() } ?: firstCve(root.a("identifiers"))
+        val cvssScore = root.obj("cvss")?.d("score") ?: root.d("cvss_score")
+        val severity = severityFrom(cvssScore, root.s("severity"))
+        val vulnerabilities = root.a("vulnerabilities")
+        return vulnerabilities.mapNotNull { vulnerabilityElement ->
+            val vulnerability = vulnerabilityElement as? JsonObject ?: return@mapNotNull null
+            val pkg = vulnerability.obj("package") ?: return@mapNotNull null
+            val name = SbomParser.clean(pkg.s("name"))
+            if (name.isBlank()) return@mapNotNull null
+            val ecosystem = SbomParser.normalizeEcosystem(pkg.s("ecosystem"))
+            val fixedVersion = vulnerability.obj("first_patched_version")?.s("identifier")?.takeIf {
+                it.isNotBlank()
+            }
+            AdvisoryRecord(
+                source = "ghsa",
+                advisoryId = advisoryId,
+                cveId = cveId,
+                packageName = name,
+                ecosystem = ecosystem,
+                packageType = ecosystem,
+                affectedRanges = listOf(
+                    AdvisoryRange(
+                        vulnerableRange = vulnerability.s("vulnerable_version_range").ifBlank { null },
+                        fixed = fixedVersion,
+                    )
+                ),
+                affectedVersions = emptyList(),
+                fixedVersion = fixedVersion,
+                severity = severity,
+                cvssScore = cvssScore,
+                link = root.s("permalink").ifBlank { "https://github.com/advisories/$advisoryId" },
+                summary = root.s("summary").ifBlank { root.s("description") }.take(SUMMARY_MAX_LENGTH),
+                rawAdvisory = root.toString(),
+                withdrawn = root["withdrawn_at"] != null,
+                publishedAt = root.instant("published_at"),
+                modifiedAt = root.instant("updated_at"),
+            )
+        }
+    }
+
+    private fun severityFrom(score: Double?, fallback: String?): String {
+        if (score != null) {
+            return when {
+                score >= CRITICAL_CVSS -> "critical"
+                score >= HIGH_CVSS -> "high"
+                score >= MEDIUM_CVSS -> "medium"
+                score > 0.0 -> "low"
+                else -> "info"
+            }
+        }
+        return when (fallback?.trim()?.lowercase()) {
+            "critical" -> "critical"
+            "high" -> "high"
+            "moderate", "medium" -> "medium"
+            "low" -> "low"
+            else -> "medium"
+        }
+    }
+
+    private fun firstCve(values: List<JsonElement>): String? =
+        values.mapNotNull { element ->
+            when (element) {
+                is JsonPrimitive -> element.contentOrNull
+                is JsonObject -> element.s("value").ifBlank { element.s("id") }
+                else -> null
+            }
+        }.firstOrNull { it.startsWith("CVE-", ignoreCase = true) }
+
+    private fun JsonObject.s(key: String): String =
+        (this[key] as? JsonPrimitive)?.contentOrNull ?: ""
+
+    private fun JsonObject.d(key: String): Double? =
+        (this[key] as? JsonPrimitive)?.doubleOrNull
+
+    private fun JsonObject.obj(key: String): JsonObject? =
+        this[key]?.let { it as? JsonObject }
+
+    private fun JsonObject.a(key: String): List<JsonElement> =
+        (this[key] as? JsonArray)?.jsonArray ?: emptyList()
+
+    private fun JsonObject.instant(key: String): Instant? =
+        s(key).takeIf { it.isNotBlank() }?.let { runCatching { Instant.parse(it) }.getOrNull() }
+
+    private fun JsonElement.stringOrNull(): String? =
+        (this as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+
+    private const val SUMMARY_MAX_LENGTH = 2_000
+    private const val CRITICAL_CVSS = 9.0
+    private const val HIGH_CVSS = 7.0
+    private const val MEDIUM_CVSS = 4.0
+}

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/AdvisoryParser.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/AdvisoryParser.kt
@@ -101,20 +101,32 @@ object AdvisoryParser {
         val parsed = mutableListOf<AdvisoryRange>()
         ranges.forEach { rangeElement ->
             val range = rangeElement as? JsonObject ?: return@forEach
+            val type = range.s("type").takeIf { it.isNotBlank() }
             val events = range.a("events")
             var introduced: String? = null
             events.forEach { eventElement ->
                 val event = eventElement as? JsonObject ?: return@forEach
                 val nextIntroduced = event.s("introduced").takeIf { it.isNotBlank() }
                 val fixed = event.s("fixed").takeIf { it.isNotBlank() }
+                val lastAffected = event.s("last_affected").takeIf { it.isNotBlank() }
                 if (nextIntroduced != null) introduced = nextIntroduced
                 if (fixed != null) {
-                    parsed.add(AdvisoryRange(introduced = introduced ?: "0", fixed = fixed))
+                    parsed.add(AdvisoryRange(type = type, introduced = introduced ?: "0", fixed = fixed))
+                    introduced = null
+                }
+                if (lastAffected != null) {
+                    parsed.add(
+                        AdvisoryRange(
+                            type = type,
+                            introduced = introduced ?: "0",
+                            lastAffected = lastAffected,
+                        )
+                    )
                     introduced = null
                 }
             }
             if (introduced != null) {
-                parsed.add(AdvisoryRange(introduced = introduced))
+                parsed.add(AdvisoryRange(type = type, introduced = introduced))
             }
         }
         return parsed
@@ -145,6 +157,7 @@ object AdvisoryParser {
                 packageType = ecosystem,
                 affectedRanges = listOf(
                     AdvisoryRange(
+                        type = "SEMVER",
                         vulnerableRange = vulnerability.s("vulnerable_version_range").ifBlank { null },
                         fixed = fixedVersion,
                     )

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStore.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStore.kt
@@ -112,7 +112,8 @@ class ClickHousePackageInventoryStore(
                 host,
                 image_name,
                 container_id,
-                formatDateTime(max(collected_at), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') AS last_seen
+                formatDateTime(max(collected_at), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') AS last_seen,
+                toUInt32(0) AS finding_count
             FROM `${databaseProvider()}`.security_package_inventory
             WHERE $where
             GROUP BY

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStore.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStore.kt
@@ -138,10 +138,22 @@ class ClickHousePackageInventoryStore(
             """
             SELECT count() AS total_count
             FROM (
-                SELECT package_name, package_version, package_type, target_type, target_name, host, image_name
+                SELECT
+                    package_name,
+                    package_version,
+                    package_type,
+                    ecosystem,
+                    purl,
+                    target_type,
+                    target_name,
+                    host,
+                    image_name,
+                    container_id
                 FROM `${databaseProvider()}`.security_package_inventory
                 WHERE $where
-                GROUP BY package_name, package_version, package_type, target_type, target_name, host, image_name
+                GROUP BY
+                    package_name, package_version, package_type, ecosystem, purl,
+                    target_type, target_name, host, image_name, container_id
             )
             """.trimIndent(),
             "JSONEachRow",

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStore.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStore.kt
@@ -1,0 +1,209 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.config.ClickHouseQueryException
+import com.moneat.config.isClickHouseError
+import com.moneat.utils.ClickHouseSqlUtils.escapeLikePattern
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.ClickHouseSqlUtils.mapToSqlMap
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.longOrNull
+import mu.KotlinLogging
+
+private val inventoryLogger = KotlinLogging.logger {}
+
+interface PackageInventoryStore {
+    suspend fun insert(records: List<SbomInventoryRecord>)
+    suspend fun list(orgId: Int, filters: InventoryFilters): VulnerabilityInventoryResponse
+    suspend fun countPackages(orgId: Int): Long
+}
+
+data class InventoryFilters(
+    val search: String? = null,
+    val packageName: String? = null,
+    val target: String? = null,
+    val limit: Int = 100,
+    val offset: Int = 0,
+)
+
+class ClickHousePackageInventoryStore(
+    private val databaseProvider: () -> String = { ClickHouseClient.getDatabase() },
+) : PackageInventoryStore {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun insert(records: List<SbomInventoryRecord>) {
+        if (records.isEmpty()) return
+        val rows = records.joinToString(",\n") { record ->
+            """(
+                generateUUIDv4(),
+                toUUID('${escapeSql(record.uploadId.toString())}'),
+                ${record.organizationId},
+                '${escapeSql(record.source.wire)}',
+                '${escapeSql(record.format.wire)}',
+                '${escapeSql(record.targetType)}',
+                '${escapeSql(record.targetName)}',
+                '${escapeSql(record.host)}',
+                '${escapeSql(record.containerId)}',
+                '${escapeSql(record.imageName)}',
+                '${escapeSql(record.packageName)}',
+                '${escapeSql(record.packageVersion)}',
+                '${escapeSql(record.packageType)}',
+                '${escapeSql(record.ecosystem)}',
+                '${escapeSql(record.purl)}',
+                ${arrayToSql(record.licenses)},
+                '${escapeSql(record.supplier)}',
+                '${escapeSql(record.bomRef)}',
+                ${mapToSqlMap(record.tags)},
+                fromUnixTimestamp64Milli(${record.collectedAtMs}),
+                now64(3)
+            )"""
+        }
+        val sql = """
+            INSERT INTO `${databaseProvider()}`.security_package_inventory (
+                inventory_id, upload_id, organization_id, source, format, target_type, target_name,
+                host, container_id, image_name, package_name, package_version, package_type, ecosystem,
+                purl, licenses, supplier, bom_ref, tags, collected_at, ingested_at
+            ) VALUES $rows
+        """.trimIndent()
+        val response = ClickHouseClient.execute(sql)
+        val body = response.bodyAsText()
+        if (response.isClickHouseError(body)) {
+            inventoryLogger.error { "ClickHouse inventory insert failed: ${body.take(LOG_BODY_MAX_LENGTH)}" }
+            throw ClickHouseQueryException(false, "Security package inventory insert failed")
+        }
+    }
+
+    override suspend fun list(orgId: Int, filters: InventoryFilters): VulnerabilityInventoryResponse {
+        val conditions = inventoryConditions(orgId, filters)
+        val where = conditions.joinToString(" AND ")
+        val total = countRows(where)
+        val rows = ClickHouseClient.executeWithFormat(
+            """
+            SELECT
+                package_name,
+                package_version,
+                package_type,
+                ecosystem,
+                purl,
+                target_type,
+                target_name,
+                host,
+                image_name,
+                container_id,
+                formatDateTime(max(collected_at), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') AS last_seen
+            FROM `${databaseProvider()}`.security_package_inventory
+            WHERE $where
+            GROUP BY
+                package_name, package_version, package_type, ecosystem, purl,
+                target_type, target_name, host, image_name, container_id
+            ORDER BY max(collected_at) DESC
+            LIMIT ${filters.limit} OFFSET ${filters.offset}
+            """.trimIndent(),
+            "JSONEachRow",
+        )
+        return VulnerabilityInventoryResponse(
+            inventory = parseRows(rows).map { it.toInventoryItem() },
+            totalCount = total,
+        )
+    }
+
+    override suspend fun countPackages(orgId: Int): Long =
+        countRows("organization_id = toUInt64($orgId)")
+
+    private suspend fun countRows(where: String): Long {
+        val body = ClickHouseClient.executeWithFormat(
+            """
+            SELECT count() AS total_count
+            FROM (
+                SELECT package_name, package_version, package_type, target_type, target_name, host, image_name
+                FROM `${databaseProvider()}`.security_package_inventory
+                WHERE $where
+                GROUP BY package_name, package_version, package_type, target_type, target_name, host, image_name
+            )
+            """.trimIndent(),
+            "JSONEachRow",
+        )
+        return parseRows(body).firstOrNull()?.long("total_count") ?: 0L
+    }
+
+    private fun inventoryConditions(orgId: Int, filters: InventoryFilters): List<String> {
+        val conditions = mutableListOf("organization_id = toUInt64($orgId)")
+        filters.packageName?.takeIf { it.isNotBlank() }?.let {
+            conditions.add("package_name = '${escapeSql(it)}'")
+        }
+        filters.target?.takeIf { it.isNotBlank() }?.let {
+            val escaped = escapeSql(it)
+            conditions.add("(target_name = '$escaped' OR host = '$escaped' OR image_name = '$escaped')")
+        }
+        filters.search?.takeIf { it.isNotBlank() }?.let {
+            val escaped = escapeLikePattern(it)
+            conditions.add(
+                "(package_name ILIKE '%$escaped%' OR package_version ILIKE '%$escaped%' " +
+                    "OR target_name ILIKE '%$escaped%' OR host ILIKE '%$escaped%' OR image_name ILIKE '%$escaped%')"
+            )
+        }
+        return conditions
+    }
+
+    private fun parseRows(body: String): List<JsonObject> =
+        body.trim().lineSequence()
+            .filter { it.isNotBlank() }
+            .mapNotNull { line -> runCatching { json.parseToJsonElement(line).jsonObject }.getOrNull() }
+            .toList()
+
+    private fun JsonObject.toInventoryItem(): VulnerabilityInventoryItem =
+        VulnerabilityInventoryItem(
+            packageName = string("package_name"),
+            packageVersion = string("package_version"),
+            packageType = string("package_type"),
+            ecosystem = string("ecosystem"),
+            purl = string("purl"),
+            targetType = string("target_type"),
+            targetName = string("target_name"),
+            host = string("host"),
+            imageName = string("image_name"),
+            containerId = string("container_id"),
+            lastSeen = string("last_seen"),
+            findingCount = int("finding_count"),
+        )
+
+    private fun JsonObject.string(key: String): String =
+        (this[key] as? JsonPrimitive)?.contentOrNull ?: ""
+
+    private fun JsonObject.long(key: String): Long? =
+        (this[key] as? JsonPrimitive)?.longOrNull
+
+    private fun JsonObject.int(key: String): Int =
+        (this[key] as? JsonPrimitive)?.intOrNull ?: 0
+
+    private fun arrayToSql(values: List<String>): String {
+        if (values.isEmpty()) return "[]"
+        return values.joinToString(prefix = "[", postfix = "]") { "'${escapeSql(it)}'" }
+    }
+
+    companion object {
+        private const val LOG_BODY_MAX_LENGTH = 500
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/SbomParser.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/SbomParser.kt
@@ -17,6 +17,7 @@
 package com.moneat.security.vulnerabilities
 
 import com.moneat.datadog.models.DdSbomPayload
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -24,7 +25,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
 
 private const val MAX_SBOM_BYTES = 5 * 1024 * 1024
 private const val MAX_PACKAGES = 5_000
@@ -33,7 +33,10 @@ private const val MAX_PURL_LENGTH = 2_048
 private const val MAX_LICENSES = 20
 private const val MAX_ECOSYSTEM_LENGTH = 64
 
-class SbomValidationException(message: String) : IllegalArgumentException(message)
+class SbomValidationException(
+    message: String,
+    cause: Throwable? = null,
+) : IllegalArgumentException(message, cause)
 
 object SbomParser {
     private val json = Json {
@@ -95,12 +98,14 @@ object SbomParser {
         }
     }
 
-    private fun parseJson(rawBody: ByteArray): JsonObject =
-        try {
-            json.parseToJsonElement(rawBody.decodeToString()).jsonObject
-        } catch (e: IllegalArgumentException) {
-            throw SbomValidationException("Malformed SBOM JSON")
+    private fun parseJson(rawBody: ByteArray): JsonObject {
+        val element = try {
+            json.parseToJsonElement(rawBody.decodeToString())
+        } catch (e: SerializationException) {
+            throw SbomValidationException("Malformed SBOM JSON", e)
         }
+        return element as? JsonObject ?: throw SbomValidationException("SBOM JSON root must be an object")
+    }
 
     private fun parseCycloneDx(root: JsonObject): ParsedSbom {
         val packages = root.a("components").mapNotNull { element ->

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/SbomParser.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/SbomParser.kt
@@ -1,0 +1,230 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.datadog.models.DdSbomPayload
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+
+private const val MAX_SBOM_BYTES = 5 * 1024 * 1024
+private const val MAX_PACKAGES = 5_000
+private const val MAX_STRING_LENGTH = 512
+private const val MAX_PURL_LENGTH = 2_048
+private const val MAX_LICENSES = 20
+private const val MAX_ECOSYSTEM_LENGTH = 64
+
+class SbomValidationException(message: String) : IllegalArgumentException(message)
+
+object SbomParser {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    fun parse(rawBody: ByteArray): ParsedSbom {
+        validateSize(rawBody)
+        val root = parseJson(rawBody)
+        val parsed = when {
+            root.s("bomFormat").equals("CycloneDX", ignoreCase = true) -> parseCycloneDx(root)
+            root["spdxVersion"] != null || root["SPDXID"] != null -> parseSpdx(root)
+            else -> throw SbomValidationException("Unsupported SBOM format")
+        }
+        if (parsed.packages.isEmpty()) {
+            throw SbomValidationException("SBOM contains no packages with name and version")
+        }
+        if (parsed.packages.size > MAX_PACKAGES) {
+            throw SbomValidationException("SBOM package count exceeds limit")
+        }
+        return parsed
+    }
+
+    fun parseAgentPayload(payload: DdSbomPayload): ParsedSbom {
+        if (payload.packages.size > MAX_PACKAGES) {
+            throw SbomValidationException("SBOM package count exceeds limit")
+        }
+        val packages = payload.packages.mapNotNull { pkg ->
+            val name = clean(pkg.name)
+            val version = clean(pkg.version)
+            if (name.isBlank() || version.isBlank()) {
+                null
+            } else {
+                SbomPackageRecord(
+                    name = name,
+                    version = version,
+                    packageType = clean(pkg.type),
+                    ecosystem = normalizeEcosystem(pkg.type),
+                )
+            }
+        }
+        if (packages.isEmpty()) {
+            throw SbomValidationException("SBOM contains no packages with name and version")
+        }
+        return ParsedSbom(
+            format = SbomFormat.AGENT,
+            packages = packages,
+            targetName = clean(payload.imageName).ifBlank { clean(payload.host) },
+        )
+    }
+
+    private fun validateSize(rawBody: ByteArray) {
+        if (rawBody.isEmpty()) {
+            throw SbomValidationException("SBOM payload is empty")
+        }
+        if (rawBody.size > MAX_SBOM_BYTES) {
+            throw SbomValidationException("SBOM payload is too large")
+        }
+    }
+
+    private fun parseJson(rawBody: ByteArray): JsonObject =
+        try {
+            json.parseToJsonElement(rawBody.decodeToString()).jsonObject
+        } catch (e: IllegalArgumentException) {
+            throw SbomValidationException("Malformed SBOM JSON")
+        }
+
+    private fun parseCycloneDx(root: JsonObject): ParsedSbom {
+        val packages = root.a("components").mapNotNull { element ->
+            val component = element as? JsonObject ?: return@mapNotNull null
+            val name = clean(component.s("name"))
+            val version = clean(component.s("version"))
+            if (name.isBlank() || version.isBlank()) {
+                return@mapNotNull null
+            }
+            val purl = cleanPurl(component.s("purl"))
+            val purlParts = parsePurl(purl)
+            SbomPackageRecord(
+                name = name,
+                version = version,
+                packageType = clean(purlParts.type.ifBlank { component.s("type") }),
+                ecosystem = normalizeEcosystem(purlParts.type.ifBlank { component.s("type") }),
+                purl = purl,
+                licenses = parseCycloneDxLicenses(component.a("licenses")),
+                supplier = clean(component.obj("supplier")?.s("name") ?: component.s("supplier")),
+                bomRef = clean(component.s("bom-ref")),
+            )
+        }
+        return ParsedSbom(
+            format = SbomFormat.CYCLONEDX,
+            packages = packages,
+            targetName = root.obj("metadata")?.obj("component")?.s("name")?.let(::clean).orEmpty(),
+        )
+    }
+
+    private fun parseSpdx(root: JsonObject): ParsedSbom {
+        val packages = root.a("packages").mapNotNull { element ->
+            val pkg = element as? JsonObject ?: return@mapNotNull null
+            val name = clean(pkg.s("name"))
+            val version = clean(pkg.s("versionInfo"))
+            if (name.isBlank() || version.isBlank()) {
+                return@mapNotNull null
+            }
+            val purl = spdxPurl(pkg.a("externalRefs"))
+            val purlParts = parsePurl(purl)
+            SbomPackageRecord(
+                name = name,
+                version = version,
+                packageType = clean(purlParts.type),
+                ecosystem = normalizeEcosystem(purlParts.type),
+                purl = purl,
+                licenses = spdxLicenses(pkg),
+                supplier = clean(pkg.s("supplier").removePrefix("Organization:").trim()),
+                bomRef = clean(pkg.s("SPDXID")),
+            )
+        }
+        return ParsedSbom(
+            format = SbomFormat.SPDX,
+            packages = packages,
+            targetName = clean(root.s("name")),
+        )
+    }
+
+    private fun parseCycloneDxLicenses(licenses: List<JsonElement>): List<String> =
+        licenses.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            val license = obj.obj("license")
+            val expression = obj.s("expression")
+            val value = license?.s("id").orEmpty()
+                .ifBlank { license?.s("name").orEmpty() }
+                .ifBlank { expression }
+            clean(value).takeIf { it.isNotBlank() }
+        }.take(MAX_LICENSES)
+
+    private fun spdxPurl(externalRefs: List<JsonElement>): String {
+        externalRefs.forEach { element ->
+            val ref = element as? JsonObject ?: return@forEach
+            val category = ref.s("referenceCategory")
+            val type = ref.s("referenceType")
+            if (category.equals("PACKAGE-MANAGER", ignoreCase = true) && type.equals("purl", ignoreCase = true)) {
+                return cleanPurl(ref.s("referenceLocator"))
+            }
+        }
+        return ""
+    }
+
+    private fun spdxLicenses(pkg: JsonObject): List<String> {
+        val values = listOf(pkg.s("licenseConcluded"), pkg.s("licenseDeclared"))
+        return values.map { clean(it) }
+            .filter { it.isNotBlank() && it != "NOASSERTION" && it != "NONE" }
+            .distinct()
+            .take(MAX_LICENSES)
+    }
+
+    private fun parsePurl(purl: String): PurlParts {
+        if (!purl.startsWith("pkg:")) return PurlParts()
+        val withoutPrefix = purl.removePrefix("pkg:")
+        val typeEnd = withoutPrefix.indexOf('/')
+        if (typeEnd <= 0) return PurlParts()
+        val rawType = withoutPrefix.substring(0, typeEnd)
+        return PurlParts(type = clean(rawType))
+    }
+
+    private fun cleanPurl(value: String): String = clean(value, MAX_PURL_LENGTH)
+
+    internal fun clean(value: String, maxLength: Int = MAX_STRING_LENGTH): String =
+        value.replace('\u0000', ' ').trim().take(maxLength)
+
+    internal fun normalizeEcosystem(value: String): String =
+        when (value.trim().lowercase()) {
+            "node", "nodejs", "javascript", "npm" -> "npm"
+            "python", "pip", "pypi" -> "pypi"
+            "java", "jar", "maven" -> "maven"
+            "golang", "go" -> "go"
+            "gem", "rubygems" -> "rubygems"
+            "deb", "debian" -> "debian"
+            "rpm", "redhat" -> "rpm"
+            else -> clean(value.lowercase(), MAX_ECOSYSTEM_LENGTH)
+        }
+
+    private fun JsonObject.s(key: String): String =
+        (this[key] as? JsonPrimitive)?.contentOrNull ?: ""
+
+    private fun JsonObject.obj(key: String): JsonObject? =
+        this[key]?.let { it as? JsonObject }
+
+    private fun JsonObject.a(key: String): List<JsonElement> =
+        (this[key] as? JsonArray)?.jsonArray ?: emptyList()
+
+    private data class PurlParts(
+        val type: String = "",
+    )
+}

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisoryRepository.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisoryRepository.kt
@@ -1,0 +1,157 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.math.BigDecimal
+import kotlin.time.Clock
+
+interface VulnerabilityAdvisoryRepository {
+    fun upsertAll(advisories: List<AdvisoryRecord>): Int
+    fun findCandidates(packages: Collection<SbomInventoryRecord>): List<AdvisoryRecord>
+    fun recordSyncRun(source: String, status: String, advisoryCount: Int, error: String?)
+}
+
+class PostgresVulnerabilityAdvisoryRepository : VulnerabilityAdvisoryRepository {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    override fun upsertAll(advisories: List<AdvisoryRecord>): Int =
+        transaction {
+            advisories.forEach { advisory -> upsert(advisory) }
+            advisories.size
+        }
+
+    override fun findCandidates(packages: Collection<SbomInventoryRecord>): List<AdvisoryRecord> {
+        val names = packages.map { it.packageName }.filter { it.isNotBlank() }.distinct()
+        if (names.isEmpty()) return emptyList()
+        return transaction {
+            VulnerabilityAdvisories
+                .selectAll()
+                .where {
+                    (VulnerabilityAdvisories.packageName inList names) and
+                        (VulnerabilityAdvisories.withdrawn eq false)
+                }
+                .map { it.toAdvisoryRecord(json) }
+        }
+    }
+
+    override fun recordSyncRun(source: String, status: String, advisoryCount: Int, error: String?) {
+        val now = Clock.System.now()
+        transaction {
+            VulnerabilityAdvisorySyncRuns.insert {
+                it[VulnerabilityAdvisorySyncRuns.syncSource] = source
+                it[VulnerabilityAdvisorySyncRuns.status] = status
+                it[VulnerabilityAdvisorySyncRuns.advisoryCount] = advisoryCount
+                it[VulnerabilityAdvisorySyncRuns.error] = error?.take(SYNC_ERROR_MAX_LENGTH)
+                it[startedAt] = now
+                it[finishedAt] = now
+            }
+        }
+    }
+
+    private fun upsert(advisory: AdvisoryRecord) {
+        val existingId = VulnerabilityAdvisories
+            .selectAll()
+            .where {
+                (VulnerabilityAdvisories.advisorySource eq advisory.source) and
+                    (VulnerabilityAdvisories.advisoryId eq advisory.advisoryId) and
+                    (VulnerabilityAdvisories.packageName eq advisory.packageName) and
+                    (VulnerabilityAdvisories.ecosystem eq advisory.ecosystem) and
+                    (VulnerabilityAdvisories.packageType eq advisory.packageType)
+            }
+            .limit(1)
+            .firstOrNull()
+            ?.get(VulnerabilityAdvisories.id)
+            ?.value
+        if (existingId == null) {
+            VulnerabilityAdvisories.insert { advisory.assignTo(it, json) }
+        } else {
+            VulnerabilityAdvisories.update({ VulnerabilityAdvisories.id eq existingId }) {
+                advisory.assignTo(it, json)
+            }
+        }
+    }
+
+    companion object {
+        private const val SYNC_ERROR_MAX_LENGTH = 1_000
+    }
+}
+
+private fun AdvisoryRecord.assignTo(
+    row: UpdateBuilder<*>,
+    json: Json,
+) {
+    val now = Clock.System.now()
+    row[VulnerabilityAdvisories.advisorySource] = source
+    row[VulnerabilityAdvisories.advisoryId] = advisoryId
+    row[VulnerabilityAdvisories.cveId] = cveId
+    row[VulnerabilityAdvisories.packageName] = packageName
+    row[VulnerabilityAdvisories.ecosystem] = ecosystem
+    row[VulnerabilityAdvisories.packageType] = packageType
+    row[VulnerabilityAdvisories.affectedRanges] = json.encodeToString(affectedRanges)
+    row[VulnerabilityAdvisories.affectedVersions] = json.encodeToString(affectedVersions)
+    row[VulnerabilityAdvisories.fixedVersion] = fixedVersion
+    row[VulnerabilityAdvisories.severity] = severity
+    row[VulnerabilityAdvisories.cvssScore] = cvssScore?.let { BigDecimal.valueOf(it) }
+    row[VulnerabilityAdvisories.link] = link
+    row[VulnerabilityAdvisories.summary] = summary
+    row[VulnerabilityAdvisories.rawAdvisory] = rawAdvisory
+    row[VulnerabilityAdvisories.withdrawn] = withdrawn
+    row[VulnerabilityAdvisories.publishedAt] = publishedAt
+    row[VulnerabilityAdvisories.modifiedAt] = modifiedAt
+    row[VulnerabilityAdvisories.ingestedAt] = now
+}
+
+private fun ResultRow.toAdvisoryRecord(json: Json): AdvisoryRecord =
+    AdvisoryRecord(
+        source = this[VulnerabilityAdvisories.advisorySource],
+        advisoryId = this[VulnerabilityAdvisories.advisoryId],
+        cveId = this[VulnerabilityAdvisories.cveId],
+        packageName = this[VulnerabilityAdvisories.packageName],
+        ecosystem = this[VulnerabilityAdvisories.ecosystem],
+        packageType = this[VulnerabilityAdvisories.packageType],
+        affectedRanges = decodeRanges(json, this[VulnerabilityAdvisories.affectedRanges]),
+        affectedVersions = decodeStringList(json, this[VulnerabilityAdvisories.affectedVersions]),
+        fixedVersion = this[VulnerabilityAdvisories.fixedVersion],
+        severity = this[VulnerabilityAdvisories.severity],
+        cvssScore = this[VulnerabilityAdvisories.cvssScore]?.toDouble(),
+        link = this[VulnerabilityAdvisories.link],
+        summary = this[VulnerabilityAdvisories.summary],
+        rawAdvisory = this[VulnerabilityAdvisories.rawAdvisory],
+        withdrawn = this[VulnerabilityAdvisories.withdrawn],
+        publishedAt = this[VulnerabilityAdvisories.publishedAt],
+        modifiedAt = this[VulnerabilityAdvisories.modifiedAt],
+    )
+
+private fun decodeRanges(json: Json, raw: String): List<AdvisoryRange> =
+    runCatching { json.decodeFromString<List<AdvisoryRange>>(raw) }.getOrDefault(emptyList())
+
+private fun decodeStringList(json: Json, raw: String): List<String> =
+    runCatching { json.decodeFromString<List<String>>(raw) }.getOrDefault(emptyList())

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJob.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJob.kt
@@ -1,0 +1,128 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.config.EnvConfig
+import com.moneat.shared.services.TaskLock
+import com.moneat.utils.suspendRunCatching
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import mu.KotlinLogging
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readText
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+private val advisorySyncLogger = KotlinLogging.logger {}
+
+class VulnerabilityAdvisorySyncJob(
+    private val repository: VulnerabilityAdvisoryRepository = PostgresVulnerabilityAdvisoryRepository(),
+    private val mirrorPathProvider: () -> String? = { EnvConfig.get(ENV_MIRROR_PATH) },
+) {
+    private var job: Job? = null
+
+    private val intervalHours: Int
+        get() = EnvConfig.get(ENV_INTERVAL_HOURS, DEFAULT_INTERVAL_HOURS.toString())
+            .toIntOrNull()
+            ?.coerceAtLeast(1) ?: DEFAULT_INTERVAL_HOURS
+
+    fun start(scope: CoroutineScope) {
+        advisorySyncLogger.info { "Starting VulnerabilityAdvisorySyncJob (interval=${intervalHours}h)" }
+        job = scope.launch {
+            while (isActive) {
+                TaskLock.tryWithLock(
+                    LOCK_NAME,
+                    lockAtMostFor = 30.minutes,
+                    lockAtLeastFor = 1.minutes,
+                ) {
+                    syncOnce()
+                }
+                delay(intervalHours.hours)
+            }
+        }
+    }
+
+    fun stop() {
+        advisorySyncLogger.info { "Stopping VulnerabilityAdvisorySyncJob" }
+        job?.cancel()
+        job = null
+    }
+
+    fun syncOnce(): Int {
+        val result = suspendRunCatching {
+            val advisories = loadBundledAdvisories() + loadMirrorPathAdvisories()
+            val count = repository.upsertAll(advisories)
+            repository.recordSyncRun("local", "success", count, null)
+            advisorySyncLogger.info { "Synced $count vulnerability advisories from local mirror" }
+            count
+        }
+        return result.getOrElse { error ->
+            advisorySyncLogger.error(error) { "Vulnerability advisory mirror sync failed" }
+            repository.recordSyncRun("local", "failed", 0, error.message ?: "sync failed")
+            0
+        }
+    }
+
+    private fun loadBundledAdvisories(): List<AdvisoryRecord> {
+        val stream = javaClass.classLoader.getResourceAsStream(BUNDLED_ADVISORY_RESOURCE)
+            ?: return emptyList()
+        return stream.bufferedReader().use { reader ->
+            parseAdvisoryText(reader.readText())
+        }
+    }
+
+    private fun loadMirrorPathAdvisories(): List<AdvisoryRecord> {
+        val configuredPath = mirrorPathProvider()?.takeIf { it.isNotBlank() } ?: return emptyList()
+        val path = Path.of(configuredPath)
+        return when {
+            path.isRegularFile() -> parsePath(path)
+            path.isDirectory() -> Files.walk(path).use { paths ->
+                paths
+                    .filter { it.isRegularFile() && it.extension.equals("json", ignoreCase = true) }
+                    .flatMap { parsePath(it).stream() }
+                    .toList()
+            }
+            else -> emptyList()
+        }
+    }
+
+    private fun parsePath(path: Path): List<AdvisoryRecord> =
+        suspendRunCatching { parseAdvisoryText(path.readText()) }
+            .getOrElse { error ->
+                advisorySyncLogger.warn(error) { "Skipping malformed advisory mirror file $path" }
+                emptyList()
+            }
+
+    private fun parseAdvisoryText(raw: String): List<AdvisoryRecord> =
+        suspendRunCatching { AdvisoryParser.parseDocument(raw) }
+            .getOrElse { AdvisoryParser.parseNdjson(raw) }
+
+    companion object {
+        private const val ENV_MIRROR_PATH = "VULNERABILITY_ADVISORY_MIRROR_PATH"
+        private const val ENV_INTERVAL_HOURS = "VULNERABILITY_ADVISORY_SYNC_INTERVAL_HOURS"
+        private const val DEFAULT_INTERVAL_HOURS = 24
+        private const val LOCK_NAME = "security-vulnerability-advisory-sync"
+        private const val BUNDLED_ADVISORY_RESOURCE = "security/advisories/osv-seed.json"
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchService.kt
@@ -38,7 +38,7 @@ class VulnerabilityMatchService(
 private fun AdvisoryRecord.matches(inventory: SbomInventoryRecord): Boolean {
     if (!packageName.equals(inventory.packageName, ignoreCase = true)) return false
     if (!ecosystemMatches(inventory)) return false
-    return versionAffected(inventory.packageVersion)
+    return versionAffected(inventory)
 }
 
 private fun AdvisoryRecord.ecosystemMatches(inventory: SbomInventoryRecord): Boolean {
@@ -52,102 +52,207 @@ private fun AdvisoryRecord.ecosystemMatches(inventory: SbomInventoryRecord): Boo
         advisoryType == inventoryType
 }
 
-private fun AdvisoryRecord.versionAffected(version: String): Boolean {
+private fun AdvisoryRecord.versionAffected(inventory: SbomInventoryRecord): Boolean {
+    val version = inventory.packageVersion
     if (version.isBlank()) return false
     if (affectedVersions.any { it.equals(version, ignoreCase = true) }) {
         return true
     }
+    val rangeEcosystem = ecosystem.ifBlank {
+        inventory.ecosystem.ifBlank {
+            packageType.ifBlank { inventory.packageType }
+        }
+    }
     return affectedRanges.any { range ->
-        range.vulnerableRange?.let { matchesExpression(version, it) } == true ||
-            matchesIntroducedFixed(version, range)
+        range.matchesVersion(version, rangeEcosystem)
     }
 }
 
-private fun matchesIntroducedFixed(version: String, range: AdvisoryRange): Boolean {
-    val introduced = range.introduced
-    val fixed = range.fixed
-    if (introduced.isNullOrBlank() && fixed.isNullOrBlank()) return false
-    val afterIntroduced = introduced.isNullOrBlank() ||
-        introduced == "0" ||
-        compareVersions(version, introduced) >= 0
-    val beforeFixed = fixed.isNullOrBlank() || compareVersions(version, fixed) < 0
-    return afterIntroduced && beforeFixed
+private fun AdvisoryRange.matchesVersion(version: String, ecosystem: String): Boolean {
+    if (!supportsSemanticRange(ecosystem)) return false
+    val parsedVersion = SemanticVersion.parse(version) ?: return false
+    return vulnerableRange?.let { matchesExpression(parsedVersion, it) } == true ||
+        matchesIntroducedFixed(parsedVersion, this)
 }
 
-private fun matchesExpression(version: String, expression: String): Boolean =
+private fun AdvisoryRange.supportsSemanticRange(ecosystem: String): Boolean {
+    val normalizedType = type?.trim()?.uppercase(Locale.ROOT)
+    return when (normalizedType) {
+        null, "" -> ecosystem.normalizeEcosystem() in SEMVER_ECOSYSTEMS
+        "SEMVER" -> true
+        "ECOSYSTEM" -> ecosystem.normalizeEcosystem() in SEMVER_ECOSYSTEMS
+        else -> false
+    }
+}
+
+private fun String.normalizeEcosystem(): String =
+    lowercase(Locale.ROOT).replace(" ", "")
+
+private fun matchesIntroducedFixed(version: SemanticVersion, range: AdvisoryRange): Boolean {
+    val introduced = parseBoundary(range.introduced, zeroIsUnbounded = true)
+    val fixed = parseBoundary(range.fixed, zeroIsUnbounded = false)
+    val lastAffected = parseBoundary(range.lastAffected, zeroIsUnbounded = false)
+    if (introduced is VersionBoundary.Invalid ||
+        fixed is VersionBoundary.Invalid ||
+        lastAffected is VersionBoundary.Invalid
+    ) {
+        return false
+    }
+    if (introduced is VersionBoundary.Unbounded &&
+        fixed is VersionBoundary.Unbounded &&
+        lastAffected is VersionBoundary.Unbounded
+    ) {
+        return false
+    }
+    val boundaries = listOfNotNull(
+        (introduced as? VersionBoundary.Parsed)?.version,
+        (fixed as? VersionBoundary.Parsed)?.version,
+        (lastAffected as? VersionBoundary.Parsed)?.version,
+    )
+    if (!version.canMatchPreRelease(boundaries)) return false
+    val afterIntroduced = (introduced as? VersionBoundary.Parsed)?.let { version >= it.version } ?: true
+    val beforeFixed = (fixed as? VersionBoundary.Parsed)?.let { version < it.version } ?: true
+    val beforeLastAffected = (lastAffected as? VersionBoundary.Parsed)?.let { version <= it.version } ?: true
+    return afterIntroduced && beforeFixed && beforeLastAffected
+}
+
+private fun matchesExpression(version: SemanticVersion, expression: String): Boolean =
     expression
         .split("||")
         .map { it.trim() }
         .filter { it.isNotBlank() }
         .any { segment -> matchesAllComparators(version, segment) }
 
-private fun matchesAllComparators(version: String, segment: String): Boolean =
-    COMPARATOR.findAll(segment)
-        .map { match -> match.value.trim() }
-        .toList()
-        .let { comparators ->
-            comparators.isNotEmpty() && comparators.all { comparator -> matchesComparator(version, comparator) }
+private fun matchesAllComparators(version: SemanticVersion, segment: String): Boolean {
+    val comparators = parseComparators(segment) ?: return false
+    val targets = comparators.map { it.version }
+    if (!version.canMatchPreRelease(targets)) return false
+    return comparators.all { comparator ->
+        val compared = version.compareTo(comparator.version)
+        when (comparator.operator) {
+            ">=" -> compared >= 0
+            "<=" -> compared <= 0
+            ">" -> compared > 0
+            "<" -> compared < 0
+            else -> compared == 0
         }
-
-private fun matchesComparator(version: String, comparator: String): Boolean {
-    val operator = when {
-        comparator.startsWith(">=") -> ">="
-        comparator.startsWith("<=") -> "<="
-        comparator.startsWith(">") -> ">"
-        comparator.startsWith("<") -> "<"
-        comparator.startsWith("=") -> "="
-        else -> "="
-    }
-    val target = comparator.removePrefix(operator).trim()
-    if (target.isBlank()) return true
-    val compared = compareVersions(version, target)
-    return when (operator) {
-        ">=" -> compared >= 0
-        "<=" -> compared <= 0
-        ">" -> compared > 0
-        "<" -> compared < 0
-        else -> compared == 0
     }
 }
 
-internal fun compareVersions(left: String, right: String): Int {
-    val leftTokens = versionTokens(left)
-    val rightTokens = versionTokens(right)
-    val size = maxOf(leftTokens.size, rightTokens.size)
-    for (index in 0 until size) {
-        val l = leftTokens.getOrNull(index) ?: VersionToken.Number(0)
-        val r = rightTokens.getOrNull(index) ?: VersionToken.Number(0)
-        val compared = l.compareTo(r)
-        if (compared != 0) return compared
+private fun parseComparators(segment: String): List<VersionComparator>? {
+    val comparators = mutableListOf<VersionComparator>()
+    var cursor = 0
+    COMPARATOR.findAll(segment).forEach { match ->
+        if (!isComparatorSeparator(segment.substring(cursor, match.range.first))) return null
+        val version = SemanticVersion.parse(match.groupValues[COMPARATOR_VERSION_GROUP]) ?: return null
+        comparators += VersionComparator(
+            operator = match.groupValues[COMPARATOR_OPERATOR_GROUP].ifBlank { "=" },
+            version = version,
+        )
+        cursor = match.range.last + 1
     }
-    return 0
+    if (!isComparatorSeparator(segment.substring(cursor))) return null
+    return comparators.takeIf { it.isNotEmpty() }
 }
 
-private fun versionTokens(version: String): List<VersionToken> =
-    VERSION_TOKEN.findAll(version.removePrefix("v").lowercase(Locale.ROOT))
-        .map { match ->
-            val token = match.value
-            token.toLongOrNull()?.let { VersionToken.Number(it) } ?: VersionToken.Text(token)
+private fun isComparatorSeparator(value: String): Boolean =
+    value.all { it.isWhitespace() || it == ',' }
+
+private fun parseBoundary(value: String?, zeroIsUnbounded: Boolean): VersionBoundary {
+    val cleaned = value?.trim().orEmpty()
+    if (cleaned.isBlank()) return VersionBoundary.Unbounded
+    if (zeroIsUnbounded && cleaned == "0") return VersionBoundary.Unbounded
+    return SemanticVersion.parse(cleaned)?.let { VersionBoundary.Parsed(it) } ?: VersionBoundary.Invalid
+}
+
+private fun SemanticVersion.canMatchPreRelease(boundaries: List<SemanticVersion>): Boolean =
+    !isPreRelease || boundaries.any { it.isPreRelease && it.hasSameCore(this) }
+
+private data class VersionComparator(
+    val operator: String,
+    val version: SemanticVersion,
+)
+
+private sealed interface VersionBoundary {
+    data object Unbounded : VersionBoundary
+    data object Invalid : VersionBoundary
+    data class Parsed(val version: SemanticVersion) : VersionBoundary
+}
+
+private data class SemanticVersion(
+    val major: Long,
+    val minor: Long,
+    val patch: Long,
+    val preRelease: List<String>,
+) : Comparable<SemanticVersion> {
+    val isPreRelease: Boolean = preRelease.isNotEmpty()
+
+    override fun compareTo(other: SemanticVersion): Int =
+        compareValuesBy(this, other, SemanticVersion::major, SemanticVersion::minor, SemanticVersion::patch)
+            .takeIf { it != 0 }
+            ?: comparePreRelease(other)
+
+    fun hasSameCore(other: SemanticVersion): Boolean =
+        major == other.major && minor == other.minor && patch == other.patch
+
+    private fun comparePreRelease(other: SemanticVersion): Int {
+        if (preRelease.isEmpty() && other.preRelease.isEmpty()) return 0
+        if (preRelease.isEmpty()) return 1
+        if (other.preRelease.isEmpty()) return -1
+        val size = maxOf(preRelease.size, other.preRelease.size)
+        for (index in 0 until size) {
+            val left = preRelease.getOrNull(index) ?: return -1
+            val right = other.preRelease.getOrNull(index) ?: return 1
+            val compared = comparePreReleaseIdentifier(left, right)
+            if (compared != 0) return compared
         }
-        .toList()
-
-private sealed interface VersionToken : Comparable<VersionToken> {
-    data class Number(val value: Long) : VersionToken {
-        override fun compareTo(other: VersionToken): Int =
-            when (other) {
-                is Number -> value.compareTo(other.value)
-                is Text -> 1
-            }
+        return 0
     }
 
-    data class Text(val value: String) : VersionToken {
-        override fun compareTo(other: VersionToken): Int =
-            when (other) {
-                is Number -> -1
-                is Text -> value.compareTo(other.value)
-            }
+    companion object {
+        fun parse(value: String): SemanticVersion? {
+            val match = SEMANTIC_VERSION.matchEntire(value.trim()) ?: return null
+            val preRelease = match.groupValues[SEMVER_PRERELEASE_GROUP]
+                .takeIf { it.isNotBlank() }
+                ?.split(".")
+                .orEmpty()
+            if (preRelease.any { it.hasInvalidNumericIdentifier() }) return null
+            return SemanticVersion(
+                major = match.groupValues[SEMVER_MAJOR_GROUP].toLongOrNull() ?: return null,
+                minor = match.groupValues[SEMVER_MINOR_GROUP].toLongOrNull() ?: return null,
+                patch = match.groupValues[SEMVER_PATCH_GROUP].toLongOrNull() ?: return null,
+                preRelease = preRelease,
+            )
+        }
     }
 }
 
-private val VERSION_TOKEN = Regex("""[0-9]+|[a-z]+""")
-private val COMPARATOR = Regex("""(?:>=|<=|>|<|=)?\s*[0-9A-Za-z][0-9A-Za-z.+_-]*""")
+private fun comparePreReleaseIdentifier(left: String, right: String): Int {
+    val leftNumber = left.toLongOrNull()
+    val rightNumber = right.toLongOrNull()
+    return when {
+        leftNumber != null && rightNumber != null -> leftNumber.compareTo(rightNumber)
+        leftNumber != null -> -1
+        rightNumber != null -> 1
+        else -> left.compareTo(right)
+    }
+}
+
+private fun String.hasInvalidNumericIdentifier(): Boolean =
+    all { it.isDigit() } && length > 1 && startsWith("0")
+
+private val SEMVER_ECOSYSTEMS = setOf("npm", "go", "maven", "pypi", "rubygems")
+private val SEMANTIC_VERSION = Regex(
+    """^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)""" +
+        """(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"""
+)
+private val COMPARATOR = Regex(
+    """(>=|<=|>|<|=)?\s*(v?(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)""" +
+        """(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)"""
+)
+private const val COMPARATOR_OPERATOR_GROUP = 1
+private const val COMPARATOR_VERSION_GROUP = 2
+private const val SEMVER_MAJOR_GROUP = 1
+private const val SEMVER_MINOR_GROUP = 2
+private const val SEMVER_PATCH_GROUP = 3
+private const val SEMVER_PRERELEASE_GROUP = 4

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchService.kt
@@ -1,0 +1,153 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import java.util.Locale
+
+class VulnerabilityMatchService(
+    private val advisoryRepository: VulnerabilityAdvisoryRepository = PostgresVulnerabilityAdvisoryRepository(),
+) {
+    fun match(packages: List<SbomInventoryRecord>): List<VulnerabilityMatch> {
+        if (packages.isEmpty()) return emptyList()
+        val advisories = advisoryRepository.findCandidates(packages)
+        if (advisories.isEmpty()) return emptyList()
+        return packages.flatMap { inventory ->
+            advisories.filter { advisory ->
+                advisory.matches(inventory)
+            }.map { advisory ->
+                VulnerabilityMatch(advisory = advisory, inventory = inventory)
+            }
+        }
+    }
+}
+
+private fun AdvisoryRecord.matches(inventory: SbomInventoryRecord): Boolean {
+    if (!packageName.equals(inventory.packageName, ignoreCase = true)) return false
+    if (!ecosystemMatches(inventory)) return false
+    return versionAffected(inventory.packageVersion)
+}
+
+private fun AdvisoryRecord.ecosystemMatches(inventory: SbomInventoryRecord): Boolean {
+    val advisoryEcosystem = ecosystem.lowercase(Locale.ROOT)
+    val inventoryEcosystem = inventory.ecosystem.lowercase(Locale.ROOT)
+    val advisoryType = packageType.lowercase(Locale.ROOT)
+    val inventoryType = inventory.packageType.lowercase(Locale.ROOT)
+    return advisoryEcosystem.isBlank() ||
+        inventoryEcosystem.isBlank() ||
+        advisoryEcosystem == inventoryEcosystem ||
+        advisoryType == inventoryType
+}
+
+private fun AdvisoryRecord.versionAffected(version: String): Boolean {
+    if (version.isBlank()) return false
+    if (affectedVersions.any { it.equals(version, ignoreCase = true) }) {
+        return true
+    }
+    return affectedRanges.any { range ->
+        range.vulnerableRange?.let { matchesExpression(version, it) } == true ||
+            matchesIntroducedFixed(version, range)
+    }
+}
+
+private fun matchesIntroducedFixed(version: String, range: AdvisoryRange): Boolean {
+    val introduced = range.introduced
+    val fixed = range.fixed
+    if (introduced.isNullOrBlank() && fixed.isNullOrBlank()) return false
+    val afterIntroduced = introduced.isNullOrBlank() ||
+        introduced == "0" ||
+        compareVersions(version, introduced) >= 0
+    val beforeFixed = fixed.isNullOrBlank() || compareVersions(version, fixed) < 0
+    return afterIntroduced && beforeFixed
+}
+
+private fun matchesExpression(version: String, expression: String): Boolean =
+    expression
+        .split("||")
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .any { segment -> matchesAllComparators(version, segment) }
+
+private fun matchesAllComparators(version: String, segment: String): Boolean =
+    COMPARATOR.findAll(segment)
+        .map { match -> match.value.trim() }
+        .toList()
+        .let { comparators ->
+            comparators.isNotEmpty() && comparators.all { comparator -> matchesComparator(version, comparator) }
+        }
+
+private fun matchesComparator(version: String, comparator: String): Boolean {
+    val operator = when {
+        comparator.startsWith(">=") -> ">="
+        comparator.startsWith("<=") -> "<="
+        comparator.startsWith(">") -> ">"
+        comparator.startsWith("<") -> "<"
+        comparator.startsWith("=") -> "="
+        else -> "="
+    }
+    val target = comparator.removePrefix(operator).trim()
+    if (target.isBlank()) return true
+    val compared = compareVersions(version, target)
+    return when (operator) {
+        ">=" -> compared >= 0
+        "<=" -> compared <= 0
+        ">" -> compared > 0
+        "<" -> compared < 0
+        else -> compared == 0
+    }
+}
+
+internal fun compareVersions(left: String, right: String): Int {
+    val leftTokens = versionTokens(left)
+    val rightTokens = versionTokens(right)
+    val size = maxOf(leftTokens.size, rightTokens.size)
+    for (index in 0 until size) {
+        val l = leftTokens.getOrNull(index) ?: VersionToken.Number(0)
+        val r = rightTokens.getOrNull(index) ?: VersionToken.Number(0)
+        val compared = l.compareTo(r)
+        if (compared != 0) return compared
+    }
+    return 0
+}
+
+private fun versionTokens(version: String): List<VersionToken> =
+    VERSION_TOKEN.findAll(version.removePrefix("v").lowercase(Locale.ROOT))
+        .map { match ->
+            val token = match.value
+            token.toLongOrNull()?.let { VersionToken.Number(it) } ?: VersionToken.Text(token)
+        }
+        .toList()
+
+private sealed interface VersionToken : Comparable<VersionToken> {
+    data class Number(val value: Long) : VersionToken {
+        override fun compareTo(other: VersionToken): Int =
+            when (other) {
+                is Number -> value.compareTo(other.value)
+                is Text -> 1
+            }
+    }
+
+    data class Text(val value: String) : VersionToken {
+        override fun compareTo(other: VersionToken): Int =
+            when (other) {
+                is Number -> -1
+                is Text -> value.compareTo(other.value)
+            }
+    }
+}
+
+private val VERSION_TOKEN = Regex("""[0-9]+|[a-z]+""")
+private val COMPARATOR = Regex("""(?:>=|<=|>|<|=)?\s*[0-9A-Za-z][0-9A-Za-z.+_-]*""")

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityModels.kt
@@ -146,8 +146,10 @@ data class VulnerabilitySummaryResponse(
 
 @Serializable
 data class AdvisoryRange(
+    val type: String? = null,
     val introduced: String? = null,
     val fixed: String? = null,
+    @SerialName("last_affected") val lastAffected: String? = null,
     @SerialName("vulnerable_range") val vulnerableRange: String? = null,
 )
 

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityModels.kt
@@ -1,0 +1,207 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.shared.models.jsonb
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import java.util.UUID
+
+enum class SbomFormat(val wire: String) {
+    CYCLONEDX("cyclonedx"),
+    SPDX("spdx"),
+    AGENT("agent")
+}
+
+enum class SbomSource(val wire: String) {
+    DIRECT("direct"),
+    AGENT("agent")
+}
+
+data class SbomUploadContext(
+    val source: SbomSource,
+    val targetType: String = "",
+    val targetName: String = "",
+    val host: String = "",
+    val containerId: String = "",
+    val imageName: String = "",
+    val tags: Map<String, String> = emptyMap(),
+)
+
+data class ParsedSbom(
+    val format: SbomFormat,
+    val packages: List<SbomPackageRecord>,
+    val targetName: String = "",
+)
+
+data class SbomPackageRecord(
+    val name: String,
+    val version: String,
+    val packageType: String = "",
+    val ecosystem: String = "",
+    val purl: String = "",
+    val licenses: List<String> = emptyList(),
+    val supplier: String = "",
+    val bomRef: String = "",
+)
+
+data class SbomInventoryRecord(
+    val uploadId: UUID,
+    val organizationId: Int,
+    val source: SbomSource,
+    val format: SbomFormat,
+    val targetType: String,
+    val targetName: String,
+    val host: String,
+    val containerId: String,
+    val imageName: String,
+    val packageName: String,
+    val packageVersion: String,
+    val packageType: String,
+    val ecosystem: String,
+    val purl: String,
+    val licenses: List<String>,
+    val supplier: String,
+    val bomRef: String,
+    val tags: Map<String, String>,
+    val collectedAtMs: Long,
+)
+
+@Serializable
+data class SbomIngestResponse(
+    @SerialName("upload_id") val uploadId: String,
+    @SerialName("package_count") val packageCount: Int,
+    @SerialName("finding_count") val findingCount: Int,
+)
+
+@Serializable
+data class VulnerabilityInventoryItem(
+    @SerialName("package_name") val packageName: String,
+    @SerialName("package_version") val packageVersion: String,
+    @SerialName("package_type") val packageType: String,
+    val ecosystem: String,
+    val purl: String,
+    @SerialName("target_type") val targetType: String,
+    @SerialName("target_name") val targetName: String,
+    val host: String,
+    @SerialName("image_name") val imageName: String,
+    @SerialName("container_id") val containerId: String,
+    @SerialName("last_seen") val lastSeen: String,
+    @SerialName("finding_count") val findingCount: Int = 0,
+)
+
+@Serializable
+data class VulnerabilityInventoryResponse(
+    val inventory: List<VulnerabilityInventoryItem>,
+    @SerialName("total_count") val totalCount: Long,
+)
+
+@Serializable
+data class VulnerabilityFindingResponse(
+    @SerialName("signal_id") val signalId: Int,
+    @SerialName("advisory_id") val advisoryId: String,
+    @SerialName("cve_id") val cveId: String? = null,
+    @SerialName("package_name") val packageName: String,
+    @SerialName("package_version") val packageVersion: String,
+    @SerialName("package_type") val packageType: String,
+    val ecosystem: String,
+    @SerialName("target_name") val targetName: String,
+    val severity: String,
+    @SerialName("cvss_score") val cvssScore: Double? = null,
+    @SerialName("fixed_version") val fixedVersion: String? = null,
+    val link: String,
+    val status: String,
+    @SerialName("last_seen") val lastSeen: String,
+)
+
+@Serializable
+data class VulnerabilityFindingListResponse(
+    val findings: List<VulnerabilityFindingResponse>,
+    @SerialName("total_count") val totalCount: Long,
+)
+
+@Serializable
+data class VulnerabilitySummaryResponse(
+    @SerialName("package_count") val packageCount: Long,
+    @SerialName("finding_count") val findingCount: Long,
+    @SerialName("critical_count") val criticalCount: Long,
+    @SerialName("high_count") val highCount: Long,
+)
+
+@Serializable
+data class AdvisoryRange(
+    val introduced: String? = null,
+    val fixed: String? = null,
+    @SerialName("vulnerable_range") val vulnerableRange: String? = null,
+)
+
+data class AdvisoryRecord(
+    val source: String,
+    val advisoryId: String,
+    val cveId: String?,
+    val packageName: String,
+    val ecosystem: String,
+    val packageType: String,
+    val affectedRanges: List<AdvisoryRange>,
+    val affectedVersions: List<String>,
+    val fixedVersion: String?,
+    val severity: String,
+    val cvssScore: Double?,
+    val link: String,
+    val summary: String,
+    val rawAdvisory: String,
+    val withdrawn: Boolean = false,
+    val publishedAt: kotlin.time.Instant? = null,
+    val modifiedAt: kotlin.time.Instant? = null,
+)
+
+data class VulnerabilityMatch(
+    val advisory: AdvisoryRecord,
+    val inventory: SbomInventoryRecord,
+)
+
+object VulnerabilityAdvisories : IntIdTable("security_vulnerability_advisories") {
+    val advisorySource = varchar("source", 32)
+    val advisoryId = varchar("advisory_id", 255)
+    val cveId = varchar("cve_id", 64).nullable()
+    val packageName = varchar("package_name", 512)
+    val ecosystem = varchar("ecosystem", 64).default("")
+    val packageType = varchar("package_type", 64).default("")
+    val affectedRanges = jsonb("affected_ranges").default("[]")
+    val affectedVersions = jsonb("affected_versions").default("[]")
+    val fixedVersion = varchar("fixed_version", 128).nullable()
+    val severity = varchar("severity", 16).default("medium")
+    val cvssScore = decimal("cvss_score", 4, 1).nullable()
+    val link = text("link").default("")
+    val summary = text("summary").default("")
+    val rawAdvisory = jsonb("raw_advisory").default("{}")
+    val withdrawn = bool("withdrawn").default(false)
+    val publishedAt = timestamp("published_at").nullable()
+    val modifiedAt = timestamp("modified_at").nullable()
+    val ingestedAt = timestamp("ingested_at")
+}
+
+object VulnerabilityAdvisorySyncRuns : IntIdTable("security_vulnerability_advisory_sync_runs") {
+    val syncSource = varchar("source", 32)
+    val status = varchar("status", 16)
+    val advisoryCount = integer("advisory_count").default(0)
+    val error = text("error").nullable()
+    val startedAt = timestamp("started_at")
+    val finishedAt = timestamp("finished_at")
+}

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
@@ -47,8 +47,10 @@ private const val DEFAULT_LIMIT = 100
 private const val MAX_LIMIT = 500
 private const val MISSING_ORG_MESSAGE = "No active organization"
 private const val FORBIDDEN_MESSAGE = "Insufficient permissions"
+private const val NOT_MEMBER_MESSAGE = "Not a member of this organization"
 private const val INVALID_SBOM_MESSAGE = "Invalid SBOM payload"
 private const val UNSUPPORTED_PROTOBUF_SBOM_MESSAGE = "Protobuf SBOM uploads are not supported"
+private const val UNSUPPORTED_EXPORT_FORMAT_MESSAGE = "Unsupported SBOM export format"
 
 private val routeJson = Json {
     ignoreUnknownKeys = true
@@ -123,8 +125,12 @@ private suspend fun RoutingContext.handleExport(service: VulnerabilityService) {
     val orgId = currentOrganizationId()
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
     val format = when (call.parameters["format"]?.lowercase()) {
+        null, "", "cyclonedx" -> SbomFormat.CYCLONEDX
         "spdx" -> SbomFormat.SPDX
-        else -> SbomFormat.CYCLONEDX
+        else -> {
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse(UNSUPPORTED_EXPORT_FORMAT_MESSAGE))
+            return
+        }
     }
     val fileName = if (format == SbomFormat.SPDX) "moneat-sbom.spdx.json" else "moneat-sbom.cdx.json"
     val exported = service.exportSbom(orgId, format)
@@ -177,10 +183,10 @@ private suspend fun ingestAgentBody(
     orgId: Int,
     body: ByteArray,
 ): SbomIngestResponse {
-    val direct = suspendRunCatching {
-        service.ingestRaw(orgId, body, SbomUploadContext(source = SbomSource.AGENT))
-    }.getOrNull()
-    if (direct != null) return direct
+    val direct = parseAgentDirectSbom(body)
+    if (direct != null) {
+        return service.ingestParsed(orgId, direct, SbomUploadContext(source = SbomSource.AGENT))
+    }
     val payload = routeJson.decodeFromString<DdSbomPayload>(body.decodeToString())
     val parsed = SbomParser.parseAgentPayload(payload)
     val context = SbomUploadContext(
@@ -194,6 +200,13 @@ private suspend fun ingestAgentBody(
     )
     return service.ingestParsed(orgId, parsed, context)
 }
+
+private fun parseAgentDirectSbom(body: ByteArray): ParsedSbom? =
+    try {
+        SbomParser.parse(body)
+    } catch (_: SbomValidationException) {
+        null
+    }
 
 private suspend fun RoutingContext.reserveAgentQuota(
     quotaService: BillingQuotaService,
@@ -221,12 +234,20 @@ private suspend fun RoutingContext.requireAdmin(membershipService: OrgMembership
     val allowed = suspendRunCatching {
         membershipService.requireRole(orgId, userId, OrgRole.ADMIN)
         true
-    }.getOrElse { false }
+    }.getOrElse { error ->
+        if (isExplicitAuthorizationDenial(error)) false else throw error
+    }
     if (!allowed) {
         call.respond(HttpStatusCode.Forbidden, ErrorResponse(FORBIDDEN_MESSAGE))
         return null
     }
     return orgId
+}
+
+private fun isExplicitAuthorizationDenial(error: Throwable): Boolean {
+    if (error !is IllegalStateException) return false
+    val message = error.message.orEmpty()
+    return message == NOT_MEMBER_MESSAGE || message.startsWith(FORBIDDEN_MESSAGE)
 }
 
 private suspend fun RoutingContext.respondIngestError(error: Throwable) {

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
@@ -1,0 +1,264 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.datadog.auth.DatadogAuthMiddleware
+import com.moneat.datadog.decompression.DecompressionService
+import com.moneat.datadog.models.DdSbomPayload
+import com.moneat.datadog.reserveDatadogQuota
+import com.moneat.org.services.OrgMembershipService
+import com.moneat.org.services.OrgRole
+import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.request.receive
+import io.ktor.server.response.header
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.json.Json
+import org.koin.core.context.GlobalContext
+
+private const val DEFAULT_LIMIT = 100
+private const val MAX_LIMIT = 500
+private const val MISSING_ORG_MESSAGE = "No active organization"
+private const val FORBIDDEN_MESSAGE = "Insufficient permissions"
+private const val INVALID_SBOM_MESSAGE = "Invalid SBOM payload"
+
+private val routeJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    coerceInputValues = true
+}
+
+fun Route.vulnerabilityRoutes(
+    service: VulnerabilityService = VulnerabilityService(),
+    membershipService: OrgMembershipService = GlobalContext.get().get(),
+    quotaService: BillingQuotaService = GlobalContext.get().get(),
+    includeApiRoutes: Boolean = true,
+    includeAgentRoutes: Boolean = true,
+) {
+    if (includeApiRoutes) {
+        route("/v1/security/vulnerabilities") {
+            authenticate("auth-jwt") {
+                get("/summary") { handleSummary(service) }
+                get("/inventory") { handleInventory(service) }
+                get("/findings") { handleFindings(service) }
+                get("/sbom/export") { handleExport(service) }
+                post("/sbom") { handleDirectUpload(service, membershipService) }
+            }
+        }
+    }
+
+    if (includeAgentRoutes) {
+        route("/dd/api/v2") {
+            post("/sbom") { handleAgentUpload(service, quotaService) }
+        }
+        route("/api/v2") {
+            post("/sbom") { handleAgentUpload(service, quotaService) }
+        }
+    }
+}
+
+private suspend fun RoutingContext.handleSummary(service: VulnerabilityService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    call.respond(service.summary(orgId))
+}
+
+private suspend fun RoutingContext.handleInventory(service: VulnerabilityService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    val filters = InventoryFilters(
+        search = call.parameters["search"],
+        packageName = call.parameters["package"],
+        target = call.parameters["target"],
+        limit = paramLimit(),
+        offset = paramOffset(),
+    )
+    call.respond(service.listInventory(orgId, filters))
+}
+
+private suspend fun RoutingContext.handleFindings(service: VulnerabilityService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    call.respond(
+        service.listFindings(
+            orgId = orgId,
+            severity = call.parameters["severity"],
+            status = call.parameters["status"],
+            packageName = call.parameters["package"],
+            limit = paramLimit(),
+            offset = paramOffset(),
+        )
+    )
+}
+
+private suspend fun RoutingContext.handleExport(service: VulnerabilityService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    val format = when (call.parameters["format"]?.lowercase()) {
+        "spdx" -> SbomFormat.SPDX
+        else -> SbomFormat.CYCLONEDX
+    }
+    val fileName = if (format == SbomFormat.SPDX) "moneat-sbom.spdx.json" else "moneat-sbom.cdx.json"
+    val exported = service.exportSbom(orgId, format)
+    call.response.header(HttpHeaders.ContentDisposition, "attachment; filename=\"$fileName\"")
+    call.respondText(exported, ContentType.Application.Json)
+}
+
+private suspend fun RoutingContext.handleDirectUpload(
+    service: VulnerabilityService,
+    membershipService: OrgMembershipService,
+) {
+    val orgId = requireAdmin(membershipService) ?: return
+    val rawBody = call.receive<ByteArray>()
+    val body = DecompressionService.decompress(rawBody, call.request.headers[HttpHeaders.ContentEncoding])
+    val context = SbomUploadContext(
+        source = SbomSource.DIRECT,
+        targetType = call.parameters["target_type"].orEmpty(),
+        targetName = call.parameters["target_name"].orEmpty(),
+        host = call.parameters["host"].orEmpty(),
+        imageName = call.parameters["image"].orEmpty(),
+        containerId = call.parameters["container_id"].orEmpty(),
+    )
+    suspendRunCatching { service.ingestRaw(orgId, body, context) }.fold(
+        onSuccess = { call.respond(HttpStatusCode.Created, it) },
+        onFailure = { respondIngestError(it) },
+    )
+}
+
+private suspend fun RoutingContext.handleAgentUpload(
+    service: VulnerabilityService,
+    quotaService: BillingQuotaService,
+) {
+    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
+    val contentType = call.request.headers[HttpHeaders.ContentType].orEmpty()
+    if (contentType.contains("protobuf")) {
+        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
+        return
+    }
+    val rawBody = call.receive<ByteArray>()
+    val body = DecompressionService.decompress(rawBody, call.request.headers[HttpHeaders.ContentEncoding])
+    if (!reserveAgentQuota(quotaService, orgId, body)) return
+    suspendRunCatching { ingestAgentBody(service, orgId, body) }.fold(
+        onSuccess = { call.respond(HttpStatusCode.Accepted, it) },
+        onFailure = { respondIngestError(it) },
+    )
+}
+
+private suspend fun ingestAgentBody(
+    service: VulnerabilityService,
+    orgId: Int,
+    body: ByteArray,
+): SbomIngestResponse {
+    val direct = suspendRunCatching {
+        service.ingestRaw(orgId, body, SbomUploadContext(source = SbomSource.AGENT))
+    }.getOrNull()
+    if (direct != null) return direct
+    val payload = routeJson.decodeFromString<DdSbomPayload>(body.decodeToString())
+    val parsed = SbomParser.parseAgentPayload(payload)
+    val context = SbomUploadContext(
+        source = SbomSource.AGENT,
+        targetType = if (payload.imageName.isNotBlank()) "image" else "host",
+        targetName = payload.imageName.ifBlank { payload.host },
+        host = payload.host,
+        imageName = payload.imageName,
+        containerId = payload.containerId,
+        tags = parseAgentTags(payload.tags),
+    )
+    return service.ingestParsed(orgId, parsed, context)
+}
+
+private suspend fun RoutingContext.reserveAgentQuota(
+    quotaService: BillingQuotaService,
+    organizationId: Int,
+    body: ByteArray,
+): Boolean =
+    reserveDatadogQuota(
+        call = call,
+        quotaService = quotaService,
+        organizationId = organizationId,
+        requestedUnits = 1,
+        eventType = "security_sbom",
+        requestedBytes = body.size.toLong(),
+    )
+
+private suspend fun RoutingContext.requireAdmin(membershipService: OrgMembershipService): Int? {
+    val orgId = currentOrganizationId() ?: run {
+        call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+        return null
+    }
+    val userId = currentUserId() ?: run {
+        call.respond(HttpStatusCode.Forbidden, ErrorResponse(FORBIDDEN_MESSAGE))
+        return null
+    }
+    val allowed = suspendRunCatching {
+        membershipService.requireRole(orgId, userId, OrgRole.ADMIN)
+        true
+    }.getOrElse { false }
+    if (!allowed) {
+        call.respond(HttpStatusCode.Forbidden, ErrorResponse(FORBIDDEN_MESSAGE))
+        return null
+    }
+    return orgId
+}
+
+private suspend fun RoutingContext.respondIngestError(error: Throwable) {
+    if (error is IllegalArgumentException) {
+        val message = if (error is SbomValidationException) {
+            error.message?.takeIf { it.isNotBlank() } ?: INVALID_SBOM_MESSAGE
+        } else {
+            INVALID_SBOM_MESSAGE
+        }
+        call.respond(HttpStatusCode.BadRequest, ErrorResponse(message))
+    } else {
+        throw error
+    }
+}
+
+private fun parseAgentTags(tags: List<String>): Map<String, String> =
+    tags.associate { tag ->
+        val index = tag.indexOf(':')
+        if (index > 0) {
+            tag.substring(0, index) to tag.substring(index + 1)
+        } else {
+            tag to ""
+        }
+    }
+
+private fun RoutingContext.currentOrganizationId(): Int? =
+    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+
+private fun RoutingContext.currentUserId(): Int? =
+    call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()
+
+private fun RoutingContext.paramLimit(): Int =
+    (call.parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+
+private fun RoutingContext.paramOffset(): Int =
+    (call.parameters["offset"]?.toIntOrNull() ?: 0).coerceAtLeast(0)

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
@@ -48,6 +48,7 @@ private const val MAX_LIMIT = 500
 private const val MISSING_ORG_MESSAGE = "No active organization"
 private const val FORBIDDEN_MESSAGE = "Insufficient permissions"
 private const val INVALID_SBOM_MESSAGE = "Invalid SBOM payload"
+private const val UNSUPPORTED_PROTOBUF_SBOM_MESSAGE = "Protobuf SBOM uploads are not supported"
 
 private val routeJson = Json {
     ignoreUnknownKeys = true
@@ -158,8 +159,8 @@ private suspend fun RoutingContext.handleAgentUpload(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     val contentType = call.request.headers[HttpHeaders.ContentType].orEmpty()
-    if (contentType.contains("protobuf")) {
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
+    if (contentType.contains("protobuf", ignoreCase = true)) {
+        call.respond(HttpStatusCode.UnsupportedMediaType, ErrorResponse(UNSUPPORTED_PROTOBUF_SBOM_MESSAGE))
         return
     }
     val rawBody = call.receive<ByteArray>()

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityService.kt
@@ -1,0 +1,332 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.security.signals.SecuritySignals
+import com.moneat.security.signals.SignalOutcome
+import com.moneat.security.signals.SignalSeverity
+import com.moneat.security.signals.SignalSource
+import com.moneat.security.signals.SignalSpec
+import com.moneat.security.signals.SignalWriter
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.time.Clock
+
+private const val DEFAULT_FINDING_LIMIT = 100
+private const val MAX_FINDING_LIMIT = 500
+private const val EXPORT_LIMIT = 5_000
+
+class VulnerabilityService(
+    private val inventoryStore: PackageInventoryStore = ClickHousePackageInventoryStore(),
+    private val matchService: VulnerabilityMatchService = VulnerabilityMatchService(),
+    private val upsertSignal: (Int, SignalSpec) -> SignalOutcome = SignalWriter::upsert,
+    private val now: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    suspend fun ingestRaw(orgId: Int, body: ByteArray, context: SbomUploadContext): SbomIngestResponse =
+        ingestParsed(orgId, SbomParser.parse(body), context)
+
+    suspend fun ingestParsed(orgId: Int, parsed: ParsedSbom, context: SbomUploadContext): SbomIngestResponse {
+        val uploadId = UUID.randomUUID()
+        val records = parsed.packages.map { pkg ->
+            pkg.toInventoryRecord(uploadId, orgId, parsed, context)
+        }
+        inventoryStore.insert(records)
+        val matches = matchService.match(records)
+        matches.forEach { match -> upsertVulnerabilitySignal(orgId, match) }
+        return SbomIngestResponse(
+            uploadId = uploadId.toString(),
+            packageCount = records.size,
+            findingCount = matches.size,
+        )
+    }
+
+    suspend fun listInventory(orgId: Int, filters: InventoryFilters): VulnerabilityInventoryResponse =
+        inventoryStore.list(
+            orgId,
+            filters.copy(
+                limit = filters.limit.coerceIn(1, MAX_FINDING_LIMIT),
+                offset = filters.offset.coerceAtLeast(0),
+            ),
+        )
+
+    fun listFindings(
+        orgId: Int,
+        severity: String? = null,
+        status: String? = null,
+        packageName: String? = null,
+        limit: Int = DEFAULT_FINDING_LIMIT,
+        offset: Int = 0,
+    ): VulnerabilityFindingListResponse =
+        transaction {
+            val predicate = findingPredicate(orgId, severity, status)
+            val filtered = SecuritySignals
+                .selectAll()
+                .where(predicate)
+                .orderBy(SecuritySignals.lastSeen to SortOrder.DESC, SecuritySignals.id to SortOrder.DESC)
+                .mapNotNull { row ->
+                    row.toFindingResponse(json).takeIf { finding ->
+                        packageName.isNullOrBlank() || finding.packageName.equals(packageName, ignoreCase = true)
+                    }
+                }
+            val rows = filtered
+                .drop(offset.coerceAtLeast(0))
+                .take(limit.coerceIn(1, MAX_FINDING_LIMIT))
+            val total = filtered.size.toLong()
+            VulnerabilityFindingListResponse(findings = rows, totalCount = total)
+        }
+
+    suspend fun summary(orgId: Int): VulnerabilitySummaryResponse {
+        val packageCount = inventoryStore.countPackages(orgId)
+        val findingCounts = transaction {
+            val rows = SecuritySignals
+                .selectAll()
+                .where {
+                    (SecuritySignals.organizationId eq orgId) and
+                        (SecuritySignals.signalSource eq SignalSource.VULNERABILITY.wire)
+                }
+                .map { it[SecuritySignals.severity] }
+            FindingCounts(
+                total = rows.size.toLong(),
+                critical = rows.count { it == SignalSeverity.CRITICAL.wire }.toLong(),
+                high = rows.count { it == SignalSeverity.HIGH.wire }.toLong(),
+            )
+        }
+        return VulnerabilitySummaryResponse(
+            packageCount = packageCount,
+            findingCount = findingCounts.total,
+            criticalCount = findingCounts.critical,
+            highCount = findingCounts.high,
+        )
+    }
+
+    suspend fun exportSbom(orgId: Int, format: SbomFormat): String {
+        val inventory = listInventory(orgId, InventoryFilters(limit = EXPORT_LIMIT)).inventory
+        return when (format) {
+            SbomFormat.CYCLONEDX -> exportCycloneDx(inventory)
+            SbomFormat.SPDX -> exportSpdx(inventory)
+            SbomFormat.AGENT -> exportCycloneDx(inventory)
+        }
+    }
+
+    private fun SbomPackageRecord.toInventoryRecord(
+        uploadId: UUID,
+        orgId: Int,
+        parsed: ParsedSbom,
+        context: SbomUploadContext,
+    ): SbomInventoryRecord {
+        val targetName = context.targetName.ifBlank {
+            parsed.targetName.ifBlank {
+                context.imageName.ifBlank { context.host }
+            }
+        }
+        return SbomInventoryRecord(
+            uploadId = uploadId,
+            organizationId = orgId,
+            source = context.source,
+            format = parsed.format,
+            targetType = context.targetType,
+            targetName = targetName,
+            host = context.host,
+            containerId = context.containerId,
+            imageName = context.imageName,
+            packageName = name,
+            packageVersion = version,
+            packageType = packageType,
+            ecosystem = ecosystem,
+            purl = purl,
+            licenses = licenses,
+            supplier = supplier,
+            bomRef = bomRef,
+            tags = context.tags,
+            collectedAtMs = now(),
+        )
+    }
+
+    private fun upsertVulnerabilitySignal(orgId: Int, match: VulnerabilityMatch) {
+        val advisory = match.advisory
+        val inventory = match.inventory
+        val cve = advisory.cveId.orEmpty()
+        val advisoryLabel = advisory.cveId ?: advisory.advisoryId
+        val entities = linkedMapOf(
+            "kind" to "vulnerability",
+            "advisory_id" to advisory.advisoryId,
+            "package" to inventory.packageName,
+            "version" to inventory.packageVersion,
+            "package_type" to inventory.packageType,
+            "ecosystem" to inventory.ecosystem,
+            "severity" to advisory.severity,
+            "link" to advisory.link,
+            "target_type" to inventory.targetType,
+            "target_name" to inventory.targetName,
+            "host" to inventory.host,
+            "image_name" to inventory.imageName,
+        )
+        if (cve.isNotBlank()) entities["cve"] = cve
+        advisory.cvssScore?.let { entities["cvss"] = it.toString() }
+        advisory.fixedVersion?.takeIf { it.isNotBlank() }?.let { entities["fix_version"] = it }
+        val spec = SignalSpec(
+            source = SignalSource.VULNERABILITY,
+            ruleId = "vulnerability:${advisory.advisoryId}",
+            ruleName = "$advisoryLabel in ${inventory.packageName}",
+            severity = SignalSeverity.fromWire(advisory.severity),
+            dedupKey = vulnerabilityDedupKey(advisory, inventory),
+            entities = entities,
+            evidenceType = "vulnerability_finding",
+            evidenceReference = "advisory=${advisory.advisoryId} package=${inventory.packageName}",
+            occurredAtMs = inventory.collectedAtMs,
+            tags = vulnerabilityTags(advisory, inventory),
+        )
+        upsertSignal(orgId, spec)
+    }
+
+    private fun findingPredicate(orgId: Int, severity: String?, status: String?): Op<Boolean> {
+        var predicate: Op<Boolean> = (SecuritySignals.organizationId eq orgId) and
+            (SecuritySignals.signalSource eq SignalSource.VULNERABILITY.wire)
+        if (!severity.isNullOrBlank()) {
+            predicate = predicate and (SecuritySignals.severity eq severity)
+        }
+        if (!status.isNullOrBlank()) {
+            predicate = predicate and (SecuritySignals.status eq status)
+        }
+        return predicate
+    }
+
+    private fun ResultRow.toFindingResponse(json: Json): VulnerabilityFindingResponse {
+        val entities = decodeEntities(json, this[SecuritySignals.entities])
+        return VulnerabilityFindingResponse(
+            signalId = this[SecuritySignals.id].value,
+            advisoryId = entities["advisory_id"].orEmpty(),
+            cveId = entities["cve"],
+            packageName = entities["package"].orEmpty(),
+            packageVersion = entities["version"].orEmpty(),
+            packageType = entities["package_type"].orEmpty(),
+            ecosystem = entities["ecosystem"].orEmpty(),
+            targetName = entities["target_name"].orEmpty(),
+            severity = this[SecuritySignals.severity],
+            cvssScore = entities["cvss"]?.toDoubleOrNull(),
+            fixedVersion = entities["fix_version"],
+            link = entities["link"].orEmpty(),
+            status = this[SecuritySignals.status],
+            lastSeen = this[SecuritySignals.lastSeen].toString(),
+        )
+    }
+
+    private fun decodeEntities(json: Json, raw: String): Map<String, String> =
+        runCatching {
+            json.parseToJsonElement(raw).jsonObject.mapValues { (_, value) ->
+                (value as? JsonPrimitive)?.contentOrNull ?: value.toString()
+            }
+        }.getOrDefault(emptyMap())
+
+    private fun vulnerabilityDedupKey(advisory: AdvisoryRecord, inventory: SbomInventoryRecord): String =
+        listOf(
+            advisory.advisoryId,
+            inventory.packageName,
+            inventory.packageVersion,
+            inventory.targetType,
+            inventory.targetName,
+            inventory.host,
+            inventory.imageName,
+        ).joinToString("|")
+
+    private fun vulnerabilityTags(advisory: AdvisoryRecord, inventory: SbomInventoryRecord): List<String> =
+        listOfNotNull(
+            "kind:vulnerability",
+            "package:${inventory.packageName}",
+            "severity:${advisory.severity}",
+            advisory.cveId?.let { "cve:$it" },
+        )
+
+    private fun exportCycloneDx(inventory: List<VulnerabilityInventoryItem>): String =
+        json.encodeToString(
+            buildJsonObject {
+                put("bomFormat", "CycloneDX")
+                put("specVersion", "1.5")
+                put("version", 1)
+                put(
+                    "components",
+                    buildJsonArray {
+                        inventory.forEach { item ->
+                            add(packageComponent(item))
+                        }
+                    },
+                )
+            }
+        )
+
+    private fun exportSpdx(inventory: List<VulnerabilityInventoryItem>): String =
+        json.encodeToString(
+            buildJsonObject {
+                put("spdxVersion", "SPDX-2.3")
+                put("SPDXID", "SPDXRef-DOCUMENT")
+                put("name", "Moneat SBOM export")
+                put(
+                    "packages",
+                    buildJsonArray {
+                        inventory.forEach { item ->
+                            add(spdxPackage(item))
+                        }
+                    },
+                )
+            }
+        )
+
+    private fun packageComponent(item: VulnerabilityInventoryItem): JsonObject =
+        buildJsonObject {
+            put("type", item.packageType.ifBlank { "library" })
+            put("name", item.packageName)
+            put("version", item.packageVersion)
+            if (item.purl.isNotBlank()) put("purl", item.purl)
+        }
+
+    private fun spdxPackage(item: VulnerabilityInventoryItem): JsonObject =
+        buildJsonObject {
+            put("name", item.packageName)
+            put("SPDXID", "SPDXRef-Package-${safeSpdxId(item.packageName)}")
+            put("versionInfo", item.packageVersion)
+            put("downloadLocation", "NOASSERTION")
+        }
+
+    private fun safeSpdxId(value: String): String =
+        value.replace(Regex("[^A-Za-z0-9.-]"), "-").ifBlank { "unknown" }
+
+    private data class FindingCounts(
+        val total: Long,
+        val critical: Long,
+        val high: Long,
+    )
+}

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityService.kt
@@ -38,12 +38,16 @@ import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.security.MessageDigest
 import java.util.UUID
 import kotlin.time.Clock
 
 private const val DEFAULT_FINDING_LIMIT = 100
 private const val MAX_FINDING_LIMIT = 500
 private const val EXPORT_LIMIT = 5_000
+private const val SPDX_ID_HASH_LENGTH = 12
+private const val SHA_256_ALGORITHM = "SHA-256"
+private const val BYTE_MASK = 0xff
 
 class VulnerabilityService(
     private val inventoryStore: PackageInventoryStore = ClickHousePackageInventoryStore(),
@@ -81,7 +85,7 @@ class VulnerabilityService(
                 limit = filters.limit.coerceIn(1, MAX_FINDING_LIMIT),
                 offset = filters.offset.coerceAtLeast(0),
             ),
-        )
+        ).withFindingCounts(orgId)
 
     fun listFindings(
         orgId: Int,
@@ -252,6 +256,50 @@ class VulnerabilityService(
             }
         }.getOrDefault(emptyMap())
 
+    private fun VulnerabilityInventoryResponse.withFindingCounts(orgId: Int): VulnerabilityInventoryResponse {
+        if (inventory.isEmpty()) return this
+        val requestedKeys = inventory.map { it.inventoryKey() }.toSet()
+        val counts = transaction {
+            SecuritySignals
+                .selectAll()
+                .where {
+                    (SecuritySignals.organizationId eq orgId) and
+                        (SecuritySignals.signalSource eq SignalSource.VULNERABILITY.wire)
+                }
+                .mapNotNull { row -> decodeEntities(json, row[SecuritySignals.entities]).inventoryKey() }
+                .filter { it in requestedKeys }
+                .groupingBy { it }
+                .eachCount()
+        }
+        return copy(
+            inventory = inventory.map { item ->
+                item.copy(findingCount = counts[item.inventoryKey()] ?: 0)
+            }
+        )
+    }
+
+    private fun VulnerabilityInventoryItem.inventoryKey(): InventoryFindingKey =
+        InventoryFindingKey(
+            packageName = packageName,
+            packageVersion = packageVersion,
+            targetType = targetType,
+            targetName = targetName,
+            host = host,
+            imageName = imageName,
+        )
+
+    private fun Map<String, String>.inventoryKey(): InventoryFindingKey? {
+        val packageName = this["package"] ?: return null
+        return InventoryFindingKey(
+            packageName = packageName,
+            packageVersion = this["version"].orEmpty(),
+            targetType = this["target_type"].orEmpty(),
+            targetName = this["target_name"].orEmpty(),
+            host = this["host"].orEmpty(),
+            imageName = this["image_name"].orEmpty(),
+        )
+    }
+
     private fun vulnerabilityDedupKey(advisory: AdvisoryRecord, inventory: SbomInventoryRecord): String =
         listOf(
             advisory.advisoryId,
@@ -316,7 +364,7 @@ class VulnerabilityService(
     private fun spdxPackage(item: VulnerabilityInventoryItem): JsonObject =
         buildJsonObject {
             put("name", item.packageName)
-            put("SPDXID", "SPDXRef-Package-${safeSpdxId(item.packageName)}")
+            put("SPDXID", "SPDXRef-Package-${safeSpdxId(item.packageName)}-${stableSpdxSuffix(item)}")
             put("versionInfo", item.packageVersion)
             put("downloadLocation", "NOASSERTION")
         }
@@ -324,9 +372,36 @@ class VulnerabilityService(
     private fun safeSpdxId(value: String): String =
         value.replace(Regex("[^A-Za-z0-9.-]"), "-").ifBlank { "unknown" }
 
+    private fun stableSpdxSuffix(item: VulnerabilityInventoryItem): String =
+        MessageDigest.getInstance(SHA_256_ALGORITHM)
+            .digest(item.spdxIdentity().toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and BYTE_MASK) }
+            .take(SPDX_ID_HASH_LENGTH)
+
+    private fun VulnerabilityInventoryItem.spdxIdentity(): String =
+        listOf(
+            packageName,
+            packageVersion,
+            packageType,
+            targetType,
+            targetName,
+            host,
+            imageName,
+            containerId,
+        ).joinToString("|")
+
     private data class FindingCounts(
         val total: Long,
         val critical: Long,
         val high: Long,
+    )
+
+    private data class InventoryFindingKey(
+        val packageName: String,
+        val packageVersion: String,
+        val targetType: String,
+        val targetName: String,
+        val host: String,
+        val imageName: String,
     )
 }

--- a/backend/src/main/resources/db/clickhouse_migration/V46__add_security_vulnerability_tables.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V46__add_security_vulnerability_tables.sql
@@ -1,0 +1,43 @@
+-- Security vulnerability package inventory.
+--
+-- This is the OSS SBOM inventory table used by direct uploads and compatibility ingest.
+-- It is deliberately org-keyed first in ORDER BY so every query can stay tenant scoped.
+
+CREATE TABLE IF NOT EXISTS security_package_inventory (
+    inventory_id UUID DEFAULT generateUUIDv4(),
+    upload_id UUID,
+    organization_id UInt64,
+    source LowCardinality(String) DEFAULT 'direct',
+    format LowCardinality(String) DEFAULT 'cyclonedx',
+    target_type LowCardinality(String) DEFAULT '',
+    target_name String DEFAULT '',
+    host String DEFAULT '',
+    container_id String DEFAULT '',
+    image_name String DEFAULT '',
+    package_name String DEFAULT '',
+    package_version String DEFAULT '',
+    package_type LowCardinality(String) DEFAULT '',
+    ecosystem LowCardinality(String) DEFAULT '',
+    purl String DEFAULT '',
+    licenses Array(String),
+    supplier String DEFAULT '',
+    bom_ref String DEFAULT '',
+    tags Map(String, String),
+    collected_at DateTime64(3, 'UTC') DEFAULT now(),
+    ingested_at DateTime64(3, 'UTC') DEFAULT now(),
+    INDEX idx_security_pkg_name package_name TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_security_pkg_purl purl TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_security_pkg_target target_name TYPE bloom_filter GRANULARITY 1
+) ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(collected_at)
+ORDER BY (
+    organization_id,
+    target_type,
+    target_name,
+    package_name,
+    package_version,
+    package_type,
+    purl
+)
+TTL toDateTime(collected_at) + INTERVAL 180 DAY
+SETTINGS index_granularity = 8192;

--- a/backend/src/main/resources/db/migration/V121__security_vulnerability_advisories.sql
+++ b/backend/src/main/resources/db/migration/V121__security_vulnerability_advisories.sql
@@ -1,0 +1,46 @@
+-- Local advisory mirror for vulnerability matching. Matching reads this mirror only; request-time
+-- SBOM ingest never calls external advisory feeds.
+
+CREATE TABLE security_vulnerability_advisories (
+    id SERIAL PRIMARY KEY,
+    source VARCHAR(32) NOT NULL,
+    advisory_id VARCHAR(255) NOT NULL,
+    cve_id VARCHAR(64),
+    package_name VARCHAR(512) NOT NULL,
+    ecosystem VARCHAR(64) NOT NULL DEFAULT '',
+    package_type VARCHAR(64) NOT NULL DEFAULT '',
+    affected_ranges JSONB NOT NULL DEFAULT '[]'::JSONB,
+    affected_versions JSONB NOT NULL DEFAULT '[]'::JSONB,
+    fixed_version VARCHAR(128),
+    severity VARCHAR(16) NOT NULL DEFAULT 'medium',
+    cvss_score NUMERIC(4, 1),
+    link TEXT NOT NULL DEFAULT '',
+    summary TEXT NOT NULL DEFAULT '',
+    raw_advisory JSONB NOT NULL DEFAULT '{}'::JSONB,
+    withdrawn BOOLEAN NOT NULL DEFAULT FALSE,
+    published_at TIMESTAMPTZ,
+    modified_at TIMESTAMPTZ,
+    ingested_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_security_vuln_advisory_unique
+    ON security_vulnerability_advisories (source, advisory_id, package_name, ecosystem, package_type);
+
+CREATE INDEX idx_security_vuln_advisory_package
+    ON security_vulnerability_advisories (package_name, ecosystem, package_type);
+
+CREATE INDEX idx_security_vuln_advisory_cve
+    ON security_vulnerability_advisories (cve_id);
+
+CREATE TABLE security_vulnerability_advisory_sync_runs (
+    id SERIAL PRIMARY KEY,
+    source VARCHAR(32) NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    advisory_count INTEGER NOT NULL DEFAULT 0,
+    error TEXT,
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_security_vuln_sync_runs_started
+    ON security_vulnerability_advisory_sync_runs (started_at);

--- a/backend/src/main/resources/security/advisories/osv-seed.json
+++ b/backend/src/main/resources/security/advisories/osv-seed.json
@@ -1,0 +1,60 @@
+[
+  {
+    "schema_version": "1.6.0",
+    "id": "CVE-2019-10744",
+    "aliases": ["GHSA-jf85-cpcp-j695"],
+    "summary": "Prototype pollution in lodash before 4.17.12",
+    "published": "2019-07-25T00:00:00Z",
+    "modified": "2025-01-01T00:00:00Z",
+    "database_specific": {
+      "severity": "critical",
+      "cvss_score": 9.8
+    },
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "npm",
+          "name": "lodash"
+        },
+        "ranges": [
+          {
+            "type": "SEMVER",
+            "events": [
+              {"introduced": "0"},
+              {"fixed": "4.17.12"}
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": "1.6.0",
+    "id": "CVE-2021-44906",
+    "aliases": ["GHSA-vh95-rmgr-6w4m", "GHSA-xvch-5gv4-984h"],
+    "summary": "Prototype pollution in minimist versions up to 1.2.5",
+    "published": "2022-03-18T00:00:00Z",
+    "modified": "2025-01-01T00:00:00Z",
+    "database_specific": {
+      "severity": "critical",
+      "cvss_score": 9.8
+    },
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "npm",
+          "name": "minimist"
+        },
+        "ranges": [
+          {
+            "type": "SEMVER",
+            "events": [
+              {"introduced": "0"},
+              {"fixed": "1.2.6"}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
@@ -95,6 +95,7 @@ class SignalWriterTest {
 
     @Test
     fun `repeat within an open signal refreshes entities tags and title`() {
+        // ──── Initial Signal ────
         val first = SignalWriter.upsert(
             orgId,
             spec(
@@ -105,6 +106,7 @@ class SignalWriterTest {
             )
         )
 
+        // ──── Repeat Occurrence ────
         SignalWriter.upsert(
             orgId,
             spec(
@@ -115,6 +117,7 @@ class SignalWriterTest {
             )
         )
 
+        // ──── Refreshed Metadata ────
         transaction {
             val row = SecuritySignals.selectAll().where { SecuritySignals.id eq first.signalId }.single()
             assertEquals("Updated advisory", row[SecuritySignals.ruleName])

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalWriterTest.kt
@@ -94,6 +94,36 @@ class SignalWriterTest {
     }
 
     @Test
+    fun `repeat within an open signal refreshes entities tags and title`() {
+        val first = SignalWriter.upsert(
+            orgId,
+            spec(
+                severity = SignalSeverity.MEDIUM,
+                ruleName = "Old advisory",
+                entities = mapOf("package" to "lodash", "fix_version" to "1.0.0"),
+                tags = listOf("severity:medium"),
+            )
+        )
+
+        SignalWriter.upsert(
+            orgId,
+            spec(
+                severity = SignalSeverity.MEDIUM,
+                ruleName = "Updated advisory",
+                entities = mapOf("package" to "lodash", "fix_version" to "2.0.0"),
+                tags = listOf("severity:medium", "cve:CVE-2026-0001"),
+            )
+        )
+
+        transaction {
+            val row = SecuritySignals.selectAll().where { SecuritySignals.id eq first.signalId }.single()
+            assertEquals("Updated advisory", row[SecuritySignals.ruleName])
+            assertTrue(row[SecuritySignals.entities].contains("\"fix_version\":\"2.0.0\""))
+            assertTrue(row[SecuritySignals.tags].contains("CVE-2026-0001"))
+        }
+    }
+
+    @Test
     fun `an out-of-order fold never moves last_seen back and lowers first_seen to the earliest`() {
         // Agent events can arrive out of order (Redis queue, multiple workers, producer retries).
         val baseMs = 1_700_000_000_000
@@ -187,16 +217,23 @@ class SignalWriterTest {
         }
     }
 
-    private fun spec(severity: SignalSeverity, occurredAtMs: Long = 1_700_000_000_000) = SignalSpec(
+    private fun spec(
+        severity: SignalSeverity,
+        occurredAtMs: Long = 1_700_000_000_000,
+        ruleName: String = "Suspicious exec",
+        entities: Map<String, String> = mapOf("host" to "web-01", "process" to "bash"),
+        tags: List<String> = emptyList(),
+    ) = SignalSpec(
         source = SignalSource.AGENT_RUNTIME,
         ruleId = "cws-1",
-        ruleName = "Suspicious exec",
+        ruleName = ruleName,
         severity = severity,
         dedupKey = "cws-1|web-01|bash",
-        entities = mapOf("host" to "web-01", "process" to "bash"),
+        entities = entities,
         evidenceType = "clickhouse_query",
         evidenceReference = "table=security_events dedup=cws-1|web-01|bash",
-        occurredAtMs = occurredAtMs
+        occurredAtMs = occurredAtMs,
+        tags = tags,
     )
 
     private fun seedOrg(name: String): Int =

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
@@ -41,10 +41,14 @@ class PackageInventoryStoreTest {
 
     @Test
     fun `list query selects and maps finding count`() = runBlocking {
+        var countQuery = ""
         var listQuery = ""
         coEvery {
             ClickHouseClient.executeWithFormat(match { it.contains("SELECT count() AS total_count") }, "JSONEachRow")
-        } returns "{\"total_count\":1}\n"
+        } coAnswers {
+            countQuery = firstArg()
+            "{\"total_count\":1}\n"
+        }
         coEvery {
             ClickHouseClient.executeWithFormat(
                 match {
@@ -61,6 +65,8 @@ class PackageInventoryStoreTest {
         val response = ClickHousePackageInventoryStore { "test_db" }.list(1, InventoryFilters())
 
         assertTrue(listQuery.contains("AS finding_count"))
+        assertTrue(countQuery.contains("package_type, ecosystem, purl"))
+        assertTrue(countQuery.contains("target_type, target_name, host, image_name, container_id"))
         assertEquals(2, response.inventory.single().findingCount)
         assertEquals(1, response.totalCount)
     }

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
@@ -1,0 +1,73 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.config.ClickHouseClient
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PackageInventoryStoreTest {
+
+    @BeforeTest
+    fun setup() {
+        mockkObject(ClickHouseClient)
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkObject(ClickHouseClient)
+    }
+
+    @Test
+    fun `list query selects and maps finding count`() = runBlocking {
+        var listQuery = ""
+        coEvery {
+            ClickHouseClient.executeWithFormat(match { it.contains("SELECT count() AS total_count") }, "JSONEachRow")
+        } returns "{\"total_count\":1}\n"
+        coEvery {
+            ClickHouseClient.executeWithFormat(
+                match {
+                    it.contains("security_package_inventory") &&
+                        !it.contains("SELECT count() AS total_count")
+                },
+                "JSONEachRow",
+            )
+        } coAnswers {
+            listQuery = firstArg()
+            inventoryRow(findingCount = 2)
+        }
+
+        val response = ClickHousePackageInventoryStore { "test_db" }.list(1, InventoryFilters())
+
+        assertTrue(listQuery.contains("AS finding_count"))
+        assertEquals(2, response.inventory.single().findingCount)
+        assertEquals(1, response.totalCount)
+    }
+
+    private fun inventoryRow(findingCount: Int): String =
+        """{"package_name":"lodash","package_version":"4.17.11","package_type":"npm","ecosystem":"npm",""" +
+            """"purl":"pkg:npm/lodash@4.17.11","target_type":"service","target_name":"checkout",""" +
+            """"host":"","image_name":"","container_id":"","last_seen":"2026-05-31T00:00:00.000Z",""" +
+            """"finding_count":$findingCount}"""
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/SbomParserTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/SbomParserTest.kt
@@ -19,6 +19,7 @@ package com.moneat.security.vulnerabilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class SbomParserTest {
 
@@ -88,5 +89,15 @@ class SbomParserTest {
             SbomParser.parse("""{"components": []}""".encodeToByteArray())
         }
         assertEquals("Unsupported SBOM format", error.message)
+    }
+
+    @Test
+    fun `malformed JSON preserves cause behind sanitized validation message`() {
+        val error = assertFailsWith<SbomValidationException> {
+            SbomParser.parse("""{"bomFormat": "CycloneDX", """.encodeToByteArray())
+        }
+
+        assertEquals("Malformed SBOM JSON", error.message)
+        assertNotNull(error.cause)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/SbomParserTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/SbomParserTest.kt
@@ -1,0 +1,92 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SbomParserTest {
+
+    @Test
+    fun `parses CycloneDX packages and purl ecosystem`() {
+        val parsed = SbomParser.parse(
+            """
+            {
+              "bomFormat": "CycloneDX",
+              "metadata": {"component": {"name": "checkout-api"}},
+              "components": [
+                {
+                  "type": "library",
+                  "name": "lodash",
+                  "version": "4.17.11",
+                  "purl": "pkg:npm/lodash@4.17.11",
+                  "licenses": [{"license": {"id": "MIT"}}]
+                }
+              ]
+            }
+            """.trimIndent().encodeToByteArray()
+        )
+
+        assertEquals(SbomFormat.CYCLONEDX, parsed.format)
+        assertEquals("checkout-api", parsed.targetName)
+        assertEquals("lodash", parsed.packages.single().name)
+        assertEquals("npm", parsed.packages.single().ecosystem)
+        assertEquals(listOf("MIT"), parsed.packages.single().licenses)
+    }
+
+    @Test
+    fun `parses SPDX package external refs`() {
+        val parsed = SbomParser.parse(
+            """
+            {
+              "spdxVersion": "SPDX-2.3",
+              "name": "worker-image",
+              "packages": [
+                {
+                  "SPDXID": "SPDXRef-Package-minimist",
+                  "name": "minimist",
+                  "versionInfo": "1.2.5",
+                  "licenseDeclared": "MIT",
+                  "externalRefs": [
+                    {
+                      "referenceCategory": "PACKAGE-MANAGER",
+                      "referenceType": "purl",
+                      "referenceLocator": "pkg:npm/minimist@1.2.5"
+                    }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent().encodeToByteArray()
+        )
+
+        assertEquals(SbomFormat.SPDX, parsed.format)
+        assertEquals("worker-image", parsed.targetName)
+        assertEquals("minimist", parsed.packages.single().name)
+        assertEquals("1.2.5", parsed.packages.single().version)
+        assertEquals("npm", parsed.packages.single().packageType)
+    }
+
+    @Test
+    fun `rejects malformed SBOMs safely`() {
+        val error = assertFailsWith<SbomValidationException> {
+            SbomParser.parse("""{"components": []}""".encodeToByteArray())
+        }
+        assertEquals("Unsupported SBOM format", error.message)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJobTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJobTest.kt
@@ -1,0 +1,82 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import java.nio.file.Files
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class VulnerabilityAdvisorySyncJobTest {
+
+    @Test
+    fun `sync loads bundled seed and optional local mirror file`() {
+        val mirror = Files.createTempFile("moneat-advisory", ".json")
+        mirror.writeText(
+            """
+            {
+              "ghsa_id": "GHSA-local-1111-2222",
+              "cve_id": "CVE-2026-1000",
+              "severity": "high",
+              "cvss": {"score": 7.5},
+              "vulnerabilities": [
+                {
+                  "package": {"ecosystem": "npm", "name": "local-only"},
+                  "vulnerable_version_range": "< 2.0.0",
+                  "first_patched_version": {"identifier": "2.0.0"}
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val repository = InMemoryAdvisoryRepository()
+        val job = VulnerabilityAdvisorySyncJob(repository) { mirror.toString() }
+
+        val count = job.syncOnce()
+
+        assertTrue(count >= 3)
+        assertTrue(repository.syncRuns.any { it.startsWith("local:success:") })
+        assertTrue(
+            repository.findCandidates(listOf(packageRecord("local-only"))).any {
+                it.advisoryId == "GHSA-local-1111-2222"
+            }
+        )
+    }
+
+    private fun packageRecord(name: String): SbomInventoryRecord =
+        SbomInventoryRecord(
+            uploadId = java.util.UUID.randomUUID(),
+            organizationId = 1,
+            source = SbomSource.DIRECT,
+            format = SbomFormat.CYCLONEDX,
+            targetType = "service",
+            targetName = "checkout",
+            host = "",
+            containerId = "",
+            imageName = "",
+            packageName = name,
+            packageVersion = "1.0.0",
+            packageType = "npm",
+            ecosystem = "npm",
+            purl = "",
+            licenses = emptyList(),
+            supplier = "",
+            bomRef = "",
+            tags = emptyMap(),
+            collectedAtMs = 1_700_000_000_000,
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJobTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJobTest.kt
@@ -46,9 +46,8 @@ class VulnerabilityAdvisorySyncJobTest {
         val repository = InMemoryAdvisoryRepository()
         val job = VulnerabilityAdvisorySyncJob(repository) { mirror.toString() }
 
-        val count = job.syncOnce()
+        job.syncOnce()
 
-        assertTrue(count >= 3)
         assertTrue(repository.syncRuns.any { it.startsWith("local:success:") })
         assertTrue(
             repository.findCandidates(listOf(packageRecord("local-only"))).any {

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchServiceTest.kt
@@ -1,0 +1,104 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VulnerabilityMatchServiceTest {
+
+    @Test
+    fun `OSV range matches vulnerable version and excludes fixed version`() {
+        val advisories = AdvisoryParser.parseDocument(
+            """
+            {
+              "id": "CVE-2019-10744",
+              "aliases": ["GHSA-jf85-cpcp-j695"],
+              "summary": "Prototype pollution",
+              "database_specific": {"severity": "critical", "cvss_score": 9.8},
+              "affected": [
+                {
+                  "package": {"ecosystem": "npm", "name": "lodash"},
+                  "ranges": [
+                    {"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "4.17.12"}]}
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val service = VulnerabilityMatchService(InMemoryAdvisoryRepository(advisories.toMutableList()))
+
+        val vulnerable = service.match(listOf(pkg("lodash", "4.17.11")))
+        val fixed = service.match(listOf(pkg("lodash", "4.17.12")))
+
+        assertEquals(1, vulnerable.size)
+        assertEquals("CVE-2019-10744", vulnerable.single().advisory.advisoryId)
+        assertTrue(fixed.isEmpty())
+    }
+
+    @Test
+    fun `GHSA range parser supports comparator expressions`() {
+        val advisories = AdvisoryParser.parseDocument(
+            """
+            {
+              "ghsa_id": "GHSA-test-1234-5678",
+              "cve_id": "CVE-2026-0001",
+              "severity": "high",
+              "cvss": {"score": 7.5},
+              "permalink": "https://github.com/advisories/GHSA-test-1234-5678",
+              "vulnerabilities": [
+                {
+                  "package": {"ecosystem": "npm", "name": "left-pad"},
+                  "vulnerable_version_range": ">= 1.0.0, < 1.3.0",
+                  "first_patched_version": {"identifier": "1.3.0"}
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val service = VulnerabilityMatchService(InMemoryAdvisoryRepository(advisories.toMutableList()))
+
+        assertEquals(1, service.match(listOf(pkg("left-pad", "1.2.0"))).size)
+        assertTrue(service.match(listOf(pkg("left-pad", "1.3.0"))).isEmpty())
+    }
+
+    private fun pkg(name: String, version: String): SbomInventoryRecord =
+        SbomInventoryRecord(
+            uploadId = UUID.randomUUID(),
+            organizationId = 1,
+            source = SbomSource.DIRECT,
+            format = SbomFormat.CYCLONEDX,
+            targetType = "service",
+            targetName = "checkout",
+            host = "",
+            containerId = "",
+            imageName = "",
+            packageName = name,
+            packageVersion = version,
+            packageType = "npm",
+            ecosystem = "npm",
+            purl = "pkg:npm/$name@$version",
+            licenses = emptyList(),
+            supplier = "",
+            bomRef = "",
+            tags = emptyMap(),
+            collectedAtMs = 1_700_000_000_000,
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityMatchServiceTest.kt
@@ -79,7 +79,112 @@ class VulnerabilityMatchServiceTest {
         assertTrue(service.match(listOf(pkg("left-pad", "1.3.0"))).isEmpty())
     }
 
-    private fun pkg(name: String, version: String): SbomInventoryRecord =
+    @Test
+    fun `semver ranges skip prereleases unless the range explicitly includes a prerelease boundary`() {
+        val service = VulnerabilityMatchService(
+            InMemoryAdvisoryRepository(
+                mutableListOf(
+                    advisory(
+                        affectedRanges = listOf(AdvisoryRange(type = "SEMVER", introduced = "0", fixed = "1.0.0"))
+                    )
+                )
+            )
+        )
+
+        assertTrue(service.match(listOf(pkg("lodash", "1.0.0-alpha.1"))).isEmpty())
+    }
+
+    @Test
+    fun `semver ranges can match prereleases when a prerelease boundary is present`() {
+        val service = VulnerabilityMatchService(
+            InMemoryAdvisoryRepository(
+                mutableListOf(
+                    advisory(
+                        affectedRanges = listOf(
+                            AdvisoryRange(type = "SEMVER", introduced = "1.0.0-alpha.1", fixed = "1.0.0")
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals(1, service.match(listOf(pkg("lodash", "1.0.0-beta.1"))).size)
+    }
+
+    @Test
+    fun `unsupported range types and non-semver package versions fail closed`() {
+        val service = VulnerabilityMatchService(
+            InMemoryAdvisoryRepository(
+                mutableListOf(
+                    advisory(
+                        ecosystem = "debian",
+                        packageType = "deb",
+                        affectedRanges = listOf(AdvisoryRange(type = "ECOSYSTEM", introduced = "0", fixed = "1.2.3"))
+                    ),
+                    advisory(
+                        advisoryId = "CVE-2026-0002",
+                        affectedRanges = listOf(AdvisoryRange(type = "SEMVER", vulnerableRange = "~1.2.0"))
+                    ),
+                )
+            )
+        )
+
+        assertTrue(service.match(listOf(pkg("lodash", "1.2.0-1", ecosystem = "debian", packageType = "deb"))).isEmpty())
+        assertTrue(service.match(listOf(pkg("lodash", "1.2.1"))).isEmpty())
+    }
+
+    @Test
+    fun `OSV last affected event matches through the inclusive upper bound`() {
+        val advisories = AdvisoryParser.parseDocument(
+            """
+            {
+              "id": "CVE-2026-0003",
+              "affected": [
+                {
+                  "package": {"ecosystem": "npm", "name": "lodash"},
+                  "ranges": [
+                    {"type": "SEMVER", "events": [{"introduced": "1.0.0"}, {"last_affected": "1.2.3"}]}
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val service = VulnerabilityMatchService(InMemoryAdvisoryRepository(advisories.toMutableList()))
+
+        assertEquals(1, service.match(listOf(pkg("lodash", "1.2.3"))).size)
+        assertTrue(service.match(listOf(pkg("lodash", "1.2.4"))).isEmpty())
+    }
+
+    private fun advisory(
+        advisoryId: String = "CVE-2019-10744",
+        ecosystem: String = "npm",
+        packageType: String = "npm",
+        affectedRanges: List<AdvisoryRange>,
+    ): AdvisoryRecord =
+        AdvisoryRecord(
+            source = "osv",
+            advisoryId = advisoryId,
+            cveId = advisoryId,
+            packageName = "lodash",
+            ecosystem = ecosystem,
+            packageType = packageType,
+            affectedRanges = affectedRanges,
+            affectedVersions = emptyList(),
+            fixedVersion = null,
+            severity = "critical",
+            cvssScore = 9.8,
+            link = "https://osv.dev/vulnerability/$advisoryId",
+            summary = "Prototype pollution",
+            rawAdvisory = "{}",
+        )
+
+    private fun pkg(
+        name: String,
+        version: String,
+        ecosystem: String = "npm",
+        packageType: String = "npm",
+    ): SbomInventoryRecord =
         SbomInventoryRecord(
             uploadId = UUID.randomUUID(),
             organizationId = 1,
@@ -92,9 +197,9 @@ class VulnerabilityMatchServiceTest {
             imageName = "",
             packageName = name,
             packageVersion = version,
-            packageType = "npm",
-            ecosystem = "npm",
-            purl = "pkg:npm/$name@$version",
+            packageType = packageType,
+            ecosystem = ecosystem,
+            purl = "pkg:$ecosystem/$name@$version",
             licenses = emptyList(),
             supplier = "",
             bomRef = "",

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
@@ -19,6 +19,8 @@ package com.moneat.security.vulnerabilities
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.services.DatadogService
+import com.moneat.org.repositories.OrgMembershipRepository
+import com.moneat.org.repositories.models.OrgMemberRow
 import com.moneat.org.services.OrgMembershipService
 import com.moneat.security.signals.SignalSchemaTestSupport
 import com.moneat.testsupport.RouteTestSupport.createToken
@@ -37,6 +39,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
@@ -103,13 +106,61 @@ class VulnerabilityRoutesTest {
     }
 
     @Test
+    fun `unknown SBOM export format is rejected`() = testApplication {
+        setupApp(InMemoryPackageInventoryStore())
+
+        val response = client.get("/v1/security/vulnerabilities/sbom/export?format=xml") {
+            withAuth(createToken(userId = 12, orgId = ORG_ID))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("Unsupported SBOM export format"))
+    }
+
+    @Test
+    fun `direct upload maps explicit authorization denial to forbidden`() = testApplication {
+        setupApp(
+            store = InMemoryPackageInventoryStore(),
+            membershipService = OrgMembershipService(StaticOrgMembershipRepository(role = null)),
+        )
+
+        val response = client.post("/v1/security/vulnerabilities/sbom") {
+            withAuth(createToken(userId = 12, orgId = ORG_ID))
+            contentType(ContentType.Application.Json)
+            setBody(cycloneDx)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `direct upload surfaces membership service failures`() = testApplication {
+        setupApp(
+            store = InMemoryPackageInventoryStore(),
+            membershipService = OrgMembershipService(ThrowingOrgMembershipRepository()),
+        )
+
+        val response = client.post("/v1/security/vulnerabilities/sbom") {
+            withAuth(createToken(userId = 12, orgId = ORG_ID))
+            contentType(ContentType.Application.Json)
+            setBody(cycloneDx)
+        }
+
+        assertEquals(HttpStatusCode.InternalServerError, response.status)
+    }
+
+    @Test
     fun `agent protobuf SBOM upload is rejected instead of acknowledged`() = testApplication {
         val store = InMemoryPackageInventoryStore()
         mockkObject(DatadogService)
         try {
             DatadogAuthMiddleware.clearCache()
             every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
-            setupApp(store, includeAgentRoutes = true)
+            setupApp(
+                store = store,
+                includeAgentRoutes = true,
+                quotaService = quotaServiceWithoutEnforcement(),
+            )
 
             val response = client.post("/dd/api/v2/sbom") {
                 header("DD-API-KEY", VALID_KEY)
@@ -126,9 +177,64 @@ class VulnerabilityRoutesTest {
         }
     }
 
+    @Test
+    fun `agent JSON envelope falls back after direct SBOM validation fails`() = testApplication {
+        val store = InMemoryPackageInventoryStore()
+        mockkObject(DatadogService)
+        try {
+            DatadogAuthMiddleware.clearCache()
+            every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+            setupApp(
+                store = store,
+                includeAgentRoutes = true,
+                quotaService = quotaServiceWithoutEnforcement(),
+            )
+
+            val response = client.post("/dd/api/v2/sbom") {
+                header("DD-API-KEY", VALID_KEY)
+                contentType(ContentType.Application.Json)
+                setBody(agentSbom)
+            }
+
+            assertEquals(HttpStatusCode.Accepted, response.status)
+            assertEquals("lodash", store.inserted.single().packageName)
+            assertEquals("web-01", store.inserted.single().targetName)
+        } finally {
+            DatadogAuthMiddleware.clearCache()
+            unmockkObject(DatadogService)
+        }
+    }
+
+    @Test
+    fun `agent direct SBOM persistence failures surface instead of falling back`() = testApplication {
+        mockkObject(DatadogService)
+        try {
+            DatadogAuthMiddleware.clearCache()
+            every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+            setupApp(
+                store = FailingPackageInventoryStore(),
+                includeAgentRoutes = true,
+                quotaService = quotaServiceWithoutEnforcement(),
+            )
+
+            val response = client.post("/dd/api/v2/sbom") {
+                header("DD-API-KEY", VALID_KEY)
+                contentType(ContentType.Application.Json)
+                setBody(cycloneDx)
+            }
+
+            assertEquals(HttpStatusCode.InternalServerError, response.status)
+        } finally {
+            DatadogAuthMiddleware.clearCache()
+            unmockkObject(DatadogService)
+        }
+    }
+
     private fun ApplicationTestBuilder.setupApp(
-        store: InMemoryPackageInventoryStore,
+        store: PackageInventoryStore,
         includeAgentRoutes: Boolean = false,
+        membershipService: OrgMembershipService = OrgMembershipService(StaticOrgMembershipRepository()),
+        quotaService: BillingQuotaService = BillingQuotaService(),
     ) {
         if (db == null) {
             db = Database.connect(
@@ -146,12 +252,38 @@ class VulnerabilityRoutesTest {
                         inventoryStore = store,
                         matchService = VulnerabilityMatchService(InMemoryAdvisoryRepository()),
                     ),
-                    membershipService = OrgMembershipService(StaticOrgMembershipRepository()),
-                    quotaService = BillingQuotaService(),
+                    membershipService = membershipService,
+                    quotaService = quotaService,
                     includeAgentRoutes = includeAgentRoutes,
                 )
             }
         }
+    }
+
+    private fun quotaServiceWithoutEnforcement(): BillingQuotaService =
+        mockk<BillingQuotaService>().also {
+            every { it.isEnforcementEnabled() } returns false
+        }
+
+    private class FailingPackageInventoryStore : PackageInventoryStore {
+        override suspend fun insert(records: List<SbomInventoryRecord>) {
+            throw IllegalStateException("inventory unavailable")
+        }
+
+        override suspend fun list(orgId: Int, filters: InventoryFilters): VulnerabilityInventoryResponse =
+            VulnerabilityInventoryResponse(emptyList(), 0)
+
+        override suspend fun countPackages(orgId: Int): Long = 0
+    }
+
+    private class ThrowingOrgMembershipRepository : OrgMembershipRepository {
+        override fun getMembers(orgId: Int): List<OrgMemberRow> = emptyList()
+        override fun getMemberRole(orgId: Int, userId: Int): String = error("membership repository unavailable")
+        override fun updateMemberRole(orgId: Int, targetUserId: Int, newRole: String): Int = 0
+        override fun removeMember(orgId: Int, targetUserId: Int): Int = 0
+        override fun isMember(orgId: Int, userId: Int): Boolean = false
+        override fun getOwnerCount(orgId: Int): Int = 0
+        override fun addMember(orgId: Int, userId: Int, role: String) = Unit
     }
 
     private fun inventoryRecord(orgId: Int, packageName: String): SbomInventoryRecord =
@@ -183,6 +315,16 @@ class VulnerabilityRoutesTest {
           "components": [
             {"type": "library", "name": "lodash", "version": "4.17.11", "purl": "pkg:npm/lodash@4.17.11"}
           ]
+        }
+    """.trimIndent()
+
+    private val agentSbom = """
+        {
+          "host": "web-01",
+          "packages": [
+            {"name": "lodash", "version": "4.17.11", "type": "npm"}
+          ],
+          "tags": ["env:test"]
         }
     """.trimIndent()
 

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
@@ -17,26 +17,38 @@
 package com.moneat.security.vulnerabilities
 
 import com.moneat.billing.services.BillingQuotaService
+import com.moneat.datadog.auth.DatadogAuthMiddleware
+import com.moneat.datadog.services.DatadogService
 import com.moneat.org.services.OrgMembershipService
+import com.moneat.security.signals.SignalSchemaTestSupport
 import com.moneat.testsupport.RouteTestSupport.createToken
 import com.moneat.testsupport.RouteTestSupport.installJwtAuth
 import com.moneat.testsupport.RouteTestSupport.withAuth
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class VulnerabilityRoutesTest {
+
+    private var db: Database? = null
 
     @Test
     fun `direct upload requires authentication`() = testApplication {
@@ -90,7 +102,42 @@ class VulnerabilityRoutesTest {
         assertTrue(!body.contains("minimist"))
     }
 
-    private fun ApplicationTestBuilder.setupApp(store: InMemoryPackageInventoryStore) {
+    @Test
+    fun `agent protobuf SBOM upload is rejected instead of acknowledged`() = testApplication {
+        val store = InMemoryPackageInventoryStore()
+        mockkObject(DatadogService)
+        try {
+            DatadogAuthMiddleware.clearCache()
+            every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+            setupApp(store, includeAgentRoutes = true)
+
+            val response = client.post("/dd/api/v2/sbom") {
+                header("DD-API-KEY", VALID_KEY)
+                header(HttpHeaders.ContentType, "application/x-protobuf")
+                setBody(byteArrayOf(1, 2, 3))
+            }
+
+            assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+            assertTrue(response.bodyAsText().contains("Protobuf SBOM uploads are not supported"))
+            assertTrue(store.inserted.isEmpty())
+        } finally {
+            DatadogAuthMiddleware.clearCache()
+            unmockkObject(DatadogService)
+        }
+    }
+
+    private fun ApplicationTestBuilder.setupApp(
+        store: InMemoryPackageInventoryStore,
+        includeAgentRoutes: Boolean = false,
+    ) {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_vulnerability_routes;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        SignalSchemaTestSupport.reset()
         application {
             installJwtAuth()
             routing {
@@ -101,7 +148,7 @@ class VulnerabilityRoutesTest {
                     ),
                     membershipService = OrgMembershipService(StaticOrgMembershipRepository()),
                     quotaService = BillingQuotaService(),
-                    includeAgentRoutes = false,
+                    includeAgentRoutes = includeAgentRoutes,
                 )
             }
         }
@@ -142,5 +189,6 @@ class VulnerabilityRoutesTest {
     private companion object {
         const val ORG_ID = 101
         const val OTHER_ORG_ID = 202
+        const val VALID_KEY = "vulnerability-route-test-key"
     }
 }

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
@@ -1,0 +1,146 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.org.services.OrgMembershipService
+import com.moneat.testsupport.RouteTestSupport.createToken
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VulnerabilityRoutesTest {
+
+    @Test
+    fun `direct upload requires authentication`() = testApplication {
+        setupApp(InMemoryPackageInventoryStore())
+
+        val response = client.post("/v1/security/vulnerabilities/sbom") {
+            contentType(ContentType.Application.Json)
+            setBody(cycloneDx)
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `direct upload ingests CycloneDX without enterprise route registration`() = testApplication {
+        val store = InMemoryPackageInventoryStore()
+        setupApp(store)
+
+        val response = client.post("/v1/security/vulnerabilities/sbom?target_type=service&target_name=checkout") {
+            withAuth(createToken(userId = 12, orgId = ORG_ID))
+            contentType(ContentType.Application.Json)
+            setBody(cycloneDx)
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertTrue(response.bodyAsText().contains("\"package_count\":1"))
+        assertEquals("lodash", store.inserted.single().packageName)
+        assertEquals("checkout", store.inserted.single().targetName)
+    }
+
+    @Test
+    fun `inventory list is scoped to JWT organization`() = testApplication {
+        val store = InMemoryPackageInventoryStore()
+        runBlocking {
+            store.insert(
+                listOf(
+                    inventoryRecord(ORG_ID, "lodash"),
+                    inventoryRecord(OTHER_ORG_ID, "minimist"),
+                )
+            )
+        }
+        setupApp(store)
+
+        val response = client.get("/v1/security/vulnerabilities/inventory") {
+            withAuth(createToken(userId = 12, orgId = ORG_ID))
+        }
+
+        val body = response.bodyAsText()
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(body.contains("lodash"))
+        assertTrue(!body.contains("minimist"))
+    }
+
+    private fun ApplicationTestBuilder.setupApp(store: InMemoryPackageInventoryStore) {
+        application {
+            installJwtAuth()
+            routing {
+                vulnerabilityRoutes(
+                    service = VulnerabilityService(
+                        inventoryStore = store,
+                        matchService = VulnerabilityMatchService(InMemoryAdvisoryRepository()),
+                    ),
+                    membershipService = OrgMembershipService(StaticOrgMembershipRepository()),
+                    quotaService = BillingQuotaService(),
+                    includeAgentRoutes = false,
+                )
+            }
+        }
+    }
+
+    private fun inventoryRecord(orgId: Int, packageName: String): SbomInventoryRecord =
+        SbomInventoryRecord(
+            uploadId = java.util.UUID.randomUUID(),
+            organizationId = orgId,
+            source = SbomSource.DIRECT,
+            format = SbomFormat.CYCLONEDX,
+            targetType = "service",
+            targetName = "checkout",
+            host = "",
+            containerId = "",
+            imageName = "",
+            packageName = packageName,
+            packageVersion = "1.0.0",
+            packageType = "npm",
+            ecosystem = "npm",
+            purl = "pkg:npm/$packageName@1.0.0",
+            licenses = emptyList(),
+            supplier = "",
+            bomRef = "",
+            tags = emptyMap(),
+            collectedAtMs = 1_700_000_000_000,
+        )
+
+    private val cycloneDx = """
+        {
+          "bomFormat": "CycloneDX",
+          "components": [
+            {"type": "library", "name": "lodash", "version": "4.17.11", "purl": "pkg:npm/lodash@4.17.11"}
+          ]
+        }
+    """.trimIndent()
+
+    private companion object {
+        const val ORG_ID = 101
+        const val OTHER_ORG_ID = 202
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
@@ -21,6 +21,10 @@ import com.moneat.security.signals.SignalSchemaTestSupport
 import com.moneat.security.signals.SignalSource
 import com.moneat.shared.models.Organizations
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -94,12 +98,133 @@ class VulnerabilityServiceTest {
                 .single()
             assertEquals("vulnerability:CVE-2019-10744", row[SecuritySignals.ruleId])
             assertEquals("critical", row[SecuritySignals.severity])
+            assertEquals(1, row[SecuritySignals.sampleCount])
             assertTrue(row[SecuritySignals.entities].contains("\"cve\":\"CVE-2019-10744\""))
             assertTrue(row[SecuritySignals.entities].contains("\"fix_version\":\"4.17.12\""))
         }
+
+        val inventory = service.listInventory(orgId, InventoryFilters()).inventory.single()
+        assertEquals(1, inventory.findingCount)
     }
 
-    private fun advisory(): AdvisoryRecord =
+    @Test
+    fun `repeated vulnerable package refreshes advisory metadata on folded signal`() = runBlocking {
+        val store = InMemoryPackageInventoryStore()
+        val firstService = VulnerabilityService(
+            inventoryStore = store,
+            matchService = VulnerabilityMatchService(
+                InMemoryAdvisoryRepository(mutableListOf(advisory(fixedVersion = "4.17.12")))
+            ),
+            now = { 1_700_000_000_000 },
+        )
+        val secondService = VulnerabilityService(
+            inventoryStore = store,
+            matchService = VulnerabilityMatchService(
+                InMemoryAdvisoryRepository(
+                    mutableListOf(
+                        advisory(
+                            fixedVersion = "4.17.13",
+                            cvssScore = 8.8,
+                            link = "https://osv.dev/vulnerability/CVE-2019-10744?rev=2",
+                        )
+                    )
+                )
+            ),
+            now = { 1_700_000_060_000 },
+        )
+
+        firstService.ingestParsed(orgId, parsedLodash(), uploadContext())
+        secondService.ingestParsed(orgId, parsedLodash(), uploadContext())
+
+        transaction {
+            val row = SecuritySignals
+                .selectAll()
+                .where { SecuritySignals.signalSource eq SignalSource.VULNERABILITY.wire }
+                .single()
+            assertEquals(2, row[SecuritySignals.sampleCount])
+            assertTrue(row[SecuritySignals.entities].contains("\"fix_version\":\"4.17.13\""))
+            assertTrue(row[SecuritySignals.entities].contains("\"cvss\":\"8.8\""))
+            assertTrue(row[SecuritySignals.entities].contains("rev=2"))
+        }
+    }
+
+    @Test
+    fun `SPDX export uses stable unique IDs for same package name in different targets`() = runBlocking {
+        val store = InMemoryPackageInventoryStore()
+        store.insert(
+            listOf(
+                inventoryRecord(packageVersion = "4.17.11", targetName = "checkout"),
+                inventoryRecord(packageVersion = "4.17.12", targetName = "billing"),
+            )
+        )
+        val service = VulnerabilityService(
+            inventoryStore = store,
+            matchService = VulnerabilityMatchService(InMemoryAdvisoryRepository()),
+        )
+
+        val firstExport = spdxIds(service.exportSbom(orgId, SbomFormat.SPDX))
+        val secondExport = spdxIds(service.exportSbom(orgId, SbomFormat.SPDX))
+
+        assertEquals(firstExport, secondExport)
+        assertEquals(2, firstExport.toSet().size)
+        assertTrue(firstExport.all { it.startsWith("SPDXRef-Package-lodash-") })
+    }
+
+    private fun spdxIds(exported: String): List<String> {
+        val packages = Json.parseToJsonElement(exported).jsonObject["packages"]?.jsonArray.orEmpty()
+        return packages.map { pkg ->
+            pkg.jsonObject["SPDXID"]?.jsonPrimitive?.content.orEmpty()
+        }
+    }
+
+    private fun parsedLodash(): ParsedSbom =
+        ParsedSbom(
+            format = SbomFormat.CYCLONEDX,
+            targetName = "checkout",
+            packages = listOf(
+                SbomPackageRecord(
+                    name = "lodash",
+                    version = "4.17.11",
+                    packageType = "npm",
+                    ecosystem = "npm",
+                )
+            ),
+        )
+
+    private fun uploadContext(): SbomUploadContext =
+        SbomUploadContext(source = SbomSource.DIRECT, targetType = "service", targetName = "checkout")
+
+    private fun inventoryRecord(
+        packageVersion: String,
+        targetName: String,
+    ): SbomInventoryRecord =
+        SbomInventoryRecord(
+            uploadId = java.util.UUID.randomUUID(),
+            organizationId = orgId,
+            source = SbomSource.DIRECT,
+            format = SbomFormat.CYCLONEDX,
+            targetType = "service",
+            targetName = targetName,
+            host = "",
+            containerId = "",
+            imageName = "",
+            packageName = "lodash",
+            packageVersion = packageVersion,
+            packageType = "npm",
+            ecosystem = "npm",
+            purl = "pkg:npm/lodash@$packageVersion",
+            licenses = emptyList(),
+            supplier = "",
+            bomRef = "",
+            tags = emptyMap(),
+            collectedAtMs = 1_700_000_000_000,
+        )
+
+    private fun advisory(
+        fixedVersion: String = "4.17.12",
+        cvssScore: Double? = 9.8,
+        link: String = "https://osv.dev/vulnerability/CVE-2019-10744",
+    ): AdvisoryRecord =
         AdvisoryRecord(
             source = "osv",
             advisoryId = "CVE-2019-10744",
@@ -107,12 +232,12 @@ class VulnerabilityServiceTest {
             packageName = "lodash",
             ecosystem = "npm",
             packageType = "npm",
-            affectedRanges = listOf(AdvisoryRange(introduced = "0", fixed = "4.17.12")),
+            affectedRanges = listOf(AdvisoryRange(type = "SEMVER", introduced = "0", fixed = fixedVersion)),
             affectedVersions = emptyList(),
-            fixedVersion = "4.17.12",
+            fixedVersion = fixedVersion,
             severity = "critical",
-            cvssScore = 9.8,
-            link = "https://osv.dev/vulnerability/CVE-2019-10744",
+            cvssScore = cvssScore,
+            link = link,
             summary = "Prototype pollution",
             rawAdvisory = "{}",
         )

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
@@ -37,21 +37,16 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class VulnerabilityServiceTest {
-    companion object {
-        private var db: Database? = null
-    }
-
     private var orgId = 0
 
     @BeforeTest
     fun setup() {
-        if (db == null) {
-            db = Database.connect(
-                url = "jdbc:h2:mem:moneat_vulnerability_service;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
-                driver = "org.h2.Driver",
-            )
-        }
-        TransactionManager.defaultDatabase = db
+        val databaseName = "moneat_vulnerability_service_" +
+            java.util.UUID.randomUUID().toString().replace("-", "")
+        TransactionManager.defaultDatabase = Database.connect(
+            url = "jdbc:h2:mem:$databaseName;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver",
+        )
         SignalSchemaTestSupport.reset()
         orgId = transaction {
             Organizations.insert {

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
@@ -20,6 +20,7 @@ import com.moneat.security.signals.SecuritySignals
 import com.moneat.security.signals.SignalSchemaTestSupport
 import com.moneat.security.signals.SignalSource
 import com.moneat.shared.models.Organizations
+import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -41,10 +42,8 @@ class VulnerabilityServiceTest {
 
     @BeforeTest
     fun setup() {
-        val databaseName = "moneat_vulnerability_service_" +
-            java.util.UUID.randomUUID().toString().replace("-", "")
         TransactionManager.defaultDatabase = Database.connect(
-            url = "jdbc:h2:mem:$databaseName;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+            url = isolatedH2Url(),
             driver = "org.h2.Driver",
         )
         SignalSchemaTestSupport.reset()
@@ -54,6 +53,11 @@ class VulnerabilityServiceTest {
                 it[slug] = "acme"
             } get Organizations.id
         }
+    }
+
+    private fun isolatedH2Url(): String {
+        val databaseName = "moneat_vulnerability_service_" + UUID.randomUUID().toString().replace("-", "")
+        return "jdbc:h2:mem:$databaseName;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1"
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityServiceTest.kt
@@ -1,0 +1,119 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.security.signals.SecuritySignals
+import com.moneat.security.signals.SignalSchemaTestSupport
+import com.moneat.security.signals.SignalSource
+import com.moneat.shared.models.Organizations
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VulnerabilityServiceTest {
+    companion object {
+        private var db: Database? = null
+    }
+
+    private var orgId = 0
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_vulnerability_service;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        SignalSchemaTestSupport.reset()
+        orgId = transaction {
+            Organizations.insert {
+                it[name] = "acme"
+                it[slug] = "acme"
+            } get Organizations.id
+        }
+    }
+
+    @Test
+    fun `ingested vulnerable package upserts vulnerability signal with metadata`() = runBlocking {
+        val store = InMemoryPackageInventoryStore()
+        val repo = InMemoryAdvisoryRepository(mutableListOf(advisory()))
+        val service = VulnerabilityService(
+            inventoryStore = store,
+            matchService = VulnerabilityMatchService(repo),
+            now = { 1_700_000_000_000 },
+        )
+
+        val response = service.ingestParsed(
+            orgId,
+            ParsedSbom(
+                format = SbomFormat.CYCLONEDX,
+                targetName = "checkout",
+                packages = listOf(
+                    SbomPackageRecord(
+                        name = "lodash",
+                        version = "4.17.11",
+                        packageType = "npm",
+                        ecosystem = "npm",
+                    )
+                ),
+            ),
+            SbomUploadContext(source = SbomSource.DIRECT, targetType = "service", targetName = "checkout"),
+        )
+
+        assertEquals(1, response.packageCount)
+        assertEquals(1, response.findingCount)
+        assertEquals(1, store.inserted.size)
+        transaction {
+            val row = SecuritySignals
+                .selectAll()
+                .where { SecuritySignals.signalSource eq SignalSource.VULNERABILITY.wire }
+                .single()
+            assertEquals("vulnerability:CVE-2019-10744", row[SecuritySignals.ruleId])
+            assertEquals("critical", row[SecuritySignals.severity])
+            assertTrue(row[SecuritySignals.entities].contains("\"cve\":\"CVE-2019-10744\""))
+            assertTrue(row[SecuritySignals.entities].contains("\"fix_version\":\"4.17.12\""))
+        }
+    }
+
+    private fun advisory(): AdvisoryRecord =
+        AdvisoryRecord(
+            source = "osv",
+            advisoryId = "CVE-2019-10744",
+            cveId = "CVE-2019-10744",
+            packageName = "lodash",
+            ecosystem = "npm",
+            packageType = "npm",
+            affectedRanges = listOf(AdvisoryRange(introduced = "0", fixed = "4.17.12")),
+            affectedVersions = emptyList(),
+            fixedVersion = "4.17.12",
+            severity = "critical",
+            cvssScore = 9.8,
+            link = "https://osv.dev/vulnerability/CVE-2019-10744",
+            summary = "Prototype pollution",
+            rawAdvisory = "{}",
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityTestSupport.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityTestSupport.kt
@@ -1,0 +1,94 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.org.repositories.OrgMembershipRepository
+import com.moneat.org.repositories.models.OrgMemberRow
+
+class InMemoryAdvisoryRepository(
+    private val advisories: MutableList<AdvisoryRecord> = mutableListOf(),
+) : VulnerabilityAdvisoryRepository {
+    val syncRuns = mutableListOf<String>()
+
+    override fun upsertAll(advisories: List<AdvisoryRecord>): Int {
+        this.advisories.removeAll { existing ->
+            advisories.any { next ->
+                existing.source == next.source &&
+                    existing.advisoryId == next.advisoryId &&
+                    existing.packageName == next.packageName &&
+                    existing.ecosystem == next.ecosystem
+            }
+        }
+        this.advisories += advisories
+        return advisories.size
+    }
+
+    override fun findCandidates(packages: Collection<SbomInventoryRecord>): List<AdvisoryRecord> {
+        val names = packages.map { it.packageName }.toSet()
+        return advisories.filter { it.packageName in names && !it.withdrawn }
+    }
+
+    override fun recordSyncRun(source: String, status: String, advisoryCount: Int, error: String?) {
+        syncRuns += "$source:$status:$advisoryCount:${error.orEmpty()}"
+    }
+}
+
+class InMemoryPackageInventoryStore : PackageInventoryStore {
+    val inserted = mutableListOf<SbomInventoryRecord>()
+
+    override suspend fun insert(records: List<SbomInventoryRecord>) {
+        inserted += records
+    }
+
+    override suspend fun list(orgId: Int, filters: InventoryFilters): VulnerabilityInventoryResponse {
+        val rows = inserted
+            .filter { it.organizationId == orgId }
+            .drop(filters.offset)
+            .take(filters.limit)
+            .map {
+                VulnerabilityInventoryItem(
+                    packageName = it.packageName,
+                    packageVersion = it.packageVersion,
+                    packageType = it.packageType,
+                    ecosystem = it.ecosystem,
+                    purl = it.purl,
+                    targetType = it.targetType,
+                    targetName = it.targetName,
+                    host = it.host,
+                    imageName = it.imageName,
+                    containerId = it.containerId,
+                    lastSeen = "2026-05-31T00:00:00.000Z",
+                )
+            }
+        return VulnerabilityInventoryResponse(rows, rows.size.toLong())
+    }
+
+    override suspend fun countPackages(orgId: Int): Long =
+        inserted.count { it.organizationId == orgId }.toLong()
+}
+
+class StaticOrgMembershipRepository(
+    private val role: String? = "admin",
+) : OrgMembershipRepository {
+    override fun getMembers(orgId: Int): List<OrgMemberRow> = emptyList()
+    override fun getMemberRole(orgId: Int, userId: Int): String? = role
+    override fun updateMemberRole(orgId: Int, targetUserId: Int, newRole: String): Int = 0
+    override fun removeMember(orgId: Int, targetUserId: Int): Int = 0
+    override fun isMember(orgId: Int, userId: Int): Boolean = role != null
+    override fun getOwnerCount(orgId: Int): Int = 1
+    override fun addMember(orgId: Int, userId: Int, role: String) = Unit
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityTestSupport.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityTestSupport.kt
@@ -55,8 +55,9 @@ class InMemoryPackageInventoryStore : PackageInventoryStore {
     }
 
     override suspend fun list(orgId: Int, filters: InventoryFilters): VulnerabilityInventoryResponse {
-        val rows = inserted
+        val scoped = inserted
             .filter { it.organizationId == orgId }
+        val rows = scoped
             .drop(filters.offset)
             .take(filters.limit)
             .map {
@@ -74,7 +75,7 @@ class InMemoryPackageInventoryStore : PackageInventoryStore {
                     lastSeen = "2026-05-31T00:00:00.000Z",
                 )
             }
-        return VulnerabilityInventoryResponse(rows, rows.size.toLong())
+        return VulnerabilityInventoryResponse(rows, scoped.size.toLong())
     }
 
     override suspend fun countPackages(orgId: Int): Long =

--- a/dashboard/src/lib/api/modules/security.ts
+++ b/dashboard/src/lib/api/modules/security.ts
@@ -26,6 +26,10 @@ import type {
   SignalListResponse,
   TriageRequest,
   UpdateDetectionRuleRequest,
+  VulnerabilityFindingListResponse,
+  VulnerabilityInventoryResponse,
+  VulnerabilityListParams,
+  VulnerabilitySummaryResponse,
 } from '../types'
 
 function signalsQuery(params: SignalListParams): string {
@@ -38,10 +42,23 @@ function signalsQuery(params: SignalListParams): string {
   return qs.toString()
 }
 
+function vulnerabilityQuery(params: VulnerabilityListParams): string {
+  const qs = new URLSearchParams()
+  if (params.search) qs.set('search', params.search)
+  if (params.package) qs.set('package', params.package)
+  if (params.target) qs.set('target', params.target)
+  if (params.severity) qs.set('severity', params.severity)
+  if (params.status) qs.set('status', params.status)
+  if (params.limit !== undefined) qs.set('limit', String(params.limit))
+  if (params.offset !== undefined) qs.set('offset', String(params.offset))
+  return qs.toString()
+}
+
 export function securityMethods(core: ApiClientCore) {
   const base = core.API_BASE
   const signals = `${base}/security/signals`
   const rules = `${base}/security/detection/rules`
+  const vulnerabilities = `${base}/security/vulnerabilities`
 
   return {
     // --- Signals (triage surface) ---
@@ -85,5 +102,28 @@ export function securityMethods(core: ApiClientCore) {
       core.request<DetectionPreviewResponse>(`${rules}/${ruleId}/preview`, {
         method: 'POST',
       }),
+
+    // --- Vulnerabilities / SBOM ---
+    getVulnerabilitySummary: () =>
+      core.request<VulnerabilitySummaryResponse>(`${vulnerabilities}/summary`),
+
+    listVulnerabilityInventory: (params: VulnerabilityListParams = {}) =>
+      core.request<VulnerabilityInventoryResponse>(
+        urlWithQuery(`${vulnerabilities}/inventory`, vulnerabilityQuery(params))
+      ),
+
+    listVulnerabilityFindings: (params: VulnerabilityListParams = {}) =>
+      core.request<VulnerabilityFindingListResponse>(
+        urlWithQuery(`${vulnerabilities}/findings`, vulnerabilityQuery(params))
+      ),
+
+    exportVulnerabilitySbom: async (format: 'cyclonedx' | 'spdx') => {
+      const qs = new URLSearchParams({format})
+      const response = await core.fetchWithAuth(urlWithQuery(`${vulnerabilities}/sbom/export`, qs.toString()))
+      if (!response.ok) {
+        throw new Error(`Export failed: ${response.status}`)
+      }
+      return response.text()
+    },
   }
 }

--- a/dashboard/src/lib/api/types/security.ts
+++ b/dashboard/src/lib/api/types/security.ts
@@ -145,3 +145,62 @@ export interface DetectionPreviewResponse {
   samples: DetectionMatchSample[]
   window_seconds: number
 }
+
+export interface VulnerabilitySummaryResponse {
+  package_count: number
+  finding_count: number
+  critical_count: number
+  high_count: number
+}
+
+export interface VulnerabilityInventoryItem {
+  package_name: string
+  package_version: string
+  package_type: string
+  ecosystem: string
+  purl: string
+  target_type: string
+  target_name: string
+  host: string
+  image_name: string
+  container_id: string
+  last_seen: string
+  finding_count: number
+}
+
+export interface VulnerabilityInventoryResponse {
+  inventory: VulnerabilityInventoryItem[]
+  total_count: number
+}
+
+export interface VulnerabilityFindingResponse {
+  signal_id: number
+  advisory_id: string
+  cve_id?: string | null
+  package_name: string
+  package_version: string
+  package_type: string
+  ecosystem: string
+  target_name: string
+  severity: SignalSeverity
+  cvss_score?: number | null
+  fixed_version?: string | null
+  link: string
+  status: SignalStatus
+  last_seen: string
+}
+
+export interface VulnerabilityFindingListResponse {
+  findings: VulnerabilityFindingResponse[]
+  total_count: number
+}
+
+export interface VulnerabilityListParams {
+  search?: string
+  package?: string
+  target?: string
+  severity?: SignalSeverity
+  status?: SignalStatus
+  limit?: number
+  offset?: number
+}

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -87,6 +87,7 @@ import { Route as WorkflowsConnectionsRouteImport } from './routes/workflows.con
 import { Route as UptimeMonitorIdRouteImport } from './routes/uptime.$monitorId'
 import { Route as SyntheticsTestIdRouteImport } from './routes/synthetics.$testId'
 import { Route as StatusPagesPageIdRouteImport } from './routes/status-pages.$pageId'
+import { Route as SecurityVulnerabilitiesRouteImport } from './routes/security.vulnerabilities'
 import { Route as SecuritySignalsRouteImport } from './routes/security.signals'
 import { Route as SecurityEventsRouteImport } from './routes/security.events'
 import { Route as SecurityDetectionsRouteImport } from './routes/security.detections'
@@ -543,6 +544,11 @@ const StatusPagesPageIdRoute = StatusPagesPageIdRouteImport.update({
   path: '/status-pages/$pageId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SecurityVulnerabilitiesRoute = SecurityVulnerabilitiesRouteImport.update({
+  id: '/vulnerabilities',
+  path: '/vulnerabilities',
+  getParentRoute: () => SecurityRoute,
+} as any)
 const SecuritySignalsRoute = SecuritySignalsRouteImport.update({
   id: '/signals',
   path: '/signals',
@@ -982,6 +988,7 @@ export interface FileRoutesByFullPath {
   '/security/detections': typeof SecurityDetectionsRoute
   '/security/events': typeof SecurityEventsRoute
   '/security/signals': typeof SecuritySignalsRoute
+  '/security/vulnerabilities': typeof SecurityVulnerabilitiesRoute
   '/status-pages/$pageId': typeof StatusPagesPageIdRoute
   '/synthetics/$testId': typeof SyntheticsTestIdRoute
   '/uptime/$monitorId': typeof UptimeMonitorIdRoute
@@ -1111,6 +1118,7 @@ export interface FileRoutesByTo {
   '/security/detections': typeof SecurityDetectionsRoute
   '/security/events': typeof SecurityEventsRoute
   '/security/signals': typeof SecuritySignalsRoute
+  '/security/vulnerabilities': typeof SecurityVulnerabilitiesRoute
   '/status-pages/$pageId': typeof StatusPagesPageIdRoute
   '/synthetics/$testId': typeof SyntheticsTestIdRoute
   '/uptime/$monitorId': typeof UptimeMonitorIdRoute
@@ -1256,6 +1264,7 @@ export interface FileRoutesById {
   '/security/detections': typeof SecurityDetectionsRoute
   '/security/events': typeof SecurityEventsRoute
   '/security/signals': typeof SecuritySignalsRoute
+  '/security/vulnerabilities': typeof SecurityVulnerabilitiesRoute
   '/status-pages/$pageId': typeof StatusPagesPageIdRoute
   '/synthetics/$testId': typeof SyntheticsTestIdRoute
   '/uptime/$monitorId': typeof UptimeMonitorIdRoute
@@ -1402,6 +1411,7 @@ export interface FileRouteTypes {
     | '/security/detections'
     | '/security/events'
     | '/security/signals'
+    | '/security/vulnerabilities'
     | '/status-pages/$pageId'
     | '/synthetics/$testId'
     | '/uptime/$monitorId'
@@ -1531,6 +1541,7 @@ export interface FileRouteTypes {
     | '/security/detections'
     | '/security/events'
     | '/security/signals'
+    | '/security/vulnerabilities'
     | '/status-pages/$pageId'
     | '/synthetics/$testId'
     | '/uptime/$monitorId'
@@ -1675,6 +1686,7 @@ export interface FileRouteTypes {
     | '/security/detections'
     | '/security/events'
     | '/security/signals'
+    | '/security/vulnerabilities'
     | '/status-pages/$pageId'
     | '/synthetics/$testId'
     | '/uptime/$monitorId'
@@ -2335,6 +2347,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/status-pages/$pageId'
       preLoaderRoute: typeof StatusPagesPageIdRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/security/vulnerabilities': {
+      id: '/security/vulnerabilities'
+      path: '/vulnerabilities'
+      fullPath: '/security/vulnerabilities'
+      preLoaderRoute: typeof SecurityVulnerabilitiesRouteImport
+      parentRoute: typeof SecurityRoute
     }
     '/security/signals': {
       id: '/security/signals'
@@ -3130,6 +3149,7 @@ interface SecurityRouteChildren {
   SecurityDetectionsRoute: typeof SecurityDetectionsRoute
   SecurityEventsRoute: typeof SecurityEventsRoute
   SecuritySignalsRoute: typeof SecuritySignalsRoute
+  SecurityVulnerabilitiesRoute: typeof SecurityVulnerabilitiesRoute
   SecurityIndexRoute: typeof SecurityIndexRoute
 }
 
@@ -3138,6 +3158,7 @@ const SecurityRouteChildren: SecurityRouteChildren = {
   SecurityDetectionsRoute: SecurityDetectionsRoute,
   SecurityEventsRoute: SecurityEventsRoute,
   SecuritySignalsRoute: SecuritySignalsRoute,
+  SecurityVulnerabilitiesRoute: SecurityVulnerabilitiesRoute,
   SecurityIndexRoute: SecurityIndexRoute,
 }
 

--- a/dashboard/src/routes/__tests__/security-routes-errors.test.tsx
+++ b/dashboard/src/routes/__tests__/security-routes-errors.test.tsx
@@ -30,6 +30,10 @@ const {mockApi, mockToast} = vi.hoisted(() => ({
     listSignals: vi.fn(),
     getSignal: vi.fn(),
     triageSignal: vi.fn(),
+    getVulnerabilitySummary: vi.fn(),
+    listVulnerabilityInventory: vi.fn(),
+    listVulnerabilityFindings: vi.fn(),
+    exportVulnerabilitySbom: vi.fn(),
     get: vi.fn(),
   },
   mockToast: vi.fn(),
@@ -51,11 +55,13 @@ vi.mock('@tanstack/react-router', () => ({
 import {Route as DetectionsRouteImport} from '../security.detections'
 import {Route as EventsRouteImport} from '../security.events'
 import {Route as SignalsRouteImport} from '../security.signals'
+import {Route as VulnerabilitiesRouteImport} from '../security.vulnerabilities'
 
 type RouteLike = {component: React.ComponentType}
 const DetectionsRoute = DetectionsRouteImport as unknown as RouteLike
 const EventsRoute = EventsRouteImport as unknown as RouteLike
 const SignalsRoute = SignalsRouteImport as unknown as RouteLike
+const VulnerabilitiesRoute = VulnerabilitiesRouteImport as unknown as RouteLike
 
 function renderRoute(route: RouteLike) {
   const Component = route.component
@@ -74,6 +80,15 @@ describe('security routes error states', () => {
     vi.clearAllMocks()
     mockApi.listDetectionRules.mockResolvedValue({rules: [], total_count: 0})
     mockApi.listSignals.mockResolvedValue({signals: [], total_count: 0})
+    mockApi.getVulnerabilitySummary.mockResolvedValue({
+      package_count: 0,
+      finding_count: 0,
+      critical_count: 0,
+      high_count: 0,
+    })
+    mockApi.listVulnerabilityInventory.mockResolvedValue({inventory: [], total_count: 0})
+    mockApi.listVulnerabilityFindings.mockResolvedValue({findings: [], total_count: 0})
+    mockApi.exportVulnerabilitySbom.mockResolvedValue('{}')
     mockApi.get.mockResolvedValue({events: [], totalCount: 0})
     mockApi.getSignal.mockResolvedValue({signal: makeSignal(), evidence: [], audit: [], sample_events: []})
   })
@@ -100,6 +115,74 @@ describe('security routes error states', () => {
     expect(await screen.findByText('Couldn’t load signals')).toBeInTheDocument()
     expect(screen.getByText('signals boom')).toBeInTheDocument()
     expect(screen.queryByText(/^Signals \(/)).not.toBeInTheDocument()
+  })
+
+  it('vulnerabilities: summary failure shows an error instead of zero metric cards', async () => {
+    mockApi.getVulnerabilitySummary.mockRejectedValue(new Error('summary boom'))
+    renderRoute(VulnerabilitiesRoute)
+    expect(await screen.findByText('Couldn’t load vulnerability summary')).toBeInTheDocument()
+    expect(screen.getByText('summary boom')).toBeInTheDocument()
+    expect(screen.queryByText('Packages')).not.toBeInTheDocument()
+  })
+
+  it('vulnerabilities: paginates inventory and findings with returned totals', async () => {
+    mockApi.listVulnerabilityFindings.mockResolvedValue({
+      findings: [makeFinding()],
+      total_count: 51,
+    })
+    mockApi.listVulnerabilityInventory.mockResolvedValue({
+      inventory: [makeInventory()],
+      total_count: 51,
+    })
+
+    renderRoute(VulnerabilitiesRoute)
+
+    expect(await screen.findByText('Findings (51)')).toBeInTheDocument()
+    expect(screen.getByText('Inventory (51)')).toBeInTheDocument()
+    expect(mockApi.listVulnerabilityFindings).toHaveBeenCalledWith({
+      search: undefined,
+      limit: 50,
+      offset: 0,
+    })
+    expect(mockApi.listVulnerabilityInventory).toHaveBeenCalledWith({
+      search: undefined,
+      limit: 50,
+      offset: 0,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: 'Findings next page'}))
+    await waitFor(() =>
+      expect(mockApi.listVulnerabilityFindings).toHaveBeenLastCalledWith({
+        search: undefined,
+        limit: 50,
+        offset: 50,
+      })
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: 'Inventory next page'}))
+    await waitFor(() =>
+      expect(mockApi.listVulnerabilityInventory).toHaveBeenLastCalledWith({
+        search: undefined,
+        limit: 50,
+        offset: 50,
+      })
+    )
+  })
+
+  it('vulnerabilities: finding rows open from the keyboard', async () => {
+    mockApi.listVulnerabilityFindings.mockResolvedValue({
+      findings: [makeFinding()],
+      total_count: 1,
+    })
+    renderRoute(VulnerabilitiesRoute)
+
+    const row = await screen.findByRole('button', {
+      name: 'Open vulnerability finding CVE-2019-10744',
+    })
+    expect(row).toHaveAttribute('tabindex', '0')
+    fireEvent.keyDown(row, {key: ' '})
+
+    expect(await screen.findByText('Fixed in')).toBeInTheDocument()
   })
 
   it('signals detail drawer: shows an error state when the detail query fails', async () => {
@@ -184,3 +267,39 @@ describe('security routes error states', () => {
     )
   })
 })
+
+function makeFinding() {
+  return {
+    signal_id: 42,
+    advisory_id: 'GHSA-jf85-cpcp-j695',
+    cve_id: 'CVE-2019-10744',
+    package_name: 'lodash',
+    package_version: '4.17.11',
+    package_type: 'npm',
+    ecosystem: 'npm',
+    target_name: 'checkout',
+    severity: 'critical',
+    cvss_score: 9.8,
+    fixed_version: '4.17.12',
+    link: 'https://osv.dev/vulnerability/CVE-2019-10744',
+    status: 'open',
+    last_seen: '2026-05-31T00:00:00.000Z',
+  }
+}
+
+function makeInventory() {
+  return {
+    package_name: 'lodash',
+    package_version: '4.17.11',
+    package_type: 'npm',
+    ecosystem: 'npm',
+    purl: 'pkg:npm/lodash@4.17.11',
+    target_type: 'service',
+    target_name: 'checkout',
+    host: '',
+    image_name: '',
+    container_id: '',
+    last_seen: '2026-05-31T00:00:00.000Z',
+    finding_count: 1,
+  }
+}

--- a/dashboard/src/routes/__tests__/security-routes-errors.test.tsx
+++ b/dashboard/src/routes/__tests__/security-routes-errors.test.tsx
@@ -18,6 +18,7 @@ import React from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {fireEvent, render, screen, waitFor, within} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {makeRule, makeSignal} from '@/components/security/__tests__/fixtures'
 
 const {mockApi, mockToast} = vi.hoisted(() => ({
@@ -170,17 +171,19 @@ describe('security routes error states', () => {
   })
 
   it('vulnerabilities: finding rows open from the keyboard', async () => {
+    const user = userEvent.setup()
     mockApi.listVulnerabilityFindings.mockResolvedValue({
       findings: [makeFinding()],
       total_count: 1,
     })
     renderRoute(VulnerabilitiesRoute)
 
-    const row = await screen.findByRole('button', {
+    const openFinding = await screen.findByRole('button', {
       name: 'Open vulnerability finding CVE-2019-10744',
     })
-    expect(row).toHaveAttribute('tabindex', '0')
-    fireEvent.keyDown(row, {key: ' '})
+    openFinding.focus()
+    expect(openFinding).toHaveFocus()
+    await user.keyboard('{Enter}')
 
     expect(await screen.findByText('Fixed in')).toBeInTheDocument()
   })

--- a/dashboard/src/routes/security-sbom.tsx
+++ b/dashboard/src/routes/security-sbom.tsx
@@ -25,7 +25,9 @@ const config: FeaturePageConfig = {
   slug: pageSeo.slug,
   title: pageSeo.title,
   tagline: 'Know what you\'re running',
-  description: 'A software bill of materials with CVE tracking across your services is on the Moneat roadmap. The plan: surface which packages and versions are deployed, flag the ones with known vulnerabilities, and point to what to patch.',
+  description:
+    'Upload CycloneDX or SPDX SBOMs, inventory the packages running across your services, and surface ' +
+    'vulnerability findings with CVSS scores, fix versions, and advisory links.',
   metaDescription: pageSeo.metaDescription,
   icon: ShieldCheck,
   iconColor: 'text-emerald-400',
@@ -35,23 +37,46 @@ const config: FeaturePageConfig = {
   screenshot: pageSeo.image,
   screenshotAlt: 'Security dashboard concept showing SBOM inventory and CVE tracking',
   subFeatures: [
-    {icon: Package, title: 'Package Inventory', description: 'Planned: an inventory of the packages and versions running across your services and hosts.', iconColor: 'text-emerald-400'},
-    {icon: AlertTriangle, title: 'CVE Tracking', description: 'Planned: matching your packages against known CVEs with severity ratings and remediation links.', iconColor: 'text-red-400'},
-    {icon: Search, title: 'Vulnerability Search', description: 'Planned: search for a specific CVE or package across your infrastructure.', iconColor: 'text-blue-400'},
-    {icon: FileText, title: 'SBOM Export', description: 'Planned: export a software bill of materials in standard formats for compliance and auditing.', iconColor: 'text-violet-400'},
-    {icon: Shield, title: 'Compliance', description: 'Planned: support supply-chain security requirements with SBOM generation and tracking.', iconColor: 'text-amber-400'},
+    {
+      icon: Package,
+      title: 'Package Inventory',
+      description: 'Track packages and versions by service, host, image, or container.',
+      iconColor: 'text-emerald-400',
+    },
+    {
+      icon: AlertTriangle,
+      title: 'CVE Tracking',
+      description: 'Match inventory against a local advisory mirror with severity, CVSS, and fix data.',
+      iconColor: 'text-red-400',
+    },
+    {
+      icon: Search,
+      title: 'Vulnerability Search',
+      description: 'Search by package, target, advisory, or CVE from the Security section.',
+      iconColor: 'text-blue-400',
+    },
+    {
+      icon: FileText,
+      title: 'SBOM Export',
+      description: 'Export the current inventory as CycloneDX or SPDX JSON.',
+      iconColor: 'text-violet-400',
+    },
+    {
+      icon: Shield,
+      title: 'Compliance',
+      description: 'Keep supply-chain evidence close to the findings your team triages.',
+      iconColor: 'text-amber-400',
+    },
     {
       icon: ShieldCheck,
       title: 'Auto-Discovery',
       description:
-        'Planned: discover packages from supported infrastructure agents, so the inventory builds itself ' +
-        'with no manual work.',
+        'Ingest SBOM payloads from existing agent-compatible paths as well as direct uploads.',
       iconColor: 'text-cyan-400',
     },
   ],
   compatNote:
-    'The plan is to collect SBOM data through the infrastructure agents you already run, so no separate scanning ' +
-    'pipeline is needed when this ships.',
+    'Direct upload works in core. Agent-compatible SBOM ingest uses the same inventory and vulnerability findings.',
 }
 
 export const Route = createFileRoute('/security-sbom')({

--- a/dashboard/src/routes/security.tsx
+++ b/dashboard/src/routes/security.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {createFileRoute, Link, Outlet, useRouterState} from '@tanstack/react-router'
-import {AlertTriangle, ListFilter, ShieldAlert, ShieldCheck} from 'lucide-react'
+import {AlertTriangle, ListFilter, PackageSearch, ShieldAlert, ShieldCheck} from 'lucide-react'
 import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/security')({
@@ -24,6 +24,7 @@ export const Route = createFileRoute('/security')({
 
 const tabs = [
   {id: 'signals', label: 'Signals', href: '/security/signals', icon: AlertTriangle},
+  {id: 'vulnerabilities', label: 'Vulnerabilities', href: '/security/vulnerabilities', icon: PackageSearch},
   {id: 'detections', label: 'Detections', href: '/security/detections', icon: ListFilter},
   {id: 'events', label: 'Security Events', href: '/security/events', icon: ShieldAlert},
   {id: 'compliance', label: 'Compliance', href: '/security/compliance', icon: ShieldCheck},
@@ -37,7 +38,9 @@ function SecurityLayout() {
     <div className="space-y-2">
       <div className="p-3 space-y-2">
       <div className="flex items-center gap-2">
-        <div className="flex items-center justify-center h-7 w-7 rounded-lg bg-gradient-to-br from-red-500 to-orange-600 shrink-0">
+        <div
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-red-500 to-orange-600"
+        >
           <ShieldAlert className="h-3.5 w-3.5 text-white" />
         </div>
         <div className="min-w-0">

--- a/dashboard/src/routes/security.vulnerabilities.tsx
+++ b/dashboard/src/routes/security.vulnerabilities.tsx
@@ -6,11 +6,25 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {useMemo, useState} from 'react'
+import {type KeyboardEvent, useMemo, useState} from 'react'
 import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
-import {Download, ExternalLink, Package, Search, ShieldAlert, type LucideIcon} from 'lucide-react'
-import {api, formatErrorForLogging, type VulnerabilityFindingResponse} from '@/lib/api'
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ExternalLink,
+  Package,
+  Search,
+  ShieldAlert,
+  type LucideIcon,
+} from 'lucide-react'
+import {
+  api,
+  formatErrorForLogging,
+  type VulnerabilityFindingResponse,
+  type VulnerabilityInventoryItem,
+} from '@/lib/api'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
@@ -26,29 +40,57 @@ export const Route = createFileRoute('/security/vulnerabilities')({
 })
 
 type ExportFormat = 'cyclonedx' | 'spdx'
+type SummaryValue = number | 'Loading' | 'Unavailable'
+
+const VULNERABILITY_PAGE_SIZE = 50
 
 function VulnerabilitiesTab() {
   const {toast} = useToast()
   const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<VulnerabilityFindingResponse | null>(null)
   const [exporting, setExporting] = useState<ExportFormat | null>(null)
+  const [findingsPage, setFindingsPage] = useState(0)
+  const [inventoryPage, setInventoryPage] = useState(0)
 
-  const listParams = useMemo(() => ({search: search || undefined, limit: 100}), [search])
+  const findingsParams = useMemo(
+    () => ({
+      search: search.trim() || undefined,
+      limit: VULNERABILITY_PAGE_SIZE,
+      offset: findingsPage * VULNERABILITY_PAGE_SIZE,
+    }),
+    [findingsPage, search]
+  )
+  const inventoryParams = useMemo(
+    () => ({
+      search: search.trim() || undefined,
+      limit: VULNERABILITY_PAGE_SIZE,
+      offset: inventoryPage * VULNERABILITY_PAGE_SIZE,
+    }),
+    [inventoryPage, search]
+  )
   const summaryQuery = useQuery({
     queryKey: ['security-vulnerability-summary'],
     queryFn: () => api.getVulnerabilitySummary(),
   })
   const inventoryQuery = useQuery({
-    queryKey: ['security-vulnerability-inventory', listParams],
-    queryFn: () => api.listVulnerabilityInventory(listParams),
+    queryKey: ['security-vulnerability-inventory', inventoryParams],
+    queryFn: () => api.listVulnerabilityInventory(inventoryParams),
   })
   const findingsQuery = useQuery({
-    queryKey: ['security-vulnerability-findings', listParams],
-    queryFn: () => api.listVulnerabilityFindings(listParams),
+    queryKey: ['security-vulnerability-findings', findingsParams],
+    queryFn: () => api.listVulnerabilityFindings(findingsParams),
   })
 
   const inventory = inventoryQuery.data?.inventory ?? []
   const findings = findingsQuery.data?.findings ?? []
+  const inventoryTotal = inventoryQuery.data?.total_count ?? 0
+  const findingsTotal = findingsQuery.data?.total_count ?? 0
+
+  function handleSearchChange(value: string) {
+    setSearch(value)
+    setFindingsPage(0)
+    setInventoryPage(0)
+  }
 
   async function exportSbom(format: ExportFormat) {
     setExporting(format)
@@ -64,19 +106,39 @@ function VulnerabilitiesTab() {
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-2 md:grid-cols-4">
-        <MetricCard label="Packages" value={summaryQuery.data?.package_count ?? 0} icon={Package} />
-        <MetricCard label="Findings" value={summaryQuery.data?.finding_count ?? 0} icon={ShieldAlert} />
-        <MetricCard label="Critical" value={summaryQuery.data?.critical_count ?? 0} tone="critical" />
-        <MetricCard label="High" value={summaryQuery.data?.high_count ?? 0} tone="high" />
-      </div>
+      {summaryQuery.isError ? (
+        <SecurityError title="Couldn’t load vulnerability summary" error={summaryQuery.error} />
+      ) : (
+        <div className="grid gap-2 md:grid-cols-4">
+          <MetricCard
+            label="Packages"
+            value={summaryMetricValue(summaryQuery.isLoading, summaryQuery.data?.package_count)}
+            icon={Package}
+          />
+          <MetricCard
+            label="Findings"
+            value={summaryMetricValue(summaryQuery.isLoading, summaryQuery.data?.finding_count)}
+            icon={ShieldAlert}
+          />
+          <MetricCard
+            label="Critical"
+            value={summaryMetricValue(summaryQuery.isLoading, summaryQuery.data?.critical_count)}
+            tone="critical"
+          />
+          <MetricCard
+            label="High"
+            value={summaryMetricValue(summaryQuery.isLoading, summaryQuery.data?.high_count)}
+            tone="high"
+          />
+        </div>
+      )}
 
       <div className="flex flex-col gap-2 md:flex-row md:items-center">
         <div className="relative max-w-md flex-1">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
             value={search}
-            onChange={(event) => setSearch(event.target.value)}
+            onChange={(event) => handleSearchChange(event.target.value)}
             placeholder="Search package, version, target"
             className="pl-9"
           />
@@ -110,10 +172,24 @@ function VulnerabilitiesTab() {
       ) : (
         <Card>
           <CardHeader className="px-2.5 py-1.5">
-            <CardTitle className="text-xs">Findings ({findingsQuery.data?.total_count ?? findings.length})</CardTitle>
+            <CardTitle className="text-xs">
+              Findings ({findingsQuery.isLoading ? 'Loading' : findingsTotal})
+            </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
-            <FindingsTable findings={findings} onSelect={setSelected} />
+            {findingsQuery.isLoading ? (
+              <LoadingTable columns={6} message="Loading vulnerability findings" />
+            ) : (
+              <FindingsTable findings={findings} onSelect={setSelected} />
+            )}
+            <PaginationControls
+              label="Findings"
+              page={findingsPage}
+              pageSize={VULNERABILITY_PAGE_SIZE}
+              totalCount={findingsTotal}
+              isLoading={findingsQuery.isLoading || findingsQuery.isFetching}
+              onPageChange={setFindingsPage}
+            />
           </CardContent>
         </Card>
       )}
@@ -124,11 +200,23 @@ function VulnerabilitiesTab() {
         <Card>
           <CardHeader className="px-2.5 py-1.5">
             <CardTitle className="text-xs">
-              Inventory ({inventoryQuery.data?.total_count ?? inventory.length})
+              Inventory ({inventoryQuery.isLoading ? 'Loading' : inventoryTotal})
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
-            <InventoryTable inventory={inventory} />
+            {inventoryQuery.isLoading ? (
+              <LoadingTable columns={5} message="Loading package inventory" />
+            ) : (
+              <InventoryTable inventory={inventory} />
+            )}
+            <PaginationControls
+              label="Inventory"
+              page={inventoryPage}
+              pageSize={VULNERABILITY_PAGE_SIZE}
+              totalCount={inventoryTotal}
+              isLoading={inventoryQuery.isLoading || inventoryQuery.isFetching}
+              onPageChange={setInventoryPage}
+            />
           </CardContent>
         </Card>
       )}
@@ -145,6 +233,11 @@ function VulnerabilitiesTab() {
   )
 }
 
+function summaryMetricValue(isLoading: boolean, value: number | undefined): SummaryValue {
+  if (isLoading) return 'Loading'
+  return value ?? 'Unavailable'
+}
+
 function MetricCard({
   label,
   value,
@@ -152,7 +245,7 @@ function MetricCard({
   tone,
 }: {
   label: string
-  value: number
+  value: SummaryValue
   icon?: LucideIcon
   tone?: 'critical' | 'high'
 }) {
@@ -168,6 +261,79 @@ function MetricCard({
       </CardContent>
     </Card>
   )
+}
+
+function LoadingTable({columns, message}: {columns: number; message: string}) {
+  return (
+    <Table>
+      <TableBody>
+        <TableRow>
+          <TableCell colSpan={columns} className="py-6 text-center text-muted-foreground">
+            {message}
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  )
+}
+
+function PaginationControls({
+  label,
+  page,
+  pageSize,
+  totalCount,
+  isLoading,
+  onPageChange,
+}: {
+  label: string
+  page: number
+  pageSize: number
+  totalCount: number
+  isLoading: boolean
+  onPageChange: (page: number) => void
+}) {
+  if (totalCount <= pageSize && page === 0) return null
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
+  const canGoPrevious = page > 0 && !isLoading
+  const canGoNext = page + 1 < totalPages && !isLoading
+
+  return (
+    <div className="flex items-center justify-between border-t px-3 py-2 text-xs text-muted-foreground">
+      <span>{pageRange(page, pageSize, totalCount)}</span>
+      <div className="flex gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          aria-label={`${label} previous page`}
+          onClick={() => onPageChange(Math.max(0, page - 1))}
+          disabled={!canGoPrevious}
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          aria-label={`${label} next page`}
+          onClick={() => onPageChange(Math.min(totalPages - 1, page + 1))}
+          disabled={!canGoNext}
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function pageRange(page: number, pageSize: number, totalCount: number): string {
+  if (totalCount === 0) return '0 of 0'
+  const start = page * pageSize + 1
+  const end = Math.min(totalCount, start + pageSize - 1)
+  return `${start}-${end} of ${totalCount}`
 }
 
 function FindingsTable({
@@ -193,8 +359,12 @@ function FindingsTable({
         {findings.map((finding) => (
           <TableRow
             key={finding.signal_id}
-            className="cursor-pointer"
+            role="button"
+            tabIndex={0}
+            aria-label={`Open vulnerability finding ${finding.cve_id ?? finding.advisory_id}`}
+            className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={() => onSelect(finding)}
+            onKeyDown={(event) => handleFindingRowKeyDown(event, finding, onSelect)}
           >
             <TableCell className="pl-3 font-medium">{finding.cve_id ?? finding.advisory_id}</TableCell>
             <TableCell>
@@ -227,18 +397,20 @@ function FindingsTable({
   )
 }
 
+function handleFindingRowKeyDown(
+  event: KeyboardEvent<HTMLTableRowElement>,
+  finding: VulnerabilityFindingResponse,
+  onSelect: (finding: VulnerabilityFindingResponse) => void
+) {
+  if (event.key !== 'Enter' && event.key !== ' ') return
+  event.preventDefault()
+  onSelect(finding)
+}
+
 function InventoryTable({
   inventory,
 }: {
-  inventory: Array<{
-    package_name: string
-    package_version: string
-    package_type: string
-    target_name: string
-    host: string
-    image_name: string
-    last_seen: string
-  }>
+  inventory: VulnerabilityInventoryItem[]
 }) {
   return (
     <Table>
@@ -253,7 +425,9 @@ function InventoryTable({
       </TableHeader>
       <TableBody>
         {inventory.map((item) => (
-          <TableRow key={`${item.package_name}|${item.package_version}|${item.target_name}`}>
+          <TableRow
+            key={`${item.package_name}|${item.package_version}|${item.ecosystem}|${item.purl}|${item.target_name}`}
+          >
             <TableCell className="pl-3 font-medium">{item.package_name}</TableCell>
             <TableCell className="font-mono text-xs">{item.package_version}</TableCell>
             <TableCell>

--- a/dashboard/src/routes/security.vulnerabilities.tsx
+++ b/dashboard/src/routes/security.vulnerabilities.tsx
@@ -1,0 +1,317 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {useMemo, useState} from 'react'
+import {createFileRoute} from '@tanstack/react-router'
+import {useQuery} from '@tanstack/react-query'
+import {Download, ExternalLink, Package, Search, ShieldAlert, type LucideIcon} from 'lucide-react'
+import {api, formatErrorForLogging, type VulnerabilityFindingResponse} from '@/lib/api'
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
+import {Input} from '@/components/ui/input'
+import {Sheet, SheetContent, SheetHeader, SheetTitle} from '@/components/ui/sheet'
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
+import {useToast} from '@/hooks/useToast'
+import {SecurityError} from '@/components/security/SecurityError'
+import {colorFor, severityColors, statusColors, STATUS_LABELS} from '@/components/security/securityChips'
+
+export const Route = createFileRoute('/security/vulnerabilities')({
+  component: VulnerabilitiesTab,
+})
+
+type ExportFormat = 'cyclonedx' | 'spdx'
+
+function VulnerabilitiesTab() {
+  const {toast} = useToast()
+  const [search, setSearch] = useState('')
+  const [selected, setSelected] = useState<VulnerabilityFindingResponse | null>(null)
+  const [exporting, setExporting] = useState<ExportFormat | null>(null)
+
+  const listParams = useMemo(() => ({search: search || undefined, limit: 100}), [search])
+  const summaryQuery = useQuery({
+    queryKey: ['security-vulnerability-summary'],
+    queryFn: () => api.getVulnerabilitySummary(),
+  })
+  const inventoryQuery = useQuery({
+    queryKey: ['security-vulnerability-inventory', listParams],
+    queryFn: () => api.listVulnerabilityInventory(listParams),
+  })
+  const findingsQuery = useQuery({
+    queryKey: ['security-vulnerability-findings', listParams],
+    queryFn: () => api.listVulnerabilityFindings(listParams),
+  })
+
+  const inventory = inventoryQuery.data?.inventory ?? []
+  const findings = findingsQuery.data?.findings ?? []
+
+  async function exportSbom(format: ExportFormat) {
+    setExporting(format)
+    try {
+      const body = await api.exportVulnerabilitySbom(format)
+      downloadJson(format === 'spdx' ? 'moneat-sbom.spdx.json' : 'moneat-sbom.cdx.json', body)
+    } catch (error) {
+      toast({title: 'Export failed', description: formatErrorForLogging(error), variant: 'destructive'})
+    } finally {
+      setExporting(null)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-2 md:grid-cols-4">
+        <MetricCard label="Packages" value={summaryQuery.data?.package_count ?? 0} icon={Package} />
+        <MetricCard label="Findings" value={summaryQuery.data?.finding_count ?? 0} icon={ShieldAlert} />
+        <MetricCard label="Critical" value={summaryQuery.data?.critical_count ?? 0} tone="critical" />
+        <MetricCard label="High" value={summaryQuery.data?.high_count ?? 0} tone="high" />
+      </div>
+
+      <div className="flex flex-col gap-2 md:flex-row md:items-center">
+        <div className="relative max-w-md flex-1">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search package, version, target"
+            className="pl-9"
+          />
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void exportSbom('cyclonedx')}
+            disabled={exporting != null}
+          >
+            <Download className="mr-1.5 h-3.5 w-3.5" />
+            CycloneDX
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void exportSbom('spdx')}
+            disabled={exporting != null}
+          >
+            <Download className="mr-1.5 h-3.5 w-3.5" />
+            SPDX
+          </Button>
+        </div>
+      </div>
+
+      {findingsQuery.isError ? (
+        <SecurityError title="Couldn’t load vulnerability findings" error={findingsQuery.error} />
+      ) : (
+        <Card>
+          <CardHeader className="px-2.5 py-1.5">
+            <CardTitle className="text-xs">Findings ({findingsQuery.data?.total_count ?? findings.length})</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <FindingsTable findings={findings} onSelect={setSelected} />
+          </CardContent>
+        </Card>
+      )}
+
+      {inventoryQuery.isError ? (
+        <SecurityError title="Couldn’t load package inventory" error={inventoryQuery.error} />
+      ) : (
+        <Card>
+          <CardHeader className="px-2.5 py-1.5">
+            <CardTitle className="text-xs">
+              Inventory ({inventoryQuery.data?.total_count ?? inventory.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <InventoryTable inventory={inventory} />
+          </CardContent>
+        </Card>
+      )}
+
+      <Sheet open={selected != null} onOpenChange={(open) => !open && setSelected(null)}>
+        <SheetContent className="w-full overflow-y-auto sm:max-w-md">
+          <SheetHeader>
+            <SheetTitle className="text-sm">{selected?.cve_id ?? selected?.advisory_id}</SheetTitle>
+          </SheetHeader>
+          {selected && <FindingDetail finding={selected} />}
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+
+function MetricCard({
+  label,
+  value,
+  icon: Icon,
+  tone,
+}: {
+  label: string
+  value: number
+  icon?: LucideIcon
+  tone?: 'critical' | 'high'
+}) {
+  const toneClass = tone ? colorFor(severityColors, tone) : ''
+  return (
+    <Card>
+      <CardContent className="flex items-center justify-between px-3 py-2">
+        <div>
+          <p className="text-xs text-muted-foreground">{label}</p>
+          <p className="text-lg font-semibold tabular-nums">{value}</p>
+        </div>
+        {Icon ? <Icon className="h-4 w-4 text-muted-foreground" /> : <Badge className={toneClass}>{label}</Badge>}
+      </CardContent>
+    </Card>
+  )
+}
+
+function FindingsTable({
+  findings,
+  onSelect,
+}: {
+  findings: VulnerabilityFindingResponse[]
+  onSelect: (finding: VulnerabilityFindingResponse) => void
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="pl-3">Advisory</TableHead>
+          <TableHead>Package</TableHead>
+          <TableHead>Target</TableHead>
+          <TableHead>Severity</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="pr-3 text-right">CVSS</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {findings.map((finding) => (
+          <TableRow
+            key={finding.signal_id}
+            className="cursor-pointer"
+            onClick={() => onSelect(finding)}
+          >
+            <TableCell className="pl-3 font-medium">{finding.cve_id ?? finding.advisory_id}</TableCell>
+            <TableCell>
+              {finding.package_name}
+              <span className="ml-1 text-muted-foreground">{finding.package_version}</span>
+            </TableCell>
+            <TableCell>{finding.target_name || 'Unscoped'}</TableCell>
+            <TableCell>
+              <Badge variant="outline" className={colorFor(severityColors, finding.severity)}>
+                {finding.severity}
+              </Badge>
+            </TableCell>
+            <TableCell>
+              <Badge variant="outline" className={colorFor(statusColors, finding.status)}>
+                {STATUS_LABELS[finding.status]}
+              </Badge>
+            </TableCell>
+            <TableCell className="pr-3 text-right tabular-nums">{finding.cvss_score ?? 'None'}</TableCell>
+          </TableRow>
+        ))}
+        {findings.length === 0 && (
+          <TableRow>
+            <TableCell colSpan={6} className="py-6 text-center text-muted-foreground">
+              No vulnerability findings
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  )
+}
+
+function InventoryTable({
+  inventory,
+}: {
+  inventory: Array<{
+    package_name: string
+    package_version: string
+    package_type: string
+    target_name: string
+    host: string
+    image_name: string
+    last_seen: string
+  }>
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="pl-3">Package</TableHead>
+          <TableHead>Version</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead>Target</TableHead>
+          <TableHead className="pr-3">Last seen</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {inventory.map((item) => (
+          <TableRow key={`${item.package_name}|${item.package_version}|${item.target_name}`}>
+            <TableCell className="pl-3 font-medium">{item.package_name}</TableCell>
+            <TableCell className="font-mono text-xs">{item.package_version}</TableCell>
+            <TableCell>
+              <Badge variant="outline">{item.package_type || 'package'}</Badge>
+            </TableCell>
+            <TableCell>{item.target_name || item.host || item.image_name || 'Unscoped'}</TableCell>
+            <TableCell className="pr-3 text-muted-foreground">{item.last_seen}</TableCell>
+          </TableRow>
+        ))}
+        {inventory.length === 0 && (
+          <TableRow>
+            <TableCell colSpan={5} className="py-6 text-center text-muted-foreground">
+              No packages
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  )
+}
+
+function FindingDetail({finding}: {finding: VulnerabilityFindingResponse}) {
+  return (
+    <div className="mt-4 space-y-3 text-sm">
+      <DetailRow label="Package" value={`${finding.package_name} ${finding.package_version}`} />
+      <DetailRow label="Severity" value={finding.severity} />
+      <DetailRow label="CVSS" value={finding.cvss_score?.toString() ?? 'None'} />
+      <DetailRow label="Fixed in" value={finding.fixed_version ?? 'None'} />
+      <DetailRow label="Target" value={finding.target_name || 'Unscoped'} />
+      <a
+        href={finding.link}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center gap-1 text-primary hover:underline"
+      >
+        Advisory
+        <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    </div>
+  )
+}
+
+function DetailRow({label, value}: {label: string; value: string}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b pb-2">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  )
+}
+
+function downloadJson(filename: string, body: string) {
+  const blob = new Blob([body], {type: 'application/json'})
+  const url = globalThis.URL.createObjectURL(blob)
+  const link = globalThis.document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  link.remove()
+  globalThis.URL.revokeObjectURL(url)
+}

--- a/dashboard/src/routes/security.vulnerabilities.tsx
+++ b/dashboard/src/routes/security.vulnerabilities.tsx
@@ -6,7 +6,7 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {type KeyboardEvent, useMemo, useState} from 'react'
+import {useMemo, useState} from 'react'
 import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {
@@ -43,6 +43,17 @@ type ExportFormat = 'cyclonedx' | 'spdx'
 type SummaryValue = number | 'Loading' | 'Unavailable'
 
 const VULNERABILITY_PAGE_SIZE = 50
+const FINDING_BUTTON_CLASS_NAME = [
+  'bg-transparent',
+  'p-0',
+  'text-left',
+  'font-medium',
+  'text-foreground',
+  'hover:underline',
+  'focus-visible:outline-none',
+  'focus-visible:ring-2',
+  'focus-visible:ring-ring',
+].join(' ')
 
 function VulnerabilitiesTab() {
   const {toast} = useToast()
@@ -359,14 +370,22 @@ function FindingsTable({
         {findings.map((finding) => (
           <TableRow
             key={finding.signal_id}
-            role="button"
-            tabIndex={0}
-            aria-label={`Open vulnerability finding ${finding.cve_id ?? finding.advisory_id}`}
-            className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="cursor-pointer"
             onClick={() => onSelect(finding)}
-            onKeyDown={(event) => handleFindingRowKeyDown(event, finding, onSelect)}
           >
-            <TableCell className="pl-3 font-medium">{finding.cve_id ?? finding.advisory_id}</TableCell>
+            <TableCell className="pl-3">
+              <button
+                type="button"
+                className={FINDING_BUTTON_CLASS_NAME}
+                aria-label={`Open vulnerability finding ${finding.cve_id ?? finding.advisory_id}`}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onSelect(finding)
+                }}
+              >
+                {finding.cve_id ?? finding.advisory_id}
+              </button>
+            </TableCell>
             <TableCell>
               {finding.package_name}
               <span className="ml-1 text-muted-foreground">{finding.package_version}</span>
@@ -395,16 +414,6 @@ function FindingsTable({
       </TableBody>
     </Table>
   )
-}
-
-function handleFindingRowKeyDown(
-  event: KeyboardEvent<HTMLTableRowElement>,
-  finding: VulnerabilityFindingResponse,
-  onSelect: (finding: VulnerabilityFindingResponse) => void
-) {
-  if (event.key !== 'Enter' && event.key !== ' ') return
-  event.preventDefault()
-  onSelect(finding)
 }
 
 function InventoryTable({


### PR DESCRIPTION
Adds SBOM ingestion, package inventory, local advisory matching, and vulnerability signals.

Validation:
- backend `./gradlew :detekt :test --no-daemon` (initial known WorkflowEgress GraalJS flake, rerun passed)
- backend `./gradlew :test --rerun-tasks --no-daemon`
- dashboard `npm run lint && npm run typecheck && npm run test && npm run test:coverage`
- browser smoke `/security/vulnerabilities`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive vulnerability and SBOM (Software Bill of Materials) management system including package inventory tracking and findings discovery.
  * Introduced vulnerability dashboard with search, filtering by severity/status, and package-level findings.
  * Added SBOM export capabilities in CycloneDX and SPDX formats.
  * Enabled automatic vulnerability advisory synchronization and continuous vulnerability matching against ingested packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->