### PR TITLE
fix: restore weekly summary email delivery

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -22,6 +22,7 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.NotificationPreferences
 import com.moneat.shared.models.Projects
@@ -65,6 +66,7 @@ private const val WEEKLY_SUMMARY_HOUR = 9
 private const val FULL_PERCENTAGE = 100
 private const val MILLION = 1_000_000L
 private const val THOUSAND = 1_000L
+private const val WEEKLY_SUMMARY_JOB_NAME = "weekly_summary"
 
 class NotificationService(
     private val emailService: EmailService,
@@ -179,7 +181,8 @@ class NotificationService(
     }
 
     suspend fun sendWeeklySummary() {
-        suspendRunCatching {
+        val startedAt = Instant.now()
+        val result = suspendRunCatching {
             logger.info { "Starting weekly summary generation" }
 
             val now = Instant.now()
@@ -227,9 +230,24 @@ class NotificationService(
                     " $skippedCount skipped, $failedCount failed" +
                     " out of ${usersToNotify.size} users"
             }
-        }.getOrElse { e ->
+            if (failedCount > 0) {
+                logger.error {
+                    "Weekly summary failed to send to $failedCount users" +
+                        " out of ${usersToNotify.size} eligible users"
+                }
+            }
+            failedCount == 0
+        }
+
+        result.onFailure { e ->
             logger.error(e) { "Error in sendWeeklySummary" }
         }
+        OperationalMetrics.recordBackgroundJobRun(
+            WEEKLY_SUMMARY_JOB_NAME,
+            result.getOrDefault(false),
+            Duration.between(startedAt, Instant.now()).toMillis().toDouble() / EPOCH_SECONDS_TO_MILLIS,
+            result.exceptionOrNull()
+        )
     }
 
     suspend fun sendWeeklySummaryForUser(
@@ -275,7 +293,7 @@ class NotificationService(
         val priorStats = getStatsForPeriod(projectIds, priorStartDate, startDate)
 
         if (currentStats == null) {
-            logger.warn { "Skipping weekly summary for $email: ClickHouse stats query failed" }
+            logger.error { "Weekly summary failed to send to $email: ClickHouse stats query failed" }
             return WeeklySummaryResult.FAILED
         }
 
@@ -294,16 +312,16 @@ class NotificationService(
 
         val topIssues = getTopIssues(projectIds, startDate, endDate, limit = 5)
         if (topIssues == null) {
-            logger.warn {
-                "Skipping weekly summary for $email: ClickHouse top issues query failed"
+            logger.error {
+                "Weekly summary failed to send to $email: ClickHouse top issues query failed"
             }
             return WeeklySummaryResult.FAILED
         }
 
         val perProjectStats = getPerProjectStats(projectIds, startDate, endDate)
         if (perProjectStats == null) {
-            logger.warn {
-                "Skipping weekly summary for $email: ClickHouse per-project stats query failed"
+            logger.error {
+                "Weekly summary failed to send to $email: ClickHouse per-project stats query failed"
             }
             return WeeklySummaryResult.FAILED
         }
@@ -484,7 +502,7 @@ class NotificationService(
                 issue_id,
                 any(message) as title,
                 any(exception_type) as culprit,
-                any(project_id) as project_id,
+                any(project_id) as top_issue_project_id,
                 count() as event_count
             FROM `$clickhouseDb`.events
             WHERE project_id IN (${projectIds.joinToString(",")})
@@ -518,7 +536,7 @@ class NotificationService(
 
         return rows.mapNotNull { row ->
             val obj = row.jsonObject
-            val projectId = obj["project_id"]?.jsonPrimitive?.longOrNull ?: return@mapNotNull null
+            val projectId = obj["top_issue_project_id"]?.jsonPrimitive?.longOrNull ?: return@mapNotNull null
             EmailService.TopIssue(
                 title = obj["title"]?.jsonPrimitive?.contentOrNull ?: "Unknown error",
                 culprit = obj["culprit"]?.jsonPrimitive?.contentOrNull ?: "unknown",

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceWeeklySummaryTest.kt
@@ -70,6 +70,10 @@ class NotificationServiceWeeklySummaryTest {
         private const val LARGE_M_EVENTS = 2_000_000L
         private const val DEFAULT_CRASH_FREE = 99.0
         private const val CLICKHOUSE_ERROR_STATUS = 500
+        private const val TOP_ISSUE_EVENTS = 12L
+        private const val TOP_ISSUE_ID = "issue-top-1"
+        private const val TOP_ISSUE_TITLE = "Payment failed"
+        private const val TOP_ISSUE_CULPRIT = "IllegalStateException"
     }
 
     private val emailService = mockk<EmailService>(relaxed = true)
@@ -152,6 +156,13 @@ class NotificationServiceWeeklySummaryTest {
                         TEXT_PLAIN
                     )
                 }
+                query.contains("any(project_id) as project_id") -> {
+                    exchange.respond(
+                        CLICKHOUSE_ERROR_STATUS,
+                        "Code: 184. Aggregate function any(project_id) AS project_id is found in WHERE",
+                        TEXT_PLAIN
+                    )
+                }
                 query.contains("GROUP BY project_id") -> {
                     exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
                 }
@@ -201,6 +212,12 @@ class NotificationServiceWeeklySummaryTest {
                     exchange.respond(
                         CLICKHOUSE_ERROR_STATUS,
                         "Code: 47. Unknown expression identifier culprit",
+                        TEXT_PLAIN
+                    )
+                query.contains("any(project_id) as project_id") ->
+                    exchange.respond(
+                        CLICKHOUSE_ERROR_STATUS,
+                        "Code: 184. Aggregate function any(project_id) AS project_id is found in WHERE",
                         TEXT_PLAIN
                     )
                 query.contains("count() as total_events") -> {
@@ -471,6 +488,90 @@ class NotificationServiceWeeklySummaryTest {
             verify(exactly = 0) {
                 emailService.sendWeeklySummaryEmail(any(), any())
             }
+        }
+
+    @Test
+    fun `sendWeeklySummaryForUser maps top issues without aggregate alias collision`() =
+        runBlocking {
+            val orgId = seedOrg()
+            val userId = seedUser("topalias@moneat.io", "TopAlias User")
+            seedMembership(userId, orgId)
+            val projectId = seedProject(orgId, "TopAlias Project")
+
+            val handler: (HttpExchange) -> Unit = { exchange ->
+                val query = exchange.requestBodyText()
+                when {
+                    query.contains("any(project_id) as project_id") -> {
+                        exchange.respond(
+                            CLICKHOUSE_ERROR_STATUS,
+                            "Code: 184. Aggregate function any(project_id) AS project_id is found in WHERE",
+                            TEXT_PLAIN
+                        )
+                    }
+                    query.contains("GROUP BY project_id") -> {
+                        val body = """{"data":[{""" +
+                            """"project_id":$projectId,""" +
+                            """"total_events":$STATS_TOTAL_EVENTS,""" +
+                            """"unique_issues":$STATS_UNIQUE_ISSUES,""" +
+                            """"unique_users":$STATS_UNIQUE_USERS""" +
+                            """}]}"""
+                        exchange.respond(200, body, TEXT_PLAIN)
+                    }
+                    query.contains("countIf(errors = 0)") -> {
+                        exchange.respond(
+                            200,
+                            """{"data":[{"rate":$DEFAULT_CRASH_FREE}]}""",
+                            TEXT_PLAIN
+                        )
+                    }
+                    query.contains("any(message) as title") -> {
+                        val body = """{"data":[{""" +
+                            """"issue_id":"$TOP_ISSUE_ID",""" +
+                            """"title":"$TOP_ISSUE_TITLE",""" +
+                            """"culprit":"$TOP_ISSUE_CULPRIT",""" +
+                            """"top_issue_project_id":$projectId,""" +
+                            """"event_count":$TOP_ISSUE_EVENTS""" +
+                            """}]}"""
+                        exchange.respond(200, body, TEXT_PLAIN)
+                    }
+                    query.contains("count() as total_events") -> {
+                        exchange.respond(
+                            200,
+                            statsJson(
+                                STATS_TOTAL_EVENTS,
+                                STATS_UNIQUE_ISSUES,
+                                STATS_UNIQUE_USERS,
+                            ),
+                            TEXT_PLAIN
+                        )
+                    }
+                    else -> {
+                        exchange.respond(200, """{"data":[]}""", TEXT_PLAIN)
+                    }
+                }
+            }
+
+            val result = withMockClickHouse(handler) { service ->
+                service.sendWeeklySummaryForUser(
+                    userId,
+                    "topalias@moneat.io",
+                )
+            }
+
+            assertEquals(WeeklySummaryResult.SENT, result)
+            val dataSlot = slot<EmailService.WeeklySummaryData>()
+            verify(exactly = 1) {
+                emailService.sendWeeklySummaryEmail(
+                    "topalias@moneat.io",
+                    capture(dataSlot),
+                )
+            }
+
+            val topIssue = dataSlot.captured.topIssues.single()
+            assertEquals(TOP_ISSUE_TITLE, topIssue.title)
+            assertEquals(TOP_ISSUE_CULPRIT, topIssue.culprit)
+            assertEquals("TopAlias Project", topIssue.project)
+            assertEquals(TOP_ISSUE_EVENTS.toString(), topIssue.count)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- restore weekly summary sends by avoiding the ClickHouse aggregate alias collision in the top-issues query
- log per-user weekly summary send failures at ERROR and record weekly summary background job success/failure metrics
- add a regression test covering top issue mapping with the safe alias

## Root cause
The top-issues ClickHouse query aliased `any(project_id)` as `project_id`, which ClickHouse interpreted as an aggregate alias in the `WHERE project_id IN (...)` clause. After the weekly summary job was changed to skip sends when ClickHouse queries fail, that query failure prevented weekly summaries from sending.

## Validation
- `git diff --check`
- `./gradlew compileKotlin`
- `./gradlew detekt`
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.services.NotificationServiceWeeklySummaryTest -Dkotlin.compiler.execution.strategy=in-process`

## Production follow-up
The system health dashboard now has a weekly summary failure widget and alert based on `moneat_background_job_runs_total{job="weekly_summary",status="failure"}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weekly summary reliability by treating data retrieval failures as hard failures with proper error logging instead of silently skipping summary generation
  * Fixed database field mapping issue in weekly summary queries

* **Tests**
  * Added test coverage for weekly summary data mapping during edge case scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->