### PR TITLE
refactor: improve workflow editor UX

### DIFF
--- a/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowEngineModels.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/temporal/WorkflowEngineModels.kt
@@ -21,6 +21,7 @@ import com.moneat.workflows.models.WorkflowConditionConfig
 import com.moneat.workflows.models.WorkflowGraphConfig
 import com.moneat.workflows.models.WorkflowGraphEdge
 import com.moneat.workflows.models.WorkflowGraphNode
+import com.moneat.workflows.models.WorkflowGraphPosition
 import com.moneat.workflows.models.WorkflowRetryConfig
 import com.moneat.workflows.models.WorkflowRunStepProgress
 import com.moneat.workflows.models.WorkflowSwitchCaseConfig
@@ -181,7 +182,8 @@ data class RuntimeWorkflowGraphNode(
     var conditions: List<WorkflowConditionConfig> = emptyList(),
     var cases: List<WorkflowSwitchCaseConfig> = emptyList(),
     var retry: WorkflowRetryConfig? = null,
-    var continueOnError: Boolean = false
+    var continueOnError: Boolean = false,
+    var position: WorkflowGraphPosition? = null
 )
 
 data class RuntimeWorkflowGraphEdge(
@@ -240,7 +242,8 @@ private fun WorkflowGraphNode.toRuntimeGraphNode(): RuntimeWorkflowGraphNode =
         conditions = conditions,
         cases = cases,
         retry = retry,
-        continueOnError = continueOnError
+        continueOnError = continueOnError,
+        position = position
     )
 
 private fun RuntimeWorkflowGraphNode.toWorkflowGraphNode(): WorkflowGraphNode =
@@ -254,7 +257,8 @@ private fun RuntimeWorkflowGraphNode.toWorkflowGraphNode(): WorkflowGraphNode =
         conditions = conditions,
         cases = cases,
         retry = retry,
-        continueOnError = continueOnError
+        continueOnError = continueOnError,
+        position = position
     )
 
 private fun WorkflowRunStepProgress.toRuntimeProgress(): RuntimeWorkflowRunStepProgress =

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowModels.kt
@@ -110,6 +110,12 @@ data class WorkflowSwitchCaseConfig(
 )
 
 @Serializable
+data class WorkflowGraphPosition(
+    val x: Double,
+    val y: Double
+)
+
+@Serializable
 data class WorkflowGraphNode(
     val id: String,
     val type: String,
@@ -120,7 +126,8 @@ data class WorkflowGraphNode(
     val conditions: List<WorkflowConditionConfig> = emptyList(),
     val cases: List<WorkflowSwitchCaseConfig> = emptyList(),
     val retry: WorkflowRetryConfig? = null,
-    @SerialName("continue_on_error") val continueOnError: Boolean = false
+    @SerialName("continue_on_error") val continueOnError: Boolean = false,
+    val position: WorkflowGraphPosition? = null
 )
 
 @Serializable

--- a/dashboard/src/components/workflows/NodeConfigPanel.tsx
+++ b/dashboard/src/components/workflows/NodeConfigPanel.tsx
@@ -14,22 +14,38 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {Trash2} from 'lucide-react'
+import {useState} from 'react'
+import {useQuery} from '@tanstack/react-query'
+import {Check, ChevronsUpDown, Loader2, Trash2} from 'lucide-react'
 import type {
+  EscalationPolicy,
   WorkflowCatalogResponse,
   WorkflowConditionConfig,
+  WorkflowConnection,
+  WorkflowConnectionGroup,
   WorkflowGraphNode,
   WorkflowOperationDefinition,
   WorkflowScopeReferenceDefinition,
   WorkflowStepParamDefinition,
   WorkflowSwitchCaseConfig,
 } from '@/lib/api'
+import {api} from '@/lib/api'
 import {Button} from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
 import {Input} from '@/components/ui/input'
 import {Label} from '@/components/ui/label'
+import {Popover, PopoverContent, PopoverTrigger} from '@/components/ui/popover'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
 import {Switch} from '@/components/ui/switch'
 import {Textarea} from '@/components/ui/textarea'
+import {cn} from '@/lib/utils'
 import {nodeLabel, stepDefinition, triggerNodeId} from './workflowGraph'
 
 interface NodeConfigPanelProps {
@@ -162,6 +178,33 @@ function ParamField({
   onChange: (node: WorkflowGraphNode) => void
 }) {
   const value = node.params?.[param.name]
+  if (node.action === 'oncall.page' && param.name === 'escalation_policy_id') {
+    return (
+      <EscalationPolicyParamField
+        value={value}
+        onChange={(policyId) => updateParamValue(node, param.name, policyId, onChange)}
+      />
+    )
+  }
+  if (node.type === 'action' && param.name === 'connection_id') {
+    return (
+      <ConnectionParamField
+        value={value}
+        actionName={node.action ?? undefined}
+        onChange={(connectionId) => updateParamValue(node, param.name, connectionId, onChange)}
+      />
+    )
+  }
+  if (node.type === 'action' && param.name === 'connection_group_id') {
+    return (
+      <ConnectionGroupParamField
+        value={value}
+        actionName={node.action ?? undefined}
+        onChange={(groupId) => updateParamValue(node, param.name, groupId, onChange)}
+      />
+    )
+  }
+
   return (
     <div className="space-y-1.5">
       <Label>{param.label}</Label>
@@ -196,6 +239,311 @@ function ParamField({
         />
       )}
     </div>
+  )
+}
+
+function ConnectionParamField({
+  value,
+  actionName,
+  onChange,
+}: {
+  value: unknown
+  actionName?: string
+  onChange: (connectionId: number | '') => void
+}) {
+  const [open, setOpen] = useState(false)
+  const selectedConnectionId = numberParamValue(value)
+  const connectionType = connectionTypeForAction(actionName)
+  const {data: connections = [], isLoading} = useQuery({
+    queryKey: ['workflow-connections'],
+    queryFn: () => api.listWorkflowConnections(),
+  })
+  const visibleConnections = connections.filter((connection) => connectionMatchesAction(connection, connectionType))
+  const selectedConnection = connections.find((connection) => connection.id === selectedConnectionId)
+  const emptyLabel = connections.length === 0 ? 'No connections found.' : 'No matching connections found.'
+
+  return (
+    <div className="space-y-1.5">
+      <Label>Connection</Label>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn('w-full justify-between font-normal', !selectedConnection && 'text-muted-foreground')}
+          >
+            <span className="min-w-0 truncate">
+              {selectedConnection?.name ?? selectedConnectionFallbackLabel(selectedConnectionId)}
+            </span>
+            {isLoading ? (
+              <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin opacity-60" />
+            ) : (
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search connections..." />
+            <CommandList>
+              <CommandEmpty>{emptyLabel}</CommandEmpty>
+              <CommandGroup>
+                {selectedConnectionId !== null && (
+                  <CommandItem
+                    value="no connection"
+                    onSelect={() => {
+                      onChange('')
+                      setOpen(false)
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <Check className="h-4 w-4 shrink-0 opacity-0" />
+                    <span className="text-muted-foreground">No connection</span>
+                  </CommandItem>
+                )}
+                {visibleConnections.map((connection) => (
+                  <ConnectionItem
+                    key={connection.id}
+                    connection={connection}
+                    selected={connection.id === selectedConnectionId}
+                    onSelect={() => {
+                      onChange(connection.id)
+                      setOpen(false)
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+function ConnectionItem({
+  connection,
+  selected,
+  onSelect,
+}: {
+  connection: WorkflowConnection
+  selected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <CommandItem
+      value={`${connection.name} ${connection.type} ${connectionTagSearchText(connection)}`}
+      onSelect={onSelect}
+      className="flex items-start gap-2"
+    >
+      <Check className={cn('mt-0.5 h-4 w-4 shrink-0', selected ? 'opacity-100' : 'opacity-0')} />
+      <span className="min-w-0">
+        <span className="block truncate font-medium">{connection.name}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {connectionTypeLabel(connection.type)} - {connectionDetailLabel(connection)}
+        </span>
+      </span>
+    </CommandItem>
+  )
+}
+
+function ConnectionGroupParamField({
+  value,
+  actionName,
+  onChange,
+}: {
+  value: unknown
+  actionName?: string
+  onChange: (groupId: number | '') => void
+}) {
+  const [open, setOpen] = useState(false)
+  const selectedGroupId = numberParamValue(value)
+  const connectionType = connectionTypeForAction(actionName)
+  const {data: groups = [], isLoading} = useQuery({
+    queryKey: ['workflow-connection-groups'],
+    queryFn: () => api.listWorkflowConnectionGroups(),
+  })
+  const visibleGroups = groups.filter((group) => connectionGroupMatchesAction(group, connectionType))
+  const selectedGroup = groups.find((group) => group.id === selectedGroupId)
+  const emptyLabel = groups.length === 0 ? 'No connection groups found.' : 'No matching connection groups found.'
+
+  return (
+    <div className="space-y-1.5">
+      <Label>Connection group</Label>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn('w-full justify-between font-normal', !selectedGroup && 'text-muted-foreground')}
+          >
+            <span className="min-w-0 truncate">
+              {selectedGroup?.name ?? selectedGroupFallbackLabel(selectedGroupId)}
+            </span>
+            {isLoading ? (
+              <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin opacity-60" />
+            ) : (
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search connection groups..." />
+            <CommandList>
+              <CommandEmpty>{emptyLabel}</CommandEmpty>
+              <CommandGroup>
+                {selectedGroupId !== null && (
+                  <CommandItem
+                    value="no connection group"
+                    onSelect={() => {
+                      onChange('')
+                      setOpen(false)
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <Check className="h-4 w-4 shrink-0 opacity-0" />
+                    <span className="text-muted-foreground">No connection group</span>
+                  </CommandItem>
+                )}
+                {visibleGroups.map((group) => (
+                  <ConnectionGroupItem
+                    key={group.id}
+                    group={group}
+                    selected={group.id === selectedGroupId}
+                    onSelect={() => {
+                      onChange(group.id)
+                      setOpen(false)
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+function ConnectionGroupItem({
+  group,
+  selected,
+  onSelect,
+}: {
+  group: WorkflowConnectionGroup
+  selected: boolean
+  onSelect: () => void
+}) {
+  const memberCount = group.member_connection_ids.length
+  return (
+    <CommandItem
+      value={`${group.name} ${group.connection_type} ${group.selection_strategy} ${group.id}`}
+      onSelect={onSelect}
+      className="flex items-start gap-2"
+    >
+      <Check className={cn('mt-0.5 h-4 w-4 shrink-0', selected ? 'opacity-100' : 'opacity-0')} />
+      <span className="min-w-0">
+        <span className="block truncate font-medium">{group.name}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {connectionTypeLabel(group.connection_type)} - {memberCount} member{memberCount === 1 ? '' : 's'} -{' '}
+          {selectionStrategyLabel(group.selection_strategy)}
+        </span>
+      </span>
+    </CommandItem>
+  )
+}
+
+function EscalationPolicyParamField({
+  value,
+  onChange,
+}: {
+  value: unknown
+  onChange: (policyId: number) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const selectedPolicyId = numberParamValue(value)
+  const {data: policies = [], isLoading} = useQuery({
+    queryKey: ['escalation-policies'],
+    queryFn: () => api.getEscalationPolicies(),
+  })
+  const selectedPolicy = policies.find((policy) => policy.id === selectedPolicyId)
+
+  return (
+    <div className="space-y-1.5">
+      <Label>Escalation policy</Label>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn('w-full justify-between font-normal', !selectedPolicy && 'text-muted-foreground')}
+          >
+            <span className="min-w-0 truncate">
+              {selectedPolicy?.name ?? selectedPolicyFallbackLabel(selectedPolicyId)}
+            </span>
+            {isLoading ? (
+              <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin opacity-60" />
+            ) : (
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search escalation policies..." />
+            <CommandList>
+              <CommandEmpty>No escalation policy found.</CommandEmpty>
+              <CommandGroup>
+                {policies.map((policy) => (
+                  <EscalationPolicyItem
+                    key={policy.id}
+                    policy={policy}
+                    selected={policy.id === selectedPolicyId}
+                    onSelect={() => {
+                      onChange(policy.id)
+                      setOpen(false)
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+function EscalationPolicyItem({
+  policy,
+  selected,
+  onSelect,
+}: {
+  policy: EscalationPolicy
+  selected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <CommandItem
+      value={`${policy.name} ${policy.description ?? ''}`}
+      onSelect={onSelect}
+      className="flex items-start gap-2"
+    >
+      <Check className={cn('mt-0.5 h-4 w-4 shrink-0', selected ? 'opacity-100' : 'opacity-0')} />
+      <span className="min-w-0">
+        <span className="block truncate font-medium">{policy.name}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {policy.description || `${policy.steps.length} step${policy.steps.length === 1 ? '' : 's'}`}
+        </span>
+      </span>
+    </CommandItem>
   )
 }
 
@@ -526,7 +874,10 @@ function ConditionRow({
         </SelectContent>
       </Select>
       {condition.operation !== 'is_set' && condition.operation !== 'is_not_set' && (
-        <Input value={condition.value ?? ''} onChange={(event) => onChange({...condition, value: event.target.value})} />
+        <Input
+          value={condition.value ?? ''}
+          onChange={(event) => onChange({...condition, value: event.target.value})}
+        />
       )}
       <Button type="button" variant="ghost" size="sm" onClick={onRemove} className="justify-start text-destructive">
         <Trash2 className="mr-2 h-4 w-4" />
@@ -567,6 +918,81 @@ function updateParamValue(
   onChange: (node: WorkflowGraphNode) => void
 ) {
   onChange({...node, params: {...node.params, [name]: value}})
+}
+
+function numberParamValue(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function selectedPolicyFallbackLabel(policyId: number | null): string {
+  return policyId === null ? 'Select escalation policy...' : `Policy #${policyId}`
+}
+
+function selectedConnectionFallbackLabel(connectionId: number | null): string {
+  return connectionId === null ? 'Select connection...' : 'Unknown connection'
+}
+
+function selectedGroupFallbackLabel(groupId: number | null): string {
+  return groupId === null ? 'Select connection group...' : 'Unknown connection group'
+}
+
+function connectionMatchesAction(connection: WorkflowConnection, connectionType: string | null): boolean {
+  return connectionType === null || normalizeConnectionType(connection.type) === connectionType
+}
+
+function connectionGroupMatchesAction(group: WorkflowConnectionGroup, connectionType: string | null): boolean {
+  return connectionType === null || normalizeConnectionType(group.connection_type) === connectionType
+}
+
+function connectionTypeForAction(actionName: string | undefined): string | null {
+  const normalizedAction = normalizeConnectionType(actionName ?? '')
+  if (normalizedAction.includes('pagerduty')) return 'pagerduty'
+  if (normalizedAction.includes('servicenow')) return 'servicenow'
+  if (normalizedAction.includes('github')) return 'github'
+  if (normalizedAction.includes('jira')) return 'jira'
+  return null
+}
+
+function normalizeConnectionType(value: string): string {
+  return value.toLowerCase().replace(/[\s_.-]/g, '')
+}
+
+function connectionTypeLabel(connectionType: string): string {
+  if (normalizeConnectionType(connectionType) === 'pagerduty') return 'PagerDuty'
+  if (normalizeConnectionType(connectionType) === 'servicenow') return 'ServiceNow'
+  if (normalizeConnectionType(connectionType) === 'github') return 'GitHub'
+  if (normalizeConnectionType(connectionType) === 'jira') return 'Jira'
+  return connectionType
+}
+
+function selectionStrategyLabel(selectionStrategy: string): string {
+  return selectionStrategy
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}
+
+function connectionDetailLabel(connection: WorkflowConnection): string {
+  const tagEntries = Object.entries(connection.identifier_tags)
+  if (tagEntries.length > 0) {
+    return tagEntries
+      .slice(0, 2)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ')
+  }
+  return connection.last_four ? `Secret ending ${connection.last_four}` : 'No tags'
+}
+
+function connectionTagSearchText(connection: WorkflowConnection): string {
+  return Object.entries(connection.identifier_tags)
+    .map(([key, value]) => `${key} ${value}`)
+    .join(' ')
 }
 
 function booleanParamChecked(value: unknown): boolean {

--- a/dashboard/src/components/workflows/NodeConfigPanel.tsx
+++ b/dashboard/src/components/workflows/NodeConfigPanel.tsx
@@ -934,11 +934,11 @@ function selectedPolicyFallbackLabel(policyId: number | null): string {
 }
 
 function selectedConnectionFallbackLabel(connectionId: number | null): string {
-  return connectionId === null ? 'Select connection...' : 'Unknown connection'
+  return connectionId === null ? 'Select connection...' : `Unknown connection (id: ${connectionId})`
 }
 
 function selectedGroupFallbackLabel(groupId: number | null): string {
-  return groupId === null ? 'Select connection group...' : 'Unknown connection group'
+  return groupId === null ? 'Select connection group...' : `Unknown connection group (id: ${groupId})`
 }
 
 function connectionMatchesAction(connection: WorkflowConnection, connectionType: string | null): boolean {

--- a/dashboard/src/components/workflows/NodePalette.tsx
+++ b/dashboard/src/components/workflows/NodePalette.tsx
@@ -14,11 +14,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import type {ReactNode} from 'react'
+import type {DragEvent, ReactNode} from 'react'
 import {Bell, GitBranch, Hourglass, Mail, MessageSquare, Plus, Slack} from 'lucide-react'
 import type {WorkflowCatalogResponse, WorkflowGraphNode} from '@/lib/api'
 import {Button} from '@/components/ui/button'
-import {defaultParamsForStep} from './workflowGraph'
+import {
+  defaultParamsForStep,
+  workflowPaletteDragDataType,
+  type WorkflowPaletteDragPayload,
+} from './workflowGraph'
 
 interface NodePaletteProps {
   catalog?: WorkflowCatalogResponse
@@ -29,78 +33,135 @@ type ControlKind = 'sleep' | 'wait_until' | 'for_each' | 'while'
 
 export function NodePalette({catalog, onAddNode}: NodePaletteProps) {
   return (
-    <div className="space-y-3 rounded-md border bg-muted/20 p-3">
-      <div>
+    <div className="flex h-[560px] min-w-0 flex-col gap-3 overflow-hidden rounded-md border bg-muted/20 p-3 xl:h-[680px]">
+      <div className="shrink-0">
         <h3 className="text-sm font-semibold">Node palette</h3>
         <p className="text-xs text-muted-foreground">Add branches, waits, and workflow actions.</p>
       </div>
-      <div className="grid gap-2">
-        <PaletteButton
+      <div className="grid shrink-0 gap-2">
+        <PaletteNodeButton
           icon={<GitBranch className="h-4 w-4" />}
           label="If / else"
-          onClick={() => onAddNode(conditionNode('if'), 'condition')}
+          node={conditionNode('if')}
+          prefix="condition"
+          onAddNode={onAddNode}
         />
-        <PaletteButton
+        <PaletteNodeButton
           icon={<GitBranch className="h-4 w-4" />}
           label="Switch"
-          onClick={() => onAddNode(conditionNode('switch'), 'switch')}
+          node={conditionNode('switch')}
+          prefix="switch"
+          onAddNode={onAddNode}
         />
-        <PaletteButton
+        <PaletteNodeButton
           icon={<Hourglass className="h-4 w-4" />}
           label="Sleep"
-          onClick={() => onAddNode(controlNode('sleep'), 'sleep')}
+          node={controlNode('sleep')}
+          prefix="sleep"
+          onAddNode={onAddNode}
         />
-        <PaletteButton
+        <PaletteNodeButton
           icon={<Hourglass className="h-4 w-4" />}
           label="Wait until"
-          onClick={() => onAddNode(controlNode('wait_until'), 'wait')}
+          node={controlNode('wait_until')}
+          prefix="wait"
+          onAddNode={onAddNode}
         />
-        <PaletteButton
+        <PaletteNodeButton
           icon={<Hourglass className="h-4 w-4" />}
           label="For each"
-          onClick={() => onAddNode(controlNode('for_each'), 'loop')}
+          node={controlNode('for_each')}
+          prefix="loop"
+          onAddNode={onAddNode}
         />
-        <PaletteButton
+        <PaletteNodeButton
           icon={<Hourglass className="h-4 w-4" />}
           label="While"
-          onClick={() => onAddNode(controlNode('while'), 'while')}
+          node={controlNode('while')}
+          prefix="while"
+          onAddNode={onAddNode}
         />
       </div>
-      <div className="space-y-2">
+      <div className="flex min-h-0 flex-1 flex-col gap-2">
         <p className="text-xs font-semibold uppercase text-muted-foreground">Actions</p>
-        {catalog?.steps.map((step) => (
-          <PaletteButton
-            key={step.name}
-            icon={stepIcon(step.name)}
-            label={step.label}
-            onClick={() => onAddNode({
+        <div className="grid min-h-0 flex-1 gap-2 overflow-y-auto pr-1">
+          {catalog?.steps.map((step) => {
+            const node: Omit<WorkflowGraphNode, 'id'> = {
               type: 'action',
               action: step.name,
               params: defaultParamsForStep(step),
               conditions: [],
               cases: [],
               continue_on_error: false,
-            }, 'action')}
-          />
-        ))}
+            }
+            return (
+              <PaletteNodeButton
+                key={step.name}
+                icon={stepIcon(step.name)}
+                label={step.label}
+                node={node}
+                prefix="action"
+                onAddNode={onAddNode}
+              />
+            )
+          })}
+        </div>
       </div>
     </div>
+  )
+}
+
+function PaletteNodeButton({
+  icon,
+  label,
+  node,
+  prefix,
+  onAddNode,
+}: {
+  icon: ReactNode
+  label: string
+  node: Omit<WorkflowGraphNode, 'id'>
+  prefix: string
+  onAddNode: (node: Omit<WorkflowGraphNode, 'id'>, prefix: string) => void
+}) {
+  return (
+    <PaletteButton
+      icon={icon}
+      label={label}
+      dragPayload={{node, prefix}}
+      onClick={() => onAddNode(node, prefix)}
+    />
   )
 }
 
 function PaletteButton({
   icon,
   label,
+  dragPayload,
   onClick,
 }: {
   icon: ReactNode
   label: string
+  dragPayload: WorkflowPaletteDragPayload
   onClick: () => void
 }) {
+  const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    event.dataTransfer.effectAllowed = 'copy'
+    event.dataTransfer.setData(workflowPaletteDragDataType, JSON.stringify(dragPayload))
+  }
+
   return (
-    <Button type="button" variant="outline" size="sm" onClick={onClick} className="h-9 justify-start gap-2">
-      {icon}
-      <span className="truncate">{label}</span>
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      draggable
+      onClick={onClick}
+      onDragStart={handleDragStart}
+      className="h-9 w-full min-w-0 cursor-grab justify-start gap-2 active:cursor-grabbing"
+    >
+      <span className="shrink-0">{icon}</span>
+      <span className="min-w-0 truncate">{label}</span>
       <Plus className="ml-auto h-3.5 w-3.5" />
     </Button>
   )

--- a/dashboard/src/components/workflows/WorkflowCanvas.tsx
+++ b/dashboard/src/components/workflows/WorkflowCanvas.tsx
@@ -14,18 +14,38 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useMemo} from 'react'
-import {Background, Controls, Handle, Position, ReactFlow, type Connection, type Edge, type Node} from '@xyflow/react'
+import {useMemo, type DragEvent} from 'react'
+import {
+  Background,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  type Connection,
+  type Edge,
+  type Node,
+} from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import dagre from '@dagrejs/dagre'
 import {GitBranch, Mail, MessageSquare, Timer, Workflow} from 'lucide-react'
-import type {WorkflowCatalogResponse, WorkflowGraphConfig, WorkflowGraphEdge, WorkflowGraphNode} from '@/lib/api'
+import type {
+  WorkflowCatalogResponse,
+  WorkflowGraphConfig,
+  WorkflowGraphEdge,
+  WorkflowGraphNode,
+  WorkflowGraphPosition,
+} from '@/lib/api'
 import {Badge} from '@/components/ui/badge'
 import {cn} from '@/lib/utils'
-import {nodeLabel} from './workflowGraph'
-
-const nodeWidth = 220
-const nodeHeight = 78
+import {
+  nodeLabel,
+  parseWorkflowPaletteDragPayload,
+  resolveWorkflowNodePositions,
+  updateGraphNodePosition,
+  workflowPaletteDragDataType,
+  type WorkflowPaletteDragPayload,
+} from './workflowGraph'
 
 interface WorkflowCanvasProps {
   graph: WorkflowGraphConfig
@@ -33,6 +53,7 @@ interface WorkflowCanvasProps {
   selectedNodeId: string | null
   onSelectNode: (nodeId: string | null) => void
   onGraphChange: (graph: WorkflowGraphConfig) => void
+  onAddNode?: (payload: WorkflowPaletteDragPayload, position: WorkflowGraphPosition) => void
 }
 
 interface CanvasNodeData extends Record<string, unknown> {
@@ -47,7 +68,31 @@ export function WorkflowCanvas({
   selectedNodeId,
   onSelectNode,
   onGraphChange,
+  onAddNode,
 }: WorkflowCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <WorkflowCanvasInner
+        graph={graph}
+        catalog={catalog}
+        selectedNodeId={selectedNodeId}
+        onSelectNode={onSelectNode}
+        onGraphChange={onGraphChange}
+        onAddNode={onAddNode}
+      />
+    </ReactFlowProvider>
+  )
+}
+
+function WorkflowCanvasInner({
+  graph,
+  catalog,
+  selectedNodeId,
+  onSelectNode,
+  onGraphChange,
+  onAddNode,
+}: WorkflowCanvasProps) {
+  const {screenToFlowPosition} = useReactFlow()
   const flow = useMemo(() => graphToFlow(graph, catalog, selectedNodeId), [catalog, graph, selectedNodeId])
 
   const handleConnect = (connection: Connection) => {
@@ -65,8 +110,26 @@ export function WorkflowCanvas({
     })
   }
 
+  const handleNodeDragStop = (_: unknown, node: Node<CanvasNodeData>) => {
+    onGraphChange(updateGraphNodePosition(graph, node.id, node.position))
+  }
+
+  const handleDragOver = (event: DragEvent) => {
+    if (!onAddNode) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'copy'
+  }
+
+  const handleDrop = (event: DragEvent) => {
+    if (!onAddNode) return
+    event.preventDefault()
+    const payload = parseWorkflowPaletteDragPayload(event.dataTransfer.getData(workflowPaletteDragDataType))
+    if (!payload) return
+    onAddNode(payload, screenToFlowPosition({x: event.clientX, y: event.clientY}))
+  }
+
   return (
-    <div className="h-[560px] min-h-[420px] overflow-hidden rounded-md border bg-background">
+    <div className="h-[560px] min-h-[420px] overflow-hidden rounded-md border bg-background xl:h-[680px]">
       <ReactFlow
         nodes={flow.nodes}
         edges={flow.edges}
@@ -75,7 +138,10 @@ export function WorkflowCanvas({
         nodesDraggable
         onConnect={handleConnect}
         onNodeClick={(_, node) => onSelectNode(node.id)}
+        onNodeDragStop={handleNodeDragStop}
         onPaneClick={() => onSelectNode(null)}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
       >
         <Background gap={20} />
         <Controls />
@@ -153,11 +219,11 @@ function graphToFlow(
   catalog: WorkflowCatalogResponse | undefined,
   selectedNodeId: string | null
 ): {nodes: Node<CanvasNodeData>[]; edges: Edge[]} {
-  const layout = layoutGraph(graph)
+  const positions = resolveWorkflowNodePositions(graph)
   const nodes = graph.nodes.map((node) => ({
     id: node.id,
     type: 'workflowNode',
-    position: layout.get(node.id) ?? {x: 0, y: 0},
+    position: positions.get(node.id) ?? {x: 0, y: 0},
     data: {graphNode: node, catalog, selected: node.id === selectedNodeId},
   }))
   const edges = graph.edges.map((edge, index) => ({
@@ -170,21 +236,6 @@ function graphToFlow(
     className: edge.on === 'error' ? 'stroke-destructive' : undefined,
   }))
   return {nodes, edges}
-}
-
-function layoutGraph(graph: WorkflowGraphConfig): Map<string, {x: number; y: number}> {
-  const dagreGraph = new dagre.graphlib.Graph()
-  dagreGraph.setDefaultEdgeLabel(() => ({}))
-  dagreGraph.setGraph({rankdir: 'TB', ranksep: 80, nodesep: 80})
-  graph.nodes.forEach((node) => dagreGraph.setNode(node.id, {width: nodeWidth, height: nodeHeight}))
-  graph.edges.forEach((edge) => dagreGraph.setEdge(edge.from, edge.to))
-  dagre.layout(dagreGraph)
-  return new Map(
-    graph.nodes.map((node) => {
-      const position = dagreGraph.node(node.id)
-      return [node.id, {x: position.x - nodeWidth / 2, y: position.y - nodeHeight / 2}]
-    })
-  )
 }
 
 function edgeId(

--- a/dashboard/src/components/workflows/__tests__/workflowGraph.test.ts
+++ b/dashboard/src/components/workflows/__tests__/workflowGraph.test.ts
@@ -1,0 +1,93 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import type {WorkflowGraphConfig, WorkflowGraphNode} from '@/lib/api'
+import {
+  addGraphNode,
+  nextAppendedNodePosition,
+  parseWorkflowPaletteDragPayload,
+  removeGraphNode,
+  workflowNodeHeight,
+} from '../workflowGraph'
+
+const triggerNode: WorkflowGraphNode = {
+  id: 'trigger',
+  type: 'trigger',
+  trigger: 'alert.triggered',
+  params: {},
+  conditions: [],
+  cases: [],
+  position: {x: 20, y: 30},
+}
+
+describe('workflow graph positioning', () => {
+  it('adds explicit node positions to the graph', () => {
+    const graph: WorkflowGraphConfig = {nodes: [triggerNode], edges: []}
+    const actionNode: WorkflowGraphNode = {
+      id: 'action-2',
+      type: 'action',
+      action: 'email.send',
+      params: {},
+      conditions: [],
+      cases: [],
+    }
+
+    const updatedGraph = addGraphNode(graph, actionNode, {x: 140, y: 220})
+
+    expect(updatedGraph.nodes.find((node) => node.id === actionNode.id)?.position).toEqual({x: 140, y: 220})
+  })
+
+  it('places palette-clicked nodes below the lowest current node', () => {
+    const graph: WorkflowGraphConfig = {
+      nodes: [
+        triggerNode,
+        {
+          id: 'action-2',
+          type: 'action',
+          action: 'email.send',
+          params: {},
+          conditions: [],
+          cases: [],
+          position: {x: 20, y: 180},
+        },
+      ],
+      edges: [],
+    }
+
+    expect(nextAppendedNodePosition(graph)).toEqual({x: 20, y: 180 + workflowNodeHeight + 80})
+  })
+
+  it('allows selected trigger nodes to be removed from a draft graph', () => {
+    const graph: WorkflowGraphConfig = {nodes: [triggerNode], edges: []}
+
+    expect(removeGraphNode(graph, triggerNode.id)).toEqual({nodes: [], edges: []})
+  })
+})
+
+describe('workflow palette drag payloads', () => {
+  it('parses valid palette payloads', () => {
+    const result = parseWorkflowPaletteDragPayload(JSON.stringify({node: {type: 'control'}, prefix: 'sleep'}))
+
+    expect(result).toEqual({node: {type: 'control'}, prefix: 'sleep'})
+  })
+
+  it('rejects malformed palette payloads', () => {
+    expect(parseWorkflowPaletteDragPayload('{bad json')).toBeNull()
+    expect(parseWorkflowPaletteDragPayload(JSON.stringify({node: {type: 'bad'}, prefix: 'sleep'}))).toBeNull()
+    expect(parseWorkflowPaletteDragPayload(JSON.stringify({node: {type: 'control'}}))).toBeNull()
+  })
+})

--- a/dashboard/src/components/workflows/__tests__/workflowGraph.test.ts
+++ b/dashboard/src/components/workflows/__tests__/workflowGraph.test.ts
@@ -15,14 +15,43 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {describe, expect, it} from 'vitest'
-import type {WorkflowGraphConfig, WorkflowGraphNode} from '@/lib/api'
+import type {
+  WorkflowCatalogResponse,
+  WorkflowConditionConfig,
+  WorkflowGraphConfig,
+  WorkflowGraphNode,
+  WorkflowResponse,
+  WorkflowStepDefinition,
+} from '@/lib/api'
 import {
   addGraphNode,
+  defaultParamsForStep,
+  draftFromWorkflow,
+  draftToRequest,
+  emptyWorkflowDraft,
+  graphFromLegacy,
   nextAppendedNodePosition,
+  nextNodeId,
+  nodeLabel,
+  normalizeGraph,
   parseWorkflowPaletteDragPayload,
   removeGraphNode,
+  resolveWorkflowNodePositions,
+  splitReferences,
+  statusClass,
+  stepDefinition,
+  stepsFromGraph,
+  updateGraphNode,
+  updateGraphNodePosition,
+  validateDraft,
   workflowNodeHeight,
 } from '../workflowGraph'
+
+const alertPriorityCondition: WorkflowConditionConfig = {
+  reference: 'alert.priority',
+  operation: 'is_equal',
+  value: 'P1',
+}
 
 const triggerNode: WorkflowGraphNode = {
   id: 'trigger',
@@ -32,6 +61,50 @@ const triggerNode: WorkflowGraphNode = {
   conditions: [],
   cases: [],
   position: {x: 20, y: 30},
+}
+
+const emailStep: WorkflowStepDefinition = {
+  name: 'email.send',
+  label: 'Email organization members',
+  description: 'Send an email.',
+  params: [
+    {name: 'subject', label: 'Subject', type: 'String', required: true},
+    {name: 'body', label: 'Body', type: 'Text', required: true},
+    {name: 'retries', label: 'Retries', type: 'Number', required: false},
+    {name: 'enabled', label: 'Enabled', type: 'Boolean', required: false},
+  ],
+}
+
+const catalog: WorkflowCatalogResponse = {
+  resources: [],
+  triggers: [{
+    name: 'alert.triggered',
+    label: 'When an alert triggers',
+    description: 'Alert trigger.',
+    scope: [],
+    default_once_for_template: ['alert.deduplication_key'],
+  }],
+  steps: [emailStep],
+  node_types: [],
+}
+
+function workflowResponse(overrides: Partial<WorkflowResponse> = {}): WorkflowResponse {
+  return {
+    id: 1,
+    name: 'Workflow',
+    trigger_name: 'alert.triggered',
+    enabled: true,
+    version: 1,
+    published: false,
+    conditions: [],
+    steps: [],
+    graph: {nodes: [], edges: []},
+    once_for_template: ['alert.deduplication_key'],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    run_count: 0,
+    ...overrides,
+  }
 }
 
 describe('workflow graph positioning', () => {
@@ -49,6 +122,23 @@ describe('workflow graph positioning', () => {
     const updatedGraph = addGraphNode(graph, actionNode, {x: 140, y: 220})
 
     expect(updatedGraph.nodes.find((node) => node.id === actionNode.id)?.position).toEqual({x: 140, y: 220})
+  })
+
+  it('adds default node fields when no explicit position is supplied', () => {
+    const graph: WorkflowGraphConfig = {nodes: [triggerNode], edges: []}
+
+    const updatedGraph = addGraphNode(graph, {
+      id: 'action-2',
+      type: 'action',
+      action: 'email.send',
+    })
+
+    expect(updatedGraph.nodes[1]).toMatchObject({
+      params: {},
+      conditions: [],
+      cases: [],
+      continue_on_error: false,
+    })
   })
 
   it('places palette-clicked nodes below the lowest current node', () => {
@@ -71,10 +161,177 @@ describe('workflow graph positioning', () => {
     expect(nextAppendedNodePosition(graph)).toEqual({x: 20, y: 180 + workflowNodeHeight + 80})
   })
 
+  it('falls back to auto-layout when a saved position is invalid', () => {
+    const graph: WorkflowGraphConfig = {
+      nodes: [
+        {...triggerNode, position: {x: Number.POSITIVE_INFINITY, y: 0}},
+        {
+          id: 'action-2',
+          type: 'action',
+          action: 'email.send',
+          params: {},
+          conditions: [],
+          cases: [],
+          position: {x: 400, y: 500},
+        },
+      ],
+      edges: [{from: triggerNode.id, to: 'action-2'}],
+    }
+
+    const positions = resolveWorkflowNodePositions(graph)
+
+    expect(positions.get('action-2')).toEqual({x: 400, y: 500})
+    expect(positions.get(triggerNode.id)?.x).not.toBe(Number.POSITIVE_INFINITY)
+  })
+
+  it('updates saved node positions', () => {
+    const graph: WorkflowGraphConfig = {nodes: [triggerNode], edges: []}
+
+    expect(updateGraphNodePosition(graph, triggerNode.id, {x: 10, y: 15}).nodes[0].position).toEqual({x: 10, y: 15})
+  })
+
   it('allows selected trigger nodes to be removed from a draft graph', () => {
     const graph: WorkflowGraphConfig = {nodes: [triggerNode], edges: []}
 
     expect(removeGraphNode(graph, triggerNode.id)).toEqual({nodes: [], edges: []})
+  })
+
+  it('removes edges attached to removed nodes', () => {
+    const graph: WorkflowGraphConfig = {
+      nodes: [triggerNode, {id: 'action-2', type: 'action', action: 'email.send'}],
+      edges: [{from: triggerNode.id, to: 'action-2'}],
+    }
+
+    expect(removeGraphNode(graph, 'action-2')).toEqual({nodes: [triggerNode], edges: []})
+  })
+})
+
+describe('workflow graph conversion', () => {
+  it('creates legacy graph edges with condition and action nodes', () => {
+    const graph = graphFromLegacy(
+      'alert.triggered',
+      [alertPriorityCondition],
+      [
+        {name: 'email.send', params: {subject: 'One'}},
+        {name: 'slack.send', params: {channel: 'alerts'}},
+      ]
+    )
+
+    expect(graph.nodes.map((node) => node.id)).toEqual(['trigger', 'conditions', 'step-1', 'step-2'])
+    expect(graph.edges).toEqual([
+      {from: 'trigger', to: 'conditions'},
+      {from: 'conditions', to: 'step-1', branch: 'true'},
+      {from: 'step-1', to: 'step-2'},
+    ])
+  })
+
+  it('normalizes saved graph nodes with defaults', () => {
+    const response = workflowResponse({
+      graph: {
+        nodes: [{id: 'action-1', type: 'action', action: 'email.send'}],
+        edges: [],
+      },
+    })
+
+    expect(normalizeGraph(response).nodes[0]).toMatchObject({
+      params: {},
+      conditions: [],
+      cases: [],
+      continue_on_error: false,
+    })
+  })
+
+  it('falls back to legacy fields when no graph is stored', () => {
+    const response = workflowResponse({
+      conditions: [alertPriorityCondition],
+      steps: [{name: 'email.send', params: {subject: 'Legacy'}}],
+    })
+
+    expect(normalizeGraph(response).nodes.map((node) => node.id)).toEqual(['trigger', 'conditions', 'step-1'])
+  })
+
+  it('round-trips draft data to workflow requests', () => {
+    const graph = graphFromLegacy('alert.triggered', [alertPriorityCondition], [
+      {name: 'email.send', params: {subject: 'Hello', body: 'World'}},
+    ])
+
+    expect(draftToRequest({
+      name: '  Notify ',
+      triggerName: 'alert.triggered',
+      enabled: true,
+      published: false,
+      graph,
+      onceForTemplate: ' alert.id, alert.source ,, ',
+    })).toMatchObject({
+      name: 'Notify',
+      conditions: [alertPriorityCondition],
+      steps: [{name: 'email.send', params: {subject: 'Hello', body: 'World'}}],
+      once_for_template: ['alert.id', 'alert.source'],
+    })
+  })
+
+  it('builds drafts from catalog defaults and existing workflows', () => {
+    expect(emptyWorkflowDraft(catalog)).toMatchObject({
+      triggerName: 'alert.triggered',
+      onceForTemplate: 'alert.deduplication_key',
+    })
+
+    expect(draftFromWorkflow(workflowResponse({name: 'Existing'}))).toMatchObject({
+      id: 1,
+      name: 'Existing',
+      triggerName: 'alert.triggered',
+    })
+  })
+})
+
+describe('workflow graph labels and defaults', () => {
+  it('generates labels for triggers, actions, conditions, and controls', () => {
+    expect(nodeLabel(triggerNode, catalog)).toBe('When an alert triggers')
+    expect(nodeLabel({id: 'action-1', type: 'action', action: 'email.send'}, catalog)).toBe(
+      'Email organization members'
+    )
+    expect(nodeLabel({id: 'condition-1', type: 'condition', kind: 'switch'})).toBe('Switch')
+    expect(nodeLabel({id: 'condition-2', type: 'condition', kind: 'if'})).toBe('If / else')
+    expect(nodeLabel({id: 'wait-1', type: 'control', kind: 'wait_until'})).toBe('Wait until')
+    expect(nodeLabel({id: 'loop-1', type: 'control', kind: 'for_each'})).toBe('For each')
+    expect(nodeLabel({id: 'while-1', type: 'control', kind: 'while'})).toBe('While')
+    expect(nodeLabel({id: 'sleep-1', type: 'control', kind: 'sleep'})).toBe('Sleep')
+  })
+
+  it('falls back when catalog definitions are missing', () => {
+    expect(nodeLabel({id: 'trigger-1', type: 'trigger'})).toBe('Trigger')
+    expect(nodeLabel({id: 'action-1', type: 'action'})).toBe('Action')
+    expect(stepDefinition(catalog, 'missing')).toBeUndefined()
+  })
+
+  it('creates default params by param name and type', () => {
+    expect(defaultParamsForStep(emailStep)).toEqual({
+      subject: 'Moneat workflow: {{alert.title}}',
+      body: '{{alert.display_title}}\n\nPriority: {{alert.priority}}\nSource: {{alert.source}}\nView: {{alert.url}}',
+      retries: 100,
+      enabled: false,
+    })
+  })
+
+  it('finds next IDs and converts graph actions to legacy steps', () => {
+    const graph: WorkflowGraphConfig = {
+      nodes: [
+        triggerNode,
+        {id: 'action-2', type: 'action', action: 'email.send', params: {count: 2, enabled: true, blank: null}},
+      ],
+      edges: [],
+    }
+
+    expect(nextNodeId(graph, 'action')).toBe('action-3')
+    expect(stepsFromGraph(graph)).toEqual([{name: 'email.send', params: {count: '2', enabled: 'true', blank: ''}}])
+  })
+
+  it('formats references and statuses', () => {
+    expect(splitReferences('alert.id, , alert.source')).toEqual(['alert.id', 'alert.source'])
+    expect(statusClass('complete')).toContain('emerald')
+    expect(statusClass('failed')).toContain('red')
+    expect(statusClass('running')).toContain('blue')
+    expect(statusClass('pending')).toContain('amber')
   })
 })
 
@@ -87,7 +344,66 @@ describe('workflow palette drag payloads', () => {
 
   it('rejects malformed palette payloads', () => {
     expect(parseWorkflowPaletteDragPayload('{bad json')).toBeNull()
+    expect(parseWorkflowPaletteDragPayload(JSON.stringify(null))).toBeNull()
+    expect(parseWorkflowPaletteDragPayload(JSON.stringify([]))).toBeNull()
+    expect(parseWorkflowPaletteDragPayload(JSON.stringify({node: [], prefix: 'sleep'}))).toBeNull()
     expect(parseWorkflowPaletteDragPayload(JSON.stringify({node: {type: 'bad'}, prefix: 'sleep'}))).toBeNull()
     expect(parseWorkflowPaletteDragPayload(JSON.stringify({node: {type: 'control'}}))).toBeNull()
+  })
+})
+
+describe('workflow validation', () => {
+  it('reports invalid draft structure and missing required params', () => {
+    const issues = validateDraft({
+      name: ' ',
+      triggerName: 'missing.trigger',
+      enabled: true,
+      published: false,
+      graph: {
+        nodes: [
+          triggerNode,
+          {...triggerNode, id: 'trigger-2'},
+          {id: 'action-1', type: 'action', action: 'email.send', params: {subject: ''}},
+          {id: 'action-2', type: 'action', action: 'missing.action'},
+        ],
+        edges: [{from: 'missing', to: 'action-1'}],
+      },
+      onceForTemplate: '',
+    }, catalog)
+
+    expect(issues.map((issue) => issue.message)).toEqual([
+      'Workflow name is required.',
+      'Graph must contain exactly one trigger.',
+      'Select a valid trigger.',
+      'Remove edges connected to missing nodes.',
+      'Email organization members is missing Subject.',
+      'Email organization members is missing Body.',
+      'Unknown action missing.action.',
+    ])
+  })
+
+  it('warns when a valid draft has no actions', () => {
+    const issues = validateDraft({
+      name: 'Notify',
+      triggerName: 'alert.triggered',
+      enabled: true,
+      published: false,
+      graph: {nodes: [triggerNode], edges: []},
+      onceForTemplate: 'alert.id',
+    }, catalog)
+
+    expect(issues).toEqual([{level: 'warning', message: 'Add an action before publishing.'}])
+  })
+
+  it('updates matching nodes with default fields', () => {
+    const graph: WorkflowGraphConfig = {nodes: [{id: 'action-1', type: 'action'}], edges: []}
+
+    expect(updateGraphNode(graph, {id: 'action-1', type: 'action', action: 'email.send'}).nodes[0]).toMatchObject({
+      action: 'email.send',
+      params: {},
+      conditions: [],
+      cases: [],
+      continue_on_error: false,
+    })
   })
 })

--- a/dashboard/src/components/workflows/workflowGraph.ts
+++ b/dashboard/src/components/workflows/workflowGraph.ts
@@ -20,15 +20,28 @@ import type {
   WorkflowGraphConfig,
   WorkflowGraphEdge,
   WorkflowGraphNode,
+  WorkflowGraphPosition,
   WorkflowJsonValue,
   WorkflowRequest,
   WorkflowResponse,
   WorkflowStepConfig,
   WorkflowStepDefinition,
 } from '@/lib/api'
+import dagre from '@dagrejs/dagre'
 
 export const triggerNodeId = 'trigger'
+export const workflowNodeWidth = 220
+export const workflowNodeHeight = 78
+export const workflowPaletteDragDataType = 'application/x-moneat-workflow-node'
+
 const legacyConditionNodeId = 'conditions'
+const workflowNodeVerticalGap = 80
+const workflowNodeHorizontalGap = 80
+
+export interface WorkflowPaletteDragPayload {
+  node: Omit<WorkflowGraphNode, 'id'>
+  prefix: string
+}
 
 export interface WorkflowDraft {
   id?: number
@@ -125,9 +138,10 @@ export function graphFromLegacy(
 
 export function addGraphNode(
   graph: WorkflowGraphConfig,
-  node: WorkflowGraphNode
+  node: WorkflowGraphNode,
+  position?: WorkflowGraphPosition
 ): WorkflowGraphConfig {
-  return {...graph, nodes: [...graph.nodes, withNodeDefaults(node)]}
+  return {...graph, nodes: [...graph.nodes, withNodeDefaults(position === undefined ? node : {...node, position})]}
 }
 
 export function updateGraphNode(
@@ -144,10 +158,20 @@ export function removeGraphNode(
   graph: WorkflowGraphConfig,
   nodeId: string
 ): WorkflowGraphConfig {
-  if (nodeId === triggerNodeId) return graph
   return {
     nodes: graph.nodes.filter((node) => node.id !== nodeId),
     edges: graph.edges.filter((edge) => edge.from !== nodeId && edge.to !== nodeId),
+  }
+}
+
+export function updateGraphNodePosition(
+  graph: WorkflowGraphConfig,
+  nodeId: string,
+  position: WorkflowGraphPosition
+): WorkflowGraphConfig {
+  return {
+    ...graph,
+    nodes: graph.nodes.map((node) => (node.id === nodeId ? {...node, position} : node)),
   }
 }
 
@@ -156,6 +180,49 @@ export function nextNodeId(graph: WorkflowGraphConfig, prefix: string): string {
   let index = graph.nodes.length + 1
   while (used.has(`${prefix}-${index}`)) index += 1
   return `${prefix}-${index}`
+}
+
+export function nextAppendedNodePosition(graph: WorkflowGraphConfig): WorkflowGraphPosition {
+  const positions = resolveWorkflowNodePositions(graph)
+  let appendedPosition: WorkflowGraphPosition | null = null
+  let lowestBottom = Number.NEGATIVE_INFINITY
+
+  graph.nodes.forEach((node) => {
+    const position = positions.get(node.id)
+    if (!position) return
+    const bottom = position.y + workflowNodeHeight
+    if (bottom >= lowestBottom) {
+      lowestBottom = bottom
+      appendedPosition = {x: position.x, y: bottom + workflowNodeVerticalGap}
+    }
+  })
+
+  return appendedPosition ?? {x: 0, y: 0}
+}
+
+export function resolveWorkflowNodePositions(graph: WorkflowGraphConfig): Map<string, WorkflowGraphPosition> {
+  const layout = layoutWorkflowGraph(graph)
+  return new Map(
+    graph.nodes.map((node) => [
+      node.id,
+      validNodePosition(node) ?? layout.get(node.id) ?? {x: 0, y: 0},
+    ])
+  )
+}
+
+export function parseWorkflowPaletteDragPayload(raw: string): WorkflowPaletteDragPayload | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.node) || typeof parsed.prefix !== 'string') return null
+  if (!isWorkflowNodeType(parsed.node.type)) return null
+  return {
+    node: parsed.node as Omit<WorkflowGraphNode, 'id'>,
+    prefix: parsed.prefix,
+  }
 }
 
 export function nodeLabel(
@@ -252,6 +319,41 @@ export function stepsFromGraph(graph: WorkflowGraphConfig): WorkflowStepConfig[]
 
 function legacyConditionsFromGraph(graph: WorkflowGraphConfig): WorkflowConditionConfig[] {
   return graph.nodes.find((node) => node.type === 'condition' && node.kind === 'if')?.conditions ?? []
+}
+
+function layoutWorkflowGraph(graph: WorkflowGraphConfig): Map<string, WorkflowGraphPosition> {
+  const dagreGraph = new dagre.graphlib.Graph()
+  dagreGraph.setDefaultEdgeLabel(() => ({}))
+  dagreGraph.setGraph({
+    rankdir: 'TB',
+    ranksep: workflowNodeVerticalGap,
+    nodesep: workflowNodeHorizontalGap,
+  })
+  graph.nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, {width: workflowNodeWidth, height: workflowNodeHeight})
+  })
+  graph.edges.forEach((edge) => dagreGraph.setEdge(edge.from, edge.to))
+  dagre.layout(dagreGraph)
+  return new Map(
+    graph.nodes.map((node) => {
+      const position = dagreGraph.node(node.id)
+      return [node.id, {x: position.x - workflowNodeWidth / 2, y: position.y - workflowNodeHeight / 2}]
+    })
+  )
+}
+
+function validNodePosition(node: WorkflowGraphNode): WorkflowGraphPosition | null {
+  if (!node.position) return null
+  if (!Number.isFinite(node.position.x) || !Number.isFinite(node.position.y)) return null
+  return node.position
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isWorkflowNodeType(value: unknown): value is WorkflowGraphNode['type'] {
+  return value === 'trigger' || value === 'condition' || value === 'action' || value === 'control'
 }
 
 function legacyEdges(

--- a/dashboard/src/hooks/__tests__/useEnterpriseFeatures.test.ts
+++ b/dashboard/src/hooks/__tests__/useEnterpriseFeatures.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
-import { useEnterpriseFeatures, useHasModule } from '../useEnterpriseFeatures'
+import { hasEnterpriseModule, useEnterpriseFeatures, useHasModule } from '../useEnterpriseFeatures'
 import { server } from '../../test/mocks/server'
 import { http, HttpResponse } from 'msw'
 
@@ -76,5 +76,28 @@ describe('useHasModule', () => {
     })
 
     await waitFor(() => expect(result.current).toBe(false))
+  })
+})
+
+describe('hasEnterpriseModule', () => {
+  it('matches display module names with internal feature keys', () => {
+    const features = {
+      enterprise: true,
+      modules: [
+        'Monitoring',
+        'Analytics',
+        'Datadog',
+        'SSO',
+        'AI',
+        'SAML',
+        'On-Call',
+        'Workflows Advanced',
+        'Advanced RBAC',
+      ],
+      selfHost: false,
+    }
+
+    expect(hasEnterpriseModule(features, 'Workflows Advanced')).toBe(true)
+    expect(hasEnterpriseModule(features, 'workflows_advanced')).toBe(true)
   })
 })

--- a/dashboard/src/hooks/useEnterpriseFeatures.ts
+++ b/dashboard/src/hooks/useEnterpriseFeatures.ts
@@ -27,7 +27,6 @@ export function useEnterpriseFeatures() {
       return res.json()
     },
     staleTime: 30 * 1000,
-    refetchOnMount: 'always',
     refetchOnWindowFocus: true,
     retry: false,
   })

--- a/dashboard/src/hooks/useEnterpriseFeatures.ts
+++ b/dashboard/src/hooks/useEnterpriseFeatures.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import {API_BASE} from '@/lib/api/client'
 
 interface FeaturesResponse {
   enterprise: boolean
@@ -6,8 +7,7 @@ interface FeaturesResponse {
   selfHost: boolean
 }
 
-const API_BASE = import.meta.env.VITE_BACKEND_URL || ''
-const FEATURES_URL = `${API_BASE.replace(/\/$/, '')}/v1/features`
+const FEATURES_URL = `${API_BASE}/features`
 
 function normalizeModuleName(value: string): string {
   return value.toLowerCase().replace(/[\s_-]/g, '')
@@ -26,7 +26,9 @@ export function useEnterpriseFeatures() {
       if (!res.ok) throw new Error('Unable to load feature availability')
       return res.json()
     },
-    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+    staleTime: 30 * 1000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
     retry: false,
   })
 }

--- a/dashboard/src/lib/api/types/workflows.ts
+++ b/dashboard/src/lib/api/types/workflows.ts
@@ -47,6 +47,11 @@ export interface WorkflowSwitchCaseConfig {
   conditions: WorkflowConditionConfig[]
 }
 
+export interface WorkflowGraphPosition {
+  x: number
+  y: number
+}
+
 export interface WorkflowGraphNode {
   id: string
   type: 'trigger' | 'condition' | 'action' | 'control'
@@ -58,6 +63,7 @@ export interface WorkflowGraphNode {
   cases?: WorkflowSwitchCaseConfig[]
   retry?: WorkflowRetryConfig | null
   continue_on_error?: boolean
+  position?: WorkflowGraphPosition | null
 }
 
 export interface WorkflowGraphEdge {

--- a/dashboard/src/routes/workflows.connections.tsx
+++ b/dashboard/src/routes/workflows.connections.tsx
@@ -78,6 +78,7 @@ function ConnectionManager() {
     queryKey: ['workflow-connections'],
     queryFn: () => api.listWorkflowConnections(),
   })
+  const showEnterpriseUpsell = isError && isEnterpriseConnectionsError(error)
 
   const invalidate = () => queryClient.invalidateQueries({queryKey: ['workflow-connections']})
 
@@ -94,13 +95,17 @@ function ConnectionManager() {
 
   return (
     <div className="connections-page">
-      <PageHeader showEnterpriseBadge={showEnterpriseBadge} onCreate={() => setCreateOpen(true)} />
+      <PageHeader
+        showEnterpriseBadge={showEnterpriseBadge}
+        canCreate={!showEnterpriseUpsell}
+        onCreate={() => setCreateOpen(true)}
+      />
       <div className="px-4 py-4 lg:px-6">
         {isLoading ? (
           <div className="flex h-40 items-center justify-center rounded-md border">
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
-        ) : isError && isEnterpriseConnectionsError(error) ? (
+        ) : showEnterpriseUpsell ? (
           <EnterpriseUpsell />
         ) : isError ? (
           <ErrorState message={error.message} compact />
@@ -163,9 +168,11 @@ function ErrorState({
 
 function PageHeader({
   showEnterpriseBadge,
+  canCreate,
   onCreate,
 }: {
   showEnterpriseBadge: boolean
+  canCreate: boolean
   onCreate: () => void
 }) {
   return (
@@ -185,7 +192,7 @@ function PageHeader({
             </p>
           </div>
         </div>
-        <Button size="sm" onClick={onCreate} className="gap-1.5">
+        <Button size="sm" onClick={onCreate} disabled={!canCreate} className="gap-1.5">
           <Plus className="h-3.5 w-3.5" />
           New Connection
         </Button>

--- a/dashboard/src/routes/workflows.connections.tsx
+++ b/dashboard/src/routes/workflows.connections.tsx
@@ -20,7 +20,6 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {KeyRound, Loader2, Lock, Plus, RotateCw, Trash2} from 'lucide-react'
 import {api} from '@/lib/api'
 import type {WorkflowConnection} from '@/lib/api'
-import {hasEnterpriseModule, useEnterpriseFeatures} from '@/hooks/useEnterpriseFeatures'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {
@@ -33,9 +32,8 @@ import {
 } from '@/components/ui/dialog'
 import {Input} from '@/components/ui/input'
 import {Label} from '@/components/ui/label'
+import {hasEnterpriseModule, useEnterpriseFeatures} from '@/hooks/useEnterpriseFeatures'
 import {useToast} from '@/hooks/useToast'
-
-const WORKFLOWS_ADVANCED_MODULE = 'Workflows Advanced'
 
 export const Route = createFileRoute('/workflows/connections')({
   beforeLoad: async () => {
@@ -48,20 +46,6 @@ export const Route = createFileRoute('/workflows/connections')({
 })
 
 function ConnectionsPage() {
-  const {data: features, isLoading, isError, error} = useEnterpriseFeatures()
-  if (isLoading) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <Loader2 className="h-5 w-5 animate-spin" />
-      </div>
-    )
-  }
-  if (isError) {
-    return <ErrorState title="Unable to load feature availability" message={error.message} />
-  }
-  if (!hasEnterpriseModule(features, WORKFLOWS_ADVANCED_MODULE)) {
-    return <EnterpriseUpsell />
-  }
   return <ConnectionManager />
 }
 
@@ -87,6 +71,8 @@ function ConnectionManager() {
   const queryClient = useQueryClient()
   const [createOpen, setCreateOpen] = useState(false)
   const [rotateTarget, setRotateTarget] = useState<WorkflowConnection | null>(null)
+  const {data: features} = useEnterpriseFeatures()
+  const showEnterpriseBadge = features !== undefined && !hasEnterpriseModule(features, 'workflows_advanced')
 
   const {data: connections = [], isLoading, isError, error} = useQuery({
     queryKey: ['workflow-connections'],
@@ -108,12 +94,14 @@ function ConnectionManager() {
 
   return (
     <div className="connections-page">
-      <PageHeader onCreate={() => setCreateOpen(true)} />
+      <PageHeader showEnterpriseBadge={showEnterpriseBadge} onCreate={() => setCreateOpen(true)} />
       <div className="px-4 py-4 lg:px-6">
         {isLoading ? (
           <div className="flex h-40 items-center justify-center rounded-md border">
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
+        ) : isError && isEnterpriseConnectionsError(error) ? (
+          <EnterpriseUpsell />
         ) : isError ? (
           <ErrorState message={error.message} compact />
         ) : connections.length === 0 ? (
@@ -146,6 +134,16 @@ function ConnectionManager() {
   )
 }
 
+function isEnterpriseConnectionsError(error: Error): boolean {
+  const status = (error as Error & {status?: number}).status
+  const message = error.message.toLowerCase()
+  return (
+    status === 403 ||
+    message.includes('enterprise') ||
+    (status === 400 && message.includes('invalid workflow id'))
+  )
+}
+
 function ErrorState({
   title = 'Unable to load connections',
   message,
@@ -163,7 +161,13 @@ function ErrorState({
   )
 }
 
-function PageHeader({onCreate}: {onCreate: () => void}) {
+function PageHeader({
+  showEnterpriseBadge,
+  onCreate,
+}: {
+  showEnterpriseBadge: boolean
+  onCreate: () => void
+}) {
   return (
     <div className="border-b bg-card/50">
       <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between lg:px-6">
@@ -174,7 +178,7 @@ function PageHeader({onCreate}: {onCreate: () => void}) {
           <div>
             <div className="flex items-center gap-2">
               <h1 className="text-lg font-bold tracking-tight">Connections</h1>
-              <Badge variant="outline">Enterprise</Badge>
+              {showEnterpriseBadge && <Badge variant="outline">Enterprise</Badge>}
             </div>
             <p className="text-xs text-muted-foreground">
               Encrypted credentials for workflow actions. Secrets are entered once and never shown again.
@@ -357,7 +361,7 @@ function CreateConnectionDialog({
             />
           </div>
         </div>
-        <DialogFooter className="gap-2">
+        <DialogFooter className="gap-2 pt-5">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
@@ -427,7 +431,7 @@ function RotateConnectionDialog({
             onChange={(event) => setSecret(event.target.value)}
           />
         </div>
-        <DialogFooter className="gap-2">
+        <DialogFooter className="gap-2 pt-5">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>

--- a/dashboard/src/routes/workflows.tsx
+++ b/dashboard/src/routes/workflows.tsx
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useMemo, useState} from 'react'
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {useCallback, useEffect, useMemo, useState} from 'react'
+import {createFileRoute, Link, Outlet, redirect, useRouterState} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
   Bug,
@@ -34,6 +34,7 @@ import type {
   WorkflowCatalogResponse,
   WorkflowGraphConfig,
   WorkflowGraphNode,
+  WorkflowGraphPosition,
   WorkflowResponse,
   WorkflowRunResponse,
 } from '@/lib/api'
@@ -52,12 +53,14 @@ import {
   draftToRequest,
   emptyWorkflowDraft,
   formatDate,
+  nextAppendedNodePosition,
   nextNodeId,
   removeGraphNode,
   statusClass,
   triggerNodeId,
   updateGraphNode,
   validateDraft,
+  type WorkflowPaletteDragPayload,
   type WorkflowDraft,
 } from '@/components/workflows/workflowGraph'
 import {Badge} from '@/components/ui/badge'
@@ -74,6 +77,7 @@ import {Input} from '@/components/ui/input'
 import {Label} from '@/components/ui/label'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
 import {Switch} from '@/components/ui/switch'
+import {hasEnterpriseModule, useEnterpriseFeatures} from '@/hooks/useEnterpriseFeatures'
 import {useToast} from '@/hooks/useToast'
 import {cn} from '@/lib/utils'
 
@@ -83,10 +87,21 @@ export const Route = createFileRoute('/workflows')({
       throw redirect({to: '/login'})
     }
   },
-  component: WorkflowsPage,
+  component: WorkflowsLayout,
 })
 
 const noop = () => undefined
+
+function WorkflowsLayout() {
+  const pathname = useRouterState({select: (state) => state.location.pathname})
+  const showingChildRoute = pathname !== '/workflows'
+
+  if (showingChildRoute) {
+    return <Outlet />
+  }
+
+  return <WorkflowsPage />
+}
 
 function WorkflowsPage() {
   const {toast} = useToast()
@@ -246,6 +261,10 @@ function WorkflowsPage() {
 }
 
 function PageHeader({onCreate}: {onCreate: () => void}) {
+  const {data: features} = useEnterpriseFeatures()
+  const showConnectionsEnterpriseBadge =
+    features !== undefined && !hasEnterpriseModule(features, 'workflows_advanced')
+
   return (
     <div className="border-b bg-card/50">
       <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between lg:px-6">
@@ -269,9 +288,11 @@ function PageHeader({onCreate}: {onCreate: () => void}) {
             <Link to="/workflows/connections">
               <KeyRound className="h-3.5 w-3.5" />
               Connections
-              <Badge variant="outline" className="ml-1 text-[10px]">
-                Enterprise
-              </Badge>
+              {showConnectionsEnterpriseBadge && (
+                <Badge variant="outline" className="ml-1 text-[10px]">
+                  Enterprise
+                </Badge>
+              )}
             </Link>
           </Button>
           <Button size="sm" onClick={onCreate} className="gap-1.5">
@@ -493,10 +514,22 @@ function WorkflowEditorDialog({
   const issues = useMemo(() => validateDraft(draft, catalog), [catalog, draft])
   const selectedNode = draft.graph.nodes.find((node) => node.id === selectedNodeId)
   const updateGraph = (graph: WorkflowGraphConfig) => onDraftChange({...draft, graph})
-  const addNode = (node: Omit<WorkflowGraphNode, 'id'>, prefix: string) => {
+  const removeSelectedNode = useCallback(() => {
+    if (!selectedNodeId) return
+    onDraftChange({...draft, graph: removeGraphNode(draft.graph, selectedNodeId)})
+    setSelectedNodeId(selectedNodeId === triggerNodeId ? null : triggerNodeId)
+  }, [draft, onDraftChange, selectedNodeId])
+  const addNode = (
+    node: Omit<WorkflowGraphNode, 'id'>,
+    prefix: string,
+    position: WorkflowGraphPosition = nextAppendedNodePosition(draft.graph)
+  ) => {
     const nextNode = {...node, id: nextNodeId(draft.graph, prefix)}
-    updateGraph(addGraphNode(draft.graph, nextNode))
+    updateGraph(addGraphNode(draft.graph, nextNode, position))
     setSelectedNodeId(nextNode.id)
+  }
+  const addDroppedNode = (payload: WorkflowPaletteDragPayload, position: WorkflowGraphPosition) => {
+    addNode(payload.node, payload.prefix, position)
   }
   const changeTrigger = (triggerName: string) => {
     const graph = updateGraphTrigger(draft.graph, triggerName)
@@ -508,6 +541,22 @@ function WorkflowEditorDialog({
       onceForTemplate: trigger?.default_once_for_template.join(', ') ?? draft.onceForTemplate,
     })
   }
+
+  useEffect(() => {
+    if (!open || !selectedNodeId) return undefined
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return
+      if (event.key !== 'Delete' && event.key !== 'Backspace') return
+      if (isEditableKeyboardTarget(event.target)) return
+      event.preventDefault()
+      removeSelectedNode()
+    }
+
+    globalThis.window?.addEventListener('keydown', handleKeyDown)
+    return () => globalThis.window?.removeEventListener('keydown', handleKeyDown)
+  }, [open, removeSelectedNode, selectedNodeId])
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[92vh] max-w-[1400px] overflow-y-auto">
@@ -529,6 +578,7 @@ function WorkflowEditorDialog({
             selectedNodeId={selectedNodeId}
             onSelectNode={setSelectedNodeId}
             onGraphChange={updateGraph}
+            onAddNode={addDroppedNode}
           />
           <NodeConfigPanel
             node={selectedNode}
@@ -541,7 +591,7 @@ function WorkflowEditorDialog({
             }}
           />
         </div>
-        <DialogFooter className="gap-2">
+        <DialogFooter className="gap-2 pt-5">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
           <Button type="button" onClick={onSave} disabled={pending} className="gap-1.5">
             {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
@@ -604,10 +654,35 @@ function updateGraphTrigger(
   graph: WorkflowGraphConfig,
   triggerName: string
 ): WorkflowGraphConfig {
+  if (!graph.nodes.some((node) => node.id === triggerNodeId)) {
+    return {
+      ...graph,
+      nodes: [
+        {
+          id: triggerNodeId,
+          type: 'trigger',
+          trigger: triggerName,
+          params: {},
+          conditions: [],
+          cases: [],
+          position: nextAppendedNodePosition(graph),
+        },
+        ...graph.nodes,
+      ],
+    }
+  }
   return {
     ...graph,
     nodes: graph.nodes.map((node) => (
       node.id === triggerNodeId ? {...node, trigger: triggerName} : node
     )),
   }
+}
+
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tagName = target.tagName.toLowerCase()
+  if (target.isContentEditable) return true
+  if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') return true
+  return target.getAttribute('role') === 'textbox'
 }


### PR DESCRIPTION
## Summary

- Add direct drag-and-drop from the workflow node palette onto the React Flow canvas, including persisted node positions.
- Add fast Delete/Backspace removal for selected workflow nodes and keep palette-click additions below the current graph.
- Improve workflow connections UX with scrollable actions, full-height canvas alignment, cleaner dialogs, searchable connection/policy selectors, and entitlement-aware Enterprise labeling.
- Add targeted workflow graph tests to keep the frontend hard coverage gate above threshold.

## Why

The workflow editor had several error-prone spots: users had to enter raw IDs, palette additions appeared away from the working area, and connections looked gated even when Workflows Advanced was enabled. This update keeps the editor behavior closer to where users act on the canvas and replaces raw IDs with searchable controls.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- workflowGraph.test.ts useEnterpriseFeatures.test.ts`
- `COVERAGE_GATE_PHASE=hard npm run test:coverage`
- `./gradlew compileKotlin`
- `./gradlew detekt`
- `git diff --check`
- Browser verification on `/workflows` and `/workflows/connections`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow nodes now persist visual position coordinates on canvas
  * Drag-and-drop node creation from palette to workflow editor
  * Delete workflow nodes using keyboard shortcuts (Delete/Backspace)
  * Specialized parameter editors for escalation policies and workflow connections with searchable lists

* **Improvements**
  * Enhanced enterprise feature status indicators in workflow UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->