### PR TITLE
feat(security): add posture signals and enrichment

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
@@ -41,6 +41,7 @@ import com.moneat.datadog.routes.traceDashboardRoutes
 import com.moneat.datadog.routes.traceIngestRoutes
 import com.moneat.datadog.security.SecurityIngestionWorker
 import com.moneat.datadog.security.securityIngestRoutes
+import com.moneat.datadog.security.securityQueryRoutes
 import com.moneat.datadog.services.ProfileStorageService
 import com.moneat.datadog.workers.DatadogEventIngestionWorker
 import com.moneat.datadog.workers.DatadogInfraIngestionWorker
@@ -109,6 +110,9 @@ class DatadogModule : EnterpriseModule {
             }
 
             // Dashboard / query routes (JWT-protected, not agent ingest)
+            rateLimit(RateLimitName("api")) {
+                securityQueryRoutes()
+            }
             traceDashboardRoutes()
             profileDashboardRoutes()
             datadogEventQueryRoutes()

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
@@ -21,7 +21,9 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdActivityDumpPayload
 import com.moneat.datadog.models.DdCompliancePayload
 import com.moneat.datadog.models.DdSecurityEventPayload
+import com.moneat.security.posture.ComplianceFindingInput
 import com.moneat.security.posture.PostureRegressionAnalyzer
+import com.moneat.security.signals.RuntimeSecurityEventInput
 import com.moneat.security.signals.SignalDerivation
 import com.moneat.security.signals.SignalOutcome
 import com.moneat.security.signals.SignalWriter
@@ -180,9 +182,15 @@ object SecurityIngestionService {
     private fun deriveSignals(batch: QueuedSecurityBatch): List<SignalOutcome> {
         val specs = runCatching {
             if (batch.batchType == "findings") {
-                PostureRegressionAnalyzer.analyze(batch.organizationId, batch.findings)
+                PostureRegressionAnalyzer.analyze(
+                    batch.organizationId,
+                    batch.findings.map { it.toPostureFindingInput() },
+                )
+            } else if (batch.batchType == "events") {
+                val events = batch.events.map { it.toRuntimeSecurityEventInput() }
+                SignalDerivation.fromRuntimeEvents(events)
             } else {
-                SignalDerivation.fromBatch(batch)
+                emptyList()
             }
         }.getOrElse { e ->
             logger.warn { "Security signal analysis failed for ${batch.batchType}: ${e.message}" }
@@ -313,4 +321,27 @@ object SecurityIngestionService {
         }
         return "map($entries)"
     }
+
+    private fun QueuedComplianceEntry.toPostureFindingInput(): ComplianceFindingInput =
+        ComplianceFindingInput(
+            framework = framework,
+            ruleId = ruleId,
+            ruleName = ruleName,
+            status = status,
+            resourceType = resourceType,
+            resourceId = resourceId,
+            resourceName = resourceName,
+            timestampMs = timestampMs,
+        )
+
+    private fun QueuedSecurityEventEntry.toRuntimeSecurityEventInput(): RuntimeSecurityEventInput =
+        RuntimeSecurityEventInput(
+            ruleId = ruleId,
+            ruleName = ruleName,
+            severity = severity,
+            processName = processName,
+            filePath = filePath,
+            host = host,
+            timestampMs = timestampMs,
+        )
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionService.kt
@@ -21,6 +21,7 @@ import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdActivityDumpPayload
 import com.moneat.datadog.models.DdCompliancePayload
 import com.moneat.datadog.models.DdSecurityEventPayload
+import com.moneat.security.posture.PostureRegressionAnalyzer
 import com.moneat.security.signals.SignalDerivation
 import com.moneat.security.signals.SignalOutcome
 import com.moneat.security.signals.SignalWriter
@@ -176,12 +177,23 @@ object SecurityIngestionService {
      * signals for this batch" rather than failing the ingest or crashing the worker. Each spec is
      * upserted independently so one bad row cannot drop the rest.
      */
-    private fun deriveSignals(batch: QueuedSecurityBatch): List<SignalOutcome> =
-        SignalDerivation.fromBatch(batch).mapNotNull { spec ->
+    private fun deriveSignals(batch: QueuedSecurityBatch): List<SignalOutcome> {
+        val specs = runCatching {
+            if (batch.batchType == "findings") {
+                PostureRegressionAnalyzer.analyze(batch.organizationId, batch.findings)
+            } else {
+                SignalDerivation.fromBatch(batch)
+            }
+        }.getOrElse { e ->
+            logger.warn { "Security signal analysis failed for ${batch.batchType}: ${e.message}" }
+            emptyList()
+        }
+        return specs.mapNotNull { spec ->
             runCatching { SignalWriter.upsert(batch.organizationId, spec) }
                 .onFailure { logger.warn { "Signal derivation failed for rule ${spec.ruleId}: ${it.message}" } }
                 .getOrNull()
         }
+    }
 
     @Suppress("LongMethod")
     private suspend fun insertSecurityEvents(batch: QueuedSecurityBatch) {

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityQueryRoutes.kt
@@ -53,8 +53,9 @@ fun Route.securityQueryRoutes() {
             get("/events") { handleListEvents() }
             get("/events/{eventId}") { handleEventDetail() }
             get("/dumps") { handleListDumps() }
-            get("/compliance") { handleListFindings() }
             get("/compliance/summary") { handleComplianceSummary() }
+            get("/compliance/trends") { handleComplianceTrends() }
+            get("/compliance") { handleListFindings() }
         }
     }
 }
@@ -276,6 +277,58 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleComplianceSummar
     )
 }
 
+private suspend fun io.ktor.server.routing.RoutingContext.handleComplianceTrends() {
+    val orgId = extractOrgId() ?: return respondEmptyFrameworks()
+    val db = ClickHouseClient.getDatabase()
+    val where = ClickHouseQueryUtils.orgIdClause(orgId.toLong())
+
+    val rows = executeRows(
+        """SELECT framework,
+            formatDateTime(toStartOfDay(evaluated_at), '%Y-%m-%dT00:00:00.000Z', 'UTC') as bucket,
+            countIf(status = 'passed') as passed,
+            countIf(status = 'failed') as failed,
+            countIf(status = 'skipped') as skipped,
+            countIf(status = 'error') as error,
+            count() as total
+        FROM `$db`.compliance_findings
+        WHERE $where AND evaluated_at >= now() - INTERVAL 14 DAY
+        GROUP BY framework, bucket
+        ORDER BY framework, bucket
+        FORMAT JSONEachRow"""
+    ) { obj ->
+        val passed = obj.l("passed")
+        val failed = obj.l("failed")
+        val errors = obj.l("error")
+        val evaluated = passed + failed + errors
+        val passRate = if (evaluated > 0) passed.toDouble() / evaluated.toDouble() else 0.0
+        buildJsonObject {
+            put("framework", obj.s("framework"))
+            put("bucketStart", obj.s("bucket"))
+            put("passed", passed)
+            put("failed", failed)
+            put("skipped", obj.l("skipped"))
+            put("error", errors)
+            put("total", obj.l("total"))
+            put("passRate", passRate)
+        }
+    }
+
+    call.respond(
+        buildJsonObject {
+            putJsonArray("frameworks") {
+                rows.groupBy { it.s("framework") }.forEach { (framework, buckets) ->
+                    add(
+                        buildJsonObject {
+                            put("framework", framework)
+                            putJsonArray("buckets") { buckets.forEach { add(it) } }
+                        }
+                    )
+                }
+            }
+        }
+    )
+}
+
 /**
  * Tenant isolation is enforced by the signed `orgId` JWT claim combined with [ClickHouseQueryUtils.orgIdClause]
  * on every query, so there is no cross-tenant read path and no per-request membership lookup is needed here
@@ -299,6 +352,10 @@ private suspend fun io.ktor.server.routing.RoutingContext.respondEmptyList(array
 /** Empty summary payload returned when the caller token carries no `orgId` claim. */
 private suspend fun io.ktor.server.routing.RoutingContext.respondEmptySummary() {
     call.respond(buildJsonObject { putJsonArray("summary") {} })
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.respondEmptyFrameworks() {
+    call.respond(buildJsonObject { putJsonArray("frameworks") {} })
 }
 
 private fun io.ktor.server.routing.RoutingContext.paramLimit(): Int =
@@ -357,3 +414,5 @@ private fun JsonObject.s(key: String): String {
         el.toString()
     }
 }
+
+private fun JsonObject.l(key: String): Long = s(key).toLongOrNull() ?: 0L

--- a/backend/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.monitoring
 
-import com.moneat.datadog.security.securityQueryRoutes
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.monitor.routes.agentApiKeyRoutes
 import com.moneat.synthetics.routes.SyntheticsScheduler
@@ -28,8 +27,8 @@ import mu.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * Enterprise monitoring module that contributes infra/security/synthetics APIs
- * and the synthetics scheduler background job.
+ * Enterprise monitoring module that contributes agent/synthetics APIs and the
+ * synthetics scheduler background job.
  */
 class MonitoringModule : EnterpriseModule {
     private lateinit var syntheticsScheduler: SyntheticsScheduler
@@ -39,7 +38,6 @@ class MonitoringModule : EnterpriseModule {
     override fun registerRoutes(route: Route) {
         route.apply {
             // Note: infraRoutes() is registered in core Routing.kt, not here
-            securityQueryRoutes()
             syntheticsRoutes()
             agentApiKeyRoutes()
         }

--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -23,6 +23,7 @@ import com.moneat.billing.routes.stripeWebhookRoutes
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
 import com.moneat.config.RedisConfig
+import com.moneat.datadog.security.securityQueryRoutes
 import com.moneat.dashboards.routes.customDashboardRoutes
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.events.routes.apiRoutes
@@ -271,6 +272,7 @@ fun Application.configureRouting() {
 
         // Security signals triage surface (OSS core)
         rateLimit(RateLimitName("api")) {
+            securityQueryRoutes()
             signalRoutes()
         }
 
@@ -298,7 +300,6 @@ fun Application.configureRouting() {
         McpModule.registerRoutes(this)
         routingLogger.info { "MCP routes registered" }
 
-        // AI chat assistant endpoints
         aiChatRoutes()
 
         // Custom dashboard builder endpoints

--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -23,7 +23,6 @@ import com.moneat.billing.routes.stripeWebhookRoutes
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
 import com.moneat.config.RedisConfig
-import com.moneat.datadog.security.securityQueryRoutes
 import com.moneat.dashboards.routes.customDashboardRoutes
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.events.routes.apiRoutes
@@ -272,7 +271,6 @@ fun Application.configureRouting() {
 
         // Security signals triage surface (OSS core)
         rateLimit(RateLimitName("api")) {
-            securityQueryRoutes()
             signalRoutes()
         }
 

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionModels.kt
@@ -80,7 +80,8 @@ enum class DetectionSource(val wire: String) {
 /** The two Phase 1 rule types. */
 enum class DetectionRuleType(val wire: String) {
     THRESHOLD("threshold"),
-    NEW_VALUE("new_value");
+    NEW_VALUE("new_value"),
+    RATE_ANOMALY("rate_anomaly");
 
     companion object {
         fun fromWire(value: String?): DetectionRuleType? = entries.firstOrNull { it.wire == value }
@@ -112,6 +113,35 @@ data class DetectionRuleResponse(
 data class DetectionRuleListResponse(
     val rules: List<DetectionRuleResponse>,
     @SerialName("total_count") val totalCount: Long,
+)
+
+@Serializable
+data class DetectionCoverageResponse(
+    @SerialName("enabled_rule_count") val enabledRuleCount: Int,
+    val tactics: List<MitreTacticCoverageResponse>,
+    val techniques: List<MitreTechniqueCoverageResponse>,
+)
+
+@Serializable
+data class MitreTacticCoverageResponse(
+    val tactic: String,
+    @SerialName("technique_count") val techniqueCount: Int,
+    @SerialName("rule_count") val ruleCount: Int,
+)
+
+@Serializable
+data class MitreTechniqueCoverageResponse(
+    @SerialName("technique_id") val techniqueId: String,
+    val tactics: List<String>,
+    @SerialName("rule_count") val ruleCount: Int,
+    val rules: List<MitreCoveredRuleResponse>,
+)
+
+@Serializable
+data class MitreCoveredRuleResponse(
+    val id: Int,
+    val name: String,
+    val enabled: Boolean,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRecord.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRecord.kt
@@ -38,6 +38,7 @@ data class DetectionRuleRecord(
     val signalTitle: String,
     val signalMessage: String,
     val createdAt: Instant,
+    val tags: List<String> = emptyList(),
 ) {
     /** Stable rule identifier used as the signal `rule_id`. */
     fun ruleId(): String = "detection-$id"

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
@@ -61,6 +61,7 @@ fun Route.detectionRuleRoutes(
     service: DetectionRuleService = DetectionRuleService(),
     membershipService: OrgMembershipService = GlobalContext.get().get(),
     importService: DetectionImportService = DetectionImportService(service),
+    coverageService: MitreCoverageService = MitreCoverageService(),
 ) {
     route("/v1/security/detection/rules") {
         authenticate("auth-jwt") {
@@ -72,8 +73,17 @@ fun Route.detectionRuleRoutes(
             post("$RULE_ID_ROUTE/preview") { handlePreview(service, membershipService) }
         }
     }
+    detectionCoverageRoutes(coverageService)
     detectionImportRoutes(importService, membershipService)
     detectionTemplateRoutes(importService, membershipService)
+}
+
+private fun Route.detectionCoverageRoutes(coverageService: MitreCoverageService) {
+    route("/v1/security/detection/coverage") {
+        authenticate("auth-jwt") {
+            get { handleCoverage(coverageService) }
+        }
+    }
 }
 
 /**
@@ -223,6 +233,12 @@ private suspend fun RoutingContext.handleTemplateList(importService: DetectionIm
     currentOrganizationId()
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
     call.respond(importService.listTemplates())
+}
+
+private suspend fun RoutingContext.handleCoverage(coverageService: MitreCoverageService) {
+    val orgId = currentOrganizationId()
+        ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))
+    call.respond(coverageService.coverage(orgId))
 }
 
 private suspend fun RoutingContext.handleTemplateInstall(

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleService.kt
@@ -178,6 +178,7 @@ class DetectionRuleService(
         val matches = when (record.type) {
             DetectionRuleType.THRESHOLD -> rows
             DetectionRuleType.NEW_VALUE -> filterToNewValues(persistedRuleId, record, rows)
+            DetectionRuleType.RATE_ANOMALY -> rows
         }
         val samples = matches.take(PREVIEW_SAMPLE_LIMIT).map { row ->
             DetectionMatchSample(groupValues = row.groupValues, count = row.count)
@@ -246,6 +247,7 @@ class DetectionRuleService(
         signalTitle = this[DetectionRules.signalTitle],
         signalMessage = this[DetectionRules.signalMessage],
         createdAt = this[DetectionRules.createdAt],
+        tags = decodeStringList(this[DetectionRules.tags]),
     )
 
     private fun decodeStringList(raw: String): List<String> =

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionScheduler.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionScheduler.kt
@@ -45,6 +45,7 @@ class DetectionScheduler(
     runner: DetectionQueryRunner = DetectionQueryRunner(),
     private val thresholdEvaluator: ThresholdEvaluator = ThresholdEvaluator(compiler, runner),
     private val newValueEvaluator: NewValueEvaluator = NewValueEvaluator(compiler, runner),
+    private val rateAnomalyEvaluator: RateAnomalyEvaluator = RateAnomalyEvaluator(compiler, runner),
 ) {
     companion object {
         const val DEFAULT_INTERVAL_SECONDS = 60
@@ -110,6 +111,7 @@ class DetectionScheduler(
         when (rule.type) {
             DetectionRuleType.THRESHOLD -> thresholdEvaluator.evaluate(rule)
             DetectionRuleType.NEW_VALUE -> newValueEvaluator.evaluate(rule)
+            DetectionRuleType.RATE_ANOMALY -> rateAnomalyEvaluator.evaluate(rule)
         }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/security/detection/MitreCoverageService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/MitreCoverageService.kt
@@ -100,21 +100,25 @@ data class CoverageRule(
         MitreCoveredRuleResponse(id = id, name = name, enabled = enabled)
 }
 
-private val TECHNIQUE_REGEX = Regex("""^(?:mitre|attack)(?::technique)?:([Tt]\d{4}(?:\.\d{3})?)$""")
-private val TACTIC_ID_REGEX = Regex("""^(?:mitre|attack):([Tt][Aa]\d{4})$""")
-private val TACTIC_NAME_REGEX = Regex("""^(?:mitre|attack):(?:tactic:)?([a-z][a-z0-9_-]+)$""")
+private val TECHNIQUE_REGEX = Regex("""^(?:mitre|attack)(?::technique)?[:.]([Tt]\d{4}(?:\.\d{3})?)$""")
+private val TACTIC_ID_REGEX = Regex("""^(?:mitre|attack)[:.]([Tt][Aa]\d{4})$""")
+private val TACTIC_NAME_REGEX = Regex("""^(?:mitre|attack)[:.](?:tactic[:.])?([a-z][a-z0-9_-]+)$""")
 
 private fun normalizeTechnique(tag: String): String? =
-    TECHNIQUE_REGEX.find(tag)?.groupValues?.get(1)?.uppercase()
+    TECHNIQUE_REGEX.find(normalizeTagPrefix(tag))?.groupValues?.get(1)?.uppercase()
 
 private fun normalizeTactic(tag: String): String? {
-    val tacticId = TACTIC_ID_REGEX.find(tag)?.groupValues?.get(1)?.uppercase()
+    val normalizedTag = normalizeTagPrefix(tag)
+    val tacticId = TACTIC_ID_REGEX.find(normalizedTag)?.groupValues?.get(1)?.uppercase()
     if (tacticId != null) return TACTIC_IDS[tacticId]
-    val tactic = TACTIC_NAME_REGEX.find(tag)?.groupValues?.get(1)
+    val tactic = TACTIC_NAME_REGEX.find(normalizedTag)?.groupValues?.get(1)
         ?.lowercase()
         ?.replace('_', '-')
     return tactic?.takeIf { it in TACTIC_NAMES }
 }
+
+private fun normalizeTagPrefix(tag: String): String =
+    tag.removePrefix("sigma:")
 
 private val TACTIC_NAMES = setOf(
     "reconnaissance",

--- a/backend/src/main/kotlin/com/moneat/security/detection/MitreCoverageService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/MitreCoverageService.kt
@@ -1,0 +1,160 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+private val coverageJson = Json { ignoreUnknownKeys = true }
+
+class MitreCoverageService {
+
+    fun coverage(organizationId: Int): DetectionCoverageResponse = transaction {
+        val rules = DetectionRules
+            .selectAll()
+            .where { (DetectionRules.organizationId eq organizationId) and (DetectionRules.enabled eq true) }
+            .orderBy(DetectionRules.id, SortOrder.ASC)
+            .map { it.toCoverageRule() }
+        buildCoverage(rules)
+    }
+
+    internal fun buildCoverage(rules: List<CoverageRule>): DetectionCoverageResponse {
+        val byTechnique = mutableMapOf<String, MutableList<CoverageRule>>()
+        val techniqueTactics = mutableMapOf<String, MutableSet<String>>()
+        rules.forEach { rule ->
+            val tags = rule.tags.map { it.trim() }
+            val tacticTags = tags.mapNotNull { normalizeTactic(it) }.toSet()
+            tags.mapNotNull { normalizeTechnique(it) }.forEach { technique ->
+                byTechnique.getOrPut(technique) { mutableListOf() }.add(rule)
+                techniqueTactics.getOrPut(technique) { mutableSetOf() }.addAll(
+                    tacticTags.ifEmpty { TECHNIQUE_TACTICS[technique].orEmpty() }
+                )
+            }
+        }
+        val techniques = byTechnique.entries
+            .sortedBy { it.key }
+            .map { (technique, coveredRules) ->
+                MitreTechniqueCoverageResponse(
+                    techniqueId = technique,
+                    tactics = techniqueTactics[technique].orEmpty().sorted(),
+                    ruleCount = coveredRules.distinctBy { it.id }.size,
+                    rules = coveredRules.distinctBy { it.id }.map { it.toResponse() },
+                )
+            }
+        val tactics = techniques
+            .flatMap { technique -> technique.tactics.map { tactic -> tactic to technique } }
+            .groupBy({ it.first }, { it.second })
+            .map { (tactic, tacticTechniques) ->
+                MitreTacticCoverageResponse(
+                    tactic = tactic,
+                    techniqueCount = tacticTechniques.distinctBy { it.techniqueId }.size,
+                    ruleCount = tacticTechniques.flatMap { it.rules }.distinctBy { it.id }.size,
+                )
+            }
+            .sortedBy { it.tactic }
+        return DetectionCoverageResponse(
+            enabledRuleCount = rules.size,
+            tactics = tactics,
+            techniques = techniques,
+        )
+    }
+
+    private fun ResultRow.toCoverageRule(): CoverageRule =
+        CoverageRule(
+            id = this[DetectionRules.id].value,
+            name = this[DetectionRules.name],
+            enabled = this[DetectionRules.enabled],
+            tags = decodeStringList(this[DetectionRules.tags]),
+        )
+
+    private fun decodeStringList(raw: String): List<String> =
+        runCatching { coverageJson.decodeFromString<List<String>>(raw) }.getOrDefault(emptyList())
+}
+
+data class CoverageRule(
+    val id: Int,
+    val name: String,
+    val enabled: Boolean,
+    val tags: List<String>,
+) {
+    fun toResponse(): MitreCoveredRuleResponse =
+        MitreCoveredRuleResponse(id = id, name = name, enabled = enabled)
+}
+
+private val TECHNIQUE_REGEX = Regex("""^(?:mitre|attack)(?::technique)?:([Tt]\d{4}(?:\.\d{3})?)$""")
+private val TACTIC_ID_REGEX = Regex("""^(?:mitre|attack):([Tt][Aa]\d{4})$""")
+private val TACTIC_NAME_REGEX = Regex("""^(?:mitre|attack):(?:tactic:)?([a-z][a-z0-9_-]+)$""")
+
+private fun normalizeTechnique(tag: String): String? =
+    TECHNIQUE_REGEX.find(tag)?.groupValues?.get(1)?.uppercase()
+
+private fun normalizeTactic(tag: String): String? {
+    val tacticId = TACTIC_ID_REGEX.find(tag)?.groupValues?.get(1)?.uppercase()
+    if (tacticId != null) return TACTIC_IDS[tacticId]
+    val tactic = TACTIC_NAME_REGEX.find(tag)?.groupValues?.get(1)
+        ?.lowercase()
+        ?.replace('_', '-')
+    return tactic?.takeIf { it in TACTIC_NAMES }
+}
+
+private val TACTIC_NAMES = setOf(
+    "reconnaissance",
+    "resource-development",
+    "initial-access",
+    "execution",
+    "persistence",
+    "privilege-escalation",
+    "defense-evasion",
+    "credential-access",
+    "discovery",
+    "lateral-movement",
+    "collection",
+    "command-and-control",
+    "exfiltration",
+    "impact",
+)
+
+private val TACTIC_IDS = mapOf(
+    "TA0001" to "initial-access",
+    "TA0002" to "execution",
+    "TA0003" to "persistence",
+    "TA0004" to "privilege-escalation",
+    "TA0005" to "defense-evasion",
+    "TA0006" to "credential-access",
+    "TA0007" to "discovery",
+    "TA0008" to "lateral-movement",
+    "TA0009" to "collection",
+    "TA0010" to "exfiltration",
+    "TA0011" to "command-and-control",
+    "TA0040" to "impact",
+    "TA0042" to "resource-development",
+    "TA0043" to "reconnaissance",
+)
+
+private val TECHNIQUE_TACTICS = mapOf(
+    "T1059" to setOf("execution"),
+    "T1071" to setOf("command-and-control"),
+    "T1078" to setOf("defense-evasion", "initial-access", "persistence", "privilege-escalation"),
+    "T1110" to setOf("credential-access"),
+    "T1548" to setOf("defense-evasion", "privilege-escalation"),
+    "T1552" to setOf("credential-access"),
+)

--- a/backend/src/main/kotlin/com/moneat/security/detection/NewValueEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/NewValueEvaluator.kt
@@ -111,6 +111,7 @@ class NewValueEvaluator(
             evidenceType = "clickhouse_query",
             evidenceReference = "${compiled.evidenceDescriptor} match=new_value",
             occurredAtMs = clock().toEpochMilliseconds(),
+            tags = rule.tags,
         )
         upsert(rule.organizationId, spec)
     }

--- a/backend/src/main/kotlin/com/moneat/security/detection/RateAnomalyEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/RateAnomalyEvaluator.kt
@@ -23,28 +23,21 @@ import com.moneat.security.signals.SignalWriter
 import mu.KotlinLogging
 import kotlin.time.Clock
 
-private val logger = KotlinLogging.logger {}
+private val rateLogger = KotlinLogging.logger {}
 
-/**
- * Threshold rule type: `count() >= N` per group over the window. The compiler emits the GROUP BY +
- * `HAVING count() >= threshold`, so every row the query returns is already a match; this evaluator
- * folds each into a signal via [SignalWriter] (dedup by rule + group values).
- */
-class ThresholdEvaluator(
+class RateAnomalyEvaluator(
     private val compiler: RuleQueryCompiler,
     private val runner: DetectionQueryRunner = DetectionQueryRunner(),
     private val upsert: (Int, SignalSpec) -> SignalOutcome = SignalWriter::upsert,
     private val now: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
 
-    /** Evaluate [rule], upserting one signal per group over threshold. Returns the matches found. */
     suspend fun evaluate(rule: DetectionRuleRecord): List<DetectionGroupRow> {
-        // The compiler injects org scoping from the rule's owning org; the author cannot influence it.
         val compiled = compiler.compile(rule.organizationId, rule.compilerInput())
         val rows = runner.run(compiled)
         rows.forEach { row -> writeSignal(rule, compiled, row) }
         if (rows.isNotEmpty()) {
-            logger.info { "Threshold rule ${rule.id} produced ${rows.size} match(es)" }
+            rateLogger.info { "Rate anomaly rule ${rule.id} produced ${rows.size} match(es)" }
         }
         return rows
     }
@@ -58,7 +51,7 @@ class ThresholdEvaluator(
             dedupKey = dedupKeyFor(rule, row.groupValues),
             entities = row.groupValues,
             evidenceType = "clickhouse_query",
-            evidenceReference = "${compiled.evidenceDescriptor} match=count>=${rule.thresholdCount}",
+            evidenceReference = "${compiled.evidenceDescriptor} match=rate_deviation",
             occurredAtMs = now(),
             tags = rule.tags,
         )

--- a/backend/src/main/kotlin/com/moneat/security/detection/RuleQueryCompiler.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/RuleQueryCompiler.kt
@@ -86,11 +86,29 @@ class RuleQueryCompiler(
         /** Map columns that support `col['key']` access in a group-by. */
         val ALLOWED_MAP_COLUMNS: Set<String> = setOf("tags", "resource_attributes")
 
+        val ALLOWED_ANOMALY_GROUP_BY_COLUMNS: Set<String> = setOf(
+            "service",
+            "environment",
+            "host",
+            "level",
+            "source",
+        )
+
+        val ALLOWED_ANOMALY_FILTER_FIELDS: Set<String> = setOf(
+            "service",
+            "environment",
+            "host",
+            "level",
+            "source",
+        )
+
         const val MIN_WINDOW_SECONDS: Int = 60
         const val MAX_WINDOW_SECONDS: Int = 24 * 60 * 60
         const val MAX_GROUP_BY_COLUMNS: Int = 5
         const val MIN_THRESHOLD: Int = 1
         const val MAX_THRESHOLD: Int = 1_000_000
+        const val ANOMALY_BASELINE_SECONDS: Int = 24 * 60 * 60
+        private const val ANOMALY_STDDEV_MULTIPLIER = 3
 
         // map column, then a key restricted to a conservative safe charset (identifier-ish), with
         // optional surrounding quotes. Anything outside this set (quotes-in-key, brackets, parens,
@@ -149,6 +167,9 @@ class RuleQueryCompiler(
     fun compile(orgId: Int, rule: RuleInput): CompiledRuleQuery {
         validateSource(rule.source)
         val window = validateWindow(rule.windowSeconds)
+        if (rule.type == DetectionRuleType.RATE_ANOMALY) {
+            return compileRateAnomaly(orgId, rule, window)
+        }
         if (rule.type == DetectionRuleType.THRESHOLD) {
             validateThreshold(rule.thresholdCount)
         }
@@ -205,6 +226,115 @@ class RuleQueryCompiler(
         renderFilter(filter)?.let { conditions += it }
         return conditions.joinToString(" AND ")
     }
+
+    private fun compileRateAnomaly(
+        orgId: Int,
+        rule: RuleInput,
+        window: Int,
+    ): CompiledRuleQuery {
+        validateThreshold(rule.thresholdCount)
+        val groupBy = validateAnomalyGroupBy(validateGroupBy(rule.groupBy))
+        val aliases = groupBy.indices.map { "g$it" }
+        val groupExprs = groupBy.map { rollupColumnExpression(it) }
+        val filterSql = renderFilter(rule.filter, ::validateAnomalyFilterNode)
+        val currentWhere = buildRollupWhere(
+            orgId = orgId,
+            timeClause = "bucket_start >= now() - INTERVAL $window SECOND",
+            filterSql = filterSql,
+        )
+        val baselineWhere = buildRollupWhere(
+            orgId = orgId,
+            timeClause = "bucket_start >= now() - INTERVAL $ANOMALY_BASELINE_SECONDS SECOND " +
+                "AND bucket_start < now() - INTERVAL $window SECOND",
+            filterSql = filterSql,
+        )
+        val current = anomalyCurrentSubquery(groupExprs, aliases, currentWhere)
+        val baseline = anomalyBaselineSubquery(groupExprs, aliases, baselineWhere)
+        val selectItems = aliases.joinToString(", ") { "c.$it AS $it" }
+        val projectedGroups = if (selectItems.isBlank()) "" else "$selectItems, "
+        val join = if (aliases.isEmpty()) {
+            "($current) c CROSS JOIN ($baseline) b"
+        } else {
+            "($current) c INNER JOIN ($baseline) b USING (${aliases.joinToString(", ")})"
+        }
+        val sql = buildString {
+            append("SELECT ")
+            append(projectedGroups)
+            append("c.current_count AS match_count FROM ")
+            append(join)
+            append(" WHERE c.current_count >= ${rule.thresholdCount} AND b.baseline_avg > 0")
+            append(" AND c.current_count > b.baseline_avg + greatest(b.baseline_stddev * ")
+            append(ANOMALY_STDDEV_MULTIPLIER)
+            append(", 1)")
+            append(" ").append(settingsClause())
+        }
+        return CompiledRuleQuery(
+            sql = sql,
+            groupByColumns = groupBy,
+            groupByAliases = aliases,
+            whereClause = currentWhere,
+            evidenceDescriptor = anomalyEvidenceDescriptor(groupBy, window),
+            windowSeconds = window,
+        )
+    }
+
+    private fun buildRollupWhere(orgId: Int, timeClause: String, filterSql: String?): String {
+        if (orgId == 0) {
+            throw DetectionCompileException("Detection query is missing organization context")
+        }
+        val conditions = mutableListOf(ClickHouseQueryUtils.orgIdClause(orgId.toLong()), timeClause)
+        filterSql?.let { conditions += it }
+        return conditions.joinToString(" AND ")
+    }
+
+    private fun anomalyCurrentSubquery(
+        groupExprs: List<String>,
+        aliases: List<String>,
+        whereClause: String,
+    ): String {
+        val selectItems = groupSelectItems(groupExprs, aliases)
+        val groupByClause = groupByClause(aliases)
+        return buildString {
+            append("SELECT ")
+            if (selectItems.isNotBlank()) append("$selectItems, ")
+            append("sumMerge(event_count_state) AS current_count")
+            append(" FROM `${clickhouseDb()}`.security_log_rate_rollup_5m")
+            append(" WHERE ").append(whereClause)
+            append(groupByClause)
+        }
+    }
+
+    private fun anomalyBaselineSubquery(
+        groupExprs: List<String>,
+        aliases: List<String>,
+        whereClause: String,
+    ): String {
+        val selectItems = groupSelectItems(groupExprs, aliases)
+        val aliasesCsv = aliases.joinToString(", ")
+        val outerSelect = if (aliasesCsv.isBlank()) "" else "$aliasesCsv, "
+        val outerGroupBy = if (aliasesCsv.isBlank()) "" else " GROUP BY $aliasesCsv"
+        val innerGroupBy = if (aliasesCsv.isBlank()) {
+            " GROUP BY bucket_start"
+        } else {
+            " GROUP BY bucket_start, $aliasesCsv"
+        }
+        val inner = buildString {
+            append("SELECT ")
+            if (selectItems.isNotBlank()) append("$selectItems, ")
+            append("bucket_start, sumMerge(event_count_state) AS bucket_count")
+            append(" FROM `${clickhouseDb()}`.security_log_rate_rollup_5m")
+            append(" WHERE ").append(whereClause)
+            append(innerGroupBy)
+        }
+        return "SELECT ${outerSelect}avg(bucket_count) AS baseline_avg, " +
+            "stddevPop(bucket_count) AS baseline_stddev FROM ($inner)$outerGroupBy"
+    }
+
+    private fun groupSelectItems(groupExprs: List<String>, aliases: List<String>): String =
+        aliases.indices.joinToString(", ") { i -> "${groupExprs[i]} AS ${aliases[i]}" }
+
+    private fun groupByClause(aliases: List<String>): String =
+        if (aliases.isEmpty()) "" else " GROUP BY ${aliases.joinToString(", ")}"
 
     /** Resource-cap SETTINGS clause [compile] appends to every emitted query. */
     private fun settingsClause(): String {
@@ -287,20 +417,77 @@ class RuleQueryCompiler(
      * reports `errors`) is surfaced as a DSL-level message; the raw ClickHouse never appears because we
      * never reach ClickHouse with an unrendered filter.
      */
-    private fun renderFilter(filter: String): String? {
+    private fun renderFilter(
+        filter: String,
+        validator: ((LogQueryParser.QueryNode) -> Unit)? = null,
+    ): String? {
         if (filter.isBlank()) return null
         val parsed = parser.parse(filter)
         if (parsed.errors.isNotEmpty()) {
             throw DetectionCompileException("Invalid filter expression")
         }
         val node = parsed.rootNode ?: return null
+        validator?.invoke(node)
         val rendered = parser.toClickHouseSql(node, ::escapeSql)
         return if (rendered.isBlank() || rendered == "1=1") null else "($rendered)"
     }
 
+    private fun validateAnomalyGroupBy(groupBy: List<String>): List<String> {
+        groupBy.forEach { column ->
+            if (column.trim() !in ALLOWED_ANOMALY_GROUP_BY_COLUMNS) {
+                throw DetectionCompileException("Unknown group-by column '${sanitizeToken(column)}'")
+            }
+        }
+        return groupBy
+    }
+
+    private fun validateAnomalyFilterNode(node: LogQueryParser.QueryNode) {
+        when (node) {
+            is LogQueryParser.QueryNode.FieldNode -> requireAnomalyField(node.field)
+            is LogQueryParser.QueryNode.RangeNode -> requireAnomalyField(node.field)
+            is LogQueryParser.QueryNode.ComparisonNode -> requireAnomalyField(node.field)
+            is LogQueryParser.QueryNode.ExistsNode -> requireAnomalyField(node.field)
+            is LogQueryParser.QueryNode.AndNode -> {
+                validateAnomalyFilterNode(node.left)
+                validateAnomalyFilterNode(node.right)
+            }
+            is LogQueryParser.QueryNode.OrNode -> {
+                validateAnomalyFilterNode(node.left)
+                validateAnomalyFilterNode(node.right)
+            }
+            is LogQueryParser.QueryNode.NotNode -> validateAnomalyFilterNode(node.node)
+            is LogQueryParser.QueryNode.FullTextNode,
+            is LogQueryParser.QueryNode.TagExistsNode,
+            is LogQueryParser.QueryNode.TermNode,
+            -> throw DetectionCompileException("Rate anomaly filters may use only rollup fields")
+        }
+    }
+
+    private fun requireAnomalyField(field: String) {
+        val normalized = when (field.lowercase()) {
+            "status" -> "level"
+            else -> field
+        }
+        if (normalized !in ALLOWED_ANOMALY_FILTER_FIELDS) {
+            throw DetectionCompileException("Rate anomaly filters may use only rollup fields")
+        }
+    }
+
+    private fun rollupColumnExpression(column: String): String =
+        when (val trimmed = column.trim()) {
+            in ALLOWED_ANOMALY_GROUP_BY_COLUMNS -> trimmed
+            else -> throw DetectionCompileException("Unknown group-by column '${sanitizeToken(column)}'")
+        }
+
     private fun evidenceDescriptor(groupBy: List<String>, windowSeconds: Int): String {
         val groups = if (groupBy.isEmpty()) "-" else groupBy.joinToString(",")
         return "table=logs group_by=$groups window=${windowSeconds}s"
+    }
+
+    private fun anomalyEvidenceDescriptor(groupBy: List<String>, windowSeconds: Int): String {
+        val groups = if (groupBy.isEmpty()) "-" else groupBy.joinToString(",")
+        return "table=security_log_rate_rollup_5m group_by=$groups window=${windowSeconds}s " +
+            "baseline=${ANOMALY_BASELINE_SECONDS}s"
     }
 
     /** Coerce an env value to a non-negative long, falling back to [default] if it is not numeric. */

--- a/backend/src/main/kotlin/com/moneat/security/posture/PostureModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/posture/PostureModels.kt
@@ -1,0 +1,49 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.posture
+
+import com.moneat.shared.models.Organizations
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+
+object SecurityComplianceFindingStates : IntIdTable("security_compliance_finding_states") {
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val framework = varchar("framework", 128)
+    val ruleId = varchar("rule_id", 255)
+    val ruleName = text("rule_name").default("")
+    val resourceType = text("resource_type").default("")
+    val resourceId = text("resource_id").default("")
+    val resourceName = text("resource_name").default("")
+    val status = varchar("status", 16)
+    val firstSeen = timestamp("first_seen")
+    val lastSeen = timestamp("last_seen")
+    val lastRegressedAt = timestamp("last_regressed_at").nullable()
+    val updatedAt = timestamp("updated_at")
+}
+
+enum class ComplianceFindingStatus(val wire: String) {
+    PASSED("passed"),
+    FAILED("failed"),
+    SKIPPED("skipped"),
+    ERROR("error");
+
+    companion object {
+        fun normalize(value: String): ComplianceFindingStatus =
+            entries.firstOrNull { it.wire == value } ?: PASSED
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/posture/PostureModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/posture/PostureModels.kt
@@ -47,3 +47,14 @@ enum class ComplianceFindingStatus(val wire: String) {
             entries.firstOrNull { it.wire == value } ?: PASSED
     }
 }
+
+data class ComplianceFindingInput(
+    val framework: String = "",
+    val ruleId: String = "",
+    val ruleName: String = "",
+    val status: String = "passed",
+    val resourceType: String = "",
+    val resourceId: String = "",
+    val resourceName: String = "",
+    val timestampMs: Long,
+)

--- a/backend/src/main/kotlin/com/moneat/security/posture/PostureRegressionAnalyzer.kt
+++ b/backend/src/main/kotlin/com/moneat/security/posture/PostureRegressionAnalyzer.kt
@@ -1,0 +1,140 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.posture
+
+import com.moneat.datadog.security.QueuedComplianceEntry
+import com.moneat.security.signals.SignalSeverity
+import com.moneat.security.signals.SignalSource
+import com.moneat.security.signals.SignalSpec
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+private const val COMPLIANCE_TABLE = "compliance_findings"
+private const val EVIDENCE_TYPE = "clickhouse_query"
+
+object PostureRegressionAnalyzer {
+
+    fun analyze(organizationId: Int, findings: List<QueuedComplianceEntry>): List<SignalSpec> {
+        if (findings.isEmpty()) return emptyList()
+        return transaction {
+            findings.mapNotNull { finding ->
+                val status = ComplianceFindingStatus.normalize(finding.status)
+                val occurred = occurrenceTime(finding.timestampMs)
+                val previous = upsertState(organizationId, finding, status, occurred)
+                if (previous == ComplianceFindingStatus.PASSED && status == ComplianceFindingStatus.FAILED) {
+                    regressionSignal(finding)
+                } else {
+                    null
+                }
+            }
+        }
+    }
+
+    private fun upsertState(
+        organizationId: Int,
+        finding: QueuedComplianceEntry,
+        status: ComplianceFindingStatus,
+        occurred: Instant,
+    ): ComplianceFindingStatus? {
+        val existing = SecurityComplianceFindingStates
+            .selectAll()
+            .where {
+                (SecurityComplianceFindingStates.organizationId eq organizationId) and
+                    (SecurityComplianceFindingStates.framework eq finding.framework) and
+                    (SecurityComplianceFindingStates.ruleId eq finding.ruleId) and
+                    (SecurityComplianceFindingStates.resourceType eq finding.resourceType) and
+                    (SecurityComplianceFindingStates.resourceId eq finding.resourceId)
+            }
+            .forUpdate()
+            .firstOrNull()
+        val now = Clock.System.now()
+        if (existing == null) {
+            SecurityComplianceFindingStates.insert {
+                it[SecurityComplianceFindingStates.organizationId] = organizationId
+                it[framework] = finding.framework
+                it[ruleId] = finding.ruleId
+                it[ruleName] = finding.ruleName
+                it[resourceType] = finding.resourceType
+                it[resourceId] = finding.resourceId
+                it[resourceName] = finding.resourceName
+                it[SecurityComplianceFindingStates.status] = status.wire
+                it[firstSeen] = occurred
+                it[lastSeen] = occurred
+                it[lastRegressedAt] = null
+                it[updatedAt] = now
+            }
+            return null
+        }
+
+        val previous = ComplianceFindingStatus.normalize(existing[SecurityComplianceFindingStates.status])
+        val stateId = existing[SecurityComplianceFindingStates.id].value
+        SecurityComplianceFindingStates.update({ SecurityComplianceFindingStates.id eq stateId }) {
+            it[ruleName] = finding.ruleName
+            it[resourceName] = finding.resourceName
+            it[SecurityComplianceFindingStates.status] = status.wire
+            it[firstSeen] = minOf(existing[SecurityComplianceFindingStates.firstSeen], occurred)
+            it[lastSeen] = maxOf(existing[SecurityComplianceFindingStates.lastSeen], occurred)
+            if (previous == ComplianceFindingStatus.PASSED && status == ComplianceFindingStatus.FAILED) {
+                it[lastRegressedAt] = occurred
+            }
+            it[updatedAt] = now
+        }
+        return previous
+    }
+
+    private fun regressionSignal(finding: QueuedComplianceEntry): SignalSpec {
+        val key = findingKey(finding)
+        val resourceName = finding.resourceName.ifBlank { finding.resourceId }
+        val entities = buildMap {
+            if (finding.framework.isNotBlank()) put("framework", finding.framework)
+            if (finding.resourceType.isNotBlank()) put("resource_type", finding.resourceType)
+            if (resourceName.isNotBlank()) put("resource", resourceName)
+            if (finding.resourceId.isNotBlank()) put("resource_id", finding.resourceId)
+            put("finding_key", key)
+        }
+        return SignalSpec(
+            source = SignalSource.AGENT_COMPLIANCE,
+            ruleId = finding.ruleId,
+            ruleName = finding.ruleName.ifBlank { finding.ruleId },
+            severity = SignalSeverity.HIGH,
+            dedupKey = key,
+            entities = entities,
+            evidenceType = EVIDENCE_TYPE,
+            evidenceReference = "table=$COMPLIANCE_TABLE finding=$key rule_id=${finding.ruleId} " +
+                "resource_id=${finding.resourceId} previous=passed status=failed " +
+                "occurred_at_ms=${finding.timestampMs}",
+            occurredAtMs = finding.timestampMs,
+            tags = listOf("posture:regression"),
+        )
+    }
+
+    private fun findingKey(finding: QueuedComplianceEntry): String =
+        listOf(finding.framework, finding.ruleId, finding.resourceType, finding.resourceId)
+            .joinToString("|")
+
+    private fun occurrenceTime(timestampMs: Long): Instant {
+        val occurred = Instant.fromEpochMilliseconds(timestampMs)
+        val now = Clock.System.now()
+        return if (occurred > now) now else occurred
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/security/posture/PostureRegressionAnalyzer.kt
+++ b/backend/src/main/kotlin/com/moneat/security/posture/PostureRegressionAnalyzer.kt
@@ -19,10 +19,15 @@ package com.moneat.security.posture
 import com.moneat.security.signals.SignalSeverity
 import com.moneat.security.signals.SignalSource
 import com.moneat.security.signals.SignalSpec
+import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import kotlin.time.Clock
@@ -41,7 +46,7 @@ object PostureRegressionAnalyzer {
                 val occurred = occurrenceTime(finding.timestampMs)
                 val previous = upsertState(organizationId, finding, status, occurred)
                 if (previous == ComplianceFindingStatus.PASSED && status == ComplianceFindingStatus.FAILED) {
-                    regressionSignal(finding)
+                    regressionSignal(finding, occurred)
                 } else {
                     null
                 }
@@ -55,7 +60,17 @@ object PostureRegressionAnalyzer {
         status: ComplianceFindingStatus,
         occurred: Instant,
     ): ComplianceFindingStatus? {
-        val existing = SecurityComplianceFindingStates
+        val existing = selectStateForUpdate(organizationId, finding)
+        val now = Clock.System.now()
+        if (existing == null) {
+            return insertStateOrUpdateConcurrent(organizationId, finding, status, occurred, now)
+        }
+
+        return updateExistingState(existing, finding, status, occurred, now)
+    }
+
+    private fun selectStateForUpdate(organizationId: Int, finding: ComplianceFindingInput): ResultRow? =
+        SecurityComplianceFindingStates
             .selectAll()
             .where {
                 (SecurityComplianceFindingStates.organizationId eq organizationId) and
@@ -66,25 +81,74 @@ object PostureRegressionAnalyzer {
             }
             .forUpdate()
             .firstOrNull()
-        val now = Clock.System.now()
-        if (existing == null) {
+
+    private fun insertStateOrUpdateConcurrent(
+        organizationId: Int,
+        finding: ComplianceFindingInput,
+        status: ComplianceFindingStatus,
+        occurred: Instant,
+        now: Instant,
+    ): ComplianceFindingStatus? {
+        if (insertNewState(organizationId, finding, status, occurred, now)) return null
+
+        val concurrent = checkNotNull(selectStateForUpdate(organizationId, finding)) {
+            "Compliance finding state insert was ignored without an existing state"
+        }
+        return updateExistingState(concurrent, finding, status, occurred, now)
+    }
+
+    private fun insertNewState(
+        organizationId: Int,
+        finding: ComplianceFindingInput,
+        status: ComplianceFindingStatus,
+        occurred: Instant,
+        now: Instant,
+    ): Boolean {
+        if (!usesPostgreSqlDialect()) {
             SecurityComplianceFindingStates.insert {
-                it[SecurityComplianceFindingStates.organizationId] = organizationId
-                it[framework] = finding.framework
-                it[ruleId] = finding.ruleId
-                it[ruleName] = finding.ruleName
-                it[resourceType] = finding.resourceType
-                it[resourceId] = finding.resourceId
-                it[resourceName] = finding.resourceName
-                it[SecurityComplianceFindingStates.status] = status.wire
-                it[firstSeen] = occurred
-                it[lastSeen] = occurred
-                it[lastRegressedAt] = null
-                it[updatedAt] = now
+                assignStateInsert(it, organizationId, finding, status, occurred, now)
             }
-            return null
+            return true
         }
 
+        val insert = SecurityComplianceFindingStates.insertIgnore {
+            assignStateInsert(it, organizationId, finding, status, occurred, now)
+        }
+        return insert.insertedCount > 0
+    }
+
+    private fun assignStateInsert(
+        statement: UpdateBuilder<*>,
+        organizationId: Int,
+        finding: ComplianceFindingInput,
+        status: ComplianceFindingStatus,
+        occurred: Instant,
+        now: Instant,
+    ) {
+        statement[SecurityComplianceFindingStates.organizationId] = organizationId
+        statement[SecurityComplianceFindingStates.framework] = finding.framework
+        statement[SecurityComplianceFindingStates.ruleId] = finding.ruleId
+        statement[SecurityComplianceFindingStates.ruleName] = finding.ruleName
+        statement[SecurityComplianceFindingStates.resourceType] = finding.resourceType
+        statement[SecurityComplianceFindingStates.resourceId] = finding.resourceId
+        statement[SecurityComplianceFindingStates.resourceName] = finding.resourceName
+        statement[SecurityComplianceFindingStates.status] = status.wire
+        statement[SecurityComplianceFindingStates.firstSeen] = occurred
+        statement[SecurityComplianceFindingStates.lastSeen] = occurred
+        statement[SecurityComplianceFindingStates.lastRegressedAt] = null
+        statement[SecurityComplianceFindingStates.updatedAt] = now
+    }
+
+    private fun usesPostgreSqlDialect(): Boolean =
+        TransactionManager.current().db.dialect is PostgreSQLDialect
+
+    private fun updateExistingState(
+        existing: ResultRow,
+        finding: ComplianceFindingInput,
+        status: ComplianceFindingStatus,
+        occurred: Instant,
+        now: Instant,
+    ): ComplianceFindingStatus {
         val previous = ComplianceFindingStatus.normalize(existing[SecurityComplianceFindingStates.status])
         val stateId = existing[SecurityComplianceFindingStates.id].value
         SecurityComplianceFindingStates.update({ SecurityComplianceFindingStates.id eq stateId }) {
@@ -101,8 +165,9 @@ object PostureRegressionAnalyzer {
         return previous
     }
 
-    private fun regressionSignal(finding: ComplianceFindingInput): SignalSpec {
+    private fun regressionSignal(finding: ComplianceFindingInput, occurred: Instant): SignalSpec {
         val key = findingKey(finding)
+        val occurredAtMs = occurred.toEpochMilliseconds()
         val resourceName = finding.resourceName.ifBlank { finding.resourceId }
         val entities = buildMap {
             if (finding.framework.isNotBlank()) put("framework", finding.framework)
@@ -121,8 +186,8 @@ object PostureRegressionAnalyzer {
             evidenceType = EVIDENCE_TYPE,
             evidenceReference = "table=$COMPLIANCE_TABLE finding=$key rule_id=${finding.ruleId} " +
                 "resource_id=${finding.resourceId} previous=passed status=failed " +
-                "occurred_at_ms=${finding.timestampMs}",
-            occurredAtMs = finding.timestampMs,
+                "occurred_at_ms=$occurredAtMs",
+            occurredAtMs = occurredAtMs,
             tags = listOf("posture:regression"),
         )
     }

--- a/backend/src/main/kotlin/com/moneat/security/posture/PostureRegressionAnalyzer.kt
+++ b/backend/src/main/kotlin/com/moneat/security/posture/PostureRegressionAnalyzer.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.security.posture
 
-import com.moneat.datadog.security.QueuedComplianceEntry
 import com.moneat.security.signals.SignalSeverity
 import com.moneat.security.signals.SignalSource
 import com.moneat.security.signals.SignalSpec
@@ -34,7 +33,7 @@ private const val EVIDENCE_TYPE = "clickhouse_query"
 
 object PostureRegressionAnalyzer {
 
-    fun analyze(organizationId: Int, findings: List<QueuedComplianceEntry>): List<SignalSpec> {
+    fun analyze(organizationId: Int, findings: List<ComplianceFindingInput>): List<SignalSpec> {
         if (findings.isEmpty()) return emptyList()
         return transaction {
             findings.mapNotNull { finding ->
@@ -52,7 +51,7 @@ object PostureRegressionAnalyzer {
 
     private fun upsertState(
         organizationId: Int,
-        finding: QueuedComplianceEntry,
+        finding: ComplianceFindingInput,
         status: ComplianceFindingStatus,
         occurred: Instant,
     ): ComplianceFindingStatus? {
@@ -102,7 +101,7 @@ object PostureRegressionAnalyzer {
         return previous
     }
 
-    private fun regressionSignal(finding: QueuedComplianceEntry): SignalSpec {
+    private fun regressionSignal(finding: ComplianceFindingInput): SignalSpec {
         val key = findingKey(finding)
         val resourceName = finding.resourceName.ifBlank { finding.resourceId }
         val entities = buildMap {
@@ -128,7 +127,7 @@ object PostureRegressionAnalyzer {
         )
     }
 
-    private fun findingKey(finding: QueuedComplianceEntry): String =
+    private fun findingKey(finding: ComplianceFindingInput): String =
         listOf(finding.framework, finding.ruleId, finding.resourceType, finding.resourceId)
             .joinToString("|")
 

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalDerivation.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalDerivation.kt
@@ -16,9 +16,6 @@
 
 package com.moneat.security.signals
 
-import com.moneat.datadog.security.QueuedSecurityBatch
-import com.moneat.datadog.security.QueuedSecurityEventEntry
-
 private const val EVIDENCE_TYPE = "clickhouse_query"
 private const val EVENTS_TABLE = "security_events"
 
@@ -30,13 +27,10 @@ private const val EVENTS_TABLE = "security_events"
  */
 object SignalDerivation {
 
-    fun fromBatch(batch: QueuedSecurityBatch): List<SignalSpec> =
-        when (batch.batchType) {
-            "events" -> batch.events.map { runtimeSpec(it) }
-            else -> emptyList()
-        }
+    fun fromRuntimeEvents(events: List<RuntimeSecurityEventInput>): List<SignalSpec> =
+        events.map { runtimeSpec(it) }
 
-    private fun runtimeSpec(event: QueuedSecurityEventEntry): SignalSpec {
+    private fun runtimeSpec(event: RuntimeSecurityEventInput): SignalSpec {
         val host = event.host
         val process = event.processName
         val resource = event.filePath.ifBlank { process.ifBlank { host } }
@@ -59,7 +53,7 @@ object SignalDerivation {
         )
     }
 
-    private fun runtimeEvidence(event: QueuedSecurityEventEntry, dedupKey: String): String =
+    private fun runtimeEvidence(event: RuntimeSecurityEventInput, dedupKey: String): String =
         "table=$EVENTS_TABLE dedup=$dedupKey rule_id=${event.ruleId} " +
             "host=${event.host} process=${event.processName} occurred_at_ms=${event.timestampMs}"
 }

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalDerivation.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalDerivation.kt
@@ -16,28 +16,23 @@
 
 package com.moneat.security.signals
 
-import com.moneat.datadog.security.QueuedComplianceEntry
 import com.moneat.datadog.security.QueuedSecurityBatch
 import com.moneat.datadog.security.QueuedSecurityEventEntry
 
-private const val COMPLIANCE_STATUS_FAILED = "failed"
-private const val COMPLIANCE_STATUS_ERROR = "error"
 private const val EVIDENCE_TYPE = "clickhouse_query"
 private const val EVENTS_TABLE = "security_events"
-private const val COMPLIANCE_TABLE = "compliance_findings"
 
 /**
  * Turns an ingested agent batch into the signal specs the agent passthrough produces. A CWS runtime
- * event yields one `agent_runtime` spec (dedup by rule + host + process); a **failed** compliance
- * finding yields one `agent_compliance` spec (dedup by rule + resource). Passed/skipped findings and
- * activity dumps produce nothing. Evidence is a ClickHouse query descriptor — never the rows.
+ * event yields one `agent_runtime` spec (dedup by rule + host + process). Compliance findings are
+ * analyzed by the posture regression path because only passed-to-failed transitions become signals.
+ * Activity dumps produce nothing. Evidence is a ClickHouse query descriptor — never the rows.
  */
 object SignalDerivation {
 
     fun fromBatch(batch: QueuedSecurityBatch): List<SignalSpec> =
         when (batch.batchType) {
             "events" -> batch.events.map { runtimeSpec(it) }
-            "findings" -> batch.findings.mapNotNull { complianceSpec(it) }
             else -> emptyList()
         }
 
@@ -64,42 +59,7 @@ object SignalDerivation {
         )
     }
 
-    private fun complianceSpec(finding: QueuedComplianceEntry): SignalSpec? {
-        val severity = complianceSeverity(finding.status) ?: return null
-        val resourceId = finding.resourceId
-        val resourceName = finding.resourceName.ifBlank { resourceId }
-        val entities = buildMap {
-            if (resourceName.isNotBlank()) put("resource", resourceName)
-            if (resourceId.isNotBlank()) put("resource_id", resourceId)
-            if (finding.framework.isNotBlank()) put("framework", finding.framework)
-        }
-        val dedupKey = "${finding.ruleId}|$resourceId"
-        return SignalSpec(
-            source = SignalSource.AGENT_COMPLIANCE,
-            ruleId = finding.ruleId,
-            ruleName = finding.ruleName.ifBlank { finding.ruleId },
-            severity = severity,
-            dedupKey = dedupKey,
-            entities = entities,
-            evidenceType = EVIDENCE_TYPE,
-            evidenceReference = complianceEvidence(finding, dedupKey),
-            occurredAtMs = finding.timestampMs,
-        )
-    }
-
-    /** Compliance status → signal severity. Only failing states become signals. */
-    private fun complianceSeverity(status: String): SignalSeverity? =
-        when (status) {
-            COMPLIANCE_STATUS_FAILED -> SignalSeverity.HIGH
-            COMPLIANCE_STATUS_ERROR -> SignalSeverity.MEDIUM
-            else -> null
-        }
-
     private fun runtimeEvidence(event: QueuedSecurityEventEntry, dedupKey: String): String =
         "table=$EVENTS_TABLE dedup=$dedupKey rule_id=${event.ruleId} " +
             "host=${event.host} process=${event.processName} occurred_at_ms=${event.timestampMs}"
-
-    private fun complianceEvidence(finding: QueuedComplianceEntry, dedupKey: String): String =
-        "table=$COMPLIANCE_TABLE dedup=$dedupKey rule_id=${finding.ruleId} " +
-            "resource_id=${finding.resourceId} occurred_at_ms=${finding.timestampMs}"
 }

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
@@ -141,6 +141,16 @@ data class SignalSpec(
     val tags: List<String> = emptyList(),
 )
 
+data class RuntimeSecurityEventInput(
+    val ruleId: String = "",
+    val ruleName: String = "",
+    val severity: String = "info",
+    val processName: String = "",
+    val filePath: String = "",
+    val host: String = "",
+    val timestampMs: Long,
+)
+
 /** Result of [SignalWriter.upsert]; drives whether the workflow trigger fires (Created/Escalated only). */
 sealed interface SignalOutcome {
     val signalId: Int

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalModels.kt
@@ -18,6 +18,7 @@ package com.moneat.security.signals
 
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.jsonb
+import com.moneat.security.threatintel.ThreatIntelEnrichmentResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -237,6 +238,7 @@ data class SignalDetailResponse(
     val evidence: List<SignalEvidenceResponse>,
     val audit: List<SignalAuditResponse>,
     @SerialName("sample_events") val sampleEvents: List<JsonElement>,
+    @SerialName("threat_intel") val threatIntel: List<ThreatIntelEnrichmentResponse> = emptyList(),
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
@@ -20,6 +20,7 @@ import com.moneat.config.ClickHouseClient
 import com.moneat.config.ClickHouseQueryException
 import com.moneat.config.isClickHouseError
 import com.moneat.security.detection.RuleQueryCompiler
+import com.moneat.security.threatintel.ThreatIntelService
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
@@ -66,7 +67,9 @@ sealed interface TriageResult {
  * or mutate signals their organization owns. Sample evidence is pulled from ClickHouse on demand and
  * its errors are sanitized via [ClickHouseQueryException] so no query text or schema leaks.
  */
-class SignalService {
+class SignalService(
+    private val threatIntelService: ThreatIntelService = ThreatIntelService(),
+) {
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -127,7 +130,15 @@ class SignalService {
 
         val (signal, evidence, audit) = detail
         val sampleEvents = fetchSampleEvents(orgId, signal)
-        return SignalDetailResponse(signal = signal, evidence = evidence, audit = audit, sampleEvents = sampleEvents)
+        val threatIntel = runCatching { threatIntelService.enrich(signal.entities) }
+            .getOrDefault(emptyList())
+        return SignalDetailResponse(
+            signal = signal,
+            evidence = evidence,
+            audit = audit,
+            sampleEvents = sampleEvents,
+            threatIntel = threatIntel,
+        )
     }
 
     /**

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalService.kt
@@ -381,9 +381,9 @@ class SignalService(
             ClickHouseQueryUtils.orgIdClause(orgId.toLong()),
             "rule_id = '${escapeSql(signal.ruleId)}'",
         )
-        signal.entities["resource"]?.takeIf { it.isNotBlank() }?.let {
-            conditions.add("resource_id = '${escapeSql(it)}'")
-        }
+        conditions.addComplianceEntityFilter(signal, "framework", "framework")
+        conditions.addComplianceEntityFilter(signal, "resource_type", "resource_type")
+        conditions.addComplianceEntityFilter(signal, "resource_id", "resource_id")
         val where = conditions.joinToString(" AND ")
         return executeSamples(
             """SELECT finding_id, framework, rule_id, rule_name, status, resource_type,
@@ -403,6 +403,16 @@ class SignalService(
                 put("resourceName", obj.s("resource_name"))
                 put("evaluatedAt", obj.s("ts"))
             }
+        }
+    }
+
+    private fun MutableList<String>.addComplianceEntityFilter(
+        signal: SignalResponse,
+        entityKey: String,
+        column: String,
+    ) {
+        signal.entities[entityKey]?.takeIf { it.isNotBlank() }?.let {
+            add("$column = '${escapeSql(it)}'")
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/security/threatintel/ThreatIntelModels.kt
+++ b/backend/src/main/kotlin/com/moneat/security/threatintel/ThreatIntelModels.kt
@@ -1,0 +1,55 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.threatintel
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ThreatIntelSnapshot(
+    val feeds: List<ThreatIntelFeed> = emptyList(),
+)
+
+@Serializable
+data class ThreatIntelFeed(
+    val name: String,
+    val source: String,
+    @SerialName("updated_at") val updatedAt: String,
+    val indicators: List<ThreatIntelIndicator> = emptyList(),
+)
+
+@Serializable
+data class ThreatIntelIndicator(
+    val type: String,
+    val value: String,
+    @SerialName("threat_type") val threatType: String,
+    val confidence: Int,
+    val reference: String = "",
+)
+
+@Serializable
+data class ThreatIntelEnrichmentResponse(
+    @SerialName("entity_key") val entityKey: String,
+    @SerialName("entity_value") val entityValue: String,
+    @SerialName("indicator_type") val indicatorType: String,
+    @SerialName("feed_name") val feedName: String,
+    val source: String,
+    @SerialName("threat_type") val threatType: String,
+    val confidence: Int,
+    val reference: String = "",
+    @SerialName("updated_at") val updatedAt: String,
+)

--- a/backend/src/main/kotlin/com/moneat/security/threatintel/ThreatIntelService.kt
+++ b/backend/src/main/kotlin/com/moneat/security/threatintel/ThreatIntelService.kt
@@ -1,0 +1,147 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.threatintel
+
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+private val logger = KotlinLogging.logger {}
+
+private const val SEED_RESOURCE = "/security/threat_intel_seed.json"
+private const val HASH_MD5_LEN = 32
+private const val HASH_SHA1_LEN = 40
+private const val HASH_SHA256_LEN = 64
+private const val MAX_CONFIDENCE = 100
+
+class ThreatIntelService(
+    private val provider: ThreatIntelProvider = ResourceThreatIntelProvider(),
+    private val ttl: Duration = DEFAULT_TTL,
+    private val clock: () -> Instant = { Clock.System.now() },
+) {
+    companion object {
+        val DEFAULT_TTL: Duration = 15.minutes
+    }
+
+    @Volatile
+    private var cache: CachedSnapshot? = null
+
+    fun enrich(entities: Map<String, String>): List<ThreatIntelEnrichmentResponse> {
+        val snapshot = snapshotOrNull() ?: return emptyList()
+        val candidates = extractCandidates(entities)
+        if (candidates.isEmpty()) return emptyList()
+        val indicators = snapshot.feeds.flatMap { feed ->
+            feed.indicators.map { indicator -> IndexedIndicator(feed, indicator.normalized(), indicator) }
+        }
+        return candidates.flatMap { candidate ->
+            indicators
+                .filter { indexed ->
+                    indexed.indicator.type == candidate.type && indexed.normalizedValue == candidate.normalizedValue
+                }
+                .map { indexed -> candidate.toResponse(indexed) }
+        }
+    }
+
+    private fun snapshotOrNull(): ThreatIntelSnapshot? {
+        val now = clock()
+        val current = cache
+        if (current != null && current.expiresAt > now) return current.snapshot
+        return runCatching {
+            val snapshot = provider.load()
+            cache = CachedSnapshot(snapshot, now + ttl)
+            snapshot
+        }.getOrElse { error ->
+            logger.warn { "Threat intelligence snapshot load failed: ${error.message}" }
+            current?.snapshot
+        }
+    }
+
+    private fun ThreatIntelIndicator.normalized(): String =
+        if (type == "hash") value.lowercase() else value.lowercase().trimEnd('.')
+
+    private fun ThreatCandidate.toResponse(indexed: IndexedIndicator): ThreatIntelEnrichmentResponse =
+        ThreatIntelEnrichmentResponse(
+            entityKey = entityKey,
+            entityValue = entityValue,
+            indicatorType = indexed.indicator.type,
+            feedName = indexed.feed.name,
+            source = indexed.feed.source,
+            threatType = indexed.indicator.threatType,
+            confidence = indexed.indicator.confidence.coerceIn(0, MAX_CONFIDENCE),
+            reference = indexed.indicator.reference,
+            updatedAt = indexed.feed.updatedAt,
+        )
+
+    private data class CachedSnapshot(
+        val snapshot: ThreatIntelSnapshot,
+        val expiresAt: Instant,
+    )
+
+    private data class IndexedIndicator(
+        val feed: ThreatIntelFeed,
+        val normalizedValue: String,
+        val indicator: ThreatIntelIndicator,
+    )
+}
+
+fun interface ThreatIntelProvider {
+    fun load(): ThreatIntelSnapshot
+}
+
+class ResourceThreatIntelProvider(
+    private val resourcePath: String = SEED_RESOURCE,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : ThreatIntelProvider {
+    override fun load(): ThreatIntelSnapshot {
+        val bytes = requireNotNull(javaClass.getResourceAsStream(resourcePath)) {
+            "Threat intelligence resource not found"
+        }.use { it.readBytes() }
+        return json.decodeFromString<ThreatIntelSnapshot>(bytes.decodeToString())
+    }
+}
+
+private data class ThreatCandidate(
+    val entityKey: String,
+    val entityValue: String,
+    val type: String,
+    val normalizedValue: String,
+)
+
+private val IPV4_REGEX = Regex("""^(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}$""")
+private const val DOMAIN_PATTERN =
+    """^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[A-Za-z]{2,63}$"""
+
+private val DOMAIN_REGEX = Regex(DOMAIN_PATTERN)
+private val HASH_REGEX = Regex("""^[A-Fa-f0-9]+$""")
+
+private fun extractCandidates(entities: Map<String, String>): List<ThreatCandidate> =
+    entities.mapNotNull { (key, rawValue) ->
+        val value = rawValue.trim().trimEnd('.')
+        val lower = value.lowercase()
+        when {
+            value.matches(IPV4_REGEX) -> ThreatCandidate(key, rawValue, "ip", lower)
+            value.matches(DOMAIN_REGEX) -> ThreatCandidate(key, rawValue, "domain", lower)
+            isHash(lower) -> ThreatCandidate(key, rawValue, "hash", lower)
+            else -> null
+        }
+    }
+
+private fun isHash(value: String): Boolean =
+    value.length in setOf(HASH_MD5_LEN, HASH_SHA1_LEN, HASH_SHA256_LEN) && value.matches(HASH_REGEX)

--- a/backend/src/main/resources/db/clickhouse_migration/V47__add_security_log_rate_rollup.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V47__add_security_log_rate_rollup.sql
@@ -1,0 +1,32 @@
+-- Five-minute log-rate rollup for bounded moving-baseline security anomaly rules.
+-- Populated only by new log ingestion after this migration lands.
+
+CREATE TABLE IF NOT EXISTS security_log_rate_rollup_5m (
+    organization_id UInt64,
+    bucket_start DateTime64(3, 'UTC'),
+    service LowCardinality(String),
+    environment LowCardinality(String),
+    host LowCardinality(String),
+    level LowCardinality(String),
+    source LowCardinality(String),
+    event_count_state AggregateFunction(sum, UInt64)
+) ENGINE = AggregatingMergeTree()
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (organization_id, bucket_start, service, environment, host, level, source)
+TTL toDateTime(bucket_start) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS security_log_rate_rollup_5m_mv
+TO security_log_rate_rollup_5m
+AS
+SELECT
+    organization_id,
+    toStartOfInterval(timestamp, INTERVAL 5 MINUTE) AS bucket_start,
+    service,
+    environment,
+    host,
+    toString(level) AS level,
+    toString(source) AS source,
+    sumState(toUInt64(1)) AS event_count_state
+FROM logs
+GROUP BY organization_id, bucket_start, service, environment, host, level, source;

--- a/backend/src/main/resources/db/migration/V122__security_posture_state.sql
+++ b/backend/src/main/resources/db/migration/V122__security_posture_state.sql
@@ -1,0 +1,25 @@
+-- Compliance posture state used to detect true passed -> failed regressions.
+-- Raw findings remain in ClickHouse; this compact Postgres row tracks the latest
+-- state for each control/resource pair so repeated failures do not create noise.
+
+CREATE TABLE security_compliance_finding_states (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    framework VARCHAR(128) NOT NULL,
+    rule_id VARCHAR(255) NOT NULL,
+    rule_name TEXT NOT NULL DEFAULT '',
+    resource_type TEXT NOT NULL DEFAULT '',
+    resource_id TEXT NOT NULL DEFAULT '',
+    resource_name TEXT NOT NULL DEFAULT '',
+    status VARCHAR(16) NOT NULL,
+    first_seen TIMESTAMPTZ NOT NULL,
+    last_seen TIMESTAMPTZ NOT NULL,
+    last_regressed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_security_compliance_state_identity
+    ON security_compliance_finding_states (organization_id, framework, rule_id, resource_type, resource_id);
+
+CREATE INDEX idx_security_compliance_state_summary
+    ON security_compliance_finding_states (organization_id, framework, status, updated_at);

--- a/backend/src/main/resources/security/threat_intel_seed.json
+++ b/backend/src/main/resources/security/threat_intel_seed.json
@@ -1,0 +1,32 @@
+{
+  "feeds": [
+    {
+      "name": "urlhaus-local",
+      "source": "abuse.ch URLhaus mirror",
+      "updated_at": "2026-05-31T00:00:00Z",
+      "indicators": [
+        {
+          "type": "domain",
+          "value": "malware.example",
+          "threat_type": "malware_delivery",
+          "confidence": 80,
+          "reference": "local-urlhaus-seed"
+        },
+        {
+          "type": "ip",
+          "value": "203.0.113.66",
+          "threat_type": "command_and_control",
+          "confidence": 70,
+          "reference": "local-ip-seed"
+        },
+        {
+          "type": "hash",
+          "value": "44d88612fea8a8f36de82e1278abb02f",
+          "threat_type": "test_malware_hash",
+          "confidence": 60,
+          "reference": "local-hash-seed"
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/test/kotlin/com/moneat/datadog/security/SecurityQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/security/SecurityQueryRoutesTest.kt
@@ -52,6 +52,7 @@ class SecurityQueryRoutesTest {
         private const val DUMPS_PATH = "/v1/security/dumps"
         private const val COMPLIANCE_PATH = "/v1/security/compliance"
         private const val SUMMARY_PATH = "/v1/security/compliance/summary"
+        private const val TRENDS_PATH = "/v1/security/compliance/trends"
         private const val ORG_ID = 42
         private const val OTHER_ORG_ID = 99
         private const val DEMO_ORG_ID = -1
@@ -191,6 +192,12 @@ class SecurityQueryRoutesTest {
     fun `compliance summary returns 401 without jwt`() = testApplication {
         application { installRoutes() }
         assertEquals(HttpStatusCode.Unauthorized, client.get(SUMMARY_PATH).status)
+    }
+
+    @Test
+    fun `compliance trends returns 401 without jwt`() = testApplication {
+        application { installRoutes() }
+        assertEquals(HttpStatusCode.Unauthorized, client.get(TRENDS_PATH).status)
     }
 
     // ──── Ingest → store → query (real insert path) ────
@@ -343,6 +350,28 @@ class SecurityQueryRoutesTest {
         assertTrue(body.contains("\"findingId\":\"f-1\""))
         assertTrue(body.contains("\"framework\":\"PCI-DSS\""))
         assertTrue(body.contains("\"totalCount\":1"))
+    }
+
+    @Test
+    fun `compliance trends groups pass rate buckets by framework`() = testApplication {
+        val fake = FakeClickHouse()
+        stubClickHouse(fake)
+        fake.registerRows(
+            "GROUP BY framework, bucket",
+            listOf(
+                """{"framework":"CIS","bucket":"2026-05-30T00:00:00.000Z",
+                    "passed":"8","failed":"2","skipped":"1","error":"0","total":"11"}"""
+                    .replace("\n", " ")
+                    .replace(Regex(" +"), " "),
+            ),
+        )
+        application { installRoutes() }
+        val response = client.get(TRENDS_PATH) { withAuth(token()) }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"framework\":\"CIS\""))
+        assertTrue(body.contains("\"bucketStart\":\"2026-05-30T00:00:00.000Z\""))
+        assertTrue(body.contains("\"passRate\":0.8"))
     }
 
     // ──── Org scoping ────
@@ -499,5 +528,14 @@ class SecurityQueryRoutesTest {
         val response = client.get(SUMMARY_PATH) { withAuth(token(orgId = null)) }
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals("""{"summary":[]}""", response.bodyAsText())
+    }
+
+    @Test
+    fun `compliance trends returns empty shape when token has no org id`() = testApplication {
+        captureStub(mutableListOf())
+        application { installRoutes() }
+        val response = client.get(TRENDS_PATH) { withAuth(token(orgId = null)) }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("""{"frameworks":[]}""", response.bodyAsText())
     }
 }

--- a/backend/src/test/kotlin/com/moneat/security/detection/DetectionEvaluatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/DetectionEvaluatorTest.kt
@@ -133,6 +133,26 @@ class DetectionEvaluatorTest {
         }
     }
 
+    @Test
+    fun `rate anomaly matches become detection signals through the compiler gate`() = runBlocking {
+        val rule = rateAnomalyRule()
+        seedRule(rule)
+        val runner = fakeRunner(listOf(DetectionGroupRow(mapOf("host" to "web-01"), 120)))
+        val evaluator = RateAnomalyEvaluator(compiler, runner)
+
+        val matches = evaluator.evaluate(rule)
+
+        assertEquals(1, matches.size)
+        transaction {
+            val signal = SecuritySignals.selectAll()
+                .where { SecuritySignals.organizationId eq orgId }
+                .single()
+            assertEquals("detection-3", signal[SecuritySignals.ruleId])
+            assertEquals("detection-3|host=web-01", signal[SecuritySignals.dedupKey])
+            assertTrue(signal[SecuritySignals.tags].contains("mitre:T1059"))
+        }
+    }
+
     private fun newValueRule(createdAt: Instant) = DetectionRuleRecord(
         id = 2,
         organizationId = orgId,
@@ -147,6 +167,23 @@ class DetectionEvaluatorTest {
         signalTitle = "New value {host}",
         signalMessage = "first seen {host}",
         createdAt = createdAt,
+    )
+
+    private fun rateAnomalyRule() = DetectionRuleRecord(
+        id = 3,
+        organizationId = orgId,
+        name = "Log rate anomaly",
+        source = "logs",
+        filter = "level:error",
+        groupBy = listOf("host"),
+        windowSeconds = 300,
+        type = DetectionRuleType.RATE_ANOMALY,
+        thresholdCount = 25,
+        severity = SignalSeverity.HIGH,
+        signalTitle = "Anomalous log rate on {host}",
+        signalMessage = "{host} exceeded its moving baseline.",
+        createdAt = Instant.fromEpochMilliseconds(1_700_000_000_000),
+        tags = listOf("mitre:T1059"),
     )
 
     @Test
@@ -208,7 +245,11 @@ class DetectionEvaluatorTest {
             clock = { firstRun },
         ).evaluate(newValueRule(createdLongAgo))
         assertEquals(0, firstSweep.size, "first evaluation must warm up even when createdAt is old")
-        assertEquals(firstRun, store.warmupStartedAt(2), "warm-up marker is stamped on first run")
+        assertEquals(
+            firstRun.toEpochMilliseconds(),
+            store.warmupStartedAt(2)?.toEpochMilliseconds(),
+            "warm-up marker is stamped on first run",
+        )
 
         // After the window has elapsed *from first evaluation*, a genuinely-new value fires.
         val afterWarmup = firstRun + 2.days

--- a/backend/src/test/kotlin/com/moneat/security/detection/DetectionRuleRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/DetectionRuleRoutesTest.kt
@@ -201,6 +201,20 @@ class DetectionRuleRoutesTest {
     }
 
     @Test
+    fun `coverage reports enabled rule MITRE tags for the caller org`() = testApplication {
+        setupApp()
+        service.create(orgId, request().copy(tags = listOf("mitre:T1110")))
+        service.create(otherOrgId, request().copy(name = "Other", tags = listOf("mitre:T1059")))
+
+        val response = client.get("/v1/security/detection/coverage") { withAuth(token(memberUserId)) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("\"technique_id\":\"T1110\""))
+        assertFalse(body.contains("\"technique_id\":\"T1059\""))
+    }
+
+    @Test
     fun `delete requires admin and removes the rule`() = testApplication {
         setupApp()
         val created = service.create(orgId, request())

--- a/backend/src/test/kotlin/com/moneat/security/detection/DetectionRuleServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/DetectionRuleServiceTest.kt
@@ -192,6 +192,24 @@ class DetectionRuleServiceTest {
         assertEquals(2, preview?.matchCount, "post-warm-up new-value preview surfaces baseline-absent rows")
     }
 
+    @Test
+    fun `rate anomaly rules are compiler-gated and previewable`() = runBlocking {
+        val created = service.create(
+            orgId,
+            createRequest(
+                type = "rate_anomaly",
+                thresholdCount = 20,
+                filter = "level:error",
+                groupBy = listOf("host"),
+            ),
+        )
+
+        val preview = service.preview(orgId, created.id)
+
+        assertEquals("rate_anomaly", created.type)
+        assertEquals(2, preview?.matchCount)
+    }
+
     private fun seedOrg(name: String): Int =
         transaction {
             Organizations.insert {

--- a/backend/src/test/kotlin/com/moneat/security/detection/MitreCoverageServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/MitreCoverageServiceTest.kt
@@ -1,0 +1,40 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.detection
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MitreCoverageServiceTest {
+
+    @Test
+    fun `coverage normalizes enabled rule technique and tactic tags`() {
+        val response = MitreCoverageService().buildCoverage(
+            listOf(
+                CoverageRule(1, "Command execution", enabled = true, tags = listOf("mitre:t1059")),
+                CoverageRule(2, "Brute force", enabled = true, tags = listOf("mitre:T1110", "mitre:TA0006")),
+                CoverageRule(3, "No tag", enabled = true, tags = listOf("category:test")),
+            ),
+        )
+
+        assertEquals(3, response.enabledRuleCount)
+        assertEquals(listOf("T1059", "T1110"), response.techniques.map { it.techniqueId })
+        assertTrue(response.tactics.any { it.tactic == "execution" && it.ruleCount == 1 })
+        assertTrue(response.tactics.any { it.tactic == "credential-access" && it.ruleCount == 1 })
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/security/detection/MitreCoverageServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/MitreCoverageServiceTest.kt
@@ -26,7 +26,7 @@ class MitreCoverageServiceTest {
     fun `coverage normalizes enabled rule technique and tactic tags`() {
         val response = MitreCoverageService().buildCoverage(
             listOf(
-                CoverageRule(1, "Command execution", enabled = true, tags = listOf("mitre:t1059")),
+                CoverageRule(1, "Command execution", enabled = true, tags = listOf("sigma:attack.t1059")),
                 CoverageRule(2, "Brute force", enabled = true, tags = listOf("mitre:T1110", "mitre:TA0006")),
                 CoverageRule(3, "No tag", enabled = true, tags = listOf("category:test")),
             ),

--- a/backend/src/test/kotlin/com/moneat/security/detection/RuleQueryCompilerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/detection/RuleQueryCompilerTest.kt
@@ -276,6 +276,56 @@ class RuleQueryCompilerTest {
         assertFalse(sql.contains("HAVING"), sql)
     }
 
+    @Test
+    fun `a rate anomaly rule reads the bounded rollup with org scope and caps`() {
+        val compiled = compiler.compile(
+            orgId = 42,
+            input(
+                filter = "service:api level:error",
+                groupBy = listOf("service"),
+                type = DetectionRuleType.RATE_ANOMALY,
+                thresholdCount = 50,
+            ),
+        )
+        assertTrue(compiled.sql.contains("security_log_rate_rollup_5m"), compiled.sql)
+        assertTrue(compiled.sql.contains("organization_id = 42"), compiled.sql)
+        assertTrue(compiled.sql.contains("c.current_count >= 50"), compiled.sql)
+        assertTrue(compiled.sql.contains("max_rows_to_read"), compiled.sql)
+        assertFalse(compiled.sql.contains("`moneat`.logs"), compiled.sql)
+    }
+
+    @Test
+    fun `rate anomaly rules reject fields outside the rollup`() {
+        val ex = assertFailsWith<DetectionCompileException> {
+            compiler.compile(
+                orgId = 1,
+                input(
+                    filter = "*:failed",
+                    groupBy = listOf("service"),
+                    type = DetectionRuleType.RATE_ANOMALY,
+                    thresholdCount = 10,
+                ),
+            )
+        }
+        assertTrue(ex.message!!.contains("rollup fields"))
+        assertFalse(ex.message!!.contains("security_log_rate_rollup_5m"))
+    }
+
+    @Test
+    fun `rate anomaly group-by cannot use map fields`() {
+        val ex = assertFailsWith<DetectionCompileException> {
+            compiler.compile(
+                orgId = 1,
+                input(
+                    groupBy = listOf("tags['user']"),
+                    type = DetectionRuleType.RATE_ANOMALY,
+                    thresholdCount = 10,
+                ),
+            )
+        }
+        assertTrue(ex.message!!.contains("Unknown group-by column"))
+    }
+
     // (f) Compiler/validation errors never leak ClickHouse text.
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/security/posture/PostureRegressionAnalyzerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/posture/PostureRegressionAnalyzerTest.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.security.posture
 
-import com.moneat.datadog.security.QueuedComplianceEntry
 import com.moneat.security.signals.SignalSeverity
 import com.moneat.security.signals.SignalSource
 import com.moneat.shared.models.Organizations
@@ -100,8 +99,8 @@ class PostureRegressionAnalyzerTest {
         assertEquals(1, originalOrgSpecs.size)
     }
 
-    private fun finding(status: String): QueuedComplianceEntry =
-        QueuedComplianceEntry(
+    private fun finding(status: String): ComplianceFindingInput =
+        ComplianceFindingInput(
             framework = "cis-aws",
             ruleId = "cis-1.1",
             ruleName = "Root MFA",

--- a/backend/src/test/kotlin/com/moneat/security/posture/PostureRegressionAnalyzerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/posture/PostureRegressionAnalyzerTest.kt
@@ -25,10 +25,13 @@ import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+
+private const val ONE_DAY_MS = 86_400_000L
 
 class PostureRegressionAnalyzerTest {
     companion object {
@@ -79,6 +82,24 @@ class PostureRegressionAnalyzerTest {
     }
 
     @Test
+    fun `regression signal uses clamped occurrence time`() {
+        val futureMs = Clock.System.now().toEpochMilliseconds() + ONE_DAY_MS
+        PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "passed", timestampMs = futureMs)))
+
+        val beforeFailure = Clock.System.now().toEpochMilliseconds()
+        val specs = PostureRegressionAnalyzer.analyze(
+            orgId,
+            listOf(finding(status = "failed", timestampMs = futureMs)),
+        )
+        val afterFailure = Clock.System.now().toEpochMilliseconds()
+
+        val spec = specs.single()
+        assertTrue(spec.occurredAtMs in beforeFailure..afterFailure)
+        assertTrue(spec.occurredAtMs < futureMs)
+        assertTrue(spec.evidenceReference.contains("occurred_at_ms=${spec.occurredAtMs}"))
+    }
+
+    @Test
     fun `repeated failed finding updates state without emitting`() {
         PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "passed")))
         PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "failed")))
@@ -99,7 +120,7 @@ class PostureRegressionAnalyzerTest {
         assertEquals(1, originalOrgSpecs.size)
     }
 
-    private fun finding(status: String): ComplianceFindingInput =
+    private fun finding(status: String, timestampMs: Long = 1_700_000_000_000): ComplianceFindingInput =
         ComplianceFindingInput(
             framework = "cis-aws",
             ruleId = "cis-1.1",
@@ -108,7 +129,7 @@ class PostureRegressionAnalyzerTest {
             resourceType = "aws_account",
             resourceId = "acct-123",
             resourceName = "prod",
-            timestampMs = 1_700_000_000_000,
+            timestampMs = timestampMs,
         )
 
     private fun seedOrg(name: String): Int =

--- a/backend/src/test/kotlin/com/moneat/security/posture/PostureRegressionAnalyzerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/posture/PostureRegressionAnalyzerTest.kt
@@ -1,0 +1,120 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.posture
+
+import com.moneat.datadog.security.QueuedComplianceEntry
+import com.moneat.security.signals.SignalSeverity
+import com.moneat.security.signals.SignalSource
+import com.moneat.shared.models.Organizations
+import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PostureRegressionAnalyzerTest {
+    companion object {
+        private var db: Database? = null
+    }
+
+    private var orgId: Int = 0
+    private var otherOrgId: Int = 0
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_posture_regression;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.dropAndPatchJsonb(Organizations, SecurityComplianceFindingStates)
+        transaction {
+            SchemaUtils.create(Organizations, SecurityComplianceFindingStates)
+            orgId = seedOrg("acme")
+            otherOrgId = seedOrg("other")
+        }
+    }
+
+    @Test
+    fun `failed first sight does not emit regression signal`() {
+        val specs = PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "failed")))
+
+        assertTrue(specs.isEmpty())
+    }
+
+    @Test
+    fun `passed to failed emits one compliance regression signal`() {
+        PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "passed")))
+
+        val specs = PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "failed")))
+
+        assertEquals(1, specs.size)
+        val spec = specs.single()
+        assertEquals(SignalSource.AGENT_COMPLIANCE, spec.source)
+        assertEquals(SignalSeverity.HIGH, spec.severity)
+        assertEquals("cis-1.1", spec.ruleId)
+        assertEquals("cis-aws|cis-1.1|aws_account|acct-123", spec.dedupKey)
+        assertEquals("acct-123", spec.entities["resource_id"])
+        assertTrue(spec.evidenceReference.contains("previous=passed"))
+    }
+
+    @Test
+    fun `repeated failed finding updates state without emitting`() {
+        PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "passed")))
+        PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "failed")))
+
+        val repeat = PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "failed")))
+
+        assertTrue(repeat.isEmpty())
+    }
+
+    @Test
+    fun `state is isolated by organization`() {
+        PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "passed")))
+
+        val otherOrgSpecs = PostureRegressionAnalyzer.analyze(otherOrgId, listOf(finding(status = "failed")))
+        val originalOrgSpecs = PostureRegressionAnalyzer.analyze(orgId, listOf(finding(status = "failed")))
+
+        assertTrue(otherOrgSpecs.isEmpty())
+        assertEquals(1, originalOrgSpecs.size)
+    }
+
+    private fun finding(status: String): QueuedComplianceEntry =
+        QueuedComplianceEntry(
+            framework = "cis-aws",
+            ruleId = "cis-1.1",
+            ruleName = "Root MFA",
+            status = status,
+            resourceType = "aws_account",
+            resourceId = "acct-123",
+            resourceName = "prod",
+            timestampMs = 1_700_000_000_000,
+        )
+
+    private fun seedOrg(name: String): Int =
+        Organizations.insert {
+            it[Organizations.name] = name
+            it[slug] = name
+        } get Organizations.id
+}

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalDerivationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalDerivationTest.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.security.signals
 
-import com.moneat.datadog.security.QueuedComplianceEntry
 import com.moneat.datadog.security.QueuedSecurityBatch
 import com.moneat.datadog.security.QueuedSecurityEventEntry
 import kotlin.test.Test
@@ -58,61 +57,13 @@ class SignalDerivationTest {
     }
 
     @Test
-    fun `failed compliance finding derives an agent_compliance spec keyed by rule resource`() {
+    fun `compliance findings derive no direct signals`() {
         val batch = QueuedSecurityBatch(
             organizationId = 1,
             batchType = "findings",
-            findings = listOf(
-                QueuedComplianceEntry(
-                    framework = "cis-aws",
-                    ruleId = "cis-1.1",
-                    ruleName = "Root MFA",
-                    status = "failed",
-                    resourceType = "aws_account",
-                    resourceId = "acct-123",
-                    resourceName = "prod",
-                    timestampMs = 1_700_000_000_000
-                )
-            )
-        )
-
-        val specs = SignalDerivation.fromBatch(batch)
-
-        assertEquals(1, specs.size)
-        val spec = specs.single()
-        assertEquals(SignalSource.AGENT_COMPLIANCE, spec.source)
-        assertEquals("cis-1.1|acct-123", spec.dedupKey)
-        assertEquals(SignalSeverity.HIGH, spec.severity)
-        assertEquals("prod", spec.entities["resource"])
-        assertEquals("acct-123", spec.entities["resource_id"])
-        assertTrue(spec.evidenceReference.contains("table=compliance_findings"))
-    }
-
-    @Test
-    fun `passed and skipped compliance findings derive no signals`() {
-        val batch = QueuedSecurityBatch(
-            organizationId = 1,
-            batchType = "findings",
-            findings = listOf(
-                QueuedComplianceEntry(ruleId = "r1", status = "passed", timestampMs = 1),
-                QueuedComplianceEntry(ruleId = "r2", status = "skipped", timestampMs = 1)
-            )
         )
 
         assertTrue(SignalDerivation.fromBatch(batch).isEmpty())
-    }
-
-    @Test
-    fun `error compliance finding maps to medium severity`() {
-        val batch = QueuedSecurityBatch(
-            organizationId = 1,
-            batchType = "findings",
-            findings = listOf(
-                QueuedComplianceEntry(ruleId = "r3", status = "error", resourceId = "x", timestampMs = 1)
-            )
-        )
-
-        assertEquals(SignalSeverity.MEDIUM, SignalDerivation.fromBatch(batch).single().severity)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalDerivationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalDerivationTest.kt
@@ -16,8 +16,6 @@
 
 package com.moneat.security.signals
 
-import com.moneat.datadog.security.QueuedSecurityBatch
-import com.moneat.datadog.security.QueuedSecurityEventEntry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -26,23 +24,19 @@ class SignalDerivationTest {
 
     @Test
     fun `runtime event derives a single agent_runtime spec keyed by rule host process`() {
-        val batch = QueuedSecurityBatch(
-            organizationId = 1,
-            batchType = "events",
-            events = listOf(
-                QueuedSecurityEventEntry(
-                    ruleId = "cws-1",
-                    ruleName = "Suspicious exec",
-                    severity = "high",
-                    processName = "bash",
-                    filePath = "/etc/shadow",
-                    host = "web-01",
-                    timestampMs = 1_700_000_000_000
-                )
+        val events = listOf(
+            RuntimeSecurityEventInput(
+                ruleId = "cws-1",
+                ruleName = "Suspicious exec",
+                severity = "high",
+                processName = "bash",
+                filePath = "/etc/shadow",
+                host = "web-01",
+                timestampMs = 1_700_000_000_000
             )
         )
 
-        val specs = SignalDerivation.fromBatch(batch)
+        val specs = SignalDerivation.fromRuntimeEvents(events)
 
         assertEquals(1, specs.size)
         val spec = specs.single()
@@ -57,18 +51,7 @@ class SignalDerivationTest {
     }
 
     @Test
-    fun `compliance findings derive no direct signals`() {
-        val batch = QueuedSecurityBatch(
-            organizationId = 1,
-            batchType = "findings",
-        )
-
-        assertTrue(SignalDerivation.fromBatch(batch).isEmpty())
-    }
-
-    @Test
-    fun `activity dump batches derive no signals`() {
-        val batch = QueuedSecurityBatch(organizationId = 1, batchType = "dumps")
-        assertTrue(SignalDerivation.fromBatch(batch).isEmpty())
+    fun `empty runtime event input derives no signals`() {
+        assertTrue(SignalDerivation.fromRuntimeEvents(emptyList()).isEmpty())
     }
 }

--- a/backend/src/test/kotlin/com/moneat/security/signals/SignalServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/signals/SignalServiceTest.kt
@@ -16,7 +16,12 @@
 
 package com.moneat.security.signals
 
+import com.moneat.config.ClickHouseClient
 import com.moneat.shared.models.Organizations
+import com.moneat.testsupport.MockHttpServer
+import com.moneat.testsupport.requestBodyText
+import com.moneat.testsupport.respond
+import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -24,9 +29,11 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -35,6 +42,7 @@ class SignalServiceTest {
     companion object {
         private var db: Database? = null
         private const val ACTOR = 7
+        private const val TEXT_PLAIN = "text/plain"
     }
 
     private val service = SignalService()
@@ -53,6 +61,11 @@ class SignalServiceTest {
         SignalSchemaTestSupport.reset()
         orgId = seedOrg("acme")
         otherOrgId = seedOrg("globex")
+    }
+
+    @AfterTest
+    fun teardown() {
+        ClickHouseClient.close()
     }
 
     @Test
@@ -168,6 +181,39 @@ class SignalServiceTest {
         }
     }
 
+    @Test
+    fun `compliance samples filter by framework resource type and resource id`() = runBlocking {
+        val created = SignalWriter.upsert(
+            orgId,
+            complianceSpec(
+                entities = mapOf(
+                    "framework" to "cis-aws",
+                    "resource_type" to "aws_account",
+                    "resource" to "display-account",
+                    "resource_id" to "acct-123",
+                ),
+            ),
+        )
+        val capturedSql = mutableListOf<String>()
+        MockHttpServer { exchange ->
+            capturedSql.add(exchange.requestBodyText())
+            exchange.respond(200, complianceFindingRow(), contentType = TEXT_PLAIN)
+        }.use { server ->
+            ClickHouseClient.close()
+            ClickHouseClient.init(server.baseUrl, "test_db", "default", "")
+
+            val detail = service.get(orgId, created.signalId)
+
+            assertEquals(1, detail?.sampleEvents?.size)
+        }
+
+        val sql = capturedSql.single()
+        assertTrue(sql.contains("framework = 'cis-aws'"))
+        assertTrue(sql.contains("resource_type = 'aws_account'"))
+        assertTrue(sql.contains("resource_id = 'acct-123'"))
+        assertFalse(sql.contains("display-account"))
+    }
+
     private fun latestAudit(signalId: Int): SignalAuditResponse =
         transaction {
             SecuritySignalAudit.selectAll()
@@ -206,6 +252,23 @@ class SignalServiceTest {
         evidenceReference = "table=security_events dedup=$ruleId",
         occurredAtMs = 1_700_000_000_000
     )
+
+    private fun complianceSpec(entities: Map<String, String>) = SignalSpec(
+        source = SignalSource.AGENT_COMPLIANCE,
+        ruleId = "cis-1.1",
+        ruleName = "Root MFA",
+        severity = SignalSeverity.HIGH,
+        dedupKey = "cis-aws|cis-1.1|aws_account|acct-123",
+        entities = entities,
+        evidenceType = "clickhouse_query",
+        evidenceReference = "table=compliance_findings rule_id=cis-1.1",
+        occurredAtMs = 1_700_000_000_000,
+    )
+
+    private fun complianceFindingRow(): String =
+        """{"finding_id":"f1","framework":"cis-aws","rule_id":"cis-1.1","rule_name":"Root MFA",""" +
+            """"status":"failed","resource_type":"aws_account","resource_id":"acct-123",""" +
+            """"resource_name":"Production","ts":"2026-05-31T00:00:00.000Z"}"""
 
     private fun seedOrg(name: String): Int =
         transaction {

--- a/backend/src/test/kotlin/com/moneat/security/threatintel/ThreatIntelServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/threatintel/ThreatIntelServiceTest.kt
@@ -1,0 +1,77 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.threatintel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class ThreatIntelServiceTest {
+
+    @Test
+    fun `entity values are enriched from the cached snapshot`() {
+        var loads = 0
+        val provider = ThreatIntelProvider {
+            loads++
+            snapshot("203.0.113.66")
+        }
+        val service = ThreatIntelService(provider = provider, ttl = 15.minutes, clock = { NOW })
+
+        val first = service.enrich(mapOf("destination_ip" to "203.0.113.66"))
+        val second = service.enrich(mapOf("destination_ip" to "203.0.113.66"))
+
+        assertEquals(1, loads)
+        assertEquals("command_and_control", first.single().threatType)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `snapshot load failure is non-blocking`() {
+        val service = ThreatIntelService(
+            provider = ThreatIntelProvider { error("feed unavailable") },
+            ttl = 15.minutes,
+            clock = { NOW },
+        )
+
+        assertTrue(service.enrich(mapOf("destination_ip" to "203.0.113.66")).isEmpty())
+    }
+
+    private fun snapshot(ip: String): ThreatIntelSnapshot =
+        ThreatIntelSnapshot(
+            feeds = listOf(
+                ThreatIntelFeed(
+                    name = "local",
+                    source = "seed",
+                    updatedAt = "2026-05-31T00:00:00Z",
+                    indicators = listOf(
+                        ThreatIntelIndicator(
+                            type = "ip",
+                            value = ip,
+                            threatType = "command_and_control",
+                            confidence = 70,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    companion object {
+        private val NOW = Instant.parse("2026-05-31T00:00:00Z")
+    }
+}

--- a/dashboard/src/components/security/RuleForm.tsx
+++ b/dashboard/src/components/security/RuleForm.tsx
@@ -45,6 +45,7 @@ interface RuleFormProps {
 const TYPE_OPTIONS: {value: RuleFormState['type']; label: string}[] = [
   {value: 'threshold', label: 'Threshold'},
   {value: 'new_value', label: 'New value'},
+  {value: 'rate_anomaly', label: 'Rate anomaly'},
 ]
 
 export function RuleForm({rule, onSubmit, onPreview, onCancel, isSubmitting}: RuleFormProps) {
@@ -180,8 +181,10 @@ export function RuleForm({rule, onSubmit, onPreview, onCancel, isSubmitting}: Ru
             className="h-8 text-xs"
           />
         </Field>
-        {form.type === 'threshold' && (
-          <Field label="Threshold count" htmlFor="rule-threshold">
+        {form.type !== 'new_value' && (
+          <Field
+            label={form.type === 'rate_anomaly' ? 'Minimum count' : 'Threshold count'}
+            htmlFor="rule-threshold">
             <Input
               id="rule-threshold"
               type="number"

--- a/dashboard/src/components/security/RuleList.tsx
+++ b/dashboard/src/components/security/RuleList.tsx
@@ -24,6 +24,7 @@ import {colorFor, severityColors} from './securityChips'
 const TYPE_LABELS: Record<string, string> = {
   threshold: 'Threshold',
   new_value: 'New value',
+  rate_anomaly: 'Rate anomaly',
 }
 
 interface RuleListProps {

--- a/dashboard/src/components/security/SignalDetailContent.tsx
+++ b/dashboard/src/components/security/SignalDetailContent.tsx
@@ -52,6 +52,7 @@ function Field({label, children}: {label: string; children: React.ReactNode}) {
 
 export function SignalDetailContent({detail, onTriage, isSubmitting}: SignalDetailContentProps) {
   const {signal, evidence, audit, sample_events: sampleEvents} = detail
+  const threatIntel = detail.threat_intel ?? []
 
   return (
     <div className="space-y-4">
@@ -86,6 +87,26 @@ export function SignalDetailContent({detail, onTriage, isSubmitting}: SignalDeta
               <Badge key={k} variant="outline" className="text-[10px] font-mono">
                 {k}={v}
               </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {threatIntel.length > 0 && (
+        <div className="space-y-1">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Threat Intel</div>
+          <div className="space-y-1">
+            {threatIntel.map((item) => (
+              <div key={`${item.entity_key}:${item.entity_value}:${item.feed_name}`} className="rounded border p-1.5">
+                <div className="flex flex-wrap items-center gap-1">
+                  <Badge variant="outline" className="text-[10px]">{item.indicator_type}</Badge>
+                  <span className="font-mono text-[10px]">{item.entity_key}={item.entity_value}</span>
+                  <Badge variant="outline" className="text-[10px]">{item.confidence}%</Badge>
+                </div>
+                <div className="mt-1 text-[10px] text-muted-foreground">
+                  {item.threat_type.replace(/_/g, ' ')} - {item.feed_name}
+                </div>
+              </div>
             ))}
           </div>
         </div>

--- a/dashboard/src/components/security/__tests__/RuleForm.test.tsx
+++ b/dashboard/src/components/security/__tests__/RuleForm.test.tsx
@@ -47,11 +47,31 @@ describe('RuleForm', () => {
   })
 
   it('hides the threshold field for new_value rules', () => {
-    render(<RuleForm rule={makeRule({type: 'new_value'})} onSubmit={vi.fn()} onPreview={noopPreview()} onCancel={vi.fn()} />)
+    render(
+      <RuleForm
+        rule={makeRule({type: 'new_value'})}
+        onSubmit={vi.fn()}
+        onPreview={noopPreview()}
+        onCancel={vi.fn()}
+      />
+    )
     expect(screen.queryByLabelText('Threshold count')).not.toBeInTheDocument()
     // Switching back to threshold reveals it.
     fireEvent.change(screen.getByLabelText('Rule type'), {target: {value: 'threshold'}})
     expect(screen.getByLabelText('Threshold count')).toBeInTheDocument()
+  })
+
+  it('uses minimum count for rate anomaly rules', () => {
+    render(
+      <RuleForm
+        rule={makeRule({type: 'rate_anomaly', threshold_count: 20})}
+        onSubmit={vi.fn()}
+        onPreview={noopPreview()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByLabelText('Minimum count')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Threshold count')).not.toBeInTheDocument()
   })
 
   it('saves then previews and renders the would-be count', async () => {

--- a/dashboard/src/components/security/__tests__/SignalDetailContent.test.tsx
+++ b/dashboard/src/components/security/__tests__/SignalDetailContent.test.tsx
@@ -57,4 +57,25 @@ describe('SignalDetailContent', () => {
     render(<SignalDetailContent detail={detail} onTriage={vi.fn().mockResolvedValue(detail.signal)} />)
     expect(screen.getByText('No sample events')).toBeInTheDocument()
   })
+
+  it('renders threat intelligence enrichment when present', () => {
+    const detail = makeSignalDetail({
+      threat_intel: [
+        {
+          entity_key: 'destination_ip',
+          entity_value: '203.0.113.66',
+          indicator_type: 'ip',
+          feed_name: 'local',
+          source: 'seed',
+          threat_type: 'command_and_control',
+          confidence: 70,
+          updated_at: '2026-05-31T00:00:00Z',
+        },
+      ],
+    })
+    render(<SignalDetailContent detail={detail} onTriage={vi.fn().mockResolvedValue(detail.signal)} />)
+    expect(screen.getByText('Threat Intel')).toBeInTheDocument()
+    expect(screen.getByText('destination_ip=203.0.113.66')).toBeInTheDocument()
+    expect(screen.getByText(/command and control/)).toBeInTheDocument()
+  })
 })

--- a/dashboard/src/components/security/__tests__/fixtures.ts
+++ b/dashboard/src/components/security/__tests__/fixtures.ts
@@ -44,6 +44,7 @@ export function makeSignalDetail(overrides: Partial<SignalDetailResponse> = {}):
     evidence: [{id: 1, evidence_type: 'logs', reference: 'ref', created_at: '2026-05-30T00:00:00Z'}],
     audit: [],
     sample_events: [{message: 'login failed', user: 'alice'}],
+    threat_intel: [],
     ...overrides,
   }
 }

--- a/dashboard/src/components/security/__tests__/ruleFormState.test.ts
+++ b/dashboard/src/components/security/__tests__/ruleFormState.test.ts
@@ -62,6 +62,18 @@ describe('buildRuleRequest', () => {
     expect(buildRuleRequest(makeForm({thresholdCount: 'abc'})).ok).toBe(false)
   })
 
+  it('requires a positive minimum count for rate anomaly rules', () => {
+    const invalid = buildRuleRequest(makeForm({type: 'rate_anomaly', thresholdCount: ''}))
+    expect(invalid).toEqual({ok: false, error: 'Minimum count must be a positive integer'})
+
+    const valid = buildRuleRequest(makeForm({type: 'rate_anomaly', thresholdCount: '20'}))
+    expect(valid.ok).toBe(true)
+    if (valid.ok) {
+      expect(valid.request.type).toBe('rate_anomaly')
+      expect(valid.request.threshold_count).toBe(20)
+    }
+  })
+
   it('splits comma-separated group_by and tags', () => {
     const result = buildRuleRequest(
       makeForm({groupBy: 'user.id, source.ip ,', tags: 'auth, brute-force', thresholdCount: '5'})

--- a/dashboard/src/components/security/ruleFormState.ts
+++ b/dashboard/src/components/security/ruleFormState.ts
@@ -100,10 +100,10 @@ export function buildRuleRequest(form: RuleFormState): RuleFormValidation {
   }
 
   let thresholdCount: number | null = null
-  if (form.type === 'threshold') {
+  if (form.type !== 'new_value') {
     const parsed = Number(form.thresholdCount)
     if (!Number.isInteger(parsed) || parsed <= 0) {
-      return {ok: false, error: 'Threshold count must be a positive integer'}
+      return {ok: false, error: 'Minimum count must be a positive integer'}
     }
     thresholdCount = parsed
   }

--- a/dashboard/src/lib/__tests__/security-api.test.ts
+++ b/dashboard/src/lib/__tests__/security-api.test.ts
@@ -97,4 +97,25 @@ describe('security api module', () => {
     await api.deleteDetectionRule(9)
     expect(called).toBe(true)
   })
+
+  it('GETs detection coverage and compliance trends', async () => {
+    let coverageCalled = false
+    let trendsCalled = false
+    server.use(
+      http.get(`${API_BASE}/v1/security/detection/coverage`, () => {
+        coverageCalled = true
+        return HttpResponse.json({enabled_rule_count: 1, tactics: [], techniques: []})
+      }),
+      http.get(`${API_BASE}/v1/security/compliance/trends`, () => {
+        trendsCalled = true
+        return HttpResponse.json({frameworks: []})
+      })
+    )
+
+    await api.getDetectionCoverage()
+    await api.getComplianceTrends()
+
+    expect(coverageCalled).toBe(true)
+    expect(trendsCalled).toBe(true)
+  })
 })

--- a/dashboard/src/lib/api/modules/security.ts
+++ b/dashboard/src/lib/api/modules/security.ts
@@ -18,6 +18,8 @@ import type { ApiClientCore } from '../client'
 import { urlWithQuery } from '../utils'
 import type {
   CreateDetectionRuleRequest,
+  ComplianceTrendResponse,
+  DetectionCoverageResponse,
   DetectionPreviewResponse,
   DetectionRuleListResponse,
   DetectionRuleResponse,
@@ -78,6 +80,9 @@ export function securityMethods(core: ApiClientCore) {
     listDetectionRules: () =>
       core.request<DetectionRuleListResponse>(rules),
 
+    getDetectionCoverage: () =>
+      core.request<DetectionCoverageResponse>(`${base}/security/detection/coverage`),
+
     getDetectionRule: (ruleId: number) =>
       core.request<DetectionRuleResponse>(`${rules}/${ruleId}`),
 
@@ -125,5 +130,9 @@ export function securityMethods(core: ApiClientCore) {
       }
       return response.text()
     },
+
+    // --- Compliance posture ---
+    getComplianceTrends: () =>
+      core.request<ComplianceTrendResponse>(`${base}/security/compliance/trends`),
   }
 }

--- a/dashboard/src/lib/api/types/security.ts
+++ b/dashboard/src/lib/api/types/security.ts
@@ -70,6 +70,7 @@ export interface SignalDetailResponse {
   audit: SignalAuditResponse[]
   // Raw ClickHouse evidence rows; shape varies by source, so kept opaque.
   sample_events: Record<string, unknown>[]
+  threat_intel: ThreatIntelEnrichmentResponse[]
 }
 
 export interface SignalListParams {
@@ -88,7 +89,19 @@ export interface TriageRequest {
   note?: string
 }
 
-export type DetectionRuleType = 'threshold' | 'new_value'
+export interface ThreatIntelEnrichmentResponse {
+  entity_key: string
+  entity_value: string
+  indicator_type: string
+  feed_name: string
+  source: string
+  threat_type: string
+  confidence: number
+  reference?: string
+  updated_at: string
+}
+
+export type DetectionRuleType = 'threshold' | 'new_value' | 'rate_anomaly'
 
 export interface DetectionRuleResponse {
   id: number
@@ -113,6 +126,31 @@ export interface DetectionRuleResponse {
 export interface DetectionRuleListResponse {
   rules: DetectionRuleResponse[]
   total_count: number
+}
+
+export interface DetectionCoverageResponse {
+  enabled_rule_count: number
+  tactics: MitreTacticCoverage[]
+  techniques: MitreTechniqueCoverage[]
+}
+
+export interface MitreTacticCoverage {
+  tactic: string
+  technique_count: number
+  rule_count: number
+}
+
+export interface MitreTechniqueCoverage {
+  technique_id: string
+  tactics: string[]
+  rule_count: number
+  rules: MitreCoveredRule[]
+}
+
+export interface MitreCoveredRule {
+  id: number
+  name: string
+  enabled: boolean
 }
 
 export interface CreateDetectionRuleRequest {
@@ -144,6 +182,25 @@ export interface DetectionPreviewResponse {
   match_count: number
   samples: DetectionMatchSample[]
   window_seconds: number
+}
+
+export interface ComplianceTrendBucket {
+  bucketStart: string
+  passed: number
+  failed: number
+  skipped: number
+  error: number
+  total: number
+  passRate: number
+}
+
+export interface ComplianceFrameworkTrend {
+  framework: string
+  buckets: ComplianceTrendBucket[]
+}
+
+export interface ComplianceTrendResponse {
+  frameworks: ComplianceFrameworkTrend[]
 }
 
 export interface VulnerabilitySummaryResponse {

--- a/dashboard/src/routes/security.compliance.tsx
+++ b/dashboard/src/routes/security.compliance.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
-import {api} from '@/lib/api'
+import {api, type ComplianceFrameworkTrend} from '@/lib/api'
 import {Badge} from '@/components/ui/badge'
 import {Card, CardContent, CardHeader, CardTitle, CardDescription} from '@/components/ui/card'
 import {cn} from '@/lib/utils'
@@ -57,9 +57,14 @@ function ComplianceFindings() {
     queryKey: ['compliance-findings'],
     queryFn: () => api.get<{findings?: ComplianceFinding[]; totalCount?: number}>('/v1/security/compliance?limit=50'),
   })
+  const {data: trendData} = useQuery({
+    queryKey: ['compliance-trends'],
+    queryFn: () => api.getComplianceTrends(),
+  })
 
   const findings: ComplianceFinding[] = data?.findings ?? []
   const summary: ComplianceSummary[] = summaryData?.summary ?? []
+  const trends = trendData?.frameworks ?? []
 
   return (
     <div className="space-y-4">
@@ -84,9 +89,13 @@ function ComplianceFindings() {
         </div>
       )}
 
+      {trends.length > 0 && <PassRateTrends trends={trends} />}
+
       {/* Findings table */}
       {isLoading ? (
-        <div className="flex justify-center py-8"><div className="animate-spin rounded-full h-6 w-6 border-2 border-muted border-t-primary" /></div>
+        <div className="flex justify-center py-8">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted border-t-primary" />
+        </div>
       ) : (
         <Card>
           <CardHeader className="py-2 px-3">
@@ -108,7 +117,9 @@ function ComplianceFindings() {
                 <tbody>
                   {findings.map((f) => (
                     <tr key={f.findingId} className="border-b last:border-0 hover:bg-muted/30">
-                      <td className="py-1.5 pr-2"><Badge variant="outline" className="text-[10px]">{f.framework}</Badge></td>
+                      <td className="py-1.5 pr-2">
+                        <Badge variant="outline" className="text-[10px]">{f.framework}</Badge>
+                      </td>
                       <td className="py-1.5 pr-2">{f.ruleName}</td>
                       <td className="py-1.5 pr-2">
                         <Badge variant="outline" className={cn('text-[10px]', statusColors[f.status ?? ''] || '')}>
@@ -120,7 +131,11 @@ function ComplianceFindings() {
                     </tr>
                   ))}
                   {findings.length === 0 && (
-                    <tr><td colSpan={5} className="py-6 text-center text-muted-foreground">No compliance findings</td></tr>
+                    <tr>
+                      <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                        No compliance findings
+                      </td>
+                    </tr>
                   )}
                 </tbody>
               </table>
@@ -129,5 +144,44 @@ function ComplianceFindings() {
         </Card>
       )}
     </div>
+  )
+}
+
+function PassRateTrends({trends}: {trends: ComplianceFrameworkTrend[]}) {
+  return (
+    <Card>
+      <CardHeader className="py-2 px-3">
+        <CardTitle className="text-sm">Pass-Rate Trend</CardTitle>
+        <CardDescription className="text-xs">Daily posture pass rate by framework</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-2 p-3 pt-0 md:grid-cols-2">
+        {trends.map((trend) => {
+          const buckets = trend.buckets.slice(-14)
+          const latest = buckets.at(-1)
+          const passRate = Math.round((latest?.passRate ?? 0) * 100)
+          return (
+            <div key={trend.framework} className="rounded border p-2">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <Badge variant="outline" className="text-[10px]">{trend.framework}</Badge>
+                <span className="text-xs font-medium">{passRate}%</span>
+              </div>
+              <div className="flex h-8 items-end gap-1">
+                {buckets.map((bucket) => (
+                  <div
+                    key={bucket.bucketStart}
+                    className="min-w-2 flex-1 rounded-sm bg-emerald-500/70"
+                    style={{height: `${Math.max(8, Math.round(bucket.passRate * 32))}px`}}
+                    title={`${bucket.bucketStart}: ${Math.round(bucket.passRate * 100)}%`}
+                  />
+                ))}
+              </div>
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                {latest ? `${latest.passed} passed, ${latest.failed + latest.error} failed or errored` : 'No buckets'}
+              </div>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
   )
 }

--- a/dashboard/src/routes/security.detections.tsx
+++ b/dashboard/src/routes/security.detections.tsx
@@ -22,10 +22,12 @@ import {
   api,
   formatErrorForLogging,
   type CreateDetectionRuleRequest,
+  type DetectionCoverageResponse,
   type DetectionRuleResponse,
 } from '@/lib/api'
 import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
 import {Button} from '@/components/ui/button'
+import {Badge} from '@/components/ui/badge'
 import {Sheet, SheetContent, SheetHeader, SheetTitle} from '@/components/ui/sheet'
 import {
   AlertDialog,
@@ -58,9 +60,16 @@ function DetectionsTab() {
     queryKey: ['detection-rules'],
     queryFn: () => api.listDetectionRules(),
   })
+  const {data: coverage} = useQuery({
+    queryKey: ['detection-coverage'],
+    queryFn: () => api.getDetectionCoverage(),
+  })
   const rules = useMemo(() => data?.rules ?? [], [data])
 
-  const invalidate = () => queryClient.invalidateQueries({queryKey: ['detection-rules']})
+  const invalidate = () => {
+    void queryClient.invalidateQueries({queryKey: ['detection-rules']})
+    void queryClient.invalidateQueries({queryKey: ['detection-coverage']})
+  }
 
   const save = useMutation({
     mutationFn: (vars: {ruleId?: number; request: CreateDetectionRuleRequest}) =>
@@ -108,6 +117,8 @@ function DetectionsTab() {
           New rule
         </Button>
       </div>
+
+      {coverage && <CoveragePanel coverage={coverage} />}
 
       {isLoading ? (
         <div className="flex justify-center py-8">
@@ -172,5 +183,47 @@ function DetectionsTab() {
         </AlertDialogContent>
       </AlertDialog>
     </div>
+  )
+}
+
+function CoveragePanel({coverage}: {coverage: DetectionCoverageResponse}) {
+  const topTechniques = coverage.techniques.slice(0, 6)
+  const topTactics = coverage.tactics.slice(0, 8)
+  return (
+    <Card>
+      <CardHeader className="px-2.5 py-1.5">
+        <CardTitle className="text-xs">
+          MITRE ATT&CK Coverage ({coverage.techniques.length} techniques)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 p-2.5 pt-0">
+        <div className="flex flex-wrap gap-1">
+          {topTactics.length === 0 ? (
+            <span className="text-xs text-muted-foreground">No enabled rules with ATT&CK tags</span>
+          ) : (
+            topTactics.map((tactic) => (
+              <Badge key={tactic.tactic} variant="outline" className="text-[10px]">
+                {tactic.tactic.replace(/-/g, ' ')} - {tactic.rule_count}
+              </Badge>
+            ))
+          )}
+        </div>
+        {topTechniques.length > 0 && (
+          <div className="grid gap-1 md:grid-cols-2">
+            {topTechniques.map((technique) => (
+              <div key={technique.technique_id} className="rounded border p-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono text-xs">{technique.technique_id}</span>
+                  <Badge variant="outline" className="text-[10px]">{technique.rule_count} rules</Badge>
+                </div>
+                <div className="mt-1 truncate text-[10px] text-muted-foreground">
+                  {technique.tactics.map((tactic) => tactic.replace(/-/g, ' ')).join(', ')}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }


### PR DESCRIPTION
Adds posture regression signals, threat-intel enrichment, MITRE coverage, and rate-anomaly detection.

Local validation:
- backend: `./gradlew :detekt :test --no-daemon`
- dashboard: `npm run lint && npm run typecheck && npm run test && npm run test:coverage`
- dashboard: `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rate anomaly detection rule type for rate-based threat detection
  * Added threat intelligence enrichment to signal details, displaying indicator context
  * Added MITRE ATT&CK coverage metrics showing technique and tactic coverage by organization
  * Added compliance posture tracking with framework-specific trend visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->