### PR TITLE
fix: improve host metric chart range rendering

### DIFF
--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowEgressActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowEgressActionExecutor.kt
@@ -42,7 +42,7 @@ import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.io.IOAccess
 
 private const val DEFAULT_HTTP_TIMEOUT_SECONDS = 15L
-private const val DEFAULT_TRANSFORM_TIMEOUT_SECONDS = 2L
+private const val DEFAULT_TRANSFORM_TIMEOUT_SECONDS = 5L
 private const val DEFAULT_EGRESS_PROXY_PORT = 3128
 private const val MAX_HTTP_BODY_CHARS = 64_000
 private const val MAX_TRANSFORM_OUTPUT_CHARS = 64_000

--- a/dashboard/src/lib/__tests__/host-metrics-chart.test.ts
+++ b/dashboard/src/lib/__tests__/host-metrics-chart.test.ts
@@ -1,0 +1,88 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {
+  compactHostMetricChartData,
+  formatHostMetricAxisTick,
+  formatHostMetricTooltipLabel,
+  toHostMetricChartTimestamp,
+} from '../host-metrics-chart'
+
+const TZ = 'UTC'
+const ONE_HOUR_SECONDS = 3_600
+const SEVEN_DAYS_SECONDS = 604_800
+const THIRTY_DAYS_SECONDS = 2_592_000
+const HOUR_MS = 3_600_000
+
+describe('host metric chart helpers', () => {
+  it('keeps repeated clock labels at distinct x-axis positions', () => {
+    const firstDay = toHostMetricChartTimestamp(Date.UTC(2026, 0, 15, 17, 50) / 1000)
+    const secondDay = toHostMetricChartTimestamp(Date.UTC(2026, 0, 16, 17, 50) / 1000)
+
+    expect(formatHostMetricAxisTick(firstDay, ONE_HOUR_SECONDS, TZ)).toBe('17:50')
+    expect(formatHostMetricAxisTick(secondDay, ONE_HOUR_SECONDS, TZ)).toBe('17:50')
+    expect(firstDay).not.toBe(secondDay)
+  })
+
+  it('formats long-range ticks with dates instead of repeated clock-only labels', () => {
+    const timestamp = toHostMetricChartTimestamp(Date.UTC(2026, 0, 15, 17, 50) / 1000)
+
+    expect(formatHostMetricAxisTick(timestamp, THIRTY_DAYS_SECONDS, TZ)).toContain('Jan')
+    expect(formatHostMetricAxisTick(timestamp, THIRTY_DAYS_SECONDS, TZ)).toContain('15')
+  })
+
+  it('uses a full timestamp in tooltip labels', () => {
+    const timestamp = toHostMetricChartTimestamp(Date.UTC(2026, 0, 15, 17, 50) / 1000)
+    const label = formatHostMetricTooltipLabel(timestamp, TZ)
+
+    expect(label).toContain('Jan')
+    expect(label).toContain('15')
+    expect(label).toContain('50')
+  })
+
+  it('passes through invalid labels', () => {
+    expect(formatHostMetricAxisTick('not-a-time', THIRTY_DAYS_SECONDS, TZ)).toBe('not-a-time')
+    expect(formatHostMetricTooltipLabel('not-a-time', TZ)).toBe('not-a-time')
+  })
+
+  it('keeps short ranges at raw resolution', () => {
+    const data = [
+      {timestamp: 1000, CPU: 10},
+      {timestamp: 2000, CPU: 20},
+    ]
+
+    expect(compactHostMetricChartData(data, SEVEN_DAYS_SECONDS, ['CPU'], 1)).toBe(data)
+  })
+
+  it('compacts long ranges and averages only present values', () => {
+    const start = Date.UTC(2026, 0, 1)
+    const data = Array.from({length: 720}, (_, index) => ({
+      timestamp: start + index * HOUR_MS,
+      Received: index % 2 === 0 ? 120 : null,
+      Sent: 60,
+    }))
+
+    const compacted = compactHostMetricChartData(data, THIRTY_DAYS_SECONDS, ['Received', 'Sent'], 24)
+
+    expect(compacted).toHaveLength(24)
+    expect(compacted.every((point) => point.Sent === 60)).toBe(true)
+    expect(compacted.every((point) => point.Received === 120)).toBe(true)
+    expect(compacted.map((point) => point.timestamp)).toEqual(
+      compacted.map((point) => point.timestamp).sort((left, right) => left - right)
+    )
+  })
+})

--- a/dashboard/src/lib/host-metrics-chart.ts
+++ b/dashboard/src/lib/host-metrics-chart.ts
@@ -1,0 +1,120 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {formatDateTime, formatMonthDay, formatTimeHM} from './date-format'
+
+const MILLISECONDS_PER_SECOND = 1000
+const SECONDS_PER_DAY = 86_400
+const LONG_RANGE_COMPACT_SECONDS = 7 * SECONDS_PER_DAY
+const DEFAULT_MAX_CHART_POINTS = 360
+
+type HostMetricValue = number | null | undefined
+type HostMetricBucket = {
+  count: number
+  metricCounts: Record<string, number>
+  metricSums: Record<string, number>
+  timestampSum: number
+}
+
+export type HostMetricChartDatum = {
+  timestamp: number
+  [metric: string]: HostMetricValue
+}
+
+export function toHostMetricChartTimestamp(timestampSeconds: number): number {
+  return timestampSeconds * MILLISECONDS_PER_SECOND
+}
+
+export function formatHostMetricAxisTick(
+  value: string | number,
+  rangeSeconds: number,
+  timezone: string,
+): string {
+  const timestamp = Number(value)
+  if (Number.isNaN(timestamp)) return String(value)
+
+  const date = new Date(timestamp)
+  if (rangeSeconds > SECONDS_PER_DAY) return formatMonthDay(date, timezone)
+  return formatTimeHM(date, timezone)
+}
+
+export function formatHostMetricTooltipLabel(value: string | number | undefined, timezone: string): string {
+  if (value === undefined) return ''
+
+  const timestamp = Number(value)
+  if (Number.isNaN(timestamp)) return String(value)
+  return formatDateTime(new Date(timestamp), timezone)
+}
+
+export function compactHostMetricChartData<T extends HostMetricChartDatum>(
+  data: T[],
+  rangeSeconds: number,
+  metricKeys: readonly (keyof T & string)[],
+  maxPoints = DEFAULT_MAX_CHART_POINTS,
+): T[] {
+  if (rangeSeconds <= LONG_RANGE_COMPACT_SECONDS || data.length <= maxPoints || maxPoints <= 0) {
+    return data
+  }
+
+  const firstTimestamp = data[0]?.timestamp
+  const lastTimestamp = data[data.length - 1]?.timestamp
+  if (!Number.isFinite(firstTimestamp) || !Number.isFinite(lastTimestamp) || lastTimestamp <= firstTimestamp) {
+    return data
+  }
+
+  const spanMs = lastTimestamp - firstTimestamp + 1
+  const bucketSizeMs = Math.ceil(spanMs / maxPoints)
+  const buckets = new Map<number, HostMetricBucket>()
+
+  for (const point of data) {
+    const bucketIndex = Math.min(
+      maxPoints - 1,
+      Math.floor((point.timestamp - firstTimestamp) / bucketSizeMs),
+    )
+    const bucket = buckets.get(bucketIndex) ?? {
+      count: 0,
+      metricCounts: {},
+      metricSums: {},
+      timestampSum: 0,
+    }
+
+    bucket.count += 1
+    bucket.timestampSum += point.timestamp
+    for (const metricKey of metricKeys) {
+      const value = point[metricKey]
+      if (typeof value !== 'number' || !Number.isFinite(value)) continue
+
+      bucket.metricSums[metricKey] = (bucket.metricSums[metricKey] ?? 0) + value
+      bucket.metricCounts[metricKey] = (bucket.metricCounts[metricKey] ?? 0) + 1
+    }
+    buckets.set(bucketIndex, bucket)
+  }
+
+  return [...buckets.values()].map((bucket) => {
+    const compacted: HostMetricChartDatum = {
+      timestamp: Math.round(bucket.timestampSum / bucket.count),
+    }
+
+    for (const metricKey of metricKeys) {
+      const metricCount = bucket.metricCounts[metricKey] ?? 0
+      compacted[metricKey] = metricCount > 0
+        ? bucket.metricSums[metricKey] / metricCount
+        : null
+    }
+
+    return compacted as T
+  })
+}

--- a/dashboard/src/routes/monitoring.hosts.$hostId.tsx
+++ b/dashboard/src/routes/monitoring.hosts.$hostId.tsx
@@ -55,11 +55,19 @@ import {AlertsTab} from '@/components/monitoring/AlertsTab'
 import {Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle} from '@/components/ui/sheet'
 import {getNowDate} from '@/lib/demo'
 import {useTimezone} from '@/hooks/useTimezone'
-import {formatTimeHM} from '@/lib/date-format'
+import {
+    compactHostMetricChartData,
+    formatHostMetricAxisTick,
+    formatHostMetricTooltipLabel,
+    toHostMetricChartTimestamp,
+} from '@/lib/host-metrics-chart'
 
 type TimeRange = '1h' | '6h' | '24h' | '7d' | '30d' | '90d'
 type ContainerViewMode = 'cards' | 'compact'
 type HostMonitoringLimitKind = 'gb' | 'infraMetrics'
+type ChartTooltipValue = number | null | undefined
+type ChartTooltipEntry = { color: string; name: string; value: ChartTooltipValue; dataKey: string }
+type VisibleChartTooltipEntry = ChartTooltipEntry & { value: number }
 
 const CONTAINER_VIEW_MODE_KEY = 'moneat.host-containers.viewMode'
 const BYTES_PER_GB = 1024 * 1024 * 1024
@@ -201,18 +209,24 @@ function ChartTooltip({
   payload,
   label,
   formatter,
+  labelFormatter,
 }: {
   active?: boolean
-  payload?: { color: string; name: string; value: number; dataKey: string }[]
-  label?: string
+  payload?: ChartTooltipEntry[]
+  label?: string | number
   formatter?: (value: number, name: string) => string
+  labelFormatter?: (value: string | number | undefined) => string
 }) {
-  if (!active || !payload?.length) return null
+  const visiblePayload = payload?.filter((entry): entry is VisibleChartTooltipEntry =>
+    typeof entry.value === 'number' && Number.isFinite(entry.value)
+  )
+  if (!active || !visiblePayload?.length) return null
+  const displayLabel = labelFormatter ? labelFormatter(label) : String(label ?? '')
 
   return (
     <div className="bg-popover/95 backdrop-blur-sm border rounded-lg px-3 py-2">
-      <p className="text-xs text-muted-foreground mb-1">{label}</p>
-      {payload.map((entry, idx: number) => (
+      <p className="text-xs text-muted-foreground mb-1">{displayLabel}</p>
+      {visiblePayload.map((entry, idx: number) => (
         <div key={idx} className="flex items-center gap-2 text-sm">
           <div className="h-2 w-2 rounded-full" style={{backgroundColor: entry.color}} />
           <span className="text-muted-foreground">{entry.name}:</span>
@@ -388,45 +402,65 @@ function HostDetailPage() {
   const online = host.isOnline
 
   // Transform metrics data for charts
-  const cpuData =
+  const cpuData = compactHostMetricChartData(
     metrics?.data_points.map((point) => ({
-      time: formatTimeHM(new Date(point.timestamp * 1000), timezone),
-      CPU: point.cpu_percent || 0,
-    })) || []
+      timestamp: toHostMetricChartTimestamp(point.timestamp),
+      CPU: point.cpu_percent ?? null,
+    })) || [],
+    selectedRange.seconds,
+    ['CPU'],
+  )
 
-  const memoryData =
+  const memoryData = compactHostMetricChartData(
     metrics?.data_points.map((point) => ({
-      time: formatTimeHM(new Date(point.timestamp * 1000), timezone),
-      Memory: point.mem_percent || 0,
-    })) || []
+      timestamp: toHostMetricChartTimestamp(point.timestamp),
+      Memory: point.mem_percent ?? null,
+    })) || [],
+    selectedRange.seconds,
+    ['Memory'],
+  )
 
-  const diskData =
+  const diskData = compactHostMetricChartData(
     metrics?.data_points.map((point) => ({
-      time: formatTimeHM(new Date(point.timestamp * 1000), timezone),
-      Disk: point.disk_percent || 0,
-    })) || []
+      timestamp: toHostMetricChartTimestamp(point.timestamp),
+      Disk: point.disk_percent ?? null,
+    })) || [],
+    selectedRange.seconds,
+    ['Disk'],
+  )
 
-  const networkData =
+  const networkData = compactHostMetricChartData(
     metrics?.data_points.map((point) => ({
-      time: formatTimeHM(new Date(point.timestamp * 1000), timezone),
-      Received: point.net_recv_bytes || 0,
-      Sent: point.net_sent_bytes || 0,
-    })) || []
+      timestamp: toHostMetricChartTimestamp(point.timestamp),
+      Received: point.net_recv_bytes ?? null,
+      Sent: point.net_sent_bytes ?? null,
+    })) || [],
+    selectedRange.seconds,
+    ['Received', 'Sent'],
+  )
 
-  const loadData =
+  const loadData = compactHostMetricChartData(
     metrics?.data_points.map((point) => ({
-      time: formatTimeHM(new Date(point.timestamp * 1000), timezone),
-      '1 min': point.load_1 || 0,
-      '5 min': point.load_5 || 0,
-      '15 min': point.load_15 || 0,
-    })) || []
+      timestamp: toHostMetricChartTimestamp(point.timestamp),
+      '1 min': point.load_1 ?? null,
+      '5 min': point.load_5 ?? null,
+      '15 min': point.load_15 ?? null,
+    })) || [],
+    selectedRange.seconds,
+    ['1 min', '5 min', '15 min'],
+  )
 
   const commonXAxis = {
-    dataKey: 'time',
+    dataKey: 'timestamp',
     tick: {fontSize: 11},
     tickLine: false,
     axisLine: false,
     className: 'text-xs fill-muted-foreground',
+    type: 'number' as const,
+    domain: ['dataMin', 'dataMax'] as [string, string],
+    scale: 'time' as const,
+    tickFormatter: (value: string | number) =>
+      formatHostMetricAxisTick(value, selectedRange.seconds, timezone),
   }
 
   const commonYAxis = {
@@ -442,6 +476,8 @@ function HostDetailPage() {
     className: 'stroke-muted/50',
     vertical: false,
   }
+  const chartTooltipLabelFormatter = (value: string | number | undefined) =>
+    formatHostMetricTooltipLabel(value, timezone)
 
   // Get latest data point for metric cards
   const latestPoint = metrics?.data_points[metrics.data_points.length - 1]
@@ -669,6 +705,7 @@ function HostDetailPage() {
                           content={
                             <ChartTooltip
                               formatter={(v) => `${v.toFixed(1)}%`}
+                              labelFormatter={chartTooltipLabelFormatter}
                             />
                           }
                         />
@@ -677,6 +714,7 @@ function HostDetailPage() {
                           dataKey="CPU"
                           stroke="#3b82f6"
                           strokeWidth={2}
+                          connectNulls
                           fillOpacity={1}
                           fill="url(#cpuGradient)"
                         />
@@ -720,6 +758,7 @@ function HostDetailPage() {
                           content={
                             <ChartTooltip
                               formatter={(v) => `${v.toFixed(1)}%`}
+                              labelFormatter={chartTooltipLabelFormatter}
                             />
                           }
                         />
@@ -728,6 +767,7 @@ function HostDetailPage() {
                           dataKey="Memory"
                           stroke="#8b5cf6"
                           strokeWidth={2}
+                          connectNulls
                           fillOpacity={1}
                           fill="url(#memGradient)"
                         />
@@ -771,6 +811,7 @@ function HostDetailPage() {
                           content={
                             <ChartTooltip
                               formatter={(v) => `${v.toFixed(1)}%`}
+                              labelFormatter={chartTooltipLabelFormatter}
                             />
                           }
                         />
@@ -779,6 +820,7 @@ function HostDetailPage() {
                           dataKey="Disk"
                           stroke="#f59e0b"
                           strokeWidth={2}
+                          connectNulls
                           fillOpacity={1}
                           fill="url(#diskGradient)"
                         />
@@ -816,6 +858,7 @@ function HostDetailPage() {
                           content={
                             <ChartTooltip
                               formatter={(v) => v.toFixed(2)}
+                              labelFormatter={chartTooltipLabelFormatter}
                             />
                           }
                         />
@@ -829,6 +872,7 @@ function HostDetailPage() {
                           dataKey="1 min"
                           stroke="#ef4444"
                           strokeWidth={2}
+                          connectNulls
                           dot={false}
                           activeDot={{r: 4, strokeWidth: 0}}
                         />
@@ -837,6 +881,7 @@ function HostDetailPage() {
                           dataKey="5 min"
                           stroke="#f59e0b"
                           strokeWidth={2}
+                          connectNulls
                           dot={false}
                           activeDot={{r: 4, strokeWidth: 0}}
                         />
@@ -845,6 +890,7 @@ function HostDetailPage() {
                           dataKey="15 min"
                           stroke="#10b981"
                           strokeWidth={2}
+                          connectNulls
                           dot={false}
                           activeDot={{r: 4, strokeWidth: 0}}
                         />
@@ -1107,6 +1153,7 @@ function HostDetailPage() {
                         content={
                           <ChartTooltip
                             formatter={(v) => formatBytes(v)}
+                            labelFormatter={chartTooltipLabelFormatter}
                           />
                         }
                       />
@@ -1120,6 +1167,7 @@ function HostDetailPage() {
                         dataKey="Received"
                         stroke="#8b5cf6"
                         strokeWidth={2}
+                        connectNulls
                         fillOpacity={1}
                         fill="url(#netRecvGradient)"
                       />
@@ -1128,6 +1176,7 @@ function HostDetailPage() {
                         dataKey="Sent"
                         stroke="#f59e0b"
                         strokeWidth={2}
+                        connectNulls
                         fillOpacity={1}
                         fill="url(#netSentGradient)"
                       />


### PR DESCRIPTION
## Summary
- Use timestamp-based x-axis values for host metric charts.
- Format axis ticks and tooltip labels separately from chart positioning.
- Compact long-range chart data and preserve missing metric values as gaps instead of zeroes.
- Widen the bounded GraalJS transform timeout so CI validates oversized transform output deterministically.

## Validation
- npm test -- --run src/lib/__tests__/host-metrics-chart.test.ts
- npm run typecheck
- npm run lint -- --max-warnings 0
- git diff --check
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.workflows.services.WorkflowEgressActionExecutorTest -Dkotlin.compiler.execution.strategy=in-process
- ./gradlew detekt
- Browser check on 30-day host network chart

## Pipeline
- backend-detekt: passed
- backend-unit: passed
- frontend-unit: passed
- coverage-check: passed
- SonarQube Analysis: passed
- CodeRabbit: success, review skipped