### PR TITLE
Security monitoring coverage cleanup

### DIFF
--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/AdvisoryParserTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/AdvisoryParserTest.kt
@@ -1,0 +1,91 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AdvisoryParserTest {
+
+    @Test
+    fun `parseDocument handles arrays primitives and unsupported advisory objects`() {
+        assertEquals(emptyList(), AdvisoryParser.parseDocument(""))
+        assertEquals(emptyList(), AdvisoryParser.parseDocument("true"))
+
+        val advisories = AdvisoryParser.parseDocument(
+            """
+            [
+              {"id": "ignored"},
+              {
+                "id": "OSV-2026-0001",
+                "aliases": ["GHSA-test-0000-0000", "CVE-2026-0001"],
+                "summary": "Prototype pollution",
+                "database_specific": {"severity": "low"},
+                "affected": [
+                  {"package": {"ecosystem": "npm", "name": "lodash"}, "versions": ["4.17.11"]},
+                  {"package": {"ecosystem": "npm", "name": ""}},
+                  true
+                ],
+                "published": "2026-05-30T00:00:00Z",
+                "modified": "not-an-instant"
+              }
+            ]
+            """.trimIndent()
+        )
+
+        assertEquals(1, advisories.size)
+        val advisory = advisories.single()
+        assertEquals("OSV-2026-0001", advisory.advisoryId)
+        assertEquals("CVE-2026-0001", advisory.cveId)
+        assertEquals("low", advisory.severity)
+        assertEquals(listOf("4.17.11"), advisory.affectedVersions)
+        assertTrue(advisory.affectedRanges.isEmpty())
+        assertEquals("2026-05-30T00:00:00Z", advisory.publishedAt.toString())
+        assertNull(advisory.modifiedAt)
+    }
+
+    @Test
+    fun `parseNdjson combines GHSA rows and maps severity fallbacks`() {
+        val advisories = AdvisoryParser.parseNdjson(
+            ghsaRow(
+                """{"ghsa_id":"GHSA-critical","cvss":{"score":9.0},"vulnerabilities":[""",
+                """{"package":{"ecosystem":"npm","name":"critical-pkg"},"vulnerable_version_range":"< 2.0.0"}]}""",
+            ) + "\n" +
+                ghsaRow(
+                    """{"id":"GHSA-info","cvss_score":0.0,"vulnerabilities":[""",
+                    """{"package":{"ecosystem":"pip","name":"info-pkg"}}],""",
+                    """"withdrawn_at":"2026-05-30T00:00:00Z"}""",
+                ) + "\n" +
+                ghsaRow(
+                    """{"id":"GHSA-moderate","severity":"moderate","description":"fallback text","identifiers":[""",
+                    """{"type":"CVE","value":"CVE-2026-1000"}],"vulnerabilities":[""",
+                    """{"package":{"ecosystem":"maven","name":"moderate-pkg"}}]}""",
+                )
+        )
+
+        assertEquals(listOf("critical", "info", "medium"), advisories.map { it.severity })
+        assertEquals("https://github.com/advisories/GHSA-critical", advisories.first().link)
+        assertTrue(advisories[1].withdrawn)
+        assertEquals("CVE-2026-1000", advisories[2].cveId)
+        assertEquals("fallback text", advisories[2].summary)
+    }
+
+    private fun ghsaRow(vararg parts: String): String =
+        parts.joinToString("")
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
@@ -17,14 +17,24 @@
 package com.moneat.security.vulnerabilities
 
 import com.moneat.config.ClickHouseClient
+import com.moneat.config.ClickHouseQueryException
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
 import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
+import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class PackageInventoryStoreTest {
@@ -32,11 +42,52 @@ class PackageInventoryStoreTest {
     @BeforeTest
     fun setup() {
         mockkObject(ClickHouseClient)
+        mockkStatic(HttpResponse::bodyAsText)
     }
 
     @AfterTest
     fun teardown() {
         unmockkObject(ClickHouseClient)
+        unmockkStatic(HttpResponse::bodyAsText)
+    }
+
+    @Test
+    fun `insert writes escaped inventory rows and skips empty batches`() = runBlocking {
+        val queries = mutableListOf<String>()
+        coEvery { ClickHouseClient.execute(any()) } coAnswers {
+            queries += firstArg<String>()
+            okResponse("")
+        }
+        val store = ClickHousePackageInventoryStore { "security_db" }
+
+        store.insert(emptyList())
+        store.insert(
+            listOf(
+                inventoryRecord(
+                    packageName = "o'hara",
+                    licenses = listOf("MIT", "Apache-2.0"),
+                    tags = mapOf("team" to "security", "scope" to "runtime"),
+                )
+            )
+        )
+
+        assertEquals(1, queries.size)
+        val query = queries.single()
+        assertTrue(query.contains("INSERT INTO `security_db`.security_package_inventory"))
+        assertTrue(query.contains("'o\\'hara'"))
+        assertTrue(query.contains("['MIT', 'Apache-2.0']"))
+        assertTrue(query.contains("toUUID('"))
+        assertTrue(query.contains("fromUnixTimestamp64Milli(1700000000000)"))
+    }
+
+    @Test
+    fun `insert converts ClickHouse failures to query exception`() = runBlocking {
+        coEvery { ClickHouseClient.execute(any()) } returns okResponse("Code: 62. Syntax error")
+        val store = ClickHousePackageInventoryStore { "security_db" }
+
+        assertFailsWith<ClickHouseQueryException> {
+            store.insert(listOf(inventoryRecord(packageName = "lodash")))
+        }
     }
 
     @Test
@@ -71,9 +122,86 @@ class PackageInventoryStoreTest {
         assertEquals(1, response.totalCount)
     }
 
+    @Test
+    fun `list applies package target and search filters while ignoring malformed rows`() = runBlocking {
+        val queries = mutableListOf<String>()
+        coEvery { ClickHouseClient.executeWithFormat(any(), "JSONEachRow") } coAnswers {
+            val query = firstArg<String>()
+            queries += query
+            if (query.contains("SELECT count() AS total_count")) {
+                ""
+            } else {
+                "not-json\n" + inventoryRow(findingCount = 0)
+            }
+        }
+
+        val response = ClickHousePackageInventoryStore { "security_db" }.list(
+            42,
+            InventoryFilters(
+                search = "lod'ash_%team",
+                packageName = "lodash",
+                target = "prod-web",
+                limit = 25,
+                offset = 5,
+            ),
+        )
+
+        val listQuery = queries.last()
+        assertTrue(listQuery.contains("organization_id = toUInt64(42)"))
+        assertTrue(listQuery.contains("package_name = 'lodash'"))
+        assertTrue(listQuery.contains("(target_name = 'prod-web' OR host = 'prod-web' OR image_name = 'prod-web')"))
+        assertTrue(listQuery.contains("ILIKE '%lod\\'ash\\_\\%team%'"))
+        assertTrue(listQuery.contains("LIMIT 25 OFFSET 5"))
+        assertEquals(0, response.totalCount)
+        assertEquals("lodash", response.inventory.single().packageName)
+    }
+
+    @Test
+    fun `countPackages returns zero when ClickHouse returns no rows`() = runBlocking {
+        coEvery { ClickHouseClient.executeWithFormat(any(), "JSONEachRow") } returns ""
+
+        val count = ClickHousePackageInventoryStore { "security_db" }.countPackages(7)
+
+        assertEquals(0, count)
+    }
+
+    private fun okResponse(body: String): HttpResponse {
+        val response = mockk<HttpResponse>()
+        every { response.status } returns HttpStatusCode.OK
+        coEvery { response.bodyAsText(any()) } returns body
+        return response
+    }
+
     private fun inventoryRow(findingCount: Int): String =
         """{"package_name":"lodash","package_version":"4.17.11","package_type":"npm","ecosystem":"npm",""" +
             """"purl":"pkg:npm/lodash@4.17.11","target_type":"service","target_name":"checkout",""" +
             """"host":"","image_name":"","container_id":"","last_seen":"2026-05-31T00:00:00.000Z",""" +
             """"finding_count":$findingCount}"""
+
+    private fun inventoryRecord(
+        packageName: String,
+        licenses: List<String> = emptyList(),
+        tags: Map<String, String> = emptyMap(),
+    ): SbomInventoryRecord =
+        SbomInventoryRecord(
+            uploadId = UUID.randomUUID(),
+            organizationId = 1,
+            source = SbomSource.AGENT,
+            format = SbomFormat.AGENT,
+            targetType = "container",
+            targetName = "checkout",
+            host = "prod-web",
+            containerId = "container-1",
+            imageName = "registry/app:latest",
+            packageName = packageName,
+            packageVersion = "4.17.11",
+            packageType = "npm",
+            ecosystem = "npm",
+            purl = "pkg:npm/$packageName@4.17.11",
+            licenses = licenses,
+            supplier = "npm",
+            bomRef = "pkg-$packageName",
+            tags = tags,
+            collectedAtMs = 1_700_000_000_000,
+        )
 }

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/PackageInventoryStoreTest.kt
@@ -81,12 +81,14 @@ class PackageInventoryStoreTest {
     }
 
     @Test
-    fun `insert converts ClickHouse failures to query exception`() = runBlocking {
-        coEvery { ClickHouseClient.execute(any()) } returns okResponse("Code: 62. Syntax error")
-        val store = ClickHousePackageInventoryStore { "security_db" }
+    fun `insert converts ClickHouse failures to query exception`() {
+        runBlocking {
+            coEvery { ClickHouseClient.execute(any()) } returns okResponse("Code: 62. Syntax error")
+            val store = ClickHousePackageInventoryStore { "security_db" }
 
-        assertFailsWith<ClickHouseQueryException> {
-            store.insert(listOf(inventoryRecord(packageName = "lodash")))
+            assertFailsWith<ClickHouseQueryException> {
+                store.insert(listOf(inventoryRecord(packageName = "lodash")))
+            }
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/SbomParserTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/SbomParserTest.kt
@@ -16,6 +16,8 @@
 
 package com.moneat.security.vulnerabilities
 
+import com.moneat.datadog.models.DdSbomPackage
+import com.moneat.datadog.models.DdSbomPayload
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -123,6 +125,65 @@ class SbomParserTest {
     }
 
     @Test
+    fun `parses agent payload and drops incomplete package rows`() {
+        val parsed = SbomParser.parseAgentPayload(
+            DdSbomPayload(
+                host = "prod-web",
+                imageName = "registry/checkout:latest",
+                packages = listOf(
+                    DdSbomPackage(name = "requests", version = "2.32.0", type = "python"),
+                    DdSbomPackage(name = "ignored", version = "", type = "npm"),
+                ),
+            )
+        )
+
+        assertEquals(SbomFormat.AGENT, parsed.format)
+        assertEquals("registry/checkout:latest", parsed.targetName)
+        assertEquals("requests", parsed.packages.single().name)
+        assertEquals("pypi", parsed.packages.single().ecosystem)
+    }
+
+    @Test
+    fun `parses SPDX licenses while dropping assertions and duplicates`() {
+        val parsed = SbomParser.parse(
+            """
+            {
+              "spdxVersion": "SPDX-2.3",
+              "name": "worker-image",
+              "packages": [
+                {
+                  "SPDXID": "SPDXRef-Package-requests",
+                  "name": "requests",
+                  "versionInfo": "2.32.0",
+                  "supplier": "Organization: Python Packaging Authority",
+                  "licenseConcluded": "NOASSERTION",
+                  "licenseDeclared": "Apache-2.0",
+                  "externalRefs": [
+                    {
+                      "referenceCategory": "PACKAGE-MANAGER",
+                      "referenceType": "purl",
+                      "referenceLocator": "pkg:pypi/requests@2.32.0"
+                    }
+                  ]
+                },
+                {
+                  "SPDXID": "SPDXRef-Package-urllib3",
+                  "name": "urllib3",
+                  "versionInfo": "2.2.1",
+                  "licenseConcluded": "MIT",
+                  "licenseDeclared": "MIT"
+                }
+              ]
+            }
+            """.trimIndent().encodeToByteArray()
+        )
+
+        assertEquals(listOf("Apache-2.0"), parsed.packages.first().licenses)
+        assertEquals("Python Packaging Authority", parsed.packages.first().supplier)
+        assertEquals(listOf("MIT"), parsed.packages.last().licenses)
+    }
+
+    @Test
     fun `rejects malformed SBOMs safely`() {
         val error = assertFailsWith<SbomValidationException> {
             SbomParser.parse("""{"components": []}""".encodeToByteArray())
@@ -138,5 +199,35 @@ class SbomParserTest {
 
         assertEquals("Malformed SBOM JSON", error.message)
         assertNotNull(error.cause)
+    }
+
+    @Test
+    fun `rejects empty and non-object SBOM payloads`() {
+        assertEquals(
+            "SBOM payload is empty",
+            assertFailsWith<SbomValidationException> {
+                SbomParser.parse(ByteArray(0))
+            }.message,
+        )
+        assertEquals(
+            "SBOM JSON root must be an object",
+            assertFailsWith<SbomValidationException> {
+                SbomParser.parse("""["not-an-object"]""".encodeToByteArray())
+            }.message,
+        )
+    }
+
+    @Test
+    fun `rejects agent payloads without complete packages`() {
+        val error = assertFailsWith<SbomValidationException> {
+            SbomParser.parseAgentPayload(
+                DdSbomPayload(
+                    host = "prod-web",
+                    packages = listOf(DdSbomPackage(name = "requests", version = "")),
+                )
+            )
+        }
+
+        assertEquals("SBOM contains no packages with name and version", error.message)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisoryRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisoryRepositoryTest.kt
@@ -1,0 +1,222 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.security.vulnerabilities
+
+import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class VulnerabilityAdvisoryRepositoryTest {
+
+    @BeforeTest
+    fun setup() {
+        TransactionManager.defaultDatabase = Database.connect(
+            url = isolatedH2Url(),
+            driver = "org.h2.Driver",
+        )
+        TestDatabaseHelper.dropAndPatchJsonb(
+            VulnerabilityAdvisories,
+            VulnerabilityAdvisorySyncRuns,
+        )
+        createH2Tables()
+    }
+
+    @Test
+    fun `upsertAll inserts then updates advisory candidates`() {
+        val repository = PostgresVulnerabilityAdvisoryRepository()
+
+        assertEquals(1, repository.upsertAll(listOf(advisory(summary = "first", fixedVersion = "4.17.12"))))
+        assertEquals(1, repository.upsertAll(listOf(advisory(summary = "second", fixedVersion = "4.17.13"))))
+
+        val candidates = repository.findCandidates(
+            listOf(
+                packageRecord(""),
+                packageRecord("lodash"),
+                packageRecord("lodash"),
+            )
+        )
+
+        assertEquals(1, candidates.size)
+        val candidate = candidates.single()
+        assertEquals("second", candidate.summary)
+        assertEquals("4.17.13", candidate.fixedVersion)
+        assertEquals("CVE-2019-10744", candidate.cveId)
+        assertEquals(9.8, candidate.cvssScore)
+        assertEquals("1.0.0", candidate.affectedRanges.single().introduced)
+        assertEquals("4.17.11", candidate.affectedVersions.single())
+    }
+
+    @Test
+    fun `findCandidates filters withdrawn advisories and empty package names`() {
+        val repository = PostgresVulnerabilityAdvisoryRepository()
+        repository.upsertAll(
+            listOf(
+                advisory(packageName = "lodash"),
+                advisory(advisoryId = "CVE-2026-0002", packageName = "react", withdrawn = true),
+            )
+        )
+
+        assertEquals(emptyList(), repository.findCandidates(listOf(packageRecord(""))))
+
+        val candidates = repository.findCandidates(listOf(packageRecord("react"), packageRecord("lodash")))
+
+        assertEquals(listOf("lodash"), candidates.map { it.packageName })
+    }
+
+    @Test
+    fun `recordSyncRun stores bounded error details`() {
+        val repository = PostgresVulnerabilityAdvisoryRepository()
+        val error = "x".repeat(1_200)
+
+        repository.recordSyncRun(source = "local", status = "failed", advisoryCount = 3, error = error)
+
+        transaction {
+            val row = VulnerabilityAdvisorySyncRuns
+                .selectAll()
+                .where { VulnerabilityAdvisorySyncRuns.syncSource eq "local" }
+                .single()
+            assertEquals("failed", row[VulnerabilityAdvisorySyncRuns.status])
+            assertEquals(3, row[VulnerabilityAdvisorySyncRuns.advisoryCount])
+            assertEquals(1_000, row[VulnerabilityAdvisorySyncRuns.error]?.length)
+        }
+    }
+
+    @Test
+    fun `repository tolerates invalid serialized advisory lists`() {
+        val repository = PostgresVulnerabilityAdvisoryRepository()
+        repository.upsertAll(listOf(advisory()))
+        transaction {
+            VulnerabilityAdvisories.update(
+                { VulnerabilityAdvisories.packageName eq "lodash" }
+            ) {
+                it[affectedRanges] = "{not-json"
+                it[affectedVersions] = "{not-json"
+            }
+        }
+
+        val candidate = repository.findCandidates(listOf(packageRecord("lodash"))).single()
+
+        assertEquals(emptyList(), candidate.affectedRanges)
+        assertEquals(emptyList(), candidate.affectedVersions)
+        assertNull(candidate.publishedAt)
+    }
+
+    private fun isolatedH2Url(): String {
+        val databaseName = "moneat_vulnerability_advisory_" + UUID.randomUUID().toString().replace("-", "")
+        return "jdbc:h2:mem:$databaseName;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1"
+    }
+
+    private fun createH2Tables() {
+        transaction {
+            exec(
+                """
+                CREATE TABLE security_vulnerability_advisories (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    "source" VARCHAR(32) NOT NULL,
+                    advisory_id VARCHAR(255) NOT NULL,
+                    cve_id VARCHAR(64),
+                    package_name VARCHAR(512) NOT NULL,
+                    ecosystem VARCHAR(64) NOT NULL,
+                    package_type VARCHAR(64) NOT NULL,
+                    affected_ranges TEXT NOT NULL,
+                    affected_versions TEXT NOT NULL,
+                    fixed_version VARCHAR(128),
+                    severity VARCHAR(16) NOT NULL,
+                    cvss_score DECIMAL(4, 1),
+                    link TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    raw_advisory TEXT NOT NULL,
+                    withdrawn BOOLEAN NOT NULL,
+                    published_at TIMESTAMP,
+                    modified_at TIMESTAMP,
+                    ingested_at TIMESTAMP NOT NULL
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE security_vulnerability_advisory_sync_runs (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    "source" VARCHAR(32) NOT NULL,
+                    status VARCHAR(16) NOT NULL,
+                    advisory_count INT NOT NULL,
+                    error TEXT,
+                    started_at TIMESTAMP NOT NULL,
+                    finished_at TIMESTAMP NOT NULL
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun advisory(
+        advisoryId: String = "CVE-2019-10744",
+        packageName: String = "lodash",
+        summary: String = "Prototype pollution",
+        fixedVersion: String? = "4.17.12",
+        withdrawn: Boolean = false,
+    ): AdvisoryRecord =
+        AdvisoryRecord(
+            source = "osv",
+            advisoryId = advisoryId,
+            cveId = advisoryId.takeIf { it.startsWith("CVE-") },
+            packageName = packageName,
+            ecosystem = "npm",
+            packageType = "npm",
+            affectedRanges = listOf(AdvisoryRange(type = "SEMVER", introduced = "1.0.0", fixed = fixedVersion)),
+            affectedVersions = listOf("4.17.11"),
+            fixedVersion = fixedVersion,
+            severity = "critical",
+            cvssScore = 9.8,
+            link = "https://osv.dev/vulnerability/$advisoryId",
+            summary = summary,
+            rawAdvisory = """{"id":"$advisoryId"}""",
+            withdrawn = withdrawn,
+        )
+
+    private fun packageRecord(name: String): SbomInventoryRecord =
+        SbomInventoryRecord(
+            uploadId = UUID.randomUUID(),
+            organizationId = 1,
+            source = SbomSource.DIRECT,
+            format = SbomFormat.CYCLONEDX,
+            targetType = "service",
+            targetName = "checkout",
+            host = "",
+            containerId = "",
+            imageName = "",
+            packageName = name,
+            packageVersion = "4.17.11",
+            packageType = "npm",
+            ecosystem = "npm",
+            purl = "",
+            licenses = emptyList(),
+            supplier = "",
+            bomRef = "",
+            tags = emptyMap(),
+            collectedAtMs = 1_700_000_000_000,
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJobTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityAdvisorySyncJobTest.kt
@@ -19,6 +19,7 @@ package com.moneat.security.vulnerabilities
 import java.nio.file.Files
 import kotlin.io.path.writeText
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class VulnerabilityAdvisorySyncJobTest {
@@ -56,6 +57,56 @@ class VulnerabilityAdvisorySyncJobTest {
         )
     }
 
+    @Test
+    fun `sync loads json files from mirror directory and skips malformed entries`() {
+        val mirrorDirectory = Files.createTempDirectory("moneat-advisory-dir")
+        mirrorDirectory.resolve("ignored.txt").writeText("not-json")
+        mirrorDirectory.resolve("malformed.json").writeText("{not-json")
+        mirrorDirectory.resolve("advisory.json").writeText(
+            """
+            {
+              "schema_version": "1.6.0",
+              "id": "GHSA-directory-1111-2222",
+              "aliases": ["CVE-2026-1001"],
+              "affected": [
+                {
+                  "package": {"ecosystem": "npm", "name": "directory-only"},
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {"introduced": "0"},
+                        {"fixed": "1.1.0"}
+                      ]
+                    }
+                  ],
+                  "versions": ["1.0.0"]
+                }
+              ],
+              "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}]
+            }
+            """.trimIndent()
+        )
+        val repository = InMemoryAdvisoryRepository()
+        val job = VulnerabilityAdvisorySyncJob(repository) { mirrorDirectory.toString() }
+
+        job.syncOnce()
+
+        val candidates = repository.findCandidates(listOf(packageRecord("directory-only")))
+        assertEquals(listOf("GHSA-directory-1111-2222"), candidates.map { it.advisoryId })
+    }
+
+    @Test
+    fun `sync records failed runs without leaking repository errors`() {
+        val repository = FailingAdvisoryRepository()
+        val job = VulnerabilityAdvisorySyncJob(repository) { null }
+
+        val count = job.syncOnce()
+
+        assertEquals(0, count)
+        assertEquals(listOf("local:failed:0:repository unavailable"), repository.syncRuns)
+    }
+
     private fun packageRecord(name: String): SbomInventoryRecord =
         SbomInventoryRecord(
             uploadId = java.util.UUID.randomUUID(),
@@ -78,4 +129,18 @@ class VulnerabilityAdvisorySyncJobTest {
             tags = emptyMap(),
             collectedAtMs = 1_700_000_000_000,
         )
+
+    private class FailingAdvisoryRepository : VulnerabilityAdvisoryRepository {
+        val syncRuns = mutableListOf<String>()
+
+        override fun upsertAll(advisories: List<AdvisoryRecord>): Int =
+            error("repository unavailable")
+
+        override fun findCandidates(packages: Collection<SbomInventoryRecord>): List<AdvisoryRecord> =
+            emptyList()
+
+        override fun recordSyncRun(source: String, status: String, advisoryCount: Int, error: String?) {
+            syncRuns += "$source:$status:$advisoryCount:${error.orEmpty()}"
+        }
+    }
 }


### PR DESCRIPTION
Adds targeted vulnerability coverage tests for the security monitoring integration.\n\nValidation:\n- backend: ./gradlew :detekt :test --no-daemon --rerun-tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Tests**
  * Expanded test coverage for vulnerability advisory parsing with format-specific handling and data mapping validation
  * Enhanced package inventory storage operations testing including insertion, filtering, and error handling
  * Added SBOM payload parsing tests with license handling and validation requirements
  * Strengthened vulnerability advisory repository operations including upsert, filtering, and data persistence
  * Improved sync job testing with error boundary and resilience validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->