### PR TITLE
fix: usage insights email layout

### DIFF
--- a/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/EmailService.kt
@@ -40,10 +40,14 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.*
+import kotlin.math.roundToInt
 import kotlin.time.Clock
 import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
+
+private const val DANGER_COLOR = "#dc2626"
+private const val SUCCESS_COLOR = "#16a34a"
 
 /** Escapes HTML special characters for safe inclusion in email templates. */
 private fun String.escapeHtml(): String =
@@ -55,11 +59,28 @@ private fun String.escapeHtml(): String =
 private const val BADGE_STYLE = "margin:0;font-size:0.75rem;font-weight:600;" +
     "display:inline-block;border-radius:4px;padding:1px 8px;"
 private const val BADGE_POSITIVE =
-    "background-color:#f0fdf4;border:1px solid #bbf7d0;color:#16a34a;"
+    "background-color:#f0fdf4;border:1px solid #bbf7d0;color:" + SUCCESS_COLOR + ";"
 private const val BADGE_NEGATIVE =
-    "background-color:#fef2f2;border:1px solid #fecaca;color:#dc2626;"
+    "background-color:#fef2f2;border:1px solid #fecaca;color:" + DANGER_COLOR + ";"
 private const val BADGE_NEUTRAL = "font-weight:500;background-color:#f5f5f5;" +
     "border:1px solid #e5e5e5;color:#737373;"
+private const val BILLING_ROW_CELL_STYLE =
+    "padding:0.875rem 1rem;border-bottom:1px solid #f5f5f5;" +
+        "word-break:normal;overflow-wrap:break-word;"
+private const val BILLING_PERCENT_TEXT_STYLE =
+    "margin:0;font-size:0.875rem;font-weight:700;color:#0a0a0a;" +
+        "white-space:nowrap;word-break:normal;"
+private const val BILLING_STATUS_BADGE_STYLE =
+    "margin:0;font-size:0.6875rem;line-height:1rem;font-weight:600;display:inline-block;" +
+        "border-radius:999px;padding:1px 8px;background-color:#f5f5f5;border:1px solid #e5e5e5;" +
+        "color:#525252;white-space:nowrap;word-break:normal;"
+private const val BILLING_PROGRESS_TRACK_STYLE =
+    "width:100%;height:6px;line-height:6px;font-size:0;background-color:#e5e5e5;" +
+        "border-radius:999px;overflow:hidden;"
+private const val BILLING_PROGRESS_FILL_STYLE =
+    "height:6px;line-height:6px;font-size:0;border-radius:999px;"
+private const val FULL_PROGRESS_PERCENT = 100
+private const val MIN_VISIBLE_PROGRESS_PERCENT = 2
 private const val TOP_ISSUES_COUNT = 5
 private const val SETTINGS_URL_PLACEHOLDER = "{{ settingsUrl }}"
 private const val YEAR_PLACEHOLDER = "{{ year }}"
@@ -650,13 +671,13 @@ class EmailService {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
             </head>
             <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <div style="background-color: #fef2f2; border-left: 4px solid #dc2626; padding: 30px; border-radius: 8px;">
-                    <h1 style="color: #dc2626; margin-bottom: 20px;">🔴 Host Down</h1>
+                <div style="background-color: #fef2f2; border-left: 4px solid $DANGER_COLOR; padding: 30px; border-radius: 8px;">
+                    <h1 style="color: $DANGER_COLOR; margin-bottom: 20px;">🔴 Host Down</h1>
                     <p><strong>Host:</strong> $safeHostName</p>
                     <p><strong>Status:</strong> $safeLastSeenText</p>
                     <p>The monitoring agent has stopped reporting metrics. Please check if the host is online and the agent is running.</p>
                     <div style="margin: 30px 0;">
-                        <a href="$safeHostUrl" style="display: inline-block; background-color: #dc2626; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View</a>
+                        <a href="$safeHostUrl" style="display: inline-block; background-color: $DANGER_COLOR; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View</a>
                     </div>
                     <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
                     <p style="color: #999; font-size: 12px;">Moneat Server Monitoring</p>
@@ -694,9 +715,9 @@ class EmailService {
         val emoji = if (isDown) "🔴" else "✅"
         val subject = "$emoji Uptime Monitor ${if (isDown) "Down" else "Up"}: $monitorName"
         val bgColor = if (isDown) "#fef2f2" else "#f0fdf4"
-        val borderColor = if (isDown) "#dc2626" else "#16a34a"
-        val headingColor = if (isDown) "#dc2626" else "#16a34a"
-        val buttonColor = if (isDown) "#dc2626" else "#16a34a"
+        val borderColor = if (isDown) DANGER_COLOR else SUCCESS_COLOR
+        val headingColor = if (isDown) DANGER_COLOR else SUCCESS_COLOR
+        val buttonColor = if (isDown) DANGER_COLOR else SUCCESS_COLOR
 
         val htmlBody =
             """
@@ -751,12 +772,12 @@ class EmailService {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
             </head>
             <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <div style="background-color: #f0fdf4; border-left: 4px solid #16a34a; padding: 30px; border-radius: 8px;">
-                    <h1 style="color: #16a34a; margin-bottom: 20px;">✅ Host Recovered</h1>
+                <div style="background-color: #f0fdf4; border-left: 4px solid $SUCCESS_COLOR; padding: 30px; border-radius: 8px;">
+                    <h1 style="color: $SUCCESS_COLOR; margin-bottom: 20px;">✅ Host Recovered</h1>
                     <p><strong>Host:</strong> $safeHostName</p>
                     <p>The host is now reporting metrics again.</p>
                     <div style="margin: 30px 0;">
-                        <a href="$safeHostUrl" style="display: inline-block; background-color: #16a34a; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View</a>
+                        <a href="$safeHostUrl" style="display: inline-block; background-color: $SUCCESS_COLOR; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 500;">View</a>
                     </div>
                     <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
                     <p style="color: #999; font-size: 12px;">Moneat Server Monitoring</p>
@@ -905,7 +926,7 @@ class EmailService {
                           </td>
                           <td style="width:33%;">
                             <p style="margin:0;margin-bottom:0.25rem;font-size:0.75rem;font-weight:500;color:#737373;">Crash-Free</p>
-                            <p style="margin:0;font-size:1.125rem;font-weight:700;color:#16a34a;">${project.crashFree.escapeHtml()}</p>
+                            <p style="margin:0;font-size:1.125rem;font-weight:700;color:$SUCCESS_COLOR;">${project.crashFree.escapeHtml()}</p>
                           </td>
                         </tr>
                       </table>
@@ -984,19 +1005,73 @@ class EmailService {
             """.trimIndent()
         }
         return rows.joinToString("\n") { row ->
+            val progressPercent = billingProgressPercent(row.percent)
+            val remainingPercent = FULL_PROGRESS_PERCENT - progressPercent
+            val progressColor = billingProgressColor(row.status)
             """
             <tr>
-              <td style="padding:0.75rem 1rem;border-bottom:1px solid #f5f5f5;">
-                <p style="margin:0;font-size:0.875rem;font-weight:600;color:#0a0a0a;">${row.label.escapeHtml()}</p>
-                <p style="margin:0.25rem 0 0;font-size:0.75rem;color:#737373;">
-                  ${row.used.escapeHtml()} / ${row.limit.escapeHtml()} &middot; ${row.status.escapeHtml()}
-                </p>
-              </td>
-              <td style="padding:0.75rem 1rem;border-bottom:1px solid #f5f5f5;text-align:right;">
-                <p style="margin:0;font-size:0.875rem;font-weight:700;color:#0a0a0a;">${row.percent.escapeHtml()}</p>
+              <td colspan="2" style="$BILLING_ROW_CELL_STYLE">
+                <table width="100%" cellpadding="0" cellspacing="0" role="presentation">
+                  <tr>
+                    <td style="vertical-align:top;padding-right:12px;">
+                      <p style="margin:0;font-size:0.875rem;font-weight:600;color:#0a0a0a;">
+                        ${row.label.escapeHtml()}
+                      </p>
+                    </td>
+                    <td style="vertical-align:top;text-align:right;width:84px;white-space:nowrap;">
+                      <p style="$BILLING_PERCENT_TEXT_STYLE">${row.percent.escapeHtml()}</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding-top:0.25rem;padding-right:12px;">
+                      <p style="margin:0;font-size:0.75rem;color:#737373;">
+                        ${row.used.escapeHtml()} / ${row.limit.escapeHtml()}
+                      </p>
+                    </td>
+                    <td style="padding-top:0.25rem;text-align:right;white-space:nowrap;">
+                      <p style="$BILLING_STATUS_BADGE_STYLE">${row.status.escapeHtml()}</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td colspan="2" style="padding-top:0.625rem;">
+                      <table
+                        width="100%"
+                        cellpadding="0"
+                        cellspacing="0"
+                        role="presentation"
+                        aria-label="${row.percent.escapeHtml()} used"
+                        style="$BILLING_PROGRESS_TRACK_STYLE"
+                      >
+                        <tr>
+                          <td
+                            width="$progressPercent%"
+                            style="$BILLING_PROGRESS_FILL_STYLE background-color:$progressColor;"
+                          >&nbsp;</td>
+                          <td width="$remainingPercent%" style="line-height:6px;font-size:0;">&nbsp;</td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
               </td>
             </tr>
             """.trimIndent()
+        }
+    }
+
+    private fun billingProgressPercent(percent: String): Int {
+        if (percent == "Unlimited") return FULL_PROGRESS_PERCENT
+        val numericPercent = percent.removeSuffix("%").toDoubleOrNull() ?: return 0
+        if (numericPercent <= 0.0) return 0
+        return numericPercent.roundToInt().coerceIn(MIN_VISIBLE_PROGRESS_PERCENT, FULL_PROGRESS_PERCENT)
+    }
+
+    private fun billingProgressColor(status: String): String {
+        return when (status) {
+            "Over limit" -> DANGER_COLOR
+            "Critical" -> "#f59e0b"
+            "Approaching" -> "#2563eb"
+            else -> "#38bdf8"
         }
     }
 
@@ -1076,8 +1151,8 @@ class EmailService {
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
             </head>
             <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <div style="background-color: #fef2f2; border-left: 4px solid #dc2626; padding: 30px; border-radius: 8px;">
-                    <h1 style="color: #dc2626; margin-bottom: 20px;">Organization Deleted</h1>
+                <div style="background-color: #fef2f2; border-left: 4px solid $DANGER_COLOR; padding: 30px; border-radius: 8px;">
+                    <h1 style="color: $DANGER_COLOR; margin-bottom: 20px;">Organization Deleted</h1>
                     <p>The organization <strong>$organizationName</strong> has been deleted by its owner.</p>
                     <p>Deletion of all projects, events, LLM data, analytics, and associated data has been initiated. Data removal from storage may complete within a short period.</p>
                     <p>Your Moneat account is still active. You can <a href="$frontendUrl/organizations/new" style="color: #2563eb;">create a new organization</a> or join another organization if you have pending invitations.</p>

--- a/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
@@ -306,10 +306,74 @@ class EmailServiceTest {
 
         assertTrue(htmlSlot.captured.contains("GB-Billed Ingestion"))
         assertTrue(htmlSlot.captured.contains("80%"))
+        assertTrue(htmlSlot.captured.contains("aria-label=\"80% used\""))
+        assertTrue(htmlSlot.captured.contains("width=\"80%\""))
+        assertTrue(htmlSlot.captured.contains("white-space:nowrap;word-break:normal;"))
         assertTrue(!htmlSlot.captured.contains("<svg"))
     }
 
-    private fun billingInsightEmailData() =
+    @Test
+    fun `sendBillingInsightsEmail renders progress colors and bounds`() {
+        val service = spyk(EmailService())
+        val htmlSlot = slot<String>()
+        every {
+            service.sendEmail(
+                any(), any(), capture(htmlSlot), any(), any()
+            )
+        } just Runs
+
+        val rows =
+            listOf(
+                EmailService.BillingInsightRow("Overage", "13.31 GB", "10.00 GB", "133.1%", "Over limit"),
+                EmailService.BillingInsightRow("Critical", "0.04 GB", "10.00 GB", "0.4%", "Critical"),
+                EmailService.BillingInsightRow("Approaching", "4.52 GB", "10.00 GB", "45.2%", "Approaching"),
+                EmailService.BillingInsightRow("Unlimited", "12 spans", "Unlimited", "Unlimited", "On track"),
+                EmailService.BillingInsightRow("Unknown", "n/a", "10.00 GB", "not available", "On track"),
+                EmailService.BillingInsightRow("Zero", "0 GB", "10.00 GB", "0%", "On track")
+            )
+
+        service.sendBillingInsightsEmail("owner@example.com", billingInsightEmailData(rows = rows))
+
+        val html = htmlSlot.captured
+        assertTrue(html.contains("background-color:#dc2626;"))
+        assertTrue(html.contains("background-color:#f59e0b;"))
+        assertTrue(html.contains("background-color:#2563eb;"))
+        assertTrue(html.contains("background-color:#38bdf8;"))
+        assertTrue(html.contains("width=\"100%\""))
+        assertTrue(html.contains("width=\"45%\""))
+        assertTrue(html.contains("width=\"2%\""))
+        assertTrue(html.contains("width=\"0%\""))
+        assertTrue(html.contains("aria-label=\"Unlimited used\""))
+        assertTrue(html.contains("aria-label=\"not available used\""))
+    }
+
+    @Test
+    fun `sendBillingInsightsEmail renders empty usage state`() {
+        val service = spyk(EmailService())
+        val htmlSlot = slot<String>()
+        every {
+            service.sendEmail(
+                any(), any(), capture(htmlSlot), any(), any()
+            )
+        } just Runs
+
+        service.sendBillingInsightsEmail("owner@example.com", billingInsightEmailData(rows = emptyList()))
+
+        assertTrue(htmlSlot.captured.contains("No billable usage yet."))
+    }
+
+    private fun billingInsightEmailData(
+        rows: List<EmailService.BillingInsightRow> =
+            listOf(
+                EmailService.BillingInsightRow(
+                    label = "GB-Billed Ingestion",
+                    used = "8.00 GB",
+                    limit = "10.00 GB",
+                    percent = "80%",
+                    status = "Watch"
+                )
+            )
+    ) =
         EmailService.BillingInsightEmailData(
             organizationName = "Billing Org",
             plan = "PRO",
@@ -319,15 +383,7 @@ class EmailServiceTest {
             summary = "GB-billed ingestion is projected to reach the monthly limit.",
             dashboardUrl = "https://app.example/usage-insights",
             settingsUrl = "https://app.example/settings?tab=billing",
-            rows = listOf(
-                EmailService.BillingInsightRow(
-                    label = "GB-Billed Ingestion",
-                    used = "8.00 GB",
-                    limit = "10.00 GB",
-                    percent = "80%",
-                    status = "Watch"
-                )
-            ),
+            rows = rows,
             totalOverage = "\$0.00"
         )
 }

--- a/emails/src/components/footer.html
+++ b/emails/src/components/footer.html
@@ -1,11 +1,11 @@
-<table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
+<table class="w-full" width="100%" cellpadding="0" cellspacing="0" role="presentation">
   <tr>
-    <td class="px-8 py-6 bg-neutral-50 border-t border-neutral-200">
-      <table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
+    <td class="email-pad px-8 py-6 bg-neutral-50 border-t border-neutral-200">
+      <table class="w-full" width="100%" cellpadding="0" cellspacing="0" role="presentation">
         <!-- Divider line -->
         <tr>
           <td class="pb-5">
-            <table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
+            <table class="w-full" width="100%" cellpadding="0" cellspacing="0" role="presentation">
               <tr>
                 <td class="h-px bg-neutral-200" style="line-height: 1px; font-size: 1px;">&nbsp;</td>
               </tr>
@@ -14,17 +14,23 @@
         </tr>
         <tr>
           <td class="text-center">
-            <!-- Table/text branding keeps the footer readable in clients that block SVG. -->
             <table cellpadding="0" cellspacing="0" role="presentation" class="mx-auto" style="margin: 0 auto;">
               <tr>
                 <td style="vertical-align: middle; padding-right: 6px;">
-                  <table cellpadding="0" cellspacing="0" role="presentation">
-                    <tr>
-                      <td align="center" style="width: 18px; height: 18px; border: 1.5px solid #38bdf8; border-radius: 999px;">
-                        <p class="m-0" style="font-size: 10px; line-height: 16px; font-weight: 700; color: #38bdf8;">m</p>
-                      </td>
-                    </tr>
-                  </table>
+                  <img
+                    src="https://moneat.io/favicon.svg"
+                    width="18"
+                    height="18"
+                    alt=""
+                    style="
+                      display: block;
+                      width: 18px;
+                      height: 18px;
+                      border: 0;
+                      outline: none;
+                      text-decoration: none;
+                    "
+                  >
                 </td>
                 <td style="vertical-align: middle;">
                   <p class="m-0" style="font-size: 11px; line-height: 18px; font-weight: 700; color: #262626;">moneat</p>

--- a/emails/src/components/header.html
+++ b/emails/src/components/header.html
@@ -1,30 +1,49 @@
-<table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
+<table class="w-full" width="100%" cellpadding="0" cellspacing="0" role="presentation">
   <!-- Header content -->
   <tr>
-    <td class="px-8 py-5 bg-neutral-950 border-b border-neutral-800">
-      <table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
+    <td
+      class="email-pad px-8 py-5 bg-neutral-950 border-b border-neutral-800"
+      style="background-image: linear-gradient(#171717, #171717);"
+    >
+      <table class="w-full" width="100%" cellpadding="0" cellspacing="0" role="presentation">
         <tr>
-          <td>
-            <!-- Table/text branding keeps the email header readable in clients that block SVG. -->
-            <table cellpadding="0" cellspacing="0" role="presentation">
+          <td align="center" style="text-align: center;">
+            <table cellpadding="0" cellspacing="0" role="presentation" style="margin: 0 auto;">
               <tr>
-                <td style="vertical-align: middle; padding-right: 8px;">
-                  <table cellpadding="0" cellspacing="0" role="presentation">
-                    <tr>
-                      <td align="center" style="width: 24px; height: 24px; border: 2px solid #38bdf8; border-radius: 999px;">
-                        <p class="m-0" style="font-size: 13px; line-height: 20px; font-weight: 700; color: #38bdf8;">m</p>
-                      </td>
-                    </tr>
-                  </table>
+                <td style="vertical-align: middle; padding-right: 6px;">
+                  <img
+                    src="https://moneat.io/favicon.svg"
+                    width="24"
+                    height="24"
+                    alt=""
+                    style="
+                      display: block;
+                      width: 24px;
+                      height: 24px;
+                      border: 0;
+                      outline: none;
+                      text-decoration: none;
+                    "
+                  >
                 </td>
                 <td style="vertical-align: middle;">
-                  <p class="m-0" style="font-size: 19px; line-height: 24px; font-weight: 700; color: #ffffff;">moneat</p>
+                  <div class="gmail-blend-screen">
+                    <div class="gmail-blend-difference">
+                      <p
+                        class="m-0"
+                        style="
+                          font-size: 19px;
+                          line-height: 24px;
+                          font-weight: 700;
+                          color: #ffffff !important;
+                          text-shadow: 0 0 0 #ffffff;
+                        "
+                      >moneat</p>
+                    </div>
+                  </div>
                 </td>
               </tr>
             </table>
-          </td>
-          <td class="text-right" style="text-align: right; vertical-align: middle;">
-            <p class="m-0 text-xs font-medium text-neutral-400">Monitoring &amp; Observability</p>
           </td>
         </tr>
       </table>

--- a/emails/src/layouts/main.html
+++ b/emails/src/layouts/main.html
@@ -24,6 +24,29 @@
     @tailwind components;
     @tailwind utilities;
 
+    @media screen and (max-width: 600px) {
+      .email-shell {
+        width: calc(100vw - 24px) !important;
+        max-width: calc(100vw - 24px) !important;
+        min-width: 0 !important;
+      }
+
+      .email-pad {
+        padding-left: 16px !important;
+        padding-right: 16px !important;
+      }
+    }
+
+    u + .body .gmail-blend-screen {
+      background: #000000;
+      mix-blend-mode: screen;
+    }
+
+    u + .body .gmail-blend-difference {
+      background: #000000;
+      mix-blend-mode: difference;
+    }
+
     /* Reset for email clients */
     body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
     table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
@@ -41,11 +64,27 @@
   </style>
 </head>
 
-<body class="m-0 p-0 w-full [word-break:break-word] [-webkit-font-smoothing:antialiased]" style="margin: 0; padding: 0; width: 100%; background-color: #f5f5f5;">
+<body
+  class="body m-0 p-0 w-full [-webkit-font-smoothing:antialiased]"
+  style="
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    background-color: #f5f5f5;
+    word-break: normal;
+    overflow-wrap: break-word;
+  "
+>
   <div role="article" aria-roledescription="email" aria-label="Notification from Moneat" lang="en">
-    <table class="w-full" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+    <table
+      class="w-full"
+      width="100%"
+      style="
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      "
+    >
       <tr>
-        <td align="center" class="py-8" style="padding: 32px 16px; background-color: #f5f5f5;">
+        <td align="center" class="py-8" style="padding: 32px 12px; background-color: #f5f5f5;">
           <yield />
         </td>
       </tr>

--- a/emails/src/templates/billing-insights.html
+++ b/emails/src/templates/billing-insights.html
@@ -10,7 +10,21 @@ settingsUrl: ""
 totalOverage: ""
 ---
 <x-main>
-  <table class="w-full max-w-[600px]" cellpadding="0" cellspacing="0" role="presentation" style="border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1);">
+  <table
+    class="email-shell w-full max-w-[600px]"
+    width="100%"
+    cellpadding="0"
+    cellspacing="0"
+    role="presentation"
+    style="
+      width: 100%;
+      max-width: 600px;
+      table-layout: fixed;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1);
+    "
+  >
     <tr>
       <td>
         <component src="src/components/header.html"></component>
@@ -18,7 +32,7 @@ totalOverage: ""
     </tr>
 
     <tr>
-      <td class="px-8 pt-8 pb-4 bg-white">
+      <td class="email-pad px-8 pt-8 pb-4 bg-white">
         <p class="m-0 text-xs font-semibold uppercase" style="color: #2563eb;">Usage Insights</p>
         <h2 class="m-0 mt-2 text-2xl font-semibold" style="color: #0a0a0a;">{{ headline }}</h2>
         <p class="m-0 mt-2 text-sm" style="color: #525252;">{{ summary }}</p>
@@ -26,38 +40,42 @@ totalOverage: ""
     </tr>
 
     <tr>
-      <td class="px-8 py-4 bg-white">
-        <table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
+      <td class="email-pad px-8 py-4 bg-white">
+        <table
+          class="w-full"
+          width="100%"
+          cellpadding="0"
+          cellspacing="0"
+          role="presentation"
+          style="border-radius: 8px; border: 1px solid #e5e5e5; overflow: hidden; table-layout: fixed;"
+        >
           <tr>
-            <td class="pr-2">
-              <table class="w-full" cellpadding="0" cellspacing="0" role="presentation" style="border-radius: 8px; border: 1px solid #e5e5e5;">
+            <td class="px-4 py-3" style="background-color: #fafafa; border-bottom: 1px solid #e5e5e5;">
+              <table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
                 <tr>
-                  <td class="p-4">
-                    <p class="m-0 text-xs font-medium" style="color: #737373;">Plan</p>
-                    <p class="m-0 mt-1 text-lg font-bold" style="color: #0a0a0a;">{{ plan }}</p>
+                  <td style="vertical-align: top; padding-right: 12px;">
+                    <p class="m-0 text-xs font-medium" style="color: #737373;">Current plan</p>
+                    <p class="m-0 mt-1 text-sm font-bold uppercase" style="color: #0a0a0a;">{{ plan }}</p>
                   </td>
-                </tr>
-              </table>
-            </td>
-            <td class="px-1">
-              <table class="w-full" cellpadding="0" cellspacing="0" role="presentation" style="border-radius: 8px; border: 1px solid #e5e5e5;">
-                <tr>
-                  <td class="p-4">
+                  <td
+                    style="
+                      vertical-align: top;
+                      text-align: right;
+                      padding-left: 12px;
+                      white-space: nowrap;
+                    "
+                  >
                     <p class="m-0 text-xs font-medium" style="color: #737373;">Estimated overage</p>
-                    <p class="m-0 mt-1 text-lg font-bold" style="color: #0a0a0a;">{{ totalOverage }}</p>
+                    <p class="m-0 mt-1 text-sm font-bold" style="color: #0a0a0a;">{{ totalOverage }}</p>
                   </td>
                 </tr>
               </table>
             </td>
-            <td class="pl-2">
-              <table class="w-full" cellpadding="0" cellspacing="0" role="presentation" style="border-radius: 8px; border: 1px solid #e5e5e5;">
-                <tr>
-                  <td class="p-4">
-                    <p class="m-0 text-xs font-medium" style="color: #737373;">Period</p>
-                    <p class="m-0 mt-1 text-sm font-bold" style="color: #0a0a0a;">{{ periodStart }} - {{ periodEnd }}</p>
-                  </td>
-                </tr>
-              </table>
+          </tr>
+          <tr>
+            <td class="px-4 py-3">
+              <p class="m-0 text-xs font-medium" style="color: #737373;">Billing period</p>
+              <p class="m-0 mt-1 text-sm font-bold" style="color: #0a0a0a;">{{ periodStart }} - {{ periodEnd }}</p>
             </td>
           </tr>
         </table>
@@ -65,8 +83,15 @@ totalOverage: ""
     </tr>
 
     <tr>
-      <td class="px-8 pt-4 pb-6 bg-white">
-        <table class="w-full" cellpadding="0" cellspacing="0" role="presentation" style="border-radius: 8px; border: 1px solid #e5e5e5; overflow: hidden;">
+      <td class="email-pad px-8 pt-4 pb-6 bg-white">
+        <table
+          class="w-full"
+          width="100%"
+          cellpadding="0"
+          cellspacing="0"
+          role="presentation"
+          style="border-radius: 8px; border: 1px solid #e5e5e5; overflow: hidden; table-layout: fixed;"
+        >
           <tr>
             <td colspan="2" class="px-4 py-3" style="background-color: #fafafa; border-bottom: 1px solid #e5e5e5;">
               <table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
@@ -75,7 +100,7 @@ totalOverage: ""
                     <p class="m-0 text-sm font-semibold" style="color: #0a0a0a;">Billable usage</p>
                   </td>
                   <td style="text-align: right;">
-                    <p class="m-0 text-xs font-medium" style="color: #737373;">Used</p>
+                    <p class="m-0 text-xs font-medium" style="color: #737373;">Usage</p>
                   </td>
                 </tr>
               </table>
@@ -87,11 +112,30 @@ totalOverage: ""
     </tr>
 
     <tr>
-      <td align="center" class="px-8 pt-2 pb-8 bg-white">
+      <td align="center" class="email-pad px-8 pt-2 pb-8 bg-white">
         <table cellpadding="0" cellspacing="0" role="presentation">
           <tr>
-            <td align="center" style="border-radius: 6px; background-color: #171717; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05);">
-              <a href="{{ dashboardUrl }}" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #fafafa; text-decoration: none; padding: 12px 24px; border-radius: 6px; display: inline-block; font-size: 14px; font-weight: 500;">
+            <td
+              align="center"
+              style="
+                border-radius: 6px;
+                background-color: #171717;
+                box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05);
+              "
+            >
+              <a
+                href="{{ dashboardUrl }}"
+                style="
+                  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+                  color: #fafafa;
+                  text-decoration: none;
+                  padding: 12px 24px;
+                  border-radius: 6px;
+                  display: inline-block;
+                  font-size: 14px;
+                  font-weight: 500;
+                "
+              >
                 Open Usage Insights &rarr;
               </a>
             </td>


### PR DESCRIPTION
## Summary
- replace the usage insights email logo treatment with a centered real Moneat mark and white wordmark for dark-mode clients
- rework the top billing summary so it stays readable on mobile
- add non-wrapping usage status badges and email-safe progress bars for each billable metric
- tighten mobile email width and wrapping rules

## Validation
- `cd emails && npm run build:production`
- `cd backend && ./gradlew :test --tests com.moneat.services.EmailServiceTest`
- `cd backend && ./gradlew detekt`
- `git diff --check`

Test emails were sent during review, including the final Gmail dark-mode logo check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated email header and footer branding with improved responsive design
  * Redesigned billing insights emails to display usage progress with visual progress bars
  * Improved email layout consistency and styling across all notification emails

* **Tests**
  * Enhanced test coverage for billing email rendering with accessibility validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->