### PR TITLE
[codex] fix billing email template packaging

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -209,17 +209,62 @@ dependencies {
     runtimeOnly(project(":ee"))
 }
 
+val emailsProjectDir = project.layout.projectDirectory.dir("../emails").asFile
+val generatedEmailTemplatesDir = emailsProjectDir.resolve("build/templates/email")
+val packagedEmailTemplatesDir = project.layout.projectDirectory.dir("src/main/resources/email-templates").asFile
+val packagedBillingInsightsTemplate = packagedEmailTemplatesDir.resolve("billing-insights.html")
+
+fun shouldBuildEmailTemplates(): Boolean =
+    emailsProjectDir.resolve("package.json").exists() && !packagedBillingInsightsTemplate.exists()
+
+val installEmailTemplateDependencies =
+    tasks.register<Exec>("installEmailTemplateDependencies") {
+        group = "build"
+        description = "Installs dependencies for Maizzle email templates"
+
+        workingDir = emailsProjectDir
+        commandLine("npm", "ci")
+
+        inputs.file(emailsProjectDir.resolve("package.json"))
+        inputs.file(emailsProjectDir.resolve("package-lock.json"))
+        outputs.file(emailsProjectDir.resolve("node_modules/.package-lock.json"))
+
+        onlyIf { shouldBuildEmailTemplates() }
+    }
+
+val buildEmailTemplates =
+    tasks.register<Exec>("buildEmailTemplates") {
+        group = "build"
+        description = "Builds Maizzle email templates for backend resources"
+
+        dependsOn(installEmailTemplateDependencies)
+
+        workingDir = emailsProjectDir
+        commandLine("npm", "run", "build:production")
+
+        inputs.dir(emailsProjectDir.resolve("src"))
+        inputs.file(emailsProjectDir.resolve("config.production.js"))
+        inputs.file(emailsProjectDir.resolve("tailwind.config.js"))
+        inputs.file(emailsProjectDir.resolve("package.json"))
+        inputs.file(emailsProjectDir.resolve("package-lock.json"))
+        outputs.dir(generatedEmailTemplatesDir)
+
+        onlyIf { shouldBuildEmailTemplates() }
+    }
+
 // Task to copy email templates into resources
 val copyEmailTemplates =
     tasks.register<Copy>("copyEmailTemplates") {
         group = "build"
         description = "Copies built email templates into backend resources"
 
-        from("${project.rootDir}/../emails/build/templates/email")
+        dependsOn(buildEmailTemplates)
+
+        from(generatedEmailTemplatesDir)
         into(layout.buildDirectory.dir("resources/main/email-templates"))
 
         // Only copy if source exists
-        onlyIf { file("${project.rootDir}/../emails/build/templates/email").exists() }
+        onlyIf { generatedEmailTemplatesDir.exists() }
     }
 
 // Task to copy email templates into test resources
@@ -228,11 +273,13 @@ val copyEmailTemplatesForTest =
         group = "build"
         description = "Copies built email templates into backend test resources"
 
-        from("${project.rootDir}/../emails/build/templates/email")
+        dependsOn(buildEmailTemplates)
+
+        from(generatedEmailTemplatesDir)
         into(layout.buildDirectory.dir("resources/test/email-templates"))
 
         // Only copy if source exists
-        onlyIf { file("${project.rootDir}/../emails/build/templates/email").exists() }
+        onlyIf { generatedEmailTemplatesDir.exists() }
     }
 
 // Ensure email templates are copied before processing resources

--- a/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EmailServiceTest.kt
@@ -304,6 +304,11 @@ class EmailServiceTest {
 
         service.sendBillingInsightsEmail("owner@example.com", billingInsightEmailData())
 
+        assertTrue(
+            htmlSlot.captured.contains("email-shell"),
+            "HTML should use the packaged Maizzle template instead of the plain fallback"
+        )
+        assertTrue(htmlSlot.captured.contains("https://moneat.io/favicon.svg"))
         assertTrue(htmlSlot.captured.contains("GB-Billed Ingestion"))
         assertTrue(htmlSlot.captured.contains("80%"))
         assertTrue(htmlSlot.captured.contains("aria-label=\"80% used\""))


### PR DESCRIPTION
## Summary
- build Maizzle email templates from the backend Gradle resource pipeline when generated templates are missing
- keep the Docker image path intact by skipping the local Maizzle build when templates are already copied into `src/main/resources`
- add a regression assertion that the billing insights email uses the packaged Maizzle template and real logo instead of the plain Kotlin fallback

## Validation
- `cd backend && ./gradlew :test --tests com.moneat.services.EmailServiceTest detekt`
- `cd backend && ./gradlew shadowJar`
- verified `moneat-backend-all.jar` contains `email-templates/billing-insights.html` with `email-shell` and `https://moneat.io/favicon.svg`
- `git diff --check`