### PR TITLE
fix: improve metric ingest batching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,13 @@ REDIS_PASSWORD=moneat_dev_password
 REDIS_URL=redis://:${REDIS_PASSWORD}@localhost:6379
 
 # ----------------------------------------------------------------------------
+# Datadog metric ingestion
+# ----------------------------------------------------------------------------
+# Max rows and queued payloads to combine into one ClickHouse insert.
+DD_METRIC_BATCH_MAX_ROWS=20000
+DD_METRIC_BATCH_MAX_PAYLOADS=100
+
+# ----------------------------------------------------------------------------
 # Workflow Runtime (Temporal)
 # ----------------------------------------------------------------------------
 TEMPORAL_TARGET=localhost:7233

--- a/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthContext.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthContext.kt
@@ -1,0 +1,22 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.auth
+
+data class DatadogAuthContext(
+    val organizationId: Int,
+    val projectId: Int?,
+)

--- a/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
@@ -60,7 +60,10 @@ object DatadogAuthMiddleware {
         // Check cache first
         val cached = cache[apiKey]
         if (cached != null) {
-            return cached.organizationId
+            if (now < cached.expiresAt) {
+                return cached.organizationId
+            }
+            cache.remove(apiKey, cached)
         }
 
         val organizationId = DatadogService.validateApiKey(apiKey)
@@ -99,7 +102,12 @@ object DatadogAuthMiddleware {
         }
 
         val cached = contextCache[apiKey]
-        if (cached != null) return cached.context
+        if (cached != null) {
+            if (now < cached.expiresAt) {
+                return cached.context
+            }
+            contextCache.remove(apiKey, cached)
+        }
 
         val validation = DatadogService.validateApiKeyContext(apiKey)
         if (validation == null) {
@@ -131,7 +139,12 @@ object DatadogAuthMiddleware {
         val now = System.currentTimeMillis()
         evictExpiredEntries(now)
         val cached = cache[apiKey]
-        if (cached != null) return cached.organizationId
+        if (cached != null) {
+            if (now < cached.expiresAt) {
+                return cached.organizationId
+            }
+            cache.remove(apiKey, cached)
+        }
         val organizationId = DatadogService.validateApiKey(apiKey) ?: return null
         if (cache.size < MAX_CACHE_SIZE) {
             cache[apiKey] = CachedKey(organizationId, now + CACHE_TTL_MS)

--- a/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
@@ -30,11 +30,14 @@ private const val MAX_CACHE_SIZE = 10_000
 
 object DatadogAuthMiddleware {
     private data class CachedKey(val organizationId: Int, val expiresAt: Long)
+    private data class CachedContext(val context: DatadogAuthContext, val expiresAt: Long)
 
     private val cache = ConcurrentHashMap<String, CachedKey>()
+    private val contextCache = ConcurrentHashMap<String, CachedContext>()
 
     private fun evictExpiredEntries(now: Long) {
         cache.entries.removeIf { (_, value) -> now >= value.expiresAt }
+        contextCache.entries.removeIf { (_, value) -> now >= value.expiresAt }
     }
 
     /**
@@ -45,10 +48,7 @@ object DatadogAuthMiddleware {
         val now = System.currentTimeMillis()
         evictExpiredEntries(now)
 
-        val apiKey = call.request.headers["DD-API-KEY"]
-            ?: call.request.headers["DD-Api-Key"]
-            ?: call.request.headers["dd-api-key"]
-            ?: call.request.queryParameters["api_key"]
+        val apiKey = getApiKey(call)
         if (apiKey.isNullOrBlank()) {
             call.respond(
                 HttpStatusCode.Forbidden,
@@ -85,6 +85,44 @@ object DatadogAuthMiddleware {
         return organizationId
     }
 
+    suspend fun authenticateContext(call: ApplicationCall): DatadogAuthContext? {
+        val now = System.currentTimeMillis()
+        evictExpiredEntries(now)
+
+        val apiKey = getApiKey(call)
+        if (apiKey.isNullOrBlank()) {
+            call.respond(
+                HttpStatusCode.Forbidden,
+                mapOf("errors" to listOf("API key is missing or empty"))
+            )
+            return null
+        }
+
+        val cached = contextCache[apiKey]
+        if (cached != null) return cached.context
+
+        val validation = DatadogService.validateApiKeyContext(apiKey)
+        if (validation == null) {
+            call.respond(
+                HttpStatusCode.Forbidden,
+                mapOf("errors" to listOf("API key is not valid"))
+            )
+            return null
+        }
+
+        val context = DatadogAuthContext(
+            organizationId = validation.organizationId,
+            projectId = validation.projectId,
+        )
+        if (contextCache.size < MAX_CACHE_SIZE) {
+            contextCache[apiKey] = CachedContext(context, now + CACHE_TTL_MS)
+        } else {
+            logger.warn { "Datadog API key context cache reached max size; skipping cache insert" }
+        }
+
+        return context
+    }
+
     /**
      * Resolves an org ID from a DD-API-KEY without performing HTTP responses.
      * Uses the same cache as [authenticate] to avoid redundant DB lookups.
@@ -104,5 +142,12 @@ object DatadogAuthMiddleware {
     // For testing
     internal fun clearCache() {
         cache.clear()
+        contextCache.clear()
     }
+
+    private fun getApiKey(call: ApplicationCall): String? =
+        call.request.headers["DD-API-KEY"]
+            ?: call.request.headers["DD-Api-Key"]
+            ?: call.request.headers["dd-api-key"]
+            ?: call.request.queryParameters["api_key"]
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogDogStatsDRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogDogStatsDRoutes.kt
@@ -44,8 +44,9 @@ fun Route.datadogDogStatsDRoutes(
     route("/dd") {
         route("/dogstatsd/v2") {
             post("/proxy") {
-                val orgId = DatadogAuthMiddleware.authenticate(call)
+                val authContext = DatadogAuthMiddleware.authenticateContext(call)
                     ?: return@post
+                val orgId = authContext.organizationId
 
                 val contentEncoding =
                     call.request.headers["Content-Encoding"]
@@ -76,7 +77,8 @@ fun Route.datadogDogStatsDRoutes(
                     )
                     DatadogMetricService.enqueueMetrics(
                         organizationId = orgId.toLong(),
-                        payload = payload
+                        payload = payload,
+                        projectId = authContext.projectId?.toLong() ?: 0L,
                     )
                 }
 

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogDogStatsDRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogDogStatsDRoutes.kt
@@ -78,7 +78,7 @@ fun Route.datadogDogStatsDRoutes(
                     DatadogMetricService.enqueueMetrics(
                         organizationId = orgId.toLong(),
                         payload = payload,
-                        projectId = authContext.projectId?.toLong() ?: 0L,
+                        projectId = authContext.projectId?.toLong(),
                     )
                 }
 

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogMetricRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogMetricRoutes.kt
@@ -127,7 +127,7 @@ private suspend fun RoutingContext.acceptMetricSeries(
     val count = DatadogMetricService.enqueueMetrics(
         organizationId = orgId.toLong(),
         payload = payload,
-        projectId = authContext.projectId?.toLong() ?: 0L,
+        projectId = authContext.projectId?.toLong(),
     )
     logger.debug { "Accepted $count DD $apiVersion metrics for org $orgId" }
     call.respondAccepted()
@@ -167,7 +167,8 @@ private fun decodeMetricSeriesBody(
 private suspend fun io.ktor.server.routing.RoutingContext.handleSketches(
     quotaService: BillingQuotaService,
 ) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
+    val authContext = DatadogAuthMiddleware.authenticateContext(call) ?: return
+    val orgId = authContext.organizationId
 
     val contentType = call.request.contentType().toString()
     val body = receiveDecompressedBody()
@@ -192,7 +193,8 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSketches(
 
     val batch = DatadogMetricService.mapSketches(
         organizationId = orgId.toLong(),
-        payload = payload
+        payload = payload,
+        projectId = authContext.projectId?.toLong(),
     )
 
     touchSketchHosts(orgId, payload)

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogMetricRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogMetricRoutes.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.routes
 
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.datadog.DatadogMetricBillingRequest
+import com.moneat.datadog.auth.DatadogAuthContext
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.decompression.DecompressionService
 import com.moneat.datadog.decompression.MetricPayloadDecoder
@@ -92,39 +93,41 @@ fun Route.datadogMetricRoutes(
 private suspend fun RoutingContext.handleV1MetricSeries(
     quotaService: BillingQuotaService,
 ) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
+    val authContext = DatadogAuthMiddleware.authenticateContext(call) ?: return
     val body = receiveDecompressedBody()
     val payload = decodeV1MetricSeriesJson(body) ?: return
 
-    acceptMetricSeries(quotaService, orgId, body, payload, "V1")
+    acceptMetricSeries(quotaService, authContext, body, payload, "V1")
 }
 
 private suspend fun RoutingContext.handleMetricSeries(
     quotaService: BillingQuotaService,
     apiVersion: String
 ) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
+    val authContext = DatadogAuthMiddleware.authenticateContext(call) ?: return
     val contentType = call.request.contentType().toString()
     val body = receiveDecompressedBody()
     val payload = decodeMetricSeriesPayload(body, contentType, apiVersion) ?: return
 
-    acceptMetricSeries(quotaService, orgId, body, payload, apiVersion)
+    acceptMetricSeries(quotaService, authContext, body, payload, apiVersion)
 }
 
 private suspend fun RoutingContext.acceptMetricSeries(
     quotaService: BillingQuotaService,
-    orgId: Int,
+    authContext: DatadogAuthContext,
     body: ByteArray,
     payload: DatadogMetricSeriesV1,
     apiVersion: String
 ) {
+    val orgId = authContext.organizationId
     touchMetricHosts(orgId, payload)
     val billingRequest = metricSeriesBillingRequest(payload, body.size.toLong())
     if (!reserveMetricQuota(quotaService, orgId, billingRequest)) return
 
     val count = DatadogMetricService.enqueueMetrics(
         organizationId = orgId.toLong(),
-        payload = payload
+        payload = payload,
+        projectId = authContext.projectId?.toLong() ?: 0L,
     )
     logger.debug { "Accepted $count DD $apiVersion metrics for org $orgId" }
     call.respondAccepted()

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
@@ -42,7 +42,7 @@ private const val ERROR_BODY_MAX_LEN = 600
 @Serializable
 data class QueuedMetricBatch(
     @SerialName("organization_id") val organizationId: Long,
-    @SerialName("project_id") val projectId: Long = 0L,
+    @SerialName("project_id") val projectId: Long? = null,
     val metrics: List<QueuedMetricEntry>
 )
 
@@ -60,7 +60,7 @@ data class QueuedMetricEntry(
 
 private data class MetricInsertRow(
     val organizationId: Long,
-    val projectId: Long,
+    val projectId: Long?,
     val metric: QueuedMetricEntry,
 )
 
@@ -82,7 +82,8 @@ private data class MetricJsonEachRow(
 @Serializable
 data class QueuedSketchBatch(
     @SerialName("organization_id") val organizationId: Long,
-    val sketches: List<QueuedSketchEntry>
+    val sketches: List<QueuedSketchEntry>,
+    @SerialName("project_id") val projectId: Long? = null,
 )
 
 @Serializable
@@ -110,7 +111,7 @@ object DatadogMetricService {
     fun mapV1Series(
         organizationId: Long,
         payload: DatadogMetricSeriesV1,
-        projectId: Long = 0L,
+        projectId: Long? = null,
     ): QueuedMetricBatch {
         val metrics = payload.series.flatMap { series ->
             flattenV1Points(series)
@@ -148,7 +149,8 @@ object DatadogMetricService {
 
     fun mapSketches(
         organizationId: Long,
-        payload: DatadogSketchPayload
+        payload: DatadogSketchPayload,
+        projectId: Long? = null,
     ): QueuedSketchBatch {
         val sketches = payload.sketches.flatMap { sketch ->
             val tags = parseDdTagList(sketch.tags)
@@ -171,14 +173,15 @@ object DatadogMetricService {
 
         return QueuedSketchBatch(
             organizationId = organizationId,
-            sketches = sketches
+            sketches = sketches,
+            projectId = projectId,
         )
     }
 
     suspend fun enqueueMetrics(
         organizationId: Long,
         payload: DatadogMetricSeriesV1,
-        projectId: Long = 0L,
+        projectId: Long? = null,
         queueKey: String = METRIC_QUEUE_KEY,
     ): Int {
         val batch = mapV1Series(organizationId, payload, projectId)
@@ -242,7 +245,7 @@ object DatadogMetricService {
     private fun MetricInsertRow.toJsonEachRow(): MetricJsonEachRow =
         MetricJsonEachRow(
             organizationId = organizationId,
-            projectId = projectId,
+            projectId = projectId ?: 0L,
             metricName = metric.name,
             metricType = metric.type,
             timestamp = formatClickHouseDateTime64MillisUtc(metric.timestampMs),
@@ -266,6 +269,7 @@ object DatadogMetricService {
             val nArray = s.n.joinToString(",")
             """(
                 ${batch.organizationId},
+                ${batch.projectId ?: 0L},
                 '${escapeSql(s.name)}',
                 fromUnixTimestamp64Milli(${s.timestampMs}),
                 '${escapeSql(s.host)}',
@@ -282,7 +286,7 @@ object DatadogMetricService {
 
         val insert = """
             INSERT INTO `$db`.metric_sketches (
-                organization_id, metric_name, timestamp, host, tags,
+                organization_id, project_id, metric_name, timestamp, host, tags,
                 sketch_count, sketch_min, sketch_max, sketch_avg,
                 sketch_sum, sketch_k, sketch_n
             ) VALUES $rows

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
@@ -109,7 +109,8 @@ object DatadogMetricService {
 
     fun mapV1Series(
         organizationId: Long,
-        payload: DatadogMetricSeriesV1
+        payload: DatadogMetricSeriesV1,
+        projectId: Long = 0L,
     ): QueuedMetricBatch {
         val metrics = payload.series.flatMap { series ->
             flattenV1Points(series)
@@ -117,6 +118,7 @@ object DatadogMetricService {
 
         return QueuedMetricBatch(
             organizationId = organizationId,
+            projectId = projectId,
             metrics = metrics
         )
     }
@@ -176,9 +178,10 @@ object DatadogMetricService {
     suspend fun enqueueMetrics(
         organizationId: Long,
         payload: DatadogMetricSeriesV1,
-        queueKey: String = METRIC_QUEUE_KEY
+        projectId: Long = 0L,
+        queueKey: String = METRIC_QUEUE_KEY,
     ): Int {
-        val batch = mapV1Series(organizationId, payload)
+        val batch = mapV1Series(organizationId, payload, projectId)
         if (batch.metrics.isEmpty()) return 0
         val message = json.encodeToString(batch)
         RedisConfig.sync().lpush(queueKey, message)

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
@@ -25,11 +25,13 @@ import com.moneat.monitor.services.InfraMetricRollupRow
 import com.moneat.monitor.services.InfraTelemetryRollups
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
+import com.moneat.utils.formatClickHouseDateTime64MillisUtc
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
 
@@ -40,6 +42,7 @@ private const val ERROR_BODY_MAX_LEN = 600
 @Serializable
 data class QueuedMetricBatch(
     @SerialName("organization_id") val organizationId: Long,
+    @SerialName("project_id") val projectId: Long = 0L,
     val metrics: List<QueuedMetricEntry>
 )
 
@@ -53,6 +56,27 @@ data class QueuedMetricEntry(
     val tags: Map<String, String> = emptyMap(),
     val unit: String = "",
     @SerialName("source_type_name") val sourceTypeName: String = ""
+)
+
+private data class MetricInsertRow(
+    val organizationId: Long,
+    val projectId: Long,
+    val metric: QueuedMetricEntry,
+)
+
+@Serializable
+private data class MetricJsonEachRow(
+    @SerialName("organization_id") val organizationId: Long,
+    @SerialName("project_id") val projectId: Long,
+    @SerialName("metric_name") val metricName: String,
+    @SerialName("metric_type") val metricType: String,
+    val timestamp: String,
+    val value: Double,
+    val host: String,
+    val tags: Map<String, String>,
+    val unit: String,
+    @SerialName("source_type_name") val sourceTypeName: String,
+    val source: String,
 )
 
 @Serializable
@@ -166,32 +190,32 @@ object DatadogMetricService {
 
     suspend fun insertMetricBatch(batch: QueuedMetricBatch) {
         if (batch.metrics.isEmpty()) return
+        insertMetricRows(rowsForBatch(batch))
+        insertMetricRollupsBestEffort(batch)
+    }
+
+    suspend fun insertMetricBatches(batches: List<QueuedMetricBatch>) {
+        val nonEmptyBatches = batches.filter { it.metrics.isNotEmpty() }
+        if (nonEmptyBatches.isEmpty()) return
+        insertMetricRows(nonEmptyBatches.flatMap(::rowsForBatch))
+        nonEmptyBatches.forEach { insertMetricRollupsBestEffort(it) }
+    }
+
+    private suspend fun insertMetricRows(rows: List<MetricInsertRow>) {
+        if (rows.isEmpty()) return
         val db = ClickHouseClient.getDatabase()
 
-        val rows = batch.metrics.joinToString(",\n") { m ->
-            val tagsMap = m.tags.entries.joinToString(",") { (k, v) ->
-                "'${escapeSql(k)}','${escapeSql(v)}'"
-            }
-            """(
-                ${batch.organizationId},
-                '${escapeSql(m.name)}',
-                '${escapeSql(m.type)}',
-                fromUnixTimestamp64Milli(${m.timestampMs}),
-                ${m.value},
-                '${escapeSql(m.host)}',
-                map($tagsMap),
-                '${escapeSql(m.unit)}',
-                '${escapeSql(m.sourceTypeName)}',
-                'datadog'
-            )"""
+        val encodedRows = rows.joinToString("\n") { row ->
+            json.encodeToString(row.toJsonEachRow())
         }
 
         val insert = """
             INSERT INTO `$db`.metrics (
-                organization_id, metric_name, metric_type, timestamp,
+                organization_id, project_id, metric_name, metric_type, timestamp,
                 value, host, tags, unit, source_type_name,
                 source
-            ) VALUES $rows
+            ) FORMAT JSONEachRow
+            $encodedRows
         """.trimIndent()
 
         val response = ClickHouseClient.execute(insert)
@@ -201,8 +225,31 @@ object DatadogMetricService {
                 "Failed to insert DD metrics: ${errorBody.take(ERROR_BODY_MAX_LEN)}"
             )
         }
-        insertMetricRollupsBestEffort(batch)
     }
+
+    private fun rowsForBatch(batch: QueuedMetricBatch): List<MetricInsertRow> =
+        batch.metrics.map { metric ->
+            MetricInsertRow(
+                organizationId = batch.organizationId,
+                projectId = batch.projectId,
+                metric = metric,
+            )
+        }
+
+    private fun MetricInsertRow.toJsonEachRow(): MetricJsonEachRow =
+        MetricJsonEachRow(
+            organizationId = organizationId,
+            projectId = projectId,
+            metricName = metric.name,
+            metricType = metric.type,
+            timestamp = formatClickHouseDateTime64MillisUtc(metric.timestampMs),
+            value = metric.value,
+            host = metric.host,
+            tags = metric.tags,
+            unit = metric.unit,
+            sourceTypeName = metric.sourceTypeName,
+            source = "datadog",
+        )
 
     suspend fun insertSketchBatch(batch: QueuedSketchBatch) {
         if (batch.sketches.isEmpty()) return

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogService.kt
@@ -88,20 +88,31 @@ object DatadogService {
             DdApiKeys.deleteWhere { (id eq keyId) and (DdApiKeys.organizationId eq organizationId) } > 0
         }
 
-    fun validateApiKey(key: String): Int? {
+    data class ApiKeyValidation(
+        val organizationId: Int,
+        val projectId: Int?,
+    )
+
+    fun validateApiKey(key: String): Int? =
+        validateApiKeyContext(key)?.organizationId
+
+    fun validateApiKeyContext(key: String): ApiKeyValidation? {
         val keyHash = hashKey(key)
         return transaction {
-            DdApiKeys
+            val row = DdApiKeys
                 .selectAll()
                 .where { (DdApiKeys.keyHash eq keyHash) and (DdApiKeys.isActive eq true) }
-                .map { it[DdApiKeys.organizationId] }
                 .singleOrNull()
-                ?.also {
-                    // Update last used timestamp
-                    DdApiKeys.update({ DdApiKeys.keyHash eq keyHash }) {
-                        it[lastUsedAt] = Instant.now()
-                    }
-                }
+                ?: return@transaction null
+
+            DdApiKeys.update({ DdApiKeys.keyHash eq keyHash }) {
+                it[lastUsedAt] = Instant.now()
+            }
+
+            ApiKeyValidation(
+                organizationId = row[DdApiKeys.organizationId],
+                projectId = row[DdApiKeys.projectId],
+            )
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.workers
 
+import com.moneat.config.EnvConfig
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogMetricService
 import com.moneat.datadog.services.QueuedMetricBatch
@@ -42,8 +43,10 @@ private val logger = KotlinLogging.logger {}
 private const val BRPOP_TIMEOUT_SECONDS = 5L
 private const val ERROR_DELAY_MS = 1000L
 private const val WORKER_NAME = "DD metric"
-private const val MAX_ROWS = 20_000
-private const val MAX_PAYLOADS = 100
+private const val DEFAULT_MAX_ROWS = 20_000
+private const val DEFAULT_MAX_PAYLOADS = 100
+private const val MAX_ROWS_ENV = "DD_METRIC_BATCH_MAX_ROWS"
+private const val MAX_PAYLOADS_ENV = "DD_METRIC_BATCH_MAX_PAYLOADS"
 
 private data class DecodedMetricPayload(
     val originalPayload: String,
@@ -53,13 +56,17 @@ private data class DecodedMetricPayload(
 class DatadogMetricIngestionWorker(
     private val queueKey: String,
     private val dlqKey: String,
-    private val workerCount: Int
+    private val workerCount: Int,
+    private val processingQueueKey: String = "$queueKey:processing",
+    private val maxRows: Int = configuredPositiveInt(MAX_ROWS_ENV, DEFAULT_MAX_ROWS),
+    private val maxPayloads: Int = configuredPositiveInt(MAX_PAYLOADS_ENV, DEFAULT_MAX_PAYLOADS),
 ) {
     private val scope =
         CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var jobs: List<Job> = emptyList()
 
     fun start() {
+        recoverProcessingQueue()
         logger.info {
             "Starting DatadogMetricIngestionWorker with " +
                 "$workerCount workers, queue=$queueKey"
@@ -83,11 +90,11 @@ class DatadogMetricIngestionWorker(
             val redis = conn.sync()
             while (scope.isActive) {
                 try {
-                    val result = redis.brpop(
+                    val payload = redis.brpoplpush(
                         BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
+                        queueKey,
+                        processingQueueKey,
+                    ) ?: continue
                     processPayloads(
                         workerId,
                         collectPayloadsForProcessing(redis, payload)
@@ -128,7 +135,7 @@ class DatadogMetricIngestionWorker(
         redis: RedisCommands<String, String>,
         firstPayload: String,
     ): List<String> {
-        val payloads = ArrayList<String>(MAX_PAYLOADS)
+        val payloads = ArrayList<String>(maxPayloads)
         payloads.add(firstPayload)
 
         val drainedPayloads = drainQueuedPayloads(redis)
@@ -149,9 +156,16 @@ class DatadogMetricIngestionWorker(
     private fun drainQueuedPayloads(
         redis: RedisCommands<String, String>,
     ): List<String> {
-        val count = MAX_PAYLOADS - 1
+        val count = maxPayloads - 1
+        if (count <= 0) return emptyList()
         return try {
-            redis.rpop(queueKey, count.toLong()).orEmpty()
+            val drainedPayloads = mutableListOf<String>()
+            repeat(count) {
+                val payload = redis.rpoplpush(queueKey, processingQueueKey)
+                    ?: return drainedPayloads
+                drainedPayloads.add(payload)
+            }
+            drainedPayloads
         } catch (e: RedisException) {
             logger.warn(e) {
                 "Failed to drain additional Datadog metric payloads; processing BRPOP payload only"
@@ -170,10 +184,10 @@ class DatadogMetricIngestionWorker(
                 batch = DatadogMetricService.decodeMetricBatch(payload),
             )
         } catch (e: SerializationException) {
-            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
+            pushToDlqAndAck(payload, workerId, e)
             null
         } catch (e: IllegalArgumentException) {
-            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
+            pushToDlqAndAck(payload, workerId, e)
             null
         }
     }
@@ -211,14 +225,14 @@ class DatadogMetricIngestionWorker(
         nextRows: Int,
     ): Boolean {
         return pending.isNotEmpty() &&
-            (pending.size >= MAX_PAYLOADS || pendingRows + nextRows > MAX_ROWS)
+            (pending.size >= maxPayloads || pendingRows + nextRows > maxRows)
     }
 
     private fun shouldFlushAfterAdding(
         pending: List<DecodedMetricPayload>,
         pendingRows: Int,
     ): Boolean {
-        return pending.size >= MAX_PAYLOADS || pendingRows >= MAX_ROWS
+        return pending.size >= maxPayloads || pendingRows >= maxRows
     }
 
     private suspend fun insertPayloadChunk(
@@ -229,23 +243,18 @@ class DatadogMetricIngestionWorker(
 
         val nonEmptyBatches = payloads.map { it.batch }.filter { it.metrics.isNotEmpty() }
         if (nonEmptyBatches.isEmpty()) {
-            payloads.forEach { recordProcessed(workerId) }
+            markProcessed(workerId, payloads)
             return
         }
 
-        if (insertCombinedBatch(nonEmptyBatches).isSuccess) {
-            payloads.forEach { recordProcessed(workerId) }
+        val combinedResult = insertCombinedBatch(nonEmptyBatches)
+        if (combinedResult.isSuccess) {
+            markProcessed(workerId, payloads)
             return
         }
 
-        val retryResult = insertCombinedBatch(nonEmptyBatches)
-        if (retryResult.isSuccess) {
-            payloads.forEach { recordProcessed(workerId) }
-            return
-        }
-
-        logger.warn(retryResult.exceptionOrNull()) {
-            "Combined Datadog metric insert failed after retry; falling back to per-payload inserts"
+        logger.warn(combinedResult.exceptionOrNull()) {
+            "Combined Datadog metric insert failed; falling back to per-payload inserts"
         }
         payloads.forEach { insertSinglePayload(workerId, it) }
     }
@@ -265,13 +274,78 @@ class DatadogMetricIngestionWorker(
         suspendRunCatching {
             DatadogMetricService.insertMetricBatch(payload.batch)
         }.onSuccess {
-            recordProcessed(workerId)
+            markProcessed(workerId, listOf(payload))
         }.onFailure { e ->
-            pushToDlq(logger, dlqKey, payload.originalPayload, workerId, WORKER_NAME, e)
+            pushToDlqAndAck(payload.originalPayload, workerId, e)
+        }
+    }
+
+    private fun markProcessed(
+        workerId: Int,
+        payloads: List<DecodedMetricPayload>,
+    ) {
+        payloads.forEach { payload ->
+            acknowledgePayload(payload.originalPayload, workerId)
+            recordProcessed(workerId)
+        }
+    }
+
+    private fun pushToDlqAndAck(
+        payload: String,
+        workerId: Int,
+        cause: Throwable,
+    ) {
+        if (pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, cause)) {
+            acknowledgePayload(payload, workerId)
+        }
+    }
+
+    private fun acknowledgePayload(
+        payload: String,
+        workerId: Int,
+    ) {
+        runCatching {
+            RedisConfig.sync().lrem(processingQueueKey, 1, payload)
+        }.onFailure { e ->
+            logger.warn(e) {
+                "Failed to acknowledge Datadog metric payload for worker $workerId; " +
+                    "payload will be recovered on restart"
+            }
         }
     }
 
     private fun recordProcessed(workerId: Int) {
         OperationalMetrics.recordWorkerMessageProcessed(WORKER_NAME, workerId)
     }
+
+    private fun recoverProcessingQueue() {
+        runCatching {
+            val redis = RedisConfig.sync()
+            var recovered = 0
+            while (true) {
+                redis.rpoplpush(processingQueueKey, queueKey) ?: break
+                recovered += 1
+            }
+            recovered
+        }.onSuccess { recovered ->
+            if (recovered > 0) {
+                logger.warn {
+                    "Recovered $recovered unacknowledged Datadog metric payloads from $processingQueueKey"
+                }
+            }
+        }.onFailure { e ->
+            logger.warn(e) {
+                "Failed to recover Datadog metric processing queue $processingQueueKey"
+            }
+        }
+    }
 }
+
+private fun configuredPositiveInt(
+    key: String,
+    defaultValue: Int,
+): Int =
+    EnvConfig.get(key, defaultValue.toString())
+        .toIntOrNull()
+        ?.takeIf { it > 0 }
+        ?: defaultValue

--- a/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
@@ -18,10 +18,13 @@ package com.moneat.datadog.workers
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogMetricService
+import com.moneat.datadog.services.QueuedMetricBatch
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
+import com.moneat.utils.suspendRunCatching
 import io.lettuce.core.RedisException
+import io.lettuce.core.api.sync.RedisCommands
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -30,15 +33,22 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
 import java.io.IOException
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
 private const val BRPOP_TIMEOUT_SECONDS = 5L
 private const val ERROR_DELAY_MS = 1000L
 private const val WORKER_NAME = "DD metric"
+private const val MAX_ROWS = 20_000
+private const val MAX_PAYLOADS = 100
+
+private data class DecodedMetricPayload(
+    val originalPayload: String,
+    val batch: QueuedMetricBatch,
+)
 
 class DatadogMetricIngestionWorker(
     private val queueKey: String,
@@ -78,7 +88,10 @@ class DatadogMetricIngestionWorker(
                         queueKey
                     )
                     val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
+                    processPayloads(
+                        workerId,
+                        collectPayloadsForProcessing(redis, payload)
+                    )
                 } catch (e: CancellationException) {
                     break
                 } catch (e: RedisException) {
@@ -108,13 +121,157 @@ class DatadogMetricIngestionWorker(
         workerId: Int,
         payload: String,
     ) {
-        suspendRunCatching {
-            val batch =
-                DatadogMetricService.decodeMetricBatch(payload)
-            DatadogMetricService.insertMetricBatch(batch)
-            OperationalMetrics.recordWorkerMessageProcessed(WORKER_NAME, workerId)
-        }.getOrElse { e ->
-            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
+        processPayloads(workerId, listOf(payload))
+    }
+
+    internal fun collectPayloadsForProcessing(
+        redis: RedisCommands<String, String>,
+        firstPayload: String,
+    ): List<String> {
+        val payloads = ArrayList<String>(MAX_PAYLOADS)
+        payloads.add(firstPayload)
+
+        val drainedPayloads = drainQueuedPayloads(redis)
+        payloads.addAll(drainedPayloads)
+        return payloads
+    }
+
+    internal suspend fun processPayloads(
+        workerId: Int,
+        payloads: List<String>,
+    ) {
+        val decodedPayloads = payloads.mapNotNull { payload ->
+            decodePayload(workerId, payload)
         }
+        processDecodedPayloads(workerId, decodedPayloads)
+    }
+
+    private fun drainQueuedPayloads(
+        redis: RedisCommands<String, String>,
+    ): List<String> {
+        val count = MAX_PAYLOADS - 1
+        return try {
+            redis.rpop(queueKey, count.toLong()).orEmpty()
+        } catch (e: RedisException) {
+            logger.warn(e) {
+                "Failed to drain additional Datadog metric payloads; processing BRPOP payload only"
+            }
+            emptyList()
+        }
+    }
+
+    private fun decodePayload(
+        workerId: Int,
+        payload: String,
+    ): DecodedMetricPayload? {
+        return try {
+            DecodedMetricPayload(
+                originalPayload = payload,
+                batch = DatadogMetricService.decodeMetricBatch(payload),
+            )
+        } catch (e: SerializationException) {
+            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
+            null
+        } catch (e: IllegalArgumentException) {
+            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
+            null
+        }
+    }
+
+    private suspend fun processDecodedPayloads(
+        workerId: Int,
+        payloads: List<DecodedMetricPayload>,
+    ) {
+        val pending = mutableListOf<DecodedMetricPayload>()
+        var pendingRows = 0
+
+        payloads.forEach { payload ->
+            if (shouldFlushBeforeAdding(pending, pendingRows, payload.batch.metrics.size)) {
+                insertPayloadChunk(workerId, pending)
+                pending.clear()
+                pendingRows = 0
+            }
+
+            pending.add(payload)
+            pendingRows += payload.batch.metrics.size
+
+            if (shouldFlushAfterAdding(pending, pendingRows)) {
+                insertPayloadChunk(workerId, pending)
+                pending.clear()
+                pendingRows = 0
+            }
+        }
+
+        insertPayloadChunk(workerId, pending)
+    }
+
+    private fun shouldFlushBeforeAdding(
+        pending: List<DecodedMetricPayload>,
+        pendingRows: Int,
+        nextRows: Int,
+    ): Boolean {
+        return pending.isNotEmpty() &&
+            (pending.size >= MAX_PAYLOADS || pendingRows + nextRows > MAX_ROWS)
+    }
+
+    private fun shouldFlushAfterAdding(
+        pending: List<DecodedMetricPayload>,
+        pendingRows: Int,
+    ): Boolean {
+        return pending.size >= MAX_PAYLOADS || pendingRows >= MAX_ROWS
+    }
+
+    private suspend fun insertPayloadChunk(
+        workerId: Int,
+        payloads: List<DecodedMetricPayload>,
+    ) {
+        if (payloads.isEmpty()) return
+
+        val nonEmptyBatches = payloads.map { it.batch }.filter { it.metrics.isNotEmpty() }
+        if (nonEmptyBatches.isEmpty()) {
+            payloads.forEach { recordProcessed(workerId) }
+            return
+        }
+
+        if (insertCombinedBatch(nonEmptyBatches).isSuccess) {
+            payloads.forEach { recordProcessed(workerId) }
+            return
+        }
+
+        val retryResult = insertCombinedBatch(nonEmptyBatches)
+        if (retryResult.isSuccess) {
+            payloads.forEach { recordProcessed(workerId) }
+            return
+        }
+
+        logger.warn(retryResult.exceptionOrNull()) {
+            "Combined Datadog metric insert failed after retry; falling back to per-payload inserts"
+        }
+        payloads.forEach { insertSinglePayload(workerId, it) }
+    }
+
+    private suspend fun insertCombinedBatch(
+        batches: List<QueuedMetricBatch>,
+    ): Result<Unit> {
+        return suspendRunCatching {
+            DatadogMetricService.insertMetricBatches(batches)
+        }
+    }
+
+    private suspend fun insertSinglePayload(
+        workerId: Int,
+        payload: DecodedMetricPayload,
+    ) {
+        suspendRunCatching {
+            DatadogMetricService.insertMetricBatch(payload.batch)
+        }.onSuccess {
+            recordProcessed(workerId)
+        }.onFailure { e ->
+            pushToDlq(logger, dlqKey, payload.originalPayload, workerId, WORKER_NAME, e)
+        }
+    }
+
+    private fun recordProcessed(workerId: Int) {
+        OperationalMetrics.recordWorkerMessageProcessed(WORKER_NAME, workerId)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
@@ -25,11 +25,12 @@ import com.moneat.otlp.METRIC_BILLABLE_OVERHEAD_BYTES
 import com.moneat.otlp.OtlpParsingUtils
 import com.moneat.otlp.OtlpProtobufParser
 import com.moneat.shared.services.UsageTrackingService
-import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.formatClickHouseDateTime64MillisUtc
 import io.ktor.http.isSuccess
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
 import io.opentelemetry.proto.metrics.v1.Metric
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
@@ -81,6 +82,33 @@ data class OtlpMetricInsert(
 data class QueuedOtlpMetricsBatch(
     val organizationId: Long,
     val metrics: List<OtlpMetricInsert>
+)
+
+@Serializable
+private data class OtlpMetricJsonEachRow(
+    @SerialName("organization_id") val organizationId: Long,
+    @SerialName("project_id") val projectId: Long,
+    @SerialName("metric_name") val metricName: String,
+    @SerialName("metric_type") val metricType: String,
+    val timestamp: String,
+    val value: Double,
+    val host: String,
+    val tags: Map<String, String>,
+    val unit: String,
+    @SerialName("source_type_name") val sourceTypeName: String,
+    val source: String,
+    @SerialName("is_monotonic") val isMonotonic: Int,
+    @SerialName("aggregation_temporality") val aggregationTemporality: String,
+    @SerialName("hist_count") val histCount: Long,
+    @SerialName("hist_sum") val histSum: Double?,
+    @SerialName("hist_min") val histMin: Double?,
+    @SerialName("hist_max") val histMax: Double?,
+    @SerialName("hist_bucket_counts") val histBucketCounts: List<Long>,
+    @SerialName("hist_explicit_bounds") val histExplicitBounds: List<Double>,
+    @SerialName("resource_attributes") val resourceAttributes: Map<String, String>,
+    val service: String,
+    val env: String,
+    val description: String,
 )
 
 private data class HistLikeFields(
@@ -624,47 +652,19 @@ class OtlpMetricsService(
     suspend fun insertBatch(batch: QueuedOtlpMetricsBatch) {
         if (batch.metrics.isEmpty()) return
 
-        val rows = batch.metrics.joinToString(",\n") { m ->
-            val bucketCountsArr = m.histBucketCounts.joinToString(",")
-            val boundsArr = m.histExplicitBounds.joinToString(",")
-
-            """(
-                generateUUIDv4(),
-                ${m.organizationId},
-                ${m.projectId ?: 0L},
-                '${escapeSql(m.metricName)}',
-                '${escapeSql(m.metricType)}',
-                fromUnixTimestamp64Milli(${m.timestampMs}),
-                ${m.value},
-                '${escapeSql(m.host)}',
-                ${mapToSqlMap(m.tags)},
-                '${escapeSql(m.unit)}',
-                '',
-                'otlp',
-                ${m.isMonotonic},
-                '${escapeSql(m.aggregationTemporality)}',
-                ${m.histCount},
-                ${m.histSum?.let { "$it" } ?: "NULL"},
-                ${m.histMin?.let { "$it" } ?: "NULL"},
-                ${m.histMax?.let { "$it" } ?: "NULL"},
-                [$bucketCountsArr],
-                [$boundsArr],
-                ${mapToSqlMap(m.resourceAttributes)},
-                '${escapeSql(m.service)}',
-                '${escapeSql(m.env)}',
-                '${escapeSql(m.description)}'
-            )"""
+        val rows = batch.metrics.joinToString("\n") { metric ->
+            json.encodeToString(metric.toJsonEachRow())
         }
 
         val insert = """
             INSERT INTO `$clickhouseDb`.metrics (
-                metric_id, organization_id, project_id, metric_name, metric_type,
+                organization_id, project_id, metric_name, metric_type,
                 timestamp, value, host, tags, unit, source_type_name,
                 source, is_monotonic, aggregation_temporality,
                 hist_count, hist_sum, hist_min, hist_max,
                 hist_bucket_counts, hist_explicit_bounds,
                 resource_attributes, service, env, description
-            ) VALUES
+            ) FORMAT JSONEachRow
             $rows
         """.trimIndent()
 
@@ -694,17 +694,36 @@ class OtlpMetricsService(
         )
     }
 
+    private fun OtlpMetricInsert.toJsonEachRow(): OtlpMetricJsonEachRow =
+        OtlpMetricJsonEachRow(
+            organizationId = organizationId,
+            projectId = projectId ?: 0L,
+            metricName = metricName,
+            metricType = metricType,
+            timestamp = formatClickHouseDateTime64MillisUtc(timestampMs),
+            value = value,
+            host = host,
+            tags = tags,
+            unit = unit,
+            sourceTypeName = "",
+            source = "otlp",
+            isMonotonic = isMonotonic,
+            aggregationTemporality = aggregationTemporality,
+            histCount = histCount,
+            histSum = histSum,
+            histMin = histMin,
+            histMax = histMax,
+            histBucketCounts = histBucketCounts,
+            histExplicitBounds = histExplicitBounds,
+            resourceAttributes = resourceAttributes,
+            service = service,
+            env = env,
+            description = description,
+        )
+
     private fun mapAggregationTemporality(value: Int): String = when (value) {
         AGGREGATION_TEMPORALITY_DELTA -> "delta"
         AGGREGATION_TEMPORALITY_CUMULATIVE -> "cumulative"
         else -> ""
-    }
-
-    private fun mapToSqlMap(map: Map<String, String>): String {
-        if (map.isEmpty()) return "map()"
-        val entries = map.entries.joinToString(", ") { (k, v) ->
-            "'${escapeSql(k)}', '${escapeSql(v)}'"
-        }
-        return "map($entries)"
     }
 }

--- a/backend/src/main/kotlin/com/moneat/utils/ClickHouseJsonEachRowUtils.kt
+++ b/backend/src/main/kotlin/com/moneat/utils/ClickHouseJsonEachRowUtils.kt
@@ -1,0 +1,30 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.utils
+
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+private const val CLICKHOUSE_DATETIME64_MILLIS_UTC_PATTERN = "uuuu-MM-dd HH:mm:ss.SSS"
+
+private val clickHouseDateTime64MillisUtcFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern(CLICKHOUSE_DATETIME64_MILLIS_UTC_PATTERN)
+        .withZone(ZoneOffset.UTC)
+
+fun formatClickHouseDateTime64MillisUtc(timestampMs: Long): String =
+    clickHouseDateTime64MillisUtcFormatter.format(Instant.ofEpochMilli(timestampMs))

--- a/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
+++ b/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
@@ -49,12 +49,12 @@ fun pushToDlq(
     workerId: Int,
     workerName: String,
     cause: Throwable,
-) {
+): Boolean {
     logger.error(cause) {
         "$workerName worker $workerId failed, pushing to DLQ"
     }
     OperationalMetrics.recordWorkerProcessingFailure(workerName, workerId, cause)
-    runCatching {
+    return runCatching {
         RedisConfig.sync().rpush(dlqKey, payload)
     }.onSuccess {
         OperationalMetrics.recordDlqPush(workerName, dlqKey, "success")
@@ -63,5 +63,5 @@ fun pushToDlq(
         logger.error(dlqErr) {
             "Failed to write to DLQ for worker $workerId, dlqKey=$dlqKey"
         }
-    }
+    }.isSuccess
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -107,7 +107,14 @@ class DatadogIngestRoutesTest {
             OrchestratorIngestionService,
         )
 
-        coEvery { DatadogMetricService.enqueueMetrics(any(), any()) } returns 0
+        every { DatadogService.validateApiKeyContext(any()) } answers {
+            if (firstArg<String>() == VALID_KEY) {
+                DatadogService.ApiKeyValidation(ORG_ID, null)
+            } else {
+                null
+            }
+        }
+        coEvery { DatadogMetricService.enqueueMetrics(any(), any(), any()) } returns 0
         coEvery { DatadogLogService.enqueueLogs(any(), any()) } returns 0
         coEvery { DatadogEventService.enqueueEvents(any(), any()) } returns 0
         every { DatadogEventService.mapServiceChecks(any(), any()) } returns

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -17,6 +17,7 @@
 package com.moneat.datadog.services
 
 import com.moneat.config.ClickHouseClient
+import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DatadogMetricSeriesV1
 import com.moneat.datadog.models.DatadogMetricV1
 import com.moneat.datadog.models.DatadogSketch
@@ -24,10 +25,12 @@ import com.moneat.datadog.models.DatadogSketchPayload
 import com.moneat.datadog.models.DatadogSketchPoint
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
+import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -156,7 +159,24 @@ class DatadogMetricServiceTest {
 
         val batch = DatadogMetricService.mapV1Series(42L, payload)
         assertEquals(42L, batch.organizationId)
+        assertEquals(0L, batch.projectId)
         assertEquals(1, batch.metrics.size)
+    }
+
+    @Test
+    fun `mapV1Series preserves project id`() {
+        val payload = DatadogMetricSeriesV1(
+            series = listOf(
+                DatadogMetricV1(
+                    metric = "cpu",
+                    points = listOf(listOf(0.0, 50.0))
+                )
+            )
+        )
+
+        val batch = DatadogMetricService.mapV1Series(42L, payload, projectId = 7L)
+
+        assertEquals(7L, batch.projectId)
     }
 
     @Test
@@ -164,6 +184,40 @@ class DatadogMetricServiceTest {
         val payload = DatadogMetricSeriesV1(series = emptyList())
         val batch = DatadogMetricService.mapV1Series(1L, payload)
         assertEquals(0, batch.metrics.size)
+    }
+
+    @Test
+    fun `enqueueMetrics serializes project id in queued batch`() = runBlocking {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+        val payload = DatadogMetricSeriesV1(
+            series = listOf(
+                DatadogMetricV1(
+                    metric = "cpu",
+                    points = listOf(listOf(0.0, 50.0))
+                )
+            )
+        )
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush("test:dd:metric:queue", capture(queuedPayload)) } returns 1L
+
+            val count = DatadogMetricService.enqueueMetrics(
+                organizationId = 42L,
+                payload = payload,
+                projectId = 7L,
+                queueKey = "test:dd:metric:queue",
+            )
+
+            val batch = DatadogMetricService.decodeMetricBatch(queuedPayload.captured)
+            assertEquals(1, count)
+            assertEquals(42L, batch.organizationId)
+            assertEquals(7L, batch.projectId)
+        } finally {
+            unmockkObject(RedisConfig)
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -159,7 +159,7 @@ class DatadogMetricServiceTest {
 
         val batch = DatadogMetricService.mapV1Series(42L, payload)
         assertEquals(42L, batch.organizationId)
-        assertEquals(0L, batch.projectId)
+        assertNull(batch.projectId)
         assertEquals(1, batch.metrics.size)
     }
 
@@ -244,9 +244,10 @@ class DatadogMetricServiceTest {
             )
         )
 
-        val batch = DatadogMetricService.mapSketches(42L, payload)
+        val batch = DatadogMetricService.mapSketches(42L, payload, projectId = 7L)
 
         assertEquals(42L, batch.organizationId)
+        assertEquals(7L, batch.projectId)
         assertEquals(1, batch.sketches.size)
 
         val sketch = batch.sketches[0]
@@ -328,6 +329,73 @@ class DatadogMetricServiceTest {
             assertEquals("0", row["project_id"]?.jsonPrimitive?.content)
             assertEquals("2023-11-14 22:13:20.123", row["timestamp"]?.jsonPrimitive?.content)
             assertEquals("O'Brien \"prod\"\nline", row["tags"]?.jsonObject?.get("odd")?.jsonPrimitive?.content)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `insertMetricBatch writes non-zero project id in JSONEachRow`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "test_db"
+            every { response.status } returns HttpStatusCode.OK
+            coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+            DatadogMetricService.insertMetricBatch(
+                QueuedMetricBatch(
+                    organizationId = 42L,
+                    projectId = 7L,
+                    metrics = listOf(
+                        QueuedMetricEntry(
+                            name = "custom.metric",
+                            type = "gauge",
+                            timestampMs = 1_700_000_000_123L,
+                            value = 42.5,
+                        )
+                    )
+                )
+            )
+
+            val query = queries.single { it.contains("INSERT INTO `test_db`.metrics ") }
+            val row = jsonRows(query).single()
+            assertEquals("7", row["project_id"]?.jsonPrimitive?.content)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `insertSketchBatch writes non-zero project id`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "test_db"
+            every { response.status } returns HttpStatusCode.OK
+            coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+            DatadogMetricService.insertSketchBatch(
+                QueuedSketchBatch(
+                    organizationId = 42L,
+                    sketches = listOf(
+                        QueuedSketchEntry(
+                            name = "latency",
+                            timestampMs = 1_700_000_000_000L,
+                            host = "web-01",
+                            tags = mapOf("env" to "prod"),
+                            count = 10,
+                        )
+                    ),
+                    projectId = 7L,
+                )
+            )
+
+            val query = queries.single { it.contains("INSERT INTO `test_db`.metric_sketches ") }
+            assertTrue(query.contains("organization_id, project_id, metric_name"))
+            assertTrue(Regex("""(?s)\(\s*42,\s*7,\s*'latency'""").containsMatchIn(query))
         } finally {
             unmockkObject(ClickHouseClient)
         }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -30,8 +30,13 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DatadogMetricServiceTest {
@@ -230,6 +235,51 @@ class DatadogMetricServiceTest {
     }
 
     @Test
+    fun `insertMetricBatch writes raw metrics as JSONEachRow with UTC millis and JSON tags`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "test_db"
+            every { response.status } returns HttpStatusCode.OK
+            coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+            DatadogMetricService.insertMetricBatch(
+                QueuedMetricBatch(
+                    organizationId = 42L,
+                    metrics = listOf(
+                        QueuedMetricEntry(
+                            name = "custom.metric",
+                            type = "gauge",
+                            timestampMs = 1_700_000_000_123L,
+                            value = 42.5,
+                            host = "web-01",
+                            tags = mapOf("odd" to "O'Brien \"prod\"\nline"),
+                            unit = "%",
+                            sourceTypeName = "agent",
+                        )
+                    )
+                )
+            )
+
+            val query = queries.single { it.contains("INSERT INTO `test_db`.metrics ") }
+            assertTrue(query.contains("FORMAT JSONEachRow"))
+            assertFalse(query.contains("VALUES"))
+            assertFalse(query.contains("fromUnixTimestamp64Milli"))
+            assertFalse(query.contains("map("))
+
+            val row = jsonRows(query).single()
+            assertNull(row["metric_id"])
+            assertEquals("42", row["organization_id"]?.jsonPrimitive?.content)
+            assertEquals("0", row["project_id"]?.jsonPrimitive?.content)
+            assertEquals("2023-11-14 22:13:20.123", row["timestamp"]?.jsonPrimitive?.content)
+            assertEquals("O'Brien \"prod\"\nline", row["tags"]?.jsonObject?.get("odd")?.jsonPrimitive?.content)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
     fun `insertMetricBatch writes raw metrics and infra rollups for host metrics`() = runBlocking {
         val queries = mutableListOf<String>()
         val response = mockk<HttpResponse>()
@@ -305,4 +355,11 @@ class DatadogMetricServiceTest {
             unmockkObject(ClickHouseClient)
         }
     }
+
+    private fun jsonRows(query: String) =
+        query.lineSequence()
+            .map { it.trim() }
+            .filter { it.startsWith("{") }
+            .map { Json.parseToJsonElement(it).jsonObject }
+            .toList()
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogServiceTest.kt
@@ -91,6 +91,22 @@ class DatadogServiceTest {
     }
 
     @Test
+    fun `validateApiKeyContext returns org and project for valid key`() {
+        val created = DatadogService.createApiKey(
+            organizationId = 42,
+            name = "Project Key",
+            userId = 1,
+            projectId = 7,
+        )
+
+        val context = DatadogService.validateApiKeyContext(created.key)
+
+        assertNotNull(context)
+        assertEquals(42, context.organizationId)
+        assertEquals(7, context.projectId)
+    }
+
+    @Test
     fun `validateApiKey returns null for invalid key`() {
         val orgId = DatadogService.validateApiKey("nonexistent-key")
         assertNull(orgId)

--- a/backend/src/test/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorkerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorkerTest.kt
@@ -34,6 +34,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DatadogMetricIngestionWorkerTest {
+
+    // ──── Payload Handling ────
+
     @Test
     fun `processMessage with invalid payload does not throw`() {
         val worker =
@@ -74,18 +77,43 @@ class DatadogMetricIngestionWorkerTest {
     @Test
     fun `collectPayloadsForProcessing drains additional payloads with bounded rpop count`() {
         val redis = mockk<RedisCommands<String, String>>()
-        every { redis.rpop("test:dd:metric:queue", 99L) } returns listOf("payload-2", "payload-3")
+        every {
+            redis.rpoplpush("test:dd:metric:queue", "test:dd:metric:queue:processing")
+        } returnsMany listOf("payload-2", "payload-3")
         val worker =
             DatadogMetricIngestionWorker(
                 "test:dd:metric:queue",
                 "test:dd:metric:dlq",
                 1,
+                maxPayloads = 3,
             )
 
         val payloads = worker.collectPayloadsForProcessing(redis, "payload-1")
 
         assertEquals(listOf("payload-1", "payload-2", "payload-3"), payloads)
+        verify(exactly = 2) {
+            redis.rpoplpush("test:dd:metric:queue", "test:dd:metric:queue:processing")
+        }
     }
+
+    @Test
+    fun `collectPayloadsForProcessing does not drain when max payloads is one`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val worker =
+            DatadogMetricIngestionWorker(
+                "test:dd:metric:queue",
+                "test:dd:metric:dlq",
+                1,
+                maxPayloads = 1,
+            )
+
+        val payloads = worker.collectPayloadsForProcessing(redis, "payload-1")
+
+        assertEquals(listOf("payload-1"), payloads)
+        verify(exactly = 0) { redis.rpoplpush(any<String>(), any<String>()) }
+    }
+
+    // ──── Insert Batching ────
 
     @Test
     fun `processPayloads combines valid payloads and pushes malformed payloads individually to dlq`() = runBlocking {
@@ -118,6 +146,15 @@ class DatadogMetricIngestionWorkerTest {
             verify(exactly = 1) {
                 redis.rpush("test:dd:metric:dlq", "bad-payload")
             }
+            verify(exactly = 1) {
+                redis.lrem("test:dd:metric:queue:processing", 1, "payload-1")
+            }
+            verify(exactly = 1) {
+                redis.lrem("test:dd:metric:queue:processing", 1, "bad-payload")
+            }
+            verify(exactly = 1) {
+                redis.lrem("test:dd:metric:queue:processing", 1, "payload-2")
+            }
         } finally {
             unmockkObject(DatadogMetricService)
             unmockkObject(RedisConfig)
@@ -125,7 +162,44 @@ class DatadogMetricIngestionWorkerTest {
     }
 
     @Test
-    fun `processPayloads retries combined insert then falls back per payload`() = runBlocking {
+    fun `processPayloads flushes chunks at configured max rows`() = runBlocking {
+        val redis = mockk<RedisCommands<String, String>>(relaxed = true)
+        val firstBatch = metricBatch(1L, "cpu")
+        val secondBatch = metricBatch(2L, "mem")
+        val worker =
+            DatadogMetricIngestionWorker(
+                "test:dd:metric:queue",
+                "test:dd:metric:dlq",
+                1,
+                maxRows = 1,
+            )
+
+        mockkObject(DatadogMetricService)
+        mockkObject(RedisConfig)
+        try {
+            every { DatadogMetricService.decodeMetricBatch("payload-1") } returns firstBatch
+            every { DatadogMetricService.decodeMetricBatch("payload-2") } returns secondBatch
+            every { RedisConfig.sync() } returns redis
+            coEvery { DatadogMetricService.insertMetricBatches(any()) } returns Unit
+
+            worker.processPayloads(1, listOf("payload-1", "payload-2"))
+
+            coVerify(exactly = 1) { DatadogMetricService.insertMetricBatches(listOf(firstBatch)) }
+            coVerify(exactly = 1) { DatadogMetricService.insertMetricBatches(listOf(secondBatch)) }
+            verify(exactly = 1) {
+                redis.lrem("test:dd:metric:queue:processing", 1, "payload-1")
+            }
+            verify(exactly = 1) {
+                redis.lrem("test:dd:metric:queue:processing", 1, "payload-2")
+            }
+        } finally {
+            unmockkObject(DatadogMetricService)
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `processPayloads falls back per payload after combined insert failure`() = runBlocking {
         val redis = mockk<RedisCommands<String, String>>(relaxed = true)
         val firstBatch = metricBatch(1L, "cpu")
         val secondBatch = metricBatch(2L, "mem")
@@ -149,18 +223,26 @@ class DatadogMetricIngestionWorkerTest {
 
             worker.processPayloads(1, listOf("payload-1", "payload-2"))
 
-            coVerify(exactly = 2) {
+            coVerify(exactly = 1) {
                 DatadogMetricService.insertMetricBatches(listOf(firstBatch, secondBatch))
             }
             coVerify(exactly = 1) { DatadogMetricService.insertMetricBatch(firstBatch) }
             coVerify(exactly = 1) { DatadogMetricService.insertMetricBatch(secondBatch) }
             verify(exactly = 0) { redis.rpush("test:dd:metric:dlq", "payload-1") }
             verify(exactly = 0) { redis.rpush("test:dd:metric:dlq", "payload-2") }
+            verify(exactly = 1) {
+                redis.lrem("test:dd:metric:queue:processing", 1, "payload-1")
+            }
+            verify(exactly = 1) {
+                redis.lrem("test:dd:metric:queue:processing", 1, "payload-2")
+            }
         } finally {
             unmockkObject(DatadogMetricService)
             unmockkObject(RedisConfig)
         }
     }
+
+    // ──── Lifecycle ────
 
     @Test
     fun `stop on unstarted worker does not throw`() {
@@ -172,6 +254,8 @@ class DatadogMetricIngestionWorkerTest {
             )
         worker.stop()
     }
+
+    // ──── Helpers ────
 
     private fun metricBatch(
         organizationId: Long,

--- a/backend/src/test/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorkerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorkerTest.kt
@@ -16,7 +16,20 @@
 
 package com.moneat.datadog.workers
 
+import com.moneat.config.RedisConfig
+import com.moneat.datadog.services.DatadogMetricService
+import com.moneat.datadog.services.QueuedMetricBatch
+import com.moneat.datadog.services.QueuedMetricEntry
+import io.lettuce.core.api.sync.RedisCommands
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -59,6 +72,97 @@ class DatadogMetricIngestionWorkerTest {
     }
 
     @Test
+    fun `collectPayloadsForProcessing drains additional payloads with bounded rpop count`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        every { redis.rpop("test:dd:metric:queue", 99L) } returns listOf("payload-2", "payload-3")
+        val worker =
+            DatadogMetricIngestionWorker(
+                "test:dd:metric:queue",
+                "test:dd:metric:dlq",
+                1,
+            )
+
+        val payloads = worker.collectPayloadsForProcessing(redis, "payload-1")
+
+        assertEquals(listOf("payload-1", "payload-2", "payload-3"), payloads)
+    }
+
+    @Test
+    fun `processPayloads combines valid payloads and pushes malformed payloads individually to dlq`() = runBlocking {
+        val redis = mockk<RedisCommands<String, String>>(relaxed = true)
+        val firstBatch = metricBatch(1L, "cpu")
+        val secondBatch = metricBatch(2L, "mem")
+        val worker =
+            DatadogMetricIngestionWorker(
+                "test:dd:metric:queue",
+                "test:dd:metric:dlq",
+                1,
+            )
+
+        mockkObject(DatadogMetricService)
+        mockkObject(RedisConfig)
+        try {
+            every { DatadogMetricService.decodeMetricBatch("payload-1") } returns firstBatch
+            every { DatadogMetricService.decodeMetricBatch("bad-payload") } throws
+                SerializationException("bad payload")
+            every { DatadogMetricService.decodeMetricBatch("payload-2") } returns secondBatch
+            every { RedisConfig.sync() } returns redis
+            every { redis.rpush("test:dd:metric:dlq", "bad-payload") } returns 1L
+            coEvery { DatadogMetricService.insertMetricBatches(any()) } returns Unit
+
+            worker.processPayloads(1, listOf("payload-1", "bad-payload", "payload-2"))
+
+            coVerify(exactly = 1) {
+                DatadogMetricService.insertMetricBatches(listOf(firstBatch, secondBatch))
+            }
+            verify(exactly = 1) {
+                redis.rpush("test:dd:metric:dlq", "bad-payload")
+            }
+        } finally {
+            unmockkObject(DatadogMetricService)
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `processPayloads retries combined insert then falls back per payload`() = runBlocking {
+        val redis = mockk<RedisCommands<String, String>>(relaxed = true)
+        val firstBatch = metricBatch(1L, "cpu")
+        val secondBatch = metricBatch(2L, "mem")
+        val worker =
+            DatadogMetricIngestionWorker(
+                "test:dd:metric:queue",
+                "test:dd:metric:dlq",
+                1,
+            )
+
+        mockkObject(DatadogMetricService)
+        mockkObject(RedisConfig)
+        try {
+            every { DatadogMetricService.decodeMetricBatch("payload-1") } returns firstBatch
+            every { DatadogMetricService.decodeMetricBatch("payload-2") } returns secondBatch
+            every { RedisConfig.sync() } returns redis
+            coEvery { DatadogMetricService.insertMetricBatches(listOf(firstBatch, secondBatch)) } throws
+                IllegalStateException("combined insert failed")
+            coEvery { DatadogMetricService.insertMetricBatch(firstBatch) } returns Unit
+            coEvery { DatadogMetricService.insertMetricBatch(secondBatch) } returns Unit
+
+            worker.processPayloads(1, listOf("payload-1", "payload-2"))
+
+            coVerify(exactly = 2) {
+                DatadogMetricService.insertMetricBatches(listOf(firstBatch, secondBatch))
+            }
+            coVerify(exactly = 1) { DatadogMetricService.insertMetricBatch(firstBatch) }
+            coVerify(exactly = 1) { DatadogMetricService.insertMetricBatch(secondBatch) }
+            verify(exactly = 0) { redis.rpush("test:dd:metric:dlq", "payload-1") }
+            verify(exactly = 0) { redis.rpush("test:dd:metric:dlq", "payload-2") }
+        } finally {
+            unmockkObject(DatadogMetricService)
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
     fun `stop on unstarted worker does not throw`() {
         val worker =
             DatadogMetricIngestionWorker(
@@ -68,4 +172,20 @@ class DatadogMetricIngestionWorkerTest {
             )
         worker.stop()
     }
+
+    private fun metricBatch(
+        organizationId: Long,
+        metricName: String,
+    ): QueuedMetricBatch =
+        QueuedMetricBatch(
+            organizationId = organizationId,
+            metrics = listOf(
+                QueuedMetricEntry(
+                    name = metricName,
+                    type = "gauge",
+                    timestampMs = 1_700_000_000_000L,
+                    value = 1.0,
+                )
+            )
+        )
 }

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpMetricsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpMetricsServiceTest.kt
@@ -42,11 +42,15 @@ import io.opentelemetry.proto.metrics.v1.SummaryDataPoint
 import io.opentelemetry.proto.resource.v1.Resource
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -645,6 +649,60 @@ class OtlpMetricsServiceTest {
         assertTrue(queries.any { it.contains("metrics_rollup_1m") })
     }
 
+    @Test
+    fun `insertBatch writes raw metrics as JSONEachRow with UTC millis and JSON maps`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        every { response.status } returns HttpStatusCode.OK
+        coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+        val localService = OtlpMetricsService(mockk<UsageTrackingService>(relaxed = true))
+        localService.insertBatch(
+            QueuedOtlpMetricsBatch(
+                organizationId = 42L,
+                metrics = listOf(
+                    OtlpMetricInsert(
+                        organizationId = 42L,
+                        projectId = 123L,
+                        metricName = "custom.otlp.metric",
+                        metricType = "gauge",
+                        description = "quoted \"metric\"",
+                        unit = "%",
+                        timestampMs = 1_700_000_000_123L,
+                        value = 2048.0,
+                        isMonotonic = 0,
+                        aggregationTemporality = "",
+                        histCount = 0,
+                        histSum = null,
+                        histMin = null,
+                        histMax = null,
+                        histBucketCounts = emptyList(),
+                        histExplicitBounds = emptyList(),
+                        tags = mapOf("odd" to "O'Brien \"prod\"\nline"),
+                        resourceAttributes = mapOf("service.name" to TEST_SVC),
+                        service = TEST_SVC,
+                        env = TEST_ENV,
+                        host = TEST_HOST,
+                    )
+                )
+            )
+        )
+
+        val query = queries.single { it.contains("INSERT INTO `test_db`.metrics ") }
+        assertTrue(query.contains("FORMAT JSONEachRow"))
+        assertFalse(query.contains("VALUES"))
+        assertFalse(query.contains("fromUnixTimestamp64Milli"))
+        assertFalse(query.contains("map("))
+        assertFalse(query.contains("metric_id"))
+
+        val row = jsonRows(query).single()
+        assertEquals("42", row["organization_id"]?.jsonPrimitive?.content)
+        assertEquals("123", row["project_id"]?.jsonPrimitive?.content)
+        assertEquals("2023-11-14 22:13:20.123", row["timestamp"]?.jsonPrimitive?.content)
+        assertEquals("O'Brien \"prod\"\nline", row["tags"]?.jsonObject?.get("odd")?.jsonPrimitive?.content)
+        assertEquals(TEST_SVC, row["resource_attributes"]?.jsonObject?.get("service.name")?.jsonPrimitive?.content)
+    }
+
     // ──── PROTOBUF PARSING ────
 
     @Nested
@@ -854,4 +912,11 @@ class OtlpMetricsServiceTest {
             assertTrue(metrics.isEmpty())
         }
     }
+
+    private fun jsonRows(query: String) =
+        query.lineSequence()
+            .map { it.trim() }
+            .filter { it.startsWith("{") }
+            .map { Json.parseToJsonElement(it).jsonObject }
+            .toList()
 }

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -20,6 +20,7 @@ import com.moneat.billing.models.BillingUsageResponse
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.billing.services.QuotaReservationResult
 import com.moneat.config.ClickHouseClient
+import com.moneat.datadog.auth.DatadogAuthContext
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.models.DdApiKeys
 import com.moneat.datadog.models.DdApmErrorsResponse
@@ -187,12 +188,15 @@ class DatadogRoutesExtendedTest {
         coEvery {
             DatadogAuthMiddleware.authenticate(any())
         } returns TEST_ORG_ID
+        coEvery {
+            DatadogAuthMiddleware.authenticateContext(any())
+        } returns DatadogAuthContext(TEST_ORG_ID, null)
 
         // Default stubs for ingest services
         every { DatadogHostService.upsertFromMetadata(any(), any()) } just Runs
         every { DatadogHostService.upsertFromIntake(any(), any()) } just Runs
         every { DatadogHostService.touchHostLastSeen(any(), any()) } just Runs
-        coEvery { DatadogMetricService.enqueueMetrics(any(), any()) } returns 1
+        coEvery { DatadogMetricService.enqueueMetrics(any(), any(), any()) } returns 1
         every { DatadogMetricService.mapSketches(any(), any()) } returns
             com.moneat.datadog.services.QueuedSketchBatch(1L, emptyList())
         coEvery { DatadogMetricService.insertSketchBatch(any()) } just Runs

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -197,7 +197,7 @@ class DatadogRoutesExtendedTest {
         every { DatadogHostService.upsertFromIntake(any(), any()) } just Runs
         every { DatadogHostService.touchHostLastSeen(any(), any()) } just Runs
         coEvery { DatadogMetricService.enqueueMetrics(any(), any(), any()) } returns 1
-        every { DatadogMetricService.mapSketches(any(), any()) } returns
+        every { DatadogMetricService.mapSketches(any(), any(), any()) } returns
             com.moneat.datadog.services.QueuedSketchBatch(1L, emptyList())
         coEvery { DatadogMetricService.insertSketchBatch(any()) } just Runs
         every { DatadogEventService.mapServiceChecks(any(), any()) } returns
@@ -903,7 +903,7 @@ class DatadogRoutesExtendedTest {
             )
         }
         verify { DatadogHostService.touchHostLastSeen(TEST_ORG_ID, setOf("h1")) }
-        coVerify(exactly = 0) { DatadogMetricService.enqueueMetrics(any(), any()) }
+        coVerify(exactly = 0) { DatadogMetricService.enqueueMetrics(any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- use JSONEachRow for Datadog and OTLP metric inserts
- coalesce Datadog metric queue payloads with per-payload fallback
- add focused backend coverage

## Validation
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.datadog.services.DatadogMetricServiceTest --tests com.moneat.datadog.workers.DatadogMetricIngestionWorkerTest --tests com.moneat.otlp.services.OtlpMetricsServiceTest -Dkotlin.compiler.execution.strategy=in-process
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon compileKotlin -Dkotlin.compiler.execution.strategy=in-process
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon detekt -Dkotlin.compiler.execution.strategy=in-process
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional project ID support throughout metric/sketch ingestion and project-scoped auth context.

* **Refactor**
  * ClickHouse ingestion now uses newline-delimited JSON rows with UTC millisecond timestamps.
  * Worker processes payloads in configurable batches and improved queue/drain pipeline.

* **Bug Fixes**
  * More robust handling of decode/insert failures with targeted DLQ and acknowledgements.

* **Tests**
  * Expanded coverage for batching, DLQ flows, timestamp/JSON output, and auth context.

* **Documentation**
  * Example env vars added for batch sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->