### PR TITLE
fix: scope dashboard log widgets by organization

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
@@ -360,7 +360,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDashboardQuery(
             )
             call.respond(results)
         } else {
-            val results = queryEngine.executeQuery(effectiveQuery, projectId, demoEpochMs, retentionDays)
+            val results = queryEngine.executeQuery(effectiveQuery, projectId, demoEpochMs, retentionDays, orgId)
             call.respond(results)
         }
     } catch (e: IllegalArgumentException) {
@@ -379,7 +379,7 @@ private suspend fun executeSingleQuery(
     dataSourceExecutor: CustomDataSourceExecutor,
 ): List<Map<String, kotlinx.serialization.json.JsonElement>>? {
     if (!queryEngine.isCustomDataSource(effectiveQuery.dataSource)) {
-        return queryEngine.executeQuery(effectiveQuery, projectId, demoEpochMs, retentionDays)
+        return queryEngine.executeQuery(effectiveQuery, projectId, demoEpochMs, retentionDays, orgId)
     }
     val sourceId = queryEngine.parseCustomDataSourceId(effectiveQuery.dataSource) ?: return null
     val source = dataSourceService.getDataSource(sourceId, orgId) ?: return null

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -500,7 +500,7 @@ class DashboardAlertService(
         val builtInProjectId = projectId ?: return emptyList()
         val retentionDays =
             retentionPolicyService.getRetentionDaysForProject(builtInProjectId) ?: DEFAULT_RETENTION_DAYS
-        return queryEngine.executeQuery(queryDsl, builtInProjectId, null, retentionDays)
+        return queryEngine.executeQuery(queryDsl, builtInProjectId, null, retentionDays, orgId)
     }
 
     private fun resolveCustomDataSource(

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
@@ -75,6 +75,7 @@ class DashboardQueryEngine {
         )
 
         private val TIME_RANGE_REGEX = Regex("""^now-(\d+)([smhdwMy])$""")
+        private val ORG_SCOPED_TABLES = setOf("logs", "metrics", "containers")
 
         private const val MILLIS_PER_MINUTE = 60_000L
         private const val MILLIS_PER_WEEK = 604_800_000L
@@ -192,7 +193,8 @@ class DashboardQueryEngine {
         dsl: QueryDsl,
         projectId: Long,
         demoEpochMs: Long? = null,
-        retentionDays: Int = 90
+        retentionDays: Int = 90,
+        orgId: Long? = null
     ): String {
         val dataSource = DataSource.fromString(dsl.dataSource)
             ?: throw IllegalArgumentException("Unknown data source: ${dsl.dataSource}")
@@ -205,7 +207,7 @@ class DashboardQueryEngine {
         val tsCol = TIMESTAMP_COLUMNS[dataSource.tableName] ?: "timestamp"
 
         val selectClauses = buildSelectClauses(dsl, tsCol)
-        val whereClauses = buildWhereClauses(dsl, projectId, tsCol, demoEpochMs, retentionDays)
+        val whereClauses = buildWhereClauses(dsl, projectId, tsCol, demoEpochMs, retentionDays, orgId)
         val groupByClauses = buildGroupByClauses(dsl)
         val orderByClause = buildOrderByClause(dsl)
 
@@ -272,11 +274,12 @@ class DashboardQueryEngine {
         projectId: Long,
         tsCol: String,
         demoEpochMs: Long?,
-        retentionDays: Int
+        retentionDays: Int,
+        orgId: Long? = null
     ): List<String> {
         val clauses = mutableListOf<String>()
 
-        clauses.add(ClickHouseQueryUtils.projectIdClause(projectId))
+        clauses.add(buildScopeClause(dsl, projectId, orgId))
         clauses.add(ClickHouseQueryUtils.timestampRetentionClause(tsCol, retentionDays, demoEpochMs))
         clauses.addAll(buildTimeRangeClauses(dsl.timeRange, tsCol, demoEpochMs))
 
@@ -285,6 +288,14 @@ class DashboardQueryEngine {
         }
 
         return clauses
+    }
+
+    internal fun buildScopeClause(dsl: QueryDsl, projectId: Long, orgId: Long?): String {
+        val tableName = DataSource.fromString(dsl.dataSource)?.tableName
+        if (orgId != null && tableName != null && tableName in ORG_SCOPED_TABLES) {
+            return ClickHouseQueryUtils.orgIdClause(orgId)
+        }
+        return ClickHouseQueryUtils.projectIdClause(projectId)
     }
 
     internal fun buildTimeRangeClauses(
@@ -378,14 +389,15 @@ class DashboardQueryEngine {
         dsl: QueryDsl,
         projectId: Long,
         demoEpochMs: Long? = null,
-        retentionDays: Int = 90
+        retentionDays: Int = 90,
+        orgId: Long? = null
     ): List<Map<String, JsonElement>> {
         if (dsl.rawQuery != null) {
             logger.warn { "Skipping raw query execution for security - use query DSL" }
             return emptyList()
         }
 
-        val sql = buildQuery(dsl, projectId, demoEpochMs, retentionDays)
+        val sql = buildQuery(dsl, projectId, demoEpochMs, retentionDays, orgId)
         logger.debug {
             "Executing dashboard query dataSource=${dsl.dataSource} " +
                 "metrics=${dsl.metrics.size} filters=${dsl.filters.size} groupBy=${dsl.groupBy.size}"

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -814,7 +814,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(any())
             } returns RECOVERY_RETENTION_DAYS
             coEvery {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(RECOVERED_TOTAL)))
 
             val dashboardId = seedDashboard()
@@ -878,7 +878,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(any())
             } returns RECOVERY_RETENTION_DAYS
             coEvery {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(90.0)))
 
             val dashboardId = seedDashboard()
@@ -930,7 +930,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(any())
             } returns RECOVERY_RETENTION_DAYS
             coEvery {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(125.0)))
 
             val dashboardId = seedDashboard()
@@ -990,7 +990,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(any())
             } returns RECOVERY_RETENTION_DAYS
             coEvery {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(90.0)))
 
             val dashboardId = seedDashboard()
@@ -1032,7 +1032,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(any())
             } returns RECOVERY_RETENTION_DAYS
             coEvery {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(90.0)))
 
             val dashboardId = seedDashboard()
@@ -1071,7 +1071,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(any())
             } returns RECOVERY_RETENTION_DAYS
             coEvery {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(70.0)))
 
             val dashboardId = seedDashboard()
@@ -1117,7 +1117,7 @@ class DashboardAlertServiceTest {
 
             callPrivateSuspend("evaluateAlerts")
 
-            coVerify(exactly = 0) { queryEngine.executeQuery(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { queryEngine.executeQuery(any(), any(), any(), any(), any()) }
         }
 
     @Test
@@ -1130,7 +1130,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(any())
             } returns RECOVERY_RETENTION_DAYS
             coEvery {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             } throws RuntimeException("query failed")
 
             val dashboardId = seedDashboard()
@@ -1230,7 +1230,7 @@ class DashboardAlertServiceTest {
 
             assertTrue(result.isEmpty())
             coVerify(exactly = 0) {
-                queryEngine.executeQuery(any(), any(), any(), any())
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
             }
         }
 
@@ -1243,7 +1243,7 @@ class DashboardAlertServiceTest {
                 retentionPolicyService.getRetentionDaysForProject(DEFAULT_PROJECT_ID)
             } returns null
             coEvery {
-                queryEngine.executeQuery(query, DEFAULT_PROJECT_ID, null, RECOVERY_RETENTION_DAYS)
+                queryEngine.executeQuery(query, DEFAULT_PROJECT_ID, null, RECOVERY_RETENTION_DAYS, ORG_ID)
             } returns rows
 
             val result = service.executeQueryForAlert(

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
@@ -364,6 +364,22 @@ class DashboardQueryEngineTest {
     }
 
     @Test
+    fun `buildWhereClauses scopes log queries by organization when org id is available`() {
+        val dsl = QueryDsl(dataSource = "logs")
+        val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90, orgId = 456)
+        assertTrue(clauses.any { it.contains("organization_id = 456") })
+        assertFalse(clauses.any { it.contains("project_id = 123") })
+    }
+
+    @Test
+    fun `buildWhereClauses keeps event queries project scoped when org id is available`() {
+        val dsl = QueryDsl(dataSource = "events")
+        val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90, orgId = 456)
+        assertTrue(clauses.any { it.contains("project_id = 123") })
+        assertFalse(clauses.any { it.contains("organization_id = 456") })
+    }
+
+    @Test
     fun `buildWhereClauses includes retention clause`() {
         val dsl = QueryDsl(dataSource = "events")
         val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90)

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
@@ -372,6 +372,25 @@ class DashboardQueryEngineTest {
     }
 
     @Test
+    fun `buildWhereClauses scopes log queries by project when org id is unavailable`() {
+        val dsl = QueryDsl(dataSource = "logs")
+        val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90)
+        assertTrue(clauses.any { it.contains("project_id = 123") })
+        assertFalse(clauses.any { it.contains("organization_id =") })
+    }
+
+    @Test
+    fun `buildWhereClauses scopes metrics and containers by organization when org id is available`() {
+        val orgScopedSources = listOf("metrics", "containers")
+        for (source in orgScopedSources) {
+            val dsl = QueryDsl(dataSource = source)
+            val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90, orgId = 456)
+            assertTrue(clauses.any { it.contains("organization_id = 456") })
+            assertFalse(clauses.any { it.contains("project_id = 123") })
+        }
+    }
+
+    @Test
     fun `buildWhereClauses keeps event queries project scoped when org id is available`() {
         val dsl = QueryDsl(dataSource = "events")
         val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90, orgId = 456)

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -47,6 +47,7 @@ import type {ValueMapping} from './formatValue'
 import {formatValue} from './formatValue'
 import {pivotData, valueKeySeries} from './widgetSeries'
 import {isWarningThresholdValid, type AlertThresholdPreview} from './alertThresholds'
+import {widgetQueryFingerprint} from './widgetQueryFingerprint'
 
 const COLORS = [
   'hsl(var(--chart-1))',
@@ -146,8 +147,7 @@ export const WidgetRenderer = memo(function WidgetRenderer({
   const queries = widget.query_configs?.length > 0 ? widget.query_configs : []
   const isBatch = queries.length > 1
   const isExtendedWidget = isExtendedWidgetType(widgetType)
-  // Include query config fingerprint so datasource/query changes trigger refetch
-  const queryFingerprint = JSON.stringify(queries.map(q => ({d: q.dataSource, r: q.rawQuery || ''})))
+  const queryFingerprint = widgetQueryFingerprint(queries)
 
   const {data, isLoading, error} = useQuery({
     queryKey: ['widget-data', widget.id, dashboardId, projectId, timeRange, queryFingerprint, variables],

--- a/dashboard/src/components/dashboards/__tests__/widgetQueryFingerprint.test.ts
+++ b/dashboard/src/components/dashboards/__tests__/widgetQueryFingerprint.test.ts
@@ -1,0 +1,51 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import type {QueryDsl} from '@/lib/api'
+import {widgetQueryFingerprint} from '../widgetQueryFingerprint'
+
+const baseQuery: QueryDsl = {
+  dataSource: 'logs',
+  metrics: [{function: 'count', alias: 'error_logs'}],
+  groupBy: [{field: 'timestamp', type: 'time', interval: 'auto'}],
+  filters: [{field: 'level', op: 'eq', value: 'error'}],
+  limit: 5000,
+  timeRange: {from: 'now-24h', to: 'now'},
+}
+
+describe('widgetQueryFingerprint', () => {
+  it('changes when dashboard widget filters change', () => {
+    const filteredQuery: QueryDsl = {
+      ...baseQuery,
+      filters: [
+        ...baseQuery.filters,
+        {field: 'service', op: 'eq', value: 'moneat-backend'},
+      ],
+    }
+
+    expect(widgetQueryFingerprint([filteredQuery])).not.toBe(widgetQueryFingerprint([baseQuery]))
+  })
+
+  it('changes when metric aliases change', () => {
+    const renamedMetricQuery: QueryDsl = {
+      ...baseQuery,
+      metrics: [{function: 'count', alias: 'backend_errors'}],
+    }
+
+    expect(widgetQueryFingerprint([renamedMetricQuery])).not.toBe(widgetQueryFingerprint([baseQuery]))
+  })
+})

--- a/dashboard/src/components/dashboards/widgetQueryFingerprint.ts
+++ b/dashboard/src/components/dashboards/widgetQueryFingerprint.ts
@@ -1,0 +1,21 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {QueryDsl} from '@/lib/api'
+
+export function widgetQueryFingerprint(queries: QueryDsl[]): string {
+  return JSON.stringify(queries)
+}


### PR DESCRIPTION
Fix dashboard log widgets returning empty results for org-scoped log data. Refresh widget data when query filters or aliases change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboards now enforce organization-level query scoping for logs, metrics, and containers data

* **Improvements**
  * Alerts now respect per-project retention policies during query execution
  * Widget data refresh logic optimized with improved fingerprinting mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->