### PR TITLE
fix: handle DBM payload arrays

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DbmIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DbmIngestRoutes.kt
@@ -87,7 +87,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmQueries(
 
         val payloads = decodeDbmPayloads<DdDbmQueryPayload>(body)
         if (!reserveDbmQuota(quotaService, organizationId, payloads.sumOf { it.rows.size }, bytes)) return
-        val count = payloads.sumOf { DbmIngestionService.enqueueQueries(organizationId, it) }
+        val count = DbmIngestionService.enqueueQueryPayloads(organizationId, payloads)
 
         logger.debug { "Enqueued $count DBM queries for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -108,7 +108,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmMetrics(
 
         val payloads = decodeDbmPayloads<DdDbmMetricsPayload>(body)
         if (!reserveDbmQuota(quotaService, organizationId, payloads.sumOf { it.rows.size }, bytes)) return
-        val count = payloads.sumOf { DbmIngestionService.enqueueMetrics(organizationId, it) }
+        val count = DbmIngestionService.enqueueMetricPayloads(organizationId, payloads)
 
         logger.debug { "Enqueued $count DBM metrics for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -129,7 +129,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmActivity(
 
         val payloads = decodeDbmPayloads<DdDbmActivityPayload>(body)
         if (!reserveDbmQuota(quotaService, organizationId, payloads.sumOf { it.activity.size }, bytes)) return
-        val count = payloads.sumOf { DbmIngestionService.enqueueActivity(organizationId, it) }
+        val count = DbmIngestionService.enqueueActivityPayloads(organizationId, payloads)
 
         logger.debug { "Enqueued $count DBM activity for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -150,7 +150,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmMetadata(
 
         val payloads = decodeDbmPayloads<DdDbmMetadataPayload>(body)
         if (!reserveDbmQuota(quotaService, organizationId, payloads.size, bytes)) return
-        val count = payloads.sumOf { DbmIngestionService.enqueueMetadata(organizationId, it) }
+        val count = DbmIngestionService.enqueueMetadataPayloads(organizationId, payloads)
 
         logger.debug { "Enqueued $count DBM metadata for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -171,7 +171,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmHealth(
 
         val payloads = decodeDbmPayloads<DdDbmHealthPayload>(body)
         if (!reserveDbmQuota(quotaService, organizationId, payloads.size, bytes)) return
-        val count = payloads.sumOf { DbmIngestionService.enqueueHealth(organizationId, it) }
+        val count = DbmIngestionService.enqueueHealthPayloads(organizationId, payloads)
 
         logger.debug { "Enqueued $count DBM health for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DbmIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DbmIngestRoutes.kt
@@ -26,6 +26,7 @@ import com.moneat.datadog.models.DdDbmMetadataPayload
 import com.moneat.datadog.models.DdDbmMetricsPayload
 import com.moneat.datadog.models.DdDbmQueryPayload
 import com.moneat.datadog.services.DbmIngestionService
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receiveChannel
 import io.ktor.server.response.respond
@@ -34,8 +35,10 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.utils.io.toByteArray
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import mu.KotlinLogging
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 private val json = Json {
@@ -82,9 +85,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmQueries(
         val bytes = DecompressionService.decompress(rawBytes, call.request.headers["Content-Encoding"])
         val body = bytes.decodeToString()
 
-        val payload = json.decodeFromString<DdDbmQueryPayload>(body)
-        if (!reserveDbmQuota(quotaService, organizationId, payload.rows.size, bytes)) return
-        val count = DbmIngestionService.enqueueQueries(organizationId, payload)
+        val payloads = decodeDbmPayloads<DdDbmQueryPayload>(body)
+        if (!reserveDbmQuota(quotaService, organizationId, payloads.sumOf { it.rows.size }, bytes)) return
+        val count = payloads.sumOf { DbmIngestionService.enqueueQueries(organizationId, it) }
 
         logger.debug { "Enqueued $count DBM queries for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -103,9 +106,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmMetrics(
         val bytes = DecompressionService.decompress(rawBytes, call.request.headers["Content-Encoding"])
         val body = bytes.decodeToString()
 
-        val payload = json.decodeFromString<DdDbmMetricsPayload>(body)
-        if (!reserveDbmQuota(quotaService, organizationId, payload.rows.size, bytes)) return
-        val count = DbmIngestionService.enqueueMetrics(organizationId, payload)
+        val payloads = decodeDbmPayloads<DdDbmMetricsPayload>(body)
+        if (!reserveDbmQuota(quotaService, organizationId, payloads.sumOf { it.rows.size }, bytes)) return
+        val count = payloads.sumOf { DbmIngestionService.enqueueMetrics(organizationId, it) }
 
         logger.debug { "Enqueued $count DBM metrics for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -124,9 +127,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmActivity(
         val bytes = DecompressionService.decompress(rawBytes, call.request.headers["Content-Encoding"])
         val body = bytes.decodeToString()
 
-        val payload = json.decodeFromString<DdDbmActivityPayload>(body)
-        if (!reserveDbmQuota(quotaService, organizationId, payload.activity.size, bytes)) return
-        val count = DbmIngestionService.enqueueActivity(organizationId, payload)
+        val payloads = decodeDbmPayloads<DdDbmActivityPayload>(body)
+        if (!reserveDbmQuota(quotaService, organizationId, payloads.sumOf { it.activity.size }, bytes)) return
+        val count = payloads.sumOf { DbmIngestionService.enqueueActivity(organizationId, it) }
 
         logger.debug { "Enqueued $count DBM activity for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -145,9 +148,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmMetadata(
         val bytes = DecompressionService.decompress(rawBytes, call.request.headers["Content-Encoding"])
         val body = bytes.decodeToString()
 
-        val payload = json.decodeFromString<DdDbmMetadataPayload>(body)
-        if (!reserveDbmQuota(quotaService, organizationId, 1, bytes)) return
-        val count = DbmIngestionService.enqueueMetadata(organizationId, payload)
+        val payloads = decodeDbmPayloads<DdDbmMetadataPayload>(body)
+        if (!reserveDbmQuota(quotaService, organizationId, payloads.size, bytes)) return
+        val count = payloads.sumOf { DbmIngestionService.enqueueMetadata(organizationId, it) }
 
         logger.debug { "Enqueued $count DBM metadata for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -166,9 +169,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDbmHealth(
         val bytes = DecompressionService.decompress(rawBytes, call.request.headers["Content-Encoding"])
         val body = bytes.decodeToString()
 
-        val payload = json.decodeFromString<DdDbmHealthPayload>(body)
-        if (!reserveDbmQuota(quotaService, organizationId, 1, bytes)) return
-        val count = DbmIngestionService.enqueueHealth(organizationId, payload)
+        val payloads = decodeDbmPayloads<DdDbmHealthPayload>(body)
+        if (!reserveDbmQuota(quotaService, organizationId, payloads.size, bytes)) return
+        val count = payloads.sumOf { DbmIngestionService.enqueueHealth(organizationId, it) }
 
         logger.debug { "Enqueued $count DBM health for org=$organizationId" }
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
@@ -192,4 +195,19 @@ private suspend fun io.ktor.server.routing.RoutingContext.reserveDbmQuota(
         eventType = "dd_dbm",
         requestedBytes = bytes.size.toLong(),
     )
+}
+
+private inline fun <reified T> decodeDbmPayloads(body: String): List<T> {
+    return when (val root = json.parseToJsonElement(body)) {
+        is JsonArray -> root.mapNotNull { element ->
+            val objectElement = element as? JsonObject
+            if (objectElement?.isEmpty() == true) {
+                null
+            } else {
+                json.decodeFromJsonElement<T>(element)
+            }
+        }
+        is JsonObject -> listOf(json.decodeFromJsonElement(root))
+        else -> throw IllegalArgumentException("DBM payload must be a JSON object or array")
+    }
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DbmIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DbmIngestionService.kt
@@ -195,54 +195,94 @@ object DbmIngestionService {
     }
 
     fun enqueueQueries(organizationId: Int, payload: DdDbmQueryPayload, queueKey: String = DBM_QUEUE_KEY): Int {
-        val batch = mapQueries(organizationId, payload)
-        if (batch.queries.isEmpty()) return 0
-        RedisConfig.sync().lpush(queueKey, json.encodeToString(batch))
-        return batch.queries.size
+        return enqueueQueryPayloads(organizationId, listOf(payload), queueKey)
+    }
+
+    fun enqueueQueryPayloads(
+        organizationId: Int,
+        payloads: List<DdDbmQueryPayload>,
+        queueKey: String = DBM_QUEUE_KEY,
+    ): Int {
+        val queries = payloads.flatMap { mapQueries(organizationId, it).queries }
+        return enqueueBatch(QueuedDbmBatch(organizationId, "queries", queries = queries), queries.size, queueKey)
     }
 
     fun enqueueMetrics(organizationId: Int, payload: DdDbmMetricsPayload, queueKey: String = DBM_QUEUE_KEY): Int {
-        val batch = mapMetrics(organizationId, payload)
-        if (batch.metrics.isEmpty()) return 0
-        RedisConfig.sync().lpush(queueKey, json.encodeToString(batch))
-        return batch.metrics.size
+        return enqueueMetricPayloads(organizationId, listOf(payload), queueKey)
+    }
+
+    fun enqueueMetricPayloads(
+        organizationId: Int,
+        payloads: List<DdDbmMetricsPayload>,
+        queueKey: String = DBM_QUEUE_KEY,
+    ): Int {
+        val metrics = payloads.flatMap { mapMetrics(organizationId, it).metrics }
+        return enqueueBatch(QueuedDbmBatch(organizationId, "metrics", metrics = metrics), metrics.size, queueKey)
     }
 
     fun enqueueActivity(organizationId: Int, payload: DdDbmActivityPayload, queueKey: String = DBM_QUEUE_KEY): Int {
-        val batch = mapActivity(organizationId, payload)
-        if (batch.activity.isEmpty()) return 0
-        RedisConfig.sync().lpush(queueKey, json.encodeToString(batch))
-        return batch.activity.size
+        return enqueueActivityPayloads(organizationId, listOf(payload), queueKey)
+    }
+
+    fun enqueueActivityPayloads(
+        organizationId: Int,
+        payloads: List<DdDbmActivityPayload>,
+        queueKey: String = DBM_QUEUE_KEY,
+    ): Int {
+        val activity = payloads.flatMap { mapActivity(organizationId, it).activity }
+        return enqueueBatch(QueuedDbmBatch(organizationId, "activity", activity = activity), activity.size, queueKey)
     }
 
     fun enqueueMetadata(organizationId: Int, payload: DdDbmMetadataPayload, queueKey: String = DBM_QUEUE_KEY): Int {
-        val entry = QueuedDbmMetadataEntry(
-            host = payload.host,
-            dbSystem = payload.dbSystem,
-            schemaJson = payload.schemaJson,
-            explainPlanHash = payload.explainPlanHash,
-            explainPlan = payload.explainPlan,
-            timestampMs = System.currentTimeMillis(),
-        )
-        val batch = QueuedDbmBatch(organizationId, "metadata", metadata = listOf(entry))
-        RedisConfig.sync().lpush(queueKey, json.encodeToString(batch))
-        return 1
+        return enqueueMetadataPayloads(organizationId, listOf(payload), queueKey)
+    }
+
+    fun enqueueMetadataPayloads(
+        organizationId: Int,
+        payloads: List<DdDbmMetadataPayload>,
+        queueKey: String = DBM_QUEUE_KEY,
+    ): Int {
+        val metadata = payloads.map { payload ->
+            QueuedDbmMetadataEntry(
+                host = payload.host,
+                dbSystem = payload.dbSystem,
+                schemaJson = payload.schemaJson,
+                explainPlanHash = payload.explainPlanHash,
+                explainPlan = payload.explainPlan,
+                timestampMs = System.currentTimeMillis(),
+            )
+        }
+        return enqueueBatch(QueuedDbmBatch(organizationId, "metadata", metadata = metadata), metadata.size, queueKey)
     }
 
     fun enqueueHealth(organizationId: Int, payload: DdDbmHealthPayload, queueKey: String = DBM_QUEUE_KEY): Int {
-        val entry = QueuedDbmHealthEntry(
-            host = payload.host,
-            dbSystem = payload.dbSystem,
-            agentVersion = payload.agentVersion,
-            status = payload.status,
-            checksRun = payload.checksRun,
-            checksFailed = payload.checksFailed,
-            hostName = payload.hostName,
-            timestampMs = System.currentTimeMillis(),
-        )
-        val batch = QueuedDbmBatch(organizationId, "health", health = listOf(entry))
+        return enqueueHealthPayloads(organizationId, listOf(payload), queueKey)
+    }
+
+    fun enqueueHealthPayloads(
+        organizationId: Int,
+        payloads: List<DdDbmHealthPayload>,
+        queueKey: String = DBM_QUEUE_KEY,
+    ): Int {
+        val health = payloads.map { payload ->
+            QueuedDbmHealthEntry(
+                host = payload.host,
+                dbSystem = payload.dbSystem,
+                agentVersion = payload.agentVersion,
+                status = payload.status,
+                checksRun = payload.checksRun,
+                checksFailed = payload.checksFailed,
+                hostName = payload.hostName,
+                timestampMs = System.currentTimeMillis(),
+            )
+        }
+        return enqueueBatch(QueuedDbmBatch(organizationId, "health", health = health), health.size, queueKey)
+    }
+
+    private fun enqueueBatch(batch: QueuedDbmBatch, entryCount: Int, queueKey: String): Int {
+        if (entryCount == 0) return 0
         RedisConfig.sync().lpush(queueKey, json.encodeToString(batch))
-        return 1
+        return entryCount
     }
 
     suspend fun insertBatch(batch: QueuedDbmBatch) {

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
@@ -438,9 +438,7 @@ object ProfileIngestionService {
         val sparkQuery = """
             SELECT
                 service,
-                toUnixTimestamp64Milli(
-                    toStartOfInterval(start_time, INTERVAL $sparkStep SECOND)
-                ) AS ts,
+                ${bucketTimestampMsSql("start_time", sparkStep)} AS ts,
                 count() AS count
             FROM `$clickhouseDb`.profiles
             WHERE $sparkWhere
@@ -516,9 +514,7 @@ object ProfileIngestionService {
         )
         val sql = """
             SELECT
-                toUnixTimestamp64Milli(
-                    toStartOfInterval(start_time, INTERVAL $stepSeconds SECOND)
-                ) AS ts,
+                ${bucketTimestampMsSql("start_time", stepSeconds)} AS ts,
                 count() AS count,
                 sum(size_bytes) AS sizeBytes
             FROM `$clickhouseDb`.profiles
@@ -709,6 +705,9 @@ object ProfileIngestionService {
         val windowSec = (toMs - fromMs) / MILLIS_PER_SECOND_L
         return (windowSec / SPARKLINE_BUCKETS).coerceAtLeast(MIN_BUCKET_SECONDS)
     }
+
+    private fun bucketTimestampMsSql(column: String, stepSeconds: Long): String =
+        "toInt64(toUnixTimestamp(toStartOfInterval($column, INTERVAL $stepSeconds SECOND))) * $MILLIS_PER_SECOND_L"
 
     private data class ExistingSession(
         val profileId: String,

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -130,10 +130,15 @@ class DatadogIngestRoutesTest {
         every { MiscIngestionService.enqueueContainerImage(any(), any()) } returns Unit
         every { MiscIngestionService.enqueueSbom(any(), any()) } returns 0
         every { DbmIngestionService.enqueueQueries(any(), any()) } returns 0
+        every { DbmIngestionService.enqueueQueryPayloads(any(), any()) } returns 0
         every { DbmIngestionService.enqueueMetrics(any(), any()) } returns 0
+        every { DbmIngestionService.enqueueMetricPayloads(any(), any()) } returns 0
         every { DbmIngestionService.enqueueActivity(any(), any()) } returns 0
+        every { DbmIngestionService.enqueueActivityPayloads(any(), any()) } returns 0
         every { DbmIngestionService.enqueueMetadata(any(), any()) } returns 0
+        every { DbmIngestionService.enqueueMetadataPayloads(any(), any()) } returns 0
         every { DbmIngestionService.enqueueHealth(any(), any()) } returns 0
+        every { DbmIngestionService.enqueueHealthPayloads(any(), any()) } returns 0
         every { DebuggerIngestionService.enqueueDebuggerLogs(any(), any()) } returns 0
         every { DebuggerIngestionService.enqueueDiagnostics(any(), any()) } returns 0
         every { OrchestratorIngestionService.enqueueResources(any(), any()) } returns 0
@@ -845,9 +850,9 @@ class DatadogIngestRoutesTest {
         }
         assertEquals(HttpStatusCode.Accepted, response.status)
         verify {
-            DbmIngestionService.enqueueQueries(
+            DbmIngestionService.enqueueQueryPayloads(
                 ORG_ID,
-                match { it.dbHost == "pg-primary" && it.rows.single().querySignature == "sig-1" },
+                match { it.single().dbHost == "pg-primary" && it.single().rows.single().querySignature == "sig-1" },
             )
         }
     }
@@ -862,7 +867,7 @@ class DatadogIngestRoutesTest {
             setBody("[{}]")
         }
         assertEquals(HttpStatusCode.Accepted, response.status)
-        verify(exactly = 0) { DbmIngestionService.enqueueQueries(any(), any()) }
+        verify { DbmIngestionService.enqueueQueryPayloads(ORG_ID, match { it.isEmpty() }) }
     }
 
     @Test
@@ -938,9 +943,12 @@ class DatadogIngestRoutesTest {
         }
         assertEquals(HttpStatusCode.Accepted, response.status)
         verify {
-            DbmIngestionService.enqueueActivity(
+            DbmIngestionService.enqueueActivityPayloads(
                 ORG_ID,
-                match { it.dbHost == "pg-primary" && it.activity.single().querySignature == "sig-activity" },
+                match {
+                    it.single().dbHost == "pg-primary" &&
+                        it.single().activity.single().querySignature == "sig-activity"
+                },
             )
         }
     }

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -49,6 +49,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import kotlin.test.AfterTest
@@ -818,6 +819,53 @@ class DatadogIngestRoutesTest {
     }
 
     @Test
+    fun `dbm databasequery accepts top-level array payload`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.post("/dd/api/v2/databasequery") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Application.Json)
+            setBody(
+                """
+                [
+                  {
+                    "db_host": "pg-primary",
+                    "db_system": "postgresql",
+                    "rows": [
+                      {
+                        "query_signature": "sig-1",
+                        "statement": "SELECT 1",
+                        "timestamp": 1700000000
+                      }
+                    ]
+                  }
+                ]
+                """.trimIndent()
+            )
+        }
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        verify {
+            DbmIngestionService.enqueueQueries(
+                ORG_ID,
+                match { it.dbHost == "pg-primary" && it.rows.single().querySignature == "sig-1" },
+            )
+        }
+    }
+
+    @Test
+    fun `dbm databasequery accepts empty array probe`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.post("/dd/api/v2/databasequery") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Application.Json)
+            setBody("[{}]")
+        }
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        verify(exactly = 0) { DbmIngestionService.enqueueQueries(any(), any()) }
+    }
+
+    @Test
     fun `dbm dbmmetrics returns 403 when api key is missing`() = testApplication {
         installRoutes()()
         val response = client.post("/dd/api/v2/dbmmetrics") {
@@ -859,6 +907,42 @@ class DatadogIngestRoutesTest {
             setBody("{}")
         }
         assertEquals(HttpStatusCode.Accepted, response.status)
+    }
+
+    @Test
+    fun `dbm dbmactivity accepts top-level array payload`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.post("/dd/api/v2/dbmactivity") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Application.Json)
+            setBody(
+                """
+                [
+                  {
+                    "db_host": "pg-primary",
+                    "db_system": "postgresql",
+                    "activity": [
+                      {
+                        "db_name": "postgres",
+                        "query_signature": "sig-activity",
+                        "statement": "SELECT pg_sleep(1)",
+                        "state": "active",
+                        "timestamp": 1700000000
+                      }
+                    ]
+                  }
+                ]
+                """.trimIndent()
+            )
+        }
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        verify {
+            DbmIngestionService.enqueueActivity(
+                ORG_ID,
+                match { it.dbHost == "pg-primary" && it.activity.single().querySignature == "sig-activity" },
+            )
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DbmIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DbmIngestionServiceTest.kt
@@ -19,6 +19,8 @@ package com.moneat.datadog.services
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdDbmActivityPayload
 import com.moneat.datadog.models.DdDbmActivityRow
+import com.moneat.datadog.models.DdDbmHealthPayload
+import com.moneat.datadog.models.DdDbmMetadataPayload
 import com.moneat.datadog.models.DdDbmMetricRow
 import com.moneat.datadog.models.DdDbmMetricsPayload
 import com.moneat.datadog.models.DdDbmQueryPayload
@@ -34,6 +36,8 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+
+private const val TEST_DBM_QUEUE = "test:dd:dbm:queue"
 
 class DbmIngestionServiceTest {
 
@@ -282,7 +286,7 @@ class DbmIngestionServiceTest {
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush("test:dd:dbm:queue", capture(queuedPayload)) } returns 1L
+            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
 
             val count = DbmIngestionService.enqueueQueryPayloads(
                 organizationId = 42,
@@ -296,7 +300,6 @@ class DbmIngestionServiceTest {
                         rows = listOf(DdDbmQueryRow(querySignature = "sig-b", statement = "SELECT 2")),
                     ),
                 ),
-                queueKey = "test:dd:dbm:queue",
             )
 
             val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
@@ -304,7 +307,202 @@ class DbmIngestionServiceTest {
             assertEquals(42, batch.organizationId)
             assertEquals("queries", batch.batchType)
             assertEquals(listOf("sig-a", "sig-b"), batch.queries.map { it.querySignature })
-            verify(exactly = 1) { redis.lpush("test:dd:dbm:queue", any<String>()) }
+            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueQueryPayloads skips Redis when batch is empty`() {
+        val redis = mockk<RedisCommands<String, String>>(relaxed = true)
+
+        mockkObject(RedisConfig)
+        try {
+            val count = DbmIngestionService.enqueueQueryPayloads(
+                organizationId = 42,
+                payloads = listOf(DdDbmQueryPayload(rows = emptyList())),
+            )
+
+            assertEquals(0, count)
+            verify(exactly = 0) { RedisConfig.sync() }
+            verify(exactly = 0) { redis.lpush(any<String>(), any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueMetricPayloads writes one combined Redis batch`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+
+            val count = DbmIngestionService.enqueueMetricPayloads(
+                organizationId = 42,
+                payloads = listOf(
+                    DdDbmMetricsPayload(
+                        dbHost = "pg-a",
+                        rows = listOf(DdDbmMetricRow(dbName = "db-a", querySignature = "sig-a", calls = 10)),
+                    ),
+                    DdDbmMetricsPayload(
+                        dbHost = "pg-b",
+                        rows = listOf(DdDbmMetricRow(dbName = "db-b", querySignature = "sig-b", calls = 20)),
+                    ),
+                ),
+            )
+
+            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(2, count)
+            assertEquals("metrics", batch.batchType)
+            assertEquals(listOf("sig-a", "sig-b"), batch.metrics.map { it.querySignature })
+            assertEquals(listOf(10L, 20L), batch.metrics.map { it.calls })
+            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueActivityPayloads writes one combined Redis batch`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+
+            val count = DbmIngestionService.enqueueActivityPayloads(
+                organizationId = 42,
+                payloads = listOf(
+                    DdDbmActivityPayload(
+                        dbHost = "pg-a",
+                        activity = listOf(
+                            DdDbmActivityRow(querySignature = "sig-a", statement = "SELECT 1", state = "active"),
+                        ),
+                    ),
+                    DdDbmActivityPayload(
+                        dbHost = "pg-b",
+                        activity = listOf(
+                            DdDbmActivityRow(querySignature = "sig-b", statement = "SELECT 2", state = "idle"),
+                        ),
+                    ),
+                ),
+            )
+
+            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(2, count)
+            assertEquals("activity", batch.batchType)
+            assertEquals(listOf("sig-a", "sig-b"), batch.activity.map { it.querySignature })
+            assertEquals(listOf("active", "idle"), batch.activity.map { it.state })
+            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueMetadataPayloads writes one combined Redis batch`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+
+            val count = DbmIngestionService.enqueueMetadataPayloads(
+                organizationId = 42,
+                payloads = listOf(
+                    DdDbmMetadataPayload(host = "pg-a", dbSystem = "postgres", schemaJson = """{"a":1}"""),
+                    DdDbmMetadataPayload(host = "pg-b", dbSystem = "postgres", explainPlanHash = "plan-b"),
+                ),
+            )
+
+            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(2, count)
+            assertEquals("metadata", batch.batchType)
+            assertEquals(listOf("pg-a", "pg-b"), batch.metadata.map { it.host })
+            assertEquals("plan-b", batch.metadata[1].explainPlanHash)
+            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueHealthPayloads writes one combined Redis batch`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+
+            val count = DbmIngestionService.enqueueHealthPayloads(
+                organizationId = 42,
+                payloads = listOf(
+                    DdDbmHealthPayload(host = "pg-a", status = "ok", checksRun = 3),
+                    DdDbmHealthPayload(host = "pg-b", status = "degraded", checksFailed = 1),
+                ),
+            )
+
+            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(2, count)
+            assertEquals("health", batch.batchType)
+            assertEquals(listOf("pg-a", "pg-b"), batch.health.map { it.host })
+            assertEquals(listOf("ok", "degraded"), batch.health.map { it.status })
+            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `single payload enqueue methods delegate to batch helpers`() {
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(TEST_DBM_QUEUE, any<String>()) } returns 1L
+
+            val counts = listOf(
+                DbmIngestionService.enqueueQueries(
+                    42,
+                    DdDbmQueryPayload(rows = listOf(DdDbmQueryRow(querySignature = "sig", statement = "SELECT 1"))),
+                    TEST_DBM_QUEUE,
+                ),
+                DbmIngestionService.enqueueMetrics(
+                    42,
+                    DdDbmMetricsPayload(rows = listOf(DdDbmMetricRow(querySignature = "sig", calls = 1))),
+                    TEST_DBM_QUEUE,
+                ),
+                DbmIngestionService.enqueueActivity(
+                    42,
+                    DdDbmActivityPayload(activity = listOf(DdDbmActivityRow(querySignature = "sig"))),
+                    TEST_DBM_QUEUE,
+                ),
+                DbmIngestionService.enqueueMetadata(
+                    42,
+                    DdDbmMetadataPayload(host = "pg-a", dbSystem = "postgres"),
+                    TEST_DBM_QUEUE,
+                ),
+                DbmIngestionService.enqueueHealth(
+                    42,
+                    DdDbmHealthPayload(host = "pg-a", status = "ok"),
+                    TEST_DBM_QUEUE,
+                ),
+            )
+
+            assertEquals(listOf(1, 1, 1, 1, 1), counts)
+            verify(exactly = 5) { redis.lpush(TEST_DBM_QUEUE, any<String>()) }
         } finally {
             unmockkObject(RedisConfig)
         }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DbmIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DbmIngestionServiceTest.kt
@@ -16,12 +16,20 @@
 
 package com.moneat.datadog.services
 
+import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DdDbmActivityPayload
 import com.moneat.datadog.models.DdDbmActivityRow
 import com.moneat.datadog.models.DdDbmMetricRow
 import com.moneat.datadog.models.DdDbmMetricsPayload
 import com.moneat.datadog.models.DdDbmQueryPayload
 import com.moneat.datadog.models.DdDbmQueryRow
+import io.lettuce.core.api.sync.RedisCommands
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -264,6 +272,42 @@ class DbmIngestionServiceTest {
         assertEquals("activity", decoded.batchType)
         assertEquals(1, decoded.activity.size)
         assertEquals(listOf(1L, 2L), decoded.activity[0].blockingPids)
+    }
+
+    @Test
+    fun `enqueueQueryPayloads writes one combined Redis batch`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush("test:dd:dbm:queue", capture(queuedPayload)) } returns 1L
+
+            val count = DbmIngestionService.enqueueQueryPayloads(
+                organizationId = 42,
+                payloads = listOf(
+                    DdDbmQueryPayload(
+                        dbHost = "pg-a",
+                        rows = listOf(DdDbmQueryRow(querySignature = "sig-a", statement = "SELECT 1")),
+                    ),
+                    DdDbmQueryPayload(
+                        dbHost = "pg-b",
+                        rows = listOf(DdDbmQueryRow(querySignature = "sig-b", statement = "SELECT 2")),
+                    ),
+                ),
+                queueKey = "test:dd:dbm:queue",
+            )
+
+            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(2, count)
+            assertEquals(42, batch.organizationId)
+            assertEquals("queries", batch.batchType)
+            assertEquals(listOf("sig-a", "sig-b"), batch.queries.map { it.querySignature })
+            verify(exactly = 1) { redis.lpush("test:dd:dbm:queue", any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
     }
 
     // ──── TAG PARSING TESTS ────

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
@@ -464,6 +464,9 @@ class ProfileIngestionServiceTest {
             assertEquals(0, service.series.single().ts)
             assertEquals(2, service.series.single().count)
             assertTrue(queries.any { it.contains("now() - INTERVAL") })
+            val sparkQuery = queries.single { it.contains("GROUP BY service, ts") }
+            assertTrue(sparkQuery.contains("toUnixTimestamp(toStartOfInterval"))
+            assertTrue(!sparkQuery.contains("toUnixTimestamp64Milli("))
         } finally {
             unmockkObject(ClickHouseClient)
         }
@@ -497,8 +500,11 @@ class ProfileIngestionServiceTest {
             assertEquals(60, response.bucketSeconds)
             assertEquals(4, response.points.single().count)
             assertEquals(4096, response.points.single().sizeBytes)
-            assertTrue(queries.single().contains("profile_type = 'cpu'"))
-            assertTrue(queries.single().contains("host = 'host-a'"))
+            val sql = queries.single()
+            assertTrue(sql.contains("profile_type = 'cpu'"))
+            assertTrue(sql.contains("host = 'host-a'"))
+            assertTrue(sql.contains("toUnixTimestamp(toStartOfInterval"))
+            assertTrue(!sql.contains("toUnixTimestamp64Milli("))
         } finally {
             unmockkObject(ClickHouseClient)
         }

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
@@ -466,6 +466,7 @@ class ProfileIngestionServiceTest {
             assertTrue(queries.any { it.contains("now() - INTERVAL") })
             val sparkQuery = queries.single { it.contains("GROUP BY service, ts") }
             assertTrue(sparkQuery.contains("toUnixTimestamp(toStartOfInterval"))
+            assertTrue(sparkQuery.contains("* 1000"))
             assertTrue(!sparkQuery.contains("toUnixTimestamp64Milli("))
         } finally {
             unmockkObject(ClickHouseClient)
@@ -504,6 +505,7 @@ class ProfileIngestionServiceTest {
             assertTrue(sql.contains("profile_type = 'cpu'"))
             assertTrue(sql.contains("host = 'host-a'"))
             assertTrue(sql.contains("toUnixTimestamp(toStartOfInterval"))
+            assertTrue(sql.contains("* 1000"))
             assertTrue(!sql.contains("toUnixTimestamp64Milli("))
         } finally {
             unmockkObject(ClickHouseClient)

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -213,10 +213,15 @@ class DatadogRoutesExtendedTest {
         every { MiscIngestionService.enqueueContainerImage(any(), any()) } just Runs
         every { MiscIngestionService.enqueueSbom(any(), any()) } returns 1
         every { DbmIngestionService.enqueueQueries(any(), any()) } returns 1
+        every { DbmIngestionService.enqueueQueryPayloads(any(), any()) } returns 1
         every { DbmIngestionService.enqueueMetrics(any(), any()) } returns 1
+        every { DbmIngestionService.enqueueMetricPayloads(any(), any()) } returns 1
         every { DbmIngestionService.enqueueActivity(any(), any()) } returns 1
+        every { DbmIngestionService.enqueueActivityPayloads(any(), any()) } returns 1
         every { DbmIngestionService.enqueueMetadata(any(), any()) } returns 1
+        every { DbmIngestionService.enqueueMetadataPayloads(any(), any()) } returns 1
         every { DbmIngestionService.enqueueHealth(any(), any()) } returns 1
+        every { DbmIngestionService.enqueueHealthPayloads(any(), any()) } returns 1
         every { OrchestratorIngestionService.enqueueResources(any(), any()) } returns 1
         every { OrchestratorIngestionService.enqueueManifests(any(), any()) } returns 1
         every { DebuggerIngestionService.enqueueDebuggerLogs(any(), any()) } returns 1


### PR DESCRIPTION
Fixes DBM array payload handling and profile bucket timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DBM ingest endpoints accept single JSON objects or top-level arrays (including empty-object probes) for batch submissions.

* **Bug Fixes**
  * Dashboard queries now use consistent millisecond-aligned bucket timestamps for more accurate sparklines and timeseries.

* **Tests**
  * Added tests covering array payloads, empty-array probes, and batch enqueue behavior for DBM ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->