### PR TITLE
fix: allow demo viewers to sign up

### DIFF
--- a/dashboard/src/routes/-signup-route-guard.ts
+++ b/dashboard/src/routes/-signup-route-guard.ts
@@ -1,0 +1,17 @@
+import {redirect} from '@tanstack/react-router'
+import {api} from '@/lib/api'
+import {isDemo} from '@/lib/demo'
+import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
+
+export async function ensureSignupRouteCanLoad() {
+  if (!api.isAuthenticated()) {
+    return
+  }
+
+  if (isDemo()) {
+    await api.logout()
+    return
+  }
+
+  throw redirect({ to: '/', search: APP_OVERVIEW_SEARCH })
+}

--- a/dashboard/src/routes/__tests__/-signup-route.test.tsx
+++ b/dashboard/src/routes/__tests__/-signup-route.test.tsx
@@ -18,17 +18,10 @@ vi.mock('@/lib/demo', () => ({
 }))
 
 vi.mock('@tanstack/react-router', () => ({
-  createFileRoute: () => (options: Record<string, unknown>) => ({
-    ...options,
-    options,
-  }),
-  Link: ({children}: {children: unknown}) => children,
   redirect: (opts: Record<string, unknown>) => ({...opts, __redirect: true}),
 }))
 
-import {Route as SignupRoute} from '../signup'
-
-const beforeLoad = (SignupRoute as unknown as {beforeLoad: () => Promise<void>}).beforeLoad
+import {ensureSignupRouteCanLoad} from '../-signup-route-guard'
 
 describe('signup route guard', () => {
   beforeEach(() => {
@@ -39,7 +32,7 @@ describe('signup route guard', () => {
   })
 
   it('lets unauthenticated visitors load signup', async () => {
-    await expect(beforeLoad()).resolves.toBeUndefined()
+    await expect(ensureSignupRouteCanLoad()).resolves.toBeUndefined()
 
     expect(mockApi.logout).not.toHaveBeenCalled()
   })
@@ -48,7 +41,7 @@ describe('signup route guard', () => {
     mockApi.isAuthenticated.mockReturnValue(true)
     mockIsDemo.mockReturnValue(true)
 
-    await expect(beforeLoad()).resolves.toBeUndefined()
+    await expect(ensureSignupRouteCanLoad()).resolves.toBeUndefined()
 
     expect(mockApi.logout).toHaveBeenCalledTimes(1)
   })
@@ -56,7 +49,7 @@ describe('signup route guard', () => {
   it('redirects signed-in non-demo users to the app overview', async () => {
     mockApi.isAuthenticated.mockReturnValue(true)
 
-    await expect(beforeLoad()).rejects.toMatchObject({
+    await expect(ensureSignupRouteCanLoad()).rejects.toMatchObject({
       __redirect: true,
       to: '/',
       search: APP_OVERVIEW_SEARCH,

--- a/dashboard/src/routes/__tests__/-signup-route.test.tsx
+++ b/dashboard/src/routes/__tests__/-signup-route.test.tsx
@@ -1,0 +1,67 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
+
+const {mockApi, mockIsDemo} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    logout: vi.fn(),
+  },
+  mockIsDemo: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+}))
+
+vi.mock('@/lib/demo', () => ({
+  isDemo: mockIsDemo,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    options,
+  }),
+  Link: ({children}: {children: unknown}) => children,
+  redirect: (opts: Record<string, unknown>) => ({...opts, __redirect: true}),
+}))
+
+import {Route as SignupRoute} from '../signup'
+
+const beforeLoad = (SignupRoute as unknown as {beforeLoad: () => Promise<void>}).beforeLoad
+
+describe('signup route guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.isAuthenticated.mockReturnValue(false)
+    mockApi.logout.mockResolvedValue(undefined)
+    mockIsDemo.mockReturnValue(false)
+  })
+
+  it('lets unauthenticated visitors load signup', async () => {
+    await expect(beforeLoad()).resolves.toBeUndefined()
+
+    expect(mockApi.logout).not.toHaveBeenCalled()
+  })
+
+  it('logs out demo viewers before loading signup', async () => {
+    mockApi.isAuthenticated.mockReturnValue(true)
+    mockIsDemo.mockReturnValue(true)
+
+    await expect(beforeLoad()).resolves.toBeUndefined()
+
+    expect(mockApi.logout).toHaveBeenCalledTimes(1)
+  })
+
+  it('redirects signed-in non-demo users to the app overview', async () => {
+    mockApi.isAuthenticated.mockReturnValue(true)
+
+    await expect(beforeLoad()).rejects.toMatchObject({
+      __redirect: true,
+      to: '/',
+      search: APP_OVERVIEW_SEARCH,
+    })
+
+    expect(mockApi.logout).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/routes/signup.tsx
+++ b/dashboard/src/routes/signup.tsx
@@ -20,6 +20,7 @@ import {Github} from 'lucide-react'
 import {api} from '@/lib/api'
 import {trackEvent} from '@/lib/analytics'
 import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
+import {isDemo} from '@/lib/demo'
 import {Button} from '@/components/ui/button'
 import {Checkbox} from '@/components/ui/checkbox'
 import {Input} from '@/components/ui/input'
@@ -29,12 +30,21 @@ import {AuthAlert, AuthDivider, AuthField, AuthShell} from '@/components/auth/Au
 import {authInputClass, authPrimaryButtonClass, authSecondaryButtonClass} from '@/components/auth/authStyles'
 import {Helmet} from 'react-helmet-async'
 
+async function ensureSignupRouteCanLoad() {
+  if (!api.isAuthenticated()) {
+    return
+  }
+
+  if (isDemo()) {
+    await api.logout()
+    return
+  }
+
+  throw redirect({ to: '/', search: APP_OVERVIEW_SEARCH })
+}
+
 export const Route = createFileRoute('/signup')({
-  beforeLoad: () => {
-    if (api.isAuthenticated()) {
-      throw redirect({ to: '/', search: APP_OVERVIEW_SEARCH })
-    }
-  },
+  beforeLoad: ensureSignupRouteCanLoad,
   component: SignupPage,
 })
 

--- a/dashboard/src/routes/signup.tsx
+++ b/dashboard/src/routes/signup.tsx
@@ -14,13 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {useState} from 'react'
 import {Github} from 'lucide-react'
 import {api} from '@/lib/api'
 import {trackEvent} from '@/lib/analytics'
-import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
-import {isDemo} from '@/lib/demo'
+import {ensureSignupRouteCanLoad} from './-signup-route-guard'
 import {Button} from '@/components/ui/button'
 import {Checkbox} from '@/components/ui/checkbox'
 import {Input} from '@/components/ui/input'
@@ -29,19 +28,6 @@ import {GRADIENT_TEXT} from '@/components/landing/Landing'
 import {AuthAlert, AuthDivider, AuthField, AuthShell} from '@/components/auth/AuthShell'
 import {authInputClass, authPrimaryButtonClass, authSecondaryButtonClass} from '@/components/auth/authStyles'
 import {Helmet} from 'react-helmet-async'
-
-async function ensureSignupRouteCanLoad() {
-  if (!api.isAuthenticated()) {
-    return
-  }
-
-  if (isDemo()) {
-    await api.logout()
-    return
-  }
-
-  throw redirect({ to: '/', search: APP_OVERVIEW_SEARCH })
-}
 
 export const Route = createFileRoute('/signup')({
   beforeLoad: ensureSignupRouteCanLoad,


### PR DESCRIPTION
## Summary
- allow demo sessions to exit to signup instead of redirecting back to overview
- add route guard coverage for unauthenticated, demo, and authenticated users

## Tests
- npm test -- --run src/routes/__tests__/-signup-route.test.tsx
- npm run typecheck
- npm run lint
- git diff --check

## Notes
- In-app Browser validation was blocked by ERR_BLOCKED_BY_CLIENT on local targets; backend demo-login was verified directly against the local worktree backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signup access now correctly handles signed-in vs signed-out users and preserves overview navigation when redirecting signed-in users.

* **Refactor**
  * Replaced inline access check with a centralized signup access guard for clearer, consistent behavior.

* **Tests**
  * Added tests covering unauthenticated access, demo-mode logout behavior, and redirect behavior for authenticated users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->