### PR TITLE
fix: keep landing page chrome public

### DIFF
--- a/dashboard/src/lib/__tests__/overview-route.test.ts
+++ b/dashboard/src/lib/__tests__/overview-route.test.ts
@@ -3,6 +3,7 @@ import {
   APP_OVERVIEW_SEARCH,
   APP_OVERVIEW_VIEW,
   isAppOverviewSearch,
+  isPublicLandingRoute,
   normalizeAppOverviewSearch,
 } from '@/lib/overview-route'
 
@@ -20,5 +21,16 @@ describe('overview-route', () => {
     expect(isAppOverviewSearch(APP_OVERVIEW_SEARCH)).toBe(true)
     expect(isAppOverviewSearch({view: 'landing'})).toBe(false)
     expect(isAppOverviewSearch(null)).toBe(false)
+  })
+
+  it('detects plain root as the public landing route', () => {
+    expect(isPublicLandingRoute('/', {})).toBe(true)
+    expect(isPublicLandingRoute('/', {view: 'landing'})).toBe(true)
+    expect(isPublicLandingRoute('//', {})).toBe(true)
+  })
+
+  it('keeps the explicit app overview route separate from landing', () => {
+    expect(isPublicLandingRoute('/', APP_OVERVIEW_SEARCH)).toBe(false)
+    expect(isPublicLandingRoute('/issues', {})).toBe(false)
   })
 })

--- a/dashboard/src/lib/overview-route.ts
+++ b/dashboard/src/lib/overview-route.ts
@@ -37,3 +37,12 @@ export function isAppOverviewSearch(search: unknown): boolean {
     search.view === APP_OVERVIEW_VIEW
   )
 }
+
+function normalizeRoutePath(pathname: string): string {
+  if (!pathname || pathname === '/') return '/'
+  return pathname.replace(/\/+$/, '') || '/'
+}
+
+export function isPublicLandingRoute(pathname: string, search: unknown): boolean {
+  return normalizeRoutePath(pathname) === '/' && !isAppOverviewSearch(search)
+}

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -22,8 +22,8 @@ import {CommandPalette} from '../components/CommandPalette'
 import {CommandPaletteProvider} from '../contexts/CommandPaletteProvider'
 import {Toaster} from '../components/ui/toaster'
 import {api} from '../lib/api'
-import {isDemo, setDemoEpoch} from '../lib/demo'
-import {APP_OVERVIEW_SEARCH, isAppOverviewSearch} from '../lib/overview-route'
+import {setDemoEpoch} from '../lib/demo'
+import {APP_OVERVIEW_SEARCH, isPublicLandingRoute} from '../lib/overview-route'
 import {DemoBanner} from '../components/demo/DemoBanner'
 import {AiFloatingPanel} from '../components/AiFloatingPanel'
 import {AiSplitPanel} from '../components/AiSplitPanel'
@@ -269,9 +269,15 @@ function RootComponent() {
     queryFn: () => api.getCurrentUser(),
     enabled: isAuthenticated,
   })
-  const isOverviewView = isAppOverviewSearch(router.location.search)
-  const isDemoSession = isAuthenticated && isDemo()
-  const isLandingPage = currentPath === '/' && (!isAuthenticated || (isDemoSession && !isOverviewView))
+  const isLandingPage = isPublicLandingRoute(currentPath, router.location.search)
+  const isPublicRoute = (
+    isLandingPage ||
+    PUBLIC_ROUTES.has(currentPath) ||
+    currentPath.startsWith('/s/') ||
+    currentPath.startsWith('/auth/') ||
+    currentPath.startsWith('/legal/') ||
+    currentPath.startsWith('/docs')
+  )
 
   // Initialize demo mode when user data is loaded
   useEffect(() => {
@@ -290,7 +296,7 @@ function RootComponent() {
 
     async function checkUserStatus() {
       // Skip check on public routes and status pages
-      if (PUBLIC_ROUTES.has(currentPath) || currentPath.startsWith('/s/') || currentPath.startsWith('/auth/') || currentPath.startsWith('/legal/') || currentPath.startsWith('/docs')) {
+      if (isPublicRoute) {
         setOnboardingChecked(true)
         setAuthCheckComplete(true)
         return
@@ -316,19 +322,11 @@ function RootComponent() {
     return () => {
       cancelled = true
     }
-  }, [isAuthenticated, currentPath, navigate])
+  }, [isAuthenticated, isPublicRoute])
 
   useEffect(() => {
     if (!isAuthenticated || !user) return
-    if (
-      PUBLIC_ROUTES.has(currentPath) ||
-      currentPath.startsWith('/s/') ||
-      currentPath.startsWith('/auth/') ||
-      currentPath.startsWith('/legal/') ||
-      currentPath.startsWith('/docs')
-    ) {
-      return
-    }
+    if (isPublicRoute) return
 
     if (!user.emailVerified && currentPath !== '/verify-email-required') {
       navigate({ to: '/verify-email-required' })
@@ -338,17 +336,24 @@ function RootComponent() {
     if (!user.onboardingCompleted && currentPath !== '/onboarding') {
       navigate({ to: '/onboarding' })
     }
-  }, [currentPath, isAuthenticated, navigate, user])
+  }, [currentPath, isAuthenticated, isPublicRoute, navigate, user])
   
-  // Don't show sidebar on auth pages, landing page (when logged out), or public status pages
-  const isAuthPage = ['/login', '/signup', '/verify-email', '/verify-email-required', '/forgot-password', '/reset-password', '/onboarding'].includes(currentPath)
+  // Don't show sidebar on auth pages, landing page, or public status pages
+  const isAuthPage = [
+    '/login',
+    '/signup',
+    '/verify-email',
+    '/verify-email-required',
+    '/forgot-password',
+    '/reset-password',
+    '/onboarding',
+  ].includes(currentPath)
   const isPublicStatusPage = currentPath.startsWith('/s/')
   const isFeaturePage = (FEATURE_ROUTES as readonly string[]).includes(currentPath)
   const showSidebar = isAuthenticated && !isAuthPage && !isLandingPage && !isPublicStatusPage && !isFeaturePage
   const sidebarWidth = isSidebarExpanded ? SIDEBAR_EXPANDED_WIDTH : SIDEBAR_COLLAPSED_WIDTH
 
   // Show loading state while checking auth and onboarding
-  const isPublicRoute = PUBLIC_ROUTES.has(currentPath) || currentPath.startsWith('/s/') || currentPath.startsWith('/auth/') || currentPath.startsWith('/legal/') || currentPath.startsWith('/docs')
   if (!authCheckComplete && !isPublicRoute) {
     return null
   }
@@ -380,7 +385,7 @@ function RootComponent() {
           className="transition-[margin-left] duration-300"
           style={{ marginLeft: 0 }}
         >
-          <DemoBanner />
+          {isAuthenticated && !isPublicRoute && <DemoBanner />}
           <Outlet />
         </div>
       )}

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -22,7 +22,7 @@ import {api, type StatusPageDetail, type UptimeHeartbeat} from '@/lib/api'
 import {useProject} from '@/contexts/ProjectContext'
 import {hasEnterpriseModule, useEnterpriseFeatures} from '@/hooks/useEnterpriseFeatures'
 import {formatRelativeTime} from '@/lib/utils'
-import {APP_OVERVIEW_VIEW, normalizeAppOverviewSearch} from '@/lib/overview-route'
+import {APP_OVERVIEW_SEARCH, APP_OVERVIEW_VIEW, normalizeAppOverviewSearch} from '@/lib/overview-route'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {levelBadgeVariant, levelBorderClass} from '@/lib/severity'
 import {Button} from '@/components/ui/button'
@@ -54,7 +54,7 @@ import {
 } from 'lucide-react'
 import {StatsCard, StatsCardSkeleton} from '@/components/charts/StatsCard'
 import {EventsChart, EventsChartSkeleton} from '@/components/charts/EventsChart'
-import {getNow, isDemo} from '@/lib/demo'
+import {getNow} from '@/lib/demo'
 
 // ─── Incident status → badge variant ─────────────────────────────────
 function incidentStatusVariant(status: string): BadgeProps['variant'] {
@@ -216,9 +216,13 @@ function IndexPage() {
     return null
   }
 
-  const showPublicLandingPage = !isAuthenticated || (isDemo() && view !== APP_OVERVIEW_VIEW)
+  const isOverviewView = view === APP_OVERVIEW_VIEW
+  const showPublicLandingPage = !isAuthenticated || !isOverviewView
   if (showPublicLandingPage) {
     if (features?.selfHost) {
+      if (isAuthenticated) {
+        return <Navigate to="/" search={APP_OVERVIEW_SEARCH} />
+      }
       return <Navigate to="/login" />
     }
     return <LandingPage />


### PR DESCRIPTION
## Summary
- keep plain `/` on the public landing shell
- keep the app overview on `/?view=overview`
- suppress app-only demo chrome on public routes

## Validation
- `npm run test -- --run src/lib/__tests__/overview-route.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of public landing routes to properly handle root paths and various search parameter states.

* **Improvements**
  * Enhanced route classification logic to better separate public landing pages from authenticated sections.
  * Updated demo banner visibility to display only for authenticated users on non-public routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->