### PR TITLE
feat: add telemetry version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,10 @@ Authenticate with an OTLP API key (created in **Settings → OTLP API Keys**) pa
 
 ## Telemetry
 
-Self-hosted deployments collect anonymous usage telemetry (CPU count, memory, aggregate event counts, deployment config). No personal data, event contents, or secrets are collected. [Learn more.](https://moneat.io/docs/self-hosting/telemetry)
+Self-hosted deployments send a periodic telemetry pulse. These are the exact fields included:
+Moneat version, CPU count, memory usage, OS name and architecture, JVM version, aggregate
+project/user/event/issue counts, SSL enabled status, and a random deployment ID. No other fields
+are included in the telemetry payload. [Learn more.](https://moneat.io/docs/self-hosting/telemetry)
 
 Opt out:
 

--- a/backend/src/main/kotlin/com/moneat/events/routes/TelemetryIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/TelemetryIngestRoutes.kt
@@ -42,12 +42,13 @@ fun Route.telemetryIngestRoutes(
         ClickHouseClient.execute(
             """
             INSERT INTO telemetry_pulses (
-                deployment_id, cpu_count, mem_total_bytes, mem_used_bytes,
+                deployment_id, version, cpu_count, mem_total_bytes, mem_used_bytes,
                 os_name, os_arch, jvm_version,
                 project_count, user_count, event_count, issue_count,
                 ssl_enabled
             ) VALUES (
                 '${esc(pulse.deploymentId)}',
+                '${esc(pulse.version)}',
                 ${pulse.cpuCount},
                 ${pulse.memTotalBytes},
                 ${pulse.memUsedBytes},

--- a/backend/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
@@ -77,6 +77,7 @@ private val adminJson = Json { ignoreUnknownKeys = true }
 data class ReceivedPulse(
     val deploymentId: String,
     val receivedAt: String,
+    val version: String,
     val cpuCount: Int,
     val memTotalBytes: Long,
     val memUsedBytes: Long,
@@ -103,6 +104,7 @@ private suspend fun queryReceivedTelemetry(): ReceivedTelemetryStatus {
         SELECT
             deployment_id,
             toString(argMax(received_at, received_at)) AS last_seen,
+            argMax(version, received_at)          AS version,
             argMax(cpu_count, received_at)       AS cpu_count,
             argMax(mem_total_bytes, received_at) AS mem_total_bytes,
             argMax(mem_used_bytes, received_at)  AS mem_used_bytes,
@@ -138,6 +140,7 @@ private suspend fun queryReceivedTelemetry(): ReceivedTelemetryStatus {
                 ReceivedPulse(
                     deploymentId = obj["deployment_id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null,
                     receivedAt = obj["last_seen"]?.jsonPrimitive?.contentOrNull ?: "",
+                    version = obj["version"]?.jsonPrimitive?.contentOrNull ?: "",
                     cpuCount = obj["cpu_count"]?.jsonPrimitive?.intOrNull ?: 0,
                     memTotalBytes = obj["mem_total_bytes"]?.jsonPrimitive?.longOrNull ?: 0,
                     memUsedBytes = obj["mem_used_bytes"]?.jsonPrimitive?.longOrNull ?: 0,

--- a/backend/src/main/kotlin/com/moneat/shared/services/PulseService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/PulseService.kt
@@ -43,12 +43,10 @@ import kotlin.time.Duration.Companion.hours
 private val logger = KotlinLogging.logger {}
 
 /**
- * PulseService collects anonymous, aggregated telemetry from self-hosted Moneat
- * deployments. This helps us understand how Moneat is used in the wild so we can
- * prioritise features, resource requirements, and compatibility.
+ * PulseService sends the small self-hosted usage pulse described by PulsePayload.
+ * It reports version adoption and rough instance size.
  *
  * - Only active when SELF_HOSTED=true and TELEMETRY_ENABLED=true (the default).
- * - No personally-identifiable information is ever collected.
  * - Set TELEMETRY_ENABLED=false to disable.
  *
  * @see <a href="https://moneat.io/docs/self-hosting/telemetry">Telemetry docs</a>
@@ -102,6 +100,7 @@ class PulseService(
 
         return PulsePayload(
             deploymentId = getOrCreateDeploymentId(),
+            version = resolveVersion(),
             // System
             cpuCount = runtime.availableProcessors(),
             memTotalBytes = runtime.maxMemory(),
@@ -209,8 +208,20 @@ class PulseService(
         return backendUrl.startsWith("https://") || frontendUrl.startsWith("https://")
     }
 
+    private fun resolveVersion(): String {
+        return sequenceOf(
+            EnvConfig.get("MONEAT_VERSION"),
+            EnvConfig.get("RELEASE_VERSION"),
+            System.getProperty("app.version")
+        )
+            .mapNotNull { it?.trim() }
+            .firstOrNull { it.isNotBlank() }
+            ?: DEFAULT_VERSION
+    }
+
     companion object {
         private const val PULSE_INTERVAL_MS = 60_000L
+        private const val DEFAULT_VERSION = "dev"
 
         fun isEnabled(): Boolean {
             val selfHost = EnvConfig.SelfHost.enabled
@@ -252,6 +263,7 @@ class PulseService(
 @Serializable
 data class PulsePayload(
     val deploymentId: String,
+    val version: String = "",
     // System metrics
     val cpuCount: Int = 0,
     val memTotalBytes: Long = 0,

--- a/backend/src/main/kotlin/com/moneat/shared/services/PulseService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/PulseService.kt
@@ -221,7 +221,7 @@ class PulseService(
 
     companion object {
         private const val PULSE_INTERVAL_MS = 60_000L
-        private const val DEFAULT_VERSION = "dev"
+        private const val DEFAULT_VERSION = ""
 
         fun isEnabled(): Boolean {
             val selfHost = EnvConfig.SelfHost.enabled

--- a/backend/src/main/resources/db/clickhouse_migration/V49__add_telemetry_pulse_version.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V49__add_telemetry_pulse_version.sql
@@ -1,0 +1,4 @@
+-- Track the Moneat release version reported by anonymous self-hosted telemetry pulses.
+
+ALTER TABLE telemetry_pulses
+    ADD COLUMN IF NOT EXISTS version LowCardinality(String) DEFAULT '' AFTER deployment_id;

--- a/backend/src/test/kotlin/com/moneat/routes/TelemetryIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/TelemetryIngestRoutesTest.kt
@@ -42,6 +42,7 @@ class TelemetryIngestRoutesTest {
 
     private fun samplePayload(deploymentId: String = "test-deploy-abc123") = PulsePayload(
         deploymentId = deploymentId,
+        version = "v1.2.3",
         cpuCount = 8,
         memTotalBytes = 8_589_934_592L,
         memUsedBytes = 2_147_483_648L,
@@ -74,6 +75,7 @@ class TelemetryIngestRoutesTest {
         assertEquals(1, captured.size)
         val pulse = captured.first()
         assertEquals("test-deploy-abc123", pulse.deploymentId)
+        assertEquals("v1.2.3", pulse.version)
         assertEquals(8, pulse.cpuCount)
         assertEquals(8_589_934_592L, pulse.memTotalBytes)
         assertEquals(2_147_483_648L, pulse.memUsedBytes)
@@ -167,6 +169,7 @@ class TelemetryIngestRoutesTest {
                 """
                 {
                   "deploymentId": "deploy-xyz",
+                  "version": "v2.0.0",
                   "cpuCount": 4,
                   "memTotalBytes": 4294967296,
                   "memUsedBytes": 1073741824,
@@ -187,5 +190,6 @@ class TelemetryIngestRoutesTest {
 
         assertEquals(HttpStatusCode.Accepted, response.status)
         assertEquals("deploy-xyz", captured.first().deploymentId)
+        assertEquals("v2.0.0", captured.first().version)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/SharedServicesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SharedServicesTest.kt
@@ -567,6 +567,7 @@ class SharedServicesTest {
     fun `PulsePayload serializes and deserializes correctly`() {
         val payload = PulsePayload(
             deploymentId = "test-id-123",
+            version = "v1.2.3",
             cpuCount = 4,
             memTotalBytes = 8_000_000_000,
             memUsedBytes = 4_000_000_000,
@@ -586,6 +587,7 @@ class SharedServicesTest {
         val decoded = json.decodeFromString(PulsePayload.serializer(), encoded)
 
         assertEquals(payload.deploymentId, decoded.deploymentId)
+        assertEquals(payload.version, decoded.version)
         assertEquals(payload.cpuCount, decoded.cpuCount)
         assertEquals(payload.memTotalBytes, decoded.memTotalBytes)
         assertEquals(payload.memUsedBytes, decoded.memUsedBytes)
@@ -599,6 +601,7 @@ class SharedServicesTest {
         val payload = PulsePayload(deploymentId = "minimal")
 
         assertEquals(0, payload.cpuCount)
+        assertEquals("", payload.version)
         assertEquals(0L, payload.memTotalBytes)
         assertEquals("", payload.osName)
         assertEquals(0L, payload.projectCount)

--- a/dashboard/src/docs/pages/self-hosting.mdx
+++ b/dashboard/src/docs/pages/self-hosting.mdx
@@ -73,4 +73,8 @@ Database migrations run automatically on backend startup.
 
 ## Telemetry
 
-Self-hosted deployments collect anonymous usage telemetry (aggregate event counts, deployment config). No personal data or event contents are collected. Opt out by setting `TELEMETRY_ENABLED=false` in your `.env`.
+Self-hosted deployments send a periodic telemetry pulse. These are the exact fields included:
+Moneat version, CPU count, memory usage, OS name and architecture, JVM version, aggregate
+project/user/event/issue counts, SSL enabled status, and a random deployment ID. No other fields
+are included in the telemetry payload. Turn it off by setting
+`TELEMETRY_ENABLED=false` in your `.env`.

--- a/dashboard/src/lib/api/modules/__tests__/admin.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/admin.test.ts
@@ -717,6 +717,7 @@ describe('adminMethods', () => {
           {
             deploymentId: 'dep-1',
             receivedAt: '2026-01-01T00:00:00Z',
+            version: 'v1.2.3',
             cpuCount: 4,
             memTotalBytes: 8000000000,
             memUsedBytes: 4000000000,

--- a/dashboard/src/lib/api/modules/admin.ts
+++ b/dashboard/src/lib/api/modules/admin.ts
@@ -283,6 +283,7 @@ export function adminMethods(core: ApiClientCore) {
         deployments: {
           deploymentId: string
           receivedAt: string
+          version: string
           cpuCount: number
           memTotalBytes: number
           memUsedBytes: number

--- a/dashboard/src/routes/admin.telemetry.tsx
+++ b/dashboard/src/routes/admin.telemetry.tsx
@@ -17,7 +17,7 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
-import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
+import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
@@ -47,7 +47,7 @@ function AdminTelemetryPage() {
     <div className="space-y-8">
       <SectionHeader
         title="Telemetry"
-        description="Anonymous usage diagnostics received from self-hosted deployments."
+        description="Exact fields received from self-hosted deployments with telemetry enabled."
       />
 
       {/* Summary */}
@@ -85,7 +85,9 @@ function AdminTelemetryPage() {
                 <Radio className="h-5 w-5 text-chart-6" />
               </div>
               <div>
-                <p className="text-sm font-medium">{lastSeenAt ? formatDateTime(new Date(lastSeenAt), timezone) : '—'}</p>
+                <p className="text-sm font-medium">
+                  {lastSeenAt ? formatDateTime(new Date(lastSeenAt), timezone) : '—'}
+                </p>
                 <p className="text-sm text-muted-foreground">Last pulse received</p>
               </div>
             </div>
@@ -99,7 +101,8 @@ function AdminTelemetryPage() {
           <CardContent className="py-12 text-center">
             <Radio className="h-10 w-10 text-muted-foreground/40 mx-auto mb-3" />
             <p className="text-sm text-muted-foreground">
-              No telemetry pulses received yet. Self-hosted instances send a pulse every 4 hours when <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">TELEMETRY_ENABLED=true</code>.
+              No telemetry pulses received yet. Self-hosted instances send a pulse every 4 hours when{' '}
+              <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">TELEMETRY_ENABLED=true</code>.
             </p>
           </CardContent>
         </Card>
@@ -115,6 +118,7 @@ function AdminTelemetryPage() {
               <TableHeader>
                 <TableRow className="hover:bg-transparent">
                   <TableHead className="text-xs">Deployment</TableHead>
+                  <TableHead className="text-xs">Version</TableHead>
                   <TableHead className="text-xs">Environment</TableHead>
                   <TableHead className="text-xs">SSL</TableHead>
                   <TableHead className="text-xs text-right">CPU</TableHead>
@@ -147,6 +151,9 @@ function AdminTelemetryPage() {
                           <Copy className="h-3 w-3" />
                         </Button>
                       </div>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {d.version || 'unknown'}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       {d.osName} {d.osArch} · JVM {d.jvmVersion}
@@ -188,43 +195,6 @@ function AdminTelemetryPage() {
         </Card>
       )}
 
-      {/* What We Collect */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">What We Collect</CardTitle>
-          <CardDescription>
-            All data is anonymous and tied only to a randomly-generated deployment ID. No personal
-            information, event contents, or secrets are ever transmitted.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 text-sm">
-            <div>
-              <p className="font-medium mb-2 text-success-fg">✓ Collected</p>
-              <ul className="space-y-1 text-muted-foreground">
-                <li>• CPU count, memory usage, OS name &amp; architecture</li>
-                <li>• JVM version</li>
-                <li>• Aggregate counts: projects, users, events, issues</li>
-                <li>• SSL enabled status</li>
-                <li>• Randomly-generated deployment identifier</li>
-              </ul>
-            </div>
-            <div>
-              <p className="font-medium mb-2 text-danger-fg">✗ Never Collected</p>
-              <ul className="space-y-1 text-muted-foreground">
-                <li>• User emails, names, or personal data</li>
-                <li>• Event contents, stack traces, or session replays</li>
-                <li>• API keys, DSNs, or secrets</li>
-                <li>• IP addresses or geolocation</li>
-              </ul>
-            </div>
-          </div>
-          <div className="mt-6 p-3 rounded-lg bg-muted/50 text-xs text-muted-foreground">
-            Self-hosted instances opt out by setting <code className="font-mono bg-muted px-1 py-0.5 rounded">TELEMETRY_ENABLED=false</code> in
-            their <code className="font-mono bg-muted px-1 py-0.5 rounded">.env</code> file.
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }

--- a/install.sh
+++ b/install.sh
@@ -320,9 +320,16 @@ prompt_smtp() {
 
 prompt_telemetry() {
   echo
+  info "Anonymous telemetry fields:"
+  info "  - Moneat version"
+  info "  - CPU count, memory usage, OS name and architecture"
+  info "  - JVM version"
+  info "  - Aggregate project, user, event, and issue counts"
+  info "  - SSL enabled status"
+  info "  - Random deployment ID"
   if prompt_yes_no "Enable anonymous telemetry to help improve Moneat?" "y"; then
     TELEMETRY_ENABLED=true
-    success "Telemetry enabled (anonymous usage stats only)"
+    success "Telemetry enabled"
   else
     TELEMETRY_ENABLED=false
     info "Telemetry disabled"


### PR DESCRIPTION
## Summary
- report the Moneat version in self-hosted telemetry pulses
- store and show the latest version per telemetry deployment
- list telemetry fields during install and in docs

## Tests
- bash -n install.sh
- git diff --check
- npm test -- src/lib/api/modules/__tests__/admin.test.ts
- npm run lint
- npm run typecheck
- ./gradlew compileKotlin detekt
- ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" -Dkotlin.compiler.execution.strategy=in-process :test --tests com.moneat.routes.TelemetryIngestRoutesTest --tests com.moneat.services.SharedServicesTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Telemetry pulses now include deployment version information.
  * Admin dashboard displays deployment versions in the telemetry table.

* **Documentation**
  * Updated documentation to detail specific telemetry fields collected (version, system metrics, usage counts, SSL status, deployment ID).
  * Installation script clarifies telemetry data collection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->