### PR TITLE
fix: scope alert workflows to episodes

### DIFF
--- a/backend/src/main/kotlin/com/moneat/Application.kt
+++ b/backend/src/main/kotlin/com/moneat/Application.kt
@@ -20,7 +20,7 @@ import com.moneat.config.EnvConfig
 import com.moneat.config.EnvironmentValidator
 import com.moneat.config.configureClickHouse
 import com.moneat.config.configureRedis
-import com.moneat.di.appModules
+import com.moneat.di.buildAppModules
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.plugins.configureBackgroundJobs
 import com.moneat.plugins.configureDatabases
@@ -82,7 +82,8 @@ fun Application.module() {
 
     install(Koin) {
         slf4jLogger()
-        modules(appModules)
+        val frontendBaseUrl = environment.config.property("email.frontendUrl").getString()
+        modules(buildAppModules(frontendBaseUrl = frontendBaseUrl))
     }
     if (workflowWorkerMode() == WorkflowWorkerMode.EGRESS) {
         configureSerialization()

--- a/backend/src/main/kotlin/com/moneat/alerts/models/AlertEpisodeModels.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/models/AlertEpisodeModels.kt
@@ -1,0 +1,72 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.alerts.models
+
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+
+object AlertEpisodes : IntIdTable("alert_episodes") {
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val sourceName = varchar("source", 64)
+    val deduplicationKey = text("deduplication_key")
+    val episodeSeq = integer("episode_seq")
+    val episodeKey = text("episode_key")
+    val status = varchar("status", 20)
+    val openedAt = timestamp("opened_at")
+    val lastSeenAt = timestamp("last_seen_at")
+    val resolvedAt = timestamp("resolved_at").nullable()
+    val lastNotificationAt = timestamp("last_notification_at").nullable()
+    val notificationCount = integer("notification_count").default(0)
+    val suppressedAt = timestamp("suppressed_at").nullable()
+    val suppressedByUserId = integer("suppressed_by_user_id")
+        .references(Users.id, onDelete = ReferenceOption.SET_NULL)
+        .nullable()
+    val suppressReason = varchar("suppress_reason", 255).nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+}
+
+@Serializable
+data class AlertEpisodeResponse(
+    val id: Int,
+    @SerialName("organization_id") val organizationId: Int,
+    val source: String,
+    @SerialName("deduplication_key") val deduplicationKey: String,
+    @SerialName("episode_seq") val episodeSeq: Int,
+    @SerialName("episode_key") val episodeKey: String,
+    val status: String,
+    @SerialName("opened_at") val openedAt: String,
+    @SerialName("last_seen_at") val lastSeenAt: String,
+    @SerialName("resolved_at") val resolvedAt: String? = null,
+    @SerialName("last_notification_at") val lastNotificationAt: String? = null,
+    @SerialName("notification_count") val notificationCount: Int,
+    @SerialName("suppressed_at") val suppressedAt: String? = null,
+    @SerialName("suppressed_by_user_id") val suppressedByUserId: Int? = null,
+    @SerialName("suppress_reason") val suppressReason: String? = null,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+@Serializable
+data class SuppressAlertEpisodeRequest(
+    val reason: String? = null
+)

--- a/backend/src/main/kotlin/com/moneat/alerts/services/AlertEpisodeService.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/services/AlertEpisodeService.kt
@@ -1,0 +1,494 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.alerts.services
+
+import com.moneat.alerts.models.AlertEpisodeResponse
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertSource
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+private const val FIRING_STATUS = "FIRING"
+private const val RESOLVED_STATUS = "RESOLVED"
+private const val INITIAL_NOTIFICATION_KIND = "initial"
+private const val REMINDER_NOTIFICATION_KIND = "reminder"
+private const val RESOLVED_NOTIFICATION_KIND = "resolved"
+private const val MAX_SUPPRESS_REASON_CHARS = 255
+private val ALERT_REMINDER_INTERVAL = 24.hours
+
+class AlertEpisodeService {
+    fun recordFiring(
+        event: AlertLifecycleEvent,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeDecision? =
+        recordFiring(
+            organizationId = event.organizationId,
+            source = event.source.name,
+            deduplicationKey = event.deduplicationKey,
+            now = now,
+            reservePublication = true
+        )
+
+    fun ensureOpenEpisodeForWorkflow(
+        event: AlertLifecycleEvent,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeContext? {
+        val decision = recordFiring(
+            organizationId = event.organizationId,
+            source = event.source.name,
+            deduplicationKey = event.deduplicationKey,
+            now = now,
+            reservePublication = false
+        )
+        return decision?.takeIf { it.shouldPublish }?.episode
+    }
+
+    fun latestEpisodeForWorkflow(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String
+    ): AlertEpisodeContext? =
+        transaction {
+            AlertEpisodes
+                .selectAll()
+                .where {
+                    (AlertEpisodes.organizationId eq organizationId) and
+                        (AlertEpisodes.sourceName eq source.name) and
+                        (AlertEpisodes.deduplicationKey eq deduplicationKey)
+                }
+                .orderBy(AlertEpisodes.lastSeenAt to SortOrder.DESC)
+                .limit(1)
+                .firstOrNull()
+                ?.toContext()
+                ?.takeIf { it.suppressedAt == null && it.notificationCount > 0 }
+        }
+
+    fun recordResolved(
+        event: AlertLifecycleEvent,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeDecision? =
+        recordResolved(
+            organizationId = event.organizationId,
+            source = event.source.name,
+            deduplicationKey = event.deduplicationKey,
+            now = now
+        )
+
+    fun recordResolved(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeDecision? =
+        recordResolved(organizationId, source.name, deduplicationKey, now)
+
+    fun closeCurrentEpisode(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String,
+        now: Instant = Clock.System.now()
+    ) {
+        recordResolved(organizationId, source.name, deduplicationKey, now)
+    }
+
+    fun openCurrentEpisode(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeContext? =
+        recordFiring(
+            organizationId = organizationId,
+            source = source.name,
+            deduplicationKey = deduplicationKey,
+            now = now,
+            reservePublication = false
+        )?.episode
+
+    fun suppressCurrentEpisode(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String,
+        userId: Int?,
+        reason: String?,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeResponse? =
+        transaction {
+            val row = findOpenEpisodeForUpdate(organizationId, source.name, deduplicationKey) ?: return@transaction null
+            suppressEpisodeInTransaction(row[AlertEpisodes.id].value, userId, reason, now)
+            findEpisode(row[AlertEpisodes.id].value, organizationId)?.toResponse()
+        }
+
+    fun unsuppressCurrentEpisode(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeResponse? =
+        transaction {
+            val row = findOpenEpisodeForUpdate(organizationId, source.name, deduplicationKey) ?: return@transaction null
+            AlertEpisodes.update({ AlertEpisodes.id eq row[AlertEpisodes.id].value }) {
+                it[suppressedAt] = null
+                it[suppressedByUserId] = null
+                it[suppressReason] = null
+                it[updatedAt] = now
+            }
+            findEpisode(row[AlertEpisodes.id].value, organizationId)?.toResponse()
+        }
+
+    fun suppressEpisode(
+        organizationId: Int,
+        episodeId: Int,
+        userId: Int?,
+        reason: String?,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeResponse? =
+        transaction {
+            val row = findEpisodeForUpdate(episodeId, organizationId) ?: return@transaction null
+            if (row[AlertEpisodes.status] != FIRING_STATUS) return@transaction row.toResponse()
+            suppressEpisodeInTransaction(episodeId, userId, reason, now)
+            findEpisode(episodeId, organizationId)?.toResponse()
+        }
+
+    fun unsuppressEpisode(
+        organizationId: Int,
+        episodeId: Int,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeResponse? =
+        transaction {
+            val row = findEpisodeForUpdate(episodeId, organizationId) ?: return@transaction null
+            AlertEpisodes.update({ AlertEpisodes.id eq row[AlertEpisodes.id].value }) {
+                it[suppressedAt] = null
+                it[suppressedByUserId] = null
+                it[suppressReason] = null
+                it[updatedAt] = now
+            }
+            findEpisode(episodeId, organizationId)?.toResponse()
+        }
+
+    fun listEpisodes(
+        organizationId: Int,
+        status: String? = null,
+        limit: Int = DEFAULT_LIST_LIMIT
+    ): List<AlertEpisodeResponse> =
+        transaction {
+            val baseQuery = AlertEpisodes.selectAll()
+            val query =
+                if (status.isNullOrBlank()) {
+                    baseQuery.where { AlertEpisodes.organizationId eq organizationId }
+                } else {
+                    baseQuery.where {
+                        (AlertEpisodes.organizationId eq organizationId) and
+                            (AlertEpisodes.status eq status.uppercase())
+                    }
+                }
+            query
+                .orderBy(AlertEpisodes.lastSeenAt to SortOrder.DESC)
+                .limit(limit.coerceIn(MIN_LIST_LIMIT, MAX_LIST_LIMIT))
+                .map { it.toResponse() }
+        }
+
+    private fun recordFiring(
+        organizationId: Int,
+        source: String,
+        deduplicationKey: String,
+        now: Instant,
+        reservePublication: Boolean
+    ): AlertEpisodeDecision? {
+        repeat(OPEN_EPISODE_ATTEMPTS) {
+            val decision =
+                transaction {
+                    val row = findOpenEpisodeForUpdate(organizationId, source, deduplicationKey)
+                        ?: createOpenEpisode(organizationId, source, deduplicationKey, now)
+                        ?: return@transaction null
+                    updateLastSeen(row[AlertEpisodes.id].value, now)
+                    val current = findEpisode(row[AlertEpisodes.id].value, organizationId)
+                        ?.toContext()
+                        ?: return@transaction null
+                    if (!reservePublication) {
+                        return@transaction AlertEpisodeDecision(
+                            episode = current,
+                            shouldPublish = current.suppressedAt == null,
+                            notificationSequence = current.notificationCount,
+                            notificationKind = INITIAL_NOTIFICATION_KIND
+                        )
+                    }
+                    reserveNotification(current, now)
+                }
+            if (decision != null) return decision
+        }
+        return null
+    }
+
+    private fun recordResolved(
+        organizationId: Int,
+        source: String,
+        deduplicationKey: String,
+        now: Instant
+    ): AlertEpisodeDecision? =
+        transaction {
+            val row = findOpenEpisodeForUpdate(organizationId, source, deduplicationKey) ?: return@transaction null
+            val episodeId = row[AlertEpisodes.id].value
+            AlertEpisodes.update({ AlertEpisodes.id eq episodeId }) {
+                it[status] = RESOLVED_STATUS
+                it[lastSeenAt] = now
+                it[resolvedAt] = now
+                it[updatedAt] = now
+            }
+            val resolved = findEpisode(episodeId, organizationId)?.toContext() ?: return@transaction null
+            val publishedBefore = row[AlertEpisodes.notificationCount] > 0
+            AlertEpisodeDecision(
+                episode = resolved,
+                shouldPublish = row[AlertEpisodes.suppressedAt] == null && publishedBefore,
+                notificationSequence = row[AlertEpisodes.notificationCount],
+                notificationKind = RESOLVED_NOTIFICATION_KIND
+            )
+        }
+
+    private fun reserveNotification(
+        episode: AlertEpisodeContext,
+        now: Instant
+    ): AlertEpisodeDecision {
+        if (episode.suppressedAt != null || !isNotificationDue(episode, now)) {
+            return AlertEpisodeDecision(
+                episode = episode,
+                shouldPublish = false,
+                notificationSequence = episode.notificationCount,
+                notificationKind = REMINDER_NOTIFICATION_KIND
+            )
+        }
+
+        val nextCount = episode.notificationCount + 1
+        AlertEpisodes.update({ AlertEpisodes.id eq episode.id }) {
+            it[lastNotificationAt] = now
+            it[notificationCount] = nextCount
+            it[updatedAt] = now
+        }
+        return AlertEpisodeDecision(
+            episode = episode.copy(lastNotificationAt = now, notificationCount = nextCount),
+            shouldPublish = true,
+            notificationSequence = nextCount,
+            notificationKind = if (nextCount == 1) INITIAL_NOTIFICATION_KIND else REMINDER_NOTIFICATION_KIND
+        )
+    }
+
+    private fun isNotificationDue(
+        episode: AlertEpisodeContext,
+        now: Instant
+    ): Boolean {
+        val lastNotificationAt = episode.lastNotificationAt ?: return true
+        return now - lastNotificationAt >= ALERT_REMINDER_INTERVAL
+    }
+
+    private fun createOpenEpisode(
+        organizationId: Int,
+        source: String,
+        deduplicationKey: String,
+        now: Instant
+    ): ResultRow? {
+        val nextSeq = nextEpisodeSequence(organizationId, source, deduplicationKey)
+        AlertEpisodes.insertIgnore {
+            it[AlertEpisodes.organizationId] = organizationId
+            it[AlertEpisodes.sourceName] = source
+            it[AlertEpisodes.deduplicationKey] = deduplicationKey
+            it[AlertEpisodes.episodeSeq] = nextSeq
+            it[AlertEpisodes.episodeKey] = episodeKey(deduplicationKey, nextSeq)
+            it[AlertEpisodes.status] = FIRING_STATUS
+            it[AlertEpisodes.openedAt] = now
+            it[AlertEpisodes.lastSeenAt] = now
+            it[AlertEpisodes.notificationCount] = 0
+            it[AlertEpisodes.createdAt] = now
+            it[AlertEpisodes.updatedAt] = now
+        }
+        return findOpenEpisodeForUpdate(organizationId, source, deduplicationKey)
+    }
+
+    private fun nextEpisodeSequence(
+        organizationId: Int,
+        source: String,
+        deduplicationKey: String
+    ): Int {
+        val latestSequence = AlertEpisodes
+            .selectAll()
+            .where {
+                (AlertEpisodes.organizationId eq organizationId) and
+                    (AlertEpisodes.sourceName eq source) and
+                    (AlertEpisodes.deduplicationKey eq deduplicationKey)
+            }
+            .orderBy(AlertEpisodes.episodeSeq to SortOrder.DESC)
+            .limit(1)
+            .firstOrNull()
+            ?.get(AlertEpisodes.episodeSeq) ?: 0
+
+        return latestSequence + 1
+    }
+
+    private fun episodeKey(
+        deduplicationKey: String,
+        episodeSeq: Int
+    ): String =
+        "$deduplicationKey#$episodeSeq"
+
+    private fun updateLastSeen(
+        episodeId: Int,
+        now: Instant
+    ) {
+        AlertEpisodes.update({ AlertEpisodes.id eq episodeId }) {
+            it[lastSeenAt] = now
+            it[updatedAt] = now
+        }
+    }
+
+    private fun suppressEpisodeInTransaction(
+        episodeId: Int,
+        userId: Int?,
+        reason: String?,
+        now: Instant
+    ) {
+        AlertEpisodes.update({ AlertEpisodes.id eq episodeId }) {
+            it[suppressedAt] = now
+            it[suppressedByUserId] = userId
+            it[suppressReason] = reason?.take(MAX_SUPPRESS_REASON_CHARS)
+            it[updatedAt] = now
+        }
+    }
+
+    private fun findOpenEpisodeForUpdate(
+        organizationId: Int,
+        source: String,
+        deduplicationKey: String
+    ): ResultRow? =
+        AlertEpisodes
+            .selectAll()
+            .where {
+                (AlertEpisodes.organizationId eq organizationId) and
+                    (AlertEpisodes.sourceName eq source) and
+                    (AlertEpisodes.deduplicationKey eq deduplicationKey) and
+                    (AlertEpisodes.status eq FIRING_STATUS)
+            }
+            .forUpdate()
+            .firstOrNull()
+
+    private fun findEpisodeForUpdate(
+        episodeId: Int,
+        organizationId: Int
+    ): ResultRow? =
+        AlertEpisodes
+            .selectAll()
+            .where {
+                (AlertEpisodes.id eq episodeId) and
+                    (AlertEpisodes.organizationId eq organizationId)
+            }
+            .forUpdate()
+            .firstOrNull()
+
+    private fun findEpisode(
+        episodeId: Int,
+        organizationId: Int
+    ): ResultRow? =
+        AlertEpisodes
+            .selectAll()
+            .where {
+                (AlertEpisodes.id eq episodeId) and
+                    (AlertEpisodes.organizationId eq organizationId)
+            }
+            .firstOrNull()
+
+    private fun ResultRow.toContext(): AlertEpisodeContext =
+        AlertEpisodeContext(
+            id = this[AlertEpisodes.id].value,
+            organizationId = this[AlertEpisodes.organizationId],
+            source = this[AlertEpisodes.sourceName],
+            deduplicationKey = this[AlertEpisodes.deduplicationKey],
+            episodeSeq = this[AlertEpisodes.episodeSeq],
+            episodeKey = this[AlertEpisodes.episodeKey],
+            status = this[AlertEpisodes.status],
+            openedAt = this[AlertEpisodes.openedAt],
+            lastSeenAt = this[AlertEpisodes.lastSeenAt],
+            resolvedAt = this[AlertEpisodes.resolvedAt],
+            lastNotificationAt = this[AlertEpisodes.lastNotificationAt],
+            notificationCount = this[AlertEpisodes.notificationCount],
+            suppressedAt = this[AlertEpisodes.suppressedAt],
+            suppressedByUserId = this[AlertEpisodes.suppressedByUserId],
+            suppressReason = this[AlertEpisodes.suppressReason]
+        )
+
+    private fun ResultRow.toResponse(): AlertEpisodeResponse {
+        val context = toContext()
+        return AlertEpisodeResponse(
+            id = context.id,
+            organizationId = context.organizationId,
+            source = context.source,
+            deduplicationKey = context.deduplicationKey,
+            episodeSeq = context.episodeSeq,
+            episodeKey = context.episodeKey,
+            status = context.status,
+            openedAt = context.openedAt.toString(),
+            lastSeenAt = context.lastSeenAt.toString(),
+            resolvedAt = context.resolvedAt?.toString(),
+            lastNotificationAt = context.lastNotificationAt?.toString(),
+            notificationCount = context.notificationCount,
+            suppressedAt = context.suppressedAt?.toString(),
+            suppressedByUserId = context.suppressedByUserId,
+            suppressReason = context.suppressReason,
+            createdAt = this[AlertEpisodes.createdAt].toString(),
+            updatedAt = this[AlertEpisodes.updatedAt].toString()
+        )
+    }
+
+    private companion object {
+        const val DEFAULT_LIST_LIMIT = 50
+        const val MIN_LIST_LIMIT = 1
+        const val MAX_LIST_LIMIT = 100
+        const val OPEN_EPISODE_ATTEMPTS = 2
+    }
+}
+
+data class AlertEpisodeContext(
+    val id: Int,
+    val organizationId: Int,
+    val source: String,
+    val deduplicationKey: String,
+    val episodeSeq: Int,
+    val episodeKey: String,
+    val status: String,
+    val openedAt: Instant,
+    val lastSeenAt: Instant,
+    val resolvedAt: Instant?,
+    val lastNotificationAt: Instant?,
+    val notificationCount: Int,
+    val suppressedAt: Instant?,
+    val suppressedByUserId: Int?,
+    val suppressReason: String?
+)
+
+data class AlertEpisodeDecision(
+    val episode: AlertEpisodeContext,
+    val shouldPublish: Boolean,
+    val notificationSequence: Int,
+    val notificationKind: String
+)

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -17,6 +17,7 @@
 package com.moneat.di
 
 import com.moneat.ai.AiChatService
+import com.moneat.alerts.services.AlertEpisodeService
 import com.moneat.analytics.services.AnalyticsService
 import com.moneat.analytics.services.GeoIpService
 import com.moneat.analytics.services.SessionHashService
@@ -72,9 +73,9 @@ import com.moneat.monitor.repositories.HostRepository
 import com.moneat.monitor.repositories.HostRepositoryImpl
 import com.moneat.monitor.services.AgentApiKeyService
 import com.moneat.monitor.services.MonitorAlertService
+import com.moneat.monitor.services.MonitorService
 import com.moneat.security.detection.DetectionScheduler
 import com.moneat.security.vulnerabilities.VulnerabilityAdvisorySyncJob
-import com.moneat.monitor.services.MonitorService
 import com.moneat.notifications.services.AlertNotificationPreferencesService
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
@@ -132,6 +133,7 @@ val sharedModule = module {
     single { SlackService() }
     single { DiscordService() }
     single { AlertNotificationPreferencesService() }
+    single { AlertEpisodeService() }
     single { WorkflowStepRenderer() }
     single {
         WorkflowTrustedActionExecutor(
@@ -150,7 +152,7 @@ val sharedModule = module {
     single { ExecuteEgressActionActivityImpl(get()) }
     single { TemporalClientProvider() }
     single<WorkflowExecutionEngine> { TemporalWorkflowExecutionEngine(get()) }
-    single { WorkflowService(get(), get(), get(), get(), get(), get(), get()) }
+    single { WorkflowService(get(), get(), get(), get(), get(), get(), get(), get()) }
     single { WorkflowGovernanceService(get()) }
     single { IncidentService(get()) }
 
@@ -265,7 +267,7 @@ val uptimeModule = module {
 
     single { UptimeService(get(), get()) }
     single { UptimeCheckExecutor() }
-    single { UptimeScheduler(get(), get(), get(), get()) }
+    single { UptimeScheduler(get(), get(), get(), get(), get()) }
     single { StatusPageService(get()) }
 }
 

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -262,12 +262,21 @@ val logsModule = module {
 }
 
 /** Uptime monitoring and status pages. */
-val uptimeModule = module {
+fun uptimeModule(frontendBaseUrl: String) = module {
     single<UptimeMonitorRepository> { UptimeMonitorRepositoryImpl() }
 
     single { UptimeService(get(), get()) }
     single { UptimeCheckExecutor() }
-    single { UptimeScheduler(get(), get(), get(), get(), get()) }
+    single {
+        UptimeScheduler(
+            uptimeService = get(),
+            checkExecutor = get(),
+            incidentService = get(),
+            billingQuotaService = get(),
+            workflowService = get(),
+            frontendBaseUrl = frontendBaseUrl
+        )
+    }
     single { StatusPageService(get()) }
 }
 
@@ -331,19 +340,24 @@ val aiModule = module {
 }
 
 /** All application modules combined in load order. */
-val appModules = listOf(
-    sharedModule,
-    authModule,
-    billingModule,
-    orgModule,
-    eventsModule,
-    monitorModule,
-    logsModule,
-    uptimeModule,
-    dashboardsModule,
-    summaryModule,
-    llmModule,
-    analyticsModule,
-    featureFlagsModule,
-    aiModule,
-)
+private const val DEFAULT_FRONTEND_BASE_URL = "https://moneat.io"
+
+fun buildAppModules(frontendBaseUrl: String = DEFAULT_FRONTEND_BASE_URL) =
+    listOf(
+        sharedModule,
+        authModule,
+        billingModule,
+        orgModule,
+        eventsModule,
+        monitorModule,
+        logsModule,
+        uptimeModule(frontendBaseUrl),
+        dashboardsModule,
+        summaryModule,
+        llmModule,
+        analyticsModule,
+        featureFlagsModule,
+        aiModule,
+    )
+
+val appModules = buildAppModules()

--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -16,6 +16,8 @@
 
 package com.moneat.events.routes
 
+import com.moneat.alerts.models.SuppressAlertEpisodeRequest
+import com.moneat.alerts.services.AlertEpisodeService
 import com.moneat.auth.routes.accountDeletionRoutes
 import com.moneat.auth.services.Quadruple
 import com.moneat.billing.routes.billingRoutes
@@ -88,11 +90,13 @@ private const val DEFAULT_EVENTS_LIMIT = 50
 private const val DEFAULT_TRANSACTIONS_LIMIT = 20
 private const val DEFAULT_REPLAYS_LIMIT = 10
 private const val DEFAULT_ALERT_FREQUENCY_MINUTES = 30
+private const val DEFAULT_ALERT_LIFECYCLE_LIMIT = 50
 private const val ERROR_NO_ORGANIZATION_ACCESS = "No organization access"
 
 @Suppress("kotlin:S3776")
 fun Route.apiRoutes() {
     val koin = GlobalContext.get()
+    val alertEpisodeService = koin.get<AlertEpisodeService>()
     val dashboardService = koin.get<DashboardService>()
     val projectIdResolver = koin.get<ProjectIdResolver>()
 
@@ -124,6 +128,8 @@ fun Route.apiRoutes() {
 
                 // Integrations
                 integrationRoutes()
+
+                alertLifecycleRoutes(alertEpisodeService)
 
                 // User profile
                 get("/user") {
@@ -1491,6 +1497,43 @@ fun Route.apiRoutes() {
     route("/v1") {
         integrationCallbackRoutes()
     }
+}
+
+private fun Route.alertLifecycleRoutes(alertEpisodeService: AlertEpisodeService) {
+    get("/alerts/lifecycles") {
+        val userId = call.principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
+        val orgId = call.resolveSubscriptionOrganizationId(userId) ?: return@get
+        val status = call.request.queryParameters["status"]
+        val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_ALERT_LIFECYCLE_LIMIT
+        call.respond(alertEpisodeService.listEpisodes(orgId, status, limit))
+    }
+
+    post("/alerts/lifecycles/{episodeId}/ignore") {
+        val userId = call.principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
+        val orgId = call.resolveSubscriptionOrganizationId(userId) ?: return@post
+        val episodeId = call.alertEpisodeId() ?: return@post
+        val request = call.receive<SuppressAlertEpisodeRequest>()
+        val episode = alertEpisodeService.suppressEpisode(orgId, episodeId, userId, request.reason)
+            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("Alert episode not found"))
+        call.respond(episode)
+    }
+
+    post("/alerts/lifecycles/{episodeId}/unignore") {
+        val userId = call.principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
+        val orgId = call.resolveSubscriptionOrganizationId(userId) ?: return@post
+        val episodeId = call.alertEpisodeId() ?: return@post
+        val episode = alertEpisodeService.unsuppressEpisode(orgId, episodeId)
+            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("Alert episode not found"))
+        call.respond(episode)
+    }
+}
+
+private suspend fun ApplicationCall.alertEpisodeId(): Int? {
+    val episodeId = parameters["episodeId"]?.toIntOrNull()
+    if (episodeId == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid alert episode ID"))
+    }
+    return episodeId
 }
 
 private fun ApplicationCall.resolveProjectPathId(projectIdResolver: ProjectIdResolver): Long? =

--- a/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
@@ -16,17 +16,23 @@
 
 package com.moneat.events.services
 
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.services.AlertEpisodeService
 import com.moneat.events.models.EventResponse
 import com.moneat.events.models.IssueDetailResponse
 import com.moneat.events.models.IssueResponse
 import com.moneat.events.models.IssueTransactionResponse
 import com.moneat.events.models.IssueUpdateRequest
 import com.moneat.events.repositories.IssueRepository
+import com.moneat.shared.models.Projects
 import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.suspendRunCatching
 import io.ktor.server.plugins.BadRequestException
 import mu.KotlinLogging
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 private val logger = KotlinLogging.logger {}
 
@@ -34,9 +40,15 @@ class IssueService(
     private val issueRepository: IssueRepository,
     private val queryHelper: DashboardQueryHelper,
     private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
+    private val alertEpisodeService: AlertEpisodeService = AlertEpisodeService(),
 ) {
     companion object {
         private const val ISSUE_OVERFETCH_MULTIPLIER = 5
+        private const val ERROR_ALERT_DEDUP_PREFIX = "moneat-error-"
+        private const val STATUS_IGNORED = "ignored"
+        private const val STATUS_RESOLVED = "resolved"
+        private const val STATUS_ARCHIVED = "archived"
+        private const val STATUS_UNRESOLVED = "unresolved"
     }
 
     suspend fun getProjectIdForIssue(issueId: String): Long? =
@@ -207,9 +219,65 @@ class IssueService(
             ?: throw IllegalArgumentException("Issue not found")
 
         if (update.status != null) {
-            val validStatuses = setOf("unresolved", "resolved", "archived", "ignored")
+            val validStatuses = setOf(STATUS_UNRESOLVED, STATUS_RESOLVED, STATUS_ARCHIVED, STATUS_IGNORED)
             if (update.status !in validStatuses) throw BadRequestException("Invalid status value")
             issueRepository.upsertIssueStatus(issueId, projectId, update.status)
+            updateErrorAlertEpisode(issueId, projectId, update.status)
         }
     }
+
+    private fun updateErrorAlertEpisode(
+        issueId: String,
+        projectId: Long,
+        status: String
+    ) {
+        val organizationId = projectOrganizationId(projectId) ?: return
+        val deduplicationKey = "$ERROR_ALERT_DEDUP_PREFIX$issueId"
+        when (status) {
+            STATUS_IGNORED ->
+                alertEpisodeService.suppressCurrentEpisode(
+                    organizationId = organizationId,
+                    source = AlertSource.ERROR_ALERT,
+                    deduplicationKey = deduplicationKey,
+                    userId = null,
+                    reason = "Issue ignored"
+                )
+            STATUS_RESOLVED,
+            STATUS_ARCHIVED ->
+                alertEpisodeService.closeCurrentEpisode(
+                    organizationId = organizationId,
+                    source = AlertSource.ERROR_ALERT,
+                    deduplicationKey = deduplicationKey
+                )
+            STATUS_UNRESOLVED -> {
+                val episode = alertEpisodeService.openCurrentEpisode(
+                    organizationId = organizationId,
+                    source = AlertSource.ERROR_ALERT,
+                    deduplicationKey = deduplicationKey
+                )
+                if (episode?.suppressedAt != null) {
+                    alertEpisodeService.unsuppressCurrentEpisode(
+                        organizationId = organizationId,
+                        source = AlertSource.ERROR_ALERT,
+                        deduplicationKey = deduplicationKey
+                    )
+                }
+            }
+        }
+    }
+
+    private fun projectOrganizationId(projectId: Long): Int? =
+        runCatching {
+            transaction {
+                Projects
+                    .selectAll()
+                    .where { Projects.id eq projectId }
+                    .firstOrNull()
+                    ?.get(Projects.organization_id)
+            }
+        }.onFailure { error ->
+            logger.warn(error) {
+                "Skipping error alert lifecycle update because project $projectId could not be loaded"
+            }
+        }.getOrNull()
 }

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
@@ -16,18 +16,19 @@
 
 package com.moneat.incident.services
 
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertSeverity
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
 import com.moneat.config.EnvConfig
 import com.moneat.enterprise.FeatureRegistry
-import com.moneat.alerts.models.AlertSource
-import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.incident.models.IncidentEventLog
 import com.moneat.incident.models.IncidentProviderConfigs
 import com.moneat.incident.models.IncidentRoutingRules
-import com.moneat.alerts.models.AlertSeverity
-import com.moneat.alerts.models.AlertStatus
 import com.moneat.incident.models.ProviderConfig
 import com.moneat.shared.models.EscalationPolicies
 import com.moneat.shared.models.EscalationPolicyAlertSources
+import com.moneat.utils.suspendRunCatching
 import com.moneat.workflows.services.WorkflowService
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -41,7 +42,6 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.slf4j.LoggerFactory
 import kotlin.time.Clock
-import com.moneat.utils.suspendRunCatching
 
 /**
  * Middleware service for dispatching incident alerts to configured providers.
@@ -170,6 +170,7 @@ class IncidentService(
             suspendRunCatching {
                 workflowService.publishIncidentResolved(
                     organizationId = organizationId,
+                    source = source,
                     deduplicationKey = deduplicationKey,
                     title = title
                 )

--- a/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsService.kt
+++ b/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsService.kt
@@ -16,16 +16,20 @@
 
 package com.moneat.synthetics.routes
 
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertSeverity
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
-import com.moneat.alerts.models.AlertSource
-import com.moneat.alerts.models.AlertLifecycleEvent
-import com.moneat.alerts.models.AlertSeverity
-import com.moneat.alerts.models.AlertStatus
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Subscriptions
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MAX
+import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MIN
+import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
+import com.moneat.utils.suspendRunCatching
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineScope
@@ -48,10 +52,6 @@ import java.util.UUID
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import com.moneat.utils.suspendRunCatching
-import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MAX
-import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MIN
-import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 
 /** Manages synthetic HTTP checks, variables, execution, and ClickHouse result storage. */
 class SyntheticsService(
@@ -313,16 +313,24 @@ class SyntheticsService(
             }
         }
 
-        // Alert on transition from passing to failing
+        // Workflow episode gating handles initial notifications and daily reminders.
         if (test.alertOnFailure &&
-            result.status == "failed" &&
-            oldStatus != "failed"
+            result.status == "failed"
         ) {
             suspendRunCatching {
                 sendFailureAlert(test, result)
             }.getOrElse { e ->
                 logger.error(e) {
                     "Failed to send alert for synthetic test ${test.id}"
+                }
+            }
+        }
+        if (test.alertOnFailure && oldStatus == "failed" && result.status == "passed") {
+            suspendRunCatching {
+                sendRecoveryAlert(test)
+            }.getOrElse { e ->
+                logger.error(e) {
+                    "Failed to send recovery alert for synthetic test ${test.id}"
                 }
             }
         }
@@ -384,6 +392,25 @@ class SyntheticsService(
                 description = message,
                 severity = AlertSeverity.HIGH,
                 status = AlertStatus.FIRING,
+                source = AlertSource.SYNTHETIC_TEST,
+                deduplicationKey = "moneat-synthetic-${test.id}",
+                organizationId = test.organizationId,
+                moneatUrl = "$frontendUrl/synthetics/${test.id}"
+            )
+        )
+    }
+
+    private suspend fun sendRecoveryAlert(test: SyntheticTestData) {
+        val frontendUrl = EnvConfig.get(
+            "FRONTEND_URL",
+            "https://moneat.io"
+        )
+        workflowService.publishAlertTriggered(
+            AlertLifecycleEvent(
+                title = "Synthetic test recovered: ${test.name}",
+                description = "Test '${test.name}' (${test.testType}) passed after previous failures.",
+                severity = AlertSeverity.LOW,
+                status = AlertStatus.RESOLVED,
                 source = AlertSource.SYNTHETIC_TEST,
                 deduplicationKey = "moneat-synthetic-${test.id}",
                 organizationId = test.organizationId,

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
@@ -29,7 +29,6 @@ import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
 import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import com.moneat.utils.suspendRunCatching
 import com.moneat.workflows.services.WorkflowService
-import io.ktor.server.config.ApplicationConfig
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -61,14 +60,12 @@ class UptimeScheduler(
     private val incidentService: IncidentService = IncidentService(),
     private val billingQuotaService: BillingQuotaService = BillingQuotaService(),
     private val workflowService: WorkflowService = WorkflowService(),
+    private val frontendBaseUrl: String,
 ) {
     companion object {
         private const val CHECK_STATUS_DOWN = 0
         private const val CHECK_STATUS_UP = 1
         private const val TIMEOUT_BUFFER_MS = 5000L
-        private val frontendBaseUrl by lazy {
-            ApplicationConfig("application.conf").property("email.frontendUrl").getString()
-        }
     }
 
     private var schedulerJob: Job? = null

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
@@ -29,6 +29,7 @@ import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
 import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import com.moneat.utils.suspendRunCatching
 import com.moneat.workflows.services.WorkflowService
+import io.ktor.server.config.ApplicationConfig
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -62,7 +63,12 @@ class UptimeScheduler(
     private val workflowService: WorkflowService = WorkflowService(),
 ) {
     companion object {
+        private const val CHECK_STATUS_DOWN = 0
+        private const val CHECK_STATUS_UP = 1
         private const val TIMEOUT_BUFFER_MS = 5000L
+        private val frontendBaseUrl by lazy {
+            ApplicationConfig("application.conf").property("email.frontendUrl").getString()
+        }
     }
 
     private var schedulerJob: Job? = null
@@ -204,11 +210,11 @@ class UptimeScheduler(
         failureMessagePrefix: String
     ): CheckResult {
         logger.error(exception) { "$failureLogPrefix for monitor ${monitor.id}: ${exception.message}" }
-        return CheckResult(0, -1, 0, "$failureMessagePrefix: ${exception.message}")
+        return CheckResult(CHECK_STATUS_DOWN, -1, 0, "$failureMessagePrefix: ${exception.message}")
     }
 
     private suspend fun CheckResult.withRetriesIfNeeded(monitor: UptimeMonitorData): CheckResult =
-        if (status == 0 && monitor.retries > 0) {
+        if (status == CHECK_STATUS_DOWN && monitor.retries > 0) {
             handleRetries(monitor, this)
         } else {
             this
@@ -262,8 +268,8 @@ class UptimeScheduler(
 
     private fun statusFromResult(result: CheckResult): String =
         when (result.status) {
-            1 -> "up"
-            0 -> "down"
+            CHECK_STATUS_UP -> "up"
+            CHECK_STATUS_DOWN -> "down"
             else -> "pending"
         }
 
@@ -289,7 +295,7 @@ class UptimeScheduler(
             lastResult = retryResult
 
             // If check succeeded, stop retrying
-            if (retryResult.status == 1) {
+            if (retryResult.status == CHECK_STATUS_UP) {
                 logger.debug { "Monitor ${monitor.name} recovered on retry $retry/${monitor.retries}" }
                 break
             }
@@ -312,10 +318,7 @@ class UptimeScheduler(
                 "Message: ${result.message}"
         }
 
-        val config =
-            io.ktor.server.config
-                .ApplicationConfig("application.conf")
-        val baseUrl = config.property("email.frontendUrl").getString()
+        val baseUrl = frontendBaseUrl
 
         // Build an alert lifecycle event; IncidentService applies incident-provider routing.
         suspendRunCatching {
@@ -342,9 +345,7 @@ class UptimeScheduler(
         monitor: UptimeMonitorData,
         result: CheckResult
     ) {
-        val config = io.ktor.server.config.ApplicationConfig("application.conf")
-        val baseUrl = config.property("email.frontendUrl").getString()
-        workflowService.publishAlertTriggered(uptimeDownEvent(monitor, result, baseUrl))
+        workflowService.publishAlertTriggered(uptimeDownEvent(monitor, result, frontendBaseUrl))
     }
 
     private fun uptimeDownEvent(

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
@@ -16,12 +16,17 @@
 
 package com.moneat.uptime.services
 
-import com.moneat.billing.services.BillingQuotaService
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.billing.services.BillingQuotaService
 import com.moneat.incident.services.IncidentService
 import com.moneat.shared.services.TaskLock
 import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
+import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import com.moneat.utils.suspendRunCatching
+import com.moneat.workflows.services.WorkflowService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -39,7 +44,6 @@ import java.sql.SQLException
 import java.util.*
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 
 private val logger = KotlinLogging.logger {}
 
@@ -52,6 +56,7 @@ class UptimeScheduler(
     private val checkExecutor: UptimeCheckExecutor = UptimeCheckExecutor(),
     private val incidentService: IncidentService = IncidentService(),
     private val billingQuotaService: BillingQuotaService = BillingQuotaService(),
+    private val workflowService: WorkflowService = WorkflowService(),
 ) {
     companion object {
         private const val TIMEOUT_BUFFER_MS = 5000L
@@ -224,6 +229,12 @@ class UptimeScheduler(
             }.onFailure { e ->
                 logger.error(e) { "Failed to send status change notification: ${e.message}" }
             }
+        } else if (oldStatus == "down" && newStatus == "down") {
+            suspendRunCatching {
+                publishStillDownWorkflow(monitor, finalResult)
+            }.onFailure { e ->
+                logger.error(e) { "Failed to publish uptime reminder workflow: ${e.message}" }
+            }
         }
     }
 
@@ -294,35 +305,7 @@ class UptimeScheduler(
         // Build an alert lifecycle event; IncidentService applies incident-provider routing.
         suspendRunCatching {
             if (newStatus == "down") {
-                // Get severity from the monitor override or fall back to routing rules.
-                val severityOverride =
-                    monitor.incidentSeverity?.let {
-                        com.moneat.alerts.models.AlertSeverity
-                            .fromString(it)
-                    }
-
-                // Use override severity if set, otherwise use a default that routing rules can override
-                val severity = severityOverride ?: com.moneat.alerts.models.AlertSeverity.HIGH
-
-                val alertLifecycleEvent =
-                    com.moneat.alerts.models.AlertLifecycleEvent(
-                        title = "Uptime Monitor Down: ${monitor.name}",
-                        description = "Monitor '${monitor.name}' (${monitor.type}) is down.\nError: ${result.message}",
-                        severity = severity,
-                        status = com.moneat.alerts.models.AlertStatus.FIRING,
-                        source = com.moneat.alerts.models.AlertSource.UPTIME_MONITOR,
-                        deduplicationKey = "moneat-uptime-${monitor.id}",
-                        organizationId = monitor.organizationId,
-                        metadata =
-                        mapOf(
-                            "monitor_id" to JsonPrimitive(monitor.id.toString()),
-                            "monitor_name" to JsonPrimitive(monitor.name),
-                            "monitor_type" to JsonPrimitive(monitor.type),
-                            "error_message" to JsonPrimitive(result.message),
-                            "response_time_ms" to JsonPrimitive(result.responseTimeMs.toString())
-                        ),
-                        moneatUrl = "$baseUrl/uptime/${monitor.id}"
-                    )
+                val alertLifecycleEvent = uptimeDownEvent(monitor, result, baseUrl)
                 incidentService.fireAlert(alertLifecycleEvent)
             } else if (newStatus == "up") {
                 // Resolve the incident
@@ -338,6 +321,41 @@ class UptimeScheduler(
         }.onFailure { e ->
             logger.error(e) { "Failed to fire/resolve incident provider alert for uptime monitor" }
         }
+    }
+
+    private suspend fun publishStillDownWorkflow(
+        monitor: com.moneat.uptime.models.UptimeMonitorData,
+        result: com.moneat.uptime.models.CheckResult
+    ) {
+        val config = io.ktor.server.config.ApplicationConfig("application.conf")
+        val baseUrl = config.property("email.frontendUrl").getString()
+        workflowService.publishAlertTriggered(uptimeDownEvent(monitor, result, baseUrl))
+    }
+
+    private fun uptimeDownEvent(
+        monitor: com.moneat.uptime.models.UptimeMonitorData,
+        result: com.moneat.uptime.models.CheckResult,
+        baseUrl: String
+    ): AlertLifecycleEvent {
+        val severityOverride = monitor.incidentSeverity?.let { AlertSeverity.fromString(it) }
+        val severity = severityOverride ?: AlertSeverity.HIGH
+        return AlertLifecycleEvent(
+            title = "Uptime Monitor Down: ${monitor.name}",
+            description = "Monitor '${monitor.name}' (${monitor.type}) is down.\nError: ${result.message}",
+            severity = severity,
+            status = AlertStatus.FIRING,
+            source = AlertSource.UPTIME_MONITOR,
+            deduplicationKey = "moneat-uptime-${monitor.id}",
+            organizationId = monitor.organizationId,
+            metadata = mapOf(
+                "monitor_id" to JsonPrimitive(monitor.id.toString()),
+                "monitor_name" to JsonPrimitive(monitor.name),
+                "monitor_type" to JsonPrimitive(monitor.type),
+                "error_message" to JsonPrimitive(result.message),
+                "response_time_ms" to JsonPrimitive(result.responseTimeMs.toString())
+            ),
+            moneatUrl = "$baseUrl/uptime/${monitor.id}"
+        )
     }
 
     private fun incrementUptimeCheckCount(organizationId: Int) {

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
@@ -23,6 +23,8 @@ import com.moneat.alerts.models.AlertStatus
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.incident.services.IncidentService
 import com.moneat.shared.services.TaskLock
+import com.moneat.uptime.models.CheckResult
+import com.moneat.uptime.models.UptimeMonitorData
 import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
 import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import com.moneat.utils.suspendRunCatching
@@ -41,7 +43,8 @@ import kotlinx.serialization.json.JsonPrimitive
 import mu.KotlinLogging
 import java.io.IOException
 import java.sql.SQLException
-import java.util.*
+import java.util.Collections
+import java.util.UUID
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -144,56 +147,77 @@ class UptimeScheduler(
      * Perform a check for a specific monitor.
      */
     private suspend fun performCheck(monitorId: UUID) {
-        // Get latest monitor data from the list we already fetched
+        val monitor = loadMonitorForCheck(monitorId) ?: return
+
+        if (monitor.type.lowercase() == "push") {
+            return
+        }
+
+        val result = executeCheckWithTimeout(monitor, "Check execution failed", "Check execution failed")
+        val finalResult = result.withRetriesIfNeeded(monitor)
+        val oldStatus = monitor.status
+        recordCheckOutcome(monitor, finalResult)
+        publishLifecycleIfNeeded(monitor, oldStatus, finalResult)
+    }
+
+    private suspend fun loadMonitorForCheck(monitorId: UUID): UptimeMonitorData? {
         val monitor =
             suspendRunCatching {
                 uptimeService.getMonitorsDueForCheck().find { it.id == monitorId }
             }.getOrElse { e ->
                 logger.error(e) { "Failed to fetch monitor $monitorId: ${e.message}" }
-                return
+                return null
             }
 
         if (monitor == null) {
             logger.warn { "Monitor $monitorId not found or not active" }
-            return
         }
 
-        // Skip push monitors (they don't have active checks)
-        if (monitor.type.lowercase() == "push") {
-            return
+        return monitor
+    }
+
+    private suspend fun executeCheckWithTimeout(
+        monitor: UptimeMonitorData,
+        failureLogPrefix: String,
+        failureMessagePrefix: String
+    ): CheckResult =
+        try {
+            withTimeout(monitor.timeoutSeconds * MILLIS_PER_SECOND_LONG + TIMEOUT_BUFFER_MS) {
+                checkExecutor.executeCheck(monitor)
+            }
+        } catch (e: TimeoutCancellationException) {
+            failedCheckResult(monitor, e, failureLogPrefix, failureMessagePrefix)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            failedCheckResult(monitor, e, failureLogPrefix, failureMessagePrefix)
+        } catch (e: IllegalStateException) {
+            failedCheckResult(monitor, e, failureLogPrefix, failureMessagePrefix)
+        } catch (e: SQLException) {
+            failedCheckResult(monitor, e, failureLogPrefix, failureMessagePrefix)
         }
 
-        // Execute the check
-        val result =
-            try {
-                withTimeout(monitor.timeoutSeconds * MILLIS_PER_SECOND_LONG + TIMEOUT_BUFFER_MS) { // Add 5s buffer
-                    checkExecutor.executeCheck(monitor)
-                }
-            } catch (e: TimeoutCancellationException) {
-                logger.error(e) { "Check execution failed for monitor ${monitor.id}: ${e.message}" }
-                com.moneat.uptime.models.CheckResult(0, -1, 0, "Check execution failed: ${e.message}")
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: IOException) {
-                logger.error(e) { "Check execution failed for monitor ${monitor.id}: ${e.message}" }
-                com.moneat.uptime.models.CheckResult(0, -1, 0, "Check execution failed: ${e.message}")
-            } catch (e: IllegalStateException) {
-                logger.error(e) { "Check execution failed for monitor ${monitor.id}: ${e.message}" }
-                com.moneat.uptime.models.CheckResult(0, -1, 0, "Check execution failed: ${e.message}")
-            } catch (e: SQLException) {
-                logger.error(e) { "Check execution failed for monitor ${monitor.id}: ${e.message}" }
-                com.moneat.uptime.models.CheckResult(0, -1, 0, "Check execution failed: ${e.message}")
-            }
+    private fun failedCheckResult(
+        monitor: UptimeMonitorData,
+        exception: Exception,
+        failureLogPrefix: String,
+        failureMessagePrefix: String
+    ): CheckResult {
+        logger.error(exception) { "$failureLogPrefix for monitor ${monitor.id}: ${exception.message}" }
+        return CheckResult(0, -1, 0, "$failureMessagePrefix: ${exception.message}")
+    }
 
-        // Handle retries for failed checks
-        val finalResult =
-            if (result.status == 0 && monitor.retries > 0) {
-                handleRetries(monitor, result)
-            } else {
-                result
-            }
+    private suspend fun CheckResult.withRetriesIfNeeded(monitor: UptimeMonitorData): CheckResult =
+        if (status == 0 && monitor.retries > 0) {
+            handleRetries(monitor, this)
+        } else {
+            this
+        }
 
-        // Record heartbeat
+    private suspend fun recordCheckOutcome(
+        monitor: UptimeMonitorData,
+        finalResult: CheckResult
+    ) {
         suspendRunCatching {
             uptimeService.recordHeartbeat(monitor.id, finalResult)
         }.getOrElse { e ->
@@ -206,22 +230,17 @@ class UptimeScheduler(
             logger.debug(e) { "Failed to increment uptime check count for org ${monitor.organizationId}" }
         }
 
-        // Update monitor status
-        val oldStatus = monitor.status
         uptimeService.updateMonitorStatus(monitor.id, finalResult)
+    }
 
-        // Detect status changes (up -> down or down -> up)
-        val newStatus =
-            when (finalResult.status) {
-                1 -> "up"
-                0 -> "down"
-                else -> "pending"
-            }
+    private suspend fun publishLifecycleIfNeeded(
+        monitor: UptimeMonitorData,
+        oldStatus: String,
+        finalResult: CheckResult
+    ) {
+        val newStatus = statusFromResult(finalResult)
 
-        if (oldStatus != newStatus &&
-            (oldStatus == "up" || oldStatus == "down") &&
-            (newStatus == "up" || newStatus == "down")
-        ) {
+        if (isUptimeStatusTransition(oldStatus, newStatus)) {
             logger.info { "Monitor ${monitor.name} status changed: $oldStatus -> $newStatus" }
 
             suspendRunCatching {
@@ -229,7 +248,10 @@ class UptimeScheduler(
             }.onFailure { e ->
                 logger.error(e) { "Failed to send status change notification: ${e.message}" }
             }
-        } else if (oldStatus == "down" && newStatus == "down") {
+            return
+        }
+
+        if (oldStatus == "down" && newStatus == "down") {
             suspendRunCatching {
                 publishStillDownWorkflow(monitor, finalResult)
             }.onFailure { e ->
@@ -238,38 +260,31 @@ class UptimeScheduler(
         }
     }
 
+    private fun statusFromResult(result: CheckResult): String =
+        when (result.status) {
+            1 -> "up"
+            0 -> "down"
+            else -> "pending"
+        }
+
+    private fun isUptimeStatusTransition(oldStatus: String, newStatus: String): Boolean =
+        oldStatus != newStatus && oldStatus.isUptimeStatus() && newStatus.isUptimeStatus()
+
+    private fun String.isUptimeStatus(): Boolean = this == "up" || this == "down"
+
     /**
      * Handle retries for failed checks.
      */
     private suspend fun handleRetries(
-        monitor: com.moneat.uptime.models.UptimeMonitorData,
-        initialResult: com.moneat.uptime.models.CheckResult
-    ): com.moneat.uptime.models.CheckResult {
+        monitor: UptimeMonitorData,
+        initialResult: CheckResult
+    ): CheckResult {
         var lastResult = initialResult
 
         for (retry in 1..monitor.retries) {
             delay(monitor.retryIntervalSeconds * MILLIS_PER_SECOND_LONG)
 
-            val retryResult =
-                try {
-                    withTimeout(monitor.timeoutSeconds * MILLIS_PER_SECOND_LONG + TIMEOUT_BUFFER_MS) {
-                        checkExecutor.executeCheck(monitor)
-                    }
-                } catch (e: TimeoutCancellationException) {
-                    logger.error(e) { "Retry $retry failed for monitor ${monitor.id}: ${e.message}" }
-                    com.moneat.uptime.models.CheckResult(0, -1, 0, "Retry failed: ${e.message}")
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: IOException) {
-                    logger.error(e) { "Retry $retry failed for monitor ${monitor.id}: ${e.message}" }
-                    com.moneat.uptime.models.CheckResult(0, -1, 0, "Retry failed: ${e.message}")
-                } catch (e: IllegalStateException) {
-                    logger.error(e) { "Retry $retry failed for monitor ${monitor.id}: ${e.message}" }
-                    com.moneat.uptime.models.CheckResult(0, -1, 0, "Retry failed: ${e.message}")
-                } catch (e: SQLException) {
-                    logger.error(e) { "Retry $retry failed for monitor ${monitor.id}: ${e.message}" }
-                    com.moneat.uptime.models.CheckResult(0, -1, 0, "Retry failed: ${e.message}")
-                }
+            val retryResult = executeCheckWithTimeout(monitor, "Retry $retry failed", "Retry failed")
 
             lastResult = retryResult
 
@@ -287,10 +302,10 @@ class UptimeScheduler(
      * Notify about status changes.
      */
     private suspend fun notifyStatusChange(
-        monitor: com.moneat.uptime.models.UptimeMonitorData,
+        monitor: UptimeMonitorData,
         oldStatus: String,
         newStatus: String,
-        result: com.moneat.uptime.models.CheckResult
+        result: CheckResult
     ) {
         logger.info {
             "Uptime alert: Monitor '${monitor.name}' (${monitor.type}) changed from $oldStatus to $newStatus. " +
@@ -324,8 +339,8 @@ class UptimeScheduler(
     }
 
     private suspend fun publishStillDownWorkflow(
-        monitor: com.moneat.uptime.models.UptimeMonitorData,
-        result: com.moneat.uptime.models.CheckResult
+        monitor: UptimeMonitorData,
+        result: CheckResult
     ) {
         val config = io.ktor.server.config.ApplicationConfig("application.conf")
         val baseUrl = config.property("email.frontendUrl").getString()
@@ -333,8 +348,8 @@ class UptimeScheduler(
     }
 
     private fun uptimeDownEvent(
-        monitor: com.moneat.uptime.models.UptimeMonitorData,
-        result: com.moneat.uptime.models.CheckResult,
+        monitor: UptimeMonitorData,
+        result: CheckResult,
         baseUrl: String
     ): AlertLifecycleEvent {
         val severityOverride = monitor.incidentSeverity?.let { AlertSeverity.fromString(it) }

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -41,6 +41,13 @@ private const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
 private const val ALERT_CONDITION_REFERENCE = "alert.condition"
 private const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
 private const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
+private const val ALERT_EPISODE_ID_REFERENCE = "alert.episode_id"
+private const val ALERT_EPISODE_KEY_REFERENCE = "alert.episode_key"
+private const val ALERT_EPISODE_SEQ_REFERENCE = "alert.episode_seq"
+private const val ALERT_NOTIFICATION_SEQUENCE_REFERENCE = "alert.notification_sequence"
+private const val ALERT_NOTIFICATION_KIND_REFERENCE = "alert.notification_kind"
+private const val ALERT_OPENED_AT_REFERENCE = "alert.opened_at"
+private const val ALERT_LAST_SEEN_AT_REFERENCE = "alert.last_seen_at"
 private const val ORGANIZATION_ID_REFERENCE = "organization.id"
 private const val WORKFLOW_INPUT_REFERENCE = "workflow.input"
 private const val WORKFLOW_ACTOR_ID_REFERENCE = "workflow.actor_id"
@@ -241,6 +248,13 @@ object WorkflowCatalog {
         WorkflowScopeReferenceDefinition(ALERT_STATUS_REFERENCE, "Status", "AlertStatus"),
         WorkflowScopeReferenceDefinition("alert.source", "Source", "AlertSource"),
         WorkflowScopeReferenceDefinition(ALERT_DEDUPLICATION_KEY_REFERENCE, DEDUPLICATION_KEY_LABEL, "String"),
+        WorkflowScopeReferenceDefinition(ALERT_EPISODE_ID_REFERENCE, "Episode ID", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_EPISODE_KEY_REFERENCE, "Episode key", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_EPISODE_SEQ_REFERENCE, "Episode sequence", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_NOTIFICATION_SEQUENCE_REFERENCE, "Notification sequence", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_NOTIFICATION_KIND_REFERENCE, "Notification kind", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_OPENED_AT_REFERENCE, "Opened at", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_LAST_SEEN_AT_REFERENCE, "Last seen at", "String"),
         WorkflowScopeReferenceDefinition("alert.url", "Moneat URL", "String"),
         WorkflowScopeReferenceDefinition(ALERT_DASHBOARD_TITLE_REFERENCE, "Dashboard title", "String"),
         WorkflowScopeReferenceDefinition(ALERT_WIDGET_TITLE_REFERENCE, "Widget title", "String"),
@@ -277,6 +291,13 @@ object WorkflowCatalog {
         WorkflowScopeReferenceDefinition(INCIDENT_STATUS_REFERENCE, "Incident status", "IncidentStatus"),
         WorkflowScopeReferenceDefinition(INCIDENT_SEVERITY_REFERENCE, "Incident severity", "AlertSeverity"),
         WorkflowScopeReferenceDefinition(ALERT_DEDUPLICATION_KEY_REFERENCE, DEDUPLICATION_KEY_LABEL, "String"),
+        WorkflowScopeReferenceDefinition(ALERT_EPISODE_ID_REFERENCE, "Episode ID", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_EPISODE_KEY_REFERENCE, "Episode key", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_EPISODE_SEQ_REFERENCE, "Episode sequence", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_NOTIFICATION_SEQUENCE_REFERENCE, "Notification sequence", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_NOTIFICATION_KIND_REFERENCE, "Notification kind", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_OPENED_AT_REFERENCE, "Opened at", "String"),
+        WorkflowScopeReferenceDefinition(ALERT_LAST_SEEN_AT_REFERENCE, "Last seen at", "String"),
         WorkflowScopeReferenceDefinition(ORGANIZATION_ID_REFERENCE, ORGANIZATION_ID_LABEL, "String")
     )
 
@@ -294,70 +315,70 @@ object WorkflowCatalog {
             label = "When an alert triggers",
             description = "Runs when Moneat fires an alert lifecycle event.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_NOTIFICATION_SEQUENCE_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "alert.resolved",
             label = "When an alert resolves",
-            description = "Runs when Moneat resolves an alert by deduplication key.",
+            description = "Runs when Moneat resolves an alert episode.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "monitor.alerted",
             label = "When a monitor alerts",
             description = "Runs when a host or dashboard monitor fires.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_NOTIFICATION_SEQUENCE_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "monitor.recovered",
             label = "When a monitor recovers",
             description = "Runs when a host or dashboard monitor recovers.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "uptime.down",
             label = "When uptime monitor is down",
             description = "Runs when an uptime monitor reports an outage.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_NOTIFICATION_SEQUENCE_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "uptime.up",
             label = "When uptime monitor recovers",
             description = "Runs when an uptime monitor returns to service.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "synthetic.failed",
             label = "When a synthetic test fails",
             description = "Runs when a synthetic test reports a failed run.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_NOTIFICATION_SEQUENCE_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "synthetic.passed",
             label = "When a synthetic test passes",
             description = "Runs when a synthetic test recovers after failures.",
             scope = alertScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_STATUS_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "incident.created",
             label = "When an incident is created",
             description = "Runs when incident routing creates or pages a response event.",
             scope = incidentScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "incident.resolved",
             label = "When an incident resolves",
             description = "Runs when incident routing resolves a response event.",
             scope = incidentScope,
-            defaultOnceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, INCIDENT_STATUS_REFERENCE)
+            defaultOnceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, INCIDENT_STATUS_REFERENCE)
         ),
         WorkflowTriggerDefinition(
             name = "security.signal",

--- a/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/engine/WorkflowCatalog.kt
@@ -24,6 +24,13 @@ import com.moneat.workflows.engine.temporal.HTTP_REQUEST_ACTION
 import com.moneat.workflows.engine.temporal.TRANSFORM_GRAALJS_ACTION
 import com.moneat.workflows.engine.temporal.WORKFLOW_EGRESS_ACTIONS
 import com.moneat.workflows.engine.temporal.workflowEgressActionsEnabled
+import com.moneat.workflows.models.ALERT_EPISODE_ID_REFERENCE
+import com.moneat.workflows.models.ALERT_EPISODE_KEY_REFERENCE
+import com.moneat.workflows.models.ALERT_EPISODE_SEQ_REFERENCE
+import com.moneat.workflows.models.ALERT_LAST_SEEN_AT_REFERENCE
+import com.moneat.workflows.models.ALERT_NOTIFICATION_KIND_REFERENCE
+import com.moneat.workflows.models.ALERT_NOTIFICATION_SEQUENCE_REFERENCE
+import com.moneat.workflows.models.ALERT_OPENED_AT_REFERENCE
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -41,13 +48,6 @@ private const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
 private const val ALERT_CONDITION_REFERENCE = "alert.condition"
 private const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
 private const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
-private const val ALERT_EPISODE_ID_REFERENCE = "alert.episode_id"
-private const val ALERT_EPISODE_KEY_REFERENCE = "alert.episode_key"
-private const val ALERT_EPISODE_SEQ_REFERENCE = "alert.episode_seq"
-private const val ALERT_NOTIFICATION_SEQUENCE_REFERENCE = "alert.notification_sequence"
-private const val ALERT_NOTIFICATION_KIND_REFERENCE = "alert.notification_kind"
-private const val ALERT_OPENED_AT_REFERENCE = "alert.opened_at"
-private const val ALERT_LAST_SEEN_AT_REFERENCE = "alert.last_seen_at"
 private const val ORGANIZATION_ID_REFERENCE = "organization.id"
 private const val WORKFLOW_INPUT_REFERENCE = "workflow.input"
 private const val WORKFLOW_ACTOR_ID_REFERENCE = "workflow.actor_id"

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowAlertReferences.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowAlertReferences.kt
@@ -1,0 +1,25 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.models
+
+internal const val ALERT_EPISODE_ID_REFERENCE = "alert.episode_id"
+internal const val ALERT_EPISODE_KEY_REFERENCE = "alert.episode_key"
+internal const val ALERT_EPISODE_SEQ_REFERENCE = "alert.episode_seq"
+internal const val ALERT_NOTIFICATION_SEQUENCE_REFERENCE = "alert.notification_sequence"
+internal const val ALERT_NOTIFICATION_KIND_REFERENCE = "alert.notification_kind"
+internal const val ALERT_OPENED_AT_REFERENCE = "alert.opened_at"
+internal const val ALERT_LAST_SEEN_AT_REFERENCE = "alert.last_seen_at"

--- a/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowScope.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/models/WorkflowScope.kt
@@ -41,7 +41,14 @@ fun Map<String, JsonElement>.workflowStringView(): Map<String, String> =
 fun JsonElement.workflowStringValue(): String =
     when (this) {
         is JsonNull -> ""
-        is JsonPrimitive -> booleanOrNull?.toString() ?: doubleOrNull?.toString() ?: contentOrNull.orEmpty()
+        is JsonPrimitive -> {
+            val rawJson = toString()
+            if (rawJson.startsWith("\"")) {
+                contentOrNull.orEmpty()
+            } else {
+                booleanOrNull?.toString() ?: doubleOrNull?.toString().orEmpty()
+            }
+        }
         else -> workflowJson.encodeToString(this)
     }
 

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowBlueprintCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowBlueprintCatalog.kt
@@ -65,7 +65,6 @@ object WorkflowBlueprintCatalog {
     private const val CATEGORY_UPTIME = "uptime"
     private const val CATEGORY_TRIAGE = "triage"
 
-    private const val DEDUP_KEY = "alert.deduplication_key"
     private const val EPISODE_KEY = "alert.episode_key"
     private const val NOTIFICATION_SEQUENCE = "alert.notification_sequence"
     private const val ALERT_STATUS = "alert.status"

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowBlueprintCatalog.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowBlueprintCatalog.kt
@@ -66,6 +66,8 @@ object WorkflowBlueprintCatalog {
     private const val CATEGORY_TRIAGE = "triage"
 
     private const val DEDUP_KEY = "alert.deduplication_key"
+    private const val EPISODE_KEY = "alert.episode_key"
+    private const val NOTIFICATION_SEQUENCE = "alert.notification_sequence"
     private const val ALERT_STATUS = "alert.status"
     private const val INCIDENT_STATUS = "incident.status"
     private const val SECURITY_RULE_ID = "security.rule_id"
@@ -82,7 +84,7 @@ object WorkflowBlueprintCatalog {
                 description = "Post a formatted message to the Slack alert channel when an alert fires.",
                 category = CATEGORY_ALERTING,
                 triggerName = TRIGGER_ALERT_TRIGGERED,
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY, NOTIFICATION_SEQUENCE),
                 tags = listOf("slack", "notifications"),
                 steps = listOf(
                     slackAlertStep(
@@ -96,7 +98,7 @@ object WorkflowBlueprintCatalog {
                 description = "Email organization members when a critical-severity alert fires.",
                 category = CATEGORY_ALERTING,
                 triggerName = TRIGGER_ALERT_TRIGGERED,
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY, NOTIFICATION_SEQUENCE),
                 tags = listOf("email", "critical"),
                 conditions = listOf(
                     WorkflowConditionConfig("alert.severity", "at_least", "HIGH")
@@ -114,7 +116,7 @@ object WorkflowBlueprintCatalog {
                 description = "Post a recovery message to Slack when an alert resolves.",
                 category = CATEGORY_ALERTING,
                 triggerName = "alert.resolved",
-                onceForTemplate = listOf(DEDUP_KEY, ALERT_STATUS),
+                onceForTemplate = listOf(EPISODE_KEY, ALERT_STATUS),
                 tags = listOf("slack", "recovery"),
                 steps = listOf(
                     slackAlertStep("*Resolved:* {{alert.display_title}}\n{{alert.url}}")
@@ -126,7 +128,7 @@ object WorkflowBlueprintCatalog {
                 description = "Send alerts to both Slack and Discord alert channels in parallel.",
                 category = CATEGORY_ALERTING,
                 triggerName = TRIGGER_ALERT_TRIGGERED,
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY, NOTIFICATION_SEQUENCE),
                 tags = listOf("slack", "discord"),
                 steps = listOf(
                     slackAlertStep("*{{alert.priority}} {{alert.display_title}}*\n{{alert.description}}"),
@@ -142,7 +144,7 @@ object WorkflowBlueprintCatalog {
                 description = "Page the on-call responders and notify Slack when a monitor fires.",
                 category = CATEGORY_ALERTING,
                 triggerName = "monitor.alerted",
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY, NOTIFICATION_SEQUENCE),
                 tags = listOf("oncall", "monitor"),
                 steps = listOf(
                     oncallPageStep(
@@ -158,7 +160,7 @@ object WorkflowBlueprintCatalog {
                 description = "Create a status page incident and notify Slack when an uptime monitor is down.",
                 category = CATEGORY_UPTIME,
                 triggerName = "uptime.down",
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY, NOTIFICATION_SEQUENCE),
                 tags = listOf("uptime", "statuspage"),
                 steps = listOf(
                     statusIncidentStep(
@@ -174,7 +176,7 @@ object WorkflowBlueprintCatalog {
                 description = "Update the status page and notify Slack when an uptime monitor recovers.",
                 category = CATEGORY_UPTIME,
                 triggerName = "uptime.up",
-                onceForTemplate = listOf(DEDUP_KEY, ALERT_STATUS),
+                onceForTemplate = listOf(EPISODE_KEY, ALERT_STATUS),
                 tags = listOf("uptime", "statuspage", "recovery"),
                 steps = listOf(
                     statusUpdateStep(description = "Service has recovered and is operating normally."),
@@ -187,7 +189,7 @@ object WorkflowBlueprintCatalog {
                 description = "Email members and post to Slack when a synthetic test fails.",
                 category = CATEGORY_ALERTING,
                 triggerName = "synthetic.failed",
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY, NOTIFICATION_SEQUENCE),
                 tags = listOf("synthetic", "notifications"),
                 steps = listOf(
                     emailAlertStep(
@@ -203,7 +205,7 @@ object WorkflowBlueprintCatalog {
                 description = "Page responders and announce a newly created incident on Slack.",
                 category = CATEGORY_INCIDENT,
                 triggerName = TRIGGER_INCIDENT_CREATED,
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY),
                 tags = listOf("incident", "oncall"),
                 steps = listOf(
                     oncallPageStep(
@@ -219,7 +221,7 @@ object WorkflowBlueprintCatalog {
                 description = "Create a status page incident when a new incident is created.",
                 category = CATEGORY_INCIDENT,
                 triggerName = TRIGGER_INCIDENT_CREATED,
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY),
                 tags = listOf("incident", "statuspage"),
                 steps = listOf(
                     statusIncidentStep(
@@ -234,7 +236,7 @@ object WorkflowBlueprintCatalog {
                 description = "Update the status page and notify Slack when an incident resolves.",
                 category = CATEGORY_INCIDENT,
                 triggerName = "incident.resolved",
-                onceForTemplate = listOf(DEDUP_KEY, INCIDENT_STATUS),
+                onceForTemplate = listOf(EPISODE_KEY, INCIDENT_STATUS),
                 tags = listOf("incident", "recovery"),
                 steps = listOf(
                     statusUpdateStep(description = "The incident has been resolved."),
@@ -284,7 +286,7 @@ object WorkflowBlueprintCatalog {
                 description = "Pull recent logs for enrichment and post a triage note to Slack.",
                 category = CATEGORY_TRIAGE,
                 triggerName = "monitor.alerted",
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY, NOTIFICATION_SEQUENCE),
                 tags = listOf("triage", "logs"),
                 steps = listOf(
                     WorkflowStepConfig(
@@ -304,7 +306,7 @@ object WorkflowBlueprintCatalog {
                 description = "Silence noisy alerts and notify Slack when an incident is created.",
                 category = CATEGORY_INCIDENT,
                 triggerName = TRIGGER_INCIDENT_CREATED,
-                onceForTemplate = listOf(DEDUP_KEY),
+                onceForTemplate = listOf(EPISODE_KEY),
                 tags = listOf("incident", "silence"),
                 steps = listOf(
                     WorkflowStepConfig(

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -20,6 +20,9 @@ import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertEpisodeContext
+import com.moneat.alerts.services.AlertEpisodeDecision
+import com.moneat.alerts.services.AlertEpisodeService
 import com.moneat.config.EnvConfig
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.security.signals.SignalOutcome
@@ -137,7 +140,8 @@ class WorkflowService(
         stepRenderer
     ),
     private val runPersistence: PersistRunActivityImpl = PersistRunActivityImpl(),
-    private val executionEngine: WorkflowExecutionEngine = TemporalWorkflowExecutionEngine(TemporalClientProvider())
+    private val executionEngine: WorkflowExecutionEngine = TemporalWorkflowExecutionEngine(TemporalClientProvider()),
+    private val alertEpisodeService: AlertEpisodeService = AlertEpisodeService()
 ) {
     private val json = workflowJson
     private val graphValidator = WorkflowGraphValidator()
@@ -625,13 +629,32 @@ class WorkflowService(
     }
 
     suspend fun publishAlertTriggered(event: AlertLifecycleEvent) {
+        if (event.status == AlertStatus.RESOLVED) {
+            publishResolvedAlertEvent(event)
+            return
+        }
+        val episode = alertEpisodeService.recordFiring(event) ?: return
+        if (!episode.shouldPublish) return
+        publishAlertWorkflowTriggers(event, episode)
+    }
+
+    private suspend fun publishResolvedAlertEvent(event: AlertLifecycleEvent) {
+        val episode = alertEpisodeService.recordResolved(event) ?: return
+        if (!episode.shouldPublish) return
+        publishAlertWorkflowTriggers(event, episode)
+    }
+
+    private suspend fun publishAlertWorkflowTriggers(
+        event: AlertLifecycleEvent,
+        episode: AlertEpisodeDecision
+    ) {
         val triggerName =
             if (event.status == AlertStatus.RESOLVED) {
                 ALERT_RESOLVED_TRIGGER
             } else {
                 ALERT_TRIGGERED_TRIGGER
             }
-        val scope = alertScope(event)
+        val scope = alertScope(event, episode)
         publishTrigger(WorkflowTriggerEvent(triggerName, event.organizationId, scope))
         sourceSpecificAlertTrigger(event)?.let { specificTriggerName ->
             publishTrigger(
@@ -653,39 +676,23 @@ class WorkflowService(
         moneatUrl: String = "",
         severity: AlertSeverity? = null
     ) {
-        val scope =
-            mapOf(
-                ALERT_TITLE_REFERENCE to title,
-                ALERT_DESCRIPTION_REFERENCE to description,
-                ALERT_SEVERITY_REFERENCE to severity?.name.orEmpty(),
-                ALERT_PRIORITY_REFERENCE to stepRenderer.priorityLabelForSeverity(severity?.name),
-                ALERT_STATUS_REFERENCE to AlertStatus.RESOLVED.name,
-                ALERT_SOURCE_REFERENCE to source,
-                ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
-                ALERT_URL_REFERENCE to moneatUrl,
-                ORGANIZATION_ID_REFERENCE to organizationId.toString()
-            ).typedWorkflowScope()
-        publishTrigger(
-            WorkflowTriggerEvent(
-                triggerName = ALERT_RESOLVED_TRIGGER,
+        val alertSource = AlertSource.entries.firstOrNull { it.name == source } ?: return
+        publishResolvedAlertEvent(
+            AlertLifecycleEvent(
+                title = title,
+                description = description,
+                severity = severity ?: AlertSeverity.LOW,
+                status = AlertStatus.RESOLVED,
+                source = alertSource,
+                deduplicationKey = deduplicationKey,
                 organizationId = organizationId,
-                scope = scope
+                moneatUrl = moneatUrl
             )
         )
-        AlertSource.entries.firstOrNull { it.name == source }?.let { alertSource ->
-            specificResolvedAlertTrigger(alertSource)?.let { triggerName ->
-                publishTrigger(
-                    WorkflowTriggerEvent(
-                        triggerName = triggerName,
-                        organizationId = organizationId,
-                        scope = scope
-                    )
-                )
-            }
-        }
     }
 
     suspend fun publishIncidentCreated(event: AlertLifecycleEvent) {
+        val episode = alertEpisodeService.ensureOpenEpisodeForWorkflow(event) ?: return
         publishTrigger(
             WorkflowTriggerEvent(
                 triggerName = INCIDENT_CREATED_TRIGGER,
@@ -695,7 +702,8 @@ class WorkflowService(
                     status = INCIDENT_STATUS_CREATED,
                     title = event.title,
                     severity = event.severity.name,
-                    deduplicationKey = event.deduplicationKey
+                    deduplicationKey = event.deduplicationKey,
+                    episode = episode
                 )
             )
         )
@@ -703,10 +711,16 @@ class WorkflowService(
 
     suspend fun publishIncidentResolved(
         organizationId: Int,
+        source: AlertSource,
         deduplicationKey: String,
         title: String,
         severity: AlertSeverity? = null
     ) {
+        val episode = alertEpisodeService.latestEpisodeForWorkflow(
+            organizationId = organizationId,
+            source = source,
+            deduplicationKey = deduplicationKey
+        ) ?: return
         publishTrigger(
             WorkflowTriggerEvent(
                 triggerName = INCIDENT_RESOLVED_TRIGGER,
@@ -716,7 +730,8 @@ class WorkflowService(
                     status = INCIDENT_STATUS_RESOLVED,
                     title = title,
                     severity = severity?.name.orEmpty(),
-                    deduplicationKey = deduplicationKey
+                    deduplicationKey = deduplicationKey,
+                    episode = episode
                 )
             )
         )
@@ -1181,7 +1196,10 @@ class WorkflowService(
             .filter { reference -> WORKFLOW_ENGINE_CONFIG_PREFIXES.any { prefix -> reference.startsWith(prefix) } }
             .distinct()
 
-    private fun alertScope(event: AlertLifecycleEvent): Map<String, JsonElement> {
+    private fun alertScope(
+        event: AlertLifecycleEvent,
+        episode: AlertEpisodeDecision
+    ): Map<String, JsonElement> {
         val baseScope =
             mapOf(
                 ALERT_TITLE_REFERENCE to event.title,
@@ -1194,8 +1212,33 @@ class WorkflowService(
                 ALERT_URL_REFERENCE to event.moneatUrl,
                 ORGANIZATION_ID_REFERENCE to event.organizationId.toString()
             ).typedWorkflowScope()
-        return baseScope + alertMetadataScope(event.metadata)
+        return baseScope + episodeScope(episode) + alertMetadataScope(event.metadata)
     }
+
+    private fun episodeScope(episode: AlertEpisodeDecision): Map<String, JsonElement> =
+        mapOf(
+            ALERT_EPISODE_ID_REFERENCE to episode.episode.id.toString(),
+            ALERT_EPISODE_KEY_REFERENCE to episode.episode.episodeKey,
+            ALERT_EPISODE_SEQ_REFERENCE to episode.episode.episodeSeq.toString(),
+            ALERT_NOTIFICATION_SEQUENCE_REFERENCE to episode.notificationSequence.toString(),
+            ALERT_NOTIFICATION_KIND_REFERENCE to episode.notificationKind,
+            ALERT_OPENED_AT_REFERENCE to episode.episode.openedAt.toString(),
+            ALERT_LAST_SEEN_AT_REFERENCE to episode.episode.lastSeenAt.toString()
+        ).typedWorkflowScope()
+
+    private fun episodeScope(
+        episode: AlertEpisodeContext,
+        notificationKind: String
+    ): Map<String, JsonElement> =
+        mapOf(
+            ALERT_EPISODE_ID_REFERENCE to episode.id.toString(),
+            ALERT_EPISODE_KEY_REFERENCE to episode.episodeKey,
+            ALERT_EPISODE_SEQ_REFERENCE to episode.episodeSeq.toString(),
+            ALERT_NOTIFICATION_SEQUENCE_REFERENCE to episode.notificationCount.toString(),
+            ALERT_NOTIFICATION_KIND_REFERENCE to notificationKind,
+            ALERT_OPENED_AT_REFERENCE to episode.openedAt.toString(),
+            ALERT_LAST_SEEN_AT_REFERENCE to episode.lastSeenAt.toString()
+        ).typedWorkflowScope()
 
     private fun alertMetadataScope(metadata: Map<String, JsonElement>): Map<String, JsonElement> =
         metadata
@@ -1209,9 +1252,10 @@ class WorkflowService(
         status: String,
         title: String,
         severity: String,
-        deduplicationKey: String
-    ): Map<String, JsonElement> =
-        mapOf(
+        deduplicationKey: String,
+        episode: AlertEpisodeContext
+    ): Map<String, JsonElement> {
+        val baseScope = mapOf(
             INCIDENT_ID_REFERENCE to deduplicationKey,
             INCIDENT_TITLE_REFERENCE to title,
             INCIDENT_STATUS_REFERENCE to status,
@@ -1219,6 +1263,8 @@ class WorkflowService(
             ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
             ORGANIZATION_ID_REFERENCE to organizationId.toString()
         ).typedWorkflowScope()
+        return baseScope + episodeScope(episode, status)
+    }
 
     private fun securitySignalScope(
         organizationId: Int,
@@ -1306,7 +1352,7 @@ class WorkflowService(
                     systemKey = "default_alert_notifications",
                     name = "Send alert notifications",
                     triggerName = ALERT_TRIGGERED_TRIGGER,
-                    onceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE),
+                    onceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_NOTIFICATION_SEQUENCE_REFERENCE),
                     steps = listOf(
                         WorkflowStepConfig(
                             name = EMAIL_ORG_STEP,
@@ -1351,7 +1397,7 @@ class WorkflowService(
                     systemKey = "default_recovery_notifications",
                     name = "Send recovery notifications",
                     triggerName = ALERT_RESOLVED_TRIGGER,
-                    onceForTemplate = listOf(ALERT_DEDUPLICATION_KEY_REFERENCE, ALERT_STATUS_REFERENCE),
+                    onceForTemplate = listOf(ALERT_EPISODE_KEY_REFERENCE, ALERT_STATUS_REFERENCE),
                     steps = listOf(
                         WorkflowStepConfig(
                             name = EMAIL_ORG_STEP,

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -42,6 +42,13 @@ import com.moneat.workflows.engine.temporal.TemporalWorkflowExecutionEngine
 import com.moneat.workflows.engine.temporal.WorkflowDirectRunExecutor
 import com.moneat.workflows.engine.temporal.WorkflowExecutionEngine
 import com.moneat.workflows.engine.temporal.WorkflowStartRequest
+import com.moneat.workflows.models.ALERT_EPISODE_ID_REFERENCE
+import com.moneat.workflows.models.ALERT_EPISODE_KEY_REFERENCE
+import com.moneat.workflows.models.ALERT_EPISODE_SEQ_REFERENCE
+import com.moneat.workflows.models.ALERT_LAST_SEEN_AT_REFERENCE
+import com.moneat.workflows.models.ALERT_NOTIFICATION_KIND_REFERENCE
+import com.moneat.workflows.models.ALERT_NOTIFICATION_SEQUENCE_REFERENCE
+import com.moneat.workflows.models.ALERT_OPENED_AT_REFERENCE
 import com.moneat.workflows.models.CreateWorkflowRequest
 import com.moneat.workflows.models.ManualWorkflowRunRequest
 import com.moneat.workflows.models.UpdateWorkflowRequest
@@ -676,7 +683,14 @@ class WorkflowService(
         moneatUrl: String = "",
         severity: AlertSeverity? = null
     ) {
-        val alertSource = AlertSource.entries.firstOrNull { it.name == source } ?: return
+        val alertSource = AlertSource.entries.firstOrNull { it.name == source }
+        if (alertSource == null) {
+            logger.warn {
+                "Skipping resolved alert workflow for unknown AlertSource '$source' " +
+                    "with deduplicationKey='$deduplicationKey' and organizationId=$organizationId"
+            }
+            return
+        }
         publishResolvedAlertEvent(
             AlertLifecycleEvent(
                 title = title,
@@ -1212,10 +1226,10 @@ class WorkflowService(
                 ALERT_URL_REFERENCE to event.moneatUrl,
                 ORGANIZATION_ID_REFERENCE to event.organizationId.toString()
             ).typedWorkflowScope()
-        return baseScope + episodeScope(episode) + alertMetadataScope(event.metadata)
+        return baseScope + episodeScopeFromDecision(episode) + alertMetadataScope(event.metadata)
     }
 
-    private fun episodeScope(episode: AlertEpisodeDecision): Map<String, JsonElement> =
+    private fun episodeScopeFromDecision(episode: AlertEpisodeDecision): Map<String, JsonElement> =
         mapOf(
             ALERT_EPISODE_ID_REFERENCE to episode.episode.id.toString(),
             ALERT_EPISODE_KEY_REFERENCE to episode.episode.episodeKey,
@@ -1226,7 +1240,7 @@ class WorkflowService(
             ALERT_LAST_SEEN_AT_REFERENCE to episode.episode.lastSeenAt.toString()
         ).typedWorkflowScope()
 
-    private fun episodeScope(
+    private fun episodeScopeFromContext(
         episode: AlertEpisodeContext,
         notificationKind: String
     ): Map<String, JsonElement> =
@@ -1263,7 +1277,7 @@ class WorkflowService(
             ALERT_DEDUPLICATION_KEY_REFERENCE to deduplicationKey,
             ORGANIZATION_ID_REFERENCE to organizationId.toString()
         ).typedWorkflowScope()
-        return baseScope + episodeScope(episode, status)
+        return baseScope + episodeScopeFromContext(episode, status)
     }
 
     private fun securitySignalScope(

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
@@ -65,6 +65,13 @@ internal const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
 internal const val ALERT_CONDITION_REFERENCE = "alert.condition"
 internal const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
 internal const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
+internal const val ALERT_EPISODE_ID_REFERENCE = "alert.episode_id"
+internal const val ALERT_EPISODE_KEY_REFERENCE = "alert.episode_key"
+internal const val ALERT_EPISODE_SEQ_REFERENCE = "alert.episode_seq"
+internal const val ALERT_NOTIFICATION_SEQUENCE_REFERENCE = "alert.notification_sequence"
+internal const val ALERT_NOTIFICATION_KIND_REFERENCE = "alert.notification_kind"
+internal const val ALERT_OPENED_AT_REFERENCE = "alert.opened_at"
+internal const val ALERT_LAST_SEEN_AT_REFERENCE = "alert.last_seen_at"
 private const val ALERT_COLOR_RED = "#E01E5A"
 private const val ALERT_COLOR_GREEN = "#2EB67D"
 private const val ALERT_COLOR_YELLOW = "#ECB22E"
@@ -108,6 +115,13 @@ class WorkflowStepRenderer {
             ALERT_STATUS_REFERENCE to status,
             ALERT_SOURCE_REFERENCE to "DASHBOARD_ALERT",
             ALERT_DEDUPLICATION_KEY_REFERENCE to "moneat-dashboard-alert-preview",
+            ALERT_EPISODE_ID_REFERENCE to "42",
+            ALERT_EPISODE_KEY_REFERENCE to "moneat-dashboard-alert-preview#3",
+            ALERT_EPISODE_SEQ_REFERENCE to "3",
+            ALERT_NOTIFICATION_SEQUENCE_REFERENCE to "1",
+            ALERT_NOTIFICATION_KIND_REFERENCE to if (resolved) "resolved" else "initial",
+            ALERT_OPENED_AT_REFERENCE to "2026-06-02T12:00:00Z",
+            ALERT_LAST_SEEN_AT_REFERENCE to "2026-06-02T12:05:00Z",
             ALERT_URL_REFERENCE to "https://moneat.io/dashboards/13",
             ALERT_DASHBOARD_TITLE_REFERENCE to "Moneat Backend System Health",
             ALERT_WIDGET_TITLE_REFERENCE to "Worker failures [1h]",
@@ -153,6 +167,13 @@ class WorkflowStepRenderer {
             "incident.status" to status,
             "incident.severity" to AlertSeverity.HIGH.name,
             ALERT_DEDUPLICATION_KEY_REFERENCE to "incident-checkout-latency",
+            ALERT_EPISODE_ID_REFERENCE to "42",
+            ALERT_EPISODE_KEY_REFERENCE to "incident-checkout-latency#3",
+            ALERT_EPISODE_SEQ_REFERENCE to "3",
+            ALERT_NOTIFICATION_SEQUENCE_REFERENCE to "1",
+            ALERT_NOTIFICATION_KIND_REFERENCE to status,
+            ALERT_OPENED_AT_REFERENCE to "2026-06-02T12:00:00Z",
+            ALERT_LAST_SEEN_AT_REFERENCE to "2026-06-02T12:05:00Z",
             ORGANIZATION_ID_REFERENCE to "1"
         )
     }

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowStepRenderer.kt
@@ -19,6 +19,13 @@ package com.moneat.workflows.services
 import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertStatus
 import com.moneat.config.EnvConfig
+import com.moneat.workflows.models.ALERT_EPISODE_ID_REFERENCE
+import com.moneat.workflows.models.ALERT_EPISODE_KEY_REFERENCE
+import com.moneat.workflows.models.ALERT_EPISODE_SEQ_REFERENCE
+import com.moneat.workflows.models.ALERT_LAST_SEEN_AT_REFERENCE
+import com.moneat.workflows.models.ALERT_NOTIFICATION_KIND_REFERENCE
+import com.moneat.workflows.models.ALERT_NOTIFICATION_SEQUENCE_REFERENCE
+import com.moneat.workflows.models.ALERT_OPENED_AT_REFERENCE
 import com.moneat.workflows.models.WorkflowPreviewField
 import com.moneat.workflows.models.WorkflowStepConfig
 import com.moneat.workflows.models.WorkflowStepPreview
@@ -65,13 +72,6 @@ internal const val ALERT_WIDGET_TITLE_REFERENCE = "alert.widget.title"
 internal const val ALERT_CONDITION_REFERENCE = "alert.condition"
 internal const val ALERT_THRESHOLD_REFERENCE = "alert.threshold"
 internal const val ALERT_CURRENT_VALUE_REFERENCE = "alert.current_value"
-internal const val ALERT_EPISODE_ID_REFERENCE = "alert.episode_id"
-internal const val ALERT_EPISODE_KEY_REFERENCE = "alert.episode_key"
-internal const val ALERT_EPISODE_SEQ_REFERENCE = "alert.episode_seq"
-internal const val ALERT_NOTIFICATION_SEQUENCE_REFERENCE = "alert.notification_sequence"
-internal const val ALERT_NOTIFICATION_KIND_REFERENCE = "alert.notification_kind"
-internal const val ALERT_OPENED_AT_REFERENCE = "alert.opened_at"
-internal const val ALERT_LAST_SEEN_AT_REFERENCE = "alert.last_seen_at"
 private const val ALERT_COLOR_RED = "#E01E5A"
 private const val ALERT_COLOR_GREEN = "#2EB67D"
 private const val ALERT_COLOR_YELLOW = "#ECB22E"

--- a/backend/src/main/resources/db/migration/V123__alert_episodes.sql
+++ b/backend/src/main/resources/db/migration/V123__alert_episodes.sql
@@ -1,0 +1,82 @@
+CREATE TABLE alert_episodes (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    source VARCHAR(64) NOT NULL,
+    deduplication_key TEXT NOT NULL,
+    episode_seq INTEGER NOT NULL,
+    episode_key TEXT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    opened_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    resolved_at TIMESTAMPTZ,
+    last_notification_at TIMESTAMPTZ,
+    notification_count INTEGER NOT NULL DEFAULT 0,
+    suppressed_at TIMESTAMPTZ,
+    suppressed_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    suppress_reason VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_alert_episodes_open_dedup
+    ON alert_episodes (organization_id, source, deduplication_key)
+    WHERE status = 'FIRING';
+
+CREATE UNIQUE INDEX idx_alert_episodes_sequence
+    ON alert_episodes (organization_id, source, deduplication_key, episode_seq);
+
+CREATE UNIQUE INDEX idx_alert_episodes_key
+    ON alert_episodes (organization_id, episode_key);
+
+CREATE INDEX idx_alert_episodes_recent_history
+    ON alert_episodes (organization_id, source, deduplication_key, opened_at DESC);
+
+CREATE INDEX idx_alert_episodes_org_status
+    ON alert_episodes (organization_id, status, last_seen_at DESC);
+
+UPDATE workflow_versions wv
+SET once_for_template = '["alert.episode_key", "alert.notification_sequence"]'::JSONB
+FROM workflows w
+WHERE w.id = wv.workflow_id
+    AND wv.most_recent = TRUE
+    AND w.trigger_name IN ('alert.triggered', 'monitor.alerted', 'uptime.down', 'synthetic.failed')
+    AND wv.once_for_template = '["alert.deduplication_key"]'::JSONB;
+
+UPDATE workflow_versions wv
+SET once_for_template = '["alert.episode_key", "alert.status"]'::JSONB
+FROM workflows w
+WHERE w.id = wv.workflow_id
+    AND wv.most_recent = TRUE
+    AND w.trigger_name IN ('alert.resolved', 'monitor.recovered', 'uptime.up', 'synthetic.passed')
+    AND wv.once_for_template = '["alert.deduplication_key", "alert.status"]'::JSONB;
+
+UPDATE workflow_versions wv
+SET once_for_template = '["alert.episode_key"]'::JSONB
+FROM workflows w
+WHERE w.id = wv.workflow_id
+    AND wv.most_recent = TRUE
+    AND w.trigger_name = 'incident.created'
+    AND wv.once_for_template = '["alert.deduplication_key"]'::JSONB;
+
+UPDATE workflow_versions wv
+SET once_for_template = '["alert.episode_key", "incident.status"]'::JSONB
+FROM workflows w
+WHERE w.id = wv.workflow_id
+    AND wv.most_recent = TRUE
+    AND w.trigger_name = 'incident.resolved'
+    AND wv.once_for_template = '["alert.deduplication_key", "incident.status"]'::JSONB;
+
+UPDATE workflows
+SET updated_at = NOW()
+WHERE trigger_name IN (
+    'alert.triggered',
+    'alert.resolved',
+    'monitor.alerted',
+    'monitor.recovered',
+    'uptime.down',
+    'uptime.up',
+    'synthetic.failed',
+    'synthetic.passed',
+    'incident.created',
+    'incident.resolved'
+);

--- a/backend/src/main/resources/docs/api/workflows.md
+++ b/backend/src/main/resources/docs/api/workflows.md
@@ -91,12 +91,37 @@ List recent runs for a workflow.
 |------|------|---------|-------------|
 | limit | integer | 50 | Number of runs to return. Values are clamped from 1 to 100. |
 
+### GET /v1/alerts/lifecycles
+
+List alert episodes for the current organization.
+
+**Query parameters:**
+
+| name | type | default | description |
+|------|------|---------|-------------|
+| status | string | all | Optional episode status, such as `FIRING` or `RESOLVED`. |
+| limit | integer | 50 | Number of episodes to return. Values are clamped from 1 to 100. |
+
+### POST /v1/alerts/lifecycles/{episodeId}/ignore
+
+Suppress notifications for the current open alert episode.
+
+**Body:**
+
+| name | type | required | description |
+|------|------|----------|-------------|
+| reason | string | no | Optional suppress reason. |
+
+### POST /v1/alerts/lifecycles/{episodeId}/unignore
+
+Resume notifications for an alert episode.
+
 ## Supported triggers
 
 | name | description |
 |------|-------------|
 | alert.triggered | Runs when Moneat fires an alert lifecycle event. |
-| alert.resolved | Runs when Moneat resolves an alert by deduplication key. |
+| alert.resolved | Runs when Moneat resolves an alert episode. |
 
 ## Supported steps
 
@@ -128,4 +153,12 @@ Dashboard alert events also expose dashboard-specific fields such as `alert.dash
 
 ## Run identity
 
-`once_for_template` is evaluated against the trigger scope to build `workflow_runs.once_for`. Moneat enforces one run per workflow and `once_for` value, which prevents repeated notification loops for the same alert.
+`once_for_template` is evaluated against the trigger scope to build `workflow_runs.once_for`. Moneat
+enforces one run per workflow and `once_for` value, which prevents repeated notification loops.
+
+Firing alert workflows default to `alert.episode_key` and `alert.notification_sequence`, so each
+new alert episode can notify again and long-running episodes can send daily reminders. Resolved alert
+workflows default to `alert.episode_key` and `alert.status`.
+
+`alert.deduplication_key` remains the stable key for the underlying alert condition. Do not use it
+alone as an alert workflow run identity unless repeat episodes should intentionally be suppressed.

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
@@ -141,6 +141,8 @@ class AlertEpisodeServiceTest {
         assertEquals("moneat-host-alert-1#2", reopened.episode.episodeKey)
     }
 
+    // ──── Workflow Helpers ────
+
     @Test
     fun `workflow helper opens episode without reserving notification`() {
         val now = Instant.parse("2026-06-02T12:00:00Z")
@@ -167,6 +169,8 @@ class AlertEpisodeServiceTest {
         assertNotNull(latestAfterPublish)
         assertEquals(helperEpisode.id, latestAfterPublish.id)
     }
+
+    // ──── Current Episode Helpers ────
 
     @Test
     fun `current episode helpers suppress unsuppress and close the open episode`() {
@@ -215,6 +219,8 @@ class AlertEpisodeServiceTest {
         assertNotNull(reopened)
         assertEquals(2, reopened.episodeSeq)
     }
+
+    // ──── Listing ────
 
     @Test
     fun `listEpisodes filters status and clamps limit`() {

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
@@ -141,6 +141,100 @@ class AlertEpisodeServiceTest {
         assertEquals("moneat-host-alert-1#2", reopened.episode.episodeKey)
     }
 
+    @Test
+    fun `workflow helper opens episode without reserving notification`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+        val event = alertEvent(deduplicationKey = "workflow-helper")
+
+        val helperEpisode = service.ensureOpenEpisodeForWorkflow(event, now)
+        val latestBeforePublish = service.latestEpisodeForWorkflow(
+            organizationId = orgId,
+            source = event.source,
+            deduplicationKey = event.deduplicationKey
+        )
+        val published = service.recordFiring(event, now + 1.hours)
+        val latestAfterPublish = service.latestEpisodeForWorkflow(
+            organizationId = orgId,
+            source = event.source,
+            deduplicationKey = event.deduplicationKey
+        )
+
+        assertNotNull(helperEpisode)
+        assertEquals(0, helperEpisode.notificationCount)
+        assertNull(latestBeforePublish)
+        assertNotNull(published)
+        assertEquals(1, published.notificationSequence)
+        assertNotNull(latestAfterPublish)
+        assertEquals(helperEpisode.id, latestAfterPublish.id)
+    }
+
+    @Test
+    fun `current episode helpers suppress unsuppress and close the open episode`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+        val deduplicationKey = "current-helper"
+        val opened = service.openCurrentEpisode(
+            organizationId = orgId,
+            source = AlertSource.ERROR_ALERT,
+            deduplicationKey = deduplicationKey,
+            now = now
+        )
+
+        assertNotNull(opened)
+        val suppressed = service.suppressCurrentEpisode(
+            organizationId = orgId,
+            source = AlertSource.ERROR_ALERT,
+            deduplicationKey = deduplicationKey,
+            userId = userId,
+            reason = "x".repeat(300),
+            now = now + 1.hours
+        )
+        val unsuppressed = service.unsuppressCurrentEpisode(
+            organizationId = orgId,
+            source = AlertSource.ERROR_ALERT,
+            deduplicationKey = deduplicationKey,
+            now = now + 2.hours
+        )
+        service.closeCurrentEpisode(
+            organizationId = orgId,
+            source = AlertSource.ERROR_ALERT,
+            deduplicationKey = deduplicationKey,
+            now = now + 3.hours
+        )
+        val reopened = service.openCurrentEpisode(
+            organizationId = orgId,
+            source = AlertSource.ERROR_ALERT,
+            deduplicationKey = deduplicationKey,
+            now = now + 4.hours
+        )
+
+        assertNotNull(suppressed)
+        assertNotNull(suppressed.suppressedAt)
+        assertEquals(255, suppressed.suppressReason?.length)
+        assertNotNull(unsuppressed)
+        assertNull(unsuppressed.suppressedAt)
+        assertNotNull(reopened)
+        assertEquals(2, reopened.episodeSeq)
+    }
+
+    @Test
+    fun `listEpisodes filters status and clamps limit`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+        val firing = alertEvent(deduplicationKey = "listed-firing")
+        val resolved = alertEvent(deduplicationKey = "listed-resolved")
+
+        service.recordFiring(firing, now)
+        service.recordFiring(resolved, now + 1.hours)
+        service.recordResolved(resolved.copy(status = AlertStatus.RESOLVED), now + 2.hours)
+
+        val all = service.listEpisodes(orgId, limit = 500)
+        val onlyFiring = service.listEpisodes(orgId, status = "firing", limit = 1)
+
+        assertEquals(2, all.size)
+        assertEquals(1, onlyFiring.size)
+        assertEquals("FIRING", onlyFiring.single().status)
+        assertEquals("listed-firing", onlyFiring.single().deduplicationKey)
+    }
+
     private fun seedUser(): Int =
         transaction {
             Users.insert {

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
@@ -1,0 +1,176 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.alerts
+
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertSeverity
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+class AlertEpisodeServiceTest {
+    companion object {
+        private var db: Database? = null
+    }
+
+    private val service = AlertEpisodeService()
+    private var orgId: Int = 0
+    private var userId: Int = 0
+
+    @BeforeTest
+    fun setup() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_alert_episodes;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.dropAndPatchJsonb(AlertEpisodes, Users, Organizations)
+        transaction {
+            SchemaUtils.create(Users, Organizations, AlertEpisodes)
+        }
+        userId = seedUser()
+        orgId = seedOrganization()
+    }
+
+    @Test
+    fun `initial firing opens episode and duplicate firing is not due before 24 hours`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+
+        val first = service.recordFiring(alertEvent(), now)
+        val duplicate = service.recordFiring(alertEvent(), now + 1.hours)
+
+        assertNotNull(first)
+        assertTrue(first.shouldPublish)
+        assertEquals(1, first.notificationSequence)
+        assertEquals("initial", first.notificationKind)
+        assertEquals("moneat-host-alert-1#1", first.episode.episodeKey)
+        assertNotNull(duplicate)
+        assertFalse(duplicate.shouldPublish)
+        assertEquals(1, duplicate.notificationSequence)
+        assertEquals("reminder", duplicate.notificationKind)
+        assertEquals(first.episode.id, duplicate.episode.id)
+    }
+
+    @Test
+    fun `firing reminder is due after 24 hours while episode remains open`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+
+        service.recordFiring(alertEvent(), now)
+        val reminder = service.recordFiring(alertEvent(), now + 25.hours)
+
+        assertNotNull(reminder)
+        assertTrue(reminder.shouldPublish)
+        assertEquals(2, reminder.notificationSequence)
+        assertEquals("reminder", reminder.notificationKind)
+        assertEquals("moneat-host-alert-1#1", reminder.episode.episodeKey)
+    }
+
+    @Test
+    fun `suppressed episode does not publish until unsuppressed`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+        val first = service.recordFiring(alertEvent(), now)
+
+        assertNotNull(first)
+        val suppressed = service.suppressEpisode(orgId, first.episode.id, userId, "Acked", now + 1.hours)
+        val whileSuppressed = service.recordFiring(alertEvent(), now + 25.hours)
+        val unsuppressed = service.unsuppressEpisode(orgId, first.episode.id, now + 26.hours)
+        val afterUnsuppress = service.recordFiring(alertEvent(), now + 27.hours)
+
+        assertNotNull(suppressed)
+        assertNotNull(suppressed.suppressedAt)
+        assertEquals(userId, suppressed.suppressedByUserId)
+        assertNotNull(whileSuppressed)
+        assertFalse(whileSuppressed.shouldPublish)
+        assertNotNull(unsuppressed)
+        assertNull(unsuppressed.suppressedAt)
+        assertNotNull(afterUnsuppress)
+        assertTrue(afterUnsuppress.shouldPublish)
+        assertEquals(2, afterUnsuppress.notificationSequence)
+    }
+
+    @Test
+    fun `resolved episode closes and next firing opens a new sequence`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+        val first = service.recordFiring(alertEvent(), now)
+
+        val resolved = service.recordResolved(alertEvent().copy(status = AlertStatus.RESOLVED), now + 1.hours)
+        val reopened = service.recordFiring(alertEvent(), now + 2.hours)
+
+        assertNotNull(first)
+        assertNotNull(resolved)
+        assertTrue(resolved.shouldPublish)
+        assertEquals("resolved", resolved.notificationKind)
+        assertEquals("RESOLVED", resolved.episode.status)
+        assertNotNull(reopened)
+        assertTrue(reopened.shouldPublish)
+        assertEquals(2, reopened.episode.episodeSeq)
+        assertEquals("moneat-host-alert-1#2", reopened.episode.episodeKey)
+    }
+
+    private fun seedUser(): Int =
+        transaction {
+            Users.insert {
+                it[email] = "episode@moneat.io"
+                it[password_hash] = "hash"
+                it[name] = "Episode User"
+                it[email_verified] = true
+            } get Users.id
+        }
+
+    private fun seedOrganization(): Int =
+        transaction {
+            Organizations.insert {
+                it[name] = "Episode Org"
+                it[slug] = "episode-org"
+            } get Organizations.id
+        }
+
+    private fun alertEvent(
+        source: AlertSource = AlertSource.HOST_ALERT,
+        deduplicationKey: String = "moneat-host-alert-1"
+    ): AlertLifecycleEvent =
+        AlertLifecycleEvent(
+            title = "CPU saturation",
+            description = "CPU has crossed the threshold",
+            severity = AlertSeverity.CRITICAL,
+            status = AlertStatus.FIRING,
+            source = source,
+            deduplicationKey = deduplicationKey,
+            organizationId = orgId,
+            moneatUrl = "https://moneat.io/hosts/1"
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
@@ -18,6 +18,9 @@
 
 package com.moneat.services
 
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.services.AlertEpisodeContext
+import com.moneat.alerts.services.AlertEpisodeService
 import com.moneat.events.models.EventResponse
 import com.moneat.events.models.FeedbackUpdateRequest
 import com.moneat.events.models.IssueTransactionResponse
@@ -29,7 +32,10 @@ import com.moneat.events.services.DashboardQueryHelper
 import com.moneat.events.services.FeedbackService
 import com.moneat.events.services.IngestionWorker
 import com.moneat.events.services.IssueService
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
 import com.moneat.shared.services.ProjectIdResolver
+import com.moneat.testsupport.TestDatabaseHelper
 import io.ktor.server.plugins.BadRequestException
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,6 +47,10 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -48,6 +58,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 /**
  * Extended tests for events/services covering:
@@ -60,14 +71,17 @@ class EventServicesExtendedTest {
 
     companion object {
         private const val ISSUE_1 = "issue-1"
+        private const val ORGANIZATION_ID = 1
         private const val TIMESTAMP_2024_01_01 = "2024-01-01T00:00:00.000Z"
         private const val UUID_550E8400 = "550e8400-e29b-41d4-a716-446655440000"
         private const val EMAIL_A_B = "a@b.com"
+        private var db: Database? = null
     }
 
     // ──── shared mocks ────
     private lateinit var issueRepository: IssueRepository
     private lateinit var queryHelper: DashboardQueryHelper
+    private lateinit var alertEpisodeService: AlertEpisodeService
     private lateinit var issueService: IssueService
 
     private val testProjectId = 10L
@@ -75,8 +89,29 @@ class EventServicesExtendedTest {
 
     @BeforeTest
     fun setup() {
+        db = db ?: Database.connect(
+            url = "jdbc:h2:mem:moneat_event_services_extended;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver"
+        )
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.resetSchema(Organizations, Projects)
+        transaction {
+            Organizations.insert {
+                it[id] = ORGANIZATION_ID
+                it[name] = "Test Org"
+                it[slug] = "test-org"
+            }
+            Projects.insert {
+                it[id] = testProjectId
+                it[organization_id] = ORGANIZATION_ID
+                it[name] = "Test Project"
+                it[slug] = "test-project"
+            }
+        }
+
         issueRepository = mockk(relaxed = true)
         queryHelper = mockk(relaxed = true)
+        alertEpisodeService = mockk(relaxed = true)
 
         coEvery { queryHelper.getProjectRetentionDays(any()) } returns 30
         every {
@@ -87,7 +122,8 @@ class EventServicesExtendedTest {
         issueService = IssueService(
             issueRepository,
             queryHelper,
-            ProjectIdResolver(lookupResourceIdByProjectId = { null })
+            ProjectIdResolver(lookupResourceIdByProjectId = { null }),
+            alertEpisodeService
         )
     }
 
@@ -396,6 +432,88 @@ class EventServicesExtendedTest {
         coEvery { issueRepository.getProjectIdForIssue(testIssueId) } returns testProjectId
         issueService.updateIssue(testIssueId, IssueUpdateRequest(status = null))
         verify(exactly = 0) { issueRepository.upsertIssueStatus(any(), any(), any()) }
+    }
+
+    @Test
+    fun `updateIssue ignored suppresses current error alert episode`() = runBlocking {
+        coEvery { issueRepository.getProjectIdForIssue(testIssueId) } returns testProjectId
+
+        issueService.updateIssue(testIssueId, IssueUpdateRequest(status = "ignored"))
+
+        verify {
+            alertEpisodeService.suppressCurrentEpisode(
+                organizationId = ORGANIZATION_ID,
+                source = AlertSource.ERROR_ALERT,
+                deduplicationKey = errorAlertDedupKey(),
+                userId = null,
+                reason = "Issue ignored",
+                now = any()
+            )
+        }
+    }
+
+    @Test
+    fun `updateIssue resolved and archived close current error alert episode`() = runBlocking {
+        coEvery { issueRepository.getProjectIdForIssue(testIssueId) } returns testProjectId
+
+        issueService.updateIssue(testIssueId, IssueUpdateRequest(status = "resolved"))
+        issueService.updateIssue(testIssueId, IssueUpdateRequest(status = "archived"))
+
+        verify(exactly = 2) {
+            alertEpisodeService.closeCurrentEpisode(
+                organizationId = ORGANIZATION_ID,
+                source = AlertSource.ERROR_ALERT,
+                deduplicationKey = errorAlertDedupKey(),
+                now = any()
+            )
+        }
+    }
+
+    @Test
+    fun `updateIssue unresolved reopens and unsuppresses existing error alert episode`() = runBlocking {
+        coEvery { issueRepository.getProjectIdForIssue(testIssueId) } returns testProjectId
+        every {
+            alertEpisodeService.openCurrentEpisode(
+                organizationId = ORGANIZATION_ID,
+                source = AlertSource.ERROR_ALERT,
+                deduplicationKey = errorAlertDedupKey(),
+                now = any()
+            )
+        } returns suppressedEpisode()
+
+        issueService.updateIssue(testIssueId, IssueUpdateRequest(status = "unresolved"))
+
+        verify {
+            alertEpisodeService.unsuppressCurrentEpisode(
+                organizationId = ORGANIZATION_ID,
+                source = AlertSource.ERROR_ALERT,
+                deduplicationKey = errorAlertDedupKey(),
+                now = any()
+            )
+        }
+    }
+
+    private fun errorAlertDedupKey(): String = "moneat-error-$testIssueId"
+
+    private fun suppressedEpisode(): AlertEpisodeContext {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+        return AlertEpisodeContext(
+            id = 1,
+            organizationId = ORGANIZATION_ID,
+            source = AlertSource.ERROR_ALERT.name,
+            deduplicationKey = errorAlertDedupKey(),
+            episodeSeq = 1,
+            episodeKey = "${errorAlertDedupKey()}#1",
+            status = "FIRING",
+            openedAt = now,
+            lastSeenAt = now,
+            resolvedAt = null,
+            lastNotificationAt = null,
+            notificationCount = 1,
+            suppressedAt = now,
+            suppressedByUserId = null,
+            suppressReason = "Issue ignored"
+        )
     }
 
     // ================================================================

--- a/backend/src/test/kotlin/com/moneat/services/SyntheticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SyntheticsServiceTest.kt
@@ -16,6 +16,10 @@
 
 package com.moneat.services
 
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.billing.services.BillingQuotaService
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Subscriptions
@@ -32,6 +36,10 @@ import com.moneat.synthetics.routes.SyntheticsCheckExecutor
 import com.moneat.synthetics.routes.SyntheticsService
 import com.moneat.synthetics.routes.UpdateSyntheticTestRequest
 import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.workflows.services.WorkflowService
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -105,6 +113,38 @@ class SyntheticsServiceTest {
             config = config
         )
     }
+
+    private fun syntheticTestData(
+        id: java.util.UUID = java.util.UUID.randomUUID(),
+        lastStatus: String? = null,
+        alertOnFailure: Boolean = true
+    ): SyntheticTestData {
+        val now = kotlin.time.Clock.System.now()
+        return SyntheticTestData(
+            id = id,
+            organizationId = TEST_ORG_ID,
+            name = "Synthetic Alert Test",
+            testType = "api",
+            active = true,
+            intervalSeconds = 60,
+            timeoutSeconds = 10,
+            url = "https://example.com/health",
+            method = "GET",
+            assertions = "[]",
+            status = "active",
+            lastStatus = lastStatus,
+            retryCount = 0,
+            retryIntervalMs = 100,
+            alertOnFailure = alertOnFailure,
+            createdAt = now,
+            updatedAt = now
+        )
+    }
+
+    private fun executorReturning(result: SyntheticCheckResult): SyntheticsCheckExecutor =
+        object : SyntheticsCheckExecutor() {
+            override suspend fun executeTest(test: SyntheticTestData): SyntheticCheckResult = result
+        }
 
     // ──── CRUD: Create ────
 
@@ -439,6 +479,62 @@ class SyntheticsServiceTest {
         val result = executor.executeTest(testData)
         assertEquals("passed", result.status)
     }
+
+    // ──── Alert Lifecycle ────
+
+    @Test
+    fun `executeTestAndRecord publishes firing alert for failed check`() =
+        runBlocking {
+            val workflowService = mockk<WorkflowService>(relaxed = true)
+            val service = SyntheticsService(
+                billingQuotaService = mockk<BillingQuotaService>(relaxed = true),
+                workflowService = workflowService
+            )
+            val eventSlot = slot<AlertLifecycleEvent>()
+            val testData = syntheticTestData()
+            val failure = SyntheticCheckResult(
+                status = "failed",
+                durationMs = 42,
+                errorMessage = "status code 500"
+            )
+
+            service.executeTestAndRecord(testData, executorReturning(failure))
+
+            coVerify(exactly = 1) {
+                workflowService.publishAlertTriggered(capture(eventSlot))
+            }
+            val event = eventSlot.captured
+            assertEquals(AlertStatus.FIRING, event.status)
+            assertEquals(AlertSource.SYNTHETIC_TEST, event.source)
+            assertEquals("moneat-synthetic-${testData.id}", event.deduplicationKey)
+            assertEquals(TEST_ORG_ID, event.organizationId)
+            assertTrue(event.description.contains("status code 500"))
+        }
+
+    @Test
+    fun `executeTestAndRecord publishes recovery alert after failed synthetic passes`() =
+        runBlocking {
+            val workflowService = mockk<WorkflowService>(relaxed = true)
+            val service = SyntheticsService(
+                billingQuotaService = mockk<BillingQuotaService>(relaxed = true),
+                workflowService = workflowService
+            )
+            val eventSlot = slot<AlertLifecycleEvent>()
+            val testData = syntheticTestData(lastStatus = "failed")
+            val success = SyntheticCheckResult(status = "passed", durationMs = 33)
+
+            service.executeTestAndRecord(testData, executorReturning(success))
+
+            coVerify(exactly = 1) {
+                workflowService.publishAlertTriggered(capture(eventSlot))
+            }
+            val event = eventSlot.captured
+            assertEquals(AlertStatus.RESOLVED, event.status)
+            assertEquals(AlertSource.SYNTHETIC_TEST, event.source)
+            assertEquals("moneat-synthetic-${testData.id}", event.deduplicationKey)
+            assertEquals(TEST_ORG_ID, event.organizationId)
+            assertTrue(event.description.contains("passed after previous failures"))
+        }
 
     // ──── Global Variables CRUD ────
 

--- a/backend/src/test/kotlin/com/moneat/services/UptimeExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/UptimeExtendedTest.kt
@@ -737,6 +737,7 @@ class UptimeExtendedTest {
             uptimeService = uptimeService,
             checkExecutor = checkExecutor,
             incidentService = incidentService,
+            frontendBaseUrl = "https://moneat.io",
         )
 
         scheduler.start()
@@ -787,6 +788,7 @@ class UptimeExtendedTest {
             uptimeService = uptimeService,
             checkExecutor = checkExecutor,
             incidentService = mockk(relaxed = true),
+            frontendBaseUrl = "https://moneat.io",
         )
 
         scheduler.start()

--- a/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
@@ -16,7 +16,10 @@
 
 package com.moneat.services
 
+import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.billing.services.BillingQuotaService
 import com.moneat.incident.services.IncidentService
 import com.moneat.shared.services.TaskLock
 import com.moneat.uptime.models.CheckResult
@@ -24,17 +27,21 @@ import com.moneat.uptime.models.UptimeMonitorData
 import com.moneat.uptime.services.UptimeCheckExecutor
 import com.moneat.uptime.services.UptimeScheduler
 import com.moneat.uptime.services.UptimeService
+import com.moneat.workflows.services.WorkflowService
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.isAccessible
@@ -45,11 +52,15 @@ class UptimeSchedulerTest {
     private val uptimeService = mockk<UptimeService>(relaxed = true)
     private val checkExecutor = mockk<UptimeCheckExecutor>(relaxed = true)
     private val incidentService = mockk<IncidentService>(relaxed = true)
+    private val billingQuotaService = mockk<BillingQuotaService>(relaxed = true)
+    private val workflowService = mockk<WorkflowService>(relaxed = true)
 
     private val scheduler = UptimeScheduler(
         uptimeService = uptimeService,
         checkExecutor = checkExecutor,
         incidentService = incidentService,
+        billingQuotaService = billingQuotaService,
+        workflowService = workflowService,
     )
 
     @AfterTest
@@ -239,6 +250,38 @@ class UptimeSchedulerTest {
         }
 
     // ──── Recovery ────
+
+    @Test
+    fun `performCheck publishes workflow event when monitor remains down`() =
+        runBlocking {
+            val monitor = testMonitor(status = "down")
+            val eventSlot = slot<AlertLifecycleEvent>()
+
+            every {
+                uptimeService.getMonitorsDueForCheck()
+            } returns listOf(monitor)
+            coEvery {
+                checkExecutor.executeCheck(monitor)
+            } returns CheckResult(
+                status = 0,
+                responseTimeMs = 250,
+                statusCode = 0,
+                message = "Connection refused"
+            )
+
+            callPrivateSuspend("performCheck", monitor.id)
+
+            coVerify(exactly = 1) {
+                workflowService.publishAlertTriggered(capture(eventSlot))
+            }
+            val event = eventSlot.captured
+            assertEquals(AlertStatus.FIRING, event.status)
+            assertEquals(AlertSource.UPTIME_MONITOR, event.source)
+            assertEquals("moneat-uptime-${monitor.id}", event.deduplicationKey)
+            assertEquals(monitor.organizationId, event.organizationId)
+            assertEquals(JsonPrimitive(monitor.id.toString()), event.metadata["monitor_id"])
+            assertEquals(JsonPrimitive("Connection refused"), event.metadata["error_message"])
+        }
 
     @Test
     fun `notifyStatusChange auto resolves incident when monitor recovers`() =

--- a/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
@@ -47,6 +47,8 @@ import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.isAccessible
 import kotlin.time.Instant
 
+private const val TEST_FRONTEND_BASE_URL = "https://moneat.io"
+
 class UptimeSchedulerTest {
 
     private val uptimeService = mockk<UptimeService>(relaxed = true)
@@ -61,6 +63,7 @@ class UptimeSchedulerTest {
         incidentService = incidentService,
         billingQuotaService = billingQuotaService,
         workflowService = workflowService,
+        frontendBaseUrl = TEST_FRONTEND_BASE_URL,
     )
 
     @AfterTest

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowGovernanceServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowGovernanceServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.workflows
 
+import com.moneat.alerts.models.AlertEpisodes
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertSource
@@ -521,7 +522,8 @@ class WorkflowGovernanceServiceTest {
             WorkflowRuns,
             WorkflowRunSteps,
             WorkflowAuditEvents,
-            WorkflowUsageEvents
+            WorkflowUsageEvents,
+            AlertEpisodes
         )
         transaction {
             // Drop child-to-parent so foreign keys never block a re-create between tests.
@@ -530,9 +532,10 @@ class WorkflowGovernanceServiceTest {
                 "workflow_runs",
                 "workflow_versions",
                 "workflow_audit_events",
-                "workflow_usage_events"
+                "workflow_usage_events",
+                "alert_episodes"
             ).forEach { table -> exec("DROP TABLE IF EXISTS $table") }
-            SchemaUtils.create(Users, Organizations, Memberships, Workflows)
+            SchemaUtils.create(Users, Organizations, Memberships, Workflows, AlertEpisodes)
             createWorkflowVersionTable()
             createWorkflowRunTable()
             createWorkflowRunStepTable()

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -17,6 +17,7 @@
 package com.moneat.workflows
 
 import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertEpisodes
 import com.moneat.alerts.models.AlertSeverity
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
@@ -65,6 +66,7 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import kotlin.test.BeforeTest
@@ -75,6 +77,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 class WorkflowServiceTest {
     companion object {
@@ -119,10 +123,11 @@ class WorkflowServiceTest {
             WorkflowRuns,
             WorkflowRunSteps,
             WorkflowAuditEvents,
-            WorkflowUsageEvents
+            WorkflowUsageEvents,
+            AlertEpisodes
         )
         transaction {
-            SchemaUtils.create(Users, Organizations, Memberships, Workflows)
+            SchemaUtils.create(Users, Organizations, Memberships, Workflows, AlertEpisodes)
             exec("DROP TABLE IF EXISTS workflow_runs")
             exec("DROP TABLE IF EXISTS workflow_versions")
             exec(
@@ -266,10 +271,13 @@ class WorkflowServiceTest {
                 .any { it.name == "contains" && it.valueType == "String" }
         )
         assertEquals("alert.triggered", response.triggers.first().name)
-        assertEquals(listOf("alert.deduplication_key"), response.triggers.first().defaultOnceForTemplate)
+        assertEquals(
+            listOf("alert.episode_key", "alert.notification_sequence"),
+            response.triggers.first().defaultOnceForTemplate
+        )
         val resolvedTrigger = response.triggers.first { it.name == "alert.resolved" }
         assertEquals(
-            listOf("alert.deduplication_key", "alert.status"),
+            listOf("alert.episode_key", "alert.status"),
             resolvedTrigger.defaultOnceForTemplate
         )
         assertTrue(response.triggers.any { it.name == "api" })
@@ -775,6 +783,71 @@ class WorkflowServiceTest {
         }
 
     @Test
+    fun `default alert workflows run initially and once per daily episode reminder`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Default episode notifications",
+                        triggerName = "alert.triggered",
+                        steps = emptyList()
+                    )
+                )
+            publish(workflow.id)
+
+            service.publishAlertTriggered(alertEvent())
+            service.publishAlertTriggered(alertEvent())
+
+            assertEquals(
+                listOf("alert.episode_key=host-1#1|alert.notification_sequence=1"),
+                service.listRuns(orgId, workflow.id).map { it.onceFor }
+            )
+
+            transaction {
+                AlertEpisodes.update({ AlertEpisodes.deduplicationKey eq "host-1" }) {
+                    it[AlertEpisodes.lastNotificationAt] = Clock.System.now() - 25.hours
+                }
+            }
+            service.publishAlertTriggered(alertEvent())
+
+            assertEquals(
+                listOf(
+                    "alert.episode_key=host-1#1|alert.notification_sequence=1",
+                    "alert.episode_key=host-1#1|alert.notification_sequence=2"
+                ),
+                service.listRuns(orgId, workflow.id).map { it.onceFor }.sorted()
+            )
+        }
+
+    @Test
+    fun `re-fired alert episode is not blocked by historical workflow runs`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Episode-scoped alert notifications",
+                        triggerName = "alert.triggered",
+                        steps = emptyList()
+                    )
+                )
+            publish(workflow.id)
+
+            service.publishAlertTriggered(alertEvent())
+            service.publishAlertTriggered(alertEvent().copy(status = AlertStatus.RESOLVED))
+            service.publishAlertTriggered(alertEvent())
+
+            assertEquals(
+                listOf(
+                    "alert.episode_key=host-1#1|alert.notification_sequence=1",
+                    "alert.episode_key=host-1#2|alert.notification_sequence=1"
+                ),
+                service.listRuns(orgId, workflow.id).map { it.onceFor }.sorted()
+            )
+        }
+
+    @Test
     fun `source specific alert triggers preserve legacy alert workflow behavior`() =
         runBlocking {
             val alertWorkflow =
@@ -1113,6 +1186,12 @@ class WorkflowServiceTest {
                 )
             publish(workflow.id)
 
+            service.publishAlertTriggered(
+                alertEvent().copy(
+                    source = AlertSource.UPTIME_MONITOR,
+                    deduplicationKey = "uptime-1"
+                )
+            )
             service.publishAlertResolved(
                 organizationId = orgId,
                 source = AlertSource.UPTIME_MONITOR.name,
@@ -1120,7 +1199,7 @@ class WorkflowServiceTest {
             )
 
             val queuedRun = service.listRuns(orgId, workflow.id).single()
-            assertEquals("alert.deduplication_key=uptime-1|alert.status=RESOLVED", queuedRun.onceFor)
+            assertEquals("alert.episode_key=uptime-1#1|alert.status=RESOLVED", queuedRun.onceFor)
 
             service.executeRun(queuedRun.id)
 
@@ -1133,6 +1212,56 @@ class WorkflowServiceTest {
             coVerify(exactly = 1) {
                 slackService.sendWorkflowMessage(orgId, "Resolved uptime-1", false)
             }
+        }
+
+    @Test
+    fun `alert workflows run once per episode notification and not historical dedup key`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Lifecycle notifications",
+                        triggerName = "alert.triggered",
+                        steps = listOf(emailStep()),
+                        onceForTemplate = listOf("alert.episode_key", "alert.notification_sequence")
+                    )
+                )
+            publish(workflow.id)
+
+            service.publishAlertTriggered(alertEvent())
+            service.publishAlertTriggered(alertEvent())
+            assertEquals(listOf("alert.episode_key=host-1#1|alert.notification_sequence=1"), runIdentities(workflow.id))
+
+            transaction {
+                AlertEpisodes.update({ AlertEpisodes.deduplicationKey eq "host-1" }) {
+                    it[lastNotificationAt] = Clock.System.now() - 25.hours
+                }
+            }
+            service.publishAlertTriggered(alertEvent())
+            assertEquals(
+                listOf(
+                    "alert.episode_key=host-1#1|alert.notification_sequence=1",
+                    "alert.episode_key=host-1#1|alert.notification_sequence=2"
+                ),
+                runIdentities(workflow.id)
+            )
+
+            service.publishAlertResolved(
+                organizationId = orgId,
+                source = AlertSource.HOST_ALERT.name,
+                deduplicationKey = "host-1"
+            )
+            service.publishAlertTriggered(alertEvent())
+
+            assertEquals(
+                listOf(
+                    "alert.episode_key=host-1#1|alert.notification_sequence=1",
+                    "alert.episode_key=host-1#1|alert.notification_sequence=2",
+                    "alert.episode_key=host-1#2|alert.notification_sequence=1"
+                ),
+                runIdentities(workflow.id)
+            )
         }
 
     @Test
@@ -1242,6 +1371,9 @@ class WorkflowServiceTest {
     private fun publish(workflowId: Int) {
         assertNotNull(service.publishWorkflow(orgId, workflowId))
     }
+
+    private fun runIdentities(workflowId: Int): List<String> =
+        service.listRuns(orgId, workflowId).map { it.onceFor }.sorted()
 
     private fun emailStep(): WorkflowStepConfig =
         WorkflowStepConfig(

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -1265,6 +1265,74 @@ class WorkflowServiceTest {
         }
 
     @Test
+    fun `incident workflows use alert episode identity`() =
+        runBlocking {
+            val createdWorkflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Incident created",
+                        triggerName = "incident.created",
+                        steps = emptyList()
+                    )
+                )
+            val resolvedWorkflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Incident resolved",
+                        triggerName = "incident.resolved",
+                        steps = emptyList()
+                    )
+                )
+            publish(createdWorkflow.id)
+            publish(resolvedWorkflow.id)
+
+            service.publishIncidentCreated(alertEvent())
+            service.publishIncidentCreated(alertEvent())
+
+            assertEquals(listOf("alert.episode_key=host-1#1"), runIdentities(createdWorkflow.id))
+            assertEquals(emptyList(), runIdentities(resolvedWorkflow.id))
+
+            service.publishAlertTriggered(alertEvent())
+            service.publishIncidentResolved(
+                organizationId = orgId,
+                source = AlertSource.HOST_ALERT,
+                deduplicationKey = "host-1",
+                title = "CPU restored",
+                severity = AlertSeverity.HIGH
+            )
+
+            assertEquals(
+                listOf("alert.episode_key=host-1#1|incident.status=resolved"),
+                runIdentities(resolvedWorkflow.id)
+            )
+        }
+
+    @Test
+    fun `publishAlertResolved ignores unknown alert source`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Resolved alerts",
+                        triggerName = "alert.resolved",
+                        steps = emptyList()
+                    )
+                )
+            publish(workflow.id)
+
+            service.publishAlertResolved(
+                organizationId = orgId,
+                source = "UNKNOWN_SOURCE",
+                deduplicationKey = "host-1"
+            )
+
+            assertEquals(emptyList(), runIdentities(workflow.id))
+        }
+
+    @Test
     fun `non matching and disabled workflows do not create runs`() =
         runBlocking {
             val disabled =

--- a/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -805,7 +805,7 @@ class WorkflowServiceTest {
             )
 
             transaction {
-                AlertEpisodes.update({ AlertEpisodes.deduplicationKey eq "host-1" }) {
+                AlertEpisodes.update(where = { AlertEpisodes.deduplicationKey eq "host-1" }) {
                     it[AlertEpisodes.lastNotificationAt] = Clock.System.now() - 25.hours
                 }
             }
@@ -1234,8 +1234,8 @@ class WorkflowServiceTest {
             assertEquals(listOf("alert.episode_key=host-1#1|alert.notification_sequence=1"), runIdentities(workflow.id))
 
             transaction {
-                AlertEpisodes.update({ AlertEpisodes.deduplicationKey eq "host-1" }) {
-                    it[lastNotificationAt] = Clock.System.now() - 25.hours
+                AlertEpisodes.update(where = { AlertEpisodes.deduplicationKey eq "host-1" }) {
+                    it[AlertEpisodes.lastNotificationAt] = Clock.System.now() - 25.hours
                 }
             }
             service.publishAlertTriggered(alertEvent())

--- a/dashboard/src/components/workflows/__tests__/workflowGraph.test.ts
+++ b/dashboard/src/components/workflows/__tests__/workflowGraph.test.ts
@@ -82,7 +82,7 @@ const catalog: WorkflowCatalogResponse = {
     label: 'When an alert triggers',
     description: 'Alert trigger.',
     scope: [],
-    default_once_for_template: ['alert.deduplication_key'],
+    default_once_for_template: ['alert.episode_key', 'alert.notification_sequence'],
   }],
   steps: [emailStep],
   node_types: [],
@@ -273,7 +273,7 @@ describe('workflow graph conversion', () => {
   it('builds drafts from catalog defaults and existing workflows', () => {
     expect(emptyWorkflowDraft(catalog)).toMatchObject({
       triggerName: 'alert.triggered',
-      onceForTemplate: 'alert.deduplication_key',
+      onceForTemplate: 'alert.episode_key, alert.notification_sequence',
     })
 
     expect(draftFromWorkflow(workflowResponse({name: 'Existing'}))).toMatchObject({

--- a/dashboard/src/components/workflows/workflowGraph.ts
+++ b/dashboard/src/components/workflows/workflowGraph.ts
@@ -37,6 +37,7 @@ export const workflowPaletteDragDataType = 'application/x-moneat-workflow-node'
 const legacyConditionNodeId = 'conditions'
 const workflowNodeVerticalGap = 80
 const workflowNodeHorizontalGap = 80
+const defaultAlertOnceForTemplate = 'alert.episode_key, alert.notification_sequence'
 
 export interface WorkflowPaletteDragPayload {
   node: Omit<WorkflowGraphNode, 'id'>
@@ -66,7 +67,7 @@ export function emptyWorkflowDraft(catalog?: WorkflowCatalogResponse): WorkflowD
     enabled: true,
     published: false,
     graph: graphFromLegacy(trigger?.name ?? 'alert.triggered', [], []),
-    onceForTemplate: trigger?.default_once_for_template.join(', ') ?? 'alert.deduplication_key',
+    onceForTemplate: trigger?.default_once_for_template.join(', ') ?? defaultAlertOnceForTemplate,
   }
 }
 

--- a/dashboard/src/docs/pages/workflows.mdx
+++ b/dashboard/src/docs/pages/workflows.mdx
@@ -31,7 +31,7 @@ Triggers decide when a workflow is considered for execution. Moneat currently su
 | Trigger | When it runs |
 |---------|--------------|
 | **When an alert triggers** | When Moneat fires an alert lifecycle event. |
-| **When an alert resolves** | When Moneat resolves an alert by deduplication key. |
+| **When an alert resolves** | When Moneat resolves an alert episode. |
 
 The trigger also defines which alert fields are available to conditions, messages, and run identity.
 
@@ -48,7 +48,12 @@ Available alert references include:
 | `alert.severity` | Alert severity |
 | `alert.status` | Firing or resolved state |
 | `alert.source` | Source system, such as host alerts or uptime monitors |
-| `alert.deduplication_key` | Alert deduplication key |
+| `alert.deduplication_key` | Stable key for the underlying alert condition |
+| `alert.episode_key` | Key for the current alert episode |
+| `alert.notification_sequence` | Notification number within the current episode |
+| `alert.notification_kind` | Initial, reminder, or resolved notification |
+| `alert.opened_at` | When the current episode opened |
+| `alert.last_seen_at` | Last time Moneat saw the episode still active |
 | `alert.url` | Link back to the alert in Moneat |
 | `organization.id` | Organization identifier |
 
@@ -82,7 +87,7 @@ Navigate to **Workflows** in the sidebar, then click **New Workflow**.
     },
     {
       title: 'Set run identity',
-      content: 'Use "Run once per" to control idempotency. The default alert deduplication key prevents repeated executions for the same alert.',
+      content: 'Use "Run once per" to control idempotency. The default alert identity runs once per episode notification.',
     },
     {
       title: 'Add conditions',
@@ -101,14 +106,17 @@ Navigate to **Workflows** in the sidebar, then click **New Workflow**.
 
 ## Run once per
 
-The **Run once per** setting controls how often a workflow can run for matching events. By default, alert workflows run once per `alert.deduplication_key`.
+The **Run once per** setting controls how often a workflow can run for matching events. By default,
+firing alert workflows run once per `alert.episode_key` and `alert.notification_sequence`.
 
-For resolved-alert workflows, the default identity includes `alert.status` as well, so triggered and resolved events do not collapse into the same run.
+For resolved-alert workflows, the default identity includes `alert.episode_key` and `alert.status`,
+so triggered and resolved events do not collapse into the same run.
 
 You can include multiple references separated by commas in the editor. Moneat combines those values into the workflow run identity.
 
-:::tip[Use the deduplication key for alert workflows]
-Keep `alert.deduplication_key` in the run identity unless you intentionally want the same alert to run the workflow multiple times.
+:::tip[Use episode identity for alert workflows]
+Use `alert.episode_key` for alert notification idempotency. `alert.deduplication_key` stays stable
+across recoveries, so using it alone suppresses future episodes of the same underlying condition.
 :::
 
 ## Message variables

--- a/dashboard/src/lib/api/modules/__tests__/monitoring.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/monitoring.test.ts
@@ -718,6 +718,98 @@ describe('Monitoring API module', () => {
     })
   })
 
+  // ──── Alert Lifecycles ────
+
+  describe('getAlertLifecycles', () => {
+    it('passes lifecycle filters and returns episodes', async () => {
+      server.use(
+        http.get(`${API_BASE}/v1/alerts/lifecycles`, ({ request }) => {
+          const url = new URL(request.url)
+          expect(url.searchParams.get('status')).toBe('FIRING')
+          expect(url.searchParams.get('limit')).toBe('25')
+          return HttpResponse.json([
+            {
+              id: 1,
+              organization_id: 10,
+              source: 'HOST_ALERT',
+              deduplication_key: 'host-1',
+              episode_seq: 2,
+              episode_key: 'host-1#2',
+              status: 'FIRING',
+              opened_at: '2026-06-02T12:00:00Z',
+              last_seen_at: '2026-06-02T12:05:00Z',
+              notification_count: 1,
+              created_at: '2026-06-02T12:00:00Z',
+              updated_at: '2026-06-02T12:05:00Z',
+            },
+          ])
+        })
+      )
+
+      const result = await api.getAlertLifecycles({status: 'FIRING', limit: 25})
+      expect(result[0].episode_key).toBe('host-1#2')
+      expect(result[0].notification_count).toBe(1)
+    })
+  })
+
+  describe('ignoreAlertLifecycle', () => {
+    it('posts an ignore reason', async () => {
+      server.use(
+        http.post(`${API_BASE}/v1/alerts/lifecycles/7/ignore`, async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          expect(body.reason).toBe('Investigating')
+          return HttpResponse.json({
+            id: 7,
+            organization_id: 10,
+            source: 'HOST_ALERT',
+            deduplication_key: 'host-1',
+            episode_seq: 1,
+            episode_key: 'host-1#1',
+            status: 'FIRING',
+            opened_at: '2026-06-02T12:00:00Z',
+            last_seen_at: '2026-06-02T12:00:00Z',
+            notification_count: 1,
+            suppressed_at: '2026-06-02T12:10:00Z',
+            suppress_reason: 'Investigating',
+            created_at: '2026-06-02T12:00:00Z',
+            updated_at: '2026-06-02T12:10:00Z',
+          })
+        })
+      )
+
+      const result = await api.ignoreAlertLifecycle(7, 'Investigating')
+      expect(result.suppress_reason).toBe('Investigating')
+    })
+  })
+
+  describe('unignoreAlertLifecycle', () => {
+    it('posts to unignore an episode', async () => {
+      server.use(
+        http.post(`${API_BASE}/v1/alerts/lifecycles/7/unignore`, () =>
+          HttpResponse.json({
+            id: 7,
+            organization_id: 10,
+            source: 'HOST_ALERT',
+            deduplication_key: 'host-1',
+            episode_seq: 1,
+            episode_key: 'host-1#1',
+            status: 'FIRING',
+            opened_at: '2026-06-02T12:00:00Z',
+            last_seen_at: '2026-06-02T12:00:00Z',
+            notification_count: 1,
+            suppressed_at: null,
+            suppress_reason: null,
+            created_at: '2026-06-02T12:00:00Z',
+            updated_at: '2026-06-02T12:11:00Z',
+          })
+        )
+      )
+
+      const result = await api.unignoreAlertLifecycle(7)
+      expect(result.suppressed_at).toBeNull()
+    })
+  })
+
   // ──── Silence Periods (field aliasing) ────
 
   describe('getSilencePeriods', () => {

--- a/dashboard/src/lib/api/modules/monitoring.ts
+++ b/dashboard/src/lib/api/modules/monitoring.ts
@@ -26,6 +26,8 @@ import type {
   DdConnectionListResponse,
   HostAlert,
   HostAlertConfig,
+  AlertEpisode,
+  AlertLifecycleListParams,
   SilencePeriod,
   CreateSilencePeriodRequest,
   SystemMetricsHistory,
@@ -258,7 +260,10 @@ export function monitoringMethods(core: ApiClientCore) {
       if (interval) params.append('interval', interval)
       const query = params.toString()
       return core.request<ContainerMetricsHistory>(
-        urlWithQuery(`${base}/monitor/systems/${systemId}/containers/${encodeURIComponent(containerName)}/metrics`, query)
+        urlWithQuery(
+          `${base}/monitor/systems/${systemId}/containers/${encodeURIComponent(containerName)}/metrics`,
+          query
+        )
       )
     },
 
@@ -340,6 +345,26 @@ export function monitoringMethods(core: ApiClientCore) {
         `${base}/monitor/hosts/${hostId}/alerts/${alertId}?scope=${scope}`,
         { method: 'DELETE' }
       ),
+
+    // Alert lifecycles
+    getAlertLifecycles: (params: AlertLifecycleListParams = {}) => {
+      const searchParams = new URLSearchParams()
+      if (params.status) searchParams.set('status', params.status)
+      if (params.limit != null) searchParams.set('limit', String(params.limit))
+      const query = searchParams.toString()
+      return core.request<AlertEpisode[]>(urlWithQuery(`${base}/alerts/lifecycles`, query))
+    },
+
+    ignoreAlertLifecycle: (episodeId: number, reason?: string) =>
+      core.request<AlertEpisode>(`${base}/alerts/lifecycles/${episodeId}/ignore`, {
+        method: 'POST',
+        body: JSON.stringify(reason === undefined ? {} : {reason}),
+      }),
+
+    unignoreAlertLifecycle: (episodeId: number) =>
+      core.request<AlertEpisode>(`${base}/alerts/lifecycles/${episodeId}/unignore`, {
+        method: 'POST',
+      }),
 
     // Silence periods
     getSilencePeriods: async () => {

--- a/dashboard/src/lib/api/types/monitoring.ts
+++ b/dashboard/src/lib/api/types/monitoring.ts
@@ -148,3 +148,28 @@ export interface CreateSilencePeriodRequest {
   starts_at: number
   ends_at: number
 }
+
+export interface AlertEpisode {
+  id: number
+  organization_id: number
+  source: string
+  deduplication_key: string
+  episode_seq: number
+  episode_key: string
+  status: string
+  opened_at: string
+  last_seen_at: string
+  resolved_at?: string | null
+  last_notification_at?: string | null
+  notification_count: number
+  suppressed_at?: string | null
+  suppressed_by_user_id?: number | null
+  suppress_reason?: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface AlertLifecycleListParams {
+  status?: string
+  limit?: number
+}


### PR DESCRIPTION
## Summary
- Add alert lifecycle episodes for workflow dedupe
- Scope alert workflow runs to episode notifications and recoveries
- Add lifecycle API/UI types and docs

## Validation
- backend: compileKotlin, detekt, test
- dashboard: targeted Vitest, lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alert episode lifecycle management: per-episode sequencing, notification counts, suppression (ignore/unignore) with optional reason, and resolution timestamps.
  * New API endpoints to list, ignore, and unignore alert episodes; dashboard client/types updated to surface episodes.

* **Behavior Changes**
  * Deduplication, reminders and workflow run identities now use episode-based keys and notification sequences.
  * Synthetic and uptime checks publish recovery/resolved notifications.

* **Database**
  * New migration adding alert_episodes table and backfilling workflow templates.

* **Tests**
  * Added integration and unit tests covering episode lifecycle, scheduler and workflow behavior.

* **Documentation**
  * Workflows and API docs updated to describe episode lifecycle and new references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->