### PR TITLE
fix: avoid profile timestamp alias collisions

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
@@ -334,8 +334,8 @@ object ProfileIngestionService {
                 toString(profile_id) as profile_id,
                 host, service, env, version,
                 runtime, language, profile_type,
-                toString(start_time) as start_time,
-                toString(end_time) as end_time,
+                toString(start_time) as profile_start_time,
+                toString(end_time) as profile_end_time,
                 duration_ns, storage_key,
                 tags, size_bytes, source
             FROM `$clickhouseDb`.profiles
@@ -665,6 +665,8 @@ object ProfileIngestionService {
         val service = serviceFromColumn.ifBlank {
             firstNonBlankTag(tagsMap, "service", "service.name", "service_name")
         }
+        val startTime = obj["start_time"] ?: obj["profile_start_time"]
+        val endTime = obj["end_time"] ?: obj["profile_end_time"]
         return DdProfileResponse(
             profileId = obj["profile_id"]!!.jsonPrimitive.content,
             host = obj["host"]?.jsonPrimitive?.content ?: "",
@@ -674,8 +676,8 @@ object ProfileIngestionService {
             runtime = obj["runtime"]?.jsonPrimitive?.content ?: "",
             language = obj["language"]?.jsonPrimitive?.content ?: "",
             profileType = obj["profile_type"]!!.jsonPrimitive.content,
-            startTime = obj["start_time"]!!.jsonPrimitive.content,
-            endTime = obj["end_time"]!!.jsonPrimitive.content,
+            startTime = startTime!!.jsonPrimitive.content,
+            endTime = endTime!!.jsonPrimitive.content,
             durationNs = obj["duration_ns"]!!.jsonPrimitive.long,
             sizeBytes = obj["size_bytes"]!!.jsonPrimitive.long,
             tags = tagsMap,

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
@@ -308,6 +308,9 @@ class ProfileIngestionServiceTest {
             assertTrue(queries.any { it.contains("service = 'api'") })
             assertTrue(queries.any { it.contains("start_time >= fromUnixTimestamp64Milli(1000)") })
             assertTrue(queries.any { it.contains("LIMIT 5 OFFSET 2") })
+            val listQuery = queries.single { it.contains("ORDER BY start_time DESC") }
+            assertTrue(listQuery.contains("toString(start_time) as profile_start_time"))
+            assertTrue(!listQuery.contains("toString(start_time) as start_time"))
         } finally {
             unmockkObject(ClickHouseClient)
         }
@@ -384,6 +387,37 @@ class ProfileIngestionServiceTest {
             assertEquals("", profile.runtime)
             assertEquals("", profile.language)
             assertEquals("datadog", profile.source)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `listProfiles maps profile timestamp aliases`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "testdb"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val sql = firstArg<String>()
+                if (sql.contains("SELECT count()")) {
+                    "1"
+                } else {
+                    compactJson(
+                        """{"profile_id":"profile-3","service":"api","profile_type":"cpu",""",
+                        """"profile_start_time":"2026-01-01 00:00:00",""",
+                        """"profile_end_time":"2026-01-01 00:00:01",""",
+                        """"duration_ns":42,"size_bytes":7,"tags":{}}""",
+                    )
+                }
+            }
+
+            val profile = ProfileIngestionService.listProfiles(
+                organizationId = 42,
+                query = DdProfileListQuery(),
+            ).profiles.single()
+
+            assertEquals("2026-01-01 00:00:00", profile.startTime)
+            assertEquals("2026-01-01 00:00:01", profile.endTime)
         } finally {
             unmockkObject(ClickHouseClient)
         }


### PR DESCRIPTION
Fixes profile list timestamp aliases so ClickHouse filters keep using the DateTime64 column.

Validation:
- `./gradlew compileKotlin`
- `./gradlew detekt`
- `./gradlew --no-daemon :test --tests com.moneat.datadog.services.ProfileIngestionServiceTest -Dkotlin.compiler.execution.strategy=in-process`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile timestamp handling in data retrieval to ensure accurate timestamp mapping and backward compatibility.

* **Tests**
  * Added test coverage for profile timestamp aliasing to verify correct timestamp data mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->