### PR TITLE
fix: infer Datadog NDM payload types

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestRoutes.kt
@@ -43,27 +43,30 @@ fun Route.ndmIngestRoutes(
     quotaService: BillingQuotaService = BillingQuotaService(),
 ) {
     route("/dd/api/v1") {
-        post("/ndm") { handleNdmPayload(quotaService) }
+        post("/ndm") { handleNdmPayload(quotaService, "ndm") }
     }
 
     // Event platform forwarder strips path from dd_url, so these arrive without /dd/ prefix.
     route("/api/v2") {
-        post("/ndm") { handleNdmPayload(quotaService) }
-        post("/ndmconfig") { handleNdmPayload(quotaService) }
-        post("/ndmtraps") { handleNdmPayload(quotaService) }
-        post("/ndmflow") { handleNdmPayload(quotaService) }
-        post("/netpath") { handleNdmPayload(quotaService) }
+        post("/ndm") { handleNdmPayload(quotaService, "ndm") }
+        post("/ndmconfig") { handleNdmPayload(quotaService, "ndmconfig") }
+        post("/ndmtraps") { handleNdmPayload(quotaService, "ndmtraps") }
+        post("/ndmflow") { handleNdmPayload(quotaService, "ndmflow") }
+        post("/netpath") { handleNdmPayload(quotaService, "netpath") }
     }
 }
+
 private suspend fun io.ktor.server.routing.RoutingContext.handleNdmPayload(
     quotaService: BillingQuotaService,
+    endpointType: String,
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
         val contentEncoding = call.request.headers["Content-Encoding"]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val payload = json.decodeFromString<DdNdmPayload>(body.decodeToString())
+        val decodedPayload = json.decodeFromString<DdNdmPayload>(body.decodeToString())
+        val payload = decodedPayload.withEndpointType(endpointType)
         val requestedUnits = countNdmPayload(payload)
         if (requestedUnits == null) {
             call.respond(
@@ -84,6 +87,14 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleNdmPayload(
     }.getOrElse { e ->
         logger.error(e) { "Failed to process NDM payload" }
         call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+    }
+}
+
+private fun DdNdmPayload.withEndpointType(endpointType: String): DdNdmPayload {
+    return if (type.isBlank()) {
+        copy(type = endpointType)
+    } else {
+        this
     }
 }
 

--- a/backend/src/test/kotlin/com/moneat/datadog/networkdevices/NdmIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/networkdevices/NdmIngestRoutesTest.kt
@@ -18,6 +18,7 @@ package com.moneat.datadog.networkdevices
 
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.datadog.auth.DatadogAuthMiddleware
+import com.moneat.datadog.models.DdNdmPayload
 import com.moneat.datadog.services.DatadogService
 import com.moneat.testsupport.startTestKoin
 import com.moneat.testsupport.stopTestKoin
@@ -37,6 +38,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -174,5 +176,38 @@ class NdmIngestRoutesTest {
             setBody("""{"type":"netpath","paths":[]}""")
         }
         assertEquals(HttpStatusCode.Accepted, response.status)
+    }
+
+    @Test
+    fun `ndm api v2 endpoints infer payload type from path`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns 1
+        val capturedTypes = mutableListOf<String>()
+        every { NdmIngestionService.enqueue(any(), any()) } answers {
+            capturedTypes += secondArg<DdNdmPayload>().type
+            1
+        }
+        application {
+            install(ContentNegotiation) { json() }
+            routing { ndmIngestRoutes(quotaService) }
+        }
+
+        val paths = listOf(
+            "/api/v2/ndm" to "ndm",
+            "/api/v2/ndmconfig" to "ndmconfig",
+            "/api/v2/ndmtraps" to "ndmtraps",
+            "/api/v2/ndmflow" to "ndmflow",
+            "/api/v2/netpath" to "netpath",
+        )
+        for (path in paths.map { it.first }) {
+            val response = client.post(path) {
+                header(DD_API_KEY_HEADER, VALID_KEY)
+                contentType(ContentType.Application.Json)
+                setBody("{}")
+            }
+            assertEquals(HttpStatusCode.Accepted, response.status, path)
+        }
+
+        assertEquals(paths.map { it.second }, capturedTypes)
+        verify(exactly = paths.size) { NdmIngestionService.enqueue(1, any()) }
     }
 }


### PR DESCRIPTION
Uses the Agent intake path as a fallback payload type for NDM submissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NDM data ingestion now automatically infers payload types from Datadog API endpoints, ensuring accurate type classification for downstream processing and counting.

* **Tests**
  * Added comprehensive test coverage to verify payload type inference across all NDM API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->