### PR TITLE
fix: classify agent log lines

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogLogService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogLogService.kt
@@ -18,6 +18,8 @@ package com.moneat.datadog.services
 
 import com.moneat.config.RedisConfig
 import com.moneat.datadog.models.DatadogLogEntry
+import com.moneat.logs.services.LogLineClassification
+import com.moneat.logs.services.LogLineClassifier
 import com.moneat.logs.models.QueuedLogBatch
 import com.moneat.logs.models.QueuedLogEntry
 import kotlinx.serialization.json.Json
@@ -26,22 +28,9 @@ import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
 private const val LOG_QUEUE_KEY = "moneat:logs:queue"
-
-private val ddStatusToLevel = mapOf(
-    "debug" to "debug",
-    "info" to "info",
-    "informational" to "info",
-    "notice" to "info",
-    "warn" to "warn",
-    "warning" to "warn",
-    "error" to "error",
-    "err" to "error",
-    "critical" to "fatal",
-    "crit" to "fatal",
-    "alert" to "fatal",
-    "emergency" to "fatal",
-    "emerg" to "fatal"
-)
+private const val DEFAULT_LOG_LEVEL = "info"
+private const val TAG_CATEGORY = "category"
+private const val TAG_DD_SOURCE = "ddsource"
 
 object DatadogLogService {
 
@@ -57,17 +46,18 @@ object DatadogLogService {
         val logs = entries.map { entry ->
             val tags = parseDdTags(entry.ddtags).toMutableMap()
             if (entry.ddsource.isNotBlank()) {
-                tags["ddsource"] = entry.ddsource
+                tags[TAG_DD_SOURCE] = entry.ddsource
             }
+            val classification = LogLineClassifier.classify(entry.message)
+            addClassificationTags(tags, classification)
 
             QueuedLogEntry(
                 logId = UUID.randomUUID().toString(),
                 timestampMs = entry.timestamp
                     ?: System.currentTimeMillis(),
-                level = ddStatusToLevel[entry.status.lowercase()]
-                    ?: "info",
-                message = entry.message,
-                body = "",
+                level = resolveLogLevel(entry.status, classification.level),
+                message = classification.message,
+                body = classification.body.orEmpty(),
                 service = entry.service,
                 environment = tags.remove("env") ?: "",
                 host = entry.hostname,
@@ -123,5 +113,26 @@ object DatadogLogService {
             }
         }
         return tags
+    }
+
+    private fun resolveLogLevel(
+        status: String,
+        classifiedLevel: String?
+    ): String {
+        val envelopeLevel = LogLineClassifier.normalizeLevel(status) ?: DEFAULT_LOG_LEVEL
+        return LogLineClassifier.resolveLevel(envelopeLevel, classifiedLevel)
+    }
+
+    private fun addClassificationTags(
+        tags: MutableMap<String, String>,
+        classification: LogLineClassification
+    ) {
+        classification.tags.forEach { (key, value) ->
+            if (key == TAG_CATEGORY) {
+                tags.putIfAbsent(key, value)
+            } else {
+                tags[key] = value
+            }
+        }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogLineClassifier.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogLineClassifier.kt
@@ -1,0 +1,152 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs.services
+
+private const val DEFAULT_LOG_LEVEL = "info"
+private const val DATADOG_AGENT_FORMAT = "datadog_agent"
+private const val TAG_CATEGORY = "category"
+private const val TAG_CODE_FILEPATH = "code.filepath"
+private const val TAG_CODE_FUNCTION = "code.function"
+private const val TAG_DD_AGENT_COMPONENT = "datadog.agent.component"
+private const val TAG_DD_AGENT_CALLER = "datadog.agent.caller"
+private const val TAG_LOG_FORMAT = "log.format"
+private const val AGENT_LINE_COMPONENT_GROUP = 1
+private const val AGENT_LINE_LEVEL_GROUP = 2
+private const val AGENT_LINE_CALLER_GROUP = 3
+private const val AGENT_LINE_MESSAGE_GROUP = 4
+private const val AGENT_CALLER_FILEPATH_GROUP = 1
+private const val AGENT_CALLER_FUNCTION_GROUP = 2
+
+private val agentPipeLineRegex = Regex(
+    "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} UTC \\| " +
+        "([A-Z][A-Z0-9_-]*) \\| ([A-Z]+) \\| (?:\\(([^)]+)\\) \\| )?(.*)$"
+)
+private val agentCallerRegex = Regex("^(.+?)(?::\\d+)?(?: in (.+))?$")
+
+private val knownLevels = mapOf(
+    "trace" to "trace",
+    "debug" to "debug",
+    "info" to "info",
+    "informational" to "info",
+    "notice" to "info",
+    "warn" to "warn",
+    "warning" to "warn",
+    "error" to "error",
+    "err" to "error",
+    "fatal" to "fatal",
+    "critical" to "fatal",
+    "crit" to "fatal",
+    "panic" to "fatal",
+    "alert" to "fatal",
+    "emergency" to "fatal",
+    "emerg" to "fatal"
+)
+
+private val levelRank = mapOf(
+    "trace" to 0,
+    "debug" to 1,
+    "info" to 2,
+    "warn" to 3,
+    "error" to 4,
+    "fatal" to 5
+)
+
+data class LogLineClassification(
+    val level: String? = null,
+    val message: String,
+    val body: String? = null,
+    val tags: Map<String, String> = emptyMap()
+)
+
+private data class ParsedAgentLogLine(
+    val component: String,
+    val level: String,
+    val caller: String,
+    val message: String
+)
+
+object LogLineClassifier {
+
+    fun classify(message: String): LogLineClassification {
+        val agentLine = parseAgentPipeLine(message) ?: return LogLineClassification(message = message)
+        return LogLineClassification(
+            level = agentLine.level,
+            message = agentLine.message.ifBlank { message },
+            body = message,
+            tags = agentLineTags(agentLine)
+        )
+    }
+
+    fun normalizeLevel(level: String?): String? {
+        return knownLevels[level?.trim()?.lowercase()]
+    }
+
+    fun resolveLevel(
+        envelopeLevel: String,
+        classifiedLevel: String?
+    ): String {
+        if (classifiedLevel == null) return envelopeLevel
+        if (envelopeLevel == DEFAULT_LOG_LEVEL) return classifiedLevel
+        return if (levelRank.getValue(classifiedLevel) > levelRank.getValue(envelopeLevel)) {
+            classifiedLevel
+        } else {
+            envelopeLevel
+        }
+    }
+
+    private fun parseAgentPipeLine(message: String): ParsedAgentLogLine? {
+        val match = agentPipeLineRegex.matchEntire(message.trim()) ?: return null
+        val component = match.groupValues[AGENT_LINE_COMPONENT_GROUP].lowercase()
+        val level = normalizeLevel(match.groupValues[AGENT_LINE_LEVEL_GROUP]) ?: return null
+        val caller = match.groupValues[AGENT_LINE_CALLER_GROUP]
+        val cleanMessage = match.groupValues[AGENT_LINE_MESSAGE_GROUP]
+        return ParsedAgentLogLine(
+            component = component,
+            level = level,
+            caller = caller,
+            message = cleanMessage
+        )
+    }
+
+    private fun agentLineTags(agentLine: ParsedAgentLogLine): Map<String, String> {
+        val tags = mutableMapOf(
+            TAG_CATEGORY to agentLine.component,
+            TAG_DD_AGENT_COMPONENT to agentLine.component,
+            TAG_LOG_FORMAT to DATADOG_AGENT_FORMAT
+        )
+        if (agentLine.caller.isNotBlank()) {
+            tags[TAG_DD_AGENT_CALLER] = agentLine.caller
+            addCallerTags(tags, agentLine.caller)
+        }
+        return tags
+    }
+
+    private fun addCallerTags(
+        tags: MutableMap<String, String>,
+        caller: String
+    ) {
+        val match = agentCallerRegex.matchEntire(caller) ?: return
+        val filepath = match.groupValues[AGENT_CALLER_FILEPATH_GROUP]
+        val function = match.groupValues[AGENT_CALLER_FUNCTION_GROUP]
+        if (filepath.isNotBlank()) {
+            tags[TAG_CODE_FILEPATH] = filepath
+        }
+        if (function.isNotBlank()) {
+            tags[TAG_CODE_FUNCTION] = function
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogLogServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogLogServiceTest.kt
@@ -59,6 +59,7 @@ class DatadogLogServiceTest {
     @Test
     fun `mapDdLogs maps status to level correctly`() {
         val entries = listOf(
+            DatadogLogEntry(message = "trace msg", status = "trace"),
             DatadogLogEntry(message = "debug msg", status = "debug"),
             DatadogLogEntry(message = "info msg", status = "info"),
             DatadogLogEntry(message = "notice msg", status = "notice"),
@@ -73,16 +74,67 @@ class DatadogLogServiceTest {
 
         val batch = DatadogLogService.mapDdLogs(1L, entries)
 
-        assertEquals("debug", batch.logs[0].level)
-        assertEquals("info", batch.logs[1].level)
+        assertEquals("trace", batch.logs[0].level)
+        assertEquals("debug", batch.logs[1].level)
         assertEquals("info", batch.logs[2].level)
-        assertEquals("warn", batch.logs[3].level)
+        assertEquals("info", batch.logs[3].level)
         assertEquals("warn", batch.logs[4].level)
-        assertEquals("error", batch.logs[5].level)
-        assertEquals("fatal", batch.logs[6].level)
+        assertEquals("warn", batch.logs[5].level)
+        assertEquals("error", batch.logs[6].level)
         assertEquals("fatal", batch.logs[7].level)
         assertEquals("fatal", batch.logs[8].level)
-        assertEquals("info", batch.logs[9].level) // default
+        assertEquals("fatal", batch.logs[9].level)
+        assertEquals("info", batch.logs[10].level) // default
+    }
+
+    @Test
+    fun `mapDdLogs derives level and tags from Datadog Agent log lines`() {
+        val rawMessage =
+            "2026-06-03 02:05:42 UTC | TRACE | ERROR | " +
+                "(pkg/trace/log/throttled.go:46 in log) | Received unexpected status code 403"
+        val entries = listOf(
+            DatadogLogEntry(
+                message = rawMessage,
+                status = "info",
+                service = "moneat-stage",
+                ddsource = "agent"
+            )
+        )
+
+        val batch = DatadogLogService.mapDdLogs(1L, entries)
+        val log = batch.logs.single()
+
+        assertEquals("error", log.level)
+        assertEquals("Received unexpected status code 403", log.message)
+        assertEquals(rawMessage, log.body)
+        assertEquals("trace", log.tags["category"])
+        assertEquals("trace", log.tags["datadog.agent.component"])
+        assertEquals("datadog_agent", log.tags["log.format"])
+        assertEquals("pkg/trace/log/throttled.go:46 in log", log.tags["datadog.agent.caller"])
+        assertEquals("pkg/trace/log/throttled.go", log.tags["code.filepath"])
+        assertEquals("log", log.tags["code.function"])
+        assertEquals("agent", log.tags["ddsource"])
+    }
+
+    @Test
+    fun `mapDdLogs keeps more severe envelope level for Agent log lines`() {
+        val rawMessage =
+            "2026-06-03 02:05:34 UTC | CORE | WARN | " +
+                "(pkg/process/runner/submitter.go:332 in logQueueSize) | Delivery queues: process[size=42]"
+        val entries = listOf(
+            DatadogLogEntry(
+                message = rawMessage,
+                status = "error"
+            )
+        )
+
+        val batch = DatadogLogService.mapDdLogs(1L, entries)
+        val log = batch.logs.single()
+
+        assertEquals("error", log.level)
+        assertEquals("Delivery queues: process[size=42]", log.message)
+        assertEquals("core", log.tags["category"])
+        assertEquals("logQueueSize", log.tags["code.function"])
     }
 
     @Test


### PR DESCRIPTION
## Summary
- classify structured agent log lines before storage
- preserve parsed context as log tags
- cover severity and tag mapping behavior

## Validation
- ./gradlew compileKotlin
- ./gradlew detekt
- GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :test --tests com.moneat.datadog.services.DatadogLogServiceTest -Dkotlin.compiler.execution.strategy=in-process