### PR TITLE
fix: accept empty Datadog Agent SBOM payloads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/SbomParser.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/SbomParser.kt
@@ -37,6 +37,7 @@ private const val MAX_ECOSYSTEM_LENGTH = 64
 private const val CYCLONEDX_FORMAT = "cyclonedx"
 private const val SPDX_PACKAGE_MANAGER_CATEGORY = "package-manager"
 private const val PURL_REFERENCE_TYPE = "purl"
+const val SBOM_NO_USABLE_PACKAGES_MESSAGE = "SBOM contains no packages with name and version"
 
 class SbomValidationException(
     message: String,
@@ -58,7 +59,7 @@ object SbomParser {
             else -> throw SbomValidationException("Unsupported SBOM format")
         }
         if (parsed.packages.isEmpty()) {
-            throw SbomValidationException("SBOM contains no packages with name and version")
+            throw SbomValidationException(SBOM_NO_USABLE_PACKAGES_MESSAGE)
         }
         if (parsed.packages.size > MAX_PACKAGES) {
             throw SbomValidationException("SBOM package count exceeds limit")
@@ -85,7 +86,7 @@ object SbomParser {
             }
         }
         if (packages.isEmpty()) {
-            throw SbomValidationException("SBOM contains no packages with name and version")
+            throw SbomValidationException(SBOM_NO_USABLE_PACKAGES_MESSAGE)
         }
         return ParsedSbom(
             format = SbomFormat.AGENT,

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
@@ -190,7 +190,7 @@ private suspend fun ingestAgentBody(
         return service.ingestParsed(orgId, direct, SbomUploadContext(source = SbomSource.AGENT))
     }
     val payload = routeJson.decodeFromString<DdSbomPayload>(body.decodeToString())
-    val parsed = SbomParser.parseAgentPayload(payload)
+    val parsed = parseAgentEnvelope(payload) ?: return emptyAgentSbomResponse()
     val context = SbomUploadContext(
         source = SbomSource.AGENT,
         targetType = if (payload.imageName.isNotBlank()) "image" else "host",
@@ -202,6 +202,21 @@ private suspend fun ingestAgentBody(
     )
     return service.ingestParsed(orgId, parsed, context)
 }
+
+private fun parseAgentEnvelope(payload: DdSbomPayload): ParsedSbom? {
+    return try {
+        SbomParser.parseAgentPayload(payload)
+    } catch (e: SbomValidationException) {
+        if (e.message == SBOM_NO_USABLE_PACKAGES_MESSAGE) {
+            null
+        } else {
+            throw e
+        }
+    }
+}
+
+private fun emptyAgentSbomResponse(): SbomIngestResponse =
+    SbomIngestResponse(uploadId = "agent-empty-inventory", packageCount = 0, findingCount = 0)
 
 private fun parseAgentDirectSbom(body: ByteArray): ParsedSbom? =
     try {

--- a/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutesTest.kt
@@ -206,6 +206,45 @@ class VulnerabilityRoutesTest {
     }
 
     @Test
+    fun `agent SBOM envelope without usable packages is accepted as noop`() = testApplication {
+        val store = InMemoryPackageInventoryStore()
+        mockkObject(DatadogService)
+        try {
+            DatadogAuthMiddleware.clearCache()
+            every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+            setupApp(
+                store = store,
+                includeAgentRoutes = true,
+                quotaService = quotaServiceWithoutEnforcement(),
+            )
+
+            val response = client.post("/api/v2/sbom") {
+                header("DD-API-KEY", VALID_KEY)
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                        {
+                          "host": "moneat-stage",
+                          "packages": [
+                            {"name": "", "version": "", "type": "deb"}
+                          ]
+                        }
+                    """.trimIndent()
+                )
+            }
+
+            val body = response.bodyAsText()
+            assertEquals(HttpStatusCode.Accepted, response.status)
+            assertTrue(body.contains("\"upload_id\":\"agent-empty-inventory\""))
+            assertTrue(body.contains("\"package_count\":0"))
+            assertTrue(store.inserted.isEmpty())
+        } finally {
+            DatadogAuthMiddleware.clearCache()
+            unmockkObject(DatadogService)
+        }
+    }
+
+    @Test
     fun `agent direct SBOM persistence failures surface instead of falling back`() = testApplication {
         mockkObject(DatadogService)
         try {


### PR DESCRIPTION
Acknowledges Agent SBOM inventories that contain no usable package rows while preserving validation failures for malformed payloads.