### PR TITLE
fix: disable no-ssl for Agent log intake

### DIFF
--- a/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
+++ b/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
@@ -175,6 +175,7 @@ process_config:
 
 logs_config:
   logs_dd_url: ${ingestUrl}
+  logs_no_ssl: false
 
 container_lifecycle:
   dd_url: ${baseUrl}

--- a/dashboard/src/docs/pages/datadog-agent/agent-setup.mdx
+++ b/dashboard/src/docs/pages/datadog-agent/agent-setup.mdx
@@ -24,6 +24,11 @@ Copy the configuration below and save it to `/etc/datadog-agent/datadog.yaml` on
 # Increase Docker check timeout (default 5s is too short on loaded hosts)
 docker_query_timeout: 15
 
+# Log Collection
+logs_config:
+  logs_dd_url: {{INGEST_URL}}
+  logs_no_ssl: false
+
 # Container (contlcycle-intake, contimage-intake, sbom-intake)
 container_lifecycle:
   dd_url: {{BACKEND_URL}}

--- a/dashboard/src/docs/pages/datadog-agent/log-collection.mdx
+++ b/dashboard/src/docs/pages/datadog-agent/log-collection.mdx
@@ -18,6 +18,7 @@ Add log configuration to your `datadog.yaml`:
 logs_enabled: true
 logs_config:
   logs_dd_url: "{{INGEST_URL}}"
+  logs_no_ssl: false
 ```
 
 Then restart the agent:

--- a/dashboard/src/routes/monitoring.index.tsx
+++ b/dashboard/src/routes/monitoring.index.tsx
@@ -183,6 +183,15 @@ apm_config:
   profiling_dd_url: ${ingestUrl}/profiling/v1/input`
   }
 
+  if (options.logs) {
+    yaml += `
+
+# Log Collection
+logs_config:
+  logs_dd_url: ${ingestUrl}
+  logs_no_ssl: false`
+  }
+
   yaml += `
 
 # EPForwarder tracks (cannot be set via env vars)
@@ -225,7 +234,11 @@ function getDockerRunCommand(apiKey: string, options: AgentOptions): string {
   }
   
   if (options.logs) {
-    envs += `\n  -e DD_LOGS_ENABLED=true \\\n  -e DD_LOGS_CONFIG_DD_URL="${ingestUrl}" \\\n  -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \\`
+    envs +=
+      `\n  -e DD_LOGS_ENABLED=true \\` +
+      `\n  -e DD_LOGS_CONFIG_DD_URL="${ingestUrl}" \\` +
+      `\n  -e DD_LOGS_CONFIG_LOGS_NO_SSL=false \\` +
+      `\n  -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \\`
   }
   
   if (options.processes) {
@@ -260,7 +273,11 @@ function getDockerComposeCommand(apiKey: string, options: AgentOptions): string 
   }
   
   if (options.logs) {
-    envs += `\n      - DD_LOGS_ENABLED=true\n      - DD_LOGS_CONFIG_DD_URL=${ingestUrl}\n      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`
+    envs +=
+      `\n      - DD_LOGS_ENABLED=true` +
+      `\n      - DD_LOGS_CONFIG_DD_URL=${ingestUrl}` +
+      `\n      - DD_LOGS_CONFIG_LOGS_NO_SSL=false` +
+      `\n      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`
   }
   
   if (options.processes) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,7 @@ services:
       DD_PROCESS_AGENT_ENABLED: "true"
       # Log Collection
       DD_LOGS_ENABLED: "true"
+      DD_LOGS_CONFIG_LOGS_NO_SSL: "false"
       DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "true"
       # Dynamic Instrumentation (Probes / Debugger)
       DD_DYNAMIC_INSTRUMENTATION_ENABLED: "true"


### PR DESCRIPTION
Sets log intake SSL configuration explicitly in generated Agent install snippets and docs.