### PR TITLE
fix: validate Datadog Agent telemetry keys

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
@@ -27,6 +27,15 @@ private val logger = KotlinLogging.logger {}
 
 private const val CACHE_TTL_MS = 300_000L // 5 minutes
 private const val MAX_CACHE_SIZE = 10_000
+private val API_KEY_HEADER_NAMES = listOf(
+    "DD-API-KEY",
+    "DD-Api-Key",
+    "dd-api-key",
+    "X-Datadog-API-Key",
+    "X-Datadog-Api-Key",
+    "Api-Key",
+    "api-key",
+)
 
 object DatadogAuthMiddleware {
     private data class CachedKey(val organizationId: Int, val expiresAt: Long)
@@ -159,8 +168,7 @@ object DatadogAuthMiddleware {
     }
 
     private fun getApiKey(call: ApplicationCall): String? =
-        call.request.headers["DD-API-KEY"]
-            ?: call.request.headers["DD-Api-Key"]
-            ?: call.request.headers["dd-api-key"]
+        API_KEY_HEADER_NAMES.firstNotNullOfOrNull { call.request.headers[it] }
             ?: call.request.queryParameters["api_key"]
+            ?: call.request.queryParameters["api-key"]
 }

--- a/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
@@ -57,7 +57,7 @@ object DatadogAuthMiddleware {
         val now = System.currentTimeMillis()
         evictExpiredEntries(now)
 
-        val apiKey = getApiKey(call)
+        val apiKey = extractApiKey(call)
         if (apiKey.isNullOrBlank()) {
             call.respond(
                 HttpStatusCode.Forbidden,
@@ -101,7 +101,7 @@ object DatadogAuthMiddleware {
         val now = System.currentTimeMillis()
         evictExpiredEntries(now)
 
-        val apiKey = getApiKey(call)
+        val apiKey = extractApiKey(call)
         if (apiKey.isNullOrBlank()) {
             call.respond(
                 HttpStatusCode.Forbidden,
@@ -167,7 +167,7 @@ object DatadogAuthMiddleware {
         contextCache.clear()
     }
 
-    private fun getApiKey(call: ApplicationCall): String? =
+    fun extractApiKey(call: ApplicationCall): String? =
         API_KEY_HEADER_NAMES.firstNotNullOfOrNull { call.request.headers[it] }
             ?: call.request.queryParameters["api_key"]
             ?: call.request.queryParameters["api-key"]

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogValidateRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogValidateRoutes.kt
@@ -21,18 +21,45 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.head
 import io.ktor.server.routing.route
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 fun Route.datadogValidateRoutes() {
+    route("/api/v1") {
+        datadogValidateHandlers()
+    }
+
     route("/dd") {
         route("/api/v1") {
-            get("/validate") {
-                val orgId = DatadogAuthMiddleware.authenticate(call) ?: return@get
-                call.respond(
-                    HttpStatusCode.OK,
-                    mapOf("valid" to "true", "org_id" to orgId.toString())
-                )
-            }
+            datadogValidateHandlers()
         }
     }
 }
+
+private fun Route.datadogValidateHandlers() {
+    get("/validate") { handleValidateApiKey() }
+    get("/validate/") { handleValidateApiKey() }
+    head("/validate") { handleValidateApiKeyHead() }
+    head("/validate/") { handleValidateApiKeyHead() }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleValidateApiKey() {
+    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
+    call.respond(
+        HttpStatusCode.OK,
+        DatadogValidationResponse(valid = true, orgId = orgId.toString())
+    )
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleValidateApiKeyHead() {
+    DatadogAuthMiddleware.authenticate(call) ?: return
+    call.respond(HttpStatusCode.OK)
+}
+
+@Serializable
+private data class DatadogValidationResponse(
+    val valid: Boolean,
+    @SerialName("org_id") val orgId: String,
+)

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TelemetryProxyRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TelemetryProxyRoutes.kt
@@ -19,6 +19,7 @@ package com.moneat.datadog.routes
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.services.TelemetryProxyService
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.path
 import io.ktor.server.request.receiveChannel
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -31,9 +32,21 @@ import com.moneat.utils.suspendRunCatching
 private val logger = KotlinLogging.logger {}
 
 fun Route.telemetryProxyRoutes() {
+    route("/telemetry") {
+        post("/proxy/{path...}") { handleTelemetryProxy() }
+    }
+
     route("/dd/telemetry") {
         // POST /dd/telemetry/proxy/* - agent telemetry proxy
         post("/proxy/{path...}") { handleTelemetryProxy() }
+    }
+
+    route("/api/v2") {
+        post("/apmtelemetry") { handleTelemetryProxy() }
+    }
+
+    route("/dd/api/v2") {
+        post("/apmtelemetry") { handleTelemetryProxy() }
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handleTelemetryProxy() {
@@ -42,7 +55,8 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleTelemetryProxy()
     suspendRunCatching {
         val rawBytes = call.receiveChannel().toByteArray()
         val path = call.parameters.getAll("path")
-            ?.joinToString("/") ?: "unknown"
+            ?.joinToString("/")
+            ?: call.request.path().trimStart('/')
 
         TelemetryProxyService.acknowledge(organizationId, path, rawBytes.size)
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))

--- a/backend/src/main/kotlin/com/moneat/plugins/RateLimiting.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/RateLimiting.kt
@@ -168,10 +168,7 @@ fun Application.configureRateLimiting() {
         }
         register(RateLimitName("datadog-ingestion")) {
             requestKey { call ->
-                val apiKey = call.request.headers["DD-API-KEY"]
-                    ?: call.request.headers["DD-Api-Key"]
-                    ?: call.request.headers["dd-api-key"]
-                    ?: call.request.queryParameters["api_key"]
+                val apiKey = DatadogAuthMiddleware.extractApiKey(call)
                 if (apiKey != null) {
                     DatadogAuthMiddleware.resolveOrgId(apiKey)
                         ?.let { "org:$it" }

--- a/backend/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
@@ -133,4 +133,32 @@ class DatadogAuthMiddlewareTest {
             assertEquals("1", response.bodyAsText())
         }
     }
+
+    @Test
+    fun `extractApiKey accepts shared Datadog key locations`() = testApplication {
+        application {
+            routing {
+                get("/probe") {
+                    call.respondText(DatadogAuthMiddleware.extractApiKey(call) ?: "missing")
+                }
+            }
+        }
+
+        val cases = listOf(
+            "/probe" to "X-Datadog-API-Key",
+            "/probe" to "Api-Key",
+            "/probe" to "api-key",
+        )
+        cases.forEach { (path, headerName) ->
+            val response = client.get(path) {
+                header(headerName, "header-value")
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("header-value", response.bodyAsText())
+        }
+
+        assertEquals("query-value", client.get("/probe?api_key=query-value").bodyAsText())
+        assertEquals("dash-query-value", client.get("/probe?api-key=dash-query-value").bodyAsText())
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
@@ -18,6 +18,15 @@ package com.moneat.datadog.auth
 
 import com.moneat.datadog.models.DdApiKeys
 import com.moneat.datadog.services.DatadogService
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -97,5 +106,31 @@ class DatadogAuthMiddlewareTest {
         // Should still work (re-validates from DB)
         val orgId = DatadogService.validateApiKey(created.key)
         assertNotNull(orgId)
+    }
+
+    @Test
+    fun `authenticate accepts alternate Datadog API key header names`() = testApplication {
+        val created = DatadogService.createApiKey(
+            organizationId = 1,
+            name = "Trace Writer Key",
+            userId = 1
+        )
+        application {
+            routing {
+                get("/probe") {
+                    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return@get
+                    call.respondText(orgId.toString())
+                }
+            }
+        }
+
+        listOf("X-Datadog-API-Key", "Api-Key", "api-key").forEach { headerName ->
+            val response = client.get("/probe") {
+                header(headerName, created.key)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("1", response.bodyAsText())
+        }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -31,6 +31,7 @@ import com.moneat.datadog.services.OrchestratorIngestionService
 import com.moneat.testsupport.startTestKoin
 import com.moneat.testsupport.stopTestKoin
 import io.ktor.client.request.get
+import io.ktor.client.request.head
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -554,7 +555,39 @@ class DatadogIngestRoutesTest {
             header(DD_API_KEY_HEADER, VALID_KEY)
         }
         assertEquals(HttpStatusCode.OK, response.status)
-        assertTrue(response.bodyAsText().contains("true"))
+        assertTrue(response.bodyAsText().filterNot(Char::isWhitespace).contains(""""valid":true"""))
+    }
+
+    @Test
+    fun `unprefixed v1 validate returns valid with valid api key`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.get("/api/v1/validate") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().filterNot(Char::isWhitespace).contains(""""valid":true"""))
+    }
+
+    @Test
+    fun `v1 validate accepts trailing slash`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.get("/dd/api/v1/validate/") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().filterNot(Char::isWhitespace).contains(""""valid":true"""))
+    }
+
+    @Test
+    fun `v1 validate accepts HEAD`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.head("/dd/api/v1/validate") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
     }
 
     // ──── Misc Ingest – /dd prefix ────

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -69,6 +69,7 @@ import com.moneat.testsupport.RouteTestSupport.withAuth
 import com.moneat.testsupport.TestDatabaseHelper
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.head
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.put
@@ -992,7 +993,45 @@ class DatadogRoutesExtendedTest {
             header(DD_API_KEY_HEADER, TEST_API_KEY)
         }
         assertEquals(HttpStatusCode.OK, response.status)
-        assertTrue(response.bodyAsText().contains("valid"))
+        assertTrue(response.bodyAsText().filterNot(Char::isWhitespace).contains(""""valid":true"""))
+    }
+
+    @Test
+    fun `GET unprefixed api v1 validate returns 200 with orgId`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { datadogValidateRoutes() }
+        }
+        val response = client.get("/api/v1/validate") {
+            header(DD_API_KEY_HEADER, TEST_API_KEY)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().filterNot(Char::isWhitespace).contains(""""valid":true"""))
+    }
+
+    @Test
+    fun `GET dd api v1 validate accepts trailing slash`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { datadogValidateRoutes() }
+        }
+        val response = client.get("/dd/api/v1/validate/") {
+            header(DD_API_KEY_HEADER, TEST_API_KEY)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().filterNot(Char::isWhitespace).contains(""""valid":true"""))
+    }
+
+    @Test
+    fun `HEAD dd api v1 validate returns 200`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { datadogValidateRoutes() }
+        }
+        val response = client.head("/dd/api/v1/validate") {
+            header(DD_API_KEY_HEADER, TEST_API_KEY)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
     }
 
     @Test
@@ -1390,6 +1429,20 @@ class DatadogRoutesExtendedTest {
             routing { telemetryProxyRoutes() }
         }
         val response = client.post("/dd/telemetry/proxy/api/v2/apmtelemetry") {
+            header(DD_API_KEY_HEADER, TEST_API_KEY)
+            contentType(ContentType.Application.Json)
+            setBody("""{"payload":"test"}""")
+        }
+        assertEquals(HttpStatusCode.Accepted, response.status)
+    }
+
+    @Test
+    fun `POST unprefixed apm telemetry returns 202`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { telemetryProxyRoutes() }
+        }
+        val response = client.post("/api/v2/apmtelemetry") {
             header(DD_API_KEY_HEADER, TEST_API_KEY)
             contentType(ContentType.Application.Json)
             setBody("""{"payload":"test"}""")


### PR DESCRIPTION
## What changed
- Accept Datadog Agent API key header variants used by trace and telemetry senders.
- Return a Datadog-shaped boolean validation response on prefixed and unprefixed validate routes, including trailing slash and HEAD checks.
- Accept trace-agent telemetry proxy payloads on prefixed and unprefixed telemetry paths.

## Validation
- `./gradlew :test --tests com.moneat.datadog.auth.DatadogAuthMiddlewareTest --tests com.moneat.datadog.routes.DatadogIngestRoutesTest --tests com.moneat.routes.DatadogRoutesExtendedTest -Dkotlin.compiler.execution.strategy=in-process`
- `./gradlew detekt -Dkotlin.compiler.execution.strategy=in-process`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key authentication now accepts multiple header name formats for increased flexibility.
  * Validation endpoints now available at multiple paths with HTTP HEAD request support.
  * Telemetry proxy endpoints expanded to support additional base paths.
  * Validation responses now standardized with consistent structure and additional metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->