### PR TITLE
fix: accept Datadog Agent profile v2 uploads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileIngestRoutes.kt
@@ -23,10 +23,13 @@ import com.moneat.datadog.decompression.DecompressionService
 import com.moneat.datadog.models.DdProfileEvent
 import com.moneat.datadog.services.DatadogPprofFlamegraphService
 import com.moneat.datadog.services.ProfileIngestionService
+import com.moneat.utils.suspendRunCatching
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
 import io.ktor.server.application.call
+import io.ktor.server.request.contentType
 import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -51,103 +54,128 @@ internal data class ProfileUploadFilePart(
 fun Route.profileIngestRoutes(
     quotaService: BillingQuotaService = BillingQuotaService(),
 ) {
+    route("/api/v2") {
+        // POST /api/v2/profile - current Datadog Agent profiling upload endpoint
+        post("/profile") { handleProfileUpload(quotaService) }
+    }
+
+    route("/dd/api/v2") {
+        post("/profile") { handleProfileUpload(quotaService) }
+    }
+
     route("/dd/profiling/v1") {
         // POST /dd/profiling/v1/input - multipart pprof upload
-        post("/input") {
-            val organizationId = DatadogAuthMiddleware.authenticate(call)
-                ?: return@post
-
-            var event: DdProfileEvent? = null
-            val fileParts = mutableListOf<ProfileUploadFilePart>()
-
-            val multipart = call.receiveMultipart()
-            multipart.forEachPart { part ->
-                val partName = part.name
-                when {
-                    // event can arrive as FormItem or FileItem (when agent sets Content-Type: application/json)
-                    partName == "event" && part is PartData.FormItem -> {
-                        runCatching {
-                            event = json.decodeFromString<DdProfileEvent>(part.value)
-                        }.onFailure { e ->
-                            logger.warn { "Failed to parse profiling event JSON: ${e.message}" }
-                        }
-                    }
-                    partName == "event" && part is PartData.FileItem -> {
-                        runCatching {
-                            val bytes = part.provider().toByteArray()
-                            event = json.decodeFromString<DdProfileEvent>(bytes.decodeToString())
-                        }.onFailure { e ->
-                            logger.warn { "Failed to parse profiling event JSON (file part): ${e.message}" }
-                        }
-                    }
-                    part is PartData.FileItem && partName != "event" -> {
-                        val rawBytes = part.provider().toByteArray()
-                        val bytes = runCatching {
-                            DecompressionService.decompress(
-                                rawBytes,
-                                part.headers["Content-Encoding"]
-                            )
-                        }.getOrElse { e ->
-                            logger.warn { "Failed to decompress profile part: ${e.message}" }
-                            rawBytes
-                        }
-                        val filename = part.originalFileName ?: partName ?: ""
-                        fileParts += ProfileUploadFilePart(
-                            partName = partName,
-                            fileName = filename,
-                            data = bytes,
-                        )
-                    }
-                }
-                part.dispose()
-            }
-
-            // Filter to parseable profile files (pprof or JFR)
-            val profileParts = fileParts.filter { part ->
-                DatadogPprofFlamegraphService.isSupportedPprof(part.data) ||
-                    DatadogPprofFlamegraphService.isLikelyJfrPayload(part.data) ||
-                    isLikelyPprofName(part.fileName) ||
-                    isLikelyPprofName(part.partName.orEmpty()) ||
-                    isLikelyJfrName(part.fileName) ||
-                    isLikelyJfrName(part.partName.orEmpty())
-            }.ifEmpty { fileParts }
-
-            val selectedProfile = selectProfilePart(profileParts)
-            if (selectedProfile == null) {
-                logger.warn {
-                    "Profile upload rejected for org $organizationId: no parseable profile data (pprof/JFR) " +
-                        "(event=${event != null}, files=${fileParts.size}, " +
-                        "file_names=${fileParts.map { it.fileName }})"
-                }
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    mapOf("error" to "Missing profile data (pprof/JFR)")
-                )
-                return@post
-            }
-
-            val totalBytes = profileParts.sumOf { it.data.size }.toLong()
-            if (!reserveDatadogQuota(call, quotaService, organizationId, 1, "dd_profile", totalBytes)) {
-                return@post
-            }
-
-            // If event is missing synthesize a minimal one so ingestion still works
-            val resolvedEvent = event ?: DdProfileEvent()
-            val profileType = inferProfileType(selectedProfile)
-
-            val profileId = ProfileIngestionService.ingestProfile(
-                organizationId = organizationId,
-                event = resolvedEvent,
-                fileParts = profileParts.map { it.fileName to it.data },
-                profileType = profileType,
-            )
-
-            call.respond(
-                HttpStatusCode.OK,
-                mapOf("profile_id" to profileId)
-            )
-        }
+        post("/input") { handleProfileUpload(quotaService) }
     }
+
+    route("/profiling/v1") {
+        post("/input") { handleProfileUpload(quotaService) }
+    }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleProfileUpload(
+    quotaService: BillingQuotaService,
+) {
+    val organizationId = DatadogAuthMiddleware.authenticate(call)
+        ?: return
+
+    if (call.request.contentType().withoutParameters() != ContentType.MultiPart.FormData) {
+        call.respond(
+            HttpStatusCode.BadRequest,
+            mapOf("error" to "Multipart profile payload required")
+        )
+        return
+    }
+
+    var event: DdProfileEvent? = null
+    val fileParts = mutableListOf<ProfileUploadFilePart>()
+
+    val multipart = call.receiveMultipart()
+    multipart.forEachPart { part ->
+        val partName = part.name
+        when {
+            // event can arrive as FormItem or FileItem (when agent sets Content-Type: application/json)
+            partName == "event" && part is PartData.FormItem -> {
+                runCatching {
+                    event = json.decodeFromString<DdProfileEvent>(part.value)
+                }.onFailure { e ->
+                    logger.warn { "Failed to parse profiling event JSON: ${e.message}" }
+                }
+            }
+            partName == "event" && part is PartData.FileItem -> {
+                suspendRunCatching {
+                    val bytes = part.provider().toByteArray()
+                    event = json.decodeFromString<DdProfileEvent>(bytes.decodeToString())
+                }.onFailure { e ->
+                    logger.warn { "Failed to parse profiling event JSON (file part): ${e.message}" }
+                }
+            }
+            part is PartData.FileItem && partName != "event" -> {
+                val rawBytes = part.provider().toByteArray()
+                val bytes = runCatching {
+                    DecompressionService.decompress(
+                        rawBytes,
+                        part.headers["Content-Encoding"]
+                    )
+                }.getOrElse { e ->
+                    logger.warn { "Failed to decompress profile part: ${e.message}" }
+                    rawBytes
+                }
+                val filename = part.originalFileName ?: partName ?: ""
+                fileParts += ProfileUploadFilePart(
+                    partName = partName,
+                    fileName = filename,
+                    data = bytes,
+                )
+            }
+        }
+        part.dispose()
+    }
+
+    // Filter to parseable profile files (pprof or JFR)
+    val profileParts = fileParts.filter { part ->
+        DatadogPprofFlamegraphService.isSupportedPprof(part.data) ||
+            DatadogPprofFlamegraphService.isLikelyJfrPayload(part.data) ||
+            isLikelyPprofName(part.fileName) ||
+            isLikelyPprofName(part.partName.orEmpty()) ||
+            isLikelyJfrName(part.fileName) ||
+            isLikelyJfrName(part.partName.orEmpty())
+    }.ifEmpty { fileParts }
+
+    val selectedProfile = selectProfilePart(profileParts)
+    if (selectedProfile == null) {
+        logger.warn {
+            "Profile upload rejected for org $organizationId: no parseable profile data (pprof/JFR) " +
+                "(event=${event != null}, files=${fileParts.size}, " +
+                "file_names=${fileParts.map { it.fileName }})"
+        }
+        call.respond(
+            HttpStatusCode.BadRequest,
+            mapOf("error" to "Missing profile data (pprof/JFR)")
+        )
+        return
+    }
+
+    val totalBytes = profileParts.sumOf { it.data.size }.toLong()
+    if (!reserveDatadogQuota(call, quotaService, organizationId, 1, "dd_profile", totalBytes)) {
+        return
+    }
+
+    // If event is missing synthesize a minimal one so ingestion still works
+    val resolvedEvent = event ?: DdProfileEvent()
+    val profileType = inferProfileType(selectedProfile)
+
+    val profileId = ProfileIngestionService.ingestProfile(
+        organizationId = organizationId,
+        event = resolvedEvent,
+        fileParts = profileParts.map { it.fileName to it.data },
+        profileType = profileType,
+    )
+
+    call.respond(
+        HttpStatusCode.OK,
+        mapOf("profile_id" to profileId)
+    )
 }
 
 internal fun selectPprofPart(

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -1599,7 +1599,12 @@ class DatadogRoutesExtendedTest {
 
     @Test
     fun `POST profile v2 aliases ingest uploaded profile`() = testApplication {
-        val aliases = listOf("/api/v2/profile", "/dd/api/v2/profile")
+        val aliases = listOf(
+            "/api/v2/profile",
+            "/dd/api/v2/profile",
+            "/profiling/v1/input",
+            "/dd/profiling/v1/input",
+        )
         application {
             install(ContentNegotiation) { json() }
             routing { profileIngestRoutes(allowingQuotaService) }
@@ -2324,15 +2329,23 @@ class DatadogRoutesExtendedTest {
     private fun profileMultipartBody(): MultiPartFormDataContent =
         MultiPartFormDataContent(
             formData {
-                append(
-                    "event",
-                    """{"start":"2026-06-03T03:45:00Z","end":"2026-06-03T03:46:00Z"}"""
+                appendFile(
+                    name = "event",
+                    fileName = "event.json",
+                    bytes = """{"start":"2026-06-03T03:45:00Z","end":"2026-06-03T03:46:00Z"}"""
+                        .toByteArray(),
+                    contentType = ContentType.Application.Json,
                 )
                 appendFile("chunk_data", "cpu.pprof", buildPprofProfilePayload())
             }
         )
 
-    private fun FormBuilder.appendFile(name: String, fileName: String, bytes: ByteArray) {
+    private fun FormBuilder.appendFile(
+        name: String,
+        fileName: String,
+        bytes: ByteArray,
+        contentType: ContentType = ContentType.Application.OctetStream,
+    ) {
         append(
             name,
             bytes,
@@ -2341,7 +2354,7 @@ class DatadogRoutesExtendedTest {
                     HttpHeaders.ContentDisposition,
                     "form-data; name=\"$name\"; filename=\"$fileName\""
                 )
-                append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                append(HttpHeaders.ContentType, contentType.toString())
             }
         )
     }

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -45,6 +45,7 @@ import com.moneat.datadog.routes.dbmIngestRoutes
 import com.moneat.datadog.routes.debuggerIngestRoutes
 import com.moneat.datadog.routes.miscIngestRoutes
 import com.moneat.datadog.routes.orchestratorIngestRoutes
+import com.moneat.datadog.routes.profileIngestRoutes
 import com.moneat.datadog.routes.telemetryProxyRoutes
 import com.moneat.datadog.routes.traceDashboardRoutes
 import com.moneat.datadog.routes.traceIngestRoutes
@@ -61,6 +62,7 @@ import com.moneat.datadog.services.DdTraceListQuery
 import com.moneat.datadog.services.DebuggerIngestionService
 import com.moneat.datadog.services.MiscIngestionService
 import com.moneat.datadog.services.OrchestratorIngestionService
+import com.moneat.datadog.services.ProfileIngestionService
 import com.moneat.datadog.services.QueuedConnectionEntry
 import com.moneat.datadog.services.QueuedInfraBatch
 import com.moneat.datadog.services.QueuedProcessEntry
@@ -75,11 +77,13 @@ import com.moneat.testsupport.RouteTestSupport
 import com.moneat.testsupport.RouteTestSupport.installJwtAuth
 import com.moneat.testsupport.RouteTestSupport.withAuth
 import com.moneat.testsupport.TestDatabaseHelper
+import io.ktor.client.request.forms.FormBuilder
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.head
 import io.ktor.client.request.header
-import io.ktor.client.request.head
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.request
@@ -87,6 +91,8 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsBytes
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -161,6 +167,7 @@ class DatadogRoutesExtendedTest {
                 TelemetryProxyService,
                 DatadogService,
                 TraceIngestionService,
+                ProfileIngestionService,
                 ClickHouseClient,
             )
         }
@@ -208,6 +215,7 @@ class DatadogRoutesExtendedTest {
             TelemetryProxyService,
             DatadogService,
             TraceIngestionService,
+            ProfileIngestionService,
             ClickHouseClient,
         )
 
@@ -254,6 +262,7 @@ class DatadogRoutesExtendedTest {
         every { DebuggerIngestionService.enqueueDiagnostics(any(), any()) } returns 1
         every { TelemetryProxyService.acknowledge(any(), any(), any()) } just Runs
         coEvery { TraceIngestionService.insertTraceStats(any(), any()) } just Runs
+        coEvery { ProfileIngestionService.ingestProfile(any(), any(), any(), any()) } returns "profile-test"
     }
 
     private fun Application.installAuth() {
@@ -1586,6 +1595,48 @@ class DatadogRoutesExtendedTest {
         assertEquals(HttpStatusCode.Accepted, response.status)
     }
 
+    // ──── ProfileIngestRoutes ────
+
+    @Test
+    fun `POST profile v2 aliases ingest uploaded profile`() = testApplication {
+        val aliases = listOf("/api/v2/profile", "/dd/api/v2/profile")
+        application {
+            install(ContentNegotiation) { json() }
+            routing { profileIngestRoutes(allowingQuotaService) }
+        }
+
+        aliases.forEach { path ->
+            val response = client.post(path) {
+                header(DD_API_KEY_HEADER, TEST_API_KEY)
+                setBody(profileMultipartBody())
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("profile-test"))
+        }
+
+        coVerify(exactly = aliases.size) {
+            ProfileIngestionService.ingestProfile(TEST_ORG_ID, any(), any(), "cpu")
+        }
+    }
+
+    @Test
+    fun `POST profile v2 returns 400 for non multipart payload`() = testApplication {
+        application {
+            install(ContentNegotiation) { json() }
+            routing { profileIngestRoutes(allowingQuotaService) }
+        }
+
+        val response = client.post("/api/v2/profile") {
+            header(DD_API_KEY_HEADER, TEST_API_KEY)
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("Multipart profile payload required"))
+    }
+
     // ──── DatadogInfraRoutes ────
 
     @Test
@@ -2270,6 +2321,77 @@ class DatadogRoutesExtendedTest {
 
     // ──── Helpers ────
 
+    private fun profileMultipartBody(): MultiPartFormDataContent =
+        MultiPartFormDataContent(
+            formData {
+                append(
+                    "event",
+                    """{"start":"2026-06-03T03:45:00Z","end":"2026-06-03T03:46:00Z"}"""
+                )
+                appendFile("chunk_data", "cpu.pprof", buildPprofProfilePayload())
+            }
+        )
+
+    private fun FormBuilder.appendFile(name: String, fileName: String, bytes: ByteArray) {
+        append(
+            name,
+            bytes,
+            Headers.build {
+                append(
+                    HttpHeaders.ContentDisposition,
+                    "form-data; name=\"$name\"; filename=\"$fileName\""
+                )
+                append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+            }
+        )
+    }
+
+    private fun buildPprofProfilePayload(): ByteArray =
+        buildProto {
+            writeByteArray(
+                1,
+                buildProto {
+                    writeInt64(1, 1)
+                    writeInt64(2, 2)
+                }
+            )
+            writeByteArray(
+                2,
+                buildProto {
+                    writeUInt64(1, 1)
+                    writeInt64(2, 1)
+                }
+            )
+            writeByteArray(
+                4,
+                buildProto {
+                    writeUInt64(1, 1)
+                    writeByteArray(
+                        4,
+                        buildProto {
+                            writeUInt64(1, 1)
+                            writeInt64(2, 1)
+                        }
+                    )
+                }
+            )
+            writeByteArray(
+                5,
+                buildProto {
+                    writeUInt64(1, 1)
+                    writeInt64(2, 3)
+                    writeInt64(3, 3)
+                    writeInt64(4, 4)
+                }
+            )
+            writeString(6, "")
+            writeString(6, "samples")
+            writeString(6, "count")
+            writeString(6, "main")
+            writeString(6, "main.go")
+            writeInt64(14, 1)
+        }
+
     private fun sampleHost(orgId: Int = TEST_ORG_ID) = DdHostInfo(
         id = 42,
         organizationId = orgId,
@@ -2286,3 +2408,13 @@ class DatadogRoutesExtendedTest {
         isOnline = true,
     )
 }
+
+private fun buildProto(block: CodedOutputStream.() -> Unit): ByteArray {
+    val buffer = ByteArray(PROTO_TEST_BUFFER_SIZE)
+    val output = CodedOutputStream.newInstance(buffer)
+    output.block()
+    output.flush()
+    return buffer.copyOf(output.totalBytesWritten)
+}
+
+private const val PROTO_TEST_BUFFER_SIZE = 512


### PR DESCRIPTION
## Summary
- route Datadog Agent v2 profile uploads through the existing profile ingestion path
- accept prefixed and unprefixed profiling aliases without changing them into no-op ACKs
- return an explicit 400 for non-multipart profile payloads

## Validation
- ./gradlew :test --tests com.moneat.datadog.routes.ProfileIngestRoutesTest --tests com.moneat.routes.DatadogRoutesExtendedTest -Dkotlin.compiler.execution.strategy=in-process
- ./gradlew detekt -Dkotlin.compiler.execution.strategy=in-process
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple Datadog profile upload endpoints for greater compatibility.
  * Unified handling for profile uploads with authentication, multipart validation, payload parsing, quota reservation, and ingestion.

* **Bug Fixes**
  * Return 400 for non-multipart profile requests and when no parseable payloads are present.

* **Tests**
  * Added end-to-end tests for all profile endpoints and multipart payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->