### PR TITLE
fix: ingest Datadog Agent misc payloads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/decompression/MiscPayloadDecoder.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/decompression/MiscPayloadDecoder.kt
@@ -1,0 +1,565 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.decompression
+
+import com.google.protobuf.CodedInputStream
+import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_3
+import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_4
+import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_5
+import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_7
+import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_8
+import com.moneat.datadog.decompression.ProtoWireConstants.FIELD_SHIFT
+import com.moneat.datadog.models.DatadogEvent
+import com.moneat.datadog.models.DdContainerImagePayload
+import com.moneat.datadog.models.DdSbomPackage
+import com.moneat.datadog.models.DdSbomPayload
+
+/**
+ * Decodes Datadog agent-payload protobufs for miscellaneous V2 intake endpoints.
+ *
+ * IDL source:
+ * - github.com/DataDog/agent-payload/proto/contimage/contimage.proto
+ * - github.com/DataDog/agent-payload/proto/sbom/sbom.proto
+ * - github.com/DataDog/agent-payload/proto/contlcycle/contlcycle.proto
+ */
+object MiscPayloadDecoder {
+    private const val FIELD_10 = 10
+    private const val FIELD_11 = 11
+    private const val FIELD_12 = 12
+    private const val FIELD_14 = 14
+    private const val FIELD_15 = 15
+    private const val FIELD_16 = 16
+    private const val FIELD_17 = 17
+    private const val FIELD_21 = 21
+    private const val FIELD_6 = 6
+    private const val FIELD_9 = 9
+    private const val FIELD_WIRE_LEN = 2
+    private const val FIELD_WIRE_VARINT = 0
+    private const val SBOM_TYPE_CONTAINER_IMAGE_LAYERS = 1
+    private const val SBOM_TYPE_CONTAINER_FILE_SYSTEM = 2
+    private const val SBOM_TYPE_HOST_FILE_SYSTEM = 3
+    private const val SBOM_TYPE_CI_PIPELINE = 4
+    private const val SBOM_TYPE_HOST_IMAGE = 5
+    private const val SBOM_TYPE_SERVERLESS_FUNCTION = 6
+    private const val CYCLONEDX_CLASSIFICATION_APPLICATION = 1
+    private const val CYCLONEDX_CLASSIFICATION_FRAMEWORK = 2
+    private const val CYCLONEDX_CLASSIFICATION_LIBRARY = 3
+    private const val CYCLONEDX_CLASSIFICATION_OPERATING_SYSTEM = 4
+    private const val CYCLONEDX_CLASSIFICATION_CONTAINER = 7
+    private const val OBJECT_KIND_CONTAINER = 0
+    private const val OBJECT_KIND_POD = 1
+    private const val OBJECT_KIND_TASK = 2
+    private const val UNIX_NANOS_THRESHOLD = 10_000_000_000_000_000L
+    private const val UNIX_MILLIS_THRESHOLD = 10_000_000_000L
+    private const val NANOS_PER_SECOND = 1_000_000_000L
+    private const val MILLIS_PER_SECOND = 1_000L
+
+    fun decodeContainerImages(proto: ByteArray): List<DdContainerImagePayload> {
+        val input = CodedInputStream.newInstance(proto)
+        var host = ""
+        var source = ""
+        val images = mutableListOf<ContainerImageProto>()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> host = input.readString()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> images += decodeContainerImage(input.readByteArray())
+                (FIELD_4 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> source = input.readString()
+                else -> input.skipField(tag)
+            }
+        }
+
+        return images.map { image ->
+            DdContainerImagePayload(
+                imageName = image.name.ifBlank { image.shortName },
+                imageTag = image.imageTag(),
+                digest = image.digest.ifBlank { image.repoDigests.firstOrNull().orEmpty() },
+                registry = image.registry,
+                sizeBytes = image.sizeBytes,
+                os = image.osName,
+                architecture = image.architecture,
+                layers = image.layerCount,
+                tags = buildList {
+                    addAll(image.ddTags)
+                    addTag("host", host)
+                    addTag("source", source)
+                    addTag("image_id", image.id)
+                    addTag("short_name", image.shortName)
+                    image.repoTags.firstOrNull()?.let { addTag("repo_tag", it) }
+                    image.repoDigests.firstOrNull()?.let { addTag("repo_digest", it) }
+                },
+            )
+        }
+    }
+
+    fun decodeSbom(proto: ByteArray): DdSbomPayload {
+        val input = CodedInputStream.newInstance(proto)
+        var host = ""
+        var source = ""
+        var env = ""
+        val entities = mutableListOf<SbomEntityProto>()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> host = input.readString()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> source = input.readString()
+                (FIELD_4 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entities += decodeSbomEntity(input.readByteArray())
+                (FIELD_5 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> env = input.readString()
+                else -> input.skipField(tag)
+            }
+        }
+
+        val packages = mutableListOf<DdSbomPackage>()
+        val tags = mutableListOf<String>()
+        entities.forEach { entity ->
+            tags += entity.ddTags
+            tags.addTag("source", source)
+            tags.addTag("env", env)
+            tags.addTag("entity_id", entity.id)
+            tags.addTag("entity_type", entity.typeName())
+            entity.repoTags.firstOrNull()?.let { tags.addTag("repo_tag", it) }
+            entity.repoDigests.firstOrNull()?.let { tags.addTag("repo_digest", it) }
+
+            packages += entity.components.map { component ->
+                DdSbomPackage(
+                    name = component.name,
+                    version = component.version,
+                    type = component.packageType(),
+                    cveIds = component.cveIds,
+                )
+            }
+        }
+
+        return DdSbomPayload(
+            host = host,
+            containerId = entities.firstOrNull()?.id.orEmpty(),
+            imageName = entities.firstNotNullOfOrNull { it.imageName() }.orEmpty(),
+            packages = packages,
+            tags = tags.distinct(),
+        )
+    }
+
+    fun decodeContainerLifecycleEvents(proto: ByteArray): List<DatadogEvent> {
+        val input = CodedInputStream.newInstance(proto)
+        var host = ""
+        var objectKind = 0
+        var clusterId = ""
+        val events = mutableListOf<ContainerLifecycleEventProto>()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> host = input.readString()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> objectKind = input.readEnum()
+                (FIELD_4 shl FIELD_SHIFT) or FIELD_WIRE_LEN ->
+                    events += decodeContainerLifecycleEvent(input.readByteArray())
+                (FIELD_5 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> clusterId = input.readString()
+                else -> input.skipField(tag)
+            }
+        }
+
+        return events.map { event ->
+            val kind = event.kind.ifBlank { objectKindName(objectKind) }
+            val objectId = event.objectId
+            val title = "Datadog container lifecycle ${event.eventTypeName}: $kind $objectId"
+            DatadogEvent(
+                title = title,
+                text = event.description(kind),
+                dateHappened = event.exitTimestamp?.let(::normalizeUnixSeconds),
+                priority = "normal",
+                host = host,
+                tags = buildList {
+                    addTag("event_type", event.eventTypeName)
+                    addTag("object_kind", kind)
+                    addTag("source", event.source)
+                    addTag("cluster_id", clusterId)
+                    addTag("object_id", objectId)
+                    event.exitCode?.let { addTag("exit_code", it.toString()) }
+                    addAll(event.extraTags)
+                },
+                alertType = "info",
+                aggregationKey = "datadog_container_lifecycle:$kind:$objectId",
+                sourceTypeName = "datadog_container_lifecycle",
+                deviceName = objectId,
+            )
+        }
+    }
+
+    private fun decodeContainerImage(bytes: ByteArray): ContainerImageProto {
+        val input = CodedInputStream.newInstance(bytes)
+        val image = ContainerImageProto()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.id = input.readString()
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.name = input.readString()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.registry = input.readString()
+                (FIELD_4 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.shortName = input.readString()
+                (FIELD_5 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.repoTags += input.readString()
+                (FIELD_6 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.digest = input.readString()
+                (FIELD_7 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> image.sizeBytes = input.readInt64()
+                (FIELD_8 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.repoDigests += input.readString()
+                (FIELD_9 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.applyOs(input.readByteArray())
+                (FIELD_10 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> {
+                    input.readByteArray()
+                    image.layerCount += 1
+                }
+                (FIELD_12 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> image.ddTags += input.readString()
+                else -> input.skipField(tag)
+            }
+        }
+
+        return image
+    }
+
+    private fun decodeSbomEntity(bytes: ByteArray): SbomEntityProto {
+        val input = CodedInputStream.newInstance(bytes)
+        val entity = SbomEntityProto()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> entity.type = input.readEnum()
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entity.id = input.readString()
+                (FIELD_4 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entity.repoTags += input.readString()
+                (FIELD_7 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entity.ddTags += input.readString()
+                (FIELD_10 shl FIELD_SHIFT) or FIELD_WIRE_LEN ->
+                    entity.components += decodeCycloneDxComponents(input.readByteArray())
+                (FIELD_11 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> entity.status = input.readEnum()
+                (FIELD_12 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entity.error = input.readString()
+                (FIELD_14 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entity.repoDigests += input.readString()
+                (FIELD_15 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entity.kernelVersion = input.readString()
+                (FIELD_16 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> entity.cpuArchitecture = input.readString()
+                else -> input.skipField(tag)
+            }
+        }
+
+        return entity
+    }
+
+    private fun decodeCycloneDxComponents(bytes: ByteArray): List<CycloneDxComponentProto> {
+        val input = CodedInputStream.newInstance(bytes)
+        val components = mutableListOf<CycloneDxComponentProto>()
+        val cvesByRef = mutableMapOf<String, MutableSet<String>>()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (FIELD_5 shl FIELD_SHIFT) or FIELD_WIRE_LEN ->
+                    components += decodeCycloneDxComponent(input.readByteArray())
+                (FIELD_10 shl FIELD_SHIFT) or FIELD_WIRE_LEN ->
+                    decodeCycloneDxVulnerability(input.readByteArray(), cvesByRef)
+                else -> input.skipField(tag)
+            }
+        }
+
+        return components.flatMap { component ->
+            component.withCves(cvesByRef).flatten()
+        }
+    }
+
+    private fun decodeCycloneDxComponent(bytes: ByteArray): CycloneDxComponentProto {
+        val input = CodedInputStream.newInstance(bytes)
+        val component = CycloneDxComponentProto()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> component.classification = input.readEnum()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> component.bomRef = input.readString()
+                (FIELD_7 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> component.group = input.readString()
+                (FIELD_8 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> component.name = input.readString()
+                (FIELD_9 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> component.version = input.readString()
+                (FIELD_16 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> component.purl = input.readString()
+                (FIELD_21 shl FIELD_SHIFT) or FIELD_WIRE_LEN ->
+                    component.components += decodeCycloneDxComponent(input.readByteArray())
+                else -> input.skipField(tag)
+            }
+        }
+
+        return component
+    }
+
+    private fun decodeCycloneDxVulnerability(
+        bytes: ByteArray,
+        cvesByRef: MutableMap<String, MutableSet<String>>,
+    ) {
+        val input = CodedInputStream.newInstance(bytes)
+        var vulnerabilityId = ""
+        val refs = mutableListOf<String>()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> vulnerabilityId = input.readString()
+                (FIELD_17 shl FIELD_SHIFT) or FIELD_WIRE_LEN ->
+                    refs += decodeVulnerabilityAffects(input.readByteArray())
+                else -> input.skipField(tag)
+            }
+        }
+
+        if (vulnerabilityId.isBlank()) return
+        refs.filter { it.isNotBlank() }.forEach { ref ->
+            cvesByRef.getOrPut(ref) { mutableSetOf() } += vulnerabilityId
+        }
+    }
+
+    private fun decodeVulnerabilityAffects(bytes: ByteArray): String {
+        val input = CodedInputStream.newInstance(bytes)
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> return input.readString()
+                else -> input.skipField(tag)
+            }
+        }
+        return ""
+    }
+
+    private fun decodeContainerLifecycleEvent(bytes: ByteArray): ContainerLifecycleEventProto {
+        val input = CodedInputStream.newInstance(bytes)
+        var eventType = 0
+        var event = ContainerLifecycleEventProto()
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> eventType = input.readEnum()
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event = decodeContainerEvent(input.readByteArray())
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event = decodePodEvent(input.readByteArray())
+                (FIELD_4 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event = decodeTaskEvent(input.readByteArray())
+                else -> input.skipField(tag)
+            }
+        }
+
+        event.eventTypeName = when (eventType) {
+            0 -> "delete"
+            else -> "unknown"
+        }
+        return event
+    }
+
+    private fun decodeContainerEvent(bytes: ByteArray): ContainerLifecycleEventProto {
+        val input = CodedInputStream.newInstance(bytes)
+        val event = ContainerLifecycleEventProto(kind = "container")
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event.objectId = input.readString()
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event.source = input.readString()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> event.exitCode = input.readInt32()
+                (FIELD_4 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> event.exitTimestamp = input.readInt64()
+                (FIELD_5 shl FIELD_SHIFT) or FIELD_WIRE_LEN ->
+                    event.extraTags += decodeLifecycleOwner(input.readByteArray())
+                else -> input.skipField(tag)
+            }
+        }
+
+        return event
+    }
+
+    private fun decodePodEvent(bytes: ByteArray): ContainerLifecycleEventProto {
+        val input = CodedInputStream.newInstance(bytes)
+        val event = ContainerLifecycleEventProto(kind = "pod")
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event.objectId = input.readString()
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event.source = input.readString()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> event.exitTimestamp = input.readInt64()
+                else -> input.skipField(tag)
+            }
+        }
+
+        return event
+    }
+
+    private fun decodeTaskEvent(bytes: ByteArray): ContainerLifecycleEventProto {
+        val input = CodedInputStream.newInstance(bytes)
+        val event = ContainerLifecycleEventProto(kind = "task")
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event.objectId = input.readString()
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> event.source = input.readString()
+                (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> event.exitTimestamp = input.readInt64()
+                else -> input.skipField(tag)
+            }
+        }
+
+        return event
+    }
+
+    private fun decodeLifecycleOwner(bytes: ByteArray): List<String> {
+        val input = CodedInputStream.newInstance(bytes)
+        var ownerType = ""
+        var ownerUid = ""
+
+        while (!input.isAtEnd) {
+            when (val tag = input.readTag()) {
+                0 -> break
+                (1 shl FIELD_SHIFT) or FIELD_WIRE_VARINT -> ownerType = objectKindName(input.readEnum())
+                (2 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> ownerUid = input.readString()
+                else -> input.skipField(tag)
+            }
+        }
+
+        return buildList {
+            addTag("owner_type", ownerType)
+            addTag("owner_uid", ownerUid)
+        }
+    }
+
+    private class ContainerImageProto {
+        var id = ""
+        var name = ""
+        var registry = ""
+        var shortName = ""
+        var digest = ""
+        var sizeBytes = 0L
+        var osName = ""
+        var architecture = ""
+        var layerCount = 0
+        val repoTags = mutableListOf<String>()
+        val repoDigests = mutableListOf<String>()
+        val ddTags = mutableListOf<String>()
+
+        fun applyOs(bytes: ByteArray) {
+            val input = CodedInputStream.newInstance(bytes)
+            while (!input.isAtEnd) {
+                when (val tag = input.readTag()) {
+                    0 -> break
+                    (1 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> osName = input.readString()
+                    (FIELD_3 shl FIELD_SHIFT) or FIELD_WIRE_LEN -> architecture = input.readString()
+                    else -> input.skipField(tag)
+                }
+            }
+        }
+
+        fun imageTag(): String {
+            val repoTag = repoTags.firstOrNull() ?: return ""
+            val fullName = name.ifBlank { shortName }
+            return if (fullName.isNotBlank() && repoTag.startsWith("$fullName:")) {
+                repoTag.removePrefix("$fullName:")
+            } else {
+                repoTag.substringAfterLast(':', "")
+            }
+        }
+    }
+
+    private class SbomEntityProto {
+        var type = 0
+        var id = ""
+        var status = 0
+        var error = ""
+        var kernelVersion = ""
+        var cpuArchitecture = ""
+        val repoTags = mutableListOf<String>()
+        val repoDigests = mutableListOf<String>()
+        val ddTags = mutableListOf<String>()
+        val components = mutableListOf<CycloneDxComponentProto>()
+
+        fun imageName(): String? = repoTags.firstOrNull()?.substringBefore(':')?.ifBlank { null } ?: id.ifBlank { null }
+
+        fun typeName(): String = when (type) {
+            SBOM_TYPE_CONTAINER_IMAGE_LAYERS -> "container_image_layers"
+            SBOM_TYPE_CONTAINER_FILE_SYSTEM -> "container_file_system"
+            SBOM_TYPE_HOST_FILE_SYSTEM -> "host_file_system"
+            SBOM_TYPE_CI_PIPELINE -> "ci_pipeline"
+            SBOM_TYPE_HOST_IMAGE -> "host_image"
+            SBOM_TYPE_SERVERLESS_FUNCTION -> "serverless_function"
+            else -> "unspecified"
+        }
+    }
+
+    private class CycloneDxComponentProto {
+        var classification = 0
+        var bomRef = ""
+        var group = ""
+        var name = ""
+        var version = ""
+        var purl = ""
+        var cveIds = emptyList<String>()
+        val components = mutableListOf<CycloneDxComponentProto>()
+
+        fun withCves(cvesByRef: Map<String, Set<String>>): CycloneDxComponentProto {
+            cveIds = cvesByRef[bomRef]?.toList().orEmpty()
+            components.forEach { it.withCves(cvesByRef) }
+            return this
+        }
+
+        fun flatten(): List<CycloneDxComponentProto> {
+            val current = if (name.isBlank()) emptyList() else listOf(this)
+            return current + components.flatMap { it.flatten() }
+        }
+
+        fun packageType(): String {
+            val purlType = purl.removePrefix("pkg:").substringBefore('/').takeIf { it != purl && it.isNotBlank() }
+            if (purlType != null) return purlType
+            return when (classification) {
+                CYCLONEDX_CLASSIFICATION_APPLICATION -> "application"
+                CYCLONEDX_CLASSIFICATION_FRAMEWORK -> "framework"
+                CYCLONEDX_CLASSIFICATION_LIBRARY -> "library"
+                CYCLONEDX_CLASSIFICATION_OPERATING_SYSTEM -> "operating-system"
+                CYCLONEDX_CLASSIFICATION_CONTAINER -> "container"
+                else -> "unknown"
+            }
+        }
+    }
+
+    private class ContainerLifecycleEventProto(
+        var kind: String = "",
+        var objectId: String = "",
+        var source: String = "",
+        var exitCode: Int? = null,
+        var exitTimestamp: Long? = null,
+        var eventTypeName: String = "unknown",
+        val extraTags: MutableList<String> = mutableListOf(),
+    ) {
+        fun description(kind: String): String {
+            val exit = exitCode?.let { " exit_code=$it" }.orEmpty()
+            return "$kind $objectId lifecycle event: $eventTypeName from $source$exit"
+        }
+    }
+
+    private fun MutableList<String>.addTag(key: String, value: String) {
+        if (value.isNotBlank()) add("$key:$value")
+    }
+
+    private fun objectKindName(kind: Int): String {
+        return when (kind) {
+            OBJECT_KIND_CONTAINER -> "container"
+            OBJECT_KIND_POD -> "pod"
+            OBJECT_KIND_TASK -> "task"
+            else -> "unknown"
+        }
+    }
+
+    private fun normalizeUnixSeconds(timestamp: Long): Long {
+        return when {
+            timestamp > UNIX_NANOS_THRESHOLD -> timestamp / NANOS_PER_SECOND
+            timestamp > UNIX_MILLIS_THRESHOLD -> timestamp / MILLIS_PER_SECOND
+            else -> timestamp
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
@@ -31,6 +31,7 @@ import com.moneat.datadog.models.DdSymbolDbPayload
 import com.moneat.datadog.models.DdSyntheticsPayload
 import com.moneat.datadog.services.DatadogEventService
 import com.moneat.datadog.services.MiscIngestionService
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -39,7 +40,6 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
@@ -97,194 +97,146 @@ fun Route.miscIngestRoutes(
         post("/events") { handleEventManagement(quotaService) }
     }
 }
-private suspend fun io.ktor.server.routing.RoutingContext.handleSymbolDb(
-    quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val payload = json.decodeFromString<DdSymbolDbPayload>(body.decodeToString())
-        if (!reserveMiscQuota(quotaService, orgId, 1, body)) return
+private suspend fun io.ktor.server.routing.RoutingContext.handleSymbolDb(quotaService: BillingQuotaService) =
+    withDatadogPayload("symbol_db") { orgId, body ->
+        val payload = json.decodeFromString<DdSymbolDbPayload>(body.text())
+        if (!reserveMiscQuota(quotaService, orgId, 1, body.bytes)) return@withDatadogPayload
         MiscIngestionService.enqueueSymbolDb(orgId, payload)
         logger.debug { "Accepted DD symbol_db for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process symbol_db" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+        respondAccepted()
     }
-}
-private suspend fun io.ktor.server.routing.RoutingContext.handlePipelineStats(
-    quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val payload = json.decodeFromString<DdPipelineStatsPayload>(body.decodeToString())
-        if (!reserveMiscQuota(quotaService, orgId, payload.stats.size, body)) return
+
+private suspend fun io.ktor.server.routing.RoutingContext.handlePipelineStats(quotaService: BillingQuotaService) =
+    withDatadogPayload("pipeline_stats") { orgId, body ->
+        val payload = json.decodeFromString<DdPipelineStatsPayload>(body.text())
+        if (!reserveMiscQuota(quotaService, orgId, payload.stats.size, body.bytes)) return@withDatadogPayload
         val count = MiscIngestionService.enqueuePipelineStats(orgId, payload)
         logger.debug { "Accepted $count DD pipeline_stats for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process pipeline_stats" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+        respondAccepted()
     }
-}
-private suspend fun io.ktor.server.routing.RoutingContext.handleDataLineage(
-    quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val payload = json.decodeFromString<DdDataLineagePayload>(body.decodeToString())
-        if (!reserveMiscQuota(quotaService, orgId, 1, body)) return
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleDataLineage(quotaService: BillingQuotaService) =
+    withDatadogPayload("data_lineage") { orgId, body ->
+        val payload = json.decodeFromString<DdDataLineagePayload>(body.text())
+        if (!reserveMiscQuota(quotaService, orgId, 1, body.bytes)) return@withDatadogPayload
         MiscIngestionService.enqueueDataLineage(orgId, payload)
         logger.debug { "Accepted DD data_lineage for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process data_lineage" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+        respondAccepted()
     }
-}
-private suspend fun io.ktor.server.routing.RoutingContext.handleDataStreams(
-    quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val payload = json.decodeFromString<DdDataStreamsPayload>(body.decodeToString())
-        if (!reserveMiscQuota(quotaService, orgId, payload.stats.size, body)) return
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleDataStreams(quotaService: BillingQuotaService) =
+    withDatadogPayload("data_streams") { orgId, body ->
+        val payload = json.decodeFromString<DdDataStreamsPayload>(body.text())
+        if (!reserveMiscQuota(quotaService, orgId, payload.stats.size, body.bytes)) return@withDatadogPayload
         val count = MiscIngestionService.enqueueDataStreams(orgId, payload)
         logger.debug { "Accepted $count DD data_streams for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process data_streams" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+        respondAccepted()
     }
-}
-private suspend fun io.ktor.server.routing.RoutingContext.handleSynthetics(
-    quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val payload = json.decodeFromString<DdSyntheticsPayload>(body.decodeToString())
-        if (!reserveMiscQuota(quotaService, orgId, payload.results.size, body)) return
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleSynthetics(quotaService: BillingQuotaService) =
+    withDatadogPayload("synthetics") { orgId, body ->
+        val payload = json.decodeFromString<DdSyntheticsPayload>(body.text())
+        if (!reserveMiscQuota(quotaService, orgId, payload.results.size, body.bytes)) return@withDatadogPayload
         val count = MiscIngestionService.enqueueSynthetics(orgId, payload)
         logger.debug { "Accepted $count DD synthetics for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process synthetics" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+        respondAccepted()
     }
-}
-private suspend fun io.ktor.server.routing.RoutingContext.handleContainerImage(
-    quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentType = call.request.headers[CONTENT_TYPE_HEADER] ?: ""
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        if (contentType.isProtobufContent()) {
-            val payloads = MiscPayloadDecoder.decodeContainerImages(body)
-            if (!reserveMiscQuota(quotaService, orgId, payloads.size, body)) return
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleContainerImage(quotaService: BillingQuotaService) =
+    withDatadogPayload("contimage") { orgId, body ->
+        if (body.isProtobuf) {
+            val payloads = MiscPayloadDecoder.decodeContainerImages(body.bytes)
+            if (!reserveMiscQuota(quotaService, orgId, payloads.size, body.bytes)) return@withDatadogPayload
             val count = MiscIngestionService.enqueueContainerImages(orgId, payloads)
             logger.debug { "Accepted $count DD contimage protobuf images for org $orgId" }
-            call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-            return
+            respondAccepted()
+            return@withDatadogPayload
         }
-        val payload = json.decodeFromString<DdContainerImagePayload>(body.decodeToString())
-        if (!reserveMiscQuota(quotaService, orgId, 1, body)) return
+        val payload = json.decodeFromString<DdContainerImagePayload>(body.text())
+        if (!reserveMiscQuota(quotaService, orgId, 1, body.bytes)) return@withDatadogPayload
         MiscIngestionService.enqueueContainerImage(orgId, payload)
         logger.debug { "Accepted DD contimage for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process contimage" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+        respondAccepted()
     }
-}
-private suspend fun io.ktor.server.routing.RoutingContext.handleSbom(
-    quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentType = call.request.headers[CONTENT_TYPE_HEADER] ?: ""
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        if (contentType.isProtobufContent()) {
-            val payload = MiscPayloadDecoder.decodeSbom(body)
-            if (!reserveMiscQuota(quotaService, orgId, payload.packages.size, body)) return
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleSbom(quotaService: BillingQuotaService) =
+    withDatadogPayload("sbom") { orgId, body ->
+        if (body.isProtobuf) {
+            val payload = MiscPayloadDecoder.decodeSbom(body.bytes)
+            if (!reserveMiscQuota(quotaService, orgId, payload.packages.size, body.bytes)) {
+                return@withDatadogPayload
+            }
             val count = MiscIngestionService.enqueueSbom(orgId, payload)
             logger.debug { "Accepted $count DD sbom protobuf packages for org $orgId" }
-            call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-            return
+            respondAccepted()
+            return@withDatadogPayload
         }
-        val payload = json.decodeFromString<DdSbomPayload>(body.decodeToString())
-        if (!reserveMiscQuota(quotaService, orgId, payload.packages.size, body)) return
+        val payload = json.decodeFromString<DdSbomPayload>(body.text())
+        if (!reserveMiscQuota(quotaService, orgId, payload.packages.size, body.bytes)) return@withDatadogPayload
         val count = MiscIngestionService.enqueueSbom(orgId, payload)
         logger.debug { "Accepted $count DD sbom packages for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process sbom" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+        respondAccepted()
     }
-}
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleContainerLifecycle(
     quotaService: BillingQuotaService,
-) {
-    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
-    suspendRunCatching {
-        val contentType = call.request.headers[CONTENT_TYPE_HEADER] ?: ""
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val events = if (contentType.isProtobufContent()) {
-            MiscPayloadDecoder.decodeContainerLifecycleEvents(body)
-        } else if (body.decodeToString().trim().isEmptyObject()) {
-            emptyList()
-        } else {
-            throw IllegalArgumentException("Container lifecycle payload must be protobuf")
-        }
-        if (!reserveEventQuota(quotaService, orgId, events.size, body)) return
-        val count = DatadogEventService.enqueueEvents(orgId.toLong(), events)
-        logger.debug { "Accepted $count DD container lifecycle events for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
-    }.getOrElse { e ->
-        logger.error(e) { "Failed to process container lifecycle events" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
+) = withDatadogPayload("container lifecycle events") { orgId, body ->
+    val events = if (body.isProtobuf) {
+        MiscPayloadDecoder.decodeContainerLifecycleEvents(body.bytes)
+    } else if (body.text().trim().isEmptyObject()) {
+        emptyList()
+    } else {
+        throw IllegalArgumentException("Container lifecycle payload must be protobuf")
     }
+    if (!reserveEventQuota(quotaService, orgId, events.size, body.bytes)) return@withDatadogPayload
+    val count = DatadogEventService.enqueueEvents(orgId.toLong(), events)
+    logger.debug { "Accepted $count DD container lifecycle events for org $orgId" }
+    respondAccepted()
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleEventManagement(
     quotaService: BillingQuotaService,
+) = withDatadogPayload("event-management events") { orgId, body ->
+    val payload = json.decodeFromString<DatadogEventPayload>(body.text())
+    if (!reserveEventQuota(quotaService, orgId, payload.events.size, body.bytes)) return@withDatadogPayload
+    val count = DatadogEventService.enqueueEvents(orgId.toLong(), payload.events)
+    logger.debug { "Accepted $count DD event-management events for org $orgId" }
+    respondAccepted()
+}
+
+private class MiscIngestBody(
+    val bytes: ByteArray,
+    val contentType: String,
+) {
+    val isProtobuf: Boolean
+        get() = contentType.isProtobufContent()
+
+    fun text(): String = bytes.decodeToString()
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.withDatadogPayload(
+    failureName: String,
+    block: suspend io.ktor.server.routing.RoutingContext.(Int, MiscIngestBody) -> Unit,
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
-        val rawBody = call.receive<ByteArray>()
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
-        val payload = json.decodeFromString<DatadogEventPayload>(body.decodeToString())
-        if (!reserveEventQuota(quotaService, orgId, payload.events.size, body)) return
-        val count = DatadogEventService.enqueueEvents(orgId.toLong(), payload.events)
-        logger.debug { "Accepted $count DD event-management events for org $orgId" }
-        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
+        block(orgId, receiveMiscIngestBody())
     }.getOrElse { e ->
-        logger.error(e) { "Failed to process event-management events" }
+        logger.error(e) { "Failed to process $failureName" }
         call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.receiveMiscIngestBody(): MiscIngestBody {
+    val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
+    val contentType = call.request.headers[CONTENT_TYPE_HEADER] ?: ""
+    val rawBody = call.receive<ByteArray>()
+    val body = DecompressionService.decompress(rawBody, contentEncoding)
+    return MiscIngestBody(bytes = body, contentType = contentType)
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.respondAccepted() {
+    call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.reserveMiscQuota(

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
@@ -20,6 +20,8 @@ import com.moneat.billing.services.BillingQuotaService
 import com.moneat.datadog.reserveDatadogQuota
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.decompression.DecompressionService
+import com.moneat.datadog.decompression.MiscPayloadDecoder
+import com.moneat.datadog.models.DatadogEventPayload
 import com.moneat.datadog.models.DdContainerImagePayload
 import com.moneat.datadog.models.DdDataLineagePayload
 import com.moneat.datadog.models.DdDataStreamsPayload
@@ -27,6 +29,7 @@ import com.moneat.datadog.models.DdPipelineStatsPayload
 import com.moneat.datadog.models.DdSbomPayload
 import com.moneat.datadog.models.DdSymbolDbPayload
 import com.moneat.datadog.models.DdSyntheticsPayload
+import com.moneat.datadog.services.DatadogEventService
 import com.moneat.datadog.services.MiscIngestionService
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
@@ -80,14 +83,14 @@ fun Route.miscIngestRoutes(
     // The event platform forwarder strips the path from dd_url, so contlcycle/contimage/sbom
     // arrive at /api/v2/... (no /dd/ prefix) when redirected via datadog.yaml dd_url config.
     route("/api/v2") {
-        post("/contlcycle") { handleContainerLifecycle() }
+        post("/contlcycle") { handleContainerLifecycle(quotaService) }
         post("/contimage") { handleContainerImage(quotaService) }
         if (includeSbomRoutes) {
             post("/sbom") { handleSbom(quotaService) }
         }
         post("/synthetics") { handleSynthetics(quotaService) }
         post("/data_streams_messages") { handleDataStreams(quotaService) }
-        post("/events") { handleEventManagement() }
+        post("/events") { handleEventManagement(quotaService) }
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handleSymbolDb(
@@ -188,13 +191,15 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleContainerImage(
         val contentType = call.request.headers["Content-Type"] ?: ""
         val contentEncoding = call.request.headers["Content-Encoding"]
         val rawBody = call.receive<ByteArray>()
-        if (contentType.contains("protobuf")) {
-            // Agent sends application/x-protobuf; full protobuf pipeline not yet implemented.
-            logger.debug { "Accepted DD contimage (protobuf) for org $orgId" }
+        val body = DecompressionService.decompress(rawBody, contentEncoding)
+        if (contentType.isProtobufContent()) {
+            val payloads = MiscPayloadDecoder.decodeContainerImages(body)
+            if (!reserveMiscQuota(quotaService, orgId, payloads.size, body)) return
+            val count = MiscIngestionService.enqueueContainerImages(orgId, payloads)
+            logger.debug { "Accepted $count DD contimage protobuf images for org $orgId" }
             call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
             return
         }
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DdContainerImagePayload>(body.decodeToString())
         if (!reserveMiscQuota(quotaService, orgId, 1, body)) return
         MiscIngestionService.enqueueContainerImage(orgId, payload)
@@ -213,13 +218,15 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSbom(
         val contentType = call.request.headers["Content-Type"] ?: ""
         val contentEncoding = call.request.headers["Content-Encoding"]
         val rawBody = call.receive<ByteArray>()
-        if (contentType.contains("protobuf")) {
-            // Agent sends application/x-protobuf; full protobuf pipeline not yet implemented.
-            logger.debug { "Accepted DD sbom (protobuf) for org $orgId" }
+        val body = DecompressionService.decompress(rawBody, contentEncoding)
+        if (contentType.isProtobufContent()) {
+            val payload = MiscPayloadDecoder.decodeSbom(body)
+            if (!reserveMiscQuota(quotaService, orgId, payload.packages.size, body)) return
+            val count = MiscIngestionService.enqueueSbom(orgId, payload)
+            logger.debug { "Accepted $count DD sbom protobuf packages for org $orgId" }
             call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
             return
         }
-        val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DdSbomPayload>(body.decodeToString())
         if (!reserveMiscQuota(quotaService, orgId, payload.packages.size, body)) return
         val count = MiscIngestionService.enqueueSbom(orgId, payload)
@@ -231,16 +238,49 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSbom(
     }
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleContainerLifecycle() {
-    DatadogAuthMiddleware.authenticate(call) ?: return
-    // Container lifecycle events accepted; full ingestion pipeline not yet implemented.
-    call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
+private suspend fun io.ktor.server.routing.RoutingContext.handleContainerLifecycle(
+    quotaService: BillingQuotaService,
+) {
+    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
+    suspendRunCatching {
+        val contentType = call.request.headers["Content-Type"] ?: ""
+        val contentEncoding = call.request.headers["Content-Encoding"]
+        val rawBody = call.receive<ByteArray>()
+        val body = DecompressionService.decompress(rawBody, contentEncoding)
+        val events = if (contentType.isProtobufContent()) {
+            MiscPayloadDecoder.decodeContainerLifecycleEvents(body)
+        } else if (body.decodeToString().trim().isEmptyObject()) {
+            emptyList()
+        } else {
+            throw IllegalArgumentException("Container lifecycle payload must be protobuf")
+        }
+        if (!reserveEventQuota(quotaService, orgId, events.size, body)) return
+        val count = DatadogEventService.enqueueEvents(orgId.toLong(), events)
+        logger.debug { "Accepted $count DD container lifecycle events for org $orgId" }
+        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
+    }.getOrElse { e ->
+        logger.error(e) { "Failed to process container lifecycle events" }
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+    }
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleEventManagement() {
-    DatadogAuthMiddleware.authenticate(call) ?: return
-    // Event management events accepted; full ingestion pipeline not yet implemented.
-    call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
+private suspend fun io.ktor.server.routing.RoutingContext.handleEventManagement(
+    quotaService: BillingQuotaService,
+) {
+    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
+    suspendRunCatching {
+        val contentEncoding = call.request.headers["Content-Encoding"]
+        val rawBody = call.receive<ByteArray>()
+        val body = DecompressionService.decompress(rawBody, contentEncoding)
+        val payload = json.decodeFromString<DatadogEventPayload>(body.decodeToString())
+        if (!reserveEventQuota(quotaService, orgId, payload.events.size, body)) return
+        val count = DatadogEventService.enqueueEvents(orgId.toLong(), payload.events)
+        logger.debug { "Accepted $count DD event-management events for org $orgId" }
+        call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
+    }.getOrElse { e ->
+        logger.error(e) { "Failed to process event-management events" }
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+    }
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.reserveMiscQuota(
@@ -258,3 +298,25 @@ private suspend fun io.ktor.server.routing.RoutingContext.reserveMiscQuota(
         requestedBytes = bytes.size.toLong(),
     )
 }
+
+private suspend fun io.ktor.server.routing.RoutingContext.reserveEventQuota(
+    quotaService: BillingQuotaService,
+    organizationId: Int,
+    requestedUnits: Int,
+    bytes: ByteArray,
+): Boolean {
+    return reserveDatadogQuota(
+        call = call,
+        quotaService = quotaService,
+        organizationId = organizationId,
+        requestedUnits = requestedUnits,
+        eventType = "dd_event",
+        requestedBytes = bytes.size.toLong(),
+    )
+}
+
+private fun String.isProtobufContent(): Boolean =
+    contains("protobuf", ignoreCase = true)
+
+private fun String.isEmptyObject(): Boolean =
+    this == "{}" || this == "null"

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
@@ -274,5 +274,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.reserveEventQuota(
 private fun String.isProtobufContent(): Boolean =
     contains("protobuf", ignoreCase = true)
 
+private val emptyJsonObjectRegex = Regex("""\{\s*}""")
+
 private fun String.isEmptyObject(): Boolean =
-    this == "{}" || this == "null"
+    this == "null" || emptyJsonObjectRegex.matches(this)

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/MiscIngestRoutes.kt
@@ -43,6 +43,10 @@ import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
+private const val CONTENT_ENCODING_HEADER = "Content-Encoding"
+private const val CONTENT_TYPE_HEADER = "Content-Type"
+private const val INVALID_PAYLOAD_ERROR = "Invalid payload"
+
 private val json = Json {
     ignoreUnknownKeys = true
     isLenient = true
@@ -98,7 +102,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSymbolDb(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DdSymbolDbPayload>(body.decodeToString())
@@ -108,7 +112,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSymbolDb(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process symbol_db" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handlePipelineStats(
@@ -116,7 +120,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handlePipelineStats(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DdPipelineStatsPayload>(body.decodeToString())
@@ -126,7 +130,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handlePipelineStats(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process pipeline_stats" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handleDataLineage(
@@ -134,7 +138,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDataLineage(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DdDataLineagePayload>(body.decodeToString())
@@ -144,7 +148,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDataLineage(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process data_lineage" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handleDataStreams(
@@ -152,7 +156,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDataStreams(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DdDataStreamsPayload>(body.decodeToString())
@@ -162,7 +166,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDataStreams(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process data_streams" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handleSynthetics(
@@ -170,7 +174,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSynthetics(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DdSyntheticsPayload>(body.decodeToString())
@@ -180,7 +184,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSynthetics(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process synthetics" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handleContainerImage(
@@ -188,8 +192,8 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleContainerImage(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentType = call.request.headers["Content-Type"] ?: ""
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentType = call.request.headers[CONTENT_TYPE_HEADER] ?: ""
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         if (contentType.isProtobufContent()) {
@@ -207,7 +211,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleContainerImage(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process contimage" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 private suspend fun io.ktor.server.routing.RoutingContext.handleSbom(
@@ -215,8 +219,8 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSbom(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentType = call.request.headers["Content-Type"] ?: ""
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentType = call.request.headers[CONTENT_TYPE_HEADER] ?: ""
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         if (contentType.isProtobufContent()) {
@@ -234,7 +238,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSbom(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process sbom" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 
@@ -243,8 +247,8 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleContainerLifecyc
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentType = call.request.headers["Content-Type"] ?: ""
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentType = call.request.headers[CONTENT_TYPE_HEADER] ?: ""
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         val events = if (contentType.isProtobufContent()) {
@@ -260,7 +264,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleContainerLifecyc
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process container lifecycle events" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 
@@ -269,7 +273,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleEventManagement(
 ) {
     val orgId = DatadogAuthMiddleware.authenticate(call) ?: return
     suspendRunCatching {
-        val contentEncoding = call.request.headers["Content-Encoding"]
+        val contentEncoding = call.request.headers[CONTENT_ENCODING_HEADER]
         val rawBody = call.receive<ByteArray>()
         val body = DecompressionService.decompress(rawBody, contentEncoding)
         val payload = json.decodeFromString<DatadogEventPayload>(body.decodeToString())
@@ -279,7 +283,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleEventManagement(
         call.respond(HttpStatusCode.Accepted, mapOf("status" to "ok"))
     }.getOrElse { e ->
         logger.error(e) { "Failed to process event-management events" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid payload"))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to INVALID_PAYLOAD_ERROR))
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/datadog/services/MiscIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/MiscIngestionService.kt
@@ -231,16 +231,29 @@ object MiscIngestionService {
     }
 
     fun enqueueContainerImage(orgId: Int, payload: DdContainerImagePayload) {
-        val entry = QueuedContainerImageEntry(
-            imageName = payload.imageName, imageTag = payload.imageTag,
-            digest = payload.digest, registry = payload.registry,
-            sizeBytes = payload.sizeBytes, os = payload.os,
-            architecture = payload.architecture, layers = payload.layers,
-            tags = parseDdTagList(payload.tags),
-            timestampMs = System.currentTimeMillis(),
-        )
-        val batch = QueuedMiscBatch(orgId, "container_images", containerImages = listOf(entry))
+        enqueueContainerImages(orgId, listOf(payload))
+    }
+
+    fun enqueueContainerImages(orgId: Int, payloads: List<DdContainerImagePayload>): Int {
+        val now = System.currentTimeMillis()
+        val entries = payloads.map { payload ->
+            QueuedContainerImageEntry(
+                imageName = payload.imageName,
+                imageTag = payload.imageTag,
+                digest = payload.digest,
+                registry = payload.registry,
+                sizeBytes = payload.sizeBytes,
+                os = payload.os,
+                architecture = payload.architecture,
+                layers = payload.layers,
+                tags = parseDdTagList(payload.tags),
+                timestampMs = now,
+            )
+        }
+        if (entries.isEmpty()) return 0
+        val batch = QueuedMiscBatch(orgId, "container_images", containerImages = entries)
         RedisConfig.sync().lpush(MISC_QUEUE_KEY, json.encodeToString(batch))
+        return entries.size
     }
 
     fun enqueueSbom(orgId: Int, payload: DdSbomPayload): Int {

--- a/backend/src/test/kotlin/com/moneat/datadog/decompression/ProtoDecoderTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/decompression/ProtoDecoderTest.kt
@@ -525,6 +525,30 @@ class ProtoDecoderTest {
     }
 
     @Test
+    fun `MiscPayloadDecoder decodes container image fallback fields`() {
+        val image = buildProto {
+            writeString(1, "sha256:image-id")
+            writeString(4, "worker")
+            writeString(5, "worker:latest")
+            writeString(8, "registry.example.com/team/worker@sha256:fallback")
+            writeString(12, "team:infra")
+        }
+        val payload = buildProto {
+            writeByteArray(3, image)
+        }
+
+        val decoded = MiscPayloadDecoder.decodeContainerImages(payload)
+
+        assertEquals(1, decoded.size)
+        assertEquals("worker", decoded[0].imageName)
+        assertEquals("latest", decoded[0].imageTag)
+        assertEquals("registry.example.com/team/worker@sha256:fallback", decoded[0].digest)
+        assertTrue(decoded[0].tags.contains("image_id:sha256:image-id"))
+        assertTrue(decoded[0].tags.contains("repo_digest:registry.example.com/team/worker@sha256:fallback"))
+        assertTrue(decoded[0].tags.contains("team:infra"))
+    }
+
+    @Test
     fun `MiscPayloadDecoder decodes sbom protobuf packages and CVEs`() {
         val component = buildProto {
             writeEnum(1, 3)
@@ -576,6 +600,53 @@ class ProtoDecoderTest {
     }
 
     @Test
+    fun `MiscPayloadDecoder decodes nested sbom components and entity types`() {
+        val childComponent = buildProto {
+            writeEnum(1, 2)
+            writeString(3, "child-ref")
+            writeString(8, "ktor")
+            writeString(9, "3.3.0")
+        }
+        val rootComponent = buildProto {
+            writeEnum(1, 1)
+            writeString(3, "root-ref")
+            writeByteArray(21, childComponent)
+        }
+        val affects = buildProto {
+            writeString(1, "child-ref")
+        }
+        val vulnerability = buildProto {
+            writeString(2, "CVE-2026-4242")
+            writeByteArray(17, affects)
+        }
+        val cycloneDx = buildProto {
+            writeByteArray(5, rootComponent)
+            writeByteArray(10, vulnerability)
+        }
+        val entity = buildProto {
+            writeEnum(1, 3)
+            writeString(2, "host-fs")
+            writeByteArray(10, cycloneDx)
+        }
+        val payload = buildProto {
+            writeString(2, "host-d")
+            writeString(3, "agent")
+            writeByteArray(4, entity)
+        }
+
+        val decoded = MiscPayloadDecoder.decodeSbom(payload)
+
+        assertEquals("host-d", decoded.host)
+        assertEquals("host-fs", decoded.imageName)
+        assertEquals(1, decoded.packages.size)
+        assertEquals("ktor", decoded.packages[0].name)
+        assertEquals("framework", decoded.packages[0].type)
+        assertEquals(listOf("CVE-2026-4242"), decoded.packages[0].cveIds)
+        assertTrue(decoded.tags.contains("source:agent"))
+        assertTrue(decoded.tags.contains("entity_type:host_file_system"))
+    }
+
+    @Test
     fun `MiscPayloadDecoder decodes container lifecycle protobuf events`() {
         val owner = buildProto {
             writeEnum(1, 1)
@@ -609,5 +680,45 @@ class ProtoDecoderTest {
         assertTrue(decoded[0].tags.contains("cluster_id:cluster-a"))
         assertTrue(decoded[0].tags.contains("exit_code:137"))
         assertTrue(decoded[0].tags.contains("owner_uid:pod-uid"))
+    }
+
+    @Test
+    fun `MiscPayloadDecoder decodes pod and task lifecycle protobuf events`() {
+        val pod = buildProto {
+            writeString(1, "pod-1")
+            writeString(2, "kubelet")
+            writeInt64(3, 1_700_000_000_123_000_000L)
+        }
+        val task = buildProto {
+            writeString(1, "task-1")
+            writeString(2, "ecs")
+            writeInt64(3, 1_700_000_123L)
+        }
+        val podEvent = buildProto {
+            writeEnum(1, 0)
+            writeByteArray(3, pod)
+        }
+        val taskEvent = buildProto {
+            writeEnum(1, 0)
+            writeByteArray(4, task)
+        }
+        val payload = buildProto {
+            writeString(2, "host-e")
+            writeByteArray(4, podEvent)
+            writeByteArray(4, taskEvent)
+            writeString(5, "cluster-b")
+        }
+
+        val decoded = MiscPayloadDecoder.decodeContainerLifecycleEvents(payload)
+
+        assertEquals(2, decoded.size)
+        assertEquals("host-e", decoded[0].host)
+        assertEquals(1_700_000_000L, decoded[0].dateHappened)
+        assertTrue(decoded[0].title.contains("pod pod-1"))
+        assertTrue(decoded[0].tags.contains("source:kubelet"))
+        assertTrue(decoded[0].tags.contains("cluster_id:cluster-b"))
+        assertEquals(1_700_000_123L, decoded[1].dateHappened)
+        assertTrue(decoded[1].title.contains("task task-1"))
+        assertTrue(decoded[1].tags.contains("source:ecs"))
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/decompression/ProtoDecoderTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/decompression/ProtoDecoderTest.kt
@@ -480,4 +480,134 @@ class ProtoDecoderTest {
         assertEquals(ProcessAgentPayloadDecoder.TYPE_RES_COLLECTOR, header.type)
         assertEquals(0, header.encoding)
     }
+
+    @Test
+    fun `MiscPayloadDecoder decodes container image protobuf`() {
+        val os = buildProto {
+            writeString(1, "linux")
+            writeString(3, "amd64")
+        }
+        val layer = buildProto {
+            writeString(3, "sha256:layer")
+        }
+        val image = buildProto {
+            writeString(1, "sha256:image")
+            writeString(2, "registry.example.com/team/api")
+            writeString(3, "registry.example.com")
+            writeString(4, "api")
+            writeString(5, "registry.example.com/team/api:v1")
+            writeString(6, "sha256:digest")
+            writeInt64(7, 123_456L)
+            writeByteArray(9, os)
+            writeByteArray(10, layer)
+            writeString(12, "env:prod")
+        }
+        val payload = buildProto {
+            writeString(2, "host-a")
+            writeByteArray(3, image)
+            writeString(4, "agent")
+        }
+
+        val decoded = MiscPayloadDecoder.decodeContainerImages(payload)
+
+        assertEquals(1, decoded.size)
+        assertEquals("registry.example.com/team/api", decoded[0].imageName)
+        assertEquals("v1", decoded[0].imageTag)
+        assertEquals("sha256:digest", decoded[0].digest)
+        assertEquals("registry.example.com", decoded[0].registry)
+        assertEquals(123_456L, decoded[0].sizeBytes)
+        assertEquals("linux", decoded[0].os)
+        assertEquals("amd64", decoded[0].architecture)
+        assertEquals(1, decoded[0].layers)
+        assertTrue(decoded[0].tags.contains("host:host-a"))
+        assertTrue(decoded[0].tags.contains("source:agent"))
+        assertTrue(decoded[0].tags.contains("env:prod"))
+    }
+
+    @Test
+    fun `MiscPayloadDecoder decodes sbom protobuf packages and CVEs`() {
+        val component = buildProto {
+            writeEnum(1, 3)
+            writeString(3, "pkg-ref")
+            writeString(8, "openssl")
+            writeString(9, "3.0.0")
+            writeString(16, "pkg:deb/openssl@3.0.0")
+        }
+        val affects = buildProto {
+            writeString(1, "pkg-ref")
+        }
+        val vulnerability = buildProto {
+            writeString(2, "CVE-2026-0001")
+            writeByteArray(17, affects)
+        }
+        val cycloneDx = buildProto {
+            writeByteArray(5, component)
+            writeByteArray(10, vulnerability)
+        }
+        val entity = buildProto {
+            writeEnum(1, 1)
+            writeString(2, "sha256:image")
+            writeString(4, "registry.example.com/team/api:v1")
+            writeString(7, "service:api")
+            writeByteArray(10, cycloneDx)
+            writeEnum(11, 0)
+            writeString(14, "registry.example.com/team/api@sha256:image")
+        }
+        val payload = buildProto {
+            writeInt32(1, 1)
+            writeString(2, "host-b")
+            writeString(3, "agent")
+            writeByteArray(4, entity)
+            writeString(5, "prod")
+        }
+
+        val decoded = MiscPayloadDecoder.decodeSbom(payload)
+
+        assertEquals("host-b", decoded.host)
+        assertEquals("sha256:image", decoded.containerId)
+        assertEquals("registry.example.com/team/api", decoded.imageName)
+        assertEquals(1, decoded.packages.size)
+        assertEquals("openssl", decoded.packages[0].name)
+        assertEquals("3.0.0", decoded.packages[0].version)
+        assertEquals("deb", decoded.packages[0].type)
+        assertEquals(listOf("CVE-2026-0001"), decoded.packages[0].cveIds)
+        assertTrue(decoded.tags.contains("service:api"))
+        assertTrue(decoded.tags.contains("env:prod"))
+    }
+
+    @Test
+    fun `MiscPayloadDecoder decodes container lifecycle protobuf events`() {
+        val owner = buildProto {
+            writeEnum(1, 1)
+            writeString(2, "pod-uid")
+        }
+        val container = buildProto {
+            writeString(1, "container-1")
+            writeString(2, "containerd")
+            writeInt32(3, 137)
+            writeInt64(4, 1_700_000_000_123L)
+            writeByteArray(5, owner)
+        }
+        val event = buildProto {
+            writeEnum(1, 0)
+            writeByteArray(2, container)
+        }
+        val payload = buildProto {
+            writeString(2, "host-c")
+            writeEnum(3, 0)
+            writeByteArray(4, event)
+            writeString(5, "cluster-a")
+        }
+
+        val decoded = MiscPayloadDecoder.decodeContainerLifecycleEvents(payload)
+
+        assertEquals(1, decoded.size)
+        assertEquals("host-c", decoded[0].host)
+        assertEquals(1_700_000_000L, decoded[0].dateHappened)
+        assertTrue(decoded[0].title.contains("container container-1"))
+        assertTrue(decoded[0].tags.contains("source:containerd"))
+        assertTrue(decoded[0].tags.contains("cluster_id:cluster-a"))
+        assertTrue(decoded[0].tags.contains("exit_code:137"))
+        assertTrue(decoded[0].tags.contains("owner_uid:pod-uid"))
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.routes
 
+import com.google.protobuf.CodedOutputStream
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.services.DatadogEventService
@@ -37,6 +38,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
@@ -46,11 +48,13 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.clearMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.io.ByteArrayOutputStream
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import kotlin.test.AfterTest
@@ -129,6 +133,7 @@ class DatadogIngestRoutesTest {
         every { MiscIngestionService.enqueueDataStreams(any(), any()) } returns 0
         every { MiscIngestionService.enqueueSynthetics(any(), any()) } returns 0
         every { MiscIngestionService.enqueueContainerImage(any(), any()) } returns Unit
+        every { MiscIngestionService.enqueueContainerImages(any(), any()) } returns 0
         every { MiscIngestionService.enqueueSbom(any(), any()) } returns 0
         every { DbmIngestionService.enqueueQueries(any(), any()) } returns 0
         every { DbmIngestionService.enqueueQueryPayloads(any(), any()) } returns 0
@@ -166,6 +171,14 @@ class DatadogIngestRoutesTest {
                 orchestratorIngestRoutes(quotaService)
             }
         }
+    }
+
+    private fun buildProto(block: CodedOutputStream.() -> Unit): ByteArray {
+        val output = ByteArrayOutputStream()
+        val coded = CodedOutputStream.newInstance(output)
+        coded.block()
+        coded.flush()
+        return output.toByteArray()
     }
 
     // ──── V1 Metric Series ────
@@ -725,6 +738,48 @@ class DatadogIngestRoutesTest {
     }
 
     @Test
+    fun `dd contimage protobuf decodes and enqueues images`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        every { MiscIngestionService.enqueueContainerImages(any(), any()) } returns 1
+        installRoutes()()
+        val os = buildProto {
+            writeString(1, "linux")
+            writeString(3, "arm64")
+        }
+        val image = buildProto {
+            writeString(2, "registry.example.com/team/worker")
+            writeString(3, "registry.example.com")
+            writeString(5, "registry.example.com/team/worker:v2")
+            writeString(6, "sha256:worker")
+            writeInt64(7, 2048L)
+            writeByteArray(9, os)
+            writeString(12, "env:test")
+        }
+        val payload = buildProto {
+            writeString(2, "host-a")
+            writeByteArray(3, image)
+        }
+
+        val response = client.post("/dd/api/v2/contimage") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            header(HttpHeaders.ContentType, "application/x-protobuf")
+            setBody(payload)
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        verify {
+            MiscIngestionService.enqueueContainerImages(
+                ORG_ID,
+                match {
+                    it.single().imageName == "registry.example.com/team/worker" &&
+                        it.single().imageTag == "v2" &&
+                        it.single().architecture == "arm64"
+                },
+            )
+        }
+    }
+
+    @Test
     fun `dd sbom returns 403 when api key is missing`() = testApplication {
         installRoutes()()
         val response = client.post("/dd/api/v2/sbom") {
@@ -744,6 +799,52 @@ class DatadogIngestRoutesTest {
             setBody("{}")
         }
         assertEquals(HttpStatusCode.Accepted, response.status)
+    }
+
+    @Test
+    fun `dd sbom protobuf decodes and enqueues packages`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        every { MiscIngestionService.enqueueSbom(any(), any()) } returns 1
+        installRoutes()()
+        val component = buildProto {
+            writeEnum(1, 3)
+            writeString(3, "pkg-ref")
+            writeString(8, "openssl")
+            writeString(9, "3.0.0")
+            writeString(16, "pkg:deb/openssl@3.0.0")
+        }
+        val bom = buildProto {
+            writeByteArray(5, component)
+        }
+        val entity = buildProto {
+            writeEnum(1, 1)
+            writeString(2, "sha256:image")
+            writeString(4, "registry.example.com/team/api:v1")
+            writeString(7, "service:api")
+            writeByteArray(10, bom)
+        }
+        val payload = buildProto {
+            writeString(2, "host-b")
+            writeByteArray(4, entity)
+        }
+
+        val response = client.post("/dd/api/v2/sbom") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            header(HttpHeaders.ContentType, "application/x-protobuf")
+            setBody(payload)
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        verify {
+            MiscIngestionService.enqueueSbom(
+                ORG_ID,
+                match {
+                    it.host == "host-b" &&
+                        it.packages.single().name == "openssl" &&
+                        it.tags.contains("service:api")
+                },
+            )
+        }
     }
 
     // ──── Misc Ingest – non-/dd prefix ────
@@ -771,15 +872,65 @@ class DatadogIngestRoutesTest {
     }
 
     @Test
+    fun `contlcycle protobuf decodes and enqueues lifecycle events`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        coEvery { DatadogEventService.enqueueEvents(any(), any()) } returns 1
+        installRoutes()()
+        val container = buildProto {
+            writeString(1, "container-1")
+            writeString(2, "containerd")
+            writeInt32(3, 137)
+        }
+        val event = buildProto {
+            writeEnum(1, 0)
+            writeByteArray(2, container)
+        }
+        val payload = buildProto {
+            writeString(2, "host-c")
+            writeEnum(3, 0)
+            writeByteArray(4, event)
+        }
+
+        val response = client.post("/api/v2/contlcycle") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            header(HttpHeaders.ContentType, "application/x-protobuf")
+            setBody(payload)
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        coVerify {
+            DatadogEventService.enqueueEvents(
+                ORG_ID.toLong(),
+                match {
+                    it.single().host == "host-c" &&
+                        it.single().tags.contains("object_id:container-1") &&
+                        it.single().tags.contains("exit_code:137")
+                },
+            )
+        }
+    }
+
+    @Test
     fun `event management returns accepted with valid api key`() = testApplication {
         every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        coEvery { DatadogEventService.enqueueEvents(any(), any()) } returns 1
         installRoutes()()
         val response = client.post("/api/v2/events") {
             header(DD_API_KEY_HEADER, VALID_KEY)
             contentType(ContentType.Application.Json)
-            setBody("{}")
+            setBody("""{"events":[{"title":"deploy","host":"web-01","tags":["env:test"]}]}""")
         }
         assertEquals(HttpStatusCode.Accepted, response.status)
+        coVerify {
+            DatadogEventService.enqueueEvents(
+                ORG_ID.toLong(),
+                match {
+                    it.single().title == "deploy" &&
+                        it.single().host == "web-01" &&
+                        it.single().tags.contains("env:test")
+                },
+            )
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -17,7 +17,9 @@
 package com.moneat.datadog.routes
 
 import com.google.protobuf.CodedOutputStream
+import com.moneat.billing.models.BillingUsageResponse
 import com.moneat.billing.services.BillingQuotaService
+import com.moneat.billing.services.QuotaReservationResult
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.services.DatadogEventService
 import com.moneat.datadog.services.DatadogHostService
@@ -111,8 +113,10 @@ class DatadogIngestRoutesTest {
             DbmIngestionService,
             DebuggerIngestionService,
             OrchestratorIngestionService,
+            quotaService,
         )
 
+        every { quotaService.isEnforcementEnabled() } returns false
         every { DatadogService.validateApiKeyContext(any()) } answers {
             if (firstArg<String>() == VALID_KEY) {
                 DatadogService.ApiKeyValidation(ORG_ID, null)
@@ -180,6 +184,41 @@ class DatadogIngestRoutesTest {
         coded.flush()
         return output.toByteArray()
     }
+
+    private fun deniedQuotaResult(eventType: String) = QuotaReservationResult(
+        allowed = false,
+        reason = "event_type_quota_exceeded",
+        eventType = eventType,
+        usage = quotaUsageResponse(),
+    )
+
+    private fun quotaUsageResponse() = BillingUsageResponse(
+        organizationId = ORG_ID,
+        periodStart = "2026-06-01",
+        periodEnd = "2026-06-30",
+        retentionDays = 30,
+        apmTraceRetentionDays = 30,
+        usedUnits = 0,
+        usedErrors = 0,
+        errorLimit = 0,
+        usedTransactions = 0,
+        transactionLimit = 0,
+        usedReplays = 0,
+        replayLimit = 0,
+        usedFeedback = 0,
+        feedbackLimit = 0,
+        usedBytes = 0,
+        bytesLimit = 0,
+        baseLimitUnits = 0,
+        paygLimitUnits = 0,
+        totalLimitUnits = 0,
+        paygBudgetCents = 0,
+        paygUsedUnits = 0,
+        paygUsedCentsEstimate = 0,
+        plan = "FREE",
+        status = "active",
+        withinQuota = false,
+    )
 
     // ──── V1 Metric Series ────
 
@@ -738,6 +777,32 @@ class DatadogIngestRoutesTest {
     }
 
     @Test
+    fun `dd contimage returns 429 and skips enqueue when misc quota is exceeded`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        every { quotaService.isEnforcementEnabled() } returns true
+        every {
+            quotaService.reserveUnits(
+                organizationId = ORG_ID,
+                requestedUnits = 1,
+                eventType = "dd_misc",
+                requestedBytes = any(),
+            )
+        } returns deniedQuotaResult("dd_misc")
+        installRoutes()()
+
+        val response = client.post("/dd/api/v2/contimage") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+
+        assertEquals(HttpStatusCode.TooManyRequests, response.status)
+        verify(exactly = 0) {
+            MiscIngestionService.enqueueContainerImage(any(), any())
+        }
+    }
+
+    @Test
     fun `dd contimage protobuf decodes and enqueues images`() = testApplication {
         every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
         every { MiscIngestionService.enqueueContainerImages(any(), any()) } returns 1
@@ -872,6 +937,25 @@ class DatadogIngestRoutesTest {
     }
 
     @Test
+    fun `contlcycle accepts whitespace empty json probes`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+
+        listOf("{ }", "{\n}", "{\n\t}").forEach { payload ->
+            val response = client.post("/api/v2/contlcycle") {
+                header(DD_API_KEY_HEADER, VALID_KEY)
+                contentType(ContentType.Application.Json)
+                setBody(payload)
+            }
+            assertEquals(HttpStatusCode.Accepted, response.status)
+        }
+
+        coVerify(exactly = 3) {
+            DatadogEventService.enqueueEvents(ORG_ID.toLong(), emptyList())
+        }
+    }
+
+    @Test
     fun `contlcycle returns 400 for non empty json payload`() = testApplication {
         every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
         installRoutes()()
@@ -942,6 +1026,32 @@ class DatadogIngestRoutesTest {
                         it.single().tags.contains("env:test")
                 },
             )
+        }
+    }
+
+    @Test
+    fun `event management returns 429 and skips enqueue when event quota is exceeded`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        every { quotaService.isEnforcementEnabled() } returns true
+        every {
+            quotaService.reserveUnits(
+                organizationId = ORG_ID,
+                requestedUnits = 1,
+                eventType = "dd_event",
+                requestedBytes = any(),
+            )
+        } returns deniedQuotaResult("dd_event")
+        installRoutes()()
+
+        val response = client.post("/api/v2/events") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Application.Json)
+            setBody("""{"events":[{"title":"deploy","host":"web-01","tags":["env:test"]}]}""")
+        }
+
+        assertEquals(HttpStatusCode.TooManyRequests, response.status)
+        coVerify(exactly = 0) {
+            DatadogEventService.enqueueEvents(any(), any())
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -872,6 +872,18 @@ class DatadogIngestRoutesTest {
     }
 
     @Test
+    fun `contlcycle returns 400 for non empty json payload`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.post("/api/v2/contlcycle") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Application.Json)
+            setBody("""{"container_id":"container-1"}""")
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
     fun `contlcycle protobuf decodes and enqueues lifecycle events`() = testApplication {
         every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
         coEvery { DatadogEventService.enqueueEvents(any(), any()) } returns 1

--- a/backend/src/test/kotlin/com/moneat/services/MiscIngestionServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MiscIngestionServiceCoverageTest.kt
@@ -17,6 +17,10 @@
 package com.moneat.services
 
 import com.moneat.config.ClickHouseClient
+import com.moneat.config.RedisConfig
+import com.moneat.datadog.models.DdContainerImagePayload
+import com.moneat.datadog.models.DdSbomPackage
+import com.moneat.datadog.models.DdSbomPayload
 import com.moneat.datadog.services.MiscIngestionService
 import com.moneat.datadog.services.QueuedContainerImageEntry
 import com.moneat.datadog.services.QueuedDataLineageEntry
@@ -26,10 +30,14 @@ import com.moneat.datadog.services.QueuedPipelineStatEntry
 import com.moneat.datadog.services.QueuedSbomEntry
 import com.moneat.datadog.services.QueuedSymbolDbEntry
 import com.moneat.datadog.services.QueuedSyntheticEntry
+import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlin.test.AfterTest
@@ -50,6 +58,10 @@ import kotlin.test.assertTrue
  *  - testType/status normalization in synthetics
  */
 class MiscIngestionServiceCoverageTest {
+
+    private companion object {
+        private const val MISC_QUEUE_KEY = "moneat:dd:misc:queue"
+    }
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -72,6 +84,172 @@ class MiscIngestionServiceCoverageTest {
             val response = io.mockk.mockk<io.ktor.client.statement.HttpResponse>()
             every { response.status } returns io.ktor.http.HttpStatusCode.OK
             response
+        }
+    }
+
+    // ===================== enqueue batches =====================
+
+    @Test
+    fun `enqueueContainerImages writes one Redis batch with parsed tags`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(MISC_QUEUE_KEY, capture(queuedPayload)) } returns 1L
+
+            val count = MiscIngestionService.enqueueContainerImages(
+                orgId = 42,
+                payloads = listOf(
+                    DdContainerImagePayload(
+                        imageName = "nginx",
+                        imageTag = "1.25",
+                        digest = "sha256:abc123",
+                        registry = "docker.io",
+                        sizeBytes = 50_000_000,
+                        os = "linux",
+                        architecture = "amd64",
+                        layers = 5,
+                        tags = listOf("env:prod", "standalone"),
+                    ),
+                    DdContainerImagePayload(
+                        imageName = "redis",
+                        imageTag = "7.2",
+                        digest = "sha256:def456",
+                        registry = "gcr.io",
+                        sizeBytes = 30_000_000,
+                        os = "linux",
+                        architecture = "arm64",
+                        layers = 3,
+                        tags = listOf("team:platform"),
+                    ),
+                ),
+            )
+
+            val batch = MiscIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(2, count)
+            assertEquals(42, batch.organizationId)
+            assertEquals("container_images", batch.batchType)
+            assertEquals(listOf("nginx", "redis"), batch.containerImages.map { it.imageName })
+            assertEquals(listOf("amd64", "arm64"), batch.containerImages.map { it.architecture })
+            assertEquals("prod", batch.containerImages.first().tags["env"])
+            assertEquals("", batch.containerImages.first().tags["standalone"])
+            assertEquals(batch.containerImages.first().timestampMs, batch.containerImages.last().timestampMs)
+            verify(exactly = 1) { redis.lpush(MISC_QUEUE_KEY, any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueContainerImage delegates to a single-entry Redis batch`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(MISC_QUEUE_KEY, capture(queuedPayload)) } returns 1L
+
+            MiscIngestionService.enqueueContainerImage(
+                orgId = 7,
+                payload = DdContainerImagePayload(
+                    imageName = "api",
+                    imageTag = "latest",
+                    digest = "sha256:single",
+                    registry = "registry.example.com",
+                    tags = listOf("service:api"),
+                ),
+            )
+
+            val batch = MiscIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(7, batch.organizationId)
+            assertEquals("container_images", batch.batchType)
+            assertEquals(1, batch.containerImages.size)
+            assertEquals("api", batch.containerImages.single().imageName)
+            assertEquals("api", batch.containerImages.single().tags["service"])
+            verify(exactly = 1) { redis.lpush(MISC_QUEUE_KEY, any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueContainerImages skips Redis when batch is empty`() {
+        mockkObject(RedisConfig)
+        try {
+            val count = MiscIngestionService.enqueueContainerImages(orgId = 42, payloads = emptyList())
+
+            assertEquals(0, count)
+            verify(exactly = 0) { RedisConfig.sync() }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueSbom writes package rows in one Redis batch`() {
+        val redis = mockk<RedisCommands<String, String>>()
+        val queuedPayload = slot<String>()
+
+        mockkObject(RedisConfig)
+        try {
+            every { RedisConfig.sync() } returns redis
+            every { redis.lpush(MISC_QUEUE_KEY, capture(queuedPayload)) } returns 1L
+
+            val count = MiscIngestionService.enqueueSbom(
+                orgId = 99,
+                payload = DdSbomPayload(
+                    host = "node-1",
+                    containerId = "container-1",
+                    imageName = "moneat/api:latest",
+                    packages = listOf(
+                        DdSbomPackage(
+                            name = "openssl",
+                            version = "3.0.0",
+                            type = "deb",
+                            cveIds = listOf("CVE-2024-0001"),
+                        ),
+                        DdSbomPackage(
+                            name = "log4j",
+                            version = "2.17.2",
+                            type = "maven",
+                            cveIds = emptyList(),
+                        ),
+                    ),
+                    tags = listOf("env:prod", "runtime:jvm"),
+                ),
+            )
+
+            val batch = MiscIngestionService.decodeBatch(queuedPayload.captured)
+            assertEquals(2, count)
+            assertEquals(99, batch.organizationId)
+            assertEquals("sbom_packages", batch.batchType)
+            assertEquals(listOf("openssl", "log4j"), batch.sbomPackages.map { it.packageName })
+            assertEquals("container-1", batch.sbomPackages.first().containerId)
+            assertEquals(listOf("CVE-2024-0001"), batch.sbomPackages.first().cveIds)
+            assertEquals("prod", batch.sbomPackages.first().tags["env"])
+            assertEquals(batch.sbomPackages.first().timestampMs, batch.sbomPackages.last().timestampMs)
+            verify(exactly = 1) { redis.lpush(MISC_QUEUE_KEY, any<String>()) }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `enqueueSbom skips Redis when package list is empty`() {
+        mockkObject(RedisConfig)
+        try {
+            val count = MiscIngestionService.enqueueSbom(
+                orgId = 99,
+                payload = DdSbomPayload(host = "node-1", packages = emptyList()),
+            )
+
+            assertEquals(0, count)
+            verify(exactly = 0) { RedisConfig.sync() }
+        } finally {
+            unmockkObject(RedisConfig)
         }
     }
 


### PR DESCRIPTION
Adds Datadog Agent misc payload decoding for container images, SBOM, lifecycle, and stripped event intake.

Validation:
- ./gradlew :test --tests com.moneat.datadog.decompression.ProtoDecoderTest --tests com.moneat.datadog.routes.DatadogIngestRoutesTest -Dkotlin.compiler.execution.strategy=in-process
- ./gradlew :test --tests com.moneat.security.vulnerabilities.VulnerabilityRoutesTest -Dkotlin.compiler.execution.strategy=in-process
- ./gradlew detekt -Dkotlin.compiler.execution.strategy=in-process
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protobuf ingest support for container images, SBOMs, and lifecycle events with tag extraction, CVE association, timestamp normalization, and batch container-image ingestion
  * Endpoints auto-detect protobuf vs JSON, decompress payloads, and treat empty JSON as no-op

* **Bug Fixes**
  * Centralized payload handling with consistent invalid-payload responses and refined quota reservation/enforcement

* **Tests**
  * Added unit, route, and enqueue tests covering protobuf decoding, quota behaviors, and end-to-end ingestion flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->