### PR TITLE
fix: update host alert toggles immediately

### DIFF
--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -79,7 +79,6 @@ import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.head
 import io.ktor.client.request.header
-import io.ktor.client.request.head
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.request

--- a/dashboard/src/components/monitoring/AlertsTab.tsx
+++ b/dashboard/src/components/monitoring/AlertsTab.tsx
@@ -17,7 +17,7 @@
 import {useMemo, useState} from 'react'
 import {Link} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
-import {api, type HostAlert} from '@/lib/api'
+import {api, type HostAlert, type HostAlertConfig} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
 import {
@@ -63,6 +63,28 @@ const CONDITION_OPTIONS = [
   {value: '==', label: 'Equal to (==)'},
 ]
 
+const hostAlertConfigQueryKey = (hostId: number) => ['host-alert-config', hostId] as const
+
+function replaceAlert(alerts: HostAlert[], updatedAlert: HostAlert): HostAlert[] {
+  return alerts.map((alert) =>
+    alert.id === updatedAlert.id && alert.scope === updatedAlert.scope ? updatedAlert : alert
+  )
+}
+
+function updateAlertConfig(
+  alertConfig: HostAlertConfig | undefined,
+  updatedAlert: HostAlert
+): HostAlertConfig | undefined {
+  if (!alertConfig) return alertConfig
+
+  return {
+    ...alertConfig,
+    globalAlerts: replaceAlert(alertConfig.globalAlerts, updatedAlert),
+    hostAlerts: replaceAlert(alertConfig.hostAlerts, updatedAlert),
+    effectiveAlerts: replaceAlert(alertConfig.effectiveAlerts, updatedAlert),
+  }
+}
+
 export function AlertsTab({hostId}: AlertsTabProps) {
   const queryClient = useQueryClient()
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
@@ -71,7 +93,7 @@ export function AlertsTab({hostId}: AlertsTabProps) {
   const [createEnabled, setCreateEnabled] = useState(false)
 
   const {data: alertConfig, isLoading} = useQuery({
-    queryKey: ['host-alert-config', hostId],
+    queryKey: hostAlertConfigQueryKey(hostId),
     queryFn: () => api.getHostAlertConfig(hostId),
     enabled: api.isAuthenticated(),
   })
@@ -87,7 +109,7 @@ export function AlertsTab({hostId}: AlertsTabProps) {
   const scopeMutation = useMutation({
     mutationFn: (scope: HostAlertScope) => api.updateHostAlertScope(hostId, scope),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['host-alert-config', hostId]})
+      queryClient.invalidateQueries({queryKey: hostAlertConfigQueryKey(hostId)})
     },
   })
 
@@ -104,7 +126,7 @@ export function AlertsTab({hostId}: AlertsTabProps) {
       }
     }) => api.createHostAlert(hostId, alert, scope),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['host-alert-config', hostId]})
+      queryClient.invalidateQueries({queryKey: hostAlertConfigQueryKey(hostId)})
       setIsCreateDialogOpen(false)
       setCreateEnabled(false)
     },
@@ -113,8 +135,12 @@ export function AlertsTab({hostId}: AlertsTabProps) {
   const updateMutation = useMutation({
     mutationFn: ({alert, updates}: {alert: HostAlert; updates: Partial<HostAlert>}) =>
       api.updateHostAlert(hostId, alert.id, updates, alert.scope as HostAlertScope),
-    onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['host-alert-config', hostId]})
+    onSuccess: (updatedAlert, {alert, updates}) => {
+      const nextAlert = updatedAlert ?? {...alert, ...updates}
+      queryClient.setQueryData(hostAlertConfigQueryKey(hostId), (current: HostAlertConfig | undefined) =>
+        updateAlertConfig(current, nextAlert)
+      )
+      queryClient.invalidateQueries({queryKey: hostAlertConfigQueryKey(hostId)})
       setIsEditDialogOpen(false)
       setEditingAlert(null)
     },
@@ -123,15 +149,19 @@ export function AlertsTab({hostId}: AlertsTabProps) {
   const deleteMutation = useMutation({
     mutationFn: (alert: HostAlert) => api.deleteHostAlert(hostId, alert.id, alert.scope as HostAlertScope),
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['host-alert-config', hostId]})
+      queryClient.invalidateQueries({queryKey: hostAlertConfigQueryKey(hostId)})
     },
   })
 
   const toggleMutation = useMutation({
     mutationFn: ({alert, enabled}: {alert: HostAlert; enabled: boolean}) =>
       api.updateHostAlert(hostId, alert.id, {enabled}, alert.scope as HostAlertScope),
-    onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: ['host-alert-config', hostId]})
+    onSuccess: (updatedAlert, {alert, enabled}) => {
+      const nextAlert = updatedAlert ?? {...alert, enabled}
+      queryClient.setQueryData(hostAlertConfigQueryKey(hostId), (current: HostAlertConfig | undefined) =>
+        updateAlertConfig(current, nextAlert)
+      )
+      queryClient.invalidateQueries({queryKey: hostAlertConfigQueryKey(hostId)})
     },
   })
 
@@ -397,6 +427,7 @@ export function AlertsTab({hostId}: AlertsTabProps) {
                   }`}
                 >
                   <Switch
+                    aria-label={`${alert.enabled ? 'Disable' : 'Enable'} ${getMetricLabel(alert.metric)} alert`}
                     checked={alert.enabled}
                     onCheckedChange={(enabled) => toggleMutation.mutate({alert, enabled})}
                     disabled={toggleMutation.isPending}

--- a/dashboard/src/components/monitoring/__tests__/AlertsTab.test.tsx
+++ b/dashboard/src/components/monitoring/__tests__/AlertsTab.test.tsx
@@ -1,0 +1,118 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {ReactNode} from 'react'
+import {screen, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {http, HttpResponse} from 'msw'
+import {server} from '@/test/mocks/server'
+import {clearAuthStorage, renderWithQueryClient} from '@/test/utils'
+import {AlertsTab} from '../AlertsTab'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({children}: {children: ReactNode}) => <a href="/settings">{children}</a>,
+}))
+
+const API_BASE = 'http://localhost:8080'
+const HOST_ID = 5
+const ALERT_ID = 10
+
+function alertResponse(enabled: boolean) {
+  return {
+    id: ALERT_ID,
+    host_id: HOST_ID,
+    scope: 'host',
+    metric: 'cpu_percent',
+    condition: '>',
+    threshold: 90,
+    duration_seconds: 60,
+    enabled,
+    incident_severity: null,
+    last_triggered_at: null,
+    created_at: 1700000000,
+  }
+}
+
+function alertConfig(enabled: boolean) {
+  const alert = alertResponse(enabled)
+  return {
+    scope: 'host',
+    global_alerts: [],
+    host_alerts: [alert],
+    effective_alerts: [alert],
+  }
+}
+
+function installPointerCaptureMocks() {
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = () => false
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = () => {}
+  }
+  if (!HTMLElement.prototype.releasePointerCapture) {
+    HTMLElement.prototype.releasePointerCapture = () => {}
+  }
+}
+
+describe('AlertsTab', () => {
+  beforeEach(() => {
+    clearAuthStorage()
+    installPointerCaptureMocks()
+  })
+
+  it('updates an alert-rule toggle from the mutation variables before refetch completes', async () => {
+    const user = userEvent.setup()
+    let alertEnabled = true
+    let configRequests = 0
+    let releaseRefetch: (() => void) | undefined
+    let updateBody: Record<string, unknown> | undefined
+
+    server.use(
+      http.get(`${API_BASE}/v1/monitor/hosts/${HOST_ID}/alerts/config`, async () => {
+        configRequests += 1
+        if (configRequests > 1) {
+          await new Promise<void>((resolve) => {
+            releaseRefetch = resolve
+          })
+        }
+        return HttpResponse.json(alertConfig(alertEnabled))
+      }),
+      http.put(`${API_BASE}/v1/monitor/hosts/${HOST_ID}/alerts/${ALERT_ID}`, async ({request}) => {
+        updateBody = await request.json() as Record<string, unknown>
+        alertEnabled = false
+        return new HttpResponse(null, {status: 204})
+      })
+    )
+
+    renderWithQueryClient(<AlertsTab hostId={HOST_ID} />)
+
+    const toggle = await screen.findByRole('switch', {name: /disable cpu usage/i})
+    expect(toggle).toBeChecked()
+
+    await user.click(toggle)
+
+    try {
+      await waitFor(() => expect(toggle).not.toBeChecked(), {timeout: 500})
+      expect(screen.getByText('0 of 1 rules active (host-only)')).toBeInTheDocument()
+    } finally {
+      releaseRefetch?.()
+    }
+
+    expect(updateBody).toEqual({enabled: false})
+  })
+})

--- a/dashboard/src/lib/api/modules/__tests__/monitoring.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/monitoring.test.ts
@@ -690,7 +690,20 @@ describe('Monitoring API module', () => {
         })
       )
       const alert = await api.updateHostAlert(1, 50, { threshold: 95 })
-      expect(alert.threshold).toBe(95)
+      expect(alert?.threshold).toBe(95)
+    })
+
+    it('returns undefined for a no-content update response', async () => {
+      server.use(
+        http.put(`${API_BASE}/v1/monitor/hosts/1/alerts/50`, async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          expect(body.enabled).toBe(false)
+          return new HttpResponse(null, { status: 204 })
+        })
+      )
+
+      const alert = await api.updateHostAlert(1, 50, { enabled: false })
+      expect(alert).toBeUndefined()
     })
   })
 

--- a/dashboard/src/lib/api/modules/monitoring.ts
+++ b/dashboard/src/lib/api/modules/monitoring.ts
@@ -329,11 +329,11 @@ export function monitoringMethods(core: ApiClientCore) {
       updates: Partial<HostAlert>,
       scope: 'global' | 'host' = 'host'
     ) => {
-      const payload = await core.request<Record<string, unknown>>(
+      const payload = await core.request<Record<string, unknown> | undefined>(
         `${base}/monitor/hosts/${hostId}/alerts/${alertId}?scope=${scope}`,
         { method: 'PUT', body: JSON.stringify(updates) }
       )
-      return mapHostAlert(payload)
+      return payload === undefined ? undefined : mapHostAlert(payload)
     },
 
     deleteHostAlert: (


### PR DESCRIPTION
## Summary
- return updated host alert rules from the update endpoint
- merge updated alert rules into dashboard query cache immediately
- cover toggle behavior with focused frontend and backend tests

## Validation
- git diff --check
- npm test -- AlertsTab.test.tsx
- npm run typecheck
- npm run lint
- GRADLE_OPTS="-Xmx2g -XX:MaxMetaspaceSize=768m" ./gradlew --no-daemon :compileKotlin :detekt :test --tests com.moneat.routes.MonitorRoutesMockTest --tests com.moneat.services.MonitorServiceAlertTest -Dkotlin.compiler.execution.strategy=in-process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert update endpoint now returns the updated alert details instead of a generic success response, providing immediate confirmation of changes.
  * Alert configuration updates in the dashboard now apply optimistically to the UI before server confirmation, improving responsiveness.

* **Tests**
  * Enhanced test coverage for alert retrieval and toggle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->