### PR TITLE
feat: add service-first filters

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -200,7 +200,16 @@ fun Route.traceDashboardRoutes() {
         get("/v1/apm-errors") {
             val orgId = call.organizationId()
                 ?: return@get call.respondUnauthorized()
-            val service = call.parameters["service"]
+            // Accept a multi-select `services` list (comma-separated); fall back to
+            // the legacy single `service` param for backward compatibility.
+            val services = call.parameters["services"]
+                ?.split(",")
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                ?: call.parameters["service"]
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { listOf(it) }
+                ?: emptyList()
             val limit = (
                 call.parameters["limit"]
                     ?.toIntOrNull() ?: DEFAULT_LIMIT
@@ -212,7 +221,7 @@ fun Route.traceDashboardRoutes() {
 
             val result = TraceIngestionService.getApmErrors(
                 orgId,
-                service,
+                services,
                 limit,
                 offset,
                 timeRange,

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -39,9 +39,12 @@ private const val DEFAULT_APM_TIME_RANGE = "24h"
 private const val INVALID_TOKEN_ERROR = "Invalid token"
 private const val INVALID_TIME_RANGE_ERROR = "Invalid timeRange"
 private const val INVALID_STATUS_ERROR = "Invalid status"
+private const val INVALID_SERVICES_ERROR = "Invalid services"
 private const val STATUS_ERROR = "error"
 private const val STATUS_OK = "ok"
 private const val MAX_TRACE_SEARCH_LENGTH = 200
+private const val MAX_SERVICE_FILTERS = 50
+private const val MAX_SERVICE_FILTER_LENGTH = 200
 private val hexTraceIdPattern = Regex("^[0-9a-fA-F]+$")
 
 private val apmTimeRanges = mapOf(
@@ -202,14 +205,8 @@ fun Route.traceDashboardRoutes() {
                 ?: return@get call.respondUnauthorized()
             // Accept a multi-select `services` list (comma-separated); fall back to
             // the legacy single `service` param for backward compatibility.
-            val services = call.parameters["services"]
-                ?.split(",")
-                ?.map { it.trim() }
-                ?.filter { it.isNotEmpty() }
-                ?: call.parameters["service"]
-                    ?.takeIf { it.isNotBlank() }
-                    ?.let { listOf(it) }
-                ?: emptyList()
+            val services = call.serviceFilters()
+                ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
             val limit = (
                 call.parameters["limit"]
                     ?.toIntOrNull() ?: DEFAULT_LIMIT
@@ -270,6 +267,25 @@ private fun ApplicationCall.traceSearch(): String? =
         ?.trim()
         ?.take(MAX_TRACE_SEARCH_LENGTH)
         ?.takeIf { it.isNotEmpty() }
+
+private fun ApplicationCall.serviceFilters(): List<String>? {
+    val parsedServices = parameters["services"]
+        ?.split(",")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+    val rawSingleService = parameters["service"]
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { listOf(it) }
+    val rawServices = parsedServices?.takeIf { it.isNotEmpty() } ?: rawSingleService ?: emptyList()
+    if (rawServices.size > MAX_SERVICE_FILTERS) return null
+
+    val services = rawServices.distinct()
+    if (services.size > MAX_SERVICE_FILTERS) return null
+    return services.takeIf {
+        it.all { service -> service.length <= MAX_SERVICE_FILTER_LENGTH }
+    }
+}
 
 private fun String.isSupportedTraceId(): Boolean =
     isNotBlank() && (toULongOrNull() != null || hexTraceIdPattern.matches(this))

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -1027,7 +1027,7 @@ object TraceIngestionService {
 
     suspend fun getApmErrors(
         organizationId: Int,
-        service: String?,
+        services: List<String> = emptyList(),
         limit: Int,
         offset: Int,
         timeRange: DdApmQueryTimeRange = defaultApmQueryTimeRange,
@@ -1038,8 +1038,9 @@ object TraceIngestionService {
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
             timeRange.bucketStartClause()
         )
-        service?.let {
-            filters.add("service = '${escapeSql(it)}'")
+        if (services.isNotEmpty()) {
+            val serviceList = services.joinToString(", ") { "'${escapeSql(it)}'" }
+            filters.add("service IN ($serviceList)")
         }
         val whereClause = filters.joinToString(" AND ")
 

--- a/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
@@ -568,6 +568,12 @@ data class FeedbackUpdateRequest(
 )
 
 @Serializable
+data class EventIssueLinkResponse(
+    val issueId: String,
+    val projectResourceId: String
+)
+
+@Serializable
 data class TestNotificationRequest(
     val type: String, // error_alert, weekly_summary, system_up, system_down, uptime_alert, verification, password_reset
     val channel: String, // email, slack, both

--- a/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepository.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepository.kt
@@ -27,6 +27,7 @@ import com.moneat.events.repositories.models.IssueRow
  */
 interface IssueRepository {
     suspend fun getProjectIdForIssue(issueId: String): Long?
+    suspend fun getProjectIdForIssue(issueId: String, projectId: Long): Long?
     fun getIssueStatusOverrides(projectId: Long): Map<String, String>
     suspend fun getIssuesRaw(
         projectId: Long,

--- a/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepositoryImpl.kt
@@ -47,12 +47,20 @@ class IssueRepositoryImpl(
     private val clickhouseDb: String get() = queryHelper.clickhouseDb
     private val json get() = queryHelper.json
 
-    override suspend fun getProjectIdForIssue(issueId: String): Long? {
+    override suspend fun getProjectIdForIssue(issueId: String): Long? =
+        findProjectIdForIssue(issueId, projectId = null)
+
+    override suspend fun getProjectIdForIssue(issueId: String, projectId: Long): Long? =
+        findProjectIdForIssue(issueId, projectId)
+
+    private suspend fun findProjectIdForIssue(issueId: String, projectId: Long?): Long? {
         val escapedIssueId = escapeSql(issueId)
+        val projectFilter = projectId?.let { "AND project_id = $it" } ?: ""
         val query = """
             SELECT toInt64(project_id) as project_id
             FROM `$clickhouseDb`.issues FINAL
             WHERE issue_id = '$escapedIssueId'
+                $projectFilter
             LIMIT 1
             FORMAT JSONEachRow
         """.trimIndent()

--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -715,7 +715,7 @@ fun Route.apiRoutes() {
                     }
 
                     val update = call.receive<IssueUpdateRequest>()
-                    dashboardService.updateIssue(issueId, update)
+                    dashboardService.updateIssue(issueId, update, projectId)
                     call.respond(HttpStatusCode.NoContent)
                 }
 

--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -26,6 +26,7 @@ import com.moneat.billing.services.PricingTierService
 import com.moneat.events.models.AddTargetRequest
 import com.moneat.events.models.AlertNotificationPreferencesResponse
 import com.moneat.events.models.CreateProjectRequest
+import com.moneat.events.models.EventIssueLinkResponse
 import com.moneat.events.models.FeedbackUpdateRequest
 import com.moneat.events.models.IssueUpdateRequest
 import com.moneat.events.models.NotificationPreferencesData
@@ -1114,7 +1115,12 @@ fun Route.apiRoutes() {
                     if (issueId == null) {
                         call.respond(HttpStatusCode.NotFound)
                     } else {
-                        call.respond(mapOf("issueId" to issueId))
+                        call.respond(
+                            EventIssueLinkResponse(
+                                issueId = issueId,
+                                projectResourceId = projectIdResolver.resourceIdFor(projectId) ?: projectId.toString()
+                            )
+                        )
                     }
                 }
 

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -270,6 +270,7 @@ class DashboardService(
 
     suspend fun updateIssue(
         issueId: String,
-        update: com.moneat.events.models.IssueUpdateRequest
-    ) = issueService.updateIssue(issueId, update)
+        update: com.moneat.events.models.IssueUpdateRequest,
+        projectId: Long? = null
+    ) = issueService.updateIssue(issueId, update, projectId)
 }

--- a/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
@@ -29,6 +29,7 @@ import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.suspendRunCatching
 import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.NotFoundException
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -217,7 +218,7 @@ class IssueService(
         explicitProjectId: Long? = null
     ) {
         val projectId = resolveProjectIdForIssue(issueId, explicitProjectId)
-            ?: throw IllegalArgumentException("Issue not found")
+            ?: throw NotFoundException("Issue not found")
 
         if (update.status != null) {
             val validStatuses = setOf(STATUS_UNRESOLVED, STATUS_RESOLVED, STATUS_ARCHIVED, STATUS_IGNORED)

--- a/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
@@ -213,9 +213,10 @@ class IssueService(
 
     suspend fun updateIssue(
         issueId: String,
-        update: IssueUpdateRequest
+        update: IssueUpdateRequest,
+        explicitProjectId: Long? = null
     ) {
-        val projectId = issueRepository.getProjectIdForIssue(issueId)
+        val projectId = resolveProjectIdForIssue(issueId, explicitProjectId)
             ?: throw IllegalArgumentException("Issue not found")
 
         if (update.status != null) {
@@ -225,6 +226,13 @@ class IssueService(
             updateErrorAlertEpisode(issueId, projectId, update.status)
         }
     }
+
+    private suspend fun resolveProjectIdForIssue(issueId: String, explicitProjectId: Long?): Long? =
+        if (explicitProjectId != null) {
+            issueRepository.getProjectIdForIssue(issueId, explicitProjectId)
+        } else {
+            issueRepository.getProjectIdForIssue(issueId)
+        }
 
     private fun updateErrorAlertEpisode(
         issueId: String,

--- a/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
@@ -593,7 +593,7 @@ object OrgInvitations : Table("org_invitations") {
 
 object IssueStatuses : Table("issue_statuses") {
     val id = integer("id").autoIncrement()
-    val issue_id = varchar("issue_id", 64).uniqueIndex()
+    val issue_id = varchar("issue_id", 64)
     val project_id = long("project_id")
         .references(Projects.id, onDelete = ReferenceOption.CASCADE)
     val status = varchar("status", 32).default("unresolved")
@@ -601,5 +601,8 @@ object IssueStatuses : Table("issue_statuses") {
     val status_detail = jsonb("status_detail").nullable()
     val updated_at = timestamp("updated_at")
     val updated_by = integer("updated_by").references(Users.id).nullable()
+    init {
+        uniqueIndex(issue_id, project_id)
+    }
     override val primaryKey = PrimaryKey(id)
 }

--- a/backend/src/main/resources/db/migration/V124__scope_issue_statuses_by_project.sql
+++ b/backend/src/main/resources/db/migration/V124__scope_issue_statuses_by_project.sql
@@ -1,0 +1,5 @@
+ALTER TABLE issue_statuses
+    DROP CONSTRAINT IF EXISTS issue_statuses_issue_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_issue_statuses_issue_project
+    ON issue_statuses(issue_id, project_id);

--- a/backend/src/test/kotlin/com/moneat/events/repositories/IssueRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/repositories/IssueRepositoryTest.kt
@@ -132,7 +132,10 @@ class IssueRepositoryTest {
             } get Projects.id
         }
         repository.upsertIssueStatus("shared-issue", projectId, "resolved")
-        assertNull(repository.getIssueStatus("shared-issue", otherProjectId))
+        repository.upsertIssueStatus("shared-issue", otherProjectId, "ignored")
+
+        assertEquals("resolved", repository.getIssueStatus("shared-issue", projectId))
+        assertEquals("ignored", repository.getIssueStatus("shared-issue", otherProjectId))
     }
 
     // ──── getProjectName ────

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -2318,7 +2318,7 @@ class DatadogRoutesExtendedTest {
     fun `GET v1 apm-errors returns 200`() = testApplication {
         val (userId, orgId) = seedUserAndOrg()
         coEvery {
-            TraceIngestionService.getApmErrors(orgId, any(), any(), any(), any())
+            TraceIngestionService.getApmErrors(orgId, any(), any(), any(), any(), any())
         } returns DdApmErrorsResponse(emptyList(), 0L)
         application {
             installAuth()
@@ -2328,6 +2328,123 @@ class DatadogRoutesExtendedTest {
             withAuth(jwtToken(userId, orgId))
         }
         assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `GET v1 apm-errors trims deduplicates and forwards service filters`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        coEvery {
+            TraceIngestionService.getApmErrors(
+                orgId,
+                listOf("api", "worker"),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns DdApmErrorsResponse(emptyList(), 0L)
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val response = client.get("/v1/apm-errors?services=api,%20worker,api&service=ignored") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            TraceIngestionService.getApmErrors(
+                orgId,
+                listOf("api", "worker"),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `GET v1 apm-errors falls back to legacy service when services is empty`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        coEvery {
+            TraceIngestionService.getApmErrors(
+                orgId,
+                listOf("api"),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns DdApmErrorsResponse(emptyList(), 0L)
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val response = client.get("/v1/apm-errors?services=,%20&service=api") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            TraceIngestionService.getApmErrors(
+                orgId,
+                listOf("api"),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `GET v1 apm-errors rejects too many service filters`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val services = (1..51).joinToString(",") { "service-$it" }
+        val response = client.get("/v1/apm-errors?services=$services") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) {
+            TraceIngestionService.getApmErrors(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `GET v1 apm-errors rejects too many raw service filters before dedupe`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val services = (1..51).joinToString(",") { "api" }
+        val response = client.get("/v1/apm-errors?services=$services") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) {
+            TraceIngestionService.getApmErrors(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `GET v1 apm-errors rejects oversized service filters`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val serviceName = "a".repeat(201)
+        val response = client.get("/v1/apm-errors?services=$serviceName") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) {
+            TraceIngestionService.getApmErrors(any(), any(), any(), any(), any(), any())
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -2318,7 +2318,7 @@ class DatadogRoutesExtendedTest {
     fun `GET v1 apm-errors returns 200`() = testApplication {
         val (userId, orgId) = seedUserAndOrg()
         coEvery {
-            TraceIngestionService.getApmErrors(orgId, null, any(), any(), any())
+            TraceIngestionService.getApmErrors(orgId, any(), any(), any(), any())
         } returns DdApmErrorsResponse(emptyList(), 0L)
         application {
             installAuth()

--- a/backend/src/test/kotlin/com/moneat/routes/EventApiRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/EventApiRoutesTest.kt
@@ -555,6 +555,7 @@ class EventApiRoutesTest {
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("issue-found-1"))
+        assertTrue(response.bodyAsText().contains("projectResourceId"))
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
@@ -428,6 +428,20 @@ class EventServicesExtendedTest {
     }
 
     @Test
+    fun `updateIssue uses explicit project scope`() = runBlocking {
+        coEvery { issueRepository.getProjectIdForIssue(testIssueId, testProjectId) } returns testProjectId
+
+        issueService.updateIssue(
+            testIssueId,
+            IssueUpdateRequest(status = "resolved"),
+            explicitProjectId = testProjectId
+        )
+
+        coVerify(exactly = 0) { issueRepository.getProjectIdForIssue(testIssueId) }
+        verify { issueRepository.upsertIssueStatus(testIssueId, testProjectId, "resolved") }
+    }
+
+    @Test
     fun `updateIssue with null status does not call repository`() = runBlocking {
         coEvery { issueRepository.getProjectIdForIssue(testIssueId) } returns testProjectId
         issueService.updateIssue(testIssueId, IssueUpdateRequest(status = null))

--- a/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
@@ -37,6 +37,7 @@ import com.moneat.shared.models.Projects
 import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.testsupport.TestDatabaseHelper
 import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.NotFoundException
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -397,7 +398,7 @@ class EventServicesExtendedTest {
     @Test
     fun `updateIssue throws when issue not found`() {
         coEvery { issueRepository.getProjectIdForIssue("missing") } returns null
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<NotFoundException> {
             runBlocking {
                 issueService.updateIssue("missing", IssueUpdateRequest(status = "resolved"))
             }

--- a/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
@@ -597,7 +597,7 @@ class TraceIngestionServiceCoverageTest {
 
         val result = TraceIngestionService.getApmErrors(
             organizationId = 1,
-            service = null,
+            services = emptyList(),
             limit = 10,
             offset = 0
         )
@@ -640,7 +640,7 @@ class TraceIngestionServiceCoverageTest {
 
         val result = TraceIngestionService.getApmErrors(
             organizationId = 1,
-            service = "api",
+            services = listOf("api"),
             limit = 10,
             offset = 0
         )
@@ -778,7 +778,7 @@ class TraceIngestionServiceCoverageTest {
         )
         TraceIngestionService.getApmErrors(
             organizationId = 1,
-            service = null,
+            services = emptyList(),
             limit = 10,
             offset = 0,
             timeRange = timeRange

--- a/dashboard/src/components/ReplayTimelinePanel.tsx
+++ b/dashboard/src/components/ReplayTimelinePanel.tsx
@@ -56,6 +56,10 @@ export interface ReplayTimelinePanelProps {
 
 type FilterValue = 'all' | 'error' | 'transaction' | 'span'
 
+function issueSearch(projectId?: string | number): { projectId: string | undefined } {
+  return { projectId: projectId === undefined ? undefined : String(projectId) }
+}
+
 function formatOffset(offsetMs: number): string {
   if (offsetMs < 0) return '0:00'
   const totalSeconds = Math.floor(offsetMs / 1000)
@@ -200,7 +204,13 @@ function serializeValue(value: unknown): string {
   return String(value ?? '')
 }
 
-function BreadcrumbDetailPanel({ item }: { readonly item: TimelineItem }) {
+function BreadcrumbDetailPanel({
+  item,
+  projectId,
+}: {
+  readonly item: TimelineItem
+  readonly projectId?: string | number
+}) {
   const { timezone } = useTimezone()
   const colors = typeColorClasses(item.type)
   const data = item.data ?? {}
@@ -278,6 +288,7 @@ function BreadcrumbDetailPanel({ item }: { readonly item: TimelineItem }) {
             <Link
               to="/issues/$issueId"
               params={{ issueId: item.issueId }}
+              search={issueSearch(projectId)}
               className="inline-flex items-center gap-1 text-[11px] font-medium text-danger-fg hover:underline"
             >
               View Issue <ExternalLink className="h-3 w-3" />
@@ -351,6 +362,7 @@ function WaterfallPanel({
             <Link
               to="/issues/$issueId"
               params={{ issueId: item.issueId }}
+              search={issueSearch(projectId)}
               className="inline-flex items-center gap-1 text-[11px] font-medium text-danger-fg hover:underline"
             >
               View Issue <ExternalLink className="h-3 w-3" />
@@ -404,7 +416,7 @@ function ExpandedItemPanel({
   if (canFetchSpans(item)) {
     return <WaterfallPanel item={item} projectId={projectId} />
   }
-  return <BreadcrumbDetailPanel item={item} />
+  return <BreadcrumbDetailPanel item={item} projectId={projectId} />
 }
 
 /* ── Main component ── */
@@ -636,6 +648,7 @@ const TimelineList = React.forwardRef<HTMLDivElement, TimelineListProps>(functio
                     <Link
                       to="/issues/$issueId"
                       params={{ issueId: item.issueId }}
+                      search={issueSearch(projectId)}
                       onClick={(e) => e.stopPropagation()}
                       className="shrink-0 p-1.5 rounded-md hover:bg-danger-bg text-danger-fg transition-colors"
                       aria-label="View issue"

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -55,6 +55,7 @@ import {
     Settings,
     Shield,
     ShieldAlert,
+    SlidersHorizontal,
     Sparkles,
     Timer,
     Workflow,
@@ -276,6 +277,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
     { key: 'workflows', icon: Workflow, label: 'Workflows', href: '/workflows', requiresProject: false, group: 'operations' },
     { key: 'analytics', icon: BarChart3, label: 'Analytics', href: '/analytics', requiresProject: false, group: 'analytics' },
     // Management
+    { key: 'configuration', icon: SlidersHorizontal, label: 'Configuration', href: '/configuration', requiresProject: false, group: 'management' },
     ...adminNavItems,
   ]
 
@@ -368,7 +370,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  aria-label="Switch project"
+                  aria-label="Switch service"
                   className="flex w-full items-center gap-1.5 rounded-md border bg-muted/50 px-2 py-1 text-left text-xs cursor-default transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
                 >
                   {activeProject && (
@@ -410,7 +412,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('open-create-project-dialog'))} className="text-xs">
                   <Plus className="h-3 w-3" />
-                  New Project
+                  New Service
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -419,8 +421,8 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  aria-label={activeProject ? `Switch project: ${activeProject.name}` : 'Switch project'}
-                  title={activeProject ? `Switch project: ${activeProject.name}` : 'Switch project'}
+                  aria-label={activeProject ? `Switch service: ${activeProject.name}` : 'Switch service'}
+                  title={activeProject ? `Switch service: ${activeProject.name}` : 'Switch service'}
                   className="flex w-full items-center justify-center rounded-md border bg-muted/50 p-1.5 cursor-default transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
                 >
                   {activeProject && (
@@ -460,7 +462,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => window.dispatchEvent(new CustomEvent('open-create-project-dialog'))} className="text-xs">
                   <Plus className="h-3 w-3" />
-                  New Project
+                  New Service
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -475,14 +477,14 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
               className="w-full justify-center gap-1 h-7 text-xs"
             >
               <Plus className="h-3 w-3" />
-              New Project
+              New Service
             </Button>
           ) : (
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  aria-label="Create new project"
+                  aria-label="Create new service"
                   onClick={() => window.dispatchEvent(new CustomEvent('open-create-project-dialog'))}
                   className="flex w-full items-center justify-center rounded-md border bg-muted/50 p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 >
@@ -490,7 +492,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                 </button>
               </TooltipTrigger>
               <TooltipContent side="right">
-                <p>New Project</p>
+                <p>New Service</p>
               </TooltipContent>
             </Tooltip>
           )
@@ -767,9 +769,9 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
       <Dialog open={showCreateDialog} onOpenChange={(open) => { if (!open) resetCreateForm() }}>
         <DialogContent className="max-w-4xl">
           <DialogHeader>
-            <DialogTitle>Create New Project</DialogTitle>
+            <DialogTitle>Create New Service</DialogTitle>
             <DialogDescription>
-              Pick the application and telemetry sources you want Moneat to walk you through.
+              Pick the service and telemetry sources you want Moneat to walk you through.
             </DialogDescription>
           </DialogHeader>
 

--- a/dashboard/src/components/filters/ExplorerShell.tsx
+++ b/dashboard/src/components/filters/ExplorerShell.tsx
@@ -1,0 +1,108 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useState} from 'react'
+import type {ReactNode} from 'react'
+import {PanelLeftClose, PanelLeftOpen} from 'lucide-react'
+
+import {cn} from '@/lib/utils'
+
+export interface ExplorerShellProps {
+  /** The search/filter bar (typically a <SearchFilterBar/>), stretched to fill. */
+  searchBar: ReactNode
+  /** Optional left-of-search label (icon badge + title), the log-viewer style. */
+  title?: string
+  icon?: ReactNode
+  /** Header right side — page actions (e.g. New Project). */
+  actions?: ReactNode
+  /** The collapsible facet rail (typically a <FacetRail/>). Omit for no rail. */
+  rail?: ReactNode
+  /** Row above the content (e.g. select-all, result count). */
+  toolbar?: ReactNode
+  defaultRailOpen?: boolean
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * Compact filter-view shell, generalized from the log explorer: a dense header
+ * (title + search bar + actions) over a collapsible facet rail beside the
+ * content, with a thin toolbar carrying the rail toggle. The standard compact
+ * layout for result surfaces.
+ */
+export function ExplorerShell({
+  searchBar,
+  title,
+  icon,
+  actions,
+  rail,
+  toolbar,
+  defaultRailOpen = true,
+  children,
+  className,
+}: ExplorerShellProps) {
+  const [railOpen, setRailOpen] = useState(defaultRailOpen)
+
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      {/* Header bar */}
+      <div className="flex items-center gap-2 border-b px-2 py-1.5 sm:px-3">
+        {(icon || title) && (
+          <div className="flex shrink-0 items-center gap-2">
+            {icon}
+            {title && <h2 className="hidden text-xs font-semibold leading-tight sm:block">{title}</h2>}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">{searchBar}</div>
+        {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+      </div>
+
+      {/* Body: rail + content */}
+      <div className="flex min-h-0 flex-1">
+        {rail && (
+          <div
+            className={cn(
+              'shrink-0 border-r transition-all duration-200',
+              railOpen ? 'w-[220px]' : 'w-0 overflow-hidden border-r-0'
+            )}
+          >
+            {railOpen && rail}
+          </div>
+        )}
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          {(rail || toolbar) && (
+            <div className="flex items-center gap-1.5 border-b bg-card/30 px-2 py-1">
+              {rail && (
+                <button
+                  type="button"
+                  onClick={() => setRailOpen((v) => !v)}
+                  className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  title={railOpen ? 'Hide facets' : 'Show facets'}
+                  aria-label={railOpen ? 'Hide facets' : 'Show facets'}
+                >
+                  {railOpen ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}
+                </button>
+              )}
+              {toolbar}
+            </div>
+          )}
+          <div className="flex-1 overflow-y-auto">{children}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/filters/FacetRail.tsx
+++ b/dashboard/src/components/filters/FacetRail.tsx
@@ -1,0 +1,278 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useCallback, useEffect, useState} from 'react'
+import {ChevronRight, Minus, Search, SlidersHorizontal} from 'lucide-react'
+
+import {cn} from '@/lib/utils'
+import {Checkbox} from '@/components/ui/checkbox'
+import type {FacetFilter, FacetRailSection, FacetValue} from '@/lib/filters/types'
+
+/** Count formatting (matches the log viewer). */
+function formatFacetCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  if (n === 0) return ''
+  return String(n)
+}
+
+const SEARCH_THRESHOLD = 8
+const INITIAL_VISIBLE = 8
+
+export interface FacetRailProps {
+  sections: readonly FacetRailSection[]
+  facetFilters: FacetFilter[]
+  onFacetFiltersChange: (filters: FacetFilter[]) => void
+  title?: string
+  icon?: React.ComponentType<{className?: string}>
+  className?: string
+}
+
+/**
+ * Facet-filter rail (generalized from the log viewer's TagFacets): a bordered
+ * column of collapsible sections with checkboxes, counts, include/exclude
+ * tri-state, per-section search, and "Clear all". `FacetFilter[]`-controlled by
+ * the owner. Whole-rail show/hide is the shell's job, not the rail's.
+ */
+export function FacetRail({
+  sections,
+  facetFilters,
+  onFacetFiltersChange,
+  title = 'Filters',
+  icon: Icon = SlidersHorizontal,
+  className,
+}: FacetRailProps) {
+  const nonEmpty = sections.filter((s) => (s.options?.length ?? 0) > 0 || s.loadOptions)
+
+  return (
+    <div className={cn('flex h-full flex-col overflow-hidden bg-card/50', className)}>
+      <div className="flex h-8 shrink-0 items-center gap-1.5 border-b px-2">
+        <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="text-xs font-semibold uppercase tracking-wider">{title}</span>
+        {facetFilters.length > 0 && (
+          <button
+            type="button"
+            onClick={() => onFacetFiltersChange([])}
+            className="ml-auto text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {nonEmpty.map((section) => (
+          <RailSection
+            key={section.key}
+            section={section}
+            facetFilters={facetFilters}
+            onFacetFiltersChange={onFacetFiltersChange}
+          />
+        ))}
+        {nonEmpty.length === 0 && (
+          <div className="px-4 py-8 text-center text-xs text-muted-foreground">
+            No facets available yet.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface RailSectionProps {
+  section: FacetRailSection
+  facetFilters: FacetFilter[]
+  onFacetFiltersChange: (filters: FacetFilter[]) => void
+}
+
+function RailSection({section, facetFilters, onFacetFiltersChange}: RailSectionProps) {
+  const {key, label, color, singleSelect, allowExclude = true, options, loadOptions} = section
+  // Eager sections open by default (values are ready); lazy ones stay closed
+  // until opened, which also triggers their first load.
+  const [expanded, setExpanded] = useState(options != null)
+  const [query, setQuery] = useState('')
+  const [showAll, setShowAll] = useState(false)
+  const [loaded, setLoaded] = useState<readonly FacetValue[] | null>(null)
+
+  // Lazily load values the first time the section is opened.
+  useEffect(() => {
+    if (expanded && !options && loadOptions && loaded === null) {
+      let cancelled = false
+      void loadOptions().then((values) => {
+        if (!cancelled) setLoaded(values)
+      })
+      return () => {
+        cancelled = true
+      }
+    }
+  }, [expanded, options, loadOptions, loaded])
+
+  const values = options ?? loaded ?? []
+  const activeCount = facetFilters.filter((f) => f.key === key).length
+
+  const getState = useCallback(
+    (value: string): 'include' | 'exclude' | 'none' => {
+      const match = facetFilters.find((f) => f.key === key && f.value === value)
+      if (!match) return 'none'
+      return match.exclude ? 'exclude' : 'include'
+    },
+    [facetFilters, key]
+  )
+
+  const toggleInclude = useCallback(
+    (value: string) => {
+      const state = getState(value)
+      if (state === 'none') {
+        const base = singleSelect ? facetFilters.filter((f) => f.key !== key) : facetFilters
+        onFacetFiltersChange([...base, {key, value, exclude: false}])
+      } else {
+        onFacetFiltersChange(facetFilters.filter((f) => !(f.key === key && f.value === value)))
+      }
+    },
+    [getState, singleSelect, facetFilters, key, onFacetFiltersChange]
+  )
+
+  const toggleExclude = useCallback(
+    (value: string, event: React.MouseEvent) => {
+      event.stopPropagation()
+      event.preventDefault()
+      const state = getState(value)
+      if (state === 'exclude') {
+        onFacetFiltersChange(facetFilters.filter((f) => !(f.key === key && f.value === value)))
+      } else {
+        const without = facetFilters.filter((f) => !(f.key === key && f.value === value))
+        onFacetFiltersChange([...without, {key, value, exclude: true}])
+      }
+    },
+    [getState, facetFilters, key, onFacetFiltersChange]
+  )
+
+  const normalizedQuery = query.trim().toLowerCase()
+  const filtered = normalizedQuery
+    ? values.filter((v) => (v.label ?? v.value).toLowerCase().includes(normalizedQuery))
+    : values
+  const searchable = values.length > SEARCH_THRESHOLD
+  const shown = showAll ? filtered : filtered.slice(0, INITIAL_VISIBLE)
+
+  return (
+    <div className="border-b border-border/50 last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronRight className={cn('h-3.5 w-3.5 shrink-0 transition-transform', expanded && 'rotate-90')} />
+        <span className={cn('h-2 w-2 shrink-0 rounded-full', color || 'bg-muted-foreground/50')} />
+        <span className="truncate">{label}</span>
+        <span className="ml-auto font-normal tabular-nums text-muted-foreground/70">
+          {activeCount > 0 ? `${activeCount}/${values.length || '?'}` : values.length || ''}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="space-y-0.5 px-2 pb-2">
+          {searchable && (
+            <div className="relative mb-1">
+              <Search className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value)
+                  setShowAll(true)
+                }}
+                placeholder={`Filter ${label.toLowerCase()}`}
+                aria-label={`Filter ${label}`}
+                className="h-7 w-full rounded-md border border-input bg-background pl-7 pr-2 text-xs placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
+          )}
+
+          {values.length === 0 ? (
+            <p className="px-2 py-1 text-xs text-muted-foreground">Loading values...</p>
+          ) : shown.length === 0 ? (
+            <p className="px-2 py-1 text-xs text-muted-foreground">No matches</p>
+          ) : (
+            shown.map((item) => {
+              const state = getState(item.value)
+              const display = item.label ?? item.value
+              return (
+                <div
+                  key={item.value}
+                  className={cn(
+                    'group flex items-center gap-2 rounded-md px-2 py-1 transition-colors hover:bg-accent/50',
+                    state === 'include' && 'bg-primary/5',
+                    state === 'exclude' && 'bg-danger-bg/50'
+                  )}
+                >
+                  <Checkbox
+                    checked={state === 'include'}
+                    onCheckedChange={() => toggleInclude(item.value)}
+                    aria-label={display}
+                    className={cn(
+                      'h-3.5 w-3.5',
+                      state === 'exclude' && 'border-danger-solid data-[state=checked]:bg-danger-solid'
+                    )}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggleInclude(item.value)}
+                    title={display}
+                    className={cn(
+                      'min-w-0 flex-1 truncate text-left font-mono text-xs focus:outline-none',
+                      state === 'exclude' && 'text-muted-foreground line-through'
+                    )}
+                  >
+                    {display}
+                  </button>
+                  {item.count != null && item.count > 0 && (
+                    <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/60">
+                      {formatFacetCount(item.count)}
+                    </span>
+                  )}
+                  {allowExclude && (
+                    <button
+                      type="button"
+                      onClick={(e) => toggleExclude(item.value, e)}
+                      title={state === 'exclude' ? 'Remove exclusion' : 'Exclude this value'}
+                      className={cn(
+                        'shrink-0 rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100',
+                        state === 'exclude' ? 'text-danger-fg opacity-100' : 'text-muted-foreground hover:text-danger-fg'
+                      )}
+                    >
+                      <Minus className="h-3 w-3" />
+                    </button>
+                  )}
+                </div>
+              )
+            })
+          )}
+
+          {filtered.length > INITIAL_VISIBLE && (
+            <button
+              type="button"
+              onClick={() => setShowAll((v) => !v)}
+              className="rounded px-2 pt-1 text-[11px] text-primary hover:underline focus:outline-none"
+            >
+              {showAll ? 'Show less' : `Show ${filtered.length - INITIAL_VISIBLE} more`}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/filters/FacetRail.tsx
+++ b/dashboard/src/components/filters/FacetRail.tsx
@@ -202,7 +202,7 @@ function RailSection({section, facetFilters, onFacetFiltersChange}: RailSectionP
             </div>
           )}
 
-          {values.length === 0 ? (
+          {!options && loadOptions && loaded === null ? (
             <p className="px-2 py-1 text-xs text-muted-foreground">Loading values...</p>
           ) : shown.length === 0 ? (
             <p className="px-2 py-1 text-xs text-muted-foreground">No matches</p>

--- a/dashboard/src/components/filters/SearchFilterBar.tsx
+++ b/dashboard/src/components/filters/SearchFilterBar.tsx
@@ -1,0 +1,400 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import type {ReactNode} from 'react'
+import {Search, X} from 'lucide-react'
+
+import {cn} from '@/lib/utils'
+import {Badge} from '@/components/ui/badge'
+import {
+  type FacetFilter,
+  type FacetSchema,
+  applyFacetFilter,
+  resolveFacetDef,
+} from '@/lib/filters/types'
+
+const DEFAULT_CHIP_COLOR = 'bg-info-bg text-info-fg border-info-border'
+
+interface Suggestion {
+  type: 'key' | 'value'
+  label: string
+  value: string
+}
+
+export interface SearchFilterBarProps {
+  query: string
+  onQueryChange: (value: string) => void
+  facetFilters: FacetFilter[]
+  onFacetFiltersChange: (filters: FacetFilter[]) => void
+  /** Facets this surface understands — drives typeahead + chip routing. */
+  schema: FacetSchema
+  /** Extra keys to suggest that are NOT facet-routable (typed values → query). */
+  suggestKeys?: readonly string[]
+  /**
+   * Intercept a parsed `key:value` token before it becomes a chip/query (e.g.
+   * the log viewer routes `level:x` to its level toggle). Return true if handled.
+   */
+  onInterceptToken?: (key: string, value: string, exclude: boolean) => boolean
+  /** Surface-specific controls rendered after the search box (time, levels…). */
+  trailing?: ReactNode
+  placeholder?: string
+  /** Whether a surface-managed filter (e.g. levels) is active, for clear-all. */
+  hasExtraActiveFilters?: boolean
+  /** Reset the surface-managed filter when the bar's clear-all is pressed. */
+  onClearExtra?: () => void
+  className?: string
+}
+
+/**
+ * Unified search/filter bar in the house style (generalized from the log
+ * viewer): a free-text query plus inline removable facet chips, with
+ * `key:value` / `-key:value` typeahead. Schema-driven so any surface reuses it;
+ * surface-specific controls (time range, log levels) go in `trailing`.
+ *
+ * Dropdowns are plain positioned elements with click-outside (not Radix), so
+ * the bar — including its suggestions — is exercisable under jsdom.
+ */
+export function SearchFilterBar({
+  query,
+  onQueryChange,
+  facetFilters,
+  onFacetFiltersChange,
+  schema,
+  suggestKeys = [],
+  onInterceptToken,
+  trailing,
+  placeholder,
+  hasExtraActiveFilters = false,
+  onClearExtra,
+  className,
+}: SearchFilterBarProps) {
+  const [inputValue, setInputValue] = useState('')
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const suggestionsRef = useRef<HTMLDivElement>(null)
+
+  const allKeys = useMemo(() => {
+    const keys = new Set<string>()
+    for (const def of schema) {
+      keys.add(def.key)
+      def.aliases?.forEach((a) => keys.add(a))
+    }
+    suggestKeys.forEach((k) => keys.add(k))
+    return Array.from(keys).sort()
+  }, [schema, suggestKeys])
+
+  const suggestions = useMemo<Suggestion[]>(() => {
+    const trimmed = inputValue.trim()
+    if (!trimmed) return []
+
+    const colonIndex = trimmed.indexOf(':')
+    if (colonIndex === -1) {
+      return allKeys
+        .filter((key) => key.toLowerCase().startsWith(trimmed.toLowerCase()))
+        .slice(0, 8)
+        .map((key) => ({type: 'key' as const, label: key, value: `${key}:`}))
+    }
+
+    const rawKey = trimmed.slice(0, colonIndex).trim().toLowerCase()
+    const valuePrefix = trimmed.slice(colonIndex + 1).trim().toLowerCase()
+    const def = resolveFacetDef(schema, rawKey)
+    const possibleValues = def?.suggestions ?? []
+
+    if (possibleValues.length > 0) {
+      const filtered = valuePrefix
+        ? possibleValues.filter((v) => v.toLowerCase().includes(valuePrefix))
+        : possibleValues
+      return filtered.slice(0, 8).map((v) => ({
+        type: 'value' as const,
+        label: `${rawKey}:${v}`,
+        value: `${rawKey}:${v}`,
+      }))
+    }
+    return []
+  }, [inputValue, allKeys, schema])
+
+  // Track the selected suggestion against the suggestion set it belongs to, so a
+  // changing list never leaves a stale highlight (ported from the log bar).
+  const [selectedState, setSelectedState] = useState<{suggestions: Suggestion[]; index: number}>({
+    suggestions: [],
+    index: -1,
+  })
+  const selectedIndex = selectedState.suggestions === suggestions ? selectedState.index : -1
+  const setSelectedIndex = (updater: number | ((prev: number) => number)) => {
+    setSelectedState((prev) => {
+      const prevIndex = prev.suggestions === suggestions ? prev.index : -1
+      const newIndex = typeof updater === 'function' ? updater(prevIndex) : updater
+      return {suggestions, index: newIndex}
+    })
+  }
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        suggestionsRef.current &&
+        !suggestionsRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        setShowSuggestions(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const appendToQuery = useCallback(
+    (token: string) => {
+      const newQuery = query ? `${query} ${token}` : token
+      onQueryChange(newQuery.trim())
+    },
+    [query, onQueryChange]
+  )
+
+  const applyToken = useCallback(
+    (token: string) => {
+      // Boolean operators → treat the whole thing as a free-text query.
+      if (/\b(AND|OR)\b/.test(token)) {
+        appendToQuery(token)
+        setInputValue('')
+        setShowSuggestions(false)
+        return
+      }
+
+      const colonIndex = token.indexOf(':')
+      if (colonIndex > 0) {
+        const isExclude = token.startsWith('-')
+        const rawKey = (isExclude ? token.slice(1, colonIndex) : token.slice(0, colonIndex)).trim()
+        const value = token.slice(colonIndex + 1).trim()
+
+        if (!rawKey) return
+        // Empty value (trailing colon) or wildcards → query parser.
+        if (!value || value.includes('*') || value.includes('?')) {
+          appendToQuery(token)
+          setInputValue('')
+          setShowSuggestions(false)
+          return
+        }
+
+        const def = resolveFacetDef(schema, rawKey)
+        const canonicalKey = def?.key ?? rawKey.toLowerCase()
+
+        if (onInterceptToken?.(canonicalKey, value, isExclude)) {
+          setInputValue('')
+          setShowSuggestions(false)
+          return
+        }
+
+        if (def && (!isExclude || def.allowExclude)) {
+          onFacetFiltersChange(
+            applyFacetFilter(
+              facetFilters,
+              {key: def.key, value, exclude: isExclude},
+              {singleSelect: def.singleSelect}
+            )
+          )
+        } else {
+          // Unknown key, or an exclude on a non-excludable facet → query parser.
+          appendToQuery(token)
+        }
+      } else {
+        appendToQuery(token)
+      }
+      setInputValue('')
+      setShowSuggestions(false)
+    },
+    [appendToQuery, schema, onInterceptToken, facetFilters, onFacetFiltersChange]
+  )
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      if (selectedIndex >= 0 && selectedIndex < suggestions.length) {
+        const selected = suggestions[selectedIndex]
+        if (selected.type === 'key') {
+          setInputValue(selected.value)
+        } else {
+          applyToken(selected.value)
+        }
+      } else if (inputValue.trim()) {
+        applyToken(inputValue.trim())
+      }
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setSelectedIndex((prev) => Math.min(prev + 1, suggestions.length - 1))
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setSelectedIndex((prev) => Math.max(prev - 1, -1))
+    } else if (event.key === 'Escape') {
+      setShowSuggestions(false)
+    } else if (event.key === 'Backspace' && !inputValue) {
+      // Empty input → peel off the last query word, then the last facet chip.
+      if (query) {
+        const words = query.trim().split(/\s+/)
+        onQueryChange(words.slice(0, -1).join(' '))
+      } else if (facetFilters.length > 0) {
+        onFacetFiltersChange(facetFilters.slice(0, -1))
+      }
+    }
+  }
+
+  const removeFacetFilter = (index: number) => {
+    onFacetFiltersChange(facetFilters.filter((_, i) => i !== index))
+  }
+
+  const hasActiveFilters = Boolean(query) || facetFilters.length > 0 || hasExtraActiveFilters
+
+  const clearAll = () => {
+    onQueryChange('')
+    onFacetFiltersChange([])
+    onClearExtra?.()
+    setInputValue('')
+  }
+
+  return (
+    <div className={cn('flex items-stretch gap-1.5', className)}>
+      <div className="relative flex-1 min-w-0">
+        <div className="flex min-h-[30px] flex-wrap items-center gap-1 rounded-md border bg-card px-2 py-0.5 ring-offset-background transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+
+          {query && (
+            <Badge
+              variant="secondary"
+              className="gap-1 font-mono text-xs bg-info-bg text-info-fg border border-info-border cursor-pointer hover:opacity-80"
+              onClick={() => {
+                setInputValue(query)
+                onQueryChange('')
+                inputRef.current?.focus()
+              }}
+            >
+              {query}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onQueryChange('')
+                  setInputValue('')
+                }}
+                className="ml-0.5 rounded-full hover:bg-info-border"
+                aria-label="Remove search text"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          )}
+
+          {facetFilters.map((filter, index) => {
+            const def = resolveFacetDef(schema, filter.key)
+            return (
+              <Badge
+                key={`${filter.key}-${filter.value}-${index}`}
+                variant="outline"
+                className={cn(
+                  'gap-1 font-mono text-xs cursor-pointer hover:opacity-80',
+                  filter.exclude && 'line-through opacity-75',
+                  def?.color || DEFAULT_CHIP_COLOR
+                )}
+                onClick={() => {
+                  setInputValue(`${filter.exclude ? '-' : ''}${filter.key}:${filter.value}`)
+                  removeFacetFilter(index)
+                  inputRef.current?.focus()
+                }}
+              >
+                {filter.exclude && '- '}
+                {filter.key}:{filter.value}
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    removeFacetFilter(index)
+                  }}
+                  className="ml-0.5 rounded-full hover:bg-foreground/20"
+                  aria-label={`Remove ${filter.key}:${filter.value}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            )
+          })}
+
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={(e) => {
+              setInputValue(e.target.value)
+              setShowSuggestions(true)
+            }}
+            onFocus={() => setShowSuggestions(true)}
+            onKeyDown={handleKeyDown}
+            placeholder={hasActiveFilters ? 'Add...' : placeholder ?? 'Search...'}
+            className="min-w-[80px] sm:min-w-[200px] flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+          />
+
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Clear all filters"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+
+        {showSuggestions && suggestions.length > 0 && (
+          <div
+            ref={suggestionsRef}
+            className="absolute left-0 right-0 top-full z-50 mt-1 rounded-lg border bg-popover p-1"
+          >
+            {suggestions.map((suggestion, index) => (
+              <button
+                key={suggestion.value}
+                type="button"
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors',
+                  index === selectedIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
+                )}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  if (suggestion.type === 'key') {
+                    setInputValue(suggestion.value)
+                    inputRef.current?.focus()
+                  } else {
+                    applyToken(suggestion.value)
+                  }
+                }}
+              >
+                <span className="font-mono text-xs text-muted-foreground">
+                  {suggestion.type === 'key' ? 'facet' : 'filter'}
+                </span>
+                <span className="font-mono">{suggestion.label}</span>
+              </button>
+            ))}
+            <div className="border-t mt-1 pt-1 px-3 py-1.5 text-[11px] text-muted-foreground">
+              Use <code className="rounded bg-muted px-1">key:value</code> for facet filters,{' '}
+              <code className="rounded bg-muted px-1">-key:value</code> to exclude
+            </div>
+          </div>
+        )}
+      </div>
+
+      {trailing}
+    </div>
+  )
+}

--- a/dashboard/src/components/filters/TimeRangePicker.tsx
+++ b/dashboard/src/components/filters/TimeRangePicker.tsx
@@ -1,0 +1,168 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useEffect, useMemo, useRef, useState} from 'react'
+import {ChevronDown, Clock} from 'lucide-react'
+import {format} from 'date-fns'
+
+import {cn} from '@/lib/utils'
+import {Button} from '@/components/ui/button'
+import {DateTimePicker} from '@/components/ui/datetime-picker'
+import {type TimeRangePreset, TIME_PRESETS} from '@/lib/filters/time'
+
+interface TimeRangePickerProps {
+  timePreset: string
+  onTimePresetChange: (preset: string) => void
+  customFrom: string
+  customTo: string
+  onCustomFromChange: (value: string) => void
+  onCustomToChange: (value: string) => void
+  /** Preset list; defaults to {@link TIME_PRESETS}. */
+  presets?: TimeRangePreset[]
+  /** Allow a custom from/to range. Defaults to true. */
+  allowCustom?: boolean
+}
+
+/**
+ * Controlled time-range selector — a button showing the active range and a
+ * dropdown of presets plus an optional custom from/to range. Extracted verbatim
+ * from the log search bar so every surface gets the same control.
+ */
+export function TimeRangePicker({
+  timePreset,
+  onTimePresetChange,
+  customFrom,
+  customTo,
+  onCustomFromChange,
+  onCustomToChange,
+  presets = TIME_PRESETS,
+  allowCustom = true,
+}: TimeRangePickerProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const activeLabel = useMemo(() => {
+    if (timePreset === 'custom') {
+      if (!customFrom && !customTo) return 'Custom range'
+      try {
+        const fromDate = customFrom ? new Date(customFrom) : null
+        const toDate = customTo ? new Date(customTo) : null
+        if (fromDate && toDate) {
+          const sameDay = format(fromDate, 'yyyy-MM-dd') === format(toDate, 'yyyy-MM-dd')
+          if (sameDay) {
+            return `${format(fromDate, 'MMM d, HH:mm')} - ${format(toDate, 'HH:mm')}`
+          }
+          return `${format(fromDate, 'MMM d, HH:mm')} - ${format(toDate, 'MMM d, HH:mm')}`
+        }
+        if (fromDate) return `From ${format(fromDate, 'MMM d, HH:mm')}`
+        if (toDate) return `Until ${format(toDate, 'MMM d, HH:mm')}`
+      } catch {
+        // Invalid date
+      }
+      return 'Custom range'
+    }
+    const preset = presets.find((p) => p.value === timePreset)
+    return preset?.label ?? presets[0]?.label ?? 'Custom range'
+  }, [timePreset, customFrom, customTo, presets])
+
+  return (
+    <div className="relative" ref={ref}>
+      <Button
+        variant="outline"
+        size="default"
+        className="h-[30px] px-2 sm:px-3 gap-1.5 whitespace-nowrap font-normal text-xs"
+        onClick={() => setOpen(!open)}
+      >
+        <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="hidden sm:inline text-xs">{activeLabel}</span>
+        <ChevronDown className="hidden sm:inline h-3 w-3 text-muted-foreground" />
+      </Button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-[260px] rounded-lg border bg-popover p-1">
+          {presets.map((preset) => (
+            <button
+              key={preset.value}
+              type="button"
+              className={cn(
+                'flex w-full items-center rounded-md px-3 py-2 text-left text-sm transition-colors',
+                timePreset === preset.value
+                  ? 'bg-primary/10 text-primary font-medium'
+                  : 'hover:bg-accent/50'
+              )}
+              onClick={() => {
+                onTimePresetChange(preset.value)
+                setOpen(false)
+              }}
+            >
+              {preset.label}
+            </button>
+          ))}
+          {allowCustom && (
+            <div className="border-t mt-1 pt-1">
+              <button
+                type="button"
+                className={cn(
+                  'flex w-full items-center rounded-md px-3 py-2 text-left text-sm transition-colors',
+                  timePreset === 'custom'
+                    ? 'bg-primary/10 text-primary font-medium'
+                    : 'hover:bg-accent/50'
+                )}
+                onClick={() => onTimePresetChange('custom')}
+              >
+                Custom range...
+              </button>
+              {timePreset === 'custom' && (
+                <div className="space-y-2 px-3 py-2">
+                  <div>
+                    <label className="mb-1 block text-[11px] uppercase tracking-wide text-muted-foreground">
+                      From
+                    </label>
+                    <DateTimePicker
+                      value={customFrom}
+                      onChange={onCustomFromChange}
+                      placeholder="Select start time"
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-[11px] uppercase tracking-wide text-muted-foreground">
+                      To
+                    </label>
+                    <DateTimePicker
+                      value={customTo}
+                      onChange={onCustomToChange}
+                      placeholder="Select end time"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/filters/__tests__/ExplorerShell.test.tsx
+++ b/dashboard/src/components/filters/__tests__/ExplorerShell.test.tsx
@@ -1,0 +1,85 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {render, screen, fireEvent} from '@testing-library/react'
+import {describe, it, expect} from 'vitest'
+
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
+
+describe('ExplorerShell', () => {
+  it('renders title, icon, actions, toolbar, rail, and content', () => {
+    render(
+      <ExplorerShell
+        title="Issues"
+        icon={<span data-testid="icon">I</span>}
+        actions={<button type="button">Refresh</button>}
+        searchBar={<input aria-label="Search" />}
+        rail={<div>Facet rail</div>}
+        toolbar={<span>42 results</span>}
+      >
+        <div>Issue rows</div>
+      </ExplorerShell>
+    )
+
+    expect(screen.getByText('Issues')).toBeTruthy()
+    expect(screen.getByTestId('icon')).toBeTruthy()
+    expect(screen.getByRole('button', {name: 'Refresh'})).toBeTruthy()
+    expect(screen.getByLabelText('Search')).toBeTruthy()
+    expect(screen.getByText('Facet rail')).toBeTruthy()
+    expect(screen.getByText('42 results')).toBeTruthy()
+    expect(screen.getByText('Issue rows')).toBeTruthy()
+  })
+
+  it('toggles the rail open and closed', () => {
+    render(
+      <ExplorerShell
+        searchBar={<input aria-label="Search" />}
+        rail={<div>Facet rail</div>}
+      >
+        <div>Rows</div>
+      </ExplorerShell>
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: 'Hide facets'}))
+    expect(screen.queryByText('Facet rail')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Show facets'}))
+    expect(screen.getByText('Facet rail')).toBeTruthy()
+  })
+
+  it('respects an initially closed rail and renders without optional chrome', () => {
+    render(
+      <ExplorerShell
+        searchBar={<input aria-label="Search" />}
+        rail={<div>Facet rail</div>}
+        defaultRailOpen={false}
+      >
+        <div>Rows</div>
+      </ExplorerShell>
+    )
+
+    expect(screen.queryByText('Facet rail')).toBeNull()
+    expect(screen.getByRole('button', {name: 'Show facets'})).toBeTruthy()
+
+    render(
+      <ExplorerShell searchBar={<input aria-label="Plain search" />}>
+        <div>Plain rows</div>
+      </ExplorerShell>
+    )
+    expect(screen.getByLabelText('Plain search')).toBeTruthy()
+    expect(screen.getByText('Plain rows')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/filters/__tests__/FacetRail.test.tsx
+++ b/dashboard/src/components/filters/__tests__/FacetRail.test.tsx
@@ -64,6 +64,12 @@ describe('FacetRail', () => {
     expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'api', exclude: true}])
   })
 
+  it('removes an excluded value via the exclude affordance', () => {
+    const {onFacetFiltersChange} = setup({facetFilters: [{key: 'service', value: 'api', exclude: true}]})
+    fireEvent.click(screen.getByTitle('Remove exclusion'))
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([])
+  })
+
   it('replaces the value for a single-select section', () => {
     const {onFacetFiltersChange} = setup({facetFilters: [{key: 'status', value: 'unresolved', exclude: false}]})
     fireEvent.click(screen.getByRole('button', {name: 'resolved'}))
@@ -96,5 +102,40 @@ describe('FacetRail', () => {
     expect(screen.getByRole('button', {name: 'svc-1'})).toBeTruthy()
     expect(screen.getByRole('button', {name: 'svc-10'})).toBeTruthy()
     expect(screen.queryByRole('button', {name: 'svc-2'})).toBeNull()
+  })
+
+  it('expands and collapses long value lists', () => {
+    const many: FacetRailSection[] = [
+      {
+        key: 'tag',
+        label: 'Tags',
+        options: Array.from({length: 12}, (_, i) => ({value: `svc-${i}`})),
+      },
+    ]
+    render(<FacetRail sections={many} facetFilters={[]} onFacetFiltersChange={() => {}} />)
+
+    expect(screen.queryByRole('button', {name: 'svc-11'})).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Show 4 more'}))
+    expect(screen.getByRole('button', {name: 'svc-11'})).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Show less'}))
+    expect(screen.queryByRole('button', {name: 'svc-11'})).toBeNull()
+  })
+
+  it('shows an empty state after a lazy section loads zero values', async () => {
+    const lazySections: FacetRailSection[] = [
+      {
+        key: 'service',
+        label: 'Service',
+        loadOptions: () => Promise.resolve([]),
+      },
+    ]
+    render(<FacetRail sections={lazySections} facetFilters={[]} onFacetFiltersChange={() => {}} />)
+
+    fireEvent.click(screen.getByRole('button', {name: /Service/}))
+
+    expect(await screen.findByText('No matches')).toBeTruthy()
+    expect(screen.queryByText('Loading values...')).toBeNull()
   })
 })

--- a/dashboard/src/components/filters/__tests__/FacetRail.test.tsx
+++ b/dashboard/src/components/filters/__tests__/FacetRail.test.tsx
@@ -1,0 +1,100 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {render, screen, fireEvent} from '@testing-library/react'
+import {describe, it, expect, vi} from 'vitest'
+
+import {FacetRail} from '@/components/filters/FacetRail'
+import type {FacetRailSection} from '@/lib/filters/types'
+
+const sections: FacetRailSection[] = [
+  {key: 'service', label: 'Service', options: [{value: 'api', count: 42}, {value: 'worker', count: 5}]},
+  {key: 'status', label: 'Status', singleSelect: true, allowExclude: false, options: [{value: 'unresolved'}, {value: 'resolved'}]},
+]
+
+function setup(props: Partial<React.ComponentProps<typeof FacetRail>> = {}) {
+  const onFacetFiltersChange = vi.fn()
+  render(
+    <FacetRail
+      sections={sections}
+      facetFilters={[]}
+      onFacetFiltersChange={onFacetFiltersChange}
+      {...props}
+    />
+  )
+  return {onFacetFiltersChange}
+}
+
+describe('FacetRail', () => {
+  it('renders sections, values and counts', () => {
+    setup()
+    expect(screen.getByRole('button', {name: 'api'})).toBeTruthy()
+    expect(screen.getByText('42')).toBeTruthy()
+    expect(screen.getByRole('button', {name: 'resolved'})).toBeTruthy()
+  })
+
+  it('adds an include filter when a value is checked', () => {
+    const {onFacetFiltersChange} = setup()
+    fireEvent.click(screen.getByRole('button', {name: 'api'}))
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'api', exclude: false}])
+  })
+
+  it('removes the filter when an included value is clicked again', () => {
+    const {onFacetFiltersChange} = setup({facetFilters: [{key: 'service', value: 'api', exclude: false}]})
+    fireEvent.click(screen.getByRole('button', {name: 'api'}))
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([])
+  })
+
+  it('adds an exclude filter via the exclude affordance', () => {
+    const {onFacetFiltersChange} = setup()
+    fireEvent.click(screen.getAllByTitle('Exclude this value')[0])
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'api', exclude: true}])
+  })
+
+  it('replaces the value for a single-select section', () => {
+    const {onFacetFiltersChange} = setup({facetFilters: [{key: 'status', value: 'unresolved', exclude: false}]})
+    fireEvent.click(screen.getByRole('button', {name: 'resolved'}))
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'status', value: 'resolved', exclude: false}])
+  })
+
+  it('collapses a section to hide its values', () => {
+    setup()
+    expect(screen.getByRole('button', {name: 'api'})).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', {name: /Service/}))
+    expect(screen.queryByRole('button', {name: 'api'})).toBeNull()
+  })
+
+  it('shows "Clear all" with a selection and clears it', () => {
+    const {onFacetFiltersChange} = setup({facetFilters: [{key: 'service', value: 'api'}]})
+    fireEvent.click(screen.getByText('Clear all'))
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([])
+  })
+
+  it('filters values via the per-section search box', () => {
+    const many: FacetRailSection[] = [
+      {
+        key: 'tag',
+        label: 'Tags',
+        options: Array.from({length: 12}, (_, i) => ({value: `svc-${i}`})),
+      },
+    ]
+    render(<FacetRail sections={many} facetFilters={[]} onFacetFiltersChange={() => {}} />)
+    fireEvent.change(screen.getByLabelText('Filter Tags'), {target: {value: 'svc-1'}})
+    expect(screen.getByRole('button', {name: 'svc-1'})).toBeTruthy()
+    expect(screen.getByRole('button', {name: 'svc-10'})).toBeTruthy()
+    expect(screen.queryByRole('button', {name: 'svc-2'})).toBeNull()
+  })
+})

--- a/dashboard/src/components/filters/__tests__/SearchFilterBar.test.tsx
+++ b/dashboard/src/components/filters/__tests__/SearchFilterBar.test.tsx
@@ -110,4 +110,114 @@ describe('SearchFilterBar', () => {
     fireEvent.mouseDown(suggestion)
     expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'api', exclude: false}])
   })
+
+  it('applies key and value suggestions', () => {
+    const {onFacetFiltersChange, input} = setup()
+    fireEvent.change(input, {target: {value: 'ser'}})
+    fireEvent.mouseDown(screen.getByText('service'))
+    expect(input).toHaveValue('service:')
+
+    fireEvent.change(input, {target: {value: 'service:wor'}})
+    fireEvent.mouseDown(screen.getByText('service:worker'))
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'worker', exclude: false}])
+  })
+
+  it('routes boolean, wildcard, and unknown-key tokens to query text', () => {
+    const {onQueryChange, onFacetFiltersChange, input} = setup()
+
+    fireEvent.change(input, {target: {value: 'service:*'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    fireEvent.change(input, {target: {value: 'message:error OR timeout'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    fireEvent.change(input, {target: {value: 'unknown:value'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+
+    expect(onQueryChange).toHaveBeenCalledWith('service:*')
+    expect(onQueryChange).toHaveBeenCalledWith('message:error OR timeout')
+    expect(onQueryChange).toHaveBeenCalledWith('unknown:value')
+    expect(onFacetFiltersChange).not.toHaveBeenCalled()
+  })
+
+  it('handles suggestion keyboard navigation and escape', () => {
+    const {input} = setup()
+
+    fireEvent.change(input, {target: {value: 'service:a'}})
+    expect(screen.getByText('service:api')).toBeInTheDocument()
+    fireEvent.keyDown(input, {key: 'ArrowDown'})
+    fireEvent.keyDown(input, {key: 'ArrowUp'})
+    fireEvent.keyDown(input, {key: 'Escape'})
+
+    expect(screen.queryByText('service:api')).toBeNull()
+  })
+
+  it('edits query and facet chips and clears all filters', () => {
+    const onClearExtra = vi.fn()
+    const {onQueryChange, onFacetFiltersChange, input} = setup({
+      query: 'timeout slow',
+      facetFilters: [{key: 'service', value: 'api', exclude: true}],
+      hasExtraActiveFilters: true,
+      onClearExtra,
+    })
+
+    fireEvent.click(screen.getByText('timeout slow'))
+    expect(input).toHaveValue('timeout slow')
+    expect(onQueryChange).toHaveBeenCalledWith('')
+
+    fireEvent.click(screen.getByText(/service:api/))
+    expect(input).toHaveValue('-service:api')
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([])
+
+    fireEvent.keyDown(input, {key: 'Escape'})
+    fireEvent.click(screen.getByRole('button', {name: 'Clear all filters'}))
+    expect(onQueryChange).toHaveBeenCalledWith('')
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([])
+    expect(onClearExtra).toHaveBeenCalled()
+  })
+
+  it('peels query words before facet chips on Backspace', () => {
+    const {onQueryChange, onFacetFiltersChange, input} = setup({
+      query: 'timeout slow',
+      facetFilters: [{key: 'service', value: 'api'}],
+    })
+
+    fireEvent.keyDown(input, {key: 'Backspace'})
+
+    expect(onQueryChange).toHaveBeenCalledWith('timeout')
+    expect(onFacetFiltersChange).not.toHaveBeenCalled()
+  })
+
+  it('removes search text without opening chip edit mode', () => {
+    const {onQueryChange, input} = setup({query: 'timeout'})
+
+    fireEvent.click(screen.getByRole('button', {name: 'Remove search text'}))
+
+    expect(onQueryChange).toHaveBeenCalledWith('')
+    expect(input).toHaveValue('')
+  })
+
+  it('renders trailing controls and dismisses suggestions on outside click', () => {
+    const {input} = setup({
+      placeholder: 'Filter events...',
+      trailing: <button type="button">Refresh</button>,
+    })
+
+    expect(input).toHaveAttribute('placeholder', 'Filter events...')
+    expect(screen.getByRole('button', {name: 'Refresh'})).toBeInTheDocument()
+
+    fireEvent.change(input, {target: {value: 'serv'}})
+    expect(screen.getByText('service')).toBeInTheDocument()
+
+    fireEvent.mouseDown(document.body)
+
+    expect(screen.queryByText('service')).toBeNull()
+  })
+
+  it('leaves filters unchanged on Backspace when nothing is active', () => {
+    const {onQueryChange, onFacetFiltersChange, input} = setup()
+
+    fireEvent.keyDown(input, {key: 'Backspace'})
+
+    expect(onQueryChange).not.toHaveBeenCalled()
+    expect(onFacetFiltersChange).not.toHaveBeenCalled()
+  })
 })

--- a/dashboard/src/components/filters/__tests__/SearchFilterBar.test.tsx
+++ b/dashboard/src/components/filters/__tests__/SearchFilterBar.test.tsx
@@ -1,0 +1,113 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {render, screen, fireEvent} from '@testing-library/react'
+import {describe, it, expect, vi} from 'vitest'
+
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import type {FacetSchema} from '@/lib/filters/types'
+
+const schema: FacetSchema = [
+  {key: 'service', suggestions: ['api', 'worker']},
+  {key: 'environment', aliases: ['env'], suggestions: ['prod', 'staging'], allowExclude: true},
+  {key: 'status', singleSelect: true, suggestions: ['unresolved', 'resolved']},
+]
+
+function setup(props: Partial<React.ComponentProps<typeof SearchFilterBar>> = {}) {
+  const onQueryChange = vi.fn()
+  const onFacetFiltersChange = vi.fn()
+  render(
+    <SearchFilterBar
+      query=""
+      onQueryChange={onQueryChange}
+      facetFilters={[]}
+      onFacetFiltersChange={onFacetFiltersChange}
+      schema={schema}
+      {...props}
+    />
+  )
+  return {onQueryChange, onFacetFiltersChange, input: screen.getByRole('textbox')}
+}
+
+describe('SearchFilterBar', () => {
+  it('turns a key:value token into a facet filter on Enter', () => {
+    const {onFacetFiltersChange, input} = setup()
+    fireEvent.change(input, {target: {value: 'service:api'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'api', exclude: false}])
+  })
+
+  it('routes free text to the query', () => {
+    const {onQueryChange, input} = setup()
+    fireEvent.change(input, {target: {value: 'timeout'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(onQueryChange).toHaveBeenCalledWith('timeout')
+  })
+
+  it('resolves an alias to the canonical key and supports exclude', () => {
+    const {onFacetFiltersChange, input} = setup()
+    fireEvent.change(input, {target: {value: '-env:prod'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'environment', value: 'prod', exclude: true}])
+  })
+
+  it('routes an exclude on a non-excludable facet to the query', () => {
+    const {onQueryChange, onFacetFiltersChange, input} = setup()
+    fireEvent.change(input, {target: {value: '-service:api'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(onQueryChange).toHaveBeenCalledWith('-service:api')
+    expect(onFacetFiltersChange).not.toHaveBeenCalled()
+  })
+
+  it('replaces the value for a single-select facet', () => {
+    const {onFacetFiltersChange, input} = setup({facetFilters: [{key: 'status', value: 'unresolved'}]})
+    fireEvent.change(input, {target: {value: 'status:resolved'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'status', value: 'resolved', exclude: false}])
+  })
+
+  it('lets an interceptor claim a token (e.g. level)', () => {
+    const onInterceptToken = vi.fn().mockReturnValue(true)
+    const {onQueryChange, onFacetFiltersChange, input} = setup({onInterceptToken})
+    fireEvent.change(input, {target: {value: 'level:error'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(onInterceptToken).toHaveBeenCalledWith('level', 'error', false)
+    expect(onQueryChange).not.toHaveBeenCalled()
+    expect(onFacetFiltersChange).not.toHaveBeenCalled()
+  })
+
+  it('removes a facet chip via its dismiss button', () => {
+    const {onFacetFiltersChange} = setup({facetFilters: [{key: 'service', value: 'api'}]})
+    fireEvent.click(screen.getByRole('button', {name: 'Remove service:api'}))
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([])
+  })
+
+  it('peels off the last facet on Backspace when the input is empty', () => {
+    const {onFacetFiltersChange, input} = setup({
+      facetFilters: [{key: 'service', value: 'api'}, {key: 'environment', value: 'prod'}],
+    })
+    fireEvent.keyDown(input, {key: 'Backspace'})
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'api'}])
+  })
+
+  it('applies a value suggestion on click', () => {
+    const {onFacetFiltersChange, input} = setup()
+    fireEvent.change(input, {target: {value: 'service:ap'}})
+    const suggestion = screen.getByText('service:api')
+    fireEvent.mouseDown(suggestion)
+    expect(onFacetFiltersChange).toHaveBeenCalledWith([{key: 'service', value: 'api', exclude: false}])
+  })
+})

--- a/dashboard/src/components/filters/__tests__/TimeRangePicker.test.tsx
+++ b/dashboard/src/components/filters/__tests__/TimeRangePicker.test.tsx
@@ -1,0 +1,239 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {render, screen, fireEvent} from '@testing-library/react'
+import {describe, it, expect, vi} from 'vitest'
+
+import {TimeRangePicker} from '@/components/filters/TimeRangePicker'
+import type {TimeRangePreset} from '@/lib/filters/time'
+
+vi.mock('@/components/ui/datetime-picker', () => ({
+  DateTimePicker: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    placeholder: string
+  }) => (
+    <input
+      aria-label={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}))
+
+const presets: TimeRangePreset[] = [
+  {value: '1h', label: 'Last hour', minutes: 60},
+  {value: '24h', label: 'Last 24 hours', minutes: 1440},
+]
+
+function setup(props: Partial<React.ComponentProps<typeof TimeRangePicker>> = {}) {
+  const onTimePresetChange = vi.fn()
+  const onCustomFromChange = vi.fn()
+  const onCustomToChange = vi.fn()
+  render(
+    <TimeRangePicker
+      timePreset="1h"
+      onTimePresetChange={onTimePresetChange}
+      customFrom=""
+      customTo=""
+      onCustomFromChange={onCustomFromChange}
+      onCustomToChange={onCustomToChange}
+      presets={presets}
+      {...props}
+    />
+  )
+  return {onTimePresetChange, onCustomFromChange, onCustomToChange}
+}
+
+describe('TimeRangePicker', () => {
+  it('shows the active preset and applies another preset', () => {
+    const {onTimePresetChange} = setup()
+
+    fireEvent.click(screen.getByRole('button', {name: /Last hour/}))
+    fireEvent.click(screen.getByRole('button', {name: 'Last 24 hours'}))
+
+    expect(onTimePresetChange).toHaveBeenCalledWith('24h')
+    expect(screen.queryByRole('button', {name: 'Last 24 hours'})).toBeNull()
+  })
+
+  it('uses the default preset list when no preset list is provided', () => {
+    render(
+      <TimeRangePicker
+        timePreset="15m"
+        onTimePresetChange={() => {}}
+        customFrom=""
+        customTo=""
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: /Last 15 minutes/}))
+    expect(screen.getByRole('button', {name: 'Last 5 minutes'})).toBeTruthy()
+  })
+
+  it('falls back when a preset is unknown or unavailable', () => {
+    const {rerender} = render(
+      <TimeRangePicker
+        timePreset="missing"
+        onTimePresetChange={() => {}}
+        customFrom=""
+        customTo=""
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={presets}
+      />
+    )
+    expect(screen.getByRole('button', {name: /Last hour/})).toBeTruthy()
+
+    rerender(
+      <TimeRangePicker
+        timePreset="missing"
+        onTimePresetChange={() => {}}
+        customFrom=""
+        customTo=""
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={[]}
+      />
+    )
+    expect(screen.getByRole('button', {name: /Custom range/})).toBeTruthy()
+  })
+
+  it('formats custom range labels', () => {
+    const {rerender} = render(
+      <TimeRangePicker
+        timePreset="custom"
+        onTimePresetChange={() => {}}
+        customFrom=""
+        customTo=""
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={presets}
+      />
+    )
+    expect(screen.getByRole('button', {name: /Custom range/})).toBeTruthy()
+
+    rerender(
+      <TimeRangePicker
+        timePreset="custom"
+        onTimePresetChange={() => {}}
+        customFrom="2026-03-14T10:00"
+        customTo="2026-03-14T11:30"
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={presets}
+      />
+    )
+    expect(screen.getByRole('button', {name: /Mar 14, 10:00 - 11:30/})).toBeTruthy()
+
+    rerender(
+      <TimeRangePicker
+        timePreset="custom"
+        onTimePresetChange={() => {}}
+        customFrom="2026-03-14T10:00"
+        customTo="2026-03-15T11:30"
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={presets}
+      />
+    )
+    expect(screen.getByRole('button', {name: /Mar 14, 10:00 - Mar 15, 11:30/})).toBeTruthy()
+  })
+
+  it('formats partial and invalid custom ranges', () => {
+    const {rerender} = render(
+      <TimeRangePicker
+        timePreset="custom"
+        onTimePresetChange={() => {}}
+        customFrom="2026-03-14T10:00"
+        customTo=""
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={presets}
+      />
+    )
+    expect(screen.getByRole('button', {name: /From Mar 14, 10:00/})).toBeTruthy()
+
+    rerender(
+      <TimeRangePicker
+        timePreset="custom"
+        onTimePresetChange={() => {}}
+        customFrom=""
+        customTo="2026-03-15T11:30"
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={presets}
+      />
+    )
+    expect(screen.getByRole('button', {name: /Until Mar 15, 11:30/})).toBeTruthy()
+
+    rerender(
+      <TimeRangePicker
+        timePreset="custom"
+        onTimePresetChange={() => {}}
+        customFrom="bad-date"
+        customTo=""
+        onCustomFromChange={() => {}}
+        onCustomToChange={() => {}}
+        presets={presets}
+      />
+    )
+    expect(screen.getByRole('button', {name: /Custom range/})).toBeTruthy()
+  })
+
+  it('forwards the custom preset selection', () => {
+    const {onTimePresetChange} = setup()
+
+    fireEvent.click(screen.getByRole('button', {name: /Last hour/}))
+    fireEvent.click(screen.getByRole('button', {name: 'Custom range...'}))
+
+    expect(onTimePresetChange).toHaveBeenCalledWith('custom')
+  })
+
+  it('opens custom inputs and forwards custom changes', () => {
+    const {onCustomFromChange, onCustomToChange} = setup({timePreset: 'custom'})
+
+    fireEvent.click(screen.getByRole('button', {name: /Custom range/}))
+    fireEvent.change(screen.getByLabelText('Select start time'), {
+      target: {value: '2026-03-14T10:00'},
+    })
+    fireEvent.change(screen.getByLabelText('Select end time'), {
+      target: {value: '2026-03-14T11:00'},
+    })
+
+    expect(onCustomFromChange).toHaveBeenCalledWith('2026-03-14T10:00')
+    expect(onCustomToChange).toHaveBeenCalledWith('2026-03-14T11:00')
+  })
+
+  it('hides custom controls when disabled and closes on outside click', () => {
+    setup({allowCustom: false})
+
+    fireEvent.click(screen.getByRole('button', {name: /Last hour/}))
+    expect(screen.queryByRole('button', {name: 'Custom range...'})).toBeNull()
+    expect(screen.getByRole('button', {name: 'Last 24 hours'})).toBeTruthy()
+
+    fireEvent.mouseDown(screen.getByRole('button', {name: 'Last 24 hours'}))
+    expect(screen.getByRole('button', {name: 'Last 24 hours'})).toBeTruthy()
+
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole('button', {name: 'Last 24 hours'})).toBeNull()
+  })
+})

--- a/dashboard/src/components/projects/ProjectSetupForm.tsx
+++ b/dashboard/src/components/projects/ProjectSetupForm.tsx
@@ -14,23 +14,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useMemo, useState, type ComponentType, type FormEvent} from 'react'
-import {
-  Check,
-  DatabaseZap,
-  Loader2,
-  RadioTower,
-  ServerCog,
-} from 'lucide-react'
+import {useMemo, useState, type FormEvent} from 'react'
+import {Check, Loader2} from 'lucide-react'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
 import {Label} from '@/components/ui/label'
 import {cn} from '@/lib/utils'
 import {platforms, type PlatformType} from '@/routes/projects'
+import {TelemetrySourcePicker} from '@/components/projects/TelemetrySourcePicker'
 import {
   DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS,
-  TELEMETRY_SOURCES,
-  toggleTelemetrySourceId,
   type TelemetrySourceId,
 } from '@/lib/telemetry-sources'
 
@@ -63,12 +56,6 @@ const platformFilterTabs: Array<{id: PlatformFilter; label: string}> = [
   {id: 'desktop-gaming', label: 'Desktop & Gaming'},
 ]
 
-const sourceIcons: Record<TelemetrySourceId, ComponentType<{className?: string}>> = {
-  'opentelemetry': RadioTower,
-  'sentry-sdk': DatabaseZap,
-  'datadog-agent': ServerCog,
-}
-
 function getDefaultTargets(platformId: string): string[] {
   const platform = platforms.find((candidate) => candidate.id === platformId)
   if (platform?.targets && platform.defaultTargets) {
@@ -80,7 +67,7 @@ function getDefaultTargets(platformId: string): string[] {
 export function ProjectSetupForm({
   onSubmit,
   isSubmitting = false,
-  submitLabel = 'Create Project',
+  submitLabel = 'Create Service',
   submittingLabel = 'Creating...',
   onCancel,
   cancelLabel = 'Cancel',
@@ -132,10 +119,6 @@ export function ProjectSetupForm({
     )
   }
 
-  const handleSourceToggle = (sourceId: TelemetrySourceId) => {
-    setSelectedSourceIds((currentSourceIds) => toggleTelemetrySourceId(currentSourceIds, sourceId))
-  }
-
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
     if (!canSubmit || !selectedPlatform) return
@@ -157,7 +140,7 @@ export function ProjectSetupForm({
       ) : null}
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="project-name">Project Name</Label>
+        <Label htmlFor="project-name">Service name</Label>
         <Input
           id="project-name"
           placeholder="Checkout API"
@@ -249,43 +232,7 @@ export function ProjectSetupForm({
         </div>
       ) : null}
 
-      <div className="flex flex-col gap-3">
-        <div>
-          <Label>Telemetry sources</Label>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Pick the source setup Moneat should walk you through after the project is created.
-          </p>
-        </div>
-        <div className="grid gap-2 sm:grid-cols-2">
-          {TELEMETRY_SOURCES.map((source) => {
-            const Icon = sourceIcons[source.id]
-            const isSelected = selectedSourceIds.includes(source.id)
-            return (
-              <button
-                key={source.id}
-                type="button"
-                onClick={() => handleSourceToggle(source.id)}
-                className={cn(
-                  'flex min-h-28 items-start gap-3 rounded-lg border-2 p-3 text-left transition-all',
-                  isSelected ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/50'
-                )}
-                aria-pressed={isSelected}
-              >
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
-                  <Icon className="h-4 w-4" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="flex items-center gap-2 text-sm font-medium">
-                    {source.shortLabel}
-                    {isSelected ? <Check className="h-3.5 w-3.5 text-primary" /> : null}
-                  </span>
-                  <span className="mt-1 block text-xs leading-5 text-muted-foreground">{source.description}</span>
-                </span>
-              </button>
-            )
-          })}
-        </div>
-      </div>
+      <TelemetrySourcePicker value={selectedSourceIds} onChange={setSelectedSourceIds} />
 
       <div className="flex flex-wrap gap-2 pt-1">
         <Button type="submit" disabled={!canSubmit}>

--- a/dashboard/src/components/projects/ServiceSettingsCard.tsx
+++ b/dashboard/src/components/projects/ServiceSettingsCard.tsx
@@ -1,0 +1,506 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useEffect, useMemo, useState} from 'react'
+import {Link, useNavigate, useRouter} from '@tanstack/react-router'
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+import {
+  AlertTriangle,
+  Check,
+  Copy,
+  ExternalLink,
+  Gamepad2,
+  Layers,
+  Loader2,
+  Monitor,
+  Save,
+  Server,
+  Smartphone,
+  Trash2,
+} from 'lucide-react'
+import {api} from '@/lib/api'
+import {trackEvent} from '@/lib/analytics'
+import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
+import {useProject} from '@/contexts/ProjectContext'
+import {getPlatformInfo, platforms, type PlatformType} from '@/routes/projects'
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
+import {Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle} from '@/components/ui/dialog'
+import {Input} from '@/components/ui/input'
+import {Label} from '@/components/ui/label'
+import {useToast} from '@/hooks/useToast'
+import {cn} from '@/lib/utils'
+import type {TelemetrySourceId} from '@/lib/telemetry-sources'
+
+type PlatformFilter = 'all' | 'mobile' | 'frontend' | 'backend' | 'desktop-gaming'
+
+const platformFilterTabs: Array<{id: PlatformFilter; label: string; icon: React.ElementType}> = [
+  {id: 'all', label: 'All', icon: Layers},
+  {id: 'mobile', label: 'Mobile', icon: Smartphone},
+  {id: 'frontend', label: 'Frontend', icon: Monitor},
+  {id: 'backend', label: 'Backend', icon: Server},
+  {id: 'desktop-gaming', label: 'Desktop & Gaming', icon: Gamepad2},
+]
+
+interface ServiceSettingsCardProps {
+  /** Internal project resource id of the service to edit. */
+  readonly projectId: string
+  /** The service's enabled telemetry sources — gates which config sections show. */
+  readonly sourceIds: TelemetrySourceId[]
+  /** Called after a successful delete. When omitted, navigates to the overview. */
+  readonly onDeleted?: () => void
+}
+
+/**
+ * Editing surface for a single service, shared by the Configuration page and the
+ * legacy /projects/$projectId/settings route. Sections are gated by the service's
+ * enabled telemetry sources: Sentry slug/CLI/DSN-targets only with the Sentry SDK
+ * source; short OTLP/Datadog pointers with those sources. General + Danger always.
+ *
+ * Loads its own project by id, so callers that switch services should pass a
+ * `key={projectId}` to reset local edits on change.
+ */
+export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSettingsCardProps) {
+  const router = useRouter()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const {selectedProjectId, setSelectedProjectId} = useProject()
+  const {toast} = useToast()
+
+  const {data: project, isLoading} = useQuery({
+    queryKey: ['project', projectId],
+    queryFn: () => api.getProject(projectId),
+    enabled: !!projectId,
+  })
+
+  const [localName, setName] = useState<string | undefined>(undefined)
+  const [localFramework, setFramework] = useState<string | undefined>(undefined)
+  const [platformFilter, setPlatformFilter] = useState<PlatformFilter>('all')
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [copiedSlug, setCopiedSlug] = useState(false)
+  const [copiedConfig, setCopiedConfig] = useState(false)
+  const [orgSlug, setOrgSlug] = useState<string | null>(null)
+
+  const hasSentry = sourceIds.includes('sentry-sdk')
+  const hasOtel = sourceIds.includes('opentelemetry')
+  const hasDatadog = sourceIds.includes('datadog-agent')
+
+  useEffect(() => {
+    let cancelled = false
+    async function fetchOrgSlug() {
+      try {
+        const user = await api.getCurrentUser()
+        if (!cancelled) setOrgSlug(user.organizationSlug || null)
+      } catch (error) {
+        console.error('Failed to fetch organization slug:', error)
+      }
+    }
+    if (hasSentry) fetchOrgSlug()
+    return () => {
+      cancelled = true
+    }
+  }, [hasSentry])
+
+  const filteredPlatforms = useMemo(() => {
+    return platforms.filter((platform: PlatformType) => {
+      if (platform.alwaysVisible || platformFilter === 'all') return true
+      if (platformFilter === 'desktop-gaming') {
+        return platform.category === 'desktop' || platform.category === 'gaming'
+      }
+      return platform.category === platformFilter
+    })
+  }, [platformFilter])
+
+  const updateProjectMutation = useMutation({
+    mutationFn: (updates: {name?: string; framework?: string}) => api.updateProject(projectId, updates),
+    onSuccess: async () => {
+      trackEvent('Project Update')
+      await queryClient.invalidateQueries({queryKey: ['projects']})
+      await queryClient.invalidateQueries({queryKey: ['project', projectId]})
+      await router.invalidate()
+      toast({title: 'Service updated', description: 'Service settings were saved successfully.'})
+    },
+    onError: (err: Error) => {
+      toast({title: 'Failed to update service', description: err.message, variant: 'destructive'})
+    },
+  })
+
+  const deleteProjectMutation = useMutation({
+    mutationFn: () => api.deleteProject(projectId),
+    onSuccess: async () => {
+      trackEvent('Project Delete')
+      await queryClient.invalidateQueries({queryKey: ['projects']})
+      if (selectedProjectId === projectId) {
+        setSelectedProjectId(null)
+      }
+      toast({title: 'Service deleted', description: `"${project?.name ?? 'Service'}" has been deleted.`})
+      if (onDeleted) {
+        onDeleted()
+      } else {
+        navigate({to: '/', search: APP_OVERVIEW_SEARCH})
+      }
+    },
+    onError: (err: Error) => {
+      toast({title: 'Failed to delete service', description: err.message, variant: 'destructive'})
+    },
+  })
+
+  const addTargetMutation = useMutation({
+    mutationFn: (target: string) => api.addProjectTarget(projectId, target),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({queryKey: ['projects']})
+      await queryClient.invalidateQueries({queryKey: ['project', projectId]})
+      await router.invalidate()
+      toast({title: 'Target added', description: 'A new platform target and DSN were created.'})
+    },
+    onError: (err: Error) => {
+      toast({title: 'Failed to add target', description: err.message, variant: 'destructive'})
+    },
+  })
+
+  if (isLoading || !project) {
+    return <div className="text-sm text-muted-foreground">Loading service…</div>
+  }
+
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'https://api.moneat.io'
+  const sentryCliConfig = orgSlug
+    ? `[defaults]\nurl=${backendUrl}\norg=${orgSlug}\nproject=${project.slug}`
+    : null
+
+  const initialFramework = getPlatformInfo(project.framework)?.id ?? 'other'
+  const name = localName ?? project.name
+  const framework = localFramework ?? initialFramework
+  const trimmedName = name.trim()
+  const nameChanged = trimmedName !== project.name
+  const frameworkChanged = framework !== initialFramework
+  const frameworkInfo = getPlatformInfo(framework)
+  const isMultiplatformFramework = !!frameworkInfo?.targets?.length
+  const currentTargets = project.keys
+    .map((key) => key.platformTarget)
+    .filter((target): target is string => Boolean(target))
+  const availableTargets = frameworkInfo?.targets?.filter((target) => !currentTargets.includes(target.id)) ?? []
+
+  const handleSave = () => {
+    if (!trimmedName) {
+      toast({
+        title: 'Service name is required',
+        description: 'Please provide a service name before saving.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    const updates: {name?: string; framework?: string} = {}
+    if (nameChanged) updates.name = trimmedName
+    if (frameworkChanged) updates.framework = framework
+
+    if (Object.keys(updates).length === 0) return
+    updateProjectMutation.mutate(updates)
+  }
+
+  const copySlug = () => {
+    navigator.clipboard.writeText(project.slug)
+    setCopiedSlug(true)
+    setTimeout(() => setCopiedSlug(false), 2000)
+  }
+
+  const copyConfig = () => {
+    if (sentryCliConfig) {
+      navigator.clipboard.writeText(sentryCliConfig)
+      setCopiedConfig(true)
+      setTimeout(() => setCopiedConfig(false), 2000)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex-row items-start justify-between gap-4 space-y-0">
+          <div className="space-y-1.5">
+            <CardTitle>General</CardTitle>
+            <CardDescription>Update your service name and platform.</CardDescription>
+          </div>
+          <Button
+            onClick={handleSave}
+            disabled={!trimmedName || (!nameChanged && !frameworkChanged) || updateProjectMutation.isPending}
+          >
+            {updateProjectMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            Save Changes
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="service-name">Service name</Label>
+            <Input
+              id="service-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Checkout API"
+            />
+          </div>
+
+          {hasSentry && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="service-slug">Service slug</Label>
+                <div className="flex gap-2">
+                  <Input id="service-slug" value={project.slug} readOnly className="bg-muted" />
+                  <Button type="button" variant="outline" size="icon" onClick={copySlug}>
+                    {copiedSlug ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">Used for Sentry CLI and API endpoints</p>
+              </div>
+
+              {sentryCliConfig && (
+                <div className="space-y-2">
+                  <Label>Sentry CLI Configuration</Label>
+                  <div className="relative">
+                    <pre className="bg-muted rounded-lg p-4 text-xs overflow-x-auto pr-12">
+                      <code>{sentryCliConfig}</code>
+                    </pre>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="absolute top-2 right-2"
+                      onClick={copyConfig}
+                    >
+                      {copiedConfig ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Use this in your sentry.properties file or with sentry-cli commands
+                  </p>
+                </div>
+              )}
+            </>
+          )}
+
+          <div className="space-y-3">
+            <div>
+              <Label className="text-base">Platform / Framework</Label>
+              <p className="text-sm text-muted-foreground mt-1">
+                Changing platform does not rotate or invalidate existing DSNs.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-1">
+              {platformFilterTabs.map((tab) => {
+                const Icon = tab.icon
+                return (
+                  <Button
+                    key={tab.id}
+                    variant={platformFilter === tab.id ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setPlatformFilter(tab.id)}
+                    className="gap-2"
+                  >
+                    <Icon className="h-4 w-4" />
+                    {tab.label}
+                  </Button>
+                )
+              })}
+            </div>
+
+            <div className="max-h-96 overflow-y-auto rounded-lg border border-border p-2 pr-1">
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+                {filteredPlatforms.map((platform) => {
+                  const Icon = platform.icon
+                  return (
+                    <button
+                      key={platform.id}
+                      type="button"
+                      onClick={() => setFramework(platform.id)}
+                      className={cn(
+                        'border-2 rounded-lg p-3 text-left transition-colors',
+                        framework === platform.id
+                          ? 'border-primary bg-primary/10'
+                          : 'border-border hover:border-primary/50'
+                      )}
+                    >
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="w-6 h-6 rounded flex items-center justify-center flex-shrink-0"
+                          style={{backgroundColor: platform.color}}
+                        >
+                          <Icon className="h-4 w-4 text-white" />
+                        </div>
+                        <span className="text-sm font-medium">{platform.name}</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-2">{platform.description}</p>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+
+          {hasSentry && isMultiplatformFramework && (
+            <div className="space-y-3">
+              <div>
+                <Label className="text-base">Target Platforms</Label>
+                <p className="text-sm text-muted-foreground mt-1">Multiplatform frameworks use one DSN per target.</p>
+              </div>
+
+              {frameworkChanged ? (
+                <div className="rounded-lg border border-dashed border-border p-3 text-sm text-muted-foreground">
+                  Save framework changes first, then add target platforms here.
+                </div>
+              ) : (
+                <>
+                  <div className="flex flex-wrap gap-2">
+                    {currentTargets.length > 0 ? (
+                      currentTargets.map((target) => {
+                        const targetInfo = getPlatformInfo(target)
+                        const TargetIcon = targetInfo?.icon
+                        return (
+                          <Badge key={target} variant="secondary" className="flex items-center gap-1.5 px-2.5 py-1">
+                            {TargetIcon && (
+                              <div
+                                className="w-4 h-4 rounded flex items-center justify-center"
+                                style={{backgroundColor: targetInfo?.color}}
+                              >
+                                <TargetIcon className="w-3 h-3 text-white" />
+                              </div>
+                            )}
+                            <span>{targetInfo?.name ?? target}</span>
+                          </Badge>
+                        )
+                      })
+                    ) : (
+                      <p className="text-sm text-muted-foreground">No targets added yet.</p>
+                    )}
+                  </div>
+
+                  {availableTargets.length > 0 && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+                      {availableTargets.map((target) => {
+                        const targetInfo = getPlatformInfo(target.id)
+                        const TargetIcon = targetInfo?.icon
+                        return (
+                          <Button
+                            key={target.id}
+                            type="button"
+                            variant="outline"
+                            className="justify-start h-auto py-2.5"
+                            onClick={() => addTargetMutation.mutate(target.id)}
+                            disabled={addTargetMutation.isPending}
+                          >
+                            {TargetIcon && (
+                              <div
+                                className="w-5 h-5 rounded flex items-center justify-center"
+                                style={{backgroundColor: targetInfo?.color}}
+                              >
+                                <TargetIcon className="w-3.5 h-3.5 text-white" />
+                              </div>
+                            )}
+                            <span>Add {target.name}</span>
+                          </Button>
+                        )
+                      })}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {hasOtel && (
+        <Card>
+          <CardHeader>
+            <CardTitle>OpenTelemetry</CardTitle>
+            <CardDescription>
+              Send telemetry with the resource attribute <code className="font-mono text-xs">service.name</code> set to
+              this service.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/projects/$projectId" params={{projectId}}>
+              <Button variant="outline" size="sm">
+                <ExternalLink className="h-4 w-4" />
+                View setup guide
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      )}
+
+      {hasDatadog && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Datadog Agent</CardTitle>
+            <CardDescription>Point a compatible agent at Moneat and tag it with this service.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/projects/$projectId" params={{projectId}}>
+              <Button variant="outline" size="sm">
+                <ExternalLink className="h-4 w-4" />
+                View setup guide
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card className="border-destructive/40">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-5 w-5" />
+            Danger Zone
+          </CardTitle>
+          <CardDescription>Delete this service and all related data permanently.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            This action cannot be undone. Events, issues, releases, and DSNs for this service will be removed.
+          </p>
+          <Button variant="destructive" onClick={() => setDeleteDialogOpen(true)}>
+            <Trash2 className="h-4 w-4" />
+            Delete Service
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete service?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete <strong>{project.name}</strong> and all associated data.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={deleteProjectMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteProjectMutation.mutate()}
+              disabled={deleteProjectMutation.isPending}
+            >
+              {deleteProjectMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+              Delete Service
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/dashboard/src/components/projects/TelemetrySourcePicker.tsx
+++ b/dashboard/src/components/projects/TelemetrySourcePicker.tsx
@@ -1,0 +1,91 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {ComponentType} from 'react'
+import {Check, DatabaseZap, RadioTower, ServerCog} from 'lucide-react'
+import {Label} from '@/components/ui/label'
+import {cn} from '@/lib/utils'
+import {
+  TELEMETRY_SOURCES,
+  toggleTelemetrySourceId,
+  type TelemetrySourceId,
+} from '@/lib/telemetry-sources'
+
+const sourceIcons: Record<TelemetrySourceId, ComponentType<{className?: string}>> = {
+  'opentelemetry': RadioTower,
+  'sentry-sdk': DatabaseZap,
+  'datadog-agent': ServerCog,
+}
+
+interface TelemetrySourcePickerProps {
+  readonly value: TelemetrySourceId[]
+  readonly onChange: (next: TelemetrySourceId[]) => void
+  readonly label?: string
+  readonly description?: string
+}
+
+/**
+ * Controlled grid of telemetry sources (OpenTelemetry / Sentry SDK / Datadog Agent).
+ * Extracted from ProjectSetupForm so the same picker drives both service creation
+ * and per-service configuration. Toggling keeps at least one source selected
+ * (via toggleTelemetrySourceId).
+ */
+export function TelemetrySourcePicker({
+  value,
+  onChange,
+  label = 'Telemetry sources',
+  description = 'Pick the source setup Moneat should walk you through after the service is created.',
+}: TelemetrySourcePickerProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {(label || description) && (
+        <div>
+          {label ? <Label>{label}</Label> : null}
+          {description ? <p className="mt-1 text-sm text-muted-foreground">{description}</p> : null}
+        </div>
+      )}
+      <div className="grid gap-2 sm:grid-cols-2">
+        {TELEMETRY_SOURCES.map((source) => {
+          const Icon = sourceIcons[source.id]
+          const isSelected = value.includes(source.id)
+          return (
+            <button
+              key={source.id}
+              type="button"
+              onClick={() => onChange(toggleTelemetrySourceId(value, source.id))}
+              className={cn(
+                'flex min-h-28 items-start gap-3 rounded-lg border-2 p-3 text-left transition-all',
+                isSelected ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/50'
+              )}
+              aria-pressed={isSelected}
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+                <Icon className="h-4 w-4" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  {source.shortLabel}
+                  {isSelected ? <Check className="h-3.5 w-3.5 text-primary" /> : null}
+                </span>
+                <span className="mt-1 block text-xs leading-5 text-muted-foreground">{source.description}</span>
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/projects/__tests__/ProjectSetupForm.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ProjectSetupForm.test.tsx
@@ -10,10 +10,10 @@ describe('ProjectSetupForm', () => {
 
     render(<ProjectSetupForm onSubmit={onSubmit} />)
 
-    await user.type(screen.getByLabelText('Project Name'), 'Checkout API')
+    await user.type(screen.getByLabelText('Service name'), 'Checkout API')
     await user.click(screen.getByRole('button', {name: /React$/}))
     await user.click(screen.getByRole('button', {name: /Sentry SDK/}))
-    await user.click(screen.getByRole('button', {name: 'Create Project'}))
+    await user.click(screen.getByRole('button', {name: 'Create Service'}))
 
     expect(screen.queryByRole('button', {name: /HTTP logs/})).not.toBeInTheDocument()
     expect(onSubmit).toHaveBeenCalledWith({
@@ -30,13 +30,13 @@ describe('ProjectSetupForm', () => {
 
     render(<ProjectSetupForm onSubmit={onSubmit} />)
 
-    expect(screen.getByRole('button', {name: 'Create Project'})).toBeDisabled()
+    expect(screen.getByRole('button', {name: 'Create Service'})).toBeDisabled()
 
-    await user.type(screen.getByLabelText('Project Name'), 'Mobile app')
-    expect(screen.getByRole('button', {name: 'Create Project'})).toBeDisabled()
+    await user.type(screen.getByLabelText('Service name'), 'Mobile app')
+    expect(screen.getByRole('button', {name: 'Create Service'})).toBeDisabled()
 
     await user.click(screen.getByRole('button', {name: 'iOS'}))
-    expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled()
+    expect(screen.getByRole('button', {name: 'Create Service'})).toBeEnabled()
   })
 
   it('filters platform choices by category', async () => {
@@ -61,19 +61,19 @@ describe('ProjectSetupForm', () => {
 
     render(<ProjectSetupForm onSubmit={onSubmit} />)
 
-    await user.type(screen.getByLabelText('Project Name'), 'Game client')
+    await user.type(screen.getByLabelText('Service name'), 'Game client')
     await user.click(screen.getByRole('button', {name: 'Desktop & Gaming'}))
     await user.click(screen.getByRole('button', {name: 'Unity'}))
-    expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled()
+    expect(screen.getByRole('button', {name: 'Create Service'})).toBeEnabled()
 
     await user.click(screen.getByRole('button', {name: 'Android'}))
     await user.click(screen.getByRole('button', {name: 'iOS'}))
     expect(screen.getByText('Select at least one target platform.')).toBeInTheDocument()
-    expect(screen.getByRole('button', {name: 'Create Project'})).toBeDisabled()
+    expect(screen.getByRole('button', {name: 'Create Service'})).toBeDisabled()
 
     await user.click(screen.getByRole('button', {name: 'Web'}))
     await user.click(screen.getByRole('button', {name: /Datadog Agent/}))
-    await user.click(screen.getByRole('button', {name: 'Create Project'}))
+    await user.click(screen.getByRole('button', {name: 'Create Service'}))
 
     expect(onSubmit).toHaveBeenCalledWith({
       name: 'Game client',

--- a/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {render, screen} from '@testing-library/react'
+import {fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {ProjectProvider} from '@/contexts/ProjectContext'
 
@@ -36,14 +36,24 @@ const mockProject = {
   keys: [],
 }
 
-function renderCard(sourceIds: TelemetrySourceId[]) {
+const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, 'clipboard')
+
+function stubClipboard(writeText = vi.fn()) {
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    configurable: true,
+    value: {writeText},
+  })
+  return writeText
+}
+
+function renderCard(sourceIds: TelemetrySourceId[], onDeleted?: () => void) {
   const queryClient = new QueryClient({
     defaultOptions: {queries: {retry: false}, mutations: {retry: false}},
   })
   return render(
     <QueryClientProvider client={queryClient}>
       <ProjectProvider>
-        <ServiceSettingsCard projectId="proj-1" sourceIds={sourceIds} />
+        <ServiceSettingsCard projectId="proj-1" sourceIds={sourceIds} onDeleted={onDeleted} />
       </ProjectProvider>
     </QueryClientProvider>
   )
@@ -55,6 +65,14 @@ describe('ServiceSettingsCard', () => {
     localStorage.clear()
     mockApi.getProject.mockResolvedValue(mockProject)
     mockApi.getCurrentUser.mockResolvedValue({organizationSlug: 'acme'})
+    mockApi.updateProject.mockResolvedValue(mockProject)
+    mockApi.deleteProject.mockResolvedValue(undefined)
+    mockApi.addProjectTarget.mockResolvedValue(undefined)
+    if (originalClipboard) {
+      Object.defineProperty(globalThis.navigator, 'clipboard', originalClipboard)
+    } else {
+      delete (globalThis.navigator as {clipboard?: unknown}).clipboard
+    }
   })
 
   it('always shows General and the danger zone', async () => {
@@ -78,5 +96,104 @@ describe('ServiceSettingsCard', () => {
     expect(await screen.findByLabelText('Service slug')).toBeInTheDocument()
     expect(await screen.findByText('Sentry CLI Configuration')).toBeInTheDocument()
     expect(screen.queryByText('OpenTelemetry')).not.toBeInTheDocument()
+  })
+
+  it('copies Sentry identifiers and renders no CLI config before the org slug loads', async () => {
+    const writeText = stubClipboard()
+    mockApi.getCurrentUser.mockResolvedValueOnce({organizationSlug: null})
+
+    renderCard(['sentry-sdk'])
+    expect(await screen.findByLabelText('Service slug')).toBeInTheDocument()
+    expect(screen.queryByText('Sentry CLI Configuration')).not.toBeInTheDocument()
+
+    const slugInput = screen.getByLabelText('Service slug')
+    const slugCopyButton = slugInput.parentElement?.querySelector('button')
+    expect(slugCopyButton).not.toBeNull()
+    fireEvent.click(slugCopyButton as HTMLButtonElement)
+
+    expect(writeText).toHaveBeenCalledWith('test-service')
+  })
+
+  it('copies the Sentry CLI config after the organization slug loads', async () => {
+    const writeText = stubClipboard()
+
+    const {container} = renderCard(['sentry-sdk'])
+    expect(await screen.findByText('Sentry CLI Configuration')).toBeInTheDocument()
+
+    const configCopyButton = container.querySelector('pre')?.parentElement?.querySelector('button')
+    expect(configCopyButton).not.toBeNull()
+    fireEvent.click(configCopyButton as HTMLButtonElement)
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('project=test-service'))
+  })
+
+  it('saves name and framework changes', async () => {
+    renderCard(['sentry-sdk'])
+    const nameInput = await screen.findByLabelText('Service name')
+
+    fireEvent.change(nameInput, {target: {value: 'Renamed Service'}})
+    fireEvent.click(screen.getByText('Node.js').closest('button') as HTMLButtonElement)
+    fireEvent.click(screen.getByRole('button', {name: /Save Changes/}))
+
+    await waitFor(() => {
+      expect(mockApi.updateProject).toHaveBeenCalledWith('proj-1', {
+        name: 'Renamed Service',
+        framework: 'node',
+      })
+    })
+  })
+
+  it('filters platform tabs and blocks target edits until framework changes are saved', async () => {
+    renderCard(['sentry-sdk'])
+    await screen.findByText('General')
+
+    fireEvent.click(screen.getByRole('button', {name: /Desktop & Gaming/}))
+    expect(screen.getByText('Unity')).toBeInTheDocument()
+    expect(screen.queryByText('Android')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Unity').closest('button') as HTMLButtonElement)
+
+    expect(screen.getByText('Target Platforms')).toBeInTheDocument()
+    expect(screen.getByText('Save framework changes first, then add target platforms here.')).toBeInTheDocument()
+  })
+
+  it('renders current target platforms and adds another target', async () => {
+    mockApi.getProject.mockResolvedValueOnce({
+      ...mockProject,
+      framework: 'unity',
+      keys: [{platformTarget: 'android'}],
+    })
+
+    renderCard(['sentry-sdk'])
+    expect(await screen.findByText('Target Platforms')).toBeInTheDocument()
+    expect(screen.getAllByText('Android').length).toBeGreaterThan(1)
+
+    fireEvent.click(screen.getByRole('button', {name: /Add iOS/}))
+
+    await waitFor(() => {
+      expect(mockApi.addProjectTarget).toHaveBeenCalledWith('proj-1', 'ios')
+    })
+  })
+
+  it('renders Datadog setup guidance when that telemetry source is enabled', async () => {
+    renderCard(['datadog-agent'])
+    expect(await screen.findByText('Datadog Agent')).toBeInTheDocument()
+    expect(screen.queryByText('OpenTelemetry')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Service slug')).not.toBeInTheDocument()
+  })
+
+  it('deletes the selected service and calls the supplied delete callback', async () => {
+    localStorage.setItem('selectedProjectId', 'proj-1')
+    const onDeleted = vi.fn()
+
+    renderCard(['opentelemetry'], onDeleted)
+    fireEvent.click(await screen.findByRole('button', {name: /Delete Service/}))
+    fireEvent.click(screen.getAllByRole('button', {name: /Delete Service/}).at(-1) as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(mockApi.deleteProject).toHaveBeenCalledWith('proj-1')
+      expect(onDeleted).toHaveBeenCalledTimes(1)
+    })
+    expect(localStorage.getItem('selectedProjectId')).toBeNull()
   })
 })

--- a/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {render, screen} from '@testing-library/react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {ProjectProvider} from '@/contexts/ProjectContext'
+
+const {mockApi} = vi.hoisted(() => ({
+  mockApi: {
+    getProject: vi.fn(),
+    getCurrentUser: vi.fn(),
+    updateProject: vi.fn(),
+    deleteProject: vi.fn(),
+    addProjectTarget: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/api', () => ({api: mockApi}))
+vi.mock('@/hooks/useToast', () => ({useToast: () => ({toast: vi.fn()})}))
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => ({...opts, options: opts}),
+  redirect: (o: Record<string, unknown>) => ({...o, __redirect: true}),
+  Link: ({children, ...props}: {children: React.ReactNode}) => React.createElement('a', props, children),
+  useNavigate: () => vi.fn(),
+  useRouter: () => ({invalidate: vi.fn()}),
+}))
+
+import {ServiceSettingsCard} from '@/components/projects/ServiceSettingsCard'
+import type {TelemetrySourceId} from '@/lib/telemetry-sources'
+
+const mockProject = {
+  id: 1,
+  resourceId: 'proj-1',
+  name: 'Test Service',
+  slug: 'test-service',
+  framework: 'react',
+  keys: [],
+}
+
+function renderCard(sourceIds: TelemetrySourceId[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false}, mutations: {retry: false}},
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProjectProvider>
+        <ServiceSettingsCard projectId="proj-1" sourceIds={sourceIds} />
+      </ProjectProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('ServiceSettingsCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockApi.getProject.mockResolvedValue(mockProject)
+    mockApi.getCurrentUser.mockResolvedValue({organizationSlug: 'acme'})
+  })
+
+  it('always shows General and the danger zone', async () => {
+    renderCard(['opentelemetry'])
+    expect(await screen.findByText('General')).toBeInTheDocument()
+    expect(screen.getByLabelText('Service name')).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: /Delete Service/})).toBeInTheDocument()
+  })
+
+  it('hides the Sentry slug/CLI sections for non-Sentry services', async () => {
+    renderCard(['opentelemetry'])
+    await screen.findByText('General')
+    expect(screen.queryByLabelText('Service slug')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sentry CLI Configuration')).not.toBeInTheDocument()
+    // The OpenTelemetry pointer shows instead.
+    expect(screen.getByText('OpenTelemetry')).toBeInTheDocument()
+  })
+
+  it('shows the Sentry slug and CLI config when the Sentry SDK source is enabled', async () => {
+    renderCard(['sentry-sdk'])
+    expect(await screen.findByLabelText('Service slug')).toBeInTheDocument()
+    expect(await screen.findByText('Sentry CLI Configuration')).toBeInTheDocument()
+    expect(screen.queryByText('OpenTelemetry')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/projects/__tests__/TelemetrySourcePicker.test.tsx
+++ b/dashboard/src/components/projects/__tests__/TelemetrySourcePicker.test.tsx
@@ -1,0 +1,34 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import {describe, it, expect, vi} from 'vitest'
+
+import {TelemetrySourcePicker} from '@/components/projects/TelemetrySourcePicker'
+
+describe('TelemetrySourcePicker', () => {
+  it('renders the available sources', () => {
+    render(<TelemetrySourcePicker value={['opentelemetry']} onChange={() => {}} />)
+    expect(screen.getByRole('button', {name: /OpenTelemetry/})).toBeTruthy()
+    expect(screen.getByRole('button', {name: /Sentry SDK/})).toBeTruthy()
+    expect(screen.getByRole('button', {name: /Datadog Agent/})).toBeTruthy()
+  })
+
+  it('adds a source on click', () => {
+    const onChange = vi.fn()
+    render(<TelemetrySourcePicker value={['opentelemetry']} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', {name: /Sentry SDK/}))
+    expect(onChange).toHaveBeenCalledWith(['opentelemetry', 'sentry-sdk'])
+  })
+
+  it('removes a selected source while another remains', () => {
+    const onChange = vi.fn()
+    render(<TelemetrySourcePicker value={['opentelemetry', 'sentry-sdk']} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', {name: /Sentry SDK/}))
+    expect(onChange).toHaveBeenCalledWith(['opentelemetry'])
+  })
+
+  it('keeps the last source when toggling it off', () => {
+    const onChange = vi.fn()
+    render(<TelemetrySourcePicker value={['opentelemetry']} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', {name: /OpenTelemetry/}))
+    expect(onChange).toHaveBeenCalledWith(['opentelemetry'])
+  })
+})

--- a/dashboard/src/lib/api/modules/__tests__/replays-extended.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/replays-extended.test.ts
@@ -41,12 +41,23 @@ describe('Replays API - extended coverage', () => {
   it('resolves issue ID for event', async () => {
     server.use(
       http.get(`${API_BASE}/v1/events/evt-1/issue`, () => {
-        return HttpResponse.json({ issueId: 'iss-42' })
+        return HttpResponse.json({ issueId: 'iss-42', projectResourceId: 'proj-1' })
       })
     )
 
     const result = await api.getIssueIdForEvent('evt-1')
     expect(result).toBe('iss-42')
+  })
+
+  it('resolves scoped issue links for event', async () => {
+    server.use(
+      http.get(`${API_BASE}/v1/events/evt-scoped/issue`, () => {
+        return HttpResponse.json({ issueId: 'iss-42', projectResourceId: 'proj-1' })
+      })
+    )
+
+    const result = await api.getIssueLinkForEvent('evt-scoped')
+    expect(result).toEqual({ issueId: 'iss-42', projectResourceId: 'proj-1' })
   })
 
   it('returns null when issue lookup fails', async () => {

--- a/dashboard/src/lib/api/modules/apm.ts
+++ b/dashboard/src/lib/api/modules/apm.ts
@@ -29,6 +29,7 @@ import type {
 
 type ApmListParams = {
   service?: string
+  services?: string[]
   source?: string
   env?: string
   status?: ApmStatusFilter
@@ -40,6 +41,7 @@ type ApmListParams = {
 
 function appendApmListParams(searchParams: URLSearchParams, params: ApmListParams): void {
   if (params.service) searchParams.set('service', params.service)
+  if (params.services?.length) searchParams.set('services', params.services.join(','))
   if (params.source) searchParams.set('source', params.source)
   if (params.env) searchParams.set('env', params.env)
   if (params.status) searchParams.set('status', params.status)

--- a/dashboard/src/lib/api/modules/replays.ts
+++ b/dashboard/src/lib/api/modules/replays.ts
@@ -16,6 +16,7 @@
 
 import type { ApiClientCore } from '../client'
 import type {
+  EventIssueLink,
   Replay,
   ReplayDetail,
   ReplayRecordingResponse,
@@ -24,6 +25,15 @@ import type {
 
 export function replaysMethods(core: ApiClientCore) {
   const base = core.API_BASE
+  const getIssueLinkForEvent = async (eventId: string): Promise<EventIssueLink | null> => {
+    try {
+      return await core.request<EventIssueLink>(
+        `${base}/events/${encodeURIComponent(eventId)}/issue`
+      )
+    } catch {
+      return null
+    }
+  }
 
   return {
     getReplays: (
@@ -56,15 +66,11 @@ export function replaysMethods(core: ApiClientCore) {
         `${base}/replays/${encodeURIComponent(replayId)}/timeline`
       ),
 
+    getIssueLinkForEvent,
+
     getIssueIdForEvent: async (eventId: string): Promise<string | null> => {
-      try {
-        const response = await core.request<{ issueId: string }>(
-          `${base}/events/${encodeURIComponent(eventId)}/issue`
-        )
-        return response.issueId
-      } catch {
-        return null
-      }
+      const link = await getIssueLinkForEvent(eventId)
+      return link?.issueId ?? null
     },
 
     getReplaysForIssue: (issueId: string, limit = 10, projectId?: string | number | null) => {

--- a/dashboard/src/lib/api/types/replays.ts
+++ b/dashboard/src/lib/api/types/replays.ts
@@ -45,6 +45,11 @@ export interface ReplayRecordingResponse {
   events: unknown[]
 }
 
+export interface EventIssueLink {
+  issueId: string
+  projectResourceId: string
+}
+
 export interface Feedback {
   feedbackId: string
   message: string

--- a/dashboard/src/lib/filters/time.ts
+++ b/dashboard/src/lib/filters/time.ts
@@ -1,0 +1,36 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+export interface TimeRangePreset {
+  label: string
+  value: string
+  minutes: number
+}
+
+/** The full preset set the log viewer ships; surfaces may pass a subset. */
+export const TIME_PRESETS: TimeRangePreset[] = [
+  {label: 'Last 5 minutes', value: '5m', minutes: 5},
+  {label: 'Last 15 minutes', value: '15m', minutes: 15},
+  {label: 'Last 30 minutes', value: '30m', minutes: 30},
+  {label: 'Last 1 hour', value: '1h', minutes: 60},
+  {label: 'Last 4 hours', value: '4h', minutes: 240},
+  {label: 'Last 12 hours', value: '12h', minutes: 720},
+  {label: 'Last 24 hours', value: '24h', minutes: 1440},
+  {label: 'Last 3 days', value: '3d', minutes: 4320},
+  {label: 'Last 7 days', value: '7d', minutes: 10080},
+  {label: 'Last 14 days', value: '14d', minutes: 20160},
+  {label: 'Last 30 days', value: '30d', minutes: 43200},
+]

--- a/dashboard/src/lib/filters/types.ts
+++ b/dashboard/src/lib/filters/types.ts
@@ -1,0 +1,108 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Shared filter model — the surface-agnostic core behind every result view
+ * (logs, APM errors, issues, …). Extracted from the log viewer, whose query is
+ * just a free-text string plus a list of include/exclude facet filters.
+ */
+
+/** A single faceted constraint: `key:value`, optionally negated (`-key:value`). */
+export interface FacetFilter {
+  key: string
+  value: string
+  exclude?: boolean
+}
+
+/** A selectable facet value, optionally with an occurrence count + display label. */
+export interface FacetValue {
+  value: string
+  count?: number
+  label?: string
+}
+
+/**
+ * Declares one facet a surface supports — drives the search bar's typeahead and
+ * how a typed `key:value` token is routed. The rail uses {@link FacetRailSection}
+ * (it additionally needs counts / lazy value loading).
+ */
+export interface FacetDef {
+  key: string
+  label?: string
+  /** Chip + dot color (tailwind classes). Falls back to a neutral info style. */
+  color?: string
+  /** Alternate keys that normalize to `key` (e.g. `env` → `environment`). */
+  aliases?: readonly string[]
+  /** Only one value at a time — adding a value replaces any existing one. */
+  singleSelect?: boolean
+  /** Allow exclusion (tri-state in the rail, `-key:value` in the bar). */
+  allowExclude?: boolean
+  /** Known values for typeahead suggestions (when not lazily loaded). */
+  suggestions?: readonly string[]
+}
+
+export type FacetSchema = readonly FacetDef[]
+
+/** A rail section: eager `options` (with counts) or a lazy `loadOptions`. */
+export interface FacetRailSection {
+  key: string
+  label: string
+  color?: string
+  singleSelect?: boolean
+  allowExclude?: boolean
+  /** Eager values (already loaded, typically with counts). */
+  options?: readonly FacetValue[]
+  /** Lazy loader invoked the first time the section is expanded. */
+  loadOptions?: () => Promise<readonly FacetValue[]>
+}
+
+/** The portion of view state common to every surface. */
+export interface FilterState {
+  query: string
+  facetFilters: FacetFilter[]
+}
+
+/** Resolve a typed key (possibly an alias) to its canonical facet def. */
+export function resolveFacetDef(
+  schema: FacetSchema,
+  rawKey: string
+): FacetDef | undefined {
+  const key = rawKey.trim().toLowerCase()
+  return schema.find(
+    (def) =>
+      def.key.toLowerCase() === key ||
+      def.aliases?.some((alias) => alias.toLowerCase() === key)
+  )
+}
+
+/**
+ * Add/replace a facet filter, honoring `singleSelect` (replaces existing values
+ * for the key) and deduping identical entries. Returns a new array.
+ */
+export function applyFacetFilter(
+  filters: readonly FacetFilter[],
+  next: FacetFilter,
+  opts?: {singleSelect?: boolean}
+): FacetFilter[] {
+  const withoutDup = filters.filter(
+    (f) =>
+      !(
+        f.key === next.key &&
+        (opts?.singleSelect ? true : f.value === next.value)
+      )
+  )
+  return [...withoutDup, next]
+}

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -56,6 +56,7 @@ import { Route as DemoRouteImport } from './routes/demo'
 import { Route as DatadogAlternativeRouteImport } from './routes/datadog-alternative'
 import { Route as DashboardsRouteImport } from './routes/dashboards'
 import { Route as CustomDashboardsRouteImport } from './routes/custom-dashboards'
+import { Route as ConfigurationRouteImport } from './routes/configuration'
 import { Route as CompareRouteImport } from './routes/compare'
 import { Route as BlogRouteImport } from './routes/blog'
 import { Route as BetterStackAlternativeRouteImport } from './routes/better-stack-alternative'
@@ -388,6 +389,11 @@ const DashboardsRoute = DashboardsRouteImport.update({
 const CustomDashboardsRoute = CustomDashboardsRouteImport.update({
   id: '/custom-dashboards',
   path: '/custom-dashboards',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConfigurationRoute = ConfigurationRouteImport.update({
+  id: '/configuration',
+  path: '/configuration',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CompareRoute = CompareRouteImport.update({
@@ -900,6 +906,7 @@ export interface FileRoutesByFullPath {
   '/better-stack-alternative': typeof BetterStackAlternativeRoute
   '/blog': typeof BlogRouteWithChildren
   '/compare': typeof CompareRoute
+  '/configuration': typeof ConfigurationRoute
   '/custom-dashboards': typeof CustomDashboardsRoute
   '/dashboards': typeof DashboardsRouteWithChildren
   '/datadog-alternative': typeof DatadogAlternativeRoute
@@ -1042,6 +1049,7 @@ export interface FileRoutesByTo {
   '/alerting': typeof AlertingRoute
   '/better-stack-alternative': typeof BetterStackAlternativeRoute
   '/compare': typeof CompareRoute
+  '/configuration': typeof ConfigurationRoute
   '/custom-dashboards': typeof CustomDashboardsRoute
   '/datadog-alternative': typeof DatadogAlternativeRoute
   '/demo': typeof DemoRoute
@@ -1178,6 +1186,7 @@ export interface FileRoutesById {
   '/better-stack-alternative': typeof BetterStackAlternativeRoute
   '/blog': typeof BlogRouteWithChildren
   '/compare': typeof CompareRoute
+  '/configuration': typeof ConfigurationRoute
   '/custom-dashboards': typeof CustomDashboardsRoute
   '/dashboards': typeof DashboardsRouteWithChildren
   '/datadog-alternative': typeof DatadogAlternativeRoute
@@ -1326,6 +1335,7 @@ export interface FileRouteTypes {
     | '/better-stack-alternative'
     | '/blog'
     | '/compare'
+    | '/configuration'
     | '/custom-dashboards'
     | '/dashboards'
     | '/datadog-alternative'
@@ -1468,6 +1478,7 @@ export interface FileRouteTypes {
     | '/alerting'
     | '/better-stack-alternative'
     | '/compare'
+    | '/configuration'
     | '/custom-dashboards'
     | '/datadog-alternative'
     | '/demo'
@@ -1603,6 +1614,7 @@ export interface FileRouteTypes {
     | '/better-stack-alternative'
     | '/blog'
     | '/compare'
+    | '/configuration'
     | '/custom-dashboards'
     | '/dashboards'
     | '/datadog-alternative'
@@ -1750,6 +1762,7 @@ export interface RootRouteChildren {
   BetterStackAlternativeRoute: typeof BetterStackAlternativeRoute
   BlogRoute: typeof BlogRouteWithChildren
   CompareRoute: typeof CompareRoute
+  ConfigurationRoute: typeof ConfigurationRoute
   CustomDashboardsRoute: typeof CustomDashboardsRoute
   DashboardsRoute: typeof DashboardsRouteWithChildren
   DatadogAlternativeRoute: typeof DatadogAlternativeRoute
@@ -2141,6 +2154,13 @@ declare module '@tanstack/react-router' {
       path: '/custom-dashboards'
       fullPath: '/custom-dashboards'
       preLoaderRoute: typeof CustomDashboardsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/configuration': {
+      id: '/configuration'
+      path: '/configuration'
+      fullPath: '/configuration'
+      preLoaderRoute: typeof ConfigurationRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/compare': {
@@ -3226,6 +3246,7 @@ const rootRouteChildren: RootRouteChildren = {
   BetterStackAlternativeRoute: BetterStackAlternativeRoute,
   BlogRoute: BlogRouteWithChildren,
   CompareRoute: CompareRoute,
+  ConfigurationRoute: ConfigurationRoute,
   CustomDashboardsRoute: CustomDashboardsRoute,
   DashboardsRoute: DashboardsRouteWithChildren,
   DatadogAlternativeRoute: DatadogAlternativeRoute,

--- a/dashboard/src/routes/__tests__/-priority-routes.test.tsx
+++ b/dashboard/src/routes/__tests__/-priority-routes.test.tsx
@@ -134,11 +134,11 @@ describe('priority route coverage', () => {
     expect((IssueDetailRoute as { beforeLoad?: unknown }).beforeLoad).toBeUndefined()
   })
 
-  it('issues route renders empty project state', async () => {
+  it('issues route renders empty service state', async () => {
     const Component = (IssuesIndexRoute as unknown as { component: React.ComponentType }).component
     renderRoute(Component)
 
-    expect(await screen.findByText('No projects yet')).toBeInTheDocument()
+    expect(await screen.findByText('No services yet')).toBeInTheDocument()
     expect(mockApi.getProjects).toHaveBeenCalled()
   })
 

--- a/dashboard/src/routes/__tests__/-priority-routes.test.tsx
+++ b/dashboard/src/routes/__tests__/-priority-routes.test.tsx
@@ -69,6 +69,7 @@ vi.mock('@tanstack/react-router', () => ({
     ...options,
     options,
     useParams: () => ({ issueId: 'issue-123' }),
+    useSearch: () => ({}),
   }),
   Link: ({ children, ...props }: { children: React.ReactNode }) => React.createElement('a', props, children),
   redirect: (opts: Record<string, unknown>) => ({ ...opts, __redirect: true }),

--- a/dashboard/src/routes/__tests__/configuration-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/configuration-coverage.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {screen, fireEvent} from '@testing-library/react'
+import {renderRoute, clearAuthStorage} from '@/test/utils'
+
+const {mockApi} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    getProjects: vi.fn(),
+    getProject: vi.fn(),
+    getCurrentUser: vi.fn(),
+    updateProject: vi.fn(),
+    deleteProject: vi.fn(),
+    addProjectTarget: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/api', () => ({api: mockApi}))
+vi.mock('@/hooks/useToast', () => ({useToast: () => ({toast: vi.fn()})}))
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => ({...opts, options: opts}),
+  redirect: (o: Record<string, unknown>) => ({...o, __redirect: true}),
+  Link: ({children, ...props}: {children: React.ReactNode}) => React.createElement('a', props, children),
+  useNavigate: () => vi.fn(),
+  useRouter: () => ({invalidate: vi.fn()}),
+}))
+
+import {Route as ConfigurationRoute} from '../configuration'
+
+const mockProject = {
+  id: 1,
+  resourceId: 'proj-1',
+  name: 'Test Service',
+  slug: 'test-service',
+  framework: 'react',
+  keys: [],
+}
+
+describe('Configuration page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearAuthStorage()
+    mockApi.isAuthenticated.mockReturnValue(true)
+    mockApi.getProjects.mockResolvedValue([mockProject])
+    mockApi.getProject.mockResolvedValue(mockProject)
+    mockApi.getCurrentUser.mockResolvedValue({organizationSlug: 'acme'})
+  })
+
+  it('shows an empty state with a create affordance when there are no services', async () => {
+    mockApi.getProjects.mockResolvedValue([])
+    renderRoute(ConfigurationRoute)
+
+    expect(await screen.findByText('No services yet')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', {name: /New Service/}).length).toBeGreaterThan(0)
+  })
+
+  it('renders the service selector, telemetry picker, and settings card', async () => {
+    renderRoute(ConfigurationRoute)
+
+    expect(await screen.findByRole('option', {name: 'Test Service'})).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: /Sentry SDK/})).toBeInTheDocument()
+    expect(await screen.findByText('General')).toBeInTheDocument()
+    expect(screen.getByLabelText('Service name')).toBeInTheDocument()
+  })
+
+  it('reveals the Sentry config only when the Sentry SDK source is enabled', async () => {
+    renderRoute(ConfigurationRoute)
+
+    await screen.findByText('General')
+    // Default source is OpenTelemetry → no Sentry-specific config.
+    expect(screen.queryByLabelText('Service slug')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: /Sentry SDK/}))
+
+    expect(await screen.findByLabelText('Service slug')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/routes/__tests__/issues-detail-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-detail-coverage.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderRoute, clearAuthStorage } from '@/test/utils'
 
-const { mockNavigate, mockToast, mockApi } = vi.hoisted(() => ({
+const { mockNavigate, mockSearch, mockToast, mockApi } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
+  mockSearch: vi.fn(),
   mockToast: vi.fn(),
   mockApi: {
     isAuthenticated: vi.fn(),
@@ -52,6 +53,7 @@ vi.mock('@tanstack/react-router', () => ({
     ...options,
     options,
     useParams: () => ({ issueId: 'issue-123' }),
+    useSearch: () => mockSearch(),
   }),
   Link: ({ children, ...props }: { children: React.ReactNode }) => React.createElement('a', props, children),
   redirect: (opts: Record<string, unknown>) => ({ ...opts, __redirect: true }),
@@ -161,6 +163,7 @@ describe('Issue Detail - full data coverage', () => {
     clearAuthStorage()
     mockApi.isAuthenticated.mockReturnValue(true)
     mockApi.checkAuth.mockResolvedValue(true)
+    mockSearch.mockReturnValue({})
     mockApi.getProjects.mockResolvedValue([])
     mockApi.updateIssue.mockResolvedValue(undefined)
     mockApi.getIssue.mockResolvedValue(null)
@@ -238,6 +241,30 @@ describe('Issue Detail - full data coverage', () => {
     expect(screen.getByText('Tags & context')).toBeInTheDocument()
     expect(screen.getByText('This error has an associated APM trace')).toBeInTheDocument()
     expect(screen.getByText('View trace')).toBeInTheDocument()
+  })
+
+  it('uses the linked projectId search param for issue reads and updates', async () => {
+    mockSearch.mockReturnValue({ projectId: 'proj-2' })
+    mockApi.getIssue.mockResolvedValue({ ...mockIssue, status: 'unresolved' })
+
+    renderRoute(IssueDetailRoute)
+
+    await waitFor(() => {
+      expect(mockApi.getIssue).toHaveBeenCalledWith('issue-123', 'proj-2')
+    })
+    expect(mockApi.getIssueEvents).toHaveBeenCalledWith('issue-123', 50, 'proj-2')
+    expect(mockApi.getIssueTransactions).toHaveBeenCalledWith('issue-123', 20, 'proj-2')
+    expect(mockApi.getReplaysForIssue).toHaveBeenCalledWith('issue-123', 10, 'proj-2')
+
+    fireEvent.click(await screen.findByText('Resolve'))
+
+    await waitFor(() => {
+      expect(mockApi.updateIssue).toHaveBeenCalledWith(
+        'issue-123',
+        { status: 'resolved' },
+        'proj-2'
+      )
+    })
   })
 
   it('renders resolved issue with Unresolve button', async () => {

--- a/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
@@ -133,15 +133,16 @@ describe('Issues Index - data coverage', () => {
   it('renders issues list with projects and issues data', async () => {
     renderRoute(IssuesIndexRoute)
 
-    // Should show the dashboard header
-    expect(await screen.findByText('Dashboard')).toBeInTheDocument()
+    // Should show the search bar
+    expect(await screen.findByRole('textbox')).toBeInTheDocument()
 
     // Issues should be displayed (wait for async data)
     expect(await screen.findByText(/app.main: TypeError: null ref/)).toBeInTheDocument()
 
-    // Status badges
-    expect(screen.getByText('Resolved')).toBeInTheDocument()
-    expect(screen.getByText('Ignored')).toBeInTheDocument()
+    // Status badges (the row labels also appear as rail facet options, so the
+    // shared-cased ones can occur more than once).
+    expect(screen.getAllByText('Resolved').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Ignored').length).toBeGreaterThan(0)
     expect(screen.getByText('Next Release')).toBeInTheDocument()
 
     // New badge (multiple issues may be "new" since all were first seen recently)
@@ -161,26 +162,43 @@ describe('Issues Index - data coverage', () => {
 
     // Wait for issues to load so the select-all appears
     await screen.findByText(/app.main: TypeError: null ref/)
-    expect(screen.getByPlaceholderText('Search issues...')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
     expect(screen.getByText('Select all')).toBeInTheDocument()
   })
 
   it('filters issues by search query', async () => {
     renderRoute(IssuesIndexRoute)
 
-    await screen.findByText('Dashboard')
-    const searchInput = screen.getByPlaceholderText('Search issues...')
+    await screen.findByText(/app.main: TypeError: null ref/)
+    const searchInput = screen.getByRole('textbox')
     fireEvent.change(searchInput, { target: { value: 'TypeError' } })
+    fireEvent.keyDown(searchInput, { key: 'Enter' })
 
     expect(screen.getByText('1 result')).toBeInTheDocument()
+  })
+
+  it('filters by status from the rail and clears it again (removable, multi-select capable)', async () => {
+    renderRoute(IssuesIndexRoute)
+
+    await screen.findByText(/app.main: TypeError: null ref/)
+    expect(screen.getByText('5 results')).toBeInTheDocument()
+
+    // Include a Status facet from the rail → client-side filter to that status.
+    fireEvent.click(screen.getByRole('button', { name: 'Resolved' }))
+    expect(screen.getByText('1 result')).toBeInTheDocument()
+
+    // Toggling it off clears the filter — the last selection is removable.
+    fireEvent.click(screen.getByRole('button', { name: 'Resolved' }))
+    expect(screen.getByText('5 results')).toBeInTheDocument()
   })
 
   it('shows no issues match filters when search has no results', async () => {
     renderRoute(IssuesIndexRoute)
 
-    await screen.findByText('Dashboard')
-    const searchInput = screen.getByPlaceholderText('Search issues...')
+    await screen.findByText(/app.main: TypeError: null ref/)
+    const searchInput = screen.getByRole('textbox')
     fireEvent.change(searchInput, { target: { value: 'nonexistent-query' } })
+    fireEvent.keyDown(searchInput, { key: 'Enter' })
 
     expect(screen.getByText('No issues match your filters')).toBeInTheDocument()
   })
@@ -196,15 +214,15 @@ describe('Issues Index - data coverage', () => {
   it('switches to APM Errors tab', async () => {
     renderRoute(IssuesIndexRoute)
 
-    await screen.findByText('Dashboard')
+    await screen.findByRole('textbox')
     const apmTab = screen.getByText('APM Errors')
     fireEvent.click(apmTab)
 
     expect(await screen.findByText('No APM errors found')).toBeInTheDocument()
     expect(mockApi.getApmErrors).toHaveBeenCalledTimes(1)
     expect(mockApi.getApmErrors).toHaveBeenCalledWith({
-      service: undefined,
-      limit: 50,
+      services: undefined,
+      limit: 0,
       offset: 0,
       timeRange: '24h',
     })
@@ -239,22 +257,27 @@ describe('Issues Index - data coverage', () => {
       ],
     })
 
+    localStorage.clear()
+    localStorage.setItem('apmErrors.facetFilters', JSON.stringify([{ key: 'service', value: 'api-gateway' }]))
     renderRoute(IssuesIndexRoute)
 
-    await screen.findByText('Dashboard')
+    await screen.findByRole('textbox')
     fireEvent.click(screen.getByText('APM Errors'))
 
+    // Seed the selected service via its persisted slice (the rail/bar selection),
+    // which loads its errors.
     expect(await screen.findByText('Connection refused')).toBeInTheDocument()
     expect(screen.getByText('NetworkError')).toBeInTheDocument()
     expect(screen.getByText('View trace')).toBeInTheDocument()
-    expect(screen.getByText('worker')).toBeInTheDocument()
   })
 
-  it('renders project settings and new project buttons', async () => {
+  it('does not show create or settings affordances in the header', async () => {
     renderRoute(IssuesIndexRoute)
 
-    await screen.findByText('Dashboard')
-    expect(screen.getByText('New Project')).toBeInTheDocument()
-    expect(screen.getByLabelText('Project settings')).toBeInTheDocument()
+    await screen.findByRole('textbox')
+    // Creation/config moved to the sidebar + Configuration page.
+    expect(screen.queryByText('New Project')).not.toBeInTheDocument()
+    expect(screen.queryByText('New Service')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Project settings')).not.toBeInTheDocument()
   })
 })

--- a/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderRoute, clearAuthStorage } from '@/test/utils'
 
 const { mockNavigate, mockToast, mockApi } = vi.hoisted(() => ({
@@ -37,7 +37,17 @@ vi.mock('@tanstack/react-router', () => ({
     options,
     useParams: () => ({}),
   }),
-  Link: ({ children, ...props }: { children: React.ReactNode }) => React.createElement('a', props, children),
+  Link: ({
+    children,
+    search,
+    ...props
+  }: {
+    children: React.ReactNode
+    search?: Record<string, unknown>
+  }) => React.createElement('a', {
+    ...props,
+    'data-search': search ? JSON.stringify(search) : undefined,
+  }, children),
   redirect: (opts: Record<string, unknown>) => ({ ...opts, __redirect: true }),
   useNavigate: () => mockNavigate,
   useMatches: () => [],
@@ -190,6 +200,44 @@ describe('Issues Index - data coverage', () => {
     // Toggling it off clears the filter — the last selection is removable.
     fireEvent.click(screen.getByRole('button', { name: 'Resolved' }))
     expect(screen.getByText('5 results')).toBeInTheDocument()
+  })
+
+  it('keeps row service context for merged issue links and bulk updates', async () => {
+    const workerProject = {
+      ...mockProject,
+      id: 2,
+      resourceId: 'proj-2',
+      name: 'Worker Service',
+      slug: 'worker-service',
+    }
+    const workerIssue = {
+      ...mockIssues[0],
+      id: 'issue-worker',
+      title: 'Worker panic',
+      culprit: 'worker.handler',
+    }
+    mockApi.getProjects.mockResolvedValue([mockProject, workerProject])
+    mockApi.getIssues.mockImplementation((projectId: string) =>
+      Promise.resolve(projectId === 'proj-2' ? [workerIssue] : [mockIssues[0]])
+    )
+
+    renderRoute(IssuesIndexRoute)
+
+    fireEvent.click(await screen.findByText('Clear all'))
+    const workerTitle = await screen.findByText(/worker.handler: Worker panic/)
+    expect(workerTitle.closest('a')).toHaveAttribute('data-search', '{"projectId":"proj-2"}')
+
+    fireEvent.click(screen.getByLabelText('Select Worker panic'))
+    fireEvent.pointerDown(screen.getByRole('button', { name: /Actions/ }))
+    fireEvent.click(await screen.findByText('Resolve'))
+
+    await waitFor(() => {
+      expect(mockApi.updateIssue).toHaveBeenCalledWith(
+        'issue-worker',
+        { status: 'resolved' },
+        'proj-2'
+      )
+    })
   })
 
   it('shows no issues match filters when search has no results', async () => {

--- a/dashboard/src/routes/configuration.tsx
+++ b/dashboard/src/routes/configuration.tsx
@@ -1,0 +1,162 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useMemo, useState} from 'react'
+import {createFileRoute, redirect} from '@tanstack/react-router'
+import {useQuery} from '@tanstack/react-query'
+import {Plus, SlidersHorizontal} from 'lucide-react'
+import {api} from '@/lib/api'
+import {useProject} from '@/contexts/ProjectContext'
+import {Button} from '@/components/ui/button'
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
+import {Label} from '@/components/ui/label'
+import {PageHeader} from '@/components/ui/page-header'
+import {EmptyState} from '@/components/ui/empty-state'
+import {TelemetrySourcePicker} from '@/components/projects/TelemetrySourcePicker'
+import {ServiceSettingsCard} from '@/components/projects/ServiceSettingsCard'
+import {
+  DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS,
+  loadTelemetrySourceIdsForProject,
+  storeTelemetrySourceIdsForProject,
+  type TelemetrySourceId,
+} from '@/lib/telemetry-sources'
+
+export const Route = createFileRoute('/configuration')({
+  beforeLoad: async ({location}) => {
+    if (!api.isAuthenticated()) {
+      throw redirect({to: '/login', search: {redirect: location.href}})
+    }
+  },
+  component: ConfigurationPage,
+})
+
+// Creation is owned by the sidebar's shared dialog — Configuration just opens it.
+function openCreateServiceDialog() {
+  globalThis.dispatchEvent(new CustomEvent('open-create-project-dialog'))
+}
+
+function loadSourcesForService(serviceId: string | null): TelemetrySourceId[] {
+  if (!serviceId) return DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS
+  const stored = loadTelemetrySourceIdsForProject(serviceId)
+  return stored.length > 0 ? stored : DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS
+}
+
+function ConfigurationPage() {
+  const {selectedProjectId} = useProject()
+
+  const {data: projects, isLoading} = useQuery({
+    queryKey: ['projects'],
+    queryFn: () => api.getProjects(),
+    enabled: api.isAuthenticated(),
+  })
+
+  // Local selection, seeded from the global chooser but not written back to it.
+  const [chosenId, setChosenId] = useState<string | null>(null)
+  const selectedId = useMemo(() => {
+    if (!projects || projects.length === 0) return null
+    const ids = projects.map((project) => project.resourceId)
+    if (chosenId && ids.includes(chosenId)) return chosenId
+    if (selectedProjectId && ids.includes(selectedProjectId)) return selectedProjectId
+    return projects[0].resourceId
+  }, [projects, chosenId, selectedProjectId])
+
+  // Telemetry-source selection for the chosen service, persisted to localStorage.
+  // Reload (without an effect) whenever the selected service changes.
+  const [sources, setSources] = useState<TelemetrySourceId[]>(() => loadSourcesForService(selectedId))
+  const [sourcesServiceId, setSourcesServiceId] = useState<string | null>(selectedId)
+  if (selectedId !== sourcesServiceId) {
+    setSourcesServiceId(selectedId)
+    setSources(loadSourcesForService(selectedId))
+  }
+
+  const handleSourcesChange = (next: TelemetrySourceId[]) => {
+    setSources(next)
+    if (selectedId) storeTelemetrySourceIdsForProject(selectedId, next)
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-4 sm:p-6">
+      <PageHeader
+        icon={SlidersHorizontal}
+        title="Configuration"
+        description="Create and configure your services and their telemetry sources."
+        actions={
+          <Button size="sm" onClick={openCreateServiceDialog}>
+            <Plus className="h-4 w-4" />
+            New Service
+          </Button>
+        }
+      />
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading services…</p>
+      ) : !projects || projects.length === 0 ? (
+        <EmptyState
+          icon={SlidersHorizontal}
+          title="No services yet"
+          description="Create a service to configure its telemetry sources and platform."
+          action={
+            <Button onClick={openCreateServiceDialog}>
+              <Plus className="h-4 w-4" />
+              New Service
+            </Button>
+          }
+        />
+      ) : (
+        <>
+          <div className="flex max-w-sm flex-col gap-1.5">
+            <Label htmlFor="service-select">Service</Label>
+            <select
+              id="service-select"
+              value={selectedId ?? ''}
+              onChange={(event) => setChosenId(event.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {projects.map((project) => (
+                <option key={project.resourceId} value={project.resourceId}>
+                  {project.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {selectedId && (
+            <>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Telemetry sources</CardTitle>
+                  <CardDescription>
+                    Choose which integrations this service uses — this controls the configuration shown below.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <TelemetrySourcePicker value={sources} onChange={handleSourcesChange} label="" description="" />
+                </CardContent>
+              </Card>
+
+              <ServiceSettingsCard
+                key={selectedId}
+                projectId={selectedId}
+                sourceIds={sources}
+                onDeleted={() => setChosenId(null)}
+              />
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/routes/feedback.$feedbackId.tsx
+++ b/dashboard/src/routes/feedback.$feedbackId.tsx
@@ -488,6 +488,7 @@ function FeedbackDetailPage() {
                             <Link
                               to="/issues/$issueId"
                               params={{ issueId: issueForEvent }}
+                              search={{ projectId: undefined }}
                               className="inline-flex items-center gap-1 text-sm text-primary hover:underline font-medium"
                             >
                               View related issue

--- a/dashboard/src/routes/feedback.$feedbackId.tsx
+++ b/dashboard/src/routes/feedback.$feedbackId.tsx
@@ -157,9 +157,9 @@ function FeedbackDetailPage() {
     queryFn: () => api.getFeedbackDetail(feedbackId),
   })
 
-  const { data: issueForEvent } = useQuery({
+  const { data: issueLinkForEvent } = useQuery({
     queryKey: ['event-issue', feedback?.associatedEventId],
-    queryFn: () => api.getIssueIdForEvent(feedback!.associatedEventId!),
+    queryFn: () => api.getIssueLinkForEvent(feedback!.associatedEventId!),
     enabled: !!feedback?.associatedEventId,
   })
 
@@ -484,11 +484,11 @@ function FeedbackDetailPage() {
                         </div>
                         <div className="min-w-0">
                           <p className="text-sm font-medium mb-1">Linked Event</p>
-                          {issueForEvent ? (
+                          {issueLinkForEvent ? (
                             <Link
                               to="/issues/$issueId"
-                              params={{ issueId: issueForEvent }}
-                              search={{ projectId: undefined }}
+                              params={{ issueId: issueLinkForEvent.issueId }}
+                              search={{ projectId: issueLinkForEvent.projectResourceId }}
                               className="inline-flex items-center gap-1 text-sm text-primary hover:underline font-medium"
                             >
                               View related issue

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -694,6 +694,7 @@ function DashboardPage() {
                       key={issue.id}
                       to="/issues/$issueId"
                       params={{issueId: issue.id}}
+                      search={{projectId}}
                       className={`flex items-center gap-2 py-2 px-2.5 rounded-md border-l-2 ${levelAccent} hover:bg-muted/50 transition`}
                     >
                       <Badge variant={levelBadgeVariant(issue.level)} className="text-[10px] px-1.5 py-0 w-14 justify-center shrink-0">

--- a/dashboard/src/routes/issues.$issueId.tsx
+++ b/dashboard/src/routes/issues.$issueId.tsx
@@ -123,35 +123,40 @@ function normalizeApmTraceId(value: unknown): string | null {
 }
 
 export const Route = createFileRoute('/issues/$issueId')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    projectId: typeof search.projectId === 'string' ? search.projectId : undefined,
+  }),
   component: IssueDetailPage,
 })
 
 function IssueDetailPage() {
   const { issueId } = Route.useParams()
+  const { projectId } = Route.useSearch()
   const queryClient = useQueryClient()
   const { timezone } = useTimezone()
   const { toast } = useToast()
   const { selectedProjectId } = useProject()
+  const scopedProjectId = projectId ?? selectedProjectId
   const [expandContextsByDefault, setExpandContextsByDefault] = useState(true)
 
   const { data: issue, isLoading } = useQuery({
-    queryKey: ['issue', issueId, selectedProjectId],
-    queryFn: () => api.getIssue(issueId, selectedProjectId),
+    queryKey: ['issue', issueId, scopedProjectId],
+    queryFn: () => api.getIssue(issueId, scopedProjectId),
   })
 
   const { data: events = [] } = useQuery({
-    queryKey: ['issue-events', issueId, selectedProjectId],
-    queryFn: () => api.getIssueEvents(issueId, 50, selectedProjectId),
+    queryKey: ['issue-events', issueId, scopedProjectId],
+    queryFn: () => api.getIssueEvents(issueId, 50, scopedProjectId),
   })
 
   const { data: relatedTransactions = [] } = useQuery({
-    queryKey: ['issue-transactions', issueId, selectedProjectId],
-    queryFn: () => api.getIssueTransactions(issueId, 20, selectedProjectId),
+    queryKey: ['issue-transactions', issueId, scopedProjectId],
+    queryFn: () => api.getIssueTransactions(issueId, 20, scopedProjectId),
   })
 
   const { data: linkedReplays = [] } = useQuery({
-    queryKey: ['issue-replays', issueId, selectedProjectId],
-    queryFn: () => api.getReplaysForIssue(issueId, 10, selectedProjectId),
+    queryKey: ['issue-replays', issueId, scopedProjectId],
+    queryFn: () => api.getReplaysForIssue(issueId, 10, scopedProjectId),
   })
 
   const primaryTransactionId = relatedTransactions[0]?.eventId
@@ -164,10 +169,10 @@ function IssueDetailPage() {
   })
 
   const statusMutation = useMutation({
-    mutationFn: (status: string) => api.updateIssue(issueId, { status }, selectedProjectId),
+    mutationFn: (status: string) => api.updateIssue(issueId, { status }, scopedProjectId),
     onSuccess: (_, status) => {
       trackEvent('Issue StatusChange', { source: 'detail', status })
-      queryClient.invalidateQueries({ queryKey: ['issue', issueId, selectedProjectId] })
+      queryClient.invalidateQueries({ queryKey: ['issue', issueId, scopedProjectId] })
       const messages: Record<string, { title: string; description: string }> = {
         resolved: { title: 'Issue resolved', description: 'The issue has been marked as resolved.' },
         unresolved: { title: 'Issue unresolved', description: 'The issue has been marked as unresolved.' },

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute, Link} from '@tanstack/react-router'
 
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+import {useMutation, useQueries, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import type {ApmErrorGroup, ApmTimeRange} from '@/lib/api'
 import {trackEvent} from '@/lib/analytics'
@@ -24,10 +24,13 @@ import {useProject} from '@/contexts/ProjectContext'
 import {formatRelativeTime, cn} from '@/lib/utils'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
-import {Input} from '@/components/ui/input'
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue,} from '@/components/ui/select'
 import {Card} from '@/components/ui/card'
-import {PageHeader} from '@/components/ui/page-header'
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import {FacetRail} from '@/components/filters/FacetRail'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
+import {TimeRangePicker} from '@/components/filters/TimeRangePicker'
+import type {TimeRangePreset} from '@/lib/filters/time'
+import type {FacetFilter, FacetSchema, FacetRailSection} from '@/lib/filters/types'
 import {levelBadgeVariant, levelBorderClass} from '@/lib/severity'
 import {Checkbox} from '@/components/ui/checkbox'
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu'
@@ -43,7 +46,6 @@ import {
   Plus,
   Search,
   Server,
-  Settings,
   Timer,
 } from 'lucide-react'
 import {useEffect, useMemo, useState} from 'react'
@@ -90,8 +92,14 @@ const ISSUE_CULPRIT_RENDER_MAX_CHARS = 160
 const ISSUE_SEARCH_TEXT_MAX_CHARS = 512
 const ISSUE_ID_MAX_CHARS = 512
 
+// Until the org-wide issues API lands, multi-service views merge per-project
+// fetches client-side. Bound the work: cap projects and per-project rows.
+const MERGE_PROJECT_CAP = 50
+const MERGE_FETCH_LIMIT = 100
+
 type SafeIssue = {
   id: string
+  service: string
   title: string
   culprit: string
   level: string
@@ -179,8 +187,8 @@ function IndexPage() {
   const [activeTab, setActiveTab] = useState<'issues' | 'apm-errors'>('issues')
 
   return (
-    <div className="min-h-screen">
-      <div className="border-b px-6">
+    <div className="flex h-[calc(100vh-var(--header-height,0px))] flex-col overflow-hidden">
+      <div className="shrink-0 border-b px-6">
         <div className="flex gap-4">
           <button
             type="button"
@@ -210,22 +218,24 @@ function IndexPage() {
           </button>
         </div>
       </div>
-      {activeTab === 'issues' ? (
-        <DashboardPage />
-      ) : (
-        <ApmErrorsTab isActive />
-      )}
+      <div className="min-h-0 flex-1">
+        {activeTab === 'issues' ? (
+          <DashboardPage />
+        ) : (
+          <ApmErrorsTab isActive />
+        )}
+      </div>
     </div>
   )
 }
 
 function DashboardPage() {
   const [searchQuery, setSearchQuery] = useState('')
-  const [statusFilter, setStatusFilter] = useState<string>('unresolved')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
   const [selectedIssues, setSelectedIssues] = useState<Set<string>>(new Set())
   const [page, setPage] = useState(1)
   const pageSize = 25
-  const { selectedProjectId, setSelectedProjectId } = useProject()
+  const { selectedProjectId } = useProject()
   const { toast } = useToast()
   const queryClient = useQueryClient()
 
@@ -235,32 +245,34 @@ function DashboardPage() {
   })
   const hasProjects = (projects?.length ?? 0) > 0
 
-  const projectId = selectedProjectId || projects?.[0]?.resourceId
-  const currentProject = projects?.find(p => p.resourceId === projectId)
-
-  // Auto-select first project after data load without mutating state during render.
-  useEffect(() => {
-    if (!selectedProjectId && projects && projects.length > 0 && projects[0]?.resourceId) {
-      setSelectedProjectId(projects[0].resourceId)
-    }
-  }, [selectedProjectId, projects, setSelectedProjectId])
-
-  // Reset selection and page when the visible dataset changes (React-recommended
-  // "adjusting state during rendering" pattern avoids cascading effect renders).
-  const [prevProjectId, setPrevProjectId] = useState(projectId)
-  const [prevStatusFilter, setPrevStatusFilter] = useState(statusFilter)
-  if (projectId !== prevProjectId || statusFilter !== prevStatusFilter) {
-    setPrevProjectId(projectId)
-    setPrevStatusFilter(statusFilter)
-    setSelectedIssues(new Set())
-    setPage(1)
+  // Seed the Service facet once from the sidebar-selected project so the default
+  // view stays scoped as before; afterwards the rail/bar own the selection, and
+  // clearing Service widens to all services.
+  const [seeded, setSeeded] = useState(false)
+  if (!seeded && projects && projects.length > 0) {
+    setSeeded(true)
+    const seedProject = projects.find((p) => p.resourceId === selectedProjectId) ?? projects[0]
+    if (seedProject) setFacetFilters([{ key: 'service', value: seedProject.name }])
   }
 
-  const { data: issues = [], isError: issuesError, error: issuesErrorObj } = useQuery({
-    queryKey: ['issues', projectId, statusFilter, page, pageSize],
-    queryFn: () => (projectId ? api.getIssues(projectId, page, pageSize, statusFilter === 'all' ? undefined : statusFilter) : []),
-    enabled: !!projectId,
+  // Service include/exclude picks which projects' issues to load and merge
+  // (client-side until the org-wide issues API lands). None selected ⇒ all.
+  const includedServices = facetFilters.filter((f) => f.key === 'service' && !f.exclude).map((f) => f.value)
+  const excludedServices = facetFilters.filter((f) => f.key === 'service' && f.exclude).map((f) => f.value)
+  const targetProjects = (projects ?? [])
+    .filter((p) => (includedServices.length > 0 ? includedServices.includes(p.name) : true))
+    .filter((p) => !excludedServices.includes(p.name))
+    .slice(0, MERGE_PROJECT_CAP)
+
+  const issueQueries = useQueries({
+    queries: targetProjects.map((p) => ({
+      queryKey: ['issues', p.resourceId],
+      queryFn: () => api.getIssues(p.resourceId, 1, MERGE_FETCH_LIMIT),
+      enabled: !!p.resourceId,
+    })),
   })
+  const issuesError = issueQueries.some((q) => q.isError)
+  const issuesErrorObj = issueQueries.find((q) => q.isError)?.error
 
   const resolveMutation = useMutation({
     mutationFn: async (issueIds: string[]) => {
@@ -273,8 +285,8 @@ function DashboardPage() {
     },
     onSuccess: ({ submitted, successCount }) => {
       trackEvent('Issue Resolve', { count: String(successCount) })
-      queryClient.invalidateQueries({ queryKey: ['issues', projectId] })
-      queryClient.invalidateQueries({ queryKey: ['stats', projectId] })
+      queryClient.invalidateQueries({ queryKey: ['issues'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
       if (successCount === submitted) {
         toast({
           title: 'Success',
@@ -309,8 +321,8 @@ function DashboardPage() {
     },
     onSuccess: ({ submitted, successCount }) => {
       trackEvent('Issue Ignore', { count: String(successCount) })
-      queryClient.invalidateQueries({ queryKey: ['issues', projectId] })
-      queryClient.invalidateQueries({ queryKey: ['stats', projectId] })
+      queryClient.invalidateQueries({ queryKey: ['issues'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
       if (successCount === submitted) {
         toast({
           title: 'Success',
@@ -341,8 +353,8 @@ function DashboardPage() {
     },
     onSuccess: ({ submitted, successCount }) => {
       trackEvent('Issue ResolveInNextRelease', { count: String(successCount) })
-      queryClient.invalidateQueries({ queryKey: ['issues', projectId] })
-      queryClient.invalidateQueries({ queryKey: ['stats', projectId] })
+      queryClient.invalidateQueries({ queryKey: ['issues'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
       if (successCount === submitted) {
         toast({
           title: 'Success',
@@ -375,10 +387,10 @@ function DashboardPage() {
   }
 
   const handleToggleAll = () => {
-    if (selectedIssues.size === filteredIssues.length) {
+    if (selectedIssues.size === pagedIssues.length) {
       setSelectedIssues(new Set())
     } else {
-      setSelectedIssues(new Set(filteredIssues.map(issue => issue.id)))
+      setSelectedIssues(new Set(pagedIssues.map(issue => issue.id)))
     }
   }
 
@@ -395,11 +407,15 @@ function DashboardPage() {
   }
 
   const safeIssues = useMemo<SafeIssue[]>(() => {
-    return issues
-      .map((issue) => {
+    const out: SafeIssue[] = []
+    targetProjects.forEach((project, index) => {
+      const rows = issueQueries[index]?.data ?? []
+      for (const issue of rows) {
         const id = toSafeString(issue.id, '', ISSUE_ID_MAX_CHARS)
-        return {
+        if (!id) continue
+        out.push({
           id,
+          service: project.name,
           title: toSafeString(issue.title, '', ISSUE_SEARCH_TEXT_MAX_CHARS),
           culprit: toSafeString(issue.culprit, '', ISSUE_SEARCH_TEXT_MAX_CHARS),
           level: toSafeString(issue.level, 'error', 16) || 'error',
@@ -409,20 +425,95 @@ function DashboardPage() {
           eventCount: toSafeCount(issue.eventCount),
           userCount: toSafeCount(issue.userCount),
           status: toSafeString(issue.status, 'unresolved', 32) || 'unresolved',
-        }
-      })
-      .filter((issue) => issue.id.length > 0)
-  }, [issues])
+        })
+      }
+    })
+    return out
+  }, [targetProjects, issueQueries])
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+  const statusIncludes = facetFilters.filter((f) => f.key === 'status' && !f.exclude).map((f) => f.value)
+  const statusExcludes = facetFilters.filter((f) => f.key === 'status' && f.exclude).map((f) => f.value)
+  const levelIncludes = facetFilters.filter((f) => f.key === 'level' && !f.exclude).map((f) => f.value)
+  const levelExcludes = facetFilters.filter((f) => f.key === 'level' && f.exclude).map((f) => f.value)
 
-  const filteredIssues = safeIssues.filter((issue) => {
-    const matchesSearch =
-      normalizedSearchQuery === '' ||
-      issue.title.toLowerCase().includes(normalizedSearchQuery) ||
-      issue.culprit.toLowerCase().includes(normalizedSearchQuery)
-    return matchesSearch
-  })
+  // Service is resolved server-side (which projects we fetch); status/level/search
+  // narrow the merged set client-side, honoring include + exclude.
+  const filteredIssues = safeIssues
+    .filter((issue) => {
+      const matchesSearch =
+        normalizedSearchQuery === '' ||
+        issue.title.toLowerCase().includes(normalizedSearchQuery) ||
+        issue.culprit.toLowerCase().includes(normalizedSearchQuery)
+      const matchesStatus =
+        (statusIncludes.length === 0 || statusIncludes.includes(issue.status)) &&
+        !statusExcludes.includes(issue.status)
+      const matchesLevel =
+        (levelIncludes.length === 0 || levelIncludes.includes(issue.level)) &&
+        !levelExcludes.includes(issue.level)
+      return matchesSearch && matchesStatus && matchesLevel
+    })
+    .sort((a, b) => (b.lastSeen || '').localeCompare(a.lastSeen || ''))
+
+  const totalPages = Math.max(1, Math.ceil(filteredIssues.length / pageSize))
+  const currentPage = Math.min(page, totalPages)
+  const pagedIssues = filteredIssues.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+
+  const hasActiveIssueFilters =
+    Boolean(searchQuery) || facetFilters.some((f) => f.key === 'status' || f.key === 'level' || f.exclude)
+
+  function handleFacetFiltersChange(next: FacetFilter[]) {
+    setFacetFilters(next)
+    setSelectedIssues(new Set())
+    setPage(1)
+  }
+
+  const projectNames = useMemo(() => (projects ?? []).map((p) => p.name), [projects])
+  const issueSchema: FacetSchema = useMemo(
+    () => [
+      {key: 'service', suggestions: projectNames},
+      {
+        key: 'status',
+        suggestions: ['unresolved', 'resolved', 'ignored', 'resolvedInNextRelease'],
+      },
+      {key: 'level', suggestions: ['error', 'warning', 'fatal', 'info', 'debug']},
+    ],
+    [projectNames]
+  )
+  const issueRailSections: FacetRailSection[] = useMemo(
+    () => [
+      {
+        key: 'service',
+        label: 'Service',
+        color: 'bg-primary',
+        options: (projects ?? []).map((p) => ({value: p.name})),
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        color: 'bg-warning-solid',
+        options: [
+          {value: 'unresolved', label: 'Unresolved'},
+          {value: 'resolved', label: 'Resolved'},
+          {value: 'ignored', label: 'Ignored'},
+          {value: 'resolvedInNextRelease', label: 'Next release'},
+        ],
+      },
+      {
+        key: 'level',
+        label: 'Level',
+        color: 'bg-danger-solid',
+        options: [
+          {value: 'error', label: 'Error'},
+          {value: 'warning', label: 'Warning'},
+          {value: 'fatal', label: 'Fatal'},
+          {value: 'info', label: 'Info'},
+          {value: 'debug', label: 'Debug'},
+        ],
+      },
+    ],
+    [projects]
+  )
 
   if (isLoading) return <div className="p-8">Loading...</div>
 
@@ -432,323 +523,319 @@ function DashboardPage() {
     </div>
   )
 
-  return (
-    <div className="min-h-screen">
+  if (!hasProjects) {
+    return (
       <div className="px-6 py-4">
-        {/* Header */}
-        <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <div>
-              <h2 className="text-xl font-semibold tracking-tight">Dashboard</h2>
-              {currentProject && (
-                <p className="text-sm text-muted-foreground">{currentProject.name}</p>
-              )}
+        <Card className="p-12 text-center border-primary/20 bg-gradient-to-b from-card to-primary/5">
+          <div className="max-w-md mx-auto space-y-4">
+            <div className="flex justify-center">
+              <div className="rounded-full bg-primary/15 p-4 ring-2 ring-primary/20">
+                <FolderKanban className="h-10 w-10 text-primary" />
+              </div>
             </div>
-            <span className="hidden sm:inline-flex h-2 w-2 rounded-full bg-success-solid animate-pulse" aria-hidden />
+            <div>
+              <h3 className="text-lg font-semibold mb-2">No services yet</h3>
+              <p className="text-muted-foreground mb-4">
+                Create your first service to start tracking errors and monitoring your applications.
+              </p>
+            </div>
+            <div className="flex justify-center">
+              <Button
+                size="lg"
+                className="w-full max-w-sm sm:w-auto sm:mx-auto"
+                onClick={() => globalThis.dispatchEvent(new CustomEvent('open-create-project-dialog'))}
+              >
+                <Plus className="h-4 w-4" />
+                Create your first service
+              </Button>
+            </div>
           </div>
-          {hasProjects && (
-            <div className="flex items-center gap-2 w-full sm:w-auto">
-              {projectId && (
-                <Link to="/projects/$projectId/settings" params={{ projectId: String(projectId) }}>
-                  <Button
-                    size="icon"
-                    variant="outline"
-                    className="border-primary/30 hover:bg-primary/10 hover:border-primary/50"
-                    aria-label="Project settings"
-                  >
-                    <Settings className="h-4 w-4" />
-                  </Button>
-                </Link>
-              )}
-              <Link to="/projects" className="flex-1 sm:flex-none">
-                <Button size="sm" variant="outline" className="w-full sm:w-auto border-primary/30 hover:bg-primary/10 hover:border-primary/50">
-                  <Plus className="h-4 w-4 mr-2" />
-                  New Project
-                </Button>
-              </Link>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <ExplorerShell
+      searchBar={
+        <SearchFilterBar
+          query={searchQuery}
+          onQueryChange={(q) => { setSearchQuery(q); setPage(1); setSelectedIssues(new Set()) }}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          schema={issueSchema}
+          placeholder="Search issues..."
+        />
+      }
+      rail={
+        <FacetRail
+          sections={issueRailSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+        />
+      }
+      toolbar={
+        <>
+          {pagedIssues.length > 0 && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                checked={selectedIssues.size === pagedIssues.length && pagedIssues.length > 0}
+                onCheckedChange={handleToggleAll}
+                aria-label="Select all issues"
+              />
+              <span className="text-sm text-muted-foreground whitespace-nowrap hidden sm:inline">Select all</span>
             </div>
           )}
-        </div>
-
-        {!hasProjects ? (
-          <Card className="p-12 text-center border-primary/20 bg-gradient-to-b from-card to-primary/5">
+          {selectedIssues.size > 0 && (
+            <div className="flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-lg px-2 py-0.5">
+              <CheckCircle2 className="h-4 w-4 text-primary" />
+              <span className="text-sm font-medium whitespace-nowrap">{selectedIssues.size} selected</span>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button disabled={bulkPending} size="sm" className="h-7 ml-1">
+                    {bulkPending ? 'Updating...' : 'Actions'}
+                    <ChevronDown className="h-3 w-3 ml-1" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={handleResolveSelected}>
+                    <CheckCircle2 className="h-4 w-4 mr-2" />
+                    Resolve
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleIgnoreSelected}>
+                    <EyeOff className="h-4 w-4 mr-2" />
+                    Ignore
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleResolveNextReleaseSelected}>
+                    <Timer className="h-4 w-4 mr-2" />
+                    Resolve in Next Release
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+          <span className="ml-auto text-sm text-muted-foreground whitespace-nowrap hidden lg:inline">
+            {filteredIssues.length} result{filteredIssues.length !== 1 ? 's' : ''}
+          </span>
+        </>
+      }
+    >
+      <div className="p-4">
+        {issuesError ? (
+          <div className="p-6 text-destructive border border-destructive/30 rounded-lg bg-destructive/5">
+            Failed to load issues: {issuesErrorObj instanceof Error ? issuesErrorObj.message : 'Unknown error'}
+          </div>
+        ) : filteredIssues.length === 0 ? (
+          <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
             <div className="max-w-md mx-auto space-y-4">
               <div className="flex justify-center">
-                <div className="rounded-full bg-primary/15 p-4 ring-2 ring-primary/20">
-                  <FolderKanban className="h-10 w-10 text-primary" />
+                <div className="rounded-full bg-info-bg p-4">
+                  {hasActiveIssueFilters ? (
+                    <Search className="h-10 w-10 text-info-fg" />
+                  ) : (
+                    <AlertCircle className="h-10 w-10 text-info-fg" />
+                  )}
                 </div>
               </div>
               <div>
-                <h3 className="text-lg font-semibold mb-2">No projects yet</h3>
-                <p className="text-muted-foreground mb-4">
-                  Create your first project to start tracking errors and monitoring your applications.
+                <h3 className="text-lg font-semibold mb-2">
+                  {hasActiveIssueFilters ? 'No issues match your filters' : 'No issues yet'}
+                </h3>
+                <p className="text-muted-foreground">
+                  {hasActiveIssueFilters
+                    ? 'Try adjusting your search or filters.'
+                    : 'Start sending errors to this project to see them tracked here. Visit the setup guide to integrate your application.'}
                 </p>
               </div>
-              <Link to="/projects" className="flex justify-center">
-                <Button size="lg" className="w-full max-w-sm sm:w-auto sm:mx-auto">
-                  <Plus className="h-4 w-4" />
-                  Create Your First Project
-                </Button>
-              </Link>
             </div>
           </Card>
         ) : (
-          <>
-            {/* Toolbar */}
-            <div className="mb-3 flex gap-3 items-center">
-              {filteredIssues.length > 0 && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    checked={selectedIssues.size === filteredIssues.length && filteredIssues.length > 0}
-                    onCheckedChange={handleToggleAll}
-                    aria-label="Select all issues"
-                  />
-                  <span className="text-sm text-muted-foreground whitespace-nowrap hidden sm:inline">Select all</span>
-                </div>
-              )}
-              
-              {selectedIssues.size > 0 && (
-                <div className="flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-lg px-3 py-1.5">
-                  <CheckCircle2 className="h-4 w-4 text-primary" />
-                  <span className="text-sm font-medium whitespace-nowrap">
-                    {selectedIssues.size} selected
-                  </span>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        disabled={bulkPending}
-                        size="sm"
-                        className="h-7 ml-2"
-                      >
-                        {bulkPending ? 'Updating...' : 'Actions'}
-                        <ChevronDown className="h-3 w-3 ml-1" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={handleResolveSelected}>
-                        <CheckCircle2 className="h-4 w-4 mr-2" />
-                        Resolve
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={handleIgnoreSelected}>
-                        <EyeOff className="h-4 w-4 mr-2" />
-                        Ignore
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={handleResolveNextReleaseSelected}>
-                        <Timer className="h-4 w-4 mr-2" />
-                        Resolve in Next Release
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              )}
-
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Search issues..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10"
-                />
-              </div>
-              <Select value={statusFilter} onValueChange={(v) => { setStatusFilter(v); setPage(1) }}>
-                <SelectTrigger className="w-[180px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Issues</SelectItem>
-                  <SelectItem value="unresolved">Unresolved</SelectItem>
-                  <SelectItem value="resolved">Resolved</SelectItem>
-                  <SelectItem value="ignored">Ignored</SelectItem>
-                  <SelectItem value="resolvedInNextRelease">Resolve in Next Release</SelectItem>
-                </SelectContent>
-              </Select>
-              <span className="text-sm text-muted-foreground whitespace-nowrap hidden lg:inline">
-                {filteredIssues.length} result{filteredIssues.length !== 1 ? 's' : ''}
-              </span>
+          <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
+            {/* Table header */}
+            <div className="hidden md:flex items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
+              <div className="w-4 shrink-0" />
+              <div className="w-[4.5rem] shrink-0">Level</div>
+              <div className="flex-1 min-w-0">Issue</div>
+              <div className="hidden lg:block w-20 shrink-0">Platform</div>
+              <div className="hidden lg:block w-20 shrink-0 text-center">Trend</div>
+              <div className="w-[55px] shrink-0 text-right">Events</div>
+              <div className="hidden sm:block w-[45px] shrink-0 text-right">Users</div>
+              <div className="w-20 shrink-0 text-right">Last Seen</div>
             </div>
-
-            {issuesError ? (
-              <div className="p-6 text-destructive border border-destructive/30 rounded-lg bg-destructive/5">
-                Failed to load issues: {issuesErrorObj instanceof Error ? issuesErrorObj.message : 'Unknown error'}
-              </div>
-            ) : filteredIssues.length === 0 ? (
-              <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
-                <div className="max-w-md mx-auto space-y-4">
-                  <div className="flex justify-center">
-                    <div className="rounded-full bg-info-bg p-4">
-                      {searchQuery || statusFilter !== 'unresolved' ? (
-                        <Search className="h-10 w-10 text-info-fg" />
-                      ) : (
-                        <AlertCircle className="h-10 w-10 text-info-fg" />
-                      )}
-                    </div>
-                  </div>
-                  <div>
-                    <h3 className="text-lg font-semibold mb-2">
-                      {searchQuery || statusFilter !== 'unresolved'
-                        ? 'No issues match your filters'
-                        : 'No issues yet'}
-                    </h3>
-                    <p className="text-muted-foreground">
-                      {searchQuery || statusFilter !== 'unresolved'
-                        ? 'Try adjusting your search or filters.'
-                        : 'Start sending errors to this project to see them tracked here. Visit the setup guide to integrate your application.'}
-                    </p>
-                  </div>
-                </div>
-              </Card>
-            ) : (
-              <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
-                {/* Table header */}
-                <div className="hidden md:flex items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
-                  <div className="w-4 shrink-0" />
-                  <div className="w-[4.5rem] shrink-0">Level</div>
-                  <div className="flex-1 min-w-0">Issue</div>
-                  <div className="hidden lg:block w-20 shrink-0">Platform</div>
-                  <div className="hidden lg:block w-20 shrink-0 text-center">Trend</div>
-                  <div className="w-[55px] shrink-0 text-right">Events</div>
-                  <div className="hidden sm:block w-[45px] shrink-0 text-right">Users</div>
-                  <div className="w-20 shrink-0 text-right">Last Seen</div>
-                </div>
-                {/* Issue rows */}
-                <div className="divide-y divide-border/40">
-                  {filteredIssues.map((issue) => (
-                    <div
-                      key={issue.id}
-                      className={`hover:bg-accent/40 transition border-l-[3px] ${levelBorderClass(issue.level)}`}
+            {/* Issue rows */}
+            <div className="divide-y divide-border/40">
+              {pagedIssues.map((issue) => (
+                <div
+                  key={issue.id}
+                  className={`hover:bg-accent/40 transition border-l-[3px] ${levelBorderClass(issue.level)}`}
+                >
+                  <div className="flex items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
+                    <Checkbox
+                      checked={selectedIssues.has(issue.id)}
+                      onCheckedChange={() => handleToggleIssue(issue.id)}
+                      onClick={(e) => e.stopPropagation()}
+                      aria-label={`Select ${issue.title}`}
+                      className="shrink-0"
+                    />
+                    <Link
+                      to="/issues/$issueId"
+                      params={{ issueId: issue.id }}
+                      className="flex-1 flex items-center gap-2 sm:gap-3 min-w-0"
                     >
-                      <div className="flex items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
-                        <Checkbox
-                          checked={selectedIssues.has(issue.id)}
-                          onCheckedChange={() => handleToggleIssue(issue.id)}
-                          onClick={(e) => e.stopPropagation()}
-                          aria-label={`Select ${issue.title}`}
-                          className="shrink-0"
-                        />
-                        <Link
-                          to="/issues/$issueId"
-                          params={{ issueId: issue.id }}
-                          className="flex-1 flex items-center gap-2 sm:gap-3 min-w-0"
-                        >
-                          <div className="w-12 sm:w-[4.5rem] shrink-0">
-                            <Badge variant={levelBadgeVariant(issue.level)} className="text-[10px] sm:text-[11px] px-1.5 py-0">
-                              <span className="sm:hidden">{issue.level.toUpperCase().slice(0, 3)}</span>
-                              <span className="hidden sm:inline">{issue.level.toUpperCase()}</span>
-                            </Badge>
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-1.5 sm:gap-2 min-w-0">
-                              <span className="font-semibold truncate flex-1 min-w-0 text-sm sm:text-base" title={getIssueDisplayTitle(issue)}>
-                                {getIssueDisplayTitle(issue)}
-                              </span>
-                              <div className="flex items-center gap-2 shrink-0">
-                                {isNewIssue(issue.firstSeen) && (
-                                  <span className="text-[10px] font-bold text-success-fg bg-success-bg px-1.5 py-0.5 rounded uppercase">
-                                    New
-                                  </span>
-                                )}
-                                {issue.status === 'resolved' && (
-                                  <Badge variant="success" className="text-[11px] px-1.5 py-0">
-                                    Resolved
-                                  </Badge>
-                                )}
-                                {issue.status === 'ignored' && (
-                                  <Badge variant="secondary" className="text-[11px] px-1.5 py-0">
-                                    <EyeOff className="h-3 w-3" />
-                                    Ignored
-                                  </Badge>
-                                )}
-                                {issue.status === 'resolvedInNextRelease' && (
-                                  <Badge variant="info" className="text-[11px] px-1.5 py-0">
-                                    <Timer className="h-3 w-3" />
-                                    Next Release
-                                  </Badge>
-                                )}
-                              </div>
-                            </div>
-                            <div className="text-xs text-muted-foreground mt-0.5">
-                              <Clock className="inline h-3 w-3 mr-1 -mt-0.5" />
-                              First seen {formatRelativeTime(issue.firstSeen)}
-                            </div>
-                          </div>
-                          <div className="hidden lg:block w-20 shrink-0">
-                            <Badge variant="outline" className="text-[11px] px-1.5 py-0">{issue.platform}</Badge>
-                          </div>
-                          <div className="hidden lg:flex w-20 shrink-0 justify-center">
-                            <EventSparkline eventCount={issue.eventCount} />
-                          </div>
-                          <div className="w-[55px] shrink-0 text-right">
-                            <div className="font-semibold text-foreground">{formatCount(issue.eventCount)}</div>
-                            <div className="text-xs text-muted-foreground">events</div>
-                          </div>
-                          <div className="hidden sm:block w-[45px] shrink-0 text-right">
-                            <div className="font-semibold text-foreground">{issue.userCount ?? 0}</div>
-                            <div className="text-xs text-muted-foreground">users</div>
-                          </div>
-                          <div className="hidden md:block w-20 shrink-0 text-right">
-                            <span className={`text-xs font-medium ${getLastSeenColor(issue.lastSeen)}`}>
-                              {formatRelativeTime(issue.lastSeen)}
-                            </span>
-                          </div>
-                        </Link>
+                      <div className="w-12 sm:w-[4.5rem] shrink-0">
+                        <Badge variant={levelBadgeVariant(issue.level)} className="text-[10px] sm:text-[11px] px-1.5 py-0">
+                          <span className="sm:hidden">{issue.level.toUpperCase().slice(0, 3)}</span>
+                          <span className="hidden sm:inline">{issue.level.toUpperCase()}</span>
+                        </Badge>
                       </div>
-                    </div>
-                  ))}
-                </div>
-                {(page > 1 || issues.length === pageSize) && (
-                  <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={page <= 1}
-                      onClick={() => setPage(p => Math.max(1, p - 1))}
-                    >
-                      Previous
-                    </Button>
-                    <span className="text-sm text-muted-foreground self-center">
-                      Page {page}
-                    </span>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={issues.length < pageSize}
-                      onClick={() => setPage(p => p + 1)}
-                    >
-                      Next
-                    </Button>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5 sm:gap-2 min-w-0">
+                          <span className="font-semibold truncate flex-1 min-w-0 text-sm sm:text-base" title={getIssueDisplayTitle(issue)}>
+                            {getIssueDisplayTitle(issue)}
+                          </span>
+                          <div className="flex items-center gap-2 shrink-0">
+                            {isNewIssue(issue.firstSeen) && (
+                              <span className="text-[10px] font-bold text-success-fg bg-success-bg px-1.5 py-0.5 rounded uppercase">
+                                New
+                              </span>
+                            )}
+                            {issue.status === 'resolved' && (
+                              <Badge variant="success" className="text-[11px] px-1.5 py-0">
+                                Resolved
+                              </Badge>
+                            )}
+                            {issue.status === 'ignored' && (
+                              <Badge variant="secondary" className="text-[11px] px-1.5 py-0">
+                                <EyeOff className="h-3 w-3" />
+                                Ignored
+                              </Badge>
+                            )}
+                            {issue.status === 'resolvedInNextRelease' && (
+                              <Badge variant="info" className="text-[11px] px-1.5 py-0">
+                                <Timer className="h-3 w-3" />
+                                Next Release
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          <Clock className="inline h-3 w-3 mr-1 -mt-0.5" />
+                          First seen {formatRelativeTime(issue.firstSeen)}
+                        </div>
+                      </div>
+                      <div className="hidden lg:block w-20 shrink-0">
+                        <Badge variant="outline" className="text-[11px] px-1.5 py-0">{issue.platform}</Badge>
+                      </div>
+                      <div className="hidden lg:flex w-20 shrink-0 justify-center">
+                        <EventSparkline eventCount={issue.eventCount} />
+                      </div>
+                      <div className="w-[55px] shrink-0 text-right">
+                        <div className="font-semibold text-foreground">{formatCount(issue.eventCount)}</div>
+                        <div className="text-xs text-muted-foreground">events</div>
+                      </div>
+                      <div className="hidden sm:block w-[45px] shrink-0 text-right">
+                        <div className="font-semibold text-foreground">{issue.userCount ?? 0}</div>
+                        <div className="text-xs text-muted-foreground">users</div>
+                      </div>
+                      <div className="hidden md:block w-20 shrink-0 text-right">
+                        <span className={`text-xs font-medium ${getLastSeenColor(issue.lastSeen)}`}>
+                          {formatRelativeTime(issue.lastSeen)}
+                        </span>
+                      </div>
+                    </Link>
                   </div>
-                )}
+                </div>
+              ))}
+            </div>
+            {totalPages > 1 && (
+              <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={currentPage <= 1}
+                  onClick={() => setPage(p => Math.max(1, p - 1))}
+                >
+                  Previous
+                </Button>
+                <span className="text-sm text-muted-foreground self-center">
+                  Page {currentPage} of {totalPages}
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={currentPage >= totalPages}
+                  onClick={() => setPage(p => p + 1)}
+                >
+                  Next
+                </Button>
               </div>
             )}
-          </>
+          </div>
         )}
       </div>
-    </div>
+    </ExplorerShell>
   )
 }
 
 const APM_ERRORS_PAGE_SIZE = 50
-const APM_TIME_RANGE_OPTIONS: Array<{value: ApmTimeRange; label: string}> = [
-  {value: '1h', label: '1h'},
-  {value: '6h', label: '6h'},
-  {value: '24h', label: '24h'},
-  {value: '7d', label: '7d'},
-  {value: '30d', label: '30d'},
-  {value: '90d', label: '90d'},
+const APM_TIME_PRESETS: TimeRangePreset[] = [
+  {label: '1h', value: '1h', minutes: 60},
+  {label: '6h', value: '6h', minutes: 360},
+  {label: '24h', value: '24h', minutes: 1440},
+  {label: '7d', value: '7d', minutes: 10080},
+  {label: '30d', value: '30d', minutes: 43200},
+  {label: '90d', value: '90d', minutes: 129600},
 ]
 
 function ApmErrorsTab({ isActive }: { isActive: boolean }) {
-  const [selectedService, setSelectedService] = useState<string>('all')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => {
+    try {
+      const raw = globalThis.localStorage?.getItem('apmErrors.facetFilters')
+      const parsed = raw ? JSON.parse(raw) : null
+      return Array.isArray(parsed)
+        ? parsed.filter(
+            (f): f is FacetFilter =>
+              !!f && typeof f.key === 'string' && typeof f.value === 'string'
+          )
+        : []
+    } catch {
+      return []
+    }
+  })
+  const [query, setQuery] = useState('')
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('24h')
   const [offset, setOffset] = useState(0)
 
+  // Persist the selected facets so the slice survives reloads (service-first
+  // navigation — replaces the old global "active project" mode).
+  useEffect(() => {
+    try {
+      globalThis.localStorage?.setItem('apmErrors.facetFilters', JSON.stringify(facetFilters))
+    } catch {
+      /* ignore persistence errors */
+    }
+  }, [facetFilters])
+
+  // The trace API filters by an explicit service list (no excludes), so only
+  // include-mode service facets reach the query.
+  const selectedServices = useMemo(
+    () => facetFilters.filter((f) => f.key === 'service' && !f.exclude).map((f) => f.value),
+    [facetFilters]
+  )
+
+  function handleFacetFiltersChange(next: FacetFilter[]) {
+    setFacetFilters(next)
+    setOffset(0)
+  }
+
   const { data, isLoading } = useQuery({
-    queryKey: ['apm-errors', selectedService, timeRange, offset],
+    queryKey: ['apm-errors', selectedServices, timeRange, offset],
     queryFn: () => api.getApmErrors({
-      service: selectedService === 'all' ? undefined : selectedService,
-      limit: APM_ERRORS_PAGE_SIZE,
-      offset,
+      services: selectedServices.length ? selectedServices : undefined,
+      // Opt-in: with nothing selected we only need the facet counts (to populate
+      // the rail), not the all-services error list — so request zero rows.
+      limit: selectedServices.length ? APM_ERRORS_PAGE_SIZE : 0,
+      offset: selectedServices.length ? offset : 0,
       timeRange,
     }),
     enabled: isActive && api.isAuthenticated(),
@@ -772,212 +859,225 @@ function ApmErrorsTab({ isActive }: { isActive: boolean }) {
       .sort((a, b) => b.count - a.count)
   }, [data?.serviceFacets])
 
-  function handleServiceChange(service: string) {
-    setSelectedService(service)
-    setOffset(0)
-  }
+  const hasServices = services.length > 0
+  const hasSelection = selectedServices.length > 0
 
-  function handleTimeRangeChange(value: string) {
-    setTimeRange(value as ApmTimeRange)
-    setOffset(0)
-  }
+  // Free-text narrows the loaded page client-side (the trace API has no text query).
+  const normalizedQuery = query.trim().toLowerCase()
+  const visibleErrors = normalizedQuery
+    ? errors.filter((e: ApmErrorGroup) =>
+        `${e.resource} ${e.errorMessage} ${e.errorType}`.toLowerCase().includes(normalizedQuery)
+      )
+    : errors
 
-  const MAX_VISIBLE_TABS = 5
-  const visibleServices = services.slice(0, MAX_VISIBLE_TABS)
-  const overflowServices = services.slice(MAX_VISIBLE_TABS)
-  const overflowSelected = overflowServices.some((s) => s.service === selectedService)
+  const schema: FacetSchema = useMemo(
+    () => [{key: 'service', suggestions: services.map((s) => s.service)}],
+    [services]
+  )
+  const railSections: FacetRailSection[] = useMemo(
+    () => [
+      {
+        key: 'service',
+        label: 'Service',
+        color: 'bg-primary',
+        allowExclude: false,
+        options: services.map((s) => ({value: s.service, count: s.count})),
+      },
+    ],
+    [services]
+  )
 
   return (
-    <div className="px-6 py-4">
-      <PageHeader
-        className="mb-4"
-        title="APM Errors"
-        description="Application performance errors from traces"
-        actions={
-          <Select value={timeRange} onValueChange={handleTimeRangeChange}>
-            <SelectTrigger className="h-9 w-[110px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {APM_TIME_RANGE_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        }
-      />
-
-      {(services.length > 0 || selectedService !== 'all') && (
-        <div className="flex items-end gap-0 mb-4 border-b border-border/60">
-          <button
-            onClick={() => handleServiceChange('all')}
-            className={cn(
-              'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap',
-              selectedService === 'all'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/30',
-            )}
-          >
-            All
-          </button>
-          {visibleServices.map((svc) => (
-            <button
-              key={svc.service}
-              onClick={() => handleServiceChange(svc.service)}
-              className={cn(
-                'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap',
-                selectedService === svc.service
-                  ? 'border-primary text-foreground'
-                  : 'border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/30',
-              )}
-            >
-              <Server className="h-3 w-3" />
-              {svc.service}
-              <span className="text-xs text-muted-foreground tabular-nums">
-                {svc.count}
-              </span>
-            </button>
-          ))}
-          {overflowServices.length > 0 && (
-            <div className={cn('pb-0.5 ml-1', overflowSelected && 'border-b-2 border-primary -mb-px')}>
-              <Select
-                value={overflowSelected ? selectedService : ''}
-                onValueChange={(val) => handleServiceChange(val)}
-              >
-                <SelectTrigger className="h-8 text-sm border-0 px-2 gap-1 text-muted-foreground hover:text-foreground focus:ring-0 w-auto">
-                  <SelectValue placeholder={`+${overflowServices.length} more`} />
-                </SelectTrigger>
-                <SelectContent>
-                  {overflowServices.map((svc) => (
-                    <SelectItem key={svc.service} value={svc.service}>
-                      <span className="flex items-center gap-2">
-                        <Server className="h-3 w-3" />
-                        {svc.service}
-                        <span className="text-xs text-muted-foreground tabular-nums">{svc.count}</span>
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-        </div>
-      )}
-
-      {isLoading ? (
-        <div className="py-16 text-center text-muted-foreground">
-          Loading APM errors...
-        </div>
-      ) : errors.length === 0 ? (
-        <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
-          <div className="max-w-md mx-auto space-y-4">
-            <div className="flex justify-center">
-              <div className="rounded-full bg-info-bg p-4">
-                <AlertTriangle className="h-10 w-10 text-info-fg" />
-              </div>
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold mb-2">No APM errors found</h3>
-              <p className="text-muted-foreground">
-                Errors from application traces will appear here when spans report errors.
-              </p>
-            </div>
-          </div>
-        </Card>
-      ) : (
-        <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
-          {totalCount > APM_ERRORS_PAGE_SIZE && (
-            <div className="px-4 py-2 text-xs text-muted-foreground border-b border-border/40">
-              Showing {offset + 1}–{offset + errors.length} of {totalCount}
-            </div>
-          )}
-          <div className="hidden md:grid md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
-            <div>Service</div>
-            <div>Error</div>
-            <div className="text-right">Count</div>
-            <div className="text-right">Last Seen</div>
-            <div className="text-right">Trace</div>
-          </div>
-          <div className="divide-y divide-border/40">
-            {errors.map((error: ApmErrorGroup) => {
-              const traceId = normalizeApmTraceId(error.traceId)
-              const stableKey = `${error.service}|${error.resource}|${error.errorMessage}|${error.errorType}`
-              return (
-                <div
-                  key={stableKey}
-                  className="hover:bg-accent/40 transition border-l-[3px] border-l-red-500"
-                >
-                  <div className="grid grid-cols-[auto_1fr_auto] md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
-                    <Badge
-                      variant="outline"
-                      className="shrink-0 text-[11px] px-1.5 py-0 gap-1 w-fit"
-                    >
-                      <Server className="h-3 w-3" />
-                      {error.service}
-                    </Badge>
-                    <div className="min-w-0">
-                      <div className="font-semibold truncate text-sm">
-                        {error.errorMessage || error.resource}
-                      </div>
-                      {error.errorType && (
-                        <div className="text-xs text-muted-foreground truncate">
-                          {error.errorType}
-                        </div>
-                      )}
-                      <div className="text-xs text-muted-foreground truncate mt-0.5">
-                        {error.resource}
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <div className="font-semibold text-foreground">
-                        {formatCount(error.count)}
-                      </div>
-                      <div className="text-xs text-muted-foreground">errors</div>
-                    </div>
-                    <div className="hidden md:block text-right text-xs text-muted-foreground">
-                      {error.lastSeen ? formatRelativeTime(error.lastSeen) : '—'}
-                    </div>
-                    <div className="hidden md:block text-right">
-                      {traceId && (
-                        <Link
-                          to="/performance/traces/$traceId"
-                          params={{ traceId }}
-                          className="text-xs text-primary hover:underline"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          View trace
-                        </Link>
-                      )}
-                    </div>
+    <ExplorerShell
+      searchBar={
+        <SearchFilterBar
+          query={query}
+          onQueryChange={(q) => { setQuery(q); setOffset(0) }}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          schema={schema}
+          placeholder="Filter by service..."
+          trailing={
+            <TimeRangePicker
+              timePreset={timeRange}
+              onTimePresetChange={(v) => { setTimeRange(v as ApmTimeRange); setOffset(0) }}
+              customFrom=""
+              customTo=""
+              onCustomFromChange={() => {}}
+              onCustomToChange={() => {}}
+              presets={APM_TIME_PRESETS}
+              allowCustom={false}
+            />
+          }
+        />
+      }
+      rail={
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+        />
+      }
+      toolbar={
+        hasSelection && !isLoading ? (
+          <span className="ml-auto whitespace-nowrap text-xs tabular-nums text-muted-foreground">
+            {totalCount.toLocaleString()} error{totalCount === 1 ? '' : 's'}
+          </span>
+        ) : null
+      }
+    >
+      <div className="p-4">
+        {!hasServices ? (
+          isLoading ? (
+            <div className="py-16 text-center text-muted-foreground">Loading APM errors...</div>
+          ) : (
+            <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
+              <div className="max-w-md mx-auto space-y-4">
+                <div className="flex justify-center">
+                  <div className="rounded-full bg-info-bg p-4">
+                    <AlertTriangle className="h-10 w-10 text-info-fg" />
                   </div>
                 </div>
-              )
-            })}
-          </div>
-          {(canPrev || canNext) && (
-            <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={!canPrev}
-                onClick={() => setOffset(Math.max(0, offset - APM_ERRORS_PAGE_SIZE))}
-              >
-                Previous
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={!canNext}
-                onClick={() => setOffset(offset + APM_ERRORS_PAGE_SIZE)}
-              >
-                Next
-              </Button>
+                <div>
+                  <h3 className="text-lg font-semibold mb-2">No APM errors found</h3>
+                  <p className="text-muted-foreground">
+                    Errors from application traces will appear here when spans report errors.
+                  </p>
+                </div>
+              </div>
+            </Card>
+          )
+        ) : !hasSelection ? (
+          <Card className="p-12 text-center border-border/60">
+            <div className="max-w-md mx-auto space-y-3">
+              <div className="flex justify-center">
+                <div className="rounded-full bg-muted p-4">
+                  <Server className="h-10 w-10 text-muted-foreground" />
+                </div>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold mb-1">Select a service</h3>
+                <p className="text-muted-foreground">
+                  Pick one or more services from the search bar or the facet rail to view their errors.
+                </p>
+              </div>
             </div>
-          )}
-        </div>
-      )}
-    </div>
+          </Card>
+        ) : isLoading ? (
+          <div className="py-16 text-center text-muted-foreground">Loading APM errors...</div>
+        ) : visibleErrors.length === 0 ? (
+          <Card className="p-12 text-center border-border/60">
+            <div className="max-w-md mx-auto space-y-3">
+              <div className="flex justify-center">
+                <div className="rounded-full bg-muted p-4">
+                  <AlertTriangle className="h-10 w-10 text-muted-foreground" />
+                </div>
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold mb-1">
+                  {normalizedQuery ? 'No errors match your search' : 'No errors for the selected services'}
+                </h3>
+                <p className="text-muted-foreground">
+                  {normalizedQuery
+                    ? 'Try a different search or clear it.'
+                    : 'Try a different service or widen the time range.'}
+                </p>
+              </div>
+            </div>
+          </Card>
+        ) : (
+          <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
+            {totalCount > APM_ERRORS_PAGE_SIZE && !normalizedQuery && (
+              <div className="px-4 py-2 text-xs text-muted-foreground border-b border-border/40">
+                Showing {offset + 1}–{offset + errors.length} of {totalCount}
+              </div>
+            )}
+            <div className="hidden md:grid md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
+              <div>Service</div>
+              <div>Error</div>
+              <div className="text-right">Count</div>
+              <div className="text-right">Last Seen</div>
+              <div className="text-right">Trace</div>
+            </div>
+            <div className="divide-y divide-border/40">
+              {visibleErrors.map((error: ApmErrorGroup) => {
+                const traceId = normalizeApmTraceId(error.traceId)
+                const stableKey = `${error.service}|${error.resource}|${error.errorMessage}|${error.errorType}`
+                return (
+                  <div
+                    key={stableKey}
+                    className="hover:bg-accent/40 transition border-l-[3px] border-l-red-500"
+                  >
+                    <div className="grid grid-cols-[auto_1fr_auto] md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 text-[11px] px-1.5 py-0 gap-1 w-fit"
+                      >
+                        <Server className="h-3 w-3" />
+                        {error.service}
+                      </Badge>
+                      <div className="min-w-0">
+                        <div className="font-semibold truncate text-sm">
+                          {error.errorMessage || error.resource}
+                        </div>
+                        {error.errorType && (
+                          <div className="text-xs text-muted-foreground truncate">
+                            {error.errorType}
+                          </div>
+                        )}
+                        <div className="text-xs text-muted-foreground truncate mt-0.5">
+                          {error.resource}
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <div className="font-semibold text-foreground">
+                          {formatCount(error.count)}
+                        </div>
+                        <div className="text-xs text-muted-foreground">errors</div>
+                      </div>
+                      <div className="hidden md:block text-right text-xs text-muted-foreground">
+                        {error.lastSeen ? formatRelativeTime(error.lastSeen) : '—'}
+                      </div>
+                      <div className="hidden md:block text-right">
+                        {traceId && (
+                          <Link
+                            to="/performance/traces/$traceId"
+                            params={{ traceId }}
+                            className="text-xs text-primary hover:underline"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            View trace
+                          </Link>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            {(canPrev || canNext) && (
+              <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!canPrev}
+                  onClick={() => setOffset(Math.max(0, offset - APM_ERRORS_PAGE_SIZE))}
+                >
+                  Previous
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!canNext}
+                  onClick={() => setOffset(offset + APM_ERRORS_PAGE_SIZE)}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </ExplorerShell>
   )
 }

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -99,6 +99,7 @@ const MERGE_FETCH_LIMIT = 100
 
 type SafeIssue = {
   id: string
+  projectResourceId: string
   service: string
   title: string
   culprit: string
@@ -109,6 +110,15 @@ type SafeIssue = {
   eventCount: number
   userCount: number
   status: string
+}
+
+type IssueUpdateTarget = {
+  id: string
+  projectResourceId: string
+}
+
+function issueSelectionKey(issue: Pick<SafeIssue, 'id' | 'projectResourceId'>): string {
+  return `${issue.projectResourceId}:${issue.id}`
 }
 
 function clampText(value: string, maxChars: number): string {
@@ -232,7 +242,8 @@ function IndexPage() {
 function DashboardPage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
-  const [selectedIssues, setSelectedIssues] = useState<Set<string>>(new Set())
+  const [issueFiltersTouched, setIssueFiltersTouched] = useState(false)
+  const [selectedIssueKeys, setSelectedIssueKeys] = useState<Set<string>>(new Set())
   const [page, setPage] = useState(1)
   const pageSize = 25
   const { selectedProjectId } = useProject()
@@ -248,17 +259,17 @@ function DashboardPage() {
   // Seed the Service facet once from the sidebar-selected project so the default
   // view stays scoped as before; afterwards the rail/bar own the selection, and
   // clearing Service widens to all services.
-  const [seeded, setSeeded] = useState(false)
-  if (!seeded && projects && projects.length > 0) {
-    setSeeded(true)
+  const seedServiceFilter = useMemo<FacetFilter | null>(() => {
+    if (issueFiltersTouched || !projects?.length) return null
     const seedProject = projects.find((p) => p.resourceId === selectedProjectId) ?? projects[0]
-    if (seedProject) setFacetFilters([{ key: 'service', value: seedProject.name }])
-  }
+    return seedProject ? { key: 'service', value: seedProject.name } : null
+  }, [issueFiltersTouched, projects, selectedProjectId])
+  const effectiveFacetFilters = seedServiceFilter ? [seedServiceFilter] : facetFilters
 
   // Service include/exclude picks which projects' issues to load and merge
   // (client-side until the org-wide issues API lands). None selected ⇒ all.
-  const includedServices = facetFilters.filter((f) => f.key === 'service' && !f.exclude).map((f) => f.value)
-  const excludedServices = facetFilters.filter((f) => f.key === 'service' && f.exclude).map((f) => f.value)
+  const includedServices = effectiveFacetFilters.filter((f) => f.key === 'service' && !f.exclude).map((f) => f.value)
+  const excludedServices = effectiveFacetFilters.filter((f) => f.key === 'service' && f.exclude).map((f) => f.value)
   const targetProjects = (projects ?? [])
     .filter((p) => (includedServices.length > 0 ? includedServices.includes(p.name) : true))
     .filter((p) => !excludedServices.includes(p.name))
@@ -275,13 +286,13 @@ function DashboardPage() {
   const issuesErrorObj = issueQueries.find((q) => q.isError)?.error
 
   const resolveMutation = useMutation({
-    mutationFn: async (issueIds: string[]) => {
+    mutationFn: async (issues: IssueUpdateTarget[]) => {
       const results = await Promise.allSettled(
-        issueIds.map(id => api.updateIssue(id, { status: 'resolved' }))
+        issues.map((issue) => api.updateIssue(issue.id, { status: 'resolved' }, issue.projectResourceId))
       )
       const successCount = results.filter(r => r.status === 'fulfilled').length
       if (successCount === 0) throw new Error('All requests failed')
-      return { submitted: issueIds.length, successCount }
+      return { submitted: issues.length, successCount }
     },
     onSuccess: ({ submitted, successCount }) => {
       trackEvent('Issue Resolve', { count: String(successCount) })
@@ -299,7 +310,7 @@ function DashboardPage() {
           variant: 'destructive',
         })
       }
-      setSelectedIssues(new Set())
+      setSelectedIssueKeys(new Set())
     },
     onError: () => {
       toast({
@@ -311,13 +322,13 @@ function DashboardPage() {
   })
 
   const ignoreMutation = useMutation({
-    mutationFn: async (issueIds: string[]) => {
+    mutationFn: async (issues: IssueUpdateTarget[]) => {
       const results = await Promise.allSettled(
-        issueIds.map(id => api.updateIssue(id, { status: 'ignored' }))
+        issues.map((issue) => api.updateIssue(issue.id, { status: 'ignored' }, issue.projectResourceId))
       )
       const successCount = results.filter(r => r.status === 'fulfilled').length
       if (successCount === 0) throw new Error('All requests failed')
-      return { submitted: issueIds.length, successCount }
+      return { submitted: issues.length, successCount }
     },
     onSuccess: ({ submitted, successCount }) => {
       trackEvent('Issue Ignore', { count: String(successCount) })
@@ -335,7 +346,7 @@ function DashboardPage() {
           variant: 'destructive',
         })
       }
-      setSelectedIssues(new Set())
+      setSelectedIssueKeys(new Set())
     },
     onError: () => {
       toast({ title: 'Error', description: 'Failed to ignore issues', variant: 'destructive' })
@@ -343,13 +354,15 @@ function DashboardPage() {
   })
 
   const resolveNextReleaseMutation = useMutation({
-    mutationFn: async (issueIds: string[]) => {
+    mutationFn: async (issues: IssueUpdateTarget[]) => {
       const results = await Promise.allSettled(
-        issueIds.map(id => api.updateIssue(id, { status: 'resolvedInNextRelease' }))
+        issues.map((issue) =>
+          api.updateIssue(issue.id, { status: 'resolvedInNextRelease' }, issue.projectResourceId)
+        )
       )
       const successCount = results.filter(r => r.status === 'fulfilled').length
       if (successCount === 0) throw new Error('All requests failed')
-      return { submitted: issueIds.length, successCount }
+      return { submitted: issues.length, successCount }
     },
     onSuccess: ({ submitted, successCount }) => {
       trackEvent('Issue ResolveInNextRelease', { count: String(successCount) })
@@ -367,7 +380,7 @@ function DashboardPage() {
           variant: 'destructive',
         })
       }
-      setSelectedIssues(new Set())
+      setSelectedIssueKeys(new Set())
     },
     onError: () => {
       toast({ title: 'Error', description: 'Failed to update issues', variant: 'destructive' })
@@ -376,66 +389,84 @@ function DashboardPage() {
 
   const bulkPending = resolveMutation.isPending || ignoreMutation.isPending || resolveNextReleaseMutation.isPending
 
-  const handleToggleIssue = (issueId: string) => {
-    const newSelected = new Set(selectedIssues)
-    if (newSelected.has(issueId)) {
-      newSelected.delete(issueId)
+  const handleToggleIssue = (issue: SafeIssue) => {
+    const key = issueSelectionKey(issue)
+    const newSelected = new Set(selectedIssueKeys)
+    if (newSelected.has(key)) {
+      newSelected.delete(key)
     } else {
-      newSelected.add(issueId)
+      newSelected.add(key)
     }
-    setSelectedIssues(newSelected)
+    setSelectedIssueKeys(newSelected)
   }
 
   const handleToggleAll = () => {
-    if (selectedIssues.size === pagedIssues.length) {
-      setSelectedIssues(new Set())
+    const pageKeys = pagedIssues.map(issueSelectionKey)
+    const allPageIssuesSelected = pageKeys.every((key) => selectedIssueKeys.has(key))
+    const nextSelected = new Set(selectedIssueKeys)
+    if (allPageIssuesSelected) {
+      pageKeys.forEach((key) => nextSelected.delete(key))
     } else {
-      setSelectedIssues(new Set(pagedIssues.map(issue => issue.id)))
+      pageKeys.forEach((key) => nextSelected.add(key))
     }
+    setSelectedIssueKeys(nextSelected)
   }
 
   const handleResolveSelected = () => {
-    resolveMutation.mutate(Array.from(selectedIssues))
+    resolveMutation.mutate(selectedIssueTargets)
   }
 
   const handleIgnoreSelected = () => {
-    ignoreMutation.mutate(Array.from(selectedIssues))
+    ignoreMutation.mutate(selectedIssueTargets)
   }
 
   const handleResolveNextReleaseSelected = () => {
-    resolveNextReleaseMutation.mutate(Array.from(selectedIssues))
+    resolveNextReleaseMutation.mutate(selectedIssueTargets)
   }
 
-  const safeIssues = useMemo<SafeIssue[]>(() => {
-    const out: SafeIssue[] = []
-    targetProjects.forEach((project, index) => {
-      const rows = issueQueries[index]?.data ?? []
-      for (const issue of rows) {
-        const id = toSafeString(issue.id, '', ISSUE_ID_MAX_CHARS)
-        if (!id) continue
-        out.push({
-          id,
-          service: project.name,
-          title: toSafeString(issue.title, '', ISSUE_SEARCH_TEXT_MAX_CHARS),
-          culprit: toSafeString(issue.culprit, '', ISSUE_SEARCH_TEXT_MAX_CHARS),
-          level: toSafeString(issue.level, 'error', 16) || 'error',
-          platform: toSafeString(issue.platform, 'unknown', 64) || 'unknown',
-          firstSeen: toSafeString(issue.firstSeen, ''),
-          lastSeen: toSafeString(issue.lastSeen, ''),
-          eventCount: toSafeCount(issue.eventCount),
-          userCount: toSafeCount(issue.userCount),
-          status: toSafeString(issue.status, 'unresolved', 32) || 'unresolved',
-        })
-      }
+  const safeIssues: SafeIssue[] = []
+  targetProjects.forEach((project, index) => {
+    const projectResourceId = toSafeString(project.resourceId, '', ISSUE_ID_MAX_CHARS)
+    if (!projectResourceId) return
+    const rows = issueQueries[index]?.data ?? []
+    for (const issue of rows) {
+      const id = toSafeString(issue.id, '', ISSUE_ID_MAX_CHARS)
+      if (!id) continue
+      safeIssues.push({
+        id,
+        projectResourceId,
+        service: project.name,
+        title: toSafeString(issue.title, '', ISSUE_SEARCH_TEXT_MAX_CHARS),
+        culprit: toSafeString(issue.culprit, '', ISSUE_SEARCH_TEXT_MAX_CHARS),
+        level: toSafeString(issue.level, 'error', 16) || 'error',
+        platform: toSafeString(issue.platform, 'unknown', 64) || 'unknown',
+        firstSeen: toSafeString(issue.firstSeen, ''),
+        lastSeen: toSafeString(issue.lastSeen, ''),
+        eventCount: toSafeCount(issue.eventCount),
+        userCount: toSafeCount(issue.userCount),
+        status: toSafeString(issue.status, 'unresolved', 32) || 'unresolved',
+      })
+    }
+  })
+
+  const safeIssuesByKey = new Map<string, IssueUpdateTarget>()
+  safeIssues.forEach((issue) => {
+    safeIssuesByKey.set(issueSelectionKey(issue), {
+      id: issue.id,
+      projectResourceId: issue.projectResourceId,
     })
-    return out
-  }, [targetProjects, issueQueries])
+  })
+  const selectedIssueTargets: IssueUpdateTarget[] = []
+  selectedIssueKeys.forEach((key) => {
+    const target = safeIssuesByKey.get(key)
+    if (target) selectedIssueTargets.push(target)
+  })
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase()
-  const statusIncludes = facetFilters.filter((f) => f.key === 'status' && !f.exclude).map((f) => f.value)
-  const statusExcludes = facetFilters.filter((f) => f.key === 'status' && f.exclude).map((f) => f.value)
-  const levelIncludes = facetFilters.filter((f) => f.key === 'level' && !f.exclude).map((f) => f.value)
-  const levelExcludes = facetFilters.filter((f) => f.key === 'level' && f.exclude).map((f) => f.value)
+  const statusIncludes = effectiveFacetFilters.filter((f) => f.key === 'status' && !f.exclude).map((f) => f.value)
+  const statusExcludes = effectiveFacetFilters.filter((f) => f.key === 'status' && f.exclude).map((f) => f.value)
+  const levelIncludes = effectiveFacetFilters.filter((f) => f.key === 'level' && !f.exclude).map((f) => f.value)
+  const levelExcludes = effectiveFacetFilters.filter((f) => f.key === 'level' && f.exclude).map((f) => f.value)
 
   // Service is resolved server-side (which projects we fetch); status/level/search
   // narrow the merged set client-side, honoring include + exclude.
@@ -460,11 +491,13 @@ function DashboardPage() {
   const pagedIssues = filteredIssues.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
   const hasActiveIssueFilters =
-    Boolean(searchQuery) || facetFilters.some((f) => f.key === 'status' || f.key === 'level' || f.exclude)
+    Boolean(searchQuery) ||
+    effectiveFacetFilters.some((f) => f.key === 'status' || f.key === 'level' || f.exclude)
 
   function handleFacetFiltersChange(next: FacetFilter[]) {
+    setIssueFiltersTouched(true)
     setFacetFilters(next)
-    setSelectedIssues(new Set())
+    setSelectedIssueKeys(new Set())
     setPage(1)
   }
 
@@ -560,8 +593,8 @@ function DashboardPage() {
       searchBar={
         <SearchFilterBar
           query={searchQuery}
-          onQueryChange={(q) => { setSearchQuery(q); setPage(1); setSelectedIssues(new Set()) }}
-          facetFilters={facetFilters}
+          onQueryChange={(q) => { setSearchQuery(q); setPage(1); setSelectedIssueKeys(new Set()) }}
+          facetFilters={effectiveFacetFilters}
           onFacetFiltersChange={handleFacetFiltersChange}
           schema={issueSchema}
           placeholder="Search issues..."
@@ -570,7 +603,7 @@ function DashboardPage() {
       rail={
         <FacetRail
           sections={issueRailSections}
-          facetFilters={facetFilters}
+          facetFilters={effectiveFacetFilters}
           onFacetFiltersChange={handleFacetFiltersChange}
         />
       }
@@ -579,17 +612,19 @@ function DashboardPage() {
           {pagedIssues.length > 0 && (
             <div className="flex items-center gap-2">
               <Checkbox
-                checked={selectedIssues.size === pagedIssues.length && pagedIssues.length > 0}
+                checked={pagedIssues.length > 0 && pagedIssues.every((issue) =>
+                  selectedIssueKeys.has(issueSelectionKey(issue))
+                )}
                 onCheckedChange={handleToggleAll}
                 aria-label="Select all issues"
               />
               <span className="text-sm text-muted-foreground whitespace-nowrap hidden sm:inline">Select all</span>
             </div>
           )}
-          {selectedIssues.size > 0 && (
+          {selectedIssueTargets.length > 0 && (
             <div className="flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-lg px-2 py-0.5">
               <CheckCircle2 className="h-4 w-4 text-primary" />
-              <span className="text-sm font-medium whitespace-nowrap">{selectedIssues.size} selected</span>
+              <span className="text-sm font-medium whitespace-nowrap">{selectedIssueTargets.length} selected</span>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button disabled={bulkPending} size="sm" className="h-7 ml-1">
@@ -666,13 +701,13 @@ function DashboardPage() {
             <div className="divide-y divide-border/40">
               {pagedIssues.map((issue) => (
                 <div
-                  key={issue.id}
+                  key={issueSelectionKey(issue)}
                   className={`hover:bg-accent/40 transition border-l-[3px] ${levelBorderClass(issue.level)}`}
                 >
                   <div className="flex items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
                     <Checkbox
-                      checked={selectedIssues.has(issue.id)}
-                      onCheckedChange={() => handleToggleIssue(issue.id)}
+                      checked={selectedIssueKeys.has(issueSelectionKey(issue))}
+                      onCheckedChange={() => handleToggleIssue(issue)}
                       onClick={(e) => e.stopPropagation()}
                       aria-label={`Select ${issue.title}`}
                       className="shrink-0"
@@ -680,6 +715,7 @@ function DashboardPage() {
                     <Link
                       to="/issues/$issueId"
                       params={{ issueId: issue.id }}
+                      search={{ projectId: issue.projectResourceId }}
                       className="flex-1 flex items-center gap-2 sm:gap-3 min-w-0"
                     >
                       <div className="w-12 sm:w-[4.5rem] shrink-0">

--- a/dashboard/src/routes/projects.$projectId.settings.tsx
+++ b/dashboard/src/routes/projects.$projectId.settings.tsx
@@ -14,486 +14,53 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useEffect, useMemo, useState} from 'react'
-import {createFileRoute, Link, redirect, useNavigate, useRouter} from '@tanstack/react-router'
-import {useMutation, useQueryClient} from '@tanstack/react-query'
-import {
-  AlertTriangle,
-  ArrowLeft,
-  Check,
-  Copy,
-  Gamepad2,
-  Layers,
-  Loader2,
-  Monitor,
-  Save,
-  Server,
-  Smartphone,
-  Trash2
-} from 'lucide-react'
+import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {ArrowLeft} from 'lucide-react'
 import {api} from '@/lib/api'
-import {trackEvent} from '@/lib/analytics'
-import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
-import {useProject} from '@/contexts/ProjectContext'
-import {getPlatformInfo, platforms, type PlatformType} from '@/routes/projects'
-import {Badge} from '@/components/ui/badge'
-import {Button} from '@/components/ui/button'
-import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
-import {Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle} from '@/components/ui/dialog'
-import {Input} from '@/components/ui/input'
-import {Label} from '@/components/ui/label'
-import {useToast} from '@/hooks/useToast'
-import {cn} from '@/lib/utils'
-
-type PlatformFilter = 'all' | 'mobile' | 'frontend' | 'backend' | 'desktop-gaming'
-
-const platformFilterTabs: Array<{ id: PlatformFilter; label: string; icon: React.ElementType }> = [
-  { id: 'all', label: 'All', icon: Layers },
-  { id: 'mobile', label: 'Mobile', icon: Smartphone },
-  { id: 'frontend', label: 'Frontend', icon: Monitor },
-  { id: 'backend', label: 'Backend', icon: Server },
-  { id: 'desktop-gaming', label: 'Desktop & Gaming', icon: Gamepad2 },
-]
+import {ServiceSettingsCard} from '@/components/projects/ServiceSettingsCard'
+import {
+  DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS,
+  loadTelemetrySourceIdsForProject,
+} from '@/lib/telemetry-sources'
 
 export const Route = createFileRoute('/projects/$projectId/settings')({
-  beforeLoad: async ({ location }) => {
+  beforeLoad: async ({location}) => {
     if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
+      throw redirect({to: '/login', search: {redirect: location.href}})
     }
   },
-  loader: async ({ params }) => {
+  loader: async ({params}) => {
     const project = await api.getProject(params.projectId)
-    return { project }
+    return {project}
   },
   component: ProjectSettingsPage,
 })
 
 function ProjectSettingsPage() {
-  const { project } = Route.useLoaderData()
-  const router = useRouter()
-  const navigate = useNavigate()
-  const queryClient = useQueryClient()
-  const { selectedProjectId, setSelectedProjectId } = useProject()
-  const { toast } = useToast()
-
-  const [localName, setName] = useState<string | undefined>(undefined)
-  const [localFramework, setFramework] = useState<string | undefined>(undefined)
-  const name = localName ?? project.name
-  const framework = localFramework ?? getPlatformInfo(project.framework)?.id ?? 'other'
-  const [platformFilter, setPlatformFilter] = useState<PlatformFilter>('all')
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [copiedSlug, setCopiedSlug] = useState(false)
-  const [copiedConfig, setCopiedConfig] = useState(false)
-  const [orgSlug, setOrgSlug] = useState<string | null>(null)
-
-  // Fetch organization slug
-  useEffect(() => {
-    async function fetchOrgSlug() {
-      try {
-        const user = await api.getCurrentUser()
-        setOrgSlug(user.organizationSlug || null)
-      } catch (error) {
-        console.error('Failed to fetch organization slug:', error)
-      }
-    }
-    fetchOrgSlug()
-  }, [])
-
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'https://api.moneat.io'
-  const sentryCliConfig = orgSlug ? `[defaults]
-url=${backendUrl}
-org=${orgSlug}
-project=${project.slug}` : null
-
-  const initialFramework = getPlatformInfo(project.framework)?.id ?? 'other'
-  const trimmedName = name.trim()
-  const nameChanged = trimmedName !== project.name
-  const frameworkChanged = framework !== initialFramework
-  const frameworkInfo = getPlatformInfo(framework)
-  const isMultiplatformFramework = !!frameworkInfo?.targets?.length
-  const currentTargets = project.keys
-    .map(key => key.platformTarget)
-    .filter((target): target is string => Boolean(target))
-  const availableTargets = frameworkInfo?.targets?.filter(target => !currentTargets.includes(target.id)) ?? []
-
-  const filteredPlatforms = useMemo(() => {
-    return platforms.filter((platform: PlatformType) => {
-      if (platform.alwaysVisible || platformFilter === 'all') return true
-      if (platformFilter === 'desktop-gaming') {
-        return platform.category === 'desktop' || platform.category === 'gaming'
-      }
-      return platform.category === platformFilter
-    })
-  }, [platformFilter])
-
-  const updateProjectMutation = useMutation({
-    mutationFn: (updates: { name?: string; framework?: string }) => api.updateProject(project.resourceId, updates),
-    onSuccess: async () => {
-      trackEvent('Project Update')
-      await queryClient.invalidateQueries({ queryKey: ['projects'] })
-      await queryClient.invalidateQueries({ queryKey: ['project', project.resourceId] })
-      await router.invalidate()
-      toast({
-        title: 'Project updated',
-        description: 'Project settings were saved successfully.',
-      })
-    },
-    onError: (err: Error) => {
-      toast({
-        title: 'Failed to update project',
-        description: err.message,
-        variant: 'destructive',
-      })
-    },
-  })
-
-  const deleteProjectMutation = useMutation({
-    mutationFn: () => api.deleteProject(project.resourceId),
-    onSuccess: async () => {
-      trackEvent('Project Delete')
-      await queryClient.invalidateQueries({ queryKey: ['projects'] })
-      if (selectedProjectId === project.resourceId) {
-        setSelectedProjectId(null)
-      }
-      toast({
-        title: 'Project deleted',
-        description: `"${project.name}" has been deleted.`,
-      })
-      navigate({ to: '/', search: APP_OVERVIEW_SEARCH })
-    },
-    onError: (err: Error) => {
-      toast({
-        title: 'Failed to delete project',
-        description: err.message,
-        variant: 'destructive',
-      })
-    },
-  })
-
-  const addTargetMutation = useMutation({
-    mutationFn: (target: string) => api.addProjectTarget(project.resourceId, target),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['projects'] })
-      await router.invalidate()
-      toast({
-        title: 'Target added',
-        description: 'A new platform target and DSN were created.',
-      })
-    },
-    onError: (err: Error) => {
-      toast({
-        title: 'Failed to add target',
-        description: err.message,
-        variant: 'destructive',
-      })
-    },
-  })
-
-  const handleSave = () => {
-    if (!trimmedName) {
-      toast({
-        title: 'Project name is required',
-        description: 'Please provide a project name before saving.',
-        variant: 'destructive',
-      })
-      return
-    }
-
-    const updates: { name?: string; framework?: string } = {}
-    if (nameChanged) updates.name = trimmedName
-    if (frameworkChanged) updates.framework = framework
-
-    if (Object.keys(updates).length === 0) return
-    updateProjectMutation.mutate(updates)
-  }
-
-  const copySlug = () => {
-    navigator.clipboard.writeText(project.slug)
-    setCopiedSlug(true)
-    setTimeout(() => setCopiedSlug(false), 2000)
-  }
-
-  const copyConfig = () => {
-    if (sentryCliConfig) {
-      navigator.clipboard.writeText(sentryCliConfig)
-      setCopiedConfig(true)
-      setTimeout(() => setCopiedConfig(false), 2000)
-    }
-  }
+  const {project} = Route.useLoaderData()
+  const stored = loadTelemetrySourceIdsForProject(project.resourceId)
+  const sourceIds = stored.length > 0 ? stored : DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS
 
   return (
     <div>
       <div className="p-6 max-w-4xl mx-auto space-y-6">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
-            <Link
-              to="/projects/$projectId"
-              params={{ projectId: project.resourceId }}
-              className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back to Setup Guide
-            </Link>
-            <div>
-              <h1 className="text-2xl font-bold">Project Settings</h1>
-              <p className="text-sm text-muted-foreground">Manage project details and platform configuration.</p>
-            </div>
-          </div>
-          <Button
-            onClick={handleSave}
-            disabled={!trimmedName || (!nameChanged && !frameworkChanged) || updateProjectMutation.isPending}
+        <div className="space-y-2">
+          <Link
+            to="/projects/$projectId"
+            params={{projectId: project.resourceId}}
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
-            {updateProjectMutation.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Save className="h-4 w-4" />
-            )}
-            Save Changes
-          </Button>
+            <ArrowLeft className="h-4 w-4" />
+            Back to setup guide
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold">Service settings</h1>
+            <p className="text-sm text-muted-foreground">Manage service details and platform configuration.</p>
+          </div>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>General</CardTitle>
-            <CardDescription>Update your project name and framework.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="space-y-2">
-              <Label htmlFor="project-name">Project Name</Label>
-              <Input
-                id="project-name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="My Project"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="project-slug">Project Slug</Label>
-              <div className="flex gap-2">
-                <Input
-                  id="project-slug"
-                  value={project.slug}
-                  readOnly
-                  className="bg-muted"
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  onClick={copySlug}
-                >
-                  {copiedSlug ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                </Button>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Used for Sentry CLI and API endpoints
-              </p>
-            </div>
-
-            {sentryCliConfig && (
-              <div className="space-y-2">
-                <Label>Sentry CLI Configuration</Label>
-                <div className="relative">
-                  <pre className="bg-muted rounded-lg p-4 text-xs overflow-x-auto pr-12">
-                    <code>{sentryCliConfig}</code>
-                  </pre>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="absolute top-2 right-2"
-                    onClick={copyConfig}
-                  >
-                    {copiedConfig ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                  </Button>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Use this in your sentry.properties file or with sentry-cli commands
-                </p>
-              </div>
-            )}
-
-            <div className="space-y-3">
-              <div>
-                <Label className="text-base">Platform / Framework</Label>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Changing platform does not rotate or invalidate existing DSNs.
-                </p>
-              </div>
-
-              <div className="flex flex-wrap gap-1">
-                {platformFilterTabs.map((tab) => {
-                  const Icon = tab.icon
-                  return (
-                    <Button
-                      key={tab.id}
-                      variant={platformFilter === tab.id ? 'default' : 'outline'}
-                      size="sm"
-                      onClick={() => setPlatformFilter(tab.id)}
-                      className="gap-2"
-                    >
-                      <Icon className="h-4 w-4" />
-                      {tab.label}
-                    </Button>
-                  )
-                })}
-              </div>
-
-              <div className="max-h-96 overflow-y-auto rounded-lg border border-border p-2 pr-1">
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
-                  {filteredPlatforms.map((platform) => {
-                    const Icon = platform.icon
-                    return (
-                      <button
-                        key={platform.id}
-                        type="button"
-                        onClick={() => setFramework(platform.id)}
-                        className={cn(
-                          'border-2 rounded-lg p-3 text-left transition-colors',
-                          framework === platform.id
-                            ? 'border-primary bg-primary/10'
-                            : 'border-border hover:border-primary/50'
-                        )}
-                      >
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="w-6 h-6 rounded flex items-center justify-center flex-shrink-0"
-                            style={{ backgroundColor: platform.color }}
-                          >
-                            <Icon className="h-4 w-4 text-white" />
-                          </div>
-                          <span className="text-sm font-medium">{platform.name}</span>
-                        </div>
-                        <p className="text-xs text-muted-foreground mt-2">{platform.description}</p>
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-            </div>
-
-            {isMultiplatformFramework && (
-              <div className="space-y-3">
-                <div>
-                  <Label className="text-base">Target Platforms</Label>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Multiplatform frameworks use one DSN per target.
-                  </p>
-                </div>
-
-                {frameworkChanged ? (
-                  <div className="rounded-lg border border-dashed border-border p-3 text-sm text-muted-foreground">
-                    Save framework changes first, then add target platforms here.
-                  </div>
-                ) : (
-                  <>
-                    <div className="flex flex-wrap gap-2">
-                      {currentTargets.length > 0 ? (
-                        currentTargets.map((target) => {
-                          const targetInfo = getPlatformInfo(target)
-                          const TargetIcon = targetInfo?.icon
-                          return (
-                            <Badge key={target} variant="secondary" className="flex items-center gap-1.5 px-2.5 py-1">
-                              {TargetIcon && (
-                                <div
-                                  className="w-4 h-4 rounded flex items-center justify-center"
-                                  style={{ backgroundColor: targetInfo?.color }}
-                                >
-                                  <TargetIcon className="w-3 h-3 text-white" />
-                                </div>
-                              )}
-                              <span>{targetInfo?.name ?? target}</span>
-                            </Badge>
-                          )
-                        })
-                      ) : (
-                        <p className="text-sm text-muted-foreground">No targets added yet.</p>
-                      )}
-                    </div>
-
-                    {availableTargets.length > 0 && (
-                      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
-                        {availableTargets.map((target) => {
-                          const targetInfo = getPlatformInfo(target.id)
-                          const TargetIcon = targetInfo?.icon
-                          return (
-                            <Button
-                              key={target.id}
-                              type="button"
-                              variant="outline"
-                              className="justify-start h-auto py-2.5"
-                              onClick={() => addTargetMutation.mutate(target.id)}
-                              disabled={addTargetMutation.isPending}
-                            >
-                              {TargetIcon && (
-                                <div
-                                  className="w-5 h-5 rounded flex items-center justify-center"
-                                  style={{ backgroundColor: targetInfo?.color }}
-                                >
-                                  <TargetIcon className="w-3.5 h-3.5 text-white" />
-                                </div>
-                              )}
-                              <span>Add {target.name}</span>
-                            </Button>
-                          )
-                        })}
-                      </div>
-                    )}
-                  </>
-                )}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="border-destructive/40">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-destructive">
-              <AlertTriangle className="h-5 w-5" />
-              Danger Zone
-            </CardTitle>
-            <CardDescription>Delete this project and all related data permanently.</CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              This action cannot be undone. Events, issues, releases, and DSNs for this project will be removed.
-            </p>
-            <Button variant="destructive" onClick={() => setDeleteDialogOpen(true)}>
-              <Trash2 className="h-4 w-4" />
-              Delete Project
-            </Button>
-          </CardContent>
-        </Card>
+        <ServiceSettingsCard projectId={project.resourceId} sourceIds={sourceIds} />
       </div>
-
-      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete project?</DialogTitle>
-            <DialogDescription>
-              This will permanently delete <strong>{project.name}</strong> and all associated data.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={deleteProjectMutation.isPending}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => deleteProjectMutation.mutate()}
-              disabled={deleteProjectMutation.isPending}
-            >
-              {deleteProjectMutation.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Trash2 className="h-4 w-4" />
-              )}
-              Delete Project
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/dashboard/src/routes/releases.$version.tsx
+++ b/dashboard/src/routes/releases.$version.tsx
@@ -148,6 +148,7 @@ function ReleaseDetailPage() {
                       key={issue.issueId}
                       to="/issues/$issueId"
                       params={{ issueId: issue.issueId }}
+                      search={{ projectId }}
                       className="flex items-center justify-between p-2 rounded-lg border hover:bg-accent/40 transition-colors"
                     >
                       <div className="flex items-center gap-2 min-w-0">

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -351,6 +351,8 @@ function ReplayDetailPage() {
   )
   const durationMs =
     recordingDurationMs > 0 ? recordingDurationMs : computedDurationMs > 0 ? computedDurationMs : (replay?.durationMs ?? 0)
+  const replayProjectId = replay?.projectResourceId ??
+    (replay?.projectId != null ? String(replay.projectId) : undefined)
   const mobileCompressedTimeMapper = useMemo(
     () => (isMobileReplay ? createMobileCompressedTimeMapper(events) : null),
     [events, isMobileReplay]
@@ -665,7 +667,7 @@ function ReplayDetailPage() {
               <ReplayTimelinePanel
                 items={timelineItems}
                 currentOffsetMs={currentOffsetMs}
-                projectId={replay.projectResourceId ?? replay.projectId}
+                projectId={replayProjectId}
                 onSeek={handleSeek}
               />
             ) : (
@@ -825,6 +827,7 @@ function ReplayDetailPage() {
                       key={errorId}
                       to="/issues/$issueId"
                       params={{ issueId: errorId }}
+                      search={{ projectId: replayProjectId }}
                       className="flex items-center justify-between rounded border p-1.5 transition-colors hover:bg-accent group"
                     >
                       <span className="font-mono text-xs text-muted-foreground truncate min-w-0">{errorId}</span>


### PR DESCRIPTION
Adds shared filter primitives, service-first configuration UI, and faceted issues/APM groundwork.

Checks run locally before push: dashboard typecheck/lint/tests; backend compile/detekt/focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration page for managing services and telemetry; multi-select APM service filtering; Service settings UI and telemetry source picker; new dashboard filter components (ExplorerShell, SearchFilterBar, FacetRail, TimeRangePicker).

* **UI Changes**
  * “Project” relabeled to “Service” in flows; new Configuration sidebar item; issues/APM lists support multi-service merged views and preserve selected service context across navigation.

* **Tests**
  * Extensive new/updated tests covering filters, service setup/settings, configuration, APM filtering, and issue/project scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->