### PR TITLE
feat: add trace facet filtering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,7 +268,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          mkdir -p "${HOME}/.sonar/cache"
+          mkdir -p "${HOME}/.sonar/cache" backend/.scannerwork
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             -e SONAR_HOST_URL \
@@ -278,7 +278,8 @@ jobs:
             -v "${HOME}/.sonar:/usr/src/.sonar" \
             -w /usr/src/backend \
             "${SONAR_SCANNER_IMAGE}" \
-            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
+            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }} \
+            -Dsonar.working.directory=.scannerwork
 
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,14 +261,24 @@ jobs:
           echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v6
-        with:
-          projectBaseDir: backend
-          args: >
-            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonar.moneat.io
+          SONAR_SCANNER_IMAGE: sonarsource/sonar-scanner-cli:11.4.0.2044_7.2.0
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${HOME}/.sonar/cache"
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e SONAR_HOST_URL \
+            -e SONAR_TOKEN \
+            -e SONAR_USER_HOME=/usr/src/.sonar \
+            -v "${GITHUB_WORKSPACE}:/usr/src" \
+            -v "${HOME}/.sonar/cache:/usr/src/.sonar/cache" \
+            -w /usr/src/backend \
+            "${SONAR_SCANNER_IMAGE}" \
+            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
 
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,7 +275,7 @@ jobs:
             -e SONAR_TOKEN \
             -e SONAR_USER_HOME=/usr/src/.sonar \
             -v "${GITHUB_WORKSPACE}:/usr/src" \
-            -v "${HOME}/.sonar/cache:/usr/src/.sonar/cache" \
+            -v "${HOME}/.sonar:/usr/src/.sonar" \
             -w /usr/src/backend \
             "${SONAR_SCANNER_IMAGE}" \
             -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,25 +261,14 @@ jobs:
           echo "version=${version#v}" >> "$GITHUB_OUTPUT"
 
       - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        with:
+          projectBaseDir: backend
+          args: >
+            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonar.moneat.io
-          SONAR_SCANNER_IMAGE: sonarsource/sonar-scanner-cli:11.4.0.2044_7.2.0
-        run: |
-          set -euo pipefail
-
-          mkdir -p "${HOME}/.sonar/cache" backend/.scannerwork
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -e SONAR_HOST_URL \
-            -e SONAR_TOKEN \
-            -e SONAR_USER_HOME=/usr/src/.sonar \
-            -v "${GITHUB_WORKSPACE}:/usr/src" \
-            -v "${HOME}/.sonar:/usr/src/.sonar" \
-            -w /usr/src/backend \
-            "${SONAR_SCANNER_IMAGE}" \
-            -Dsonar.projectVersion=${{ steps.sonar-version.outputs.version }} \
-            -Dsonar.working.directory=.scannerwork
 
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check

--- a/backend/src/main/kotlin/com/moneat/datadog/models/DatadogTraceModels.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/models/DatadogTraceModels.kt
@@ -198,6 +198,7 @@ data class DdApmOverviewFacets(
     val services: List<DdApmFacetItem>,
     val sources: List<DdApmFacetItem>,
     val environments: List<DdApmFacetItem>,
+    val operations: List<DdApmFacetItem>,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -63,7 +63,8 @@ fun Route.traceDashboardRoutes() {
             get("/resources") {
                 val orgId = call.organizationId()
                     ?: return@get call.respondUnauthorized()
-                val service = call.parameters["service"]
+                val services = call.serviceFilters()
+                    ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
                 val env = call.parameters["env"]
                 val source = call.parameters["source"]
                 val search = call.traceSearch()
@@ -83,10 +84,11 @@ fun Route.traceDashboardRoutes() {
                 val result = TraceIngestionService.listResourceStats(
                     organizationId = orgId,
                     query = DdResourceStatsQuery(
-                        service = service,
+                        services = services,
                         env = env,
                         source = source,
                         status = status,
+                        operation = call.parameters["operation"]?.takeIf { it.isNotBlank() },
                         search = search,
                         limit = limit,
                         offset = offset,
@@ -101,6 +103,8 @@ fun Route.traceDashboardRoutes() {
             get("/overview") {
                 val orgId = call.organizationId()
                     ?: return@get call.respondUnauthorized()
+                val services = call.serviceFilters()
+                    ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
                 val status = call.apmStatus()
                     ?: return@get call.respondBadRequest(INVALID_STATUS_ERROR)
                 val timeRange = call.apmTimeRange()
@@ -109,10 +113,11 @@ fun Route.traceDashboardRoutes() {
                 val result = TraceIngestionService.getApmOverview(
                     organizationId = orgId,
                     query = DdTraceListQuery(
-                        service = call.parameters["service"],
+                        services = services,
                         env = call.parameters["env"],
                         source = call.parameters["source"],
                         status = status,
+                        operation = call.parameters["operation"]?.takeIf { it.isNotBlank() },
                         search = call.traceSearch(),
                         timeRange = timeRange,
                     ),
@@ -125,7 +130,8 @@ fun Route.traceDashboardRoutes() {
             get {
                 val orgId = call.organizationId()
                     ?: return@get call.respondUnauthorized()
-                val service = call.parameters["service"]
+                val services = call.serviceFilters()
+                    ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
                 val env = call.parameters["env"]
                 val source = call.parameters["source"]
                 val search = call.traceSearch()
@@ -145,10 +151,11 @@ fun Route.traceDashboardRoutes() {
                 val result = TraceIngestionService.listTraces(
                     organizationId = orgId,
                     query = DdTraceListQuery(
-                        service = service,
+                        services = services,
                         env = env,
                         source = source,
                         status = status,
+                        operation = call.parameters["operation"]?.takeIf { it.isNotBlank() },
                         search = search,
                         limit = limit,
                         offset = offset,

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -63,37 +63,12 @@ fun Route.traceDashboardRoutes() {
             get("/resources") {
                 val orgId = call.organizationId()
                     ?: return@get call.respondUnauthorized()
-                val services = call.serviceFilters()
-                    ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
-                val env = call.parameters["env"]
-                val source = call.parameters["source"]
-                val search = call.traceSearch()
-                val status = call.apmStatus()
-                    ?: return@get call.respondBadRequest(INVALID_STATUS_ERROR)
-                val limit = (
-                    call.parameters["limit"]
-                        ?.toIntOrNull() ?: DEFAULT_LIMIT
-                    )
-                    .coerceIn(1, MAX_LIMIT)
-                val offset = call.parameters["offset"]
-                    ?.toIntOrNull()
-                    ?.coerceAtLeast(0) ?: 0
-                val timeRange = call.apmTimeRange()
-                    ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
+                val query = call.apmRouteQuery()
+                    ?: return@get call.respondBadRequest(call.apmRouteQueryError())
 
                 val result = TraceIngestionService.listResourceStats(
                     organizationId = orgId,
-                    query = DdResourceStatsQuery(
-                        services = services,
-                        env = env,
-                        source = source,
-                        status = status,
-                        operation = call.parameters["operation"]?.takeIf { it.isNotBlank() },
-                        search = search,
-                        limit = limit,
-                        offset = offset,
-                        timeRange = timeRange,
-                    ),
+                    query = query.toResourceStatsQuery(),
                     parentSpan = call.getSentryTransaction(),
                 )
                 call.respond(result)
@@ -103,24 +78,12 @@ fun Route.traceDashboardRoutes() {
             get("/overview") {
                 val orgId = call.organizationId()
                     ?: return@get call.respondUnauthorized()
-                val services = call.serviceFilters()
-                    ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
-                val status = call.apmStatus()
-                    ?: return@get call.respondBadRequest(INVALID_STATUS_ERROR)
-                val timeRange = call.apmTimeRange()
-                    ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
+                val query = call.apmRouteQuery()
+                    ?: return@get call.respondBadRequest(call.apmRouteQueryError())
 
                 val result = TraceIngestionService.getApmOverview(
                     organizationId = orgId,
-                    query = DdTraceListQuery(
-                        services = services,
-                        env = call.parameters["env"],
-                        source = call.parameters["source"],
-                        status = status,
-                        operation = call.parameters["operation"]?.takeIf { it.isNotBlank() },
-                        search = call.traceSearch(),
-                        timeRange = timeRange,
-                    ),
+                    query = query.toTraceListQuery(),
                     parentSpan = call.getSentryTransaction(),
                 )
                 call.respond(result)
@@ -130,37 +93,12 @@ fun Route.traceDashboardRoutes() {
             get {
                 val orgId = call.organizationId()
                     ?: return@get call.respondUnauthorized()
-                val services = call.serviceFilters()
-                    ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
-                val env = call.parameters["env"]
-                val source = call.parameters["source"]
-                val search = call.traceSearch()
-                val status = call.apmStatus()
-                    ?: return@get call.respondBadRequest(INVALID_STATUS_ERROR)
-                val limit = (
-                    call.parameters["limit"]
-                        ?.toIntOrNull() ?: DEFAULT_LIMIT
-                    )
-                    .coerceIn(1, MAX_LIMIT)
-                val offset = call.parameters["offset"]
-                    ?.toIntOrNull()
-                    ?.coerceAtLeast(0) ?: 0
-                val timeRange = call.apmTimeRange()
-                    ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
+                val query = call.apmRouteQuery()
+                    ?: return@get call.respondBadRequest(call.apmRouteQueryError())
 
                 val result = TraceIngestionService.listTraces(
                     organizationId = orgId,
-                    query = DdTraceListQuery(
-                        services = services,
-                        env = env,
-                        source = source,
-                        status = status,
-                        operation = call.parameters["operation"]?.takeIf { it.isNotBlank() },
-                        search = search,
-                        limit = limit,
-                        offset = offset,
-                        timeRange = timeRange,
-                    ),
+                    query = query.toTraceListQuery(),
                     parentSpan = call.getSentryTransaction(),
                 )
                 call.respond(result)
@@ -255,6 +193,64 @@ private suspend fun ApplicationCall.respondBadRequest(error: String) {
     )
 }
 
+private data class ApmRouteQuery(
+    val services: List<String>,
+    val env: String?,
+    val source: String?,
+    val search: String?,
+    val status: String?,
+    val operation: String?,
+    val limit: Int,
+    val offset: Int,
+    val timeRange: DdApmQueryTimeRange,
+) {
+    fun toTraceListQuery(): DdTraceListQuery =
+        DdTraceListQuery(
+            services = services,
+            env = env,
+            source = source,
+            status = status,
+            operation = operation,
+            search = search,
+            limit = limit,
+            offset = offset,
+            timeRange = timeRange,
+        )
+
+    fun toResourceStatsQuery(): DdResourceStatsQuery =
+        DdResourceStatsQuery(
+            services = services,
+            env = env,
+            source = source,
+            status = status,
+            operation = operation,
+            search = search,
+            limit = limit,
+            offset = offset,
+            timeRange = timeRange,
+        )
+}
+
+private fun ApplicationCall.apmRouteQuery(): ApmRouteQuery? =
+    ApmRouteQuery(
+        services = serviceFilters() ?: return null,
+        env = parameters["env"],
+        source = parameters["source"],
+        search = traceSearch(),
+        status = apmStatus() ?: return null,
+        operation = parameters["operation"]?.takeIf { it.isNotBlank() },
+        limit = traceQueryLimit(),
+        offset = traceQueryOffset(),
+        timeRange = apmTimeRange() ?: return null,
+    )
+
+private fun ApplicationCall.apmRouteQueryError(): String =
+    when {
+        serviceFilters() == null -> INVALID_SERVICES_ERROR
+        apmStatus() == null -> INVALID_STATUS_ERROR
+        else -> INVALID_TIME_RANGE_ERROR
+    }
+
 private fun ApplicationCall.apmTimeRange(): DdApmQueryTimeRange? {
     val rawValue = parameters["timeRange"] ?: parameters["range"] ?: DEFAULT_APM_TIME_RANGE
     return apmTimeRanges[rawValue]
@@ -274,6 +270,12 @@ private fun ApplicationCall.traceSearch(): String? =
         ?.trim()
         ?.take(MAX_TRACE_SEARCH_LENGTH)
         ?.takeIf { it.isNotEmpty() }
+
+private fun ApplicationCall.traceQueryLimit(): Int =
+    (parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+
+private fun ApplicationCall.traceQueryOffset(): Int =
+    parameters["offset"]?.toIntOrNull()?.coerceAtLeast(0) ?: 0
 
 private fun ApplicationCall.serviceFilters(): List<String>? {
     val parsedServices = parameters["services"]

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -194,6 +194,7 @@ private suspend fun ApplicationCall.respondBadRequest(error: String) {
 }
 
 private data class ApmRouteQuery(
+    val service: String?,
     val services: List<String>,
     val env: String?,
     val source: String?,
@@ -206,6 +207,7 @@ private data class ApmRouteQuery(
 ) {
     fun toTraceListQuery(): DdTraceListQuery =
         DdTraceListQuery(
+            service = service,
             services = services,
             env = env,
             source = source,
@@ -219,6 +221,7 @@ private data class ApmRouteQuery(
 
     fun toResourceStatsQuery(): DdResourceStatsQuery =
         DdResourceStatsQuery(
+            service = service,
             services = services,
             env = env,
             source = source,
@@ -233,6 +236,7 @@ private data class ApmRouteQuery(
 
 private fun ApplicationCall.apmRouteQuery(): ApmRouteQuery? =
     ApmRouteQuery(
+        service = serviceFilter(),
         services = serviceFilters() ?: return null,
         env = parameters["env"],
         source = parameters["source"],
@@ -277,16 +281,17 @@ private fun ApplicationCall.traceQueryLimit(): Int =
 private fun ApplicationCall.traceQueryOffset(): Int =
     parameters["offset"]?.toIntOrNull()?.coerceAtLeast(0) ?: 0
 
+private fun ApplicationCall.serviceFilter(): String? =
+    parameters["service"]
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
 private fun ApplicationCall.serviceFilters(): List<String>? {
     val parsedServices = parameters["services"]
         ?.split(",")
         ?.map { it.trim() }
         ?.filter { it.isNotEmpty() }
-    val rawSingleService = parameters["service"]
-        ?.trim()
-        ?.takeIf { it.isNotEmpty() }
-        ?.let { listOf(it) }
-    val rawServices = parsedServices?.takeIf { it.isNotEmpty() } ?: rawSingleService ?: emptyList()
+    val rawServices = (parsedServices ?: emptyList()) + listOfNotNull(serviceFilter())
     if (rawServices.size > MAX_SERVICE_FILTERS) return null
 
     val services = rawServices.distinct()

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -150,7 +150,7 @@ fun Route.traceDashboardRoutes() {
                 ?: return@get call.respondUnauthorized()
             // Accept a multi-select `services` list (comma-separated); fall back to
             // the legacy single `service` param for backward compatibility.
-            val services = call.serviceFilters()
+            val services = call.apmErrorServiceFilters()
                 ?: return@get call.respondBadRequest(INVALID_SERVICES_ERROR)
             val limit = (
                 call.parameters["limit"]
@@ -292,6 +292,23 @@ private fun ApplicationCall.serviceFilters(): List<String>? {
         ?.map { it.trim() }
         ?.filter { it.isNotEmpty() }
     val rawServices = (parsedServices ?: emptyList()) + listOfNotNull(serviceFilter())
+    if (rawServices.size > MAX_SERVICE_FILTERS) return null
+
+    val services = rawServices.distinct()
+    if (services.size > MAX_SERVICE_FILTERS) return null
+    return services.takeIf {
+        it.all { service -> service.length <= MAX_SERVICE_FILTER_LENGTH }
+    }
+}
+
+private fun ApplicationCall.apmErrorServiceFilters(): List<String>? {
+    val parsedServices = parameters["services"]
+        ?.split(",")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+    val rawServices = parsedServices
+        ?.takeIf { it.isNotEmpty() }
+        ?: listOfNotNull(serviceFilter())
     if (rawServices.size > MAX_SERVICE_FILTERS) return null
 
     val services = rawServices.distinct()

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -110,9 +110,11 @@ val defaultApmQueryTimeRange = DdApmQueryTimeRange(24, DdApmQueryTimeUnit.HOUR)
 
 data class DdResourceStatsQuery(
     val service: String? = null,
+    val services: List<String> = emptyList(),
     val env: String? = null,
     val source: String? = null,
     val status: String? = null,
+    val operation: String? = null,
     val search: String? = null,
     val limit: Int = DEFAULT_QUERY_LIMIT,
     val offset: Int = 0,
@@ -121,9 +123,11 @@ data class DdResourceStatsQuery(
 
 data class DdTraceListQuery(
     val service: String? = null,
+    val services: List<String> = emptyList(),
     val env: String? = null,
     val source: String? = null,
     val status: String? = null,
+    val operation: String? = null,
     val search: String? = null,
     val limit: Int = DEFAULT_QUERY_LIMIT,
     val offset: Int = 0,
@@ -390,9 +394,10 @@ object TraceIngestionService {
             finalizedFilters.add(query.timeRange.bucketStartClause("trace_bucket"))
             finalizedFilters.add("trace_bucket < $liveBoundary")
         }
-        query.service?.let { finalizedFilters.add("root_service = '${escapeSql(it)}'") }
+        serviceFilterClause("root_service", query.service, query.services)?.let(finalizedFilters::add)
         query.env?.let { finalizedFilters.add("env = '${escapeSql(it)}'") }
         query.source?.let { finalizedFilters.add("source = '${escapeSql(it)}'") }
+        query.operation?.let { finalizedFilters.add("root_resource = '${escapeSql(it)}'") }
         when (query.status) {
             STATUS_ERROR -> finalizedFilters.add("has_error = 1")
             STATUS_OK -> finalizedFilters.add("has_error = 0")
@@ -418,9 +423,10 @@ object TraceIngestionService {
             "bucket_start >= $liveBoundary",
         )
         val liveHaving = mutableListOf<String>()
-        query.service?.let { liveHaving.add("root_service = '${escapeSql(it)}'") }
+        serviceFilterClause("root_service", query.service, query.services)?.let(liveHaving::add)
         query.env?.let { liveHaving.add("env = '${escapeSql(it)}'") }
         query.source?.let { liveHaving.add("source = '${escapeSql(it)}'") }
+        query.operation?.let { liveHaving.add("root_resource = '${escapeSql(it)}'") }
         when (query.status) {
             STATUS_ERROR -> liveHaving.add("has_error = 1")
             STATUS_OK -> liveHaving.add("has_error = 0")
@@ -772,6 +778,10 @@ object TraceIngestionService {
             SELECT 'env' as facet_type, env as value, count() as count
             FROM ($subquery) WHERE env != ''
             GROUP BY env ORDER BY count DESC, value ASC LIMIT $MAX_FILTER_FACETS
+            UNION ALL
+            SELECT 'operation' as facet_type, root_resource as value, count() as count
+            FROM ($subquery) WHERE root_resource != ''
+            GROUP BY root_resource ORDER BY count DESC, value ASC LIMIT $MAX_FILTER_FACETS
             FORMAT JSONEachRow
         """.trimIndent()
 
@@ -779,6 +789,7 @@ object TraceIngestionService {
         val services = mutableListOf<DdApmFacetItem>()
         val sources = mutableListOf<DdApmFacetItem>()
         val environments = mutableListOf<DdApmFacetItem>()
+        val operations = mutableListOf<DdApmFacetItem>()
         for (obj in rows) {
             val item = DdApmFacetItem(
                 value = obj.stringValue("value"),
@@ -788,12 +799,14 @@ object TraceIngestionService {
                 "service" -> services.add(item)
                 "source" -> sources.add(item)
                 "env" -> environments.add(item)
+                "operation" -> operations.add(item)
             }
         }
         return DdApmOverviewFacets(
             services = services,
             sources = sources,
             environments = environments,
+            operations = operations,
         )
     }
 
@@ -1176,7 +1189,7 @@ object TraceIngestionService {
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
             query.timeRange.bucketStartClause()
         )
-        query.service?.let { filters.add("service = '${escapeSql(it)}'") }
+        serviceFilterClause("service", query.service, query.services)?.let(filters::add)
         val whereClause = filters.joinToString(" AND ")
 
         val countQuery = """
@@ -1265,9 +1278,11 @@ object TraceIngestionService {
             organizationId = organizationId,
             query = DdTraceListQuery(
                 service = query.service,
+                services = query.services,
                 env = query.env,
                 source = query.source,
                 status = query.status.takeUnless { it == STATUS_ERROR },
+                operation = query.operation,
                 search = query.search,
                 timeRange = query.timeRange,
             ),
@@ -1343,9 +1358,29 @@ object TraceIngestionService {
         !env.isNullOrBlank() ||
             !source.isNullOrBlank() ||
             !status.isNullOrBlank() ||
+            !operation.isNullOrBlank() ||
             !search.isNullOrBlank()
 
     // --- Internal helpers ---
+    private fun serviceFilterClause(
+        column: String,
+        service: String?,
+        services: List<String>,
+    ): String? {
+        val values = (services + listOfNotNull(service))
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+        return when (values.size) {
+            0 -> null
+            1 -> "$column = '${escapeSql(values.first())}'"
+            else -> {
+                val serviceList = values.joinToString(", ") { "'${escapeSql(it)}'" }
+                "$column IN ($serviceList)"
+            }
+        }
+    }
+
     private suspend fun executeDashboardQuery(
         query: String,
         format: String,

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -361,7 +361,8 @@ class DatadogQueryRoutesTest {
         installTraceRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get(
-            "/v1/traces/resources?service=api&env=prod&source=otlp&status=error&search=checkout&limit=500&offset=-10"
+            "/v1/traces/resources?services=api,worker&env=prod&source=otlp&status=error" +
+                "&operation=POST%20%2Fcheckout&search=checkout&limit=500&offset=-10"
         ) {
             withAuth(token)
         }
@@ -371,10 +372,11 @@ class DatadogQueryRoutesTest {
             TraceIngestionService.listResourceStats(
                 organizationId = 10,
                 query = match {
-                    it.service == "api" &&
+                    it.services == listOf("api", "worker") &&
                         it.env == "prod" &&
                         it.source == "otlp" &&
                         it.status == "error" &&
+                        it.operation == "POST /checkout" &&
                         it.search == "checkout" &&
                         it.limit == 200 &&
                         it.offset == 0
@@ -396,7 +398,8 @@ class DatadogQueryRoutesTest {
         installTraceRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get(
-            "/v1/traces?service=api&env=prod&source=otlp&status=error&search=checkout&limit=500&offset=-10"
+            "/v1/traces?services=api,worker&env=prod&source=otlp&status=error" +
+                "&operation=POST%20%2Fcheckout&search=checkout&limit=500&offset=-10"
         ) {
             withAuth(token)
         }
@@ -406,10 +409,11 @@ class DatadogQueryRoutesTest {
             TraceIngestionService.listTraces(
                 organizationId = 10,
                 query = match {
-                    it.service == "api" &&
+                    it.services == listOf("api", "worker") &&
                         it.env == "prod" &&
                         it.source == "otlp" &&
                         it.status == "error" &&
+                        it.operation == "POST /checkout" &&
                         it.limit == 200 &&
                         it.offset == 0 &&
                         it.search == "checkout"
@@ -472,6 +476,7 @@ class DatadogQueryRoutesTest {
                 services = emptyList(),
                 sources = emptyList(),
                 environments = emptyList(),
+                operations = emptyList(),
             ),
         )
 

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -357,6 +357,15 @@ class DatadogQueryRoutesTest {
     }
 
     @Test
+    fun `traces overview rejects invalid services`() = testApplication {
+        installTraceRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val services = (1..51).joinToString(",") { "service-$it" }
+        val resp = client.get("/v1/traces/overview?services=$services") { withAuth(token) }
+        assertEquals(HttpStatusCode.BadRequest, resp.status)
+    }
+
+    @Test
     fun `traces resources forwards server side filters`() = testApplication {
         installTraceRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
@@ -391,6 +400,34 @@ class DatadogQueryRoutesTest {
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get("/v1/traces/overview?timeRange=2y") { withAuth(token) }
         assertEquals(HttpStatusCode.BadRequest, resp.status)
+    }
+
+    @Test
+    fun `traces overview forwards server side filters`() = testApplication {
+        installTraceRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
+        val resp = client.get(
+            "/v1/traces/overview?services=api,worker&env=prod&source=otlp&status=ok" +
+                "&operation=GET%20%2Forders&search=orders&timeRange=7d"
+        ) {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, resp.status)
+        coVerify {
+            TraceIngestionService.getApmOverview(
+                organizationId = 10,
+                query = match {
+                    it.services == listOf("api", "worker") &&
+                        it.env == "prod" &&
+                        it.source == "otlp" &&
+                        it.status == "ok" &&
+                        it.operation == "GET /orders" &&
+                        it.search == "orders"
+                },
+                parentSpan = any(),
+            )
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
@@ -450,6 +450,30 @@ class TraceIngestionServiceCoverageTest {
     }
 
     @Test
+    fun `listTraces applies services list to server side query`() = runBlocking {
+        val capturedQueries = mutableListOf<String>()
+        coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
+            capturedQueries.add(firstArg())
+            if (secondArg<String>() == "TabSeparated") {
+                "0"
+            } else {
+                ""
+            }
+        }
+
+        TraceIngestionService.listTraces(
+            organizationId = 1,
+            query = DdTraceListQuery(
+                services = listOf("api", "worker"),
+                limit = 10,
+                offset = 0,
+            )
+        )
+
+        assertTrue(capturedQueries.any { it.contains("root_service IN ('api', 'worker')") })
+    }
+
+    @Test
     fun `listTraces applies search to server side query`() = runBlocking {
         val capturedQueries = mutableListOf<String>()
         coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
@@ -499,6 +523,7 @@ class TraceIngestionServiceCoverageTest {
         assertTrue(capturedQueries.any { it.contains("UNION ALL") && it.contains("apm_trace_summaries") })
         assertTrue(capturedQueries.any { it.contains("trace_bucket < toStartOfHour(now() - INTERVAL 2 HOUR)") })
         assertTrue(capturedQueries.any { it.contains("bucket_start >= toStartOfHour(now() - INTERVAL 2 HOUR)") })
+        assertTrue(capturedQueries.any { it.contains("SELECT 'operation' as facet_type") })
     }
 
     // ===================== getTraceDetail =====================

--- a/dashboard/src/lib/api/modules/__tests__/apm.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/apm.test.ts
@@ -50,9 +50,11 @@ describe('APM API', () => {
       http.get(`${API_BASE}/v1/traces`, ({ request }) => {
         const url = new URL(request.url)
         expect(url.searchParams.get('service')).toBe('api-gateway')
+        expect(url.searchParams.get('services')).toBe('api-gateway,worker')
         expect(url.searchParams.get('source')).toBe('otlp')
         expect(url.searchParams.get('status')).toBe('error')
         expect(url.searchParams.get('env')).toBe('production')
+        expect(url.searchParams.get('operation')).toBe('POST /checkout')
         expect(url.searchParams.get('search')).toBe('checkout')
         expect(url.searchParams.get('limit')).toBe('20')
         expect(url.searchParams.get('offset')).toBe('10')
@@ -63,9 +65,11 @@ describe('APM API', () => {
 
     const result = await api.getApmTraces({
       service: 'api-gateway',
+      services: ['api-gateway', 'worker'],
       source: 'otlp',
       status: 'error',
       env: 'production',
+      operation: 'POST /checkout',
       search: 'checkout',
       limit: 20,
       offset: 10,
@@ -101,16 +105,18 @@ describe('APM API', () => {
       serviceHealth: [],
       resourceHotspots: [],
       errors: [],
-      facets: { services: [], sources: [], environments: [] },
+      facets: { services: [], sources: [], environments: [], operations: [] },
     }
 
     server.use(
       http.get(`${API_BASE}/v1/traces/overview`, ({ request }) => {
         const url = new URL(request.url)
         expect(url.searchParams.get('service')).toBe('api-gateway')
+        expect(url.searchParams.get('services')).toBe('api-gateway,worker')
         expect(url.searchParams.get('source')).toBe('sentry')
         expect(url.searchParams.get('status')).toBe('ok')
         expect(url.searchParams.get('env')).toBe('production')
+        expect(url.searchParams.get('operation')).toBe('GET /orders')
         expect(url.searchParams.get('search')).toBe('checkout')
         expect(url.searchParams.get('timeRange')).toBe('24h')
         return HttpResponse.json(mockResponse)
@@ -119,9 +125,11 @@ describe('APM API', () => {
 
     const result = await api.getApmOverview({
       service: 'api-gateway',
+      services: ['api-gateway', 'worker'],
       source: 'sentry',
       status: 'ok',
       env: 'production',
+      operation: 'GET /orders',
       search: 'checkout',
       timeRange: '24h',
     })
@@ -306,6 +314,7 @@ describe('APM API', () => {
       http.get(`${API_BASE}/v1/apm-errors`, ({ request }) => {
         const url = new URL(request.url)
         expect(url.searchParams.get('service')).toBe('payment-svc')
+        expect(url.searchParams.get('services')).toBe('payment-svc,worker')
         expect(url.searchParams.get('limit')).toBe('50')
         expect(url.searchParams.get('offset')).toBe('0')
         expect(url.searchParams.get('timeRange')).toBe('90d')
@@ -315,6 +324,7 @@ describe('APM API', () => {
 
     const result = await api.getApmErrors({
       service: 'payment-svc',
+      services: ['payment-svc', 'worker'],
       limit: 50,
       offset: 0,
       timeRange: '90d',
@@ -344,9 +354,11 @@ describe('APM API', () => {
       http.get(`${API_BASE}/v1/traces/resources`, ({ request }) => {
         const url = new URL(request.url)
         expect(url.searchParams.get('service')).toBe('user-svc')
+        expect(url.searchParams.get('services')).toBe('user-svc,worker')
         expect(url.searchParams.get('source')).toBe('otlp')
         expect(url.searchParams.get('status')).toBe('error')
         expect(url.searchParams.get('env')).toBe('production')
+        expect(url.searchParams.get('operation')).toBe('POST /users')
         expect(url.searchParams.get('search')).toBe('checkout')
         expect(url.searchParams.get('limit')).toBe('10')
         expect(url.searchParams.get('offset')).toBe('20')
@@ -357,9 +369,11 @@ describe('APM API', () => {
 
     const result = await api.getApmResourceStats({
       service: 'user-svc',
+      services: ['user-svc', 'worker'],
       source: 'otlp',
       status: 'error',
       env: 'production',
+      operation: 'POST /users',
       search: 'checkout',
       limit: 10,
       offset: 20,

--- a/dashboard/src/lib/api/modules/apm.ts
+++ b/dashboard/src/lib/api/modules/apm.ts
@@ -33,6 +33,7 @@ type ApmListParams = {
   source?: string
   env?: string
   status?: ApmStatusFilter
+  operation?: string
   search?: string
   limit?: number
   offset?: number
@@ -45,6 +46,7 @@ function appendApmListParams(searchParams: URLSearchParams, params: ApmListParam
   if (params.source) searchParams.set('source', params.source)
   if (params.env) searchParams.set('env', params.env)
   if (params.status) searchParams.set('status', params.status)
+  if (params.operation) searchParams.set('operation', params.operation)
   if (params.search) searchParams.set('search', params.search)
   if (params.limit != null) searchParams.set('limit', String(params.limit))
   if (params.offset != null) searchParams.set('offset', String(params.offset))

--- a/dashboard/src/lib/api/types/apm.ts
+++ b/dashboard/src/lib/api/types/apm.ts
@@ -93,6 +93,7 @@ export interface ApmOverviewFacets {
   services: ApmFacetItem[]
   sources: ApmFacetItem[]
   environments: ApmFacetItem[]
+  operations: ApmFacetItem[]
 }
 
 export interface ApmOverviewResponse {

--- a/dashboard/src/routes/__tests__/performance-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/performance-coverage.test.tsx
@@ -98,6 +98,7 @@ const mockOverview = {
     services: [{value: 'checkout-service', count: 5642}],
     sources: [{value: 'otlp', count: 5000}],
     environments: [{value: 'production', count: 5000}],
+    operations: [{value: 'POST /checkout', count: 1234}],
   },
 }
 
@@ -206,6 +207,27 @@ describe('Performance routes', () => {
     expect((await screen.findAllByText('POST /checkout')).length).toBeGreaterThan(0)
     await waitFor(() => {
       expect(mockApi.getApmTraces).toHaveBeenCalledWith(expect.objectContaining({
+        limit: 25,
+        offset: 0,
+      }))
+    })
+  })
+
+  it('applies trace facet rail filters to dashboard queries', async () => {
+    const Component = (PerformanceTracesRoute as unknown as {component: React.ComponentType}).component
+    renderWithQueryClient(Component)
+
+    fireEvent.click(await screen.findByLabelText('checkout-service'))
+    fireEvent.click(await screen.findByLabelText('POST /checkout'))
+
+    await waitFor(() => {
+      expect(mockApi.getApmOverview).toHaveBeenCalledWith(expect.objectContaining({
+        services: ['checkout-service'],
+        operation: 'POST /checkout',
+      }))
+      expect(mockApi.getApmTraces).toHaveBeenCalledWith(expect.objectContaining({
+        services: ['checkout-service'],
+        operation: 'POST /checkout',
         limit: 25,
         offset: 0,
       }))

--- a/dashboard/src/routes/__tests__/performance-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/performance-coverage.test.tsx
@@ -264,6 +264,9 @@ describe('Performance routes', () => {
       }))
     })
 
+    fireEvent.click(screen.getByRole('button', {name: /Refresh/i}))
+    await waitFor(() => expect(mockApi.getApmResourceStats).toHaveBeenCalledTimes(2))
+
     fireEvent.click(viewAllButton)
     await waitFor(() => expect(scrollIntoViewMock).toHaveBeenCalledTimes(2))
   })

--- a/dashboard/src/routes/performance.traces.index.tsx
+++ b/dashboard/src/routes/performance.traces.index.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {createFileRoute, Link} from '@tanstack/react-router'
-import {useQuery} from '@tanstack/react-query'
+import {useQuery, useQueryClient} from '@tanstack/react-query'
 import {useEffect, useMemo, useRef, useState, type ReactNode, type RefObject} from 'react'
 import {
   CartesianGrid,
@@ -214,6 +214,7 @@ const RECENT_TRACE_SKELETON_CELLS: SkeletonCellSpec[] = [
 ]
 
 function PerformanceTracesPage() {
+  const queryClient = useQueryClient()
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('24h')
   const [refresh, setRefresh] = useState<RefreshValue>('15s')
   const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
@@ -341,6 +342,7 @@ function PerformanceTracesPage() {
             onClick={() => {
               void overviewQuery.refetch()
               void tracesQuery.refetch()
+              void queryClient.refetchQueries({queryKey: ['apm-erroring-resources']})
             }}
           >
             <RefreshCw className="h-3.5 w-3.5" />

--- a/dashboard/src/routes/performance.traces.index.tsx
+++ b/dashboard/src/routes/performance.traces.index.tsx
@@ -42,7 +42,6 @@ import {
   RefreshCw,
   Search,
   Server,
-  SlidersHorizontal,
   X,
 } from 'lucide-react'
 import {
@@ -59,9 +58,12 @@ import {Button} from '@/components/ui/button'
 import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
 import {Input} from '@/components/ui/input'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
-import {Switch} from '@/components/ui/switch'
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
+import {FacetRail} from '@/components/filters/FacetRail'
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import type {FacetFilter, FacetRailSection, FacetSchema} from '@/lib/filters/types'
 import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/performance/traces/')({
@@ -99,22 +101,56 @@ const SERVICE_DOTS = [
   'bg-chart-7',
 ]
 
-type TraceStatusSelect = 'all' | ApmStatusFilter
-type RefreshValue = (typeof REFRESH_OPTIONS)[number]['value']
+const TRACE_FACET_SCHEMA = [
+  {
+    key: 'service',
+    label: 'Service',
+    aliases: ['svc'],
+    color: 'bg-chart-1',
+    allowExclude: false,
+  },
+  {
+    key: 'operation',
+    label: 'Operation',
+    aliases: ['resource', 'op'],
+    color: 'bg-chart-2',
+    singleSelect: true,
+    allowExclude: false,
+  },
+  {
+    key: 'env',
+    label: 'Environment',
+    aliases: ['environment'],
+    color: 'bg-chart-3',
+    singleSelect: true,
+    allowExclude: false,
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    color: 'bg-chart-4',
+    singleSelect: true,
+    allowExclude: false,
+    suggestions: ['error', 'ok'],
+  },
+  {
+    key: 'source',
+    label: 'Source',
+    color: 'bg-chart-6',
+    singleSelect: true,
+    allowExclude: false,
+  },
+] satisfies FacetSchema
 
-interface TraceFilters {
-  service: string
-  source: string
-  status: TraceStatusSelect
-  env: string
-}
+type RefreshValue = (typeof REFRESH_OPTIONS)[number]['value']
 
 interface OverviewParams {
   timeRange: ApmTimeRange
-  service?: string
+  services?: string[]
   source?: string
   status?: ApmStatusFilter
   env?: string
+  operation?: string
   search?: string
 }
 
@@ -180,29 +216,26 @@ const RECENT_TRACE_SKELETON_CELLS: SkeletonCellSpec[] = [
 function PerformanceTracesPage() {
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('24h')
   const [refresh, setRefresh] = useState<RefreshValue>('15s')
-  const [draftFilters, setDraftFilters] = useState<TraceFilters>(emptyFilters)
-  const [appliedFilters, setAppliedFilters] = useState<TraceFilters>(emptyFilters)
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
   const [search, setSearch] = useState('')
-  const [errorsOnly, setErrorsOnly] = useState(false)
   const [page, setPage] = useState(0)
   const [showErroringResources, setShowErroringResources] = useState(false)
   const [erroringResourcesScrollKey, setErroringResourcesScrollKey] = useState(0)
   const erroringResourcesRef = useRef<HTMLDivElement | null>(null)
 
   const queryParams = useMemo(
-    () => toOverviewParams(timeRange, appliedFilters),
-    [timeRange, appliedFilters],
+    () => toOverviewParams(timeRange, facetFilters),
+    [timeRange, facetFilters],
   )
   const debouncedSearch = useDebouncedValue(search.trim(), SEARCH_DEBOUNCE_MS)
   const traceQueryParams = useMemo<TraceListParams>(
     () => ({
       ...queryParams,
-      status: errorsOnly ? 'error' : queryParams.status,
       search: debouncedSearch === '' ? undefined : debouncedSearch,
       limit: TRACE_PAGE_SIZE,
       offset: page * TRACE_PAGE_SIZE,
     }),
-    [debouncedSearch, errorsOnly, page, queryParams],
+    [debouncedSearch, page, queryParams],
   )
   const overviewParams = useMemo<OverviewParams>(
     () => ({
@@ -229,6 +262,7 @@ function PerformanceTracesPage() {
   const traces = tracesQuery.data?.traces ?? []
   const totalTraces = tracesQuery.data?.totalCount ?? 0
   const totalPages = Math.max(1, Math.ceil(totalTraces / TRACE_PAGE_SIZE))
+  const railSections = useMemo(() => buildTraceFacetSections(overview), [overview])
 
   useEffect(() => {
     if (page >= totalPages) {
@@ -247,26 +281,13 @@ function PerformanceTracesPage() {
     panel.scrollIntoView({block: 'start', behavior: 'smooth'})
   }, [erroringResourcesScrollKey, showErroringResources])
 
-  const applyFilters = () => {
-    setAppliedFilters(draftFilters)
+  const updateFacetFilters = (filters: FacetFilter[]) => {
+    setFacetFilters(filters)
     setPage(0)
   }
 
   const updateSearch = (value: string) => {
     setSearch(value)
-    setPage(0)
-  }
-
-  const updateErrorsOnly = (value: boolean) => {
-    setErrorsOnly(value)
-    setPage(0)
-  }
-
-  const clearFilters = () => {
-    setDraftFilters(emptyFilters)
-    setAppliedFilters(emptyFilters)
-    setSearch('')
-    setErrorsOnly(false)
     setPage(0)
   }
 
@@ -276,45 +297,57 @@ function PerformanceTracesPage() {
   }
 
   return (
-    <div className="min-w-0 px-4 py-4 sm:px-6 lg:px-8">
-      <div className="mb-4 flex flex-col gap-3 border-b pb-4 lg:flex-row lg:items-end lg:justify-between">
-        <div className="min-w-0">
-          <h1 className="text-xl font-semibold tracking-tight">Health overview</h1>
-          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
-            Analyze trace health, latency, and errors across services. Telemetry sources are metadata only.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Select value={timeRange} onValueChange={(value) => {
-            setTimeRange(value as ApmTimeRange)
-            setPage(0)
-          }}>
-            <SelectTrigger className="h-9 w-[164px] gap-2">
-              <CalendarDays className="h-4 w-4 text-muted-foreground" />
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {TIME_RANGE_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+    <ExplorerShell
+      className="min-h-[calc(100vh-4rem)]"
+      title="Traces"
+      icon={<Gauge className="h-4 w-4 text-muted-foreground" />}
+      searchBar={(
+        <SearchFilterBar
+          query={search}
+          onQueryChange={updateSearch}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={updateFacetFilters}
+          schema={TRACE_FACET_SCHEMA}
+          placeholder="Search trace ID, resource, or service"
+          trailing={(
+            <Select
+              value={timeRange}
+              onValueChange={(value) => {
+                setTimeRange(value as ApmTimeRange)
+                setPage(0)
+              }}
+            >
+              <SelectTrigger className="h-[30px] w-[154px] gap-2">
+                <CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TIME_RANGE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
+      )}
+      actions={(
+        <>
           <Button
             variant="outline"
             size="sm"
-            className="h-9 gap-2"
+            className="h-[30px] gap-2"
             onClick={() => {
-              overviewQuery.refetch()
-              tracesQuery.refetch()
+              void overviewQuery.refetch()
+              void tracesQuery.refetch()
             }}
           >
-            <RefreshCw className="h-4 w-4" />
+            <RefreshCw className="h-3.5 w-3.5" />
             Refresh
           </Button>
           <Select value={refresh} onValueChange={(value) => setRefresh(value as RefreshValue)}>
-            <SelectTrigger className="h-9 w-[92px]">
+            <SelectTrigger className="h-[30px] w-[92px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -325,211 +358,119 @@ function PerformanceTracesPage() {
               ))}
             </SelectContent>
           </Select>
-        </div>
-      </div>
-
-      <TraceFilterBar
-        filters={draftFilters}
-        overview={overview}
-        onChange={setDraftFilters}
-        onApply={applyFilters}
-        onClear={clearFilters}
-      />
-
-      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
-        {overviewQuery.isLoading ? (
-          Array.from({length: KPI_CARD_COUNT}, (_, index) => (
-            <KpiCardSkeleton key={`kpi-card-skeleton-${index}`} />
-          ))
-        ) : (
-          <>
-            <KpiCard
-              title="Total Traces"
-              value={formatCount(overview.stats.totalTraces)}
-              previous={overview.stats.previous.totalTraces}
-              current={overview.stats.totalTraces}
-              icon={<Layers className="h-4 w-4" />}
-            />
-            <KpiCard
-              title="Error Rate"
-              value={formatPercent(overview.stats.errorRate)}
-              previous={overview.stats.previous.errorRate}
-              current={overview.stats.errorRate}
-              icon={<AlertTriangle className="h-4 w-4" />}
-              inverted
-            />
-            <KpiCard
-              title="p50 Latency"
-              value={formatDuration(overview.stats.p50DurationNs)}
-              previous={overview.stats.previous.p50DurationNs}
-              current={overview.stats.p50DurationNs}
-              icon={<Clock className="h-4 w-4" />}
-              series={overview.latencySeries.map((point) => point.p50DurationNs)}
-              inverted
-            />
-            <KpiCard
-              title="p95 Latency"
-              value={formatDuration(overview.stats.p95DurationNs)}
-              previous={overview.stats.previous.p95DurationNs}
-              current={overview.stats.p95DurationNs}
-              icon={<Gauge className="h-4 w-4" />}
-              series={overview.latencySeries.map((point) => point.p95DurationNs)}
-              inverted
-            />
-            <KpiCard
-              title="p99 Latency"
-              value={formatDuration(overview.stats.p99DurationNs)}
-              previous={overview.stats.previous.p99DurationNs}
-              current={overview.stats.p99DurationNs}
-              icon={<Gauge className="h-4 w-4" />}
-              series={overview.latencySeries.map((point) => point.p99DurationNs)}
-              inverted
-            />
-            <KpiCard
-              title="Avg Spans / Trace"
-              value={overview.stats.avgSpansPerTrace.toFixed(1)}
-              previous={overview.stats.previous.avgSpansPerTrace}
-              current={overview.stats.avgSpansPerTrace}
-              icon={<Hash className="h-4 w-4" />}
-              inverted
-            />
-          </>
-        )}
-      </div>
-
-      <div className="mt-4 grid min-w-0 gap-3 xl:grid-cols-2 2xl:grid-cols-[1fr_1fr_1fr]">
-        <ServiceHealthPanel overview={overview} isLoading={overviewQuery.isLoading} />
-        <LatencyPanel overview={overview} isLoading={overviewQuery.isLoading} />
-        <ErrorsResourcesPanel
-          overview={overview}
-          isLoading={overviewQuery.isLoading}
-          isShowingAllErroringResources={showErroringResources}
-          onViewAllErroringResources={viewAllErroringResources}
-        />
-      </div>
-
-      {showErroringResources && (
-        <AllErroringResourcesPanel
-          panelRef={erroringResourcesRef}
-          queryParams={queryParams}
-          refreshMs={refreshMs}
-          onClose={() => setShowErroringResources(false)}
+        </>
+      )}
+      rail={(
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={updateFacetFilters}
+          title="Trace facets"
         />
       )}
+      toolbar={<span className="text-xs text-muted-foreground">{formatCount(totalTraces)} traces</span>}
+    >
+      <div className="min-w-0 px-4 py-4 sm:px-6 lg:px-8">
+        <div className="mb-4 border-b pb-4">
+          <div className="min-w-0">
+            <h1 className="text-xl font-semibold tracking-tight">Health overview</h1>
+            <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+              Analyze trace health, latency, and errors across services. Telemetry sources are metadata only.
+            </p>
+          </div>
+        </div>
 
-      <RecentTracesPanel
-        traces={traces}
-        totalTraces={totalTraces}
-        page={page}
-        totalPages={totalPages}
-        search={search}
-        errorsOnly={errorsOnly}
-        isLoading={tracesQuery.isLoading}
-        onSearch={updateSearch}
-        onErrorsOnly={updateErrorsOnly}
-        onPageChange={setPage}
-      />
-    </div>
-  )
-}
+        <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
+          {overviewQuery.isLoading ? (
+            Array.from({length: KPI_CARD_COUNT}, (_, index) => (
+              <KpiCardSkeleton key={`kpi-card-skeleton-${index}`} />
+            ))
+          ) : (
+            <>
+              <KpiCard
+                title="Total Traces"
+                value={formatCount(overview.stats.totalTraces)}
+                previous={overview.stats.previous.totalTraces}
+                current={overview.stats.totalTraces}
+                icon={<Layers className="h-4 w-4" />}
+              />
+              <KpiCard
+                title="Error Rate"
+                value={formatPercent(overview.stats.errorRate)}
+                previous={overview.stats.previous.errorRate}
+                current={overview.stats.errorRate}
+                icon={<AlertTriangle className="h-4 w-4" />}
+                inverted
+              />
+              <KpiCard
+                title="p50 Latency"
+                value={formatDuration(overview.stats.p50DurationNs)}
+                previous={overview.stats.previous.p50DurationNs}
+                current={overview.stats.p50DurationNs}
+                icon={<Clock className="h-4 w-4" />}
+                series={overview.latencySeries.map((point) => point.p50DurationNs)}
+                inverted
+              />
+              <KpiCard
+                title="p95 Latency"
+                value={formatDuration(overview.stats.p95DurationNs)}
+                previous={overview.stats.previous.p95DurationNs}
+                current={overview.stats.p95DurationNs}
+                icon={<Gauge className="h-4 w-4" />}
+                series={overview.latencySeries.map((point) => point.p95DurationNs)}
+                inverted
+              />
+              <KpiCard
+                title="p99 Latency"
+                value={formatDuration(overview.stats.p99DurationNs)}
+                previous={overview.stats.previous.p99DurationNs}
+                current={overview.stats.p99DurationNs}
+                icon={<Gauge className="h-4 w-4" />}
+                series={overview.latencySeries.map((point) => point.p99DurationNs)}
+                inverted
+              />
+              <KpiCard
+                title="Avg Spans / Trace"
+                value={overview.stats.avgSpansPerTrace.toFixed(1)}
+                previous={overview.stats.previous.avgSpansPerTrace}
+                current={overview.stats.avgSpansPerTrace}
+                icon={<Hash className="h-4 w-4" />}
+                inverted
+              />
+            </>
+          )}
+        </div>
 
-function TraceFilterBar({
-  filters,
-  overview,
-  onChange,
-  onApply,
-  onClear,
-}: {
-  filters: TraceFilters
-  overview: ApmOverviewResponse
-  onChange: (filters: TraceFilters) => void
-  onApply: () => void
-  onClear: () => void
-}) {
-  return (
-    <div className="grid gap-2 rounded-lg border bg-card p-3 lg:grid-cols-[1fr_1fr_1fr_1fr_auto_auto]">
-      <FilterSelect
-        label="Service"
-        value={filters.service}
-        placeholder="All services"
-        options={overview.facets.services}
-        onChange={(service) => onChange({...filters, service})}
-      />
-      <FilterSelect
-        label="Source"
-        value={filters.source}
-        placeholder="All sources"
-        options={overview.facets.sources}
-        onChange={(source) => onChange({...filters, source})}
-      />
-      <div className="space-y-1">
-        <div className="text-xs font-medium text-muted-foreground">Status</div>
-        <Select
-          value={filters.status}
-          onValueChange={(status) => onChange({...filters, status: status as TraceStatusSelect})}
-        >
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All statuses</SelectItem>
-            <SelectItem value="error">Errors</SelectItem>
-            <SelectItem value="ok">OK</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <FilterSelect
-        label="Environment"
-        value={filters.env}
-        placeholder="All environments"
-        options={overview.facets.environments}
-        onChange={(env) => onChange({...filters, env})}
-      />
-      <div className="flex items-end">
-        <Button variant="outline" size="sm" className="h-9 w-full gap-2" onClick={onClear}>
-          Clear
-        </Button>
-      </div>
-      <div className="flex items-end">
-        <Button size="sm" className="h-9 w-full gap-2" onClick={onApply}>
-          <SlidersHorizontal className="h-4 w-4" />
-          Apply
-        </Button>
-      </div>
-    </div>
-  )
-}
+        <div className="mt-4 grid min-w-0 gap-3 xl:grid-cols-2 2xl:grid-cols-[1fr_1fr_1fr]">
+          <ServiceHealthPanel overview={overview} isLoading={overviewQuery.isLoading} />
+          <LatencyPanel overview={overview} isLoading={overviewQuery.isLoading} />
+          <ErrorsResourcesPanel
+            overview={overview}
+            isLoading={overviewQuery.isLoading}
+            isShowingAllErroringResources={showErroringResources}
+            onViewAllErroringResources={viewAllErroringResources}
+          />
+        </div>
 
-function FilterSelect({
-  label,
-  value,
-  placeholder,
-  options,
-  onChange,
-}: {
-  label: string
-  value: string
-  placeholder: string
-  options: Array<{value: string; count: number}>
-  onChange: (value: string) => void
-}) {
-  return (
-    <div className="space-y-1">
-      <div className="text-xs font-medium text-muted-foreground">{label}</div>
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="h-9">
-          <SelectValue placeholder={placeholder} />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">{placeholder}</SelectItem>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.value} ({formatCount(option.count)})
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+        {showErroringResources && (
+          <AllErroringResourcesPanel
+            panelRef={erroringResourcesRef}
+            queryParams={queryParams}
+            refreshMs={refreshMs}
+            onClose={() => setShowErroringResources(false)}
+          />
+        )}
+
+        <RecentTracesPanel
+          traces={traces}
+          totalTraces={totalTraces}
+          page={page}
+          totalPages={totalPages}
+          isLoading={tracesQuery.isLoading}
+          onPageChange={setPage}
+        />
+      </div>
+    </ExplorerShell>
   )
 }
 
@@ -794,9 +735,10 @@ function AllErroringResourcesPanel({
   const debouncedSearch = useDebouncedValue(resourceSearch.trim(), SEARCH_DEBOUNCE_MS)
   const resourceFilterKey = [
     queryParams.timeRange,
-    queryParams.service ?? '',
+    queryParams.services?.join(',') ?? '',
     queryParams.source ?? '',
     queryParams.env ?? '',
+    queryParams.operation ?? '',
     debouncedSearch,
   ].join('\u001f')
   const page = pageState.key === resourceFilterKey ? pageState.page : 0
@@ -1098,48 +1040,21 @@ function RecentTracesPanel({
   totalTraces,
   page,
   totalPages,
-  search,
-  errorsOnly,
   isLoading,
-  onSearch,
-  onErrorsOnly,
   onPageChange,
 }: {
   traces: ApmTraceListItem[]
   totalTraces: number
   page: number
   totalPages: number
-  search: string
-  errorsOnly: boolean
   isLoading: boolean
-  onSearch: (value: string) => void
-  onErrorsOnly: (value: boolean) => void
   onPageChange: (page: number) => void
 }) {
   return (
     <Card className="mt-4 min-w-0 overflow-hidden rounded-lg">
-      <CardHeader className="flex flex-col gap-3 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+      <CardHeader className="flex flex-row items-center justify-between gap-3 px-4 py-3">
         <CardTitle className="text-sm">Recent traces</CardTitle>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <div className="relative w-full sm:w-[320px]">
-            <Search
-              className={cn(
-                'pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2',
-                'text-muted-foreground',
-              )}
-            />
-            <Input
-              value={search}
-              onChange={(event) => onSearch(event.target.value)}
-              className="h-9 pl-9"
-              placeholder="Search by trace ID or resource..."
-            />
-          </div>
-          <label className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Switch checked={errorsOnly} onCheckedChange={onErrorsOnly} />
-            Show errors only
-          </label>
-        </div>
+        <span className="text-xs text-muted-foreground">{formatCount(totalTraces)} traces</span>
       </CardHeader>
       <CardContent className="px-0 pb-0">
         <div className="overflow-x-auto">
@@ -1411,13 +1326,6 @@ function EmptyTableRow({colSpan, label}: {colSpan: number; label: string}) {
   )
 }
 
-const emptyFilters: TraceFilters = {
-  service: 'all',
-  source: 'all',
-  status: 'all',
-  env: 'all',
-}
-
 const emptyPreviousStats = {
   totalTraces: 0,
   errorRate: 0,
@@ -1448,16 +1356,84 @@ const emptyOverview: ApmOverviewResponse = {
     services: [],
     sources: [],
     environments: [],
+    operations: [],
   },
 }
 
-function toOverviewParams(timeRange: ApmTimeRange, filters: TraceFilters): OverviewParams {
+function buildTraceFacetSections(overview: ApmOverviewResponse): FacetRailSection[] {
+  const okTraces = Math.max(0, overview.stats.totalTraces - overview.stats.errorTraces)
+
+  return [
+    {
+      key: 'service',
+      label: 'Service',
+      color: 'bg-chart-1',
+      allowExclude: false,
+      options: overview.facets.services,
+    },
+    {
+      key: 'operation',
+      label: 'Operation',
+      color: 'bg-chart-2',
+      singleSelect: true,
+      allowExclude: false,
+      options: overview.facets.operations ?? [],
+    },
+    {
+      key: 'env',
+      label: 'Environment',
+      color: 'bg-chart-3',
+      singleSelect: true,
+      allowExclude: false,
+      options: overview.facets.environments,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      color: 'bg-chart-4',
+      singleSelect: true,
+      allowExclude: false,
+      options: [
+        {value: 'error', label: 'Errors', count: overview.stats.errorTraces},
+        {value: 'ok', label: 'OK', count: okTraces},
+      ],
+    },
+    {
+      key: 'source',
+      label: 'Source',
+      color: 'bg-chart-6',
+      singleSelect: true,
+      allowExclude: false,
+      options: overview.facets.sources,
+    },
+  ]
+}
+
+function facetValues(filters: readonly FacetFilter[], key: string): string[] {
+  return filters
+    .filter((filter) => filter.key === key && !filter.exclude)
+    .map((filter) => filter.value)
+}
+
+function firstFacetValue(filters: readonly FacetFilter[], key: string): string | undefined {
+  return facetValues(filters, key)[0]
+}
+
+function toStatusFilter(value: string | undefined): ApmStatusFilter | undefined {
+  if (value === 'error' || value === 'ok') return value
+  return undefined
+}
+
+function toOverviewParams(timeRange: ApmTimeRange, filters: readonly FacetFilter[]): OverviewParams {
+  const services = facetValues(filters, 'service')
+
   return {
     timeRange,
-    service: filters.service === 'all' ? undefined : filters.service,
-    source: filters.source === 'all' ? undefined : filters.source,
-    status: filters.status === 'all' ? undefined : filters.status,
-    env: filters.env === 'all' ? undefined : filters.env,
+    services: services.length > 0 ? services : undefined,
+    source: firstFacetValue(filters, 'source'),
+    status: toStatusFilter(firstFacetValue(filters, 'status')),
+    env: firstFacetValue(filters, 'env'),
+    operation: firstFacetValue(filters, 'operation'),
   }
 }
 


### PR DESCRIPTION
Adds service-aware trace filtering support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operation-level facets and an operation filter to explore and filter traces by operation.
  * Multi-service filtering (comma-separated service lists) across APM endpoints.

* **Improvements**
  * Facet-driven trace discovery UI with refreshed paging, debounced search, and unified filter handling for consistent results and refresh behavior.

* **Tests**
  * Updated and added tests to cover operations facet, multi-service parsing, and server-side forwarding of filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->