### PR TITLE
feat: add profile facet filtering

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/ProfileDashboardRoutes.kt
@@ -79,6 +79,7 @@ private suspend fun ApplicationCall.handleListProfiles() {
     val offset = (parameters["offset"]?.toIntOrNull() ?: 0).coerceAtLeast(0)
     val query = DdProfileListQuery(
         service = parameters["service"],
+        services = serviceFilters(),
         profileType = parameters["type"],
         source = parameters["source"],
         env = parameters["env"],
@@ -212,11 +213,24 @@ private suspend fun ApplicationCall.handleProfileFlamegraph() {
 private fun ApplicationCall.profileFilters(includeVersion: Boolean = false): ProfileQueryFilters =
     ProfileQueryFilters(
         service = parameters["service"],
+        services = serviceFilters(),
         profileType = parameters["type"],
         env = parameters["env"],
         host = parameters["host"],
         version = if (includeVersion) parameters["version"] else null,
     )
+
+private fun ApplicationCall.serviceFilters(): List<String> {
+    val services = parameters["services"]
+        ?.split(",")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?: emptyList()
+    val legacyService = parameters["service"]
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+    return (services + listOfNotNull(legacyService)).distinct()
+}
 
 private suspend fun ApplicationCall.requireOrgId(): Int? {
     val orgId = orgIdOrNull()

--- a/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/ProfileIngestionService.kt
@@ -50,6 +50,7 @@ private val logger = KotlinLogging.logger {}
 /** Server-side filters/paging for the profile list endpoint. */
 data class DdProfileListQuery(
     val service: String? = null,
+    val services: List<String> = emptyList(),
     val profileType: String? = null,
     val source: String? = null,
     val env: String? = null,
@@ -64,6 +65,7 @@ data class DdProfileListQuery(
 /** Shared dimensions used by profile dashboard queries. */
 data class ProfileQueryFilters(
     val service: String? = null,
+    val services: List<String> = emptyList(),
     val profileType: String? = null,
     val source: String? = null,
     val env: String? = null,
@@ -118,6 +120,7 @@ data class ProfileMergeSelection(
 private fun DdProfileListQuery.toFilters(): ProfileQueryFilters =
     ProfileQueryFilters(
         service = service,
+        services = services,
         profileType = profileType,
         source = source,
         env = env,
@@ -635,9 +638,7 @@ object ProfileIngestionService {
         val clauses = mutableListOf(
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
         )
-        filters.service?.takeIf { it.isNotBlank() }?.let {
-            clauses.add("service = '${escapeSql(it)}'")
-        }
+        serviceFilterClause(filters.service, filters.services)?.let(clauses::add)
         filters.profileType?.takeIf { it.isNotBlank() }?.let {
             clauses.add("profile_type = '${escapeSql(it)}'")
         }
@@ -656,6 +657,21 @@ object ProfileIngestionService {
         timeFilter.fromMs?.let { clauses.add("start_time >= fromUnixTimestamp64Milli($it)") }
         timeFilter.toMs?.let { clauses.add("start_time < fromUnixTimestamp64Milli($it)") }
         return clauses.joinToString(" AND ")
+    }
+
+    private fun serviceFilterClause(service: String?, services: List<String>): String? {
+        val values = (services + listOfNotNull(service))
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+        return when (values.size) {
+            0 -> null
+            1 -> "service = '${escapeSql(values.first())}'"
+            else -> {
+                val serviceList = values.joinToString(", ") { "'${escapeSql(it)}'" }
+                "service IN ($serviceList)"
+            }
+        }
     }
 
     private fun parseProfileRow(line: String): DdProfileResponse {

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -552,7 +552,7 @@ class DatadogQueryRoutesTest {
         installProfileRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get(
-            "/v1/profiles?service=api&type=cpu&source=datadog&env=prod&host=h1&version=v1" +
+            "/v1/profiles?service=api&services=api,worker&type=cpu&source=datadog&env=prod&host=h1&version=v1" +
                 "&from=100&to=200&limit=500&offset=3",
         ) {
             withAuth(token)
@@ -564,6 +564,7 @@ class DatadogQueryRoutesTest {
                 10,
                 match {
                     it.service == "api" &&
+                        it.services == listOf("api", "worker") &&
                         it.profileType == "cpu" &&
                         it.source == "datadog" &&
                         it.env == "prod" &&
@@ -748,7 +749,8 @@ class DatadogQueryRoutesTest {
         installProfileRoutes()()
         val token = RouteTestSupport.createToken(userId = 1, orgId = 10)
         val resp = client.get(
-            "/v1/profiles/timeseries?service=api&type=cpu&env=prod&host=h1&from=1000&to=61000&buckets=10",
+            "/v1/profiles/timeseries?service=api&services=api,worker&type=cpu&env=prod" +
+                "&host=h1&from=1000&to=61000&buckets=10",
         ) {
             withAuth(token)
         }
@@ -759,6 +761,7 @@ class DatadogQueryRoutesTest {
                 match {
                     it.organizationId == 10 &&
                         it.filters.service == "api" &&
+                        it.filters.services == listOf("api", "worker") &&
                         it.filters.profileType == "cpu" &&
                         it.filters.env == "prod" &&
                         it.filters.host == "h1" &&

--- a/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/ProfileIngestionServiceTest.kt
@@ -290,6 +290,7 @@ class ProfileIngestionServiceTest {
                 organizationId = 42,
                 query = DdProfileListQuery(
                     service = "api",
+                    services = listOf("api", "worker"),
                     profileType = "cpu",
                     source = "datadog",
                     env = "prod",
@@ -305,7 +306,7 @@ class ProfileIngestionServiceTest {
             assertEquals(1, response.totalCount)
             assertEquals("profile-1", response.profiles.single().profileId)
             assertEquals("api", response.profiles.single().service)
-            assertTrue(queries.any { it.contains("service = 'api'") })
+            assertTrue(queries.any { it.contains("service IN ('api', 'worker')") })
             assertTrue(queries.any { it.contains("start_time >= fromUnixTimestamp64Milli(1000)") })
             assertTrue(queries.any { it.contains("LIMIT 5 OFFSET 2") })
             val listQuery = queries.single { it.contains("ORDER BY start_time DESC") }
@@ -523,6 +524,7 @@ class ProfileIngestionServiceTest {
                     organizationId = 42,
                     filters = ProfileQueryFilters(
                         service = "api",
+                        services = listOf("api", "worker"),
                         profileType = "cpu",
                         env = "prod",
                         host = "host-a",
@@ -536,6 +538,7 @@ class ProfileIngestionServiceTest {
             assertEquals(4, response.points.single().count)
             assertEquals(4096, response.points.single().sizeBytes)
             val sql = queries.single()
+            assertTrue(sql.contains("service IN ('api', 'worker')"))
             assertTrue(sql.contains("profile_type = 'cpu'"))
             assertTrue(sql.contains("host = 'host-a'"))
             assertTrue(sql.contains("toUnixTimestamp(toStartOfInterval"))

--- a/dashboard/src/components/profiling/ProfileList.tsx
+++ b/dashboard/src/components/profiling/ProfileList.tsx
@@ -65,23 +65,33 @@ interface Props {
   embedded?: boolean
   scope?: ProfileScope
   serviceFilter?: string
+  serviceFilters?: readonly string[]
   onServiceFilterChange?: (val: string) => void
   typeFilter?: string
   onTypeFilterChange?: (val: string) => void
+  query?: string
 }
 
 export function ProfileList({
   embedded = false,
   scope,
   serviceFilter = '',
+  serviceFilters = [],
   onServiceFilterChange,
   typeFilter = '',
   onTypeFilterChange,
+  query = '',
 }: Props) {
+  const selectedServices = useMemo(
+    () => serviceFilters.map((service) => service.trim()).filter((service) => service !== ''),
+    [serviceFilters],
+  )
+  const selectedServicesKey = selectedServices.join('\u001f')
+
   const {data, isLoading} = useQuery({
     queryKey: embedded
       ? ['profiles', 'embedded', scope]
-      : ['profiles', serviceFilter, typeFilter],
+      : ['profiles', serviceFilter, selectedServicesKey, typeFilter],
     queryFn: () =>
       api.getProfiles(
         embedded
@@ -95,6 +105,7 @@ export function ProfileList({
             }
           : {
               service: serviceFilter || undefined,
+              ...(selectedServices.length > 0 ? {services: [...selectedServices]} : {}),
               type: typeFilter || undefined,
               limit: DEFAULT_LIMIT,
             },
@@ -103,25 +114,40 @@ export function ProfileList({
   })
 
   const profiles = data?.profiles ?? []
+  const normalizedQuery = query.trim().toLowerCase()
+  const visibleProfiles = useMemo(() => {
+    if (!normalizedQuery) return profiles
+    return profiles.filter((profile) =>
+      [
+        profile.service,
+        profile.profileType,
+        profile.env,
+        profile.host,
+        profile.language,
+        profile.runtime,
+        profile.source,
+      ].some((value) => value?.toLowerCase().includes(normalizedQuery))
+    )
+  }, [normalizedQuery, profiles])
 
   const stats = useMemo(() => {
-    if (embedded || profiles.length === 0) return null
+    if (embedded || visibleProfiles.length === 0) return null
 
-    const services = new Set(profiles.map((p) => p.service))
-    const types = new Set(profiles.map((p) => p.profileType))
-    const totalSize = profiles.reduce((sum, p) => sum + p.sizeBytes, 0)
-    const durations = profiles.map((p) => p.durationNs)
+    const services = new Set(visibleProfiles.map((p) => p.service))
+    const types = new Set(visibleProfiles.map((p) => p.profileType))
+    const totalSize = visibleProfiles.reduce((sum, p) => sum + p.sizeBytes, 0)
+    const durations = visibleProfiles.map((p) => p.durationNs)
     const avgDuration =
       durations.reduce((sum, d) => sum + d, 0) / durations.length
 
     return {
-      totalProfiles: data?.totalCount ?? profiles.length,
+      totalProfiles: normalizedQuery ? visibleProfiles.length : data?.totalCount ?? profiles.length,
       serviceCount: services.size,
       typeCount: types.size,
       totalSize,
       avgDuration,
     }
-  }, [embedded, profiles, data?.totalCount])
+  }, [embedded, normalizedQuery, profiles.length, visibleProfiles, data?.totalCount])
 
   const availableTypes = useMemo(
     () => [...new Set(profiles.map((p) => p.profileType))].sort(),
@@ -147,6 +173,14 @@ export function ProfileList({
     return <ProfilingEmptyState />
   }
 
+  if (visibleProfiles.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground py-6 text-center">
+        No profiles match "{query}".
+      </p>
+    )
+  }
+
   const table = (
     <Table className="[&_th]:h-8 [&_th]:px-2 [&_th]:text-xs [&_td]:py-1.5 [&_td]:px-2 [&_td]:text-xs">
       <TableHeader>
@@ -162,7 +196,7 @@ export function ProfileList({
         </TableRow>
       </TableHeader>
       <TableBody>
-        {profiles.map((profile: ProfileResponse) => {
+        {visibleProfiles.map((profile: ProfileResponse) => {
           const parsedStart = parseUtcDate(profile.startTime)
           return (
             <TableRow key={profile.profileId} className="group">
@@ -237,38 +271,43 @@ export function ProfileList({
     return table
   }
 
+  const showInlineFilters = Boolean(onServiceFilterChange || onTypeFilterChange)
+
   return (
     <div className="space-y-2">
-      {/* Filters */}
-      <div className="flex items-center gap-1.5">
-        <div className="relative flex-1 max-w-xs">
-          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <Input
-            placeholder="Filter by service..."
-            value={serviceFilter}
-            onChange={(e) => onServiceFilterChange?.(e.target.value)}
-            className="pl-8 h-7 text-xs"
-          />
+      {showInlineFilters && (
+        <div className="flex items-center gap-1.5">
+          {onServiceFilterChange && (
+            <div className="relative flex-1 max-w-xs">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+              <Input
+                placeholder="Filter by service..."
+                value={serviceFilter}
+                onChange={(e) => onServiceFilterChange(e.target.value)}
+                className="pl-8 h-7 text-xs"
+              />
+            </div>
+          )}
+          {onTypeFilterChange && availableTypes.length > 1 && (
+            <Select
+              value={typeFilter || '__all'}
+              onValueChange={(v) => onTypeFilterChange(v === '__all' ? '' : v)}
+            >
+              <SelectTrigger className="h-7 w-[140px] text-xs">
+                <SelectValue placeholder="All types" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all">All types</SelectItem>
+                {availableTypes.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
         </div>
-        {availableTypes.length > 1 && (
-          <Select
-            value={typeFilter || '__all'}
-            onValueChange={(v) => onTypeFilterChange?.(v === '__all' ? '' : v)}
-          >
-            <SelectTrigger className="h-7 w-[140px] text-xs">
-              <SelectValue placeholder="All types" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__all">All types</SelectItem>
-              {availableTypes.map((t) => (
-                <SelectItem key={t} value={t}>
-                  {t}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      </div>
+      )}
 
       {/* Summary stats */}
       {stats && (

--- a/dashboard/src/components/profiling/ProfileServiceList.tsx
+++ b/dashboard/src/components/profiling/ProfileServiceList.tsx
@@ -37,11 +37,20 @@ import {
 } from './profileFormat'
 
 interface Props {
-  serviceFilter: string
-  onServiceFilterChange: (val: string) => void
+  serviceFilter?: string
+  serviceFilters?: readonly string[]
+  typeFilter?: string
+  query?: string
+  onServiceFilterChange?: (val: string) => void
 }
 
-export function ProfileServiceList({serviceFilter, onServiceFilterChange}: Props) {
+export function ProfileServiceList({
+  serviceFilter = '',
+  serviceFilters = [],
+  typeFilter = '',
+  query = '',
+  onServiceFilterChange,
+}: Props) {
   const {data, isLoading} = useQuery({
     queryKey: ['profileServices'],
     queryFn: () => api.getProfileServices(),
@@ -49,12 +58,29 @@ export function ProfileServiceList({serviceFilter, onServiceFilterChange}: Props
   })
 
   const services = data?.services ?? []
+  const selectedServices = useMemo(
+    () => new Set(serviceFilters.map((service) => service.trim()).filter((service) => service !== '')),
+    [serviceFilters],
+  )
 
   const filtered = useMemo(() => {
-    const q = serviceFilter.trim().toLowerCase()
-    if (!q) return services
-    return services.filter((s) => s.service.toLowerCase().includes(q))
-  }, [services, serviceFilter])
+    const q = (query || serviceFilter).trim().toLowerCase()
+    const normalizedType = typeFilter.trim().toLowerCase()
+    return services.filter((service) => {
+      const matchesSelected = selectedServices.size === 0 || selectedServices.has(service.service)
+      const matchesType =
+        normalizedType === '' ||
+        service.types.some((type) => type.profileType.toLowerCase() === normalizedType)
+      const matchesQuery = !q || [
+        service.service,
+        ...service.environments,
+        ...service.languages,
+        ...service.runtimes,
+        ...service.types.map((type) => type.profileType),
+      ].some((value) => value.toLowerCase().includes(q))
+      return matchesSelected && matchesType && matchesQuery
+    })
+  }, [query, selectedServices, services, serviceFilter, typeFilter])
 
   if (isLoading) {
     return (
@@ -70,15 +96,17 @@ export function ProfileServiceList({serviceFilter, onServiceFilterChange}: Props
 
   return (
     <div className="space-y-2">
-      <div className="relative max-w-xs">
-        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-        <Input
-          placeholder="Filter by service..."
-          value={serviceFilter}
-          onChange={(e) => onServiceFilterChange(e.target.value)}
-          className="pl-8 h-7 text-xs"
-        />
-      </div>
+      {onServiceFilterChange && (
+        <div className="relative max-w-xs">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Filter by service..."
+            value={serviceFilter}
+            onChange={(e) => onServiceFilterChange(e.target.value)}
+            className="pl-8 h-7 text-xs"
+          />
+        </div>
+      )}
 
       {data && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-1.5">
@@ -112,7 +140,7 @@ export function ProfileServiceList({serviceFilter, onServiceFilterChange}: Props
 
       {filtered.length === 0 ? (
         <p className="text-xs text-muted-foreground py-6 text-center">
-          No services match "{serviceFilter}".
+          No services match "{query || serviceFilter || [...selectedServices].join(', ')}".
         </p>
       ) : (
         <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
@@ -137,7 +165,12 @@ function ServiceCard({service}: {service: ProfileServiceSummary}) {
       params={{service: service.service || '(unknown)'}}
       className="block group focus:outline-none"
     >
-      <Card className="h-full p-3 space-y-2 transition-colors group-hover:border-primary/40 group-hover:bg-accent/30 group-focus-visible:border-primary/60">
+      <Card
+        className={cn(
+          'h-full p-3 space-y-2 transition-colors group-hover:border-primary/40',
+          'group-hover:bg-accent/30 group-focus-visible:border-primary/60',
+        )}
+      >
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-1.5 min-w-0">
             <span
@@ -152,7 +185,12 @@ function ServiceCard({service}: {service: ProfileServiceSummary}) {
             </span>
           </div>
           {language && (
-            <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
+            <span
+              className={cn(
+                'text-[10px] uppercase tracking-wide text-muted-foreground bg-muted',
+                'px-1.5 py-0.5 rounded shrink-0',
+              )}
+            >
               {language}
             </span>
           )}

--- a/dashboard/src/components/profiling/ServiceExplorer.tsx
+++ b/dashboard/src/components/profiling/ServiceExplorer.tsx
@@ -37,49 +37,100 @@ import {formatBytes, formatDuration, parseUtcDate} from './profileFormat'
 const ALL_ENVS = '__all'
 const MERGE_PROFILE_CAP = 25
 
-const RANGES: Record<string, {label: string; ms: number}> = {
+type ProfileRangeKey = '1h' | '6h' | '24h' | '7d'
+
+const PROFILE_TIME_PRESETS: Array<{
+  label: string
+  value: ProfileRangeKey
+  minutes: number
+}> = [
+  {label: '1h', value: '1h', minutes: 60},
+  {label: '6h', value: '6h', minutes: 360},
+  {label: '24h', value: '24h', minutes: 1440},
+  {label: '7d', value: '7d', minutes: 10080},
+]
+
+const RANGES: Record<ProfileRangeKey, {label: string; ms: number}> = {
   '1h': {label: '1h', ms: 60 * 60 * 1000},
   '6h': {label: '6h', ms: 6 * 60 * 60 * 1000},
   '24h': {label: '24h', ms: 24 * 60 * 60 * 1000},
   '7d': {label: '7d', ms: 7 * 24 * 60 * 60 * 1000},
 }
-type RangeKey = keyof typeof RANGES
 
-interface Props {
-  service: string
+interface ServiceExplorerFilters {
+  service?: string
+  env?: string
+  type?: string
+  rangeKey: ProfileRangeKey
 }
 
-export function ServiceExplorer({service}: Props) {
-  const [env, setEnv] = useState<string>(ALL_ENVS)
-  const [rangeKey, setRangeKey] = useState<RangeKey>('24h')
-  const [selectedType, setSelectedType] = useState<string | null>(null)
-  const [sampleType, setSampleType] = useState<string | null>(null)
-  const [thread, setThread] = useState<string | null>(null)
-  const [zoom, setZoom] = useState<{from: number; to: number} | null>(null)
+interface SampleSelection {
+  signature: string
+  sampleType: string | null
+  thread: string | null
+}
+
+interface ZoomSelection {
+  signature: string
+  from: number
+  to: number
+}
+
+interface Props {
+  service?: string
+  filters?: ServiceExplorerFilters
+}
+
+export function ServiceExplorer({service, filters}: Props) {
+  const [internalEnv, setInternalEnv] = useState<string>(ALL_ENVS)
+  const [internalRangeKey, setInternalRangeKey] = useState<ProfileRangeKey>('24h')
+  const [internalSelectedType, setInternalSelectedType] = useState<string | null>(null)
+  const [sampleSelection, setSampleSelection] = useState<SampleSelection>({
+    signature: '',
+    sampleType: null,
+    thread: null,
+  })
+  const [zoom, setZoom] = useState<ZoomSelection | null>(null)
   const [showBrowse, setShowBrowse] = useState(false)
+  const filtersControlled = filters !== undefined
+  const activeService = filtersControlled ? filters.service : service
+  const activeRangeKey = filters?.rangeKey ?? internalRangeKey
 
   const {data: servicesData, isLoading: servicesLoading} = useQuery({
     queryKey: ['profileServices'],
     queryFn: () => api.getProfileServices(),
     enabled: api.isAuthenticated(),
   })
-  const summary = servicesData?.services.find((s) => s.service === service)
+  const summary = activeService
+    ? servicesData?.services.find((s) => s.service === activeService)
+    : undefined
 
   const range = useMemo(() => {
     const to = getNow()
-    return {from: to - RANGES[rangeKey].ms, to}
-  }, [rangeKey])
-  const mergeWindow = zoom ?? range
+    return {from: to - RANGES[activeRangeKey].ms, to}
+  }, [activeRangeKey])
 
-  const envParam = env === ALL_ENVS ? undefined : env
+  const envParam = filtersControlled
+    ? filters.env
+    : internalEnv === ALL_ENVS
+      ? undefined
+      : internalEnv
   const effectiveType =
-    selectedType ?? summary?.types[0]?.profileType ?? undefined
+    filters?.type ?? internalSelectedType ?? summary?.types[0]?.profileType ?? undefined
+  const filterSignature = [activeService ?? '', envParam ?? '', effectiveType ?? ''].join('\u001f')
+  const zoomSignature = `${filterSignature}\u001f${activeRangeKey}`
+  const activeZoom = zoom?.signature === zoomSignature ? zoom : null
+  const mergeWindow = activeZoom ?? range
+  const activeSampleType =
+    sampleSelection.signature === filterSignature ? sampleSelection.sampleType : null
+  const activeThread =
+    sampleSelection.signature === filterSignature ? sampleSelection.thread : null
 
   const {data: timeseries} = useQuery({
-    queryKey: ['profileTimeseries', service, envParam, effectiveType, range.from, range.to],
+    queryKey: ['profileTimeseries', activeService, envParam, effectiveType, range.from, range.to],
     queryFn: () =>
       api.getProfileTimeseries({
-        service,
+        service: activeService,
         env: envParam,
         type: effectiveType,
         from: range.from,
@@ -92,23 +143,23 @@ export function ServiceExplorer({service}: Props) {
   const {data: merged, isFetching: mergeFetching} = useQuery({
     queryKey: [
       'mergedFlamegraph',
-      service,
+      activeService,
       envParam,
       effectiveType,
       mergeWindow.from,
       mergeWindow.to,
-      sampleType,
-      thread,
+      activeSampleType,
+      activeThread,
     ],
     queryFn: () =>
       api.getMergedFlamegraph({
-        service,
+        service: activeService,
         env: envParam,
         type: effectiveType,
         from: mergeWindow.from,
         to: mergeWindow.to,
-        sampleType,
-        thread,
+        sampleType: activeSampleType,
+        thread: activeThread,
         maxProfiles: MERGE_PROFILE_CAP,
       }),
     enabled: api.isAuthenticated(),
@@ -127,23 +178,38 @@ export function ServiceExplorer({service}: Props) {
   )
 
   const handleTypeChange = (type: string) => {
-    setSelectedType(type)
-    setSampleType(null)
-    setThread(null)
+    setInternalSelectedType(type)
+    setSampleSelection({signature: '', sampleType: null, thread: null})
   }
 
-  const handleRangeChange = (key: RangeKey) => {
-    setRangeKey(key)
+  const handleRangeChange = (key: ProfileRangeKey) => {
+    setInternalRangeKey(key)
     setZoom(null)
   }
 
   const toggleBucket = (ts: number) => {
     if (!bucketMs) return
-    if (zoom && zoom.from === ts) {
+    if (activeZoom && activeZoom.from === ts) {
       setZoom(null)
     } else {
-      setZoom({from: ts, to: ts + bucketMs})
+      setZoom({signature: zoomSignature, from: ts, to: ts + bucketMs})
     }
+  }
+
+  const handleSampleTypeChange = (value: string) => {
+    setSampleSelection({
+      signature: filterSignature,
+      sampleType: value,
+      thread: null,
+    })
+  }
+
+  const handleThreadChange = (value: string | null) => {
+    setSampleSelection((current) => ({
+      signature: filterSignature,
+      sampleType: current.signature === filterSignature ? current.sampleType : null,
+      thread: value,
+    }))
   }
 
   if (servicesLoading) {
@@ -209,7 +275,7 @@ export function ServiceExplorer({service}: Props) {
             <div className="flex items-center gap-2 flex-wrap">
               <Server className="h-4 w-4 text-muted-foreground" />
               <h1 className="text-lg font-bold tracking-tight leading-tight truncate">
-                {service}
+                {activeService ?? 'All services'}
               </h1>
               {language && (
                 <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded">
@@ -223,54 +289,56 @@ export function ServiceExplorer({service}: Props) {
           </div>
         </div>
 
-        <div className="flex items-center gap-1.5 flex-wrap">
-          {types.length > 1 && (
-            <Select value={effectiveType} onValueChange={handleTypeChange}>
-              <SelectTrigger className="h-7 w-[130px] text-xs">
-                <SelectValue placeholder="Type" />
-              </SelectTrigger>
-              <SelectContent>
-                {types.map((t) => (
-                  <SelectItem key={t.profileType} value={t.profileType}>
-                    {t.profileType} ({t.count.toLocaleString()})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-          {environments.length > 1 && (
-            <Select value={env} onValueChange={setEnv}>
-              <SelectTrigger className="h-7 w-[150px] text-xs">
-                <SelectValue placeholder="All environments" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL_ENVS}>All environments</SelectItem>
-                {environments.map((e) => (
-                  <SelectItem key={e} value={e}>
-                    {e}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-          <div className="inline-flex rounded-md border p-0.5 text-xs">
-            {(Object.keys(RANGES) as RangeKey[]).map((key) => (
-              <button
-                key={key}
-                type="button"
-                onClick={() => handleRangeChange(key)}
-                className={cn(
-                  'px-2 py-1 rounded font-medium transition-colors',
-                  rangeKey === key
-                    ? 'bg-secondary text-secondary-foreground'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                {RANGES[key].label}
-              </button>
-            ))}
+        {!filtersControlled && (
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {types.length > 1 && (
+              <Select value={effectiveType} onValueChange={handleTypeChange}>
+                <SelectTrigger className="h-7 w-[130px] text-xs">
+                  <SelectValue placeholder="Type" />
+                </SelectTrigger>
+                <SelectContent>
+                  {types.map((t) => (
+                    <SelectItem key={t.profileType} value={t.profileType}>
+                      {t.profileType} ({t.count.toLocaleString()})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            {environments.length > 1 && (
+              <Select value={internalEnv} onValueChange={setInternalEnv}>
+                <SelectTrigger className="h-7 w-[150px] text-xs">
+                  <SelectValue placeholder="All environments" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_ENVS}>All environments</SelectItem>
+                  {environments.map((e) => (
+                    <SelectItem key={e} value={e}>
+                      {e}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <div className="inline-flex rounded-md border p-0.5 text-xs">
+              {PROFILE_TIME_PRESETS.map((preset) => (
+                <button
+                  key={preset.value}
+                  type="button"
+                  onClick={() => handleRangeChange(preset.value)}
+                  className={cn(
+                    'px-2 py-1 rounded font-medium transition-colors',
+                    activeRangeKey === preset.value
+                      ? 'bg-secondary text-secondary-foreground'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Volume timeline */}
@@ -279,14 +347,14 @@ export function ServiceExplorer({service}: Props) {
           <span className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
             Profile volume
           </span>
-          {zoom ? (
+          {activeZoom ? (
             <button
               type="button"
               onClick={() => setZoom(null)}
               className="inline-flex items-center gap-1 text-[10px] text-primary hover:underline"
             >
               <X className="h-3 w-3" />
-              {new Date(zoom.from).toLocaleString()} — clear selection
+              {new Date(activeZoom.from).toLocaleString()} — clear selection
             </button>
           ) : (
             <span className="text-[10px] text-muted-foreground">
@@ -296,8 +364,8 @@ export function ServiceExplorer({service}: Props) {
         </div>
         <VolumeTimeline
           buckets={buckets}
-          rangeMs={RANGES[rangeKey].ms}
-          selectedFrom={zoom?.from ?? null}
+          rangeMs={RANGES[activeRangeKey].ms}
+          selectedFrom={activeZoom?.from ?? null}
           onSelect={toggleBucket}
         />
       </div>
@@ -315,15 +383,15 @@ export function ServiceExplorer({service}: Props) {
         <Flamegraph
           frames={merged?.frames}
           language={language}
-          service={service}
+          service={activeService}
           meta={metaSidebar}
           sampleTypes={merged?.sampleTypes}
           threads={merged?.threads}
           selectedSampleType={merged?.selectedSampleType}
           selectedThread={merged?.selectedThread ?? null}
           unit={merged?.unit}
-          onSampleTypeChange={setSampleType}
-          onThreadChange={setThread}
+          onSampleTypeChange={handleSampleTypeChange}
+          onThreadChange={handleThreadChange}
           emptyMessage={
             mergeFetching
               ? 'Aggregating profiles…'
@@ -347,7 +415,7 @@ export function ServiceExplorer({service}: Props) {
             <ProfileList
               embedded
               scope={{
-                service,
+                service: activeService,
                 env: envParam,
                 type: effectiveType,
                 from: mergeWindow.from,

--- a/dashboard/src/components/profiling/__tests__/profileDashboardComponents.test.tsx
+++ b/dashboard/src/components/profiling/__tests__/profileDashboardComponents.test.tsx
@@ -375,6 +375,13 @@ describe('ProfileServiceList', () => {
 
     expect(await screen.findByText('No services match "missing".')).toBeInTheDocument()
   })
+
+  it('filters service rollups by profile type', async () => {
+    renderWithQueryClient(<ProfileServiceList typeFilter="jfr" />)
+
+    expect(await screen.findByRole('link', {name: /checkout/})).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: /worker/})).not.toBeInTheDocument()
+  })
 })
 
 describe('ServiceExplorer', () => {
@@ -433,6 +440,40 @@ describe('ServiceExplorer', () => {
     })
   })
 
+  it('clears the selected thread when the sample type changes', async () => {
+    renderWithQueryClient(<ServiceExplorer service="checkout" />)
+
+    expect(await screen.findByRole('heading', {name: 'checkout'})).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Pick thread'}))
+    await waitFor(() =>
+      expect(mockApi.getMergedFlamegraph).toHaveBeenLastCalledWith({
+        service: 'checkout',
+        env: undefined,
+        type: 'jfr',
+        from: RANGE_24H_START,
+        to: NOW_MS,
+        sampleType: null,
+        thread: 'main',
+        maxProfiles: 25,
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: 'Pick sample type'}))
+    await waitFor(() =>
+      expect(mockApi.getMergedFlamegraph).toHaveBeenLastCalledWith({
+        service: 'checkout',
+        env: undefined,
+        type: 'jfr',
+        from: RANGE_24H_START,
+        to: NOW_MS,
+        sampleType: 'wall',
+        thread: null,
+        maxProfiles: 25,
+      }),
+    )
+  })
+
   it('renders fallback metadata for services without finite timestamps', async () => {
     renderWithQueryClient(<ServiceExplorer service="worker" />)
 
@@ -458,6 +499,36 @@ describe('profile routes', () => {
       type: undefined,
       limit: 50,
     })
+  })
+
+  it('applies profile facets to the all profiles query', async () => {
+    const ProfilesIndexComponent = getRouteComponent(ProfilesIndexRoute)
+
+    renderWithQueryClient(<ProfilesIndexComponent />)
+
+    fireEvent.click(await screen.findByLabelText('checkout'))
+    fireEvent.click(await screen.findByLabelText('jfr'))
+    fireEvent.click(screen.getByRole('button', {name: 'All profiles'}))
+
+    await waitFor(() => {
+      expect(mockApi.getProfiles).toHaveBeenCalledWith({
+        service: undefined,
+        services: ['checkout'],
+        type: 'jfr',
+        limit: 50,
+      })
+    })
+  })
+
+  it('applies the type facet to the services view', async () => {
+    const ProfilesIndexComponent = getRouteComponent(ProfilesIndexRoute)
+
+    renderWithQueryClient(<ProfilesIndexComponent />)
+
+    fireEvent.click(await screen.findByLabelText('jfr'))
+
+    expect(await screen.findByRole('link', {name: /checkout/})).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: /worker/})).not.toBeInTheDocument()
   })
 
   it('renders a profile detail route and forwards download/profile queries', async () => {
@@ -492,11 +563,89 @@ describe('profile routes', () => {
     renderWithQueryClient(<ProfileServiceComponent />)
 
     expect(await screen.findByRole('heading', {name: 'checkout'})).toBeInTheDocument()
+    expect(await screen.findByText('Profile facets')).toBeInTheDocument()
+    expect(screen.getByText('service:checkout')).toBeInTheDocument()
     expect(mockApi.getMergedFlamegraph).toHaveBeenCalledWith({
       service: 'checkout',
       env: undefined,
       type: 'jfr',
       from: RANGE_24H_START,
+      to: NOW_MS,
+      sampleType: null,
+      thread: null,
+      maxProfiles: 25,
+    })
+  })
+
+  it('forwards service route facet and time filters to profile aggregations', async () => {
+    mockRouteParams.value = {service: 'checkout'}
+    const ProfileServiceComponent = getRouteComponent(ProfileServiceRoute)
+
+    renderWithQueryClient(<ProfileServiceComponent />)
+
+    expect(await screen.findByText('Profile facets')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', {name: 'checkout'})).toBeInTheDocument()
+
+    fireEvent.click(await screen.findByLabelText('staging'))
+    await waitFor(() =>
+      expect(mockApi.getMergedFlamegraph).toHaveBeenLastCalledWith({
+        service: 'checkout',
+        env: 'staging',
+        type: 'jfr',
+        from: RANGE_24H_START,
+        to: NOW_MS,
+        sampleType: null,
+        thread: null,
+        maxProfiles: 25,
+      }),
+    )
+
+    fireEvent.click(screen.getByLabelText('pprof'))
+    await waitFor(() =>
+      expect(mockApi.getMergedFlamegraph).toHaveBeenLastCalledWith({
+        service: 'checkout',
+        env: 'staging',
+        type: 'pprof',
+        from: RANGE_24H_START,
+        to: NOW_MS,
+        sampleType: null,
+        thread: null,
+        maxProfiles: 25,
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: /24h/}))
+    fireEvent.click(screen.getByRole('button', {name: '6h'}))
+    await waitFor(() =>
+      expect(mockApi.getProfileTimeseries).toHaveBeenLastCalledWith({
+        service: 'checkout',
+        env: 'staging',
+        type: 'pprof',
+        from: NOW_MS - 6 * 60 * 60 * 1000,
+        to: NOW_MS,
+        buckets: 48,
+      }),
+    )
+    expect(mockApi.getMergedFlamegraph).toHaveBeenLastCalledWith({
+      service: 'checkout',
+      env: 'staging',
+      type: 'pprof',
+      from: NOW_MS - 6 * 60 * 60 * 1000,
+      to: NOW_MS,
+      sampleType: null,
+      thread: null,
+      maxProfiles: 25,
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: /Remove service:checkout/}))
+    await waitFor(() =>
+      expect(screen.getByText('service:checkout')).toBeInTheDocument(),
+    )
+    expect(mockApi.getMergedFlamegraph).toHaveBeenLastCalledWith({
+      service: 'checkout',
+      env: 'staging',
+      type: 'pprof',
+      from: NOW_MS - 6 * 60 * 60 * 1000,
       to: NOW_MS,
       sampleType: null,
       thread: null,

--- a/dashboard/src/lib/api/modules/__tests__/profiles.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/profiles.test.ts
@@ -50,6 +50,7 @@ describe('Profiles API', () => {
       http.get(`${API_BASE}/v1/profiles`, ({ request }) => {
         const url = new URL(request.url)
         expect(url.searchParams.get('service')).toBe('my-service')
+        expect(url.searchParams.get('services')).toBe('my-service,worker')
         expect(url.searchParams.get('type')).toBe('cpu')
         expect(url.searchParams.get('source')).toBe('agent')
         expect(url.searchParams.get('limit')).toBe('10')
@@ -60,6 +61,7 @@ describe('Profiles API', () => {
 
     const result = await api.getProfiles({
       service: 'my-service',
+      services: [' my-service ', '', 'worker '],
       type: 'cpu',
       source: 'agent',
       limit: 10,
@@ -151,6 +153,7 @@ describe('Profiles API', () => {
       http.get(`${API_BASE}/v1/profiles/timeseries`, ({ request }) => {
         const url = new URL(request.url)
         expect(url.searchParams.get('service')).toBe('api')
+        expect(url.searchParams.get('services')).toBe('api,worker')
         expect(url.searchParams.get('from')).toBe('0')
         expect(url.searchParams.get('to')).toBe('1000')
         expect(url.searchParams.get('buckets')).toBe('48')
@@ -159,6 +162,7 @@ describe('Profiles API', () => {
     )
     const result = await api.getProfileTimeseries({
       service: 'api',
+      services: [' api ', '', 'worker '],
       from: 0,
       to: 1000,
       buckets: 48,
@@ -174,6 +178,7 @@ describe('Profiles API', () => {
       http.get(`${API_BASE}/v1/profiles/merged-flamegraph`, ({ request }) => {
         const url = new URL(request.url)
         expect(url.searchParams.get('service')).toBe('api')
+        expect(url.searchParams.get('services')).toBe('api,worker')
         expect(url.searchParams.get('type')).toBe('jfr')
         expect(url.searchParams.get('sampleType')).toBe('cpu')
         expect(url.searchParams.get('maxProfiles')).toBe('25')
@@ -182,6 +187,7 @@ describe('Profiles API', () => {
     )
     const result = await api.getMergedFlamegraph({
       service: 'api',
+      services: [' api ', '', 'worker '],
       type: 'jfr',
       sampleType: 'cpu',
       maxProfiles: 25,

--- a/dashboard/src/lib/api/modules/profiles.ts
+++ b/dashboard/src/lib/api/modules/profiles.ts
@@ -25,6 +25,10 @@ import type {
   MergedFlamegraphResponse,
 } from '../types'
 
+function normalizedServices(services?: string[]): string[] {
+  return services?.map((service) => service.trim()).filter((service) => service !== '') ?? []
+}
+
 export function profilesMethods(core: ApiClientCore) {
   const base = core.API_BASE
 
@@ -32,6 +36,7 @@ export function profilesMethods(core: ApiClientCore) {
     getProfiles: (
       params: {
         service?: string
+        services?: string[]
         type?: string
         source?: string
         env?: string
@@ -45,6 +50,8 @@ export function profilesMethods(core: ApiClientCore) {
     ) => {
       const searchParams = new URLSearchParams()
       if (params.service) searchParams.set('service', params.service)
+      const services = normalizedServices(params.services)
+      if (services.length > 0) searchParams.set('services', services.join(','))
       if (params.type) searchParams.set('type', params.type)
       if (params.source) searchParams.set('source', params.source)
       if (params.env) searchParams.set('env', params.env)
@@ -72,6 +79,7 @@ export function profilesMethods(core: ApiClientCore) {
 
     getProfileTimeseries: (params: {
       service?: string
+      services?: string[]
       type?: string
       env?: string
       host?: string
@@ -81,6 +89,8 @@ export function profilesMethods(core: ApiClientCore) {
     }) => {
       const sp = new URLSearchParams()
       if (params.service) sp.set('service', params.service)
+      const services = normalizedServices(params.services)
+      if (services.length > 0) sp.set('services', services.join(','))
       if (params.type) sp.set('type', params.type)
       if (params.env) sp.set('env', params.env)
       if (params.host) sp.set('host', params.host)
@@ -94,6 +104,7 @@ export function profilesMethods(core: ApiClientCore) {
 
     getMergedFlamegraph: (params: {
       service?: string
+      services?: string[]
       type?: string
       env?: string
       host?: string
@@ -106,6 +117,8 @@ export function profilesMethods(core: ApiClientCore) {
     }) => {
       const sp = new URLSearchParams()
       if (params.service) sp.set('service', params.service)
+      const services = normalizedServices(params.services)
+      if (services.length > 0) sp.set('services', services.join(','))
       if (params.type) sp.set('type', params.type)
       if (params.env) sp.set('env', params.env)
       if (params.host) sp.set('host', params.host)

--- a/dashboard/src/routes/profiles.index.tsx
+++ b/dashboard/src/routes/profiles.index.tsx
@@ -7,10 +7,16 @@
 // (at your option) any later version.
 
 import {createFileRoute} from '@tanstack/react-router'
-import {useState} from 'react'
+import {useQuery} from '@tanstack/react-query'
+import {useMemo, useState, type ReactNode} from 'react'
+import {Flame} from 'lucide-react'
 import {ProfileServiceList} from '@/components/profiling/ProfileServiceList'
 import {ProfileList} from '@/components/profiling/ProfileList'
-import {PageHeader} from '@/components/ui/page-header'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
+import {FacetRail} from '@/components/filters/FacetRail'
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import {api, type ProfileServiceSummary} from '@/lib/api'
+import type {FacetFilter, FacetRailSection, FacetSchema} from '@/lib/filters/types'
 import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/profiles/')({
@@ -19,42 +25,100 @@ export const Route = createFileRoute('/profiles/')({
 
 type ProfilesView = 'services' | 'all'
 
+const PROFILE_FACET_SCHEMA = [
+  {
+    key: 'service',
+    label: 'Service',
+    aliases: ['svc'],
+    color: 'bg-chart-1',
+    allowExclude: false,
+  },
+  {
+    key: 'type',
+    label: 'Profile Type',
+    aliases: ['profileType', 'profile_type'],
+    color: 'bg-chart-2',
+    singleSelect: true,
+    allowExclude: false,
+  },
+] satisfies FacetSchema
+
 function ProfilesIndexPage() {
   const [view, setView] = useState<ProfilesView>('services')
-  const [serviceFilter, setServiceFilter] = useState('')
-  const [typeFilter, setTypeFilter] = useState('')
+  const [query, setQuery] = useState('')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+
+  const {data: servicesData} = useQuery({
+    queryKey: ['profileServices'],
+    queryFn: () => api.getProfileServices(),
+    enabled: api.isAuthenticated(),
+  })
+  const serviceSummaries = servicesData?.services ?? []
+  const railSections = useMemo(
+    () => buildProfileFacetSections(serviceSummaries),
+    [serviceSummaries],
+  )
+  const selectedServices = useMemo(
+    () => facetValues(facetFilters, 'service'),
+    [facetFilters],
+  )
+  const selectedType = firstFacetValue(facetFilters, 'type') ?? ''
 
   return (
-    <div className="p-3 space-y-2">
-      <PageHeader
-        title="Profiles"
-        description="Continuous profiling data from your applications"
-        actions={
-          <div className="inline-flex rounded-md border p-0.5 text-xs shrink-0">
-            <ViewToggle active={view === 'services'} onClick={() => setView('services')}>
-              Services
-            </ViewToggle>
-            <ViewToggle active={view === 'all'} onClick={() => setView('all')}>
-              All profiles
-            </ViewToggle>
-          </div>
-        }
-      />
-
-      {view === 'services' ? (
-        <ProfileServiceList
-          serviceFilter={serviceFilter}
-          onServiceFilterChange={setServiceFilter}
-        />
-      ) : (
-        <ProfileList
-          serviceFilter={serviceFilter}
-          onServiceFilterChange={setServiceFilter}
-          typeFilter={typeFilter}
-          onTypeFilterChange={setTypeFilter}
+    <ExplorerShell
+      className="min-h-[calc(100vh-4rem)]"
+      icon={<Flame className="h-4 w-4 text-muted-foreground" />}
+      title="Profiles"
+      searchBar={(
+        <SearchFilterBar
+          query={query}
+          onQueryChange={setQuery}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={setFacetFilters}
+          schema={PROFILE_FACET_SCHEMA}
+          placeholder="Search services, hosts, environments, or profile types"
         />
       )}
-    </div>
+      actions={(
+        <div className="inline-flex shrink-0 rounded-md border p-0.5 text-xs">
+          <ViewToggle active={view === 'services'} onClick={() => setView('services')}>
+            Services
+          </ViewToggle>
+          <ViewToggle active={view === 'all'} onClick={() => setView('all')}>
+            All profiles
+          </ViewToggle>
+        </div>
+      )}
+      rail={(
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={setFacetFilters}
+          title="Profile facets"
+        />
+      )}
+      toolbar={(
+        <span className="text-xs text-muted-foreground">
+          {(servicesData?.totalProfiles ?? 0).toLocaleString()} profiles
+        </span>
+      )}
+    >
+      <div className="min-w-0 p-3">
+        {view === 'services' ? (
+          <ProfileServiceList
+            serviceFilters={selectedServices}
+            typeFilter={selectedType}
+            query={query}
+          />
+        ) : (
+          <ProfileList
+            serviceFilters={selectedServices}
+            typeFilter={selectedType}
+            query={query}
+          />
+        )}
+      </div>
+    </ExplorerShell>
   )
 }
 
@@ -65,7 +129,7 @@ function ViewToggle({
 }: {
   active: boolean
   onClick: () => void
-  children: React.ReactNode
+  children: ReactNode
 }) {
   return (
     <button
@@ -81,4 +145,46 @@ function ViewToggle({
       {children}
     </button>
   )
+}
+
+function buildProfileFacetSections(services: readonly ProfileServiceSummary[]): FacetRailSection[] {
+  const profileTypeCounts = new Map<string, number>()
+  for (const service of services) {
+    for (const type of service.types) {
+      profileTypeCounts.set(type.profileType, (profileTypeCounts.get(type.profileType) ?? 0) + type.count)
+    }
+  }
+
+  return [
+    {
+      key: 'service',
+      label: 'Service',
+      color: 'bg-chart-1',
+      allowExclude: false,
+      options: services.map((service) => ({
+        value: service.service,
+        count: service.profileCount,
+      })),
+    },
+    {
+      key: 'type',
+      label: 'Profile Type',
+      color: 'bg-chart-2',
+      singleSelect: true,
+      allowExclude: false,
+      options: Array.from(profileTypeCounts.entries())
+        .sort(([, leftCount], [, rightCount]) => rightCount - leftCount)
+        .map(([value, count]) => ({value, count})),
+    },
+  ]
+}
+
+function facetValues(filters: readonly FacetFilter[], key: string): string[] {
+  return filters
+    .filter((filter) => filter.key === key && !filter.exclude)
+    .map((filter) => filter.value)
+}
+
+function firstFacetValue(filters: readonly FacetFilter[], key: string): string | undefined {
+  return facetValues(filters, key)[0]
 }

--- a/dashboard/src/routes/profiles.service.$service.tsx
+++ b/dashboard/src/routes/profiles.service.$service.tsx
@@ -7,13 +7,241 @@
 // (at your option) any later version.
 
 import {createFileRoute} from '@tanstack/react-router'
+import {useQuery} from '@tanstack/react-query'
+import {useCallback, useMemo, useState} from 'react'
+import {Flame} from 'lucide-react'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
+import {FacetRail} from '@/components/filters/FacetRail'
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import {TimeRangePicker} from '@/components/filters/TimeRangePicker'
 import {ServiceExplorer} from '@/components/profiling/ServiceExplorer'
+import {api, type ProfileServiceSummary} from '@/lib/api'
+import type {FacetFilter, FacetRailSection, FacetSchema} from '@/lib/filters/types'
 
 export const Route = createFileRoute('/profiles/service/$service')({
   component: ServiceExplorerPage,
 })
 
+type ProfileRangeKey = '1h' | '6h' | '24h' | '7d'
+
+const DEFAULT_PROFILE_RANGE: ProfileRangeKey = '24h'
+const PROFILE_TIME_PRESETS: Array<{
+  label: string
+  value: ProfileRangeKey
+  minutes: number
+}> = [
+  {label: '1h', value: '1h', minutes: 60},
+  {label: '6h', value: '6h', minutes: 360},
+  {label: '24h', value: '24h', minutes: 1440},
+  {label: '7d', value: '7d', minutes: 10080},
+]
+const PROFILE_RANGE_VALUES = new Set<string>(PROFILE_TIME_PRESETS.map((preset) => preset.value))
+
 function ServiceExplorerPage() {
-  const {service} = Route.useParams()
-  return <ServiceExplorer service={service} />
+  const {service: routeService} = Route.useParams()
+  return <SeededServiceExplorerPage key={routeService} routeService={routeService} />
+}
+
+function SeededServiceExplorerPage({routeService}: {routeService: string}) {
+  const [query, setQuery] = useState('')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => [
+    serviceFacet(routeService),
+  ])
+  const [timeRange, setTimeRange] = useState<ProfileRangeKey>(DEFAULT_PROFILE_RANGE)
+  const handleFacetFiltersChange = useCallback(
+    (filters: FacetFilter[]) => {
+      setFacetFilters(lockServiceFacet(filters, routeService))
+    },
+    [routeService],
+  )
+
+  const {data: servicesData} = useQuery({
+    queryKey: ['profileServices'],
+    queryFn: () => api.getProfileServices(),
+    enabled: api.isAuthenticated(),
+  })
+  const serviceSummaries = servicesData?.services ?? []
+  const selectedService = routeService
+  const selectedType = firstFacetValue(facetFilters, 'type')
+  const selectedEnv = firstFacetValue(facetFilters, 'env')
+  const schema = useMemo(
+    () => buildProfileServiceFacetSchema(serviceSummaries, selectedService),
+    [serviceSummaries, selectedService],
+  )
+  const railSections = useMemo(
+    () => buildProfileServiceFacetSections(serviceSummaries, selectedService),
+    [serviceSummaries, selectedService],
+  )
+  const filters = useMemo(
+    () => ({
+      service: selectedService,
+      env: selectedEnv,
+      type: selectedType,
+      rangeKey: timeRange,
+    }),
+    [selectedService, selectedEnv, selectedType, timeRange],
+  )
+
+  return (
+    <ExplorerShell
+      className="min-h-[calc(100vh-4rem)]"
+      icon={<Flame className="h-4 w-4 text-muted-foreground" />}
+      title="Profiles"
+      searchBar={(
+        <SearchFilterBar
+          query={query}
+          onQueryChange={setQuery}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          schema={schema}
+          placeholder="Filter by service, environment, or profile type"
+          trailing={(
+            <TimeRangePicker
+              timePreset={timeRange}
+              onTimePresetChange={(value) => setTimeRange(toProfileRangeKey(value))}
+              customFrom=""
+              customTo=""
+              onCustomFromChange={() => {}}
+              onCustomToChange={() => {}}
+              presets={PROFILE_TIME_PRESETS}
+              allowCustom={false}
+            />
+          )}
+        />
+      )}
+      rail={(
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          title="Profile facets"
+        />
+      )}
+      toolbar={(
+        <span className="text-xs text-muted-foreground">
+          {selectedService ?? 'All services'}
+        </span>
+      )}
+    >
+      <ServiceExplorer filters={filters} />
+    </ExplorerShell>
+  )
+}
+
+function serviceFacet(service: string): FacetFilter {
+  return {key: 'service', value: service, exclude: false}
+}
+
+function lockServiceFacet(filters: readonly FacetFilter[], routeService: string): FacetFilter[] {
+  return [
+    serviceFacet(routeService),
+    ...filters.filter((filter) => filter.key !== 'service'),
+  ]
+}
+
+function buildProfileServiceFacetSchema(
+  services: readonly ProfileServiceSummary[],
+  selectedService: string | undefined,
+): FacetSchema {
+  const relevantServices = relevantProfileServices(services, selectedService)
+  return [
+    {
+      key: 'service',
+      label: 'Service',
+      aliases: ['svc'],
+      color: 'bg-chart-1',
+      singleSelect: true,
+      allowExclude: false,
+      suggestions: uniqueSorted(services.map((service) => service.service)),
+    },
+    {
+      key: 'env',
+      label: 'Environment',
+      aliases: ['environment'],
+      color: 'bg-chart-3',
+      singleSelect: true,
+      allowExclude: false,
+      suggestions: uniqueSorted(relevantServices.flatMap((service) => service.environments)),
+    },
+    {
+      key: 'type',
+      label: 'Profile Type',
+      aliases: ['profileType', 'profile_type'],
+      color: 'bg-chart-2',
+      singleSelect: true,
+      allowExclude: false,
+      suggestions: profileTypeValues(relevantServices),
+    },
+  ]
+}
+
+function buildProfileServiceFacetSections(
+  services: readonly ProfileServiceSummary[],
+  selectedService: string | undefined,
+): FacetRailSection[] {
+  const relevantServices = relevantProfileServices(services, selectedService)
+  const profileTypeCounts = new Map<string, number>()
+  for (const service of relevantServices) {
+    for (const type of service.types) {
+      profileTypeCounts.set(type.profileType, (profileTypeCounts.get(type.profileType) ?? 0) + type.count)
+    }
+  }
+
+  return [
+    {
+      key: 'service',
+      label: 'Service',
+      color: 'bg-chart-1',
+      singleSelect: true,
+      allowExclude: false,
+      options: services.map((service) => ({
+        value: service.service,
+        count: service.profileCount,
+      })),
+    },
+    {
+      key: 'env',
+      label: 'Environment',
+      color: 'bg-chart-3',
+      singleSelect: true,
+      allowExclude: false,
+      options: uniqueSorted(relevantServices.flatMap((service) => service.environments))
+        .map((value) => ({value})),
+    },
+    {
+      key: 'type',
+      label: 'Profile Type',
+      color: 'bg-chart-2',
+      singleSelect: true,
+      allowExclude: false,
+      options: Array.from(profileTypeCounts.entries())
+        .sort(([, leftCount], [, rightCount]) => rightCount - leftCount)
+        .map(([value, count]) => ({value, count})),
+    },
+  ]
+}
+
+function relevantProfileServices(
+  services: readonly ProfileServiceSummary[],
+  selectedService: string | undefined,
+): ProfileServiceSummary[] {
+  return selectedService
+    ? services.filter((service) => service.service === selectedService)
+    : [...services]
+}
+
+function profileTypeValues(services: readonly ProfileServiceSummary[]): string[] {
+  return uniqueSorted(services.flatMap((service) => service.types.map((type) => type.profileType)))
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value.trim() !== ''))).sort()
+}
+
+function firstFacetValue(filters: readonly FacetFilter[], key: string): string | undefined {
+  return filters.find((filter) => filter.key === key && !filter.exclude)?.value
+}
+
+function toProfileRangeKey(value: string): ProfileRangeKey {
+  return PROFILE_RANGE_VALUES.has(value) ? (value as ProfileRangeKey) : DEFAULT_PROFILE_RANGE
 }


### PR DESCRIPTION
Adds profile facet controls and propagates filters through profile queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-service filtering to profile queries
  * Added free-text search across profile metadata (service, environment, host, language, runtime, etc.)
  * Introduced search filter bar with facet-based filtering on profile pages
  * Added time-range presets (1h, 6h, 24h, 7d) in profile explorer

* **Improvements**
  * Enhanced profile explorer with improved external filter control
  * Refactored profile UI with facet rail and better navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->