### PR TITLE
feat: consolidate log explorer filters

### DIFF
--- a/dashboard/src/components/filters/FacetRail.tsx
+++ b/dashboard/src/components/filters/FacetRail.tsx
@@ -98,6 +98,14 @@ interface RailSectionProps {
   onFacetFiltersChange: (filters: FacetFilter[]) => void
 }
 
+type FacetValueLoader = NonNullable<FacetRailSection['loadOptions']>
+
+interface LazyLoadState {
+  loader: FacetValueLoader | null
+  values: readonly FacetValue[] | null
+  error: boolean
+}
+
 function RailSection({section, facetFilters, onFacetFiltersChange}: RailSectionProps) {
   const {key, label, color, singleSelect, allowExclude = true, options, loadOptions} = section
   // Eager sections open by default (values are ready); lazy ones stay closed
@@ -105,20 +113,35 @@ function RailSection({section, facetFilters, onFacetFiltersChange}: RailSectionP
   const [expanded, setExpanded] = useState(options != null)
   const [query, setQuery] = useState('')
   const [showAll, setShowAll] = useState(false)
-  const [loaded, setLoaded] = useState<readonly FacetValue[] | null>(null)
+  const [lazyLoad, setLazyLoad] = useState<LazyLoadState>({
+    loader: null,
+    values: null,
+    error: false,
+  })
+  const loaded = lazyLoad.loader === loadOptions ? lazyLoad.values : null
+  const loadError = lazyLoad.loader === loadOptions && lazyLoad.error
 
-  // Lazily load values the first time the section is opened.
+  // Lazily load values the first time the section is opened, then reload when
+  // the owner changes the loader context, such as a log-viewer time range.
   useEffect(() => {
-    if (expanded && !options && loadOptions && loaded === null) {
-      let cancelled = false
-      void loadOptions().then((values) => {
-        if (!cancelled) setLoaded(values)
-      })
-      return () => {
-        cancelled = true
-      }
+    if (!expanded || options || !loadOptions || loaded !== null || loadError) {
+      return undefined
     }
-  }, [expanded, options, loadOptions, loaded])
+
+    let cancelled = false
+    void loadOptions()
+      .then((values) => {
+        if (cancelled) return
+        setLazyLoad({loader: loadOptions, values, error: false})
+      })
+      .catch(() => {
+        if (!cancelled) setLazyLoad({loader: loadOptions, values: null, error: true})
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [expanded, options, loadOptions, loaded, loadError])
 
   const values = options ?? loaded ?? []
   const activeCount = facetFilters.filter((f) => f.key === key).length
@@ -202,7 +225,20 @@ function RailSection({section, facetFilters, onFacetFiltersChange}: RailSectionP
             </div>
           )}
 
-          {!options && loadOptions && loaded === null ? (
+          {loadError ? (
+            <div className="space-y-1 px-2 py-1">
+              <p className="text-xs text-muted-foreground">Could not load values.</p>
+              <button
+                type="button"
+                onClick={() => {
+                  setLazyLoad({loader: loadOptions ?? null, values: null, error: false})
+                }}
+                className="rounded px-0 text-xs font-medium text-primary hover:underline focus:outline-none"
+              >
+                Retry
+              </button>
+            </div>
+          ) : !options && loadOptions && loaded === null ? (
             <p className="px-2 py-1 text-xs text-muted-foreground">Loading values...</p>
           ) : shown.length === 0 ? (
             <p className="px-2 py-1 text-xs text-muted-foreground">No matches</p>

--- a/dashboard/src/components/filters/__tests__/FacetRail.test.tsx
+++ b/dashboard/src/components/filters/__tests__/FacetRail.test.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {render, screen, fireEvent} from '@testing-library/react'
+import {render, screen, fireEvent, waitFor} from '@testing-library/react'
 import {describe, it, expect, vi} from 'vitest'
 
 import {FacetRail} from '@/components/filters/FacetRail'
@@ -137,5 +137,64 @@ describe('FacetRail', () => {
 
     expect(await screen.findByText('No matches')).toBeTruthy()
     expect(screen.queryByText('Loading values...')).toBeNull()
+  })
+
+  it('reloads lazy values when the loader time range changes', async () => {
+    const loadOptions = vi.fn((range: string) => Promise.resolve([{value: `${range}-api`}]))
+    const buildSections = (range: string): FacetRailSection[] => [
+      {
+        key: 'service',
+        label: 'Service',
+        loadOptions: () => loadOptions(range),
+      },
+    ]
+    const {rerender} = render(
+      <FacetRail
+        sections={buildSections('1h')}
+        facetFilters={[]}
+        onFacetFiltersChange={() => {}}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: /Service/}))
+
+    expect(await screen.findByRole('button', {name: '1h-api'})).toBeTruthy()
+    expect(loadOptions).toHaveBeenCalledWith('1h')
+
+    rerender(
+      <FacetRail
+        sections={buildSections('24h')}
+        facetFilters={[]}
+        onFacetFiltersChange={() => {}}
+      />
+    )
+
+    await waitFor(() => expect(loadOptions).toHaveBeenCalledWith('24h'))
+    expect(await screen.findByRole('button', {name: '24h-api'})).toBeTruthy()
+    expect(screen.queryByRole('button', {name: '1h-api'})).toBeNull()
+  })
+
+  it('shows a retry state when lazy loading fails', async () => {
+    const loadOptions = vi.fn()
+      .mockRejectedValueOnce(new Error('network failed'))
+      .mockResolvedValueOnce([{value: 'api'}])
+    const lazySections: FacetRailSection[] = [
+      {
+        key: 'service',
+        label: 'Service',
+        loadOptions,
+      },
+    ]
+    render(<FacetRail sections={lazySections} facetFilters={[]} onFacetFiltersChange={() => {}} />)
+
+    fireEvent.click(screen.getByRole('button', {name: /Service/}))
+
+    expect(await screen.findByText('Could not load values.')).toBeTruthy()
+    expect(screen.queryByText('Loading values...')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Retry'}))
+
+    expect(await screen.findByRole('button', {name: 'api'})).toBeTruthy()
+    expect(loadOptions).toHaveBeenCalledTimes(2)
   })
 })

--- a/dashboard/src/components/logs/LogExplorer.tsx
+++ b/dashboard/src/components/logs/LogExplorer.tsx
@@ -17,8 +17,10 @@
 import {startTransition, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {useNavigate} from '@tanstack/react-router'
 import {api, formatErrorForLogging, type LogEntry, type LogFilterOptionsWithCounts} from '@/lib/api'
-import {type FacetFilter, LEVEL_OPTIONS, LogSearchBar, TIME_PRESETS} from '@/components/logs/LogSearchBar'
-import {TagFacets} from '@/components/logs/TagFacets'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
+import {FacetRail} from '@/components/filters/FacetRail'
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import {TimeRangePicker} from '@/components/filters/TimeRangePicker'
 import {LogTable} from '@/components/logs/LogTable'
 import {LogDetail} from '@/components/logs/LogDetail'
 import {AutoRefreshToggle, type RefreshInterval} from '@/components/logs/AutoRefreshToggle'
@@ -29,8 +31,11 @@ import {LogTopList} from '@/components/logs/LogTopList'
 import {LogPieChart} from '@/components/logs/LogPieChart'
 import {LogAggregateTable} from '@/components/logs/LogAggregateTable'
 import {Button} from '@/components/ui/button'
+import {type FacetFilter, type FacetRailSection, type FacetSchema} from '@/lib/filters/types'
+import {TIME_PRESETS} from '@/lib/filters/time'
+import {logLevelBadgeClass} from '@/lib/severity'
 import {cn} from '@/lib/utils'
-import {ChevronDown, ChevronLeft, Download, Loader2, PanelLeftClose, PanelLeftOpen, TerminalSquare} from 'lucide-react'
+import {ChevronDown, ChevronLeft, Download, ListFilter, Loader2, TerminalSquare} from 'lucide-react'
 import {useQuery} from '@tanstack/react-query'
 import {
   type LogViewSearch,
@@ -54,6 +59,23 @@ interface LogExplorerProps {
   initialScrollToBottom?: boolean
   enableUrlSync?: boolean
   urlSearch?: LogViewSearch
+}
+
+const LEVEL_OPTIONS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+const LOG_LEVELS = new Set<string>(LEVEL_OPTIONS)
+const EMPTY_LOG_FILTER_OPTIONS: LogFilterOptionsWithCounts['services'] = []
+const EMPTY_TAG_KEYS: string[] = []
+
+const LOG_FACET_CHIP_COLORS: Record<string, string> = {
+  service: 'bg-[hsl(var(--primary)/0.12)] text-primary border-[hsl(var(--primary)/0.3)]',
+  environment: 'bg-success-bg text-success-fg border-success-border',
+  host: 'bg-[hsl(var(--chart-6)/0.15)] text-[hsl(var(--chart-6))] border-[hsl(var(--chart-6)/0.3)]',
+  source: 'bg-[hsl(var(--chart-7)/0.15)] text-[hsl(var(--chart-7))] border-[hsl(var(--chart-7)/0.3)]',
+}
+
+function shouldOpenFacetRail(enableFacets: boolean): boolean {
+  const viewportWidth = globalThis.window?.innerWidth ?? 0
+  return enableFacets && viewportWidth >= 1024
 }
 
 function toIsoOrUndefined(value: string): string | undefined {
@@ -93,9 +115,104 @@ function formatLogCount(n: number): string {
   return String(n)
 }
 
+function toFacetRailOptions(options: LogFilterOptionsWithCounts['services']) {
+  return options.map((option) => ({value: option.value, count: option.count}))
+}
+
+function keepPreviousLogFilterOptions(
+  previousData: LogFilterOptionsWithCounts | undefined
+): LogFilterOptionsWithCounts | undefined {
+  return previousData
+}
+
 function toDateTimeLocalValue(date: Date): string {
   const pad = (value: number) => String(value).padStart(2, '0')
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function formatLevelSummary(levels: string[]): string {
+  if (levels.length === LEVEL_OPTIONS.length) return 'All Levels'
+  if (levels.length === 0) return 'No Levels'
+  if (levels.length === 1) return levels[0].charAt(0).toUpperCase() + levels[0].slice(1)
+  return `${levels.length} Levels`
+}
+
+function LogLevelPicker({
+  levels,
+  onToggleLevel,
+  onResetLevels,
+}: {
+  levels: string[]
+  onToggleLevel: (level: string) => void
+  onResetLevels: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const hasCustomLevelFilter = levels.length > 0 && levels.length < LEVEL_OPTIONS.length
+  const levelSummary = useMemo(() => formatLevelSummary(levels), [levels])
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  return (
+    <div className="relative" ref={ref}>
+      <Button
+        variant="outline"
+        size="default"
+        className={cn(
+          'h-[30px] px-2 sm:px-3 gap-1.5 whitespace-nowrap font-normal text-xs',
+          hasCustomLevelFilter && 'border-primary/40'
+        )}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <ListFilter className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="hidden text-xs sm:inline">{levelSummary}</span>
+        <ChevronDown className="hidden h-3 w-3 text-muted-foreground sm:inline" />
+      </Button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-[200px] rounded-lg border bg-popover p-1">
+          {LEVEL_OPTIONS.map((level) => {
+            const active = levels.includes(level)
+            return (
+              <button
+                key={level}
+                type="button"
+                onClick={() => onToggleLevel(level)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm transition-colors',
+                  active ? cn(logLevelBadgeClass(level), 'border') : 'hover:bg-accent/50'
+                )}
+              >
+                <span className="font-mono text-xs uppercase">{level}</span>
+              </button>
+            )
+          })}
+          {hasCustomLevelFilter && (
+            <div className="border-t mt-1 pt-1">
+              <button
+                type="button"
+                onClick={() => {
+                  onResetLevels()
+                  setOpen(false)
+                }}
+                className="flex w-full items-center rounded-md px-3 py-1.5 text-left text-sm text-muted-foreground hover:bg-accent/50"
+              >
+                Reset to all levels
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
 }
 
 export function LogExplorer({
@@ -185,9 +302,6 @@ export function LogExplorer({
   // Detail panel
   const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
-
-  // Facets sidebar
-  const [showFacets, setShowFacets] = useState(() => enableFacets && window.innerWidth >= 1024)
 
   // Visualization mode
   const [vizMode, setVizMode] = useState<LogVizMode>(initialState.vizMode)
@@ -353,7 +467,101 @@ export function LogExplorer({
       return api.getLogFilters({from: timeRange.from, to: timeRange.to})
     },
     enabled: !systemId && enableFacets,
+    placeholderData: keepPreviousLogFilterOptions,
   })
+
+  const availableServices = filterOptions?.services ?? EMPTY_LOG_FILTER_OPTIONS
+  const availableEnvironments = filterOptions?.environments ?? EMPTY_LOG_FILTER_OPTIONS
+  const availableTagKeys = filterOptions?.tagKeys ?? EMPTY_TAG_KEYS
+  const serviceSuggestions = useMemo(
+    () => availableServices.map((service) => service.value),
+    [availableServices]
+  )
+  const environmentSuggestions = useMemo(
+    () => availableEnvironments.map((environment) => environment.value),
+    [availableEnvironments]
+  )
+  const logSearchSchema = useMemo<FacetSchema>(
+    () => [
+      {
+        key: 'environment',
+        aliases: ['env'],
+        color: LOG_FACET_CHIP_COLORS.environment,
+        singleSelect: true,
+        suggestions: environmentSuggestions,
+      },
+      {key: 'host', color: LOG_FACET_CHIP_COLORS.host},
+      {key: 'level', allowExclude: false, suggestions: LEVEL_OPTIONS},
+      {
+        key: 'service',
+        color: LOG_FACET_CHIP_COLORS.service,
+        singleSelect: true,
+        suggestions: serviceSuggestions,
+      },
+      {key: 'source', color: LOG_FACET_CHIP_COLORS.source},
+    ],
+    [environmentSuggestions, serviceSuggestions]
+  )
+  const logFacetSections = useMemo<FacetRailSection[]>(() => {
+    const sections: FacetRailSection[] = [
+      {
+        key: 'service',
+        label: 'Service',
+        color: 'bg-primary',
+        singleSelect: true,
+        options: toFacetRailOptions(availableServices),
+      },
+      {
+        key: 'environment',
+        label: 'Environment',
+        color: 'bg-success-solid',
+        singleSelect: true,
+        options: toFacetRailOptions(availableEnvironments),
+      },
+    ]
+
+    for (const tagKey of availableTagKeys) {
+      sections.push({
+        key: tagKey,
+        label: tagKey,
+        color: 'bg-primary/70',
+        singleSelect: true,
+        loadOptions: async () => {
+          const result = await api.getLogTagValues(tagKey, {
+            from: timeRange.from,
+            to: timeRange.to,
+            limit: 30,
+          })
+          return result.values.map((value) => ({value}))
+        },
+      })
+    }
+
+    return sections
+  }, [availableServices, availableEnvironments, availableTagKeys, timeRange.from, timeRange.to])
+
+  const toggleLevel = useCallback((level: string) => {
+    setLevels((current) => {
+      if (!current.includes(level)) return [...current, level]
+      const next = current.filter((item) => item !== level)
+      return next.length === 0 ? current : next
+    })
+  }, [])
+
+  const resetLevels = useCallback(() => {
+    setLevels([...LEVEL_OPTIONS])
+  }, [])
+
+  const handleSearchTokenIntercept = useCallback((key: string, value: string, exclude: boolean) => {
+    if (key !== 'level' || exclude) return false
+    const normalized = value.toLowerCase()
+    if (!LOG_LEVELS.has(normalized)) return true
+    setLevels((current) => {
+      if (current.length === LEVEL_OPTIONS.length) return [normalized]
+      return current.includes(normalized) ? current : [...current, normalized]
+    })
+    return true
+  }, [])
 
   // Fetch logs - org-scoped (getLogs) when no systemId; getSystemLogs when systemId (monitor)
   const {
@@ -554,12 +762,6 @@ export function LogExplorer({
     setDetailOpen(false)
   }, [])
 
-  const toggleLevel = (level: string) => {
-    setLevels((current) =>
-      current.includes(level) ? current.filter((item) => item !== level) : [...current, level]
-    )
-  }
-
   const handlePreviousPage = () => {
     if (cursorHistory.length === 0) return
     const previous = cursorHistory[cursorHistory.length - 1] ?? null
@@ -618,288 +820,287 @@ export function LogExplorer({
   const isInitialLoadingState =
     accumulatedLogs.length === 0 &&
     (isInitialLoading || (logPage?.logs?.length ?? 0) > 0)
-  const showEmptyState = !isInitialLoadingState && logs.length === 0 && !query && facetFilters.length === 0 && !hasCustomLevelFilter && (totalCount === 0 || totalCount === null)
+  const hasTimeRangeFilter = timePreset !== defaultTimeRange || customFrom !== '' || customTo !== ''
+  const showEmptyState =
+    !isInitialLoadingState &&
+    logs.length === 0 &&
+    !query &&
+    facetFilters.length === 0 &&
+    !hasCustomLevelFilter &&
+    !hasTimeRangeFilter &&
+    (totalCount === 0 || totalCount === null)
 
   return (
-    <div className={cn("flex flex-col overflow-hidden bg-gradient-to-br from-background via-background to-[hsl(var(--primary)/0.03)]", className)}>
-      {/* Header bar */}
-      <div className="shrink-0 border-b bg-background/95 backdrop-blur-sm z-20">
-          <div className="flex items-center gap-2 px-2 py-1.5 sm:px-3 lg:px-4">
-            <div className="flex items-center gap-2 shrink-0">
-              <div className="rounded-md bg-gradient-to-br from-primary/15 to-[hsl(var(--chart-3)/0.15)] p-1 ring-1 ring-primary/20">
-                <TerminalSquare className="h-3.5 w-3.5 text-primary" />
-              </div>
-              <h2 className="text-xs font-semibold leading-tight hidden sm:block">Log Explorer</h2>
-            </div>
-
-            <div className="flex-1 min-w-0">
-              <LogSearchBar
-                query={query}
-                onQueryChange={setQuery}
-                facetFilters={facetFilters}
-                onFacetFiltersChange={setFacetFilters}
-                levels={levels}
-                onToggleLevel={toggleLevel}
-                availableTagKeys={filterOptions?.tagKeys ?? []}
-                availableServices={(filterOptions?.services ?? []).map(s => s.value)}
-                availableEnvironments={(filterOptions?.environments ?? []).map(e => e.value)}
-                timePreset={timePreset}
-                onTimePresetChange={setTimePreset}
-                customFrom={customFrom}
-                customTo={customTo}
-                onCustomFromChange={setCustomFrom}
-                onCustomToChange={setCustomTo}
-              />
-            </div>
-
-            {enableAutoRefresh && (
-              <AutoRefreshToggle
-                interval={autoRefreshInterval}
-                onIntervalChange={setAutoRefreshInterval}
-              />
-            )}
+    <>
+      <ExplorerShell
+        className={cn(
+          'min-h-0 overflow-hidden bg-gradient-to-br from-background via-background to-[hsl(var(--primary)/0.03)]',
+          className
+        )}
+        title="Log Explorer"
+        icon={(
+          <div className="rounded-md bg-gradient-to-br from-primary/15 to-[hsl(var(--chart-3)/0.15)] p-1 ring-1 ring-primary/20">
+            <TerminalSquare className="h-3.5 w-3.5 text-primary" />
           </div>
-      </div>
-
-      {/* Main content */}
-      <div className="flex flex-1 overflow-hidden">
-          {/* Facets sidebar */}
-          <div
-            className={cn(
-              'shrink-0 border-r transition-all duration-200',
-              showFacets && enableFacets ? 'w-[200px]' : 'w-0 overflow-hidden border-r-0'
+        )}
+        searchBar={(
+          <SearchFilterBar
+            query={query}
+            onQueryChange={setQuery}
+            facetFilters={facetFilters}
+            onFacetFiltersChange={setFacetFilters}
+            schema={logSearchSchema}
+            suggestKeys={availableTagKeys}
+            onInterceptToken={handleSearchTokenIntercept}
+            placeholder="Search..."
+            hasExtraActiveFilters={hasCustomLevelFilter}
+            onClearExtra={resetLevels}
+            trailing={(
+              <>
+                <LogLevelPicker
+                  levels={levels}
+                  onToggleLevel={toggleLevel}
+                  onResetLevels={resetLevels}
+                />
+                <TimeRangePicker
+                  timePreset={timePreset}
+                  onTimePresetChange={setTimePreset}
+                  customFrom={customFrom}
+                  customTo={customTo}
+                  onCustomFromChange={setCustomFrom}
+                  onCustomToChange={setCustomTo}
+                />
+              </>
             )}
-          >
-            {showFacets && enableFacets && (
-              <TagFacets
-                availableTagKeys={filterOptions?.tagKeys ?? []}
-                availableServices={filterOptions?.services ?? []}
-                availableEnvironments={filterOptions?.environments ?? []}
-                facetFilters={facetFilters}
-                onFacetFiltersChange={setFacetFilters}
-                from={timeRange.from}
-                to={timeRange.to}
-                scopeId={systemId}
-              />
-            )}
-          </div>
+          />
+        )}
+        actions={enableAutoRefresh ? (
+          <AutoRefreshToggle
+            interval={autoRefreshInterval}
+            onIntervalChange={setAutoRefreshInterval}
+          />
+        ) : undefined}
+        rail={enableFacets ? (
+          <FacetRail
+            title="Facets"
+            sections={logFacetSections}
+            facetFilters={facetFilters}
+            onFacetFiltersChange={setFacetFilters}
+          />
+        ) : undefined}
+        defaultRailOpen={shouldOpenFacetRail(enableFacets)}
+        toolbar={(
+          <>
+            <LogVizTabs mode={vizMode} onModeChange={setVizMode} />
 
-          {/* Log content area */}
-          <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-            {/* Toolbar: facets toggle, viz tabs, group by, export, pagination */}
-            <div className="flex items-center gap-1.5 border-b bg-card/30 px-2 py-1">
-              {enableFacets && (
-                <button
-                  type="button"
-                  onClick={() => setShowFacets(!showFacets)}
-                  className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  title={showFacets ? 'Hide facets' : 'Show facets'}
+            {/* Group By / Field selector for non-list views */}
+            {(vizMode === 'toplist' || vizMode === 'pie' || vizMode === 'table') && (
+              <div className="relative">
+                <select
+                  value={topField}
+                  onChange={(e) => setTopField(e.target.value)}
+                  className="h-6 appearance-none rounded border bg-background px-1.5 pr-5 text-[11px]"
                 >
-                  {showFacets ? (
-                    <PanelLeftClose className="h-4 w-4" />
-                  ) : (
-                    <PanelLeftOpen className="h-4 w-4" />
-                  )}
-                </button>
+                  <option value="service">service</option>
+                  <option value="level">level</option>
+                  <option value="environment">environment</option>
+                  <option value="host">host</option>
+                  <option value="container_name">container</option>
+                </select>
+                <ChevronDown className="pointer-events-none absolute right-1 top-1 h-3 w-3 text-muted-foreground" />
+              </div>
+            )}
+
+            {aggregateData && aggregateData.buckets.length > 0 && (
+              <div className="relative">
+                <select
+                  value={groupBy}
+                  onChange={(e) => setGroupBy(e.target.value)}
+                  className="h-6 appearance-none rounded border bg-background px-1.5 pr-5 text-[11px]"
+                >
+                  <option value="">No grouping</option>
+                  <option value="level">Group by level</option>
+                  <option value="service">Group by service</option>
+                  <option value="environment">Group by environment</option>
+                </select>
+                <ChevronDown className="pointer-events-none absolute right-1 top-1 h-3 w-3 text-muted-foreground" />
+              </div>
+            )}
+
+            <div className="flex-1 text-xs text-muted-foreground">
+              {isInitialLoadingState ? (
+                <span className="flex items-center gap-1.5">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Loading...
+                </span>
+              ) : (
+                <span>
+                  {aggregateData?.totalCount != null
+                    ? `${formatLogCount(aggregateData.totalCount)} results found`
+                    : `${logs.length} result${logs.length !== 1 ? 's' : ''} shown`}
+                </span>
               )}
+            </div>
 
-              <LogVizTabs mode={vizMode} onModeChange={setVizMode} />
+            {/* CSV Export - org-scoped only, not for monitor systems */}
+            {!systemId && (
+              <Button variant="ghost" size="sm" onClick={handleExportCsv} className="h-6 gap-1 text-[11px]">
+                <Download className="h-3 w-3" />
+                CSV
+              </Button>
+            )}
 
-              {/* Group By / Field selector for non-list views */}
-              {(vizMode === 'toplist' || vizMode === 'pie' || vizMode === 'table') && (
-                <div className="relative">
-                  <select
-                    value={topField}
-                    onChange={(e) => setTopField(e.target.value)}
-                    className="h-6 appearance-none rounded border bg-background px-1.5 pr-5 text-[11px]"
-                  >
-                    <option value="service">service</option>
-                    <option value="level">level</option>
-                    <option value="environment">environment</option>
-                    <option value="host">host</option>
-                    <option value="container_name">container</option>
-                  </select>
-                  <ChevronDown className="pointer-events-none absolute right-1 top-1 h-3 w-3 text-muted-foreground" />
-                </div>
-              )}
-
-              {aggregateData && aggregateData.buckets.length > 0 && (
-                <div className="relative">
-                  <select
-                    value={groupBy}
-                    onChange={(e) => setGroupBy(e.target.value)}
-                    className="h-6 appearance-none rounded border bg-background px-1.5 pr-5 text-[11px]"
-                  >
-                    <option value="">No grouping</option>
-                    <option value="level">Group by level</option>
-                    <option value="service">Group by service</option>
-                    <option value="environment">Group by environment</option>
-                  </select>
-                  <ChevronDown className="pointer-events-none absolute right-1 top-1 h-3 w-3 text-muted-foreground" />
-                </div>
-              )}
-
-              <div className="flex-1 text-xs text-muted-foreground">
-                {isInitialLoadingState ? (
-                  <span className="flex items-center gap-1.5">
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                    Loading...
+            {/* Pagination (shown only if we have history) */}
+            {cursorHistory.length > 0 && (
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handlePreviousPage}
+                  disabled={cursorHistory.length === 0}
+                  className="h-6 w-6 p-0"
+                  title="Reset to first page"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      >
+        <div className="flex h-full min-h-0 flex-col overflow-hidden">
+          {/* Histogram - always visible above all modes */}
+          {vizMode === 'timeseries' && aggregateData && aggregateData.buckets.length > 0 && (
+            <div className="shrink-0 border-b bg-card/50">
+              <div className="px-2 pt-1.5 pb-1">
+                <div className="mb-0.5 flex items-center justify-between">
+                  <span className="text-[10px] font-medium text-muted-foreground">
+                    Log volume ({aggregateData.interval} buckets)
                   </span>
-                ) : (
-                  <span>
-                    {aggregateData?.totalCount != null
-                      ? `${formatLogCount(aggregateData.totalCount)} results found`
-                      : `${logs.length} result${logs.length !== 1 ? 's' : ''} shown`}
-                  </span>
+                  <span className="text-[10px] text-muted-foreground">Click a bar to zoom</span>
+                </div>
+                <LogHistogram
+                  buckets={aggregateData.buckets}
+                  grouped={true}
+                  height={72}
+                  interval={aggregateData.interval}
+                  rangeFrom={timeRange.from}
+                  rangeTo={timeRange.to ?? getNowDate().toISOString()}
+                  onBucketClick={handleHistogramBucketClick}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Additional visualizations - shown compactly above list */}
+          {(vizMode === 'toplist' || vizMode === 'pie' || vizMode === 'table') && topData && (
+            <div className="shrink-0 border-b bg-card/50">
+              <div className="px-2 py-1.5">
+                {vizMode === 'toplist' && (
+                  <div className="max-h-44 overflow-y-auto">
+                    <LogTopList
+                      values={topData.values.slice(0, 10)}
+                      totalCount={topData.totalCount}
+                      field={topField}
+                      onValueClick={(value) => {
+                        setFacetFilters((prev) => [
+                          ...prev.filter((filter) => filter.key !== topField),
+                          {key: topField, value, exclude: false},
+                        ])
+                      }}
+                    />
+                  </div>
+                )}
+                {vizMode === 'pie' && (
+                  <div className="max-h-52">
+                    <LogPieChart values={topData.values} field={topField} />
+                  </div>
+                )}
+                {vizMode === 'table' && (
+                  <div className="max-h-44 overflow-y-auto">
+                    <LogAggregateTable
+                      values={topData.values}
+                      totalCount={topData.totalCount}
+                      field={topField}
+                      onValueClick={(value) => {
+                        setFacetFilters((prev) => [
+                          ...prev.filter((filter) => filter.key !== topField),
+                          {key: topField, value, exclude: false},
+                        ])
+                      }}
+                    />
+                  </div>
                 )}
               </div>
-
-              {/* CSV Export - org-scoped only, not for monitor systems */}
-              {!systemId && (
-                <Button variant="ghost" size="sm" onClick={handleExportCsv} className="h-6 gap-1 text-[11px]">
-                  <Download className="h-3 w-3" />
-                  CSV
-                </Button>
-              )}
-
-              {/* Pagination (shown only if we have history) */}
-              {cursorHistory.length > 0 && (
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handlePreviousPage}
-                    disabled={cursorHistory.length === 0}
-                    className="h-6 w-6 p-0"
-                    title="Reset to first page"
-                  >
-                    <ChevronLeft className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
             </div>
+          )}
 
-            {/* Histogram - always visible above all modes */}
-            {vizMode === 'timeseries' && aggregateData && aggregateData.buckets.length > 0 && (
-              <div className="shrink-0 border-b bg-card/50">
-                <div className="px-2 pt-1.5 pb-1">
-                  <div className="mb-0.5 flex items-center justify-between">
-                    <span className="text-[10px] font-medium text-muted-foreground">Log volume ({aggregateData.interval} buckets)</span>
-                    <span className="text-[10px] text-muted-foreground">Click a bar to zoom</span>
-                  </div>
-                  <LogHistogram
-                    buckets={aggregateData.buckets}
-                    grouped={true}
-                    height={72}
-                    interval={aggregateData.interval}
-                    rangeFrom={timeRange.from}
-                    rangeTo={timeRange.to ?? getNowDate().toISOString()}
-                    onBucketClick={handleHistogramBucketClick}
-                  />
+          {/* Content area - logs list */}
+          <div className="flex-1 overflow-y-auto" ref={logContainerRef}>
+            {showEmptyState ? (
+              <div className="px-2 pb-4 sm:px-3 sm:pb-6">
+                <LogSetupGuide sdkVersions={sdkVersions} />
+              </div>
+            ) : isInitialLoadingState ? (
+              <div className="flex items-center justify-center py-12">
+                <div className="text-center">
+                  <Loader2 className="mx-auto h-6 w-6 animate-spin text-muted-foreground" />
+                  <p className="mt-2 text-xs text-muted-foreground">Loading logs...</p>
                 </div>
               </div>
-            )}
-
-            {/* Additional visualizations - shown compactly above list */}
-            {(vizMode === 'toplist' || vizMode === 'pie' || vizMode === 'table') && topData && (
-              <div className="shrink-0 border-b bg-card/50">
-                <div className="px-2 py-1.5">
-                  {vizMode === 'toplist' && (
-                    <div className="max-h-44 overflow-y-auto">
-                      <LogTopList
-                        values={topData.values.slice(0, 10)}
-                        totalCount={topData.totalCount}
-                        field={topField}
-                        onValueClick={(value) => {
-                          setFacetFilters(prev => [...prev.filter(f => f.key !== topField), {key: topField, value, exclude: false}])
-                        }}
-                      />
-                    </div>
-                  )}
-                  {vizMode === 'pie' && (
-                    <div className="max-h-52">
-                      <LogPieChart values={topData.values} field={topField} />
-                    </div>
-                  )}
-                  {vizMode === 'table' && (
-                    <div className="max-h-44 overflow-y-auto">
-                      <LogAggregateTable
-                        values={topData.values}
-                        totalCount={topData.totalCount}
-                        field={topField}
-                        onValueClick={(value) => {
-                          setFacetFilters(prev => [...prev.filter(f => f.key !== topField), {key: topField, value, exclude: false}])
-                        }}
-                      />
-                    </div>
-                  )}
+            ) : logs.length === 0 ? (
+              <div className="flex items-center justify-center py-12">
+                <div className="text-center">
+                  <TerminalSquare className="mx-auto h-8 w-8 text-muted-foreground/30" />
+                  <p className="mt-2 text-xs font-medium text-muted-foreground">No logs match your filters</p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground/70">
+                    Try adjusting your search query, time range, or filters
+                  </p>
                 </div>
               </div>
-            )}
+            ) : (
+              <>
+                <LogTable
+                  logs={logs}
+                  selectedLogId={selectedLog?.logId}
+                  onSelectLog={handleSelectLog}
+                  compact={true}
+                />
 
-            {/* Content area - logs list */}
-            <div className="flex-1 overflow-y-auto" ref={logContainerRef}>
-              {showEmptyState ? (
-                <div className="px-2 pb-4 sm:px-3 sm:pb-6">
-                  <LogSetupGuide sdkVersions={sdkVersions} />
-                </div>
-              ) : isInitialLoadingState ? (
-                <div className="flex items-center justify-center py-12">
-                  <div className="text-center">
-                    <Loader2 className="mx-auto h-6 w-6 animate-spin text-muted-foreground" />
-                    <p className="mt-2 text-xs text-muted-foreground">Loading logs...</p>
-                  </div>
-                </div>
-              ) : logs.length === 0 ? (
-                <div className="flex items-center justify-center py-12">
-                  <div className="text-center">
-                    <TerminalSquare className="mx-auto h-8 w-8 text-muted-foreground/30" />
-                    <p className="mt-2 text-xs font-medium text-muted-foreground">No logs match your filters</p>
-                    <p className="mt-0.5 text-[11px] text-muted-foreground/70">
-                      Try adjusting your search query, time range, or filters
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <LogTable
-                    logs={logs}
-                    selectedLogId={selectedLog?.logId}
-                    onSelectLog={handleSelectLog}
-                    compact={true}
-                  />
-                  
-                  {/* Infinite scroll sentinel and loading indicator */}
-                  <div ref={scrollSentinelRef} className="px-2 py-2">
-                    {(isLoadingMore || isFetching) && logPage?.hasMore ? (
-                      <div className="flex items-center justify-center gap-2 py-2">
-                        <div className="h-1 w-full max-w-xs overflow-hidden rounded-full bg-muted">
-                          <div className="h-full w-1/2 animate-pulse bg-primary" style={{animation: 'pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite'}} />
-                        </div>
+                {/* Infinite scroll sentinel and loading indicator */}
+                <div ref={scrollSentinelRef} className="px-2 py-2">
+                  {(isLoadingMore || isFetching) && logPage?.hasMore ? (
+                    <div className="flex items-center justify-center gap-2 py-2">
+                      <div className="h-1 w-full max-w-xs overflow-hidden rounded-full bg-muted">
+                        <div
+                          className="h-full w-1/2 animate-pulse bg-primary"
+                          style={{animation: 'pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite'}}
+                        />
                       </div>
-                    ) : logPage?.hasMore ? (
-                      <div className="text-center text-xs text-muted-foreground/50">
-                        Scroll for more
-                      </div>
-                    ) : logPage && !logPage.hasMore ? (
-                      <div className="border-t pt-2 text-center text-[11px] text-muted-foreground/70">
-                        End of results • {logs.length} logs loaded
-                      </div>
-                    ) : null}
-                  </div>
-                </>
-              )}
-            </div>
+                    </div>
+                  ) : logPage?.hasMore ? (
+                    <div className="text-center text-xs text-muted-foreground/50">
+                      Scroll for more
+                    </div>
+                  ) : logPage && !logPage.hasMore ? (
+                    <div className="border-t pt-2 text-center text-[11px] text-muted-foreground/70">
+                      End of results • {logs.length} logs loaded
+                    </div>
+                  ) : null}
+                </div>
+              </>
+            )}
           </div>
-      </div>
+        </div>
+      </ExplorerShell>
 
       {/* Log detail sheet */}
-      <LogDetail 
-        log={selectedLog} 
-        open={detailOpen} 
-        onClose={() => setDetailOpen(false)} 
+      <LogDetail
+        log={selectedLog}
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
         onViewInContext={enableUrlSync ? handleViewInContext : undefined}
       />
-    </div>
+    </>
   )
 }

--- a/dashboard/src/components/logs/TagFacets.tsx
+++ b/dashboard/src/components/logs/TagFacets.tsx
@@ -20,7 +20,7 @@ import {api} from '@/lib/api'
 import {cn} from '@/lib/utils'
 import {Checkbox} from '@/components/ui/checkbox'
 import {ChevronRight, Minus, Tag} from 'lucide-react'
-import type {FacetFilter} from './LogSearchBar'
+import type {FacetFilter} from '@/lib/filters/types'
 
 import type {LogFilterOptionWithCount} from '@/lib/api'
 

--- a/dashboard/src/components/logs/__tests__/LogExplorer.facets.test.tsx
+++ b/dashboard/src/components/logs/__tests__/LogExplorer.facets.test.tsx
@@ -1,0 +1,445 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {fireEvent, render, screen, waitFor, within} from '@testing-library/react'
+import type {ComponentProps} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {LogExplorer} from '@/components/logs/LogExplorer'
+
+const {mockApi, mockNavigate} = vi.hoisted(() => ({
+  mockApi: {
+    downloadLogExport: vi.fn(),
+    getLogAggregate: vi.fn(),
+    getLogFilters: vi.fn(),
+    getLogTagValues: vi.fn(),
+    getLogTop: vi.fn(),
+    getLogs: vi.fn(),
+    getCurrentUser: vi.fn(),
+    getSystemLogs: vi.fn(),
+    isAuthenticated: vi.fn(() => false),
+  },
+  mockNavigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+  formatErrorForLogging: (error: unknown) => String(error),
+}))
+
+vi.mock('@/lib/demo', () => ({
+  getNowDate: () => new Date('2026-06-03T12:00:00.000Z'),
+}))
+
+vi.mock('@/components/logs/LogDetail', () => ({
+  LogDetail: ({
+    log,
+    open,
+    onViewInContext,
+  }: {
+    log: {message: string; timestamp: string} | null
+    open: boolean
+    onViewInContext?: (log: {message: string; timestamp: string}) => void
+  }) => (
+    open && log
+      ? (
+        <button type="button" onClick={() => onViewInContext?.(log)}>
+          View context for {log.message}
+        </button>
+      )
+      : null
+  ),
+}))
+
+vi.mock('@/components/logs/LogSetupGuide', () => ({
+  LogSetupGuide: () => <div>log setup guide</div>,
+}))
+
+function renderLogExplorer(props: Partial<ComponentProps<typeof LogExplorer>> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LogExplorer enableAutoRefresh={false} {...props} />
+    </QueryClientProvider>
+  )
+}
+
+function sampleLog(overrides: Partial<{
+  logId: string
+  timestamp: string
+  level: string
+  message: string
+  service: string
+  environment: string
+  host: string
+}> = {}) {
+  return {
+    logId: overrides.logId ?? 'log-1',
+    timestamp: overrides.timestamp ?? '2026-06-03T11:58:00.000Z',
+    level: overrides.level ?? 'error',
+    message: overrides.message ?? 'payment failed',
+    body: overrides.message ?? 'payment failed',
+    service: overrides.service ?? 'api',
+    environment: overrides.environment ?? 'prod',
+    host: overrides.host ?? 'host-1',
+    source: 'otlp',
+    containerName: 'worker',
+    containerId: 'container-1',
+    containerImage: 'api:latest',
+    traceId: 'trace-1',
+    spanId: 'span-1',
+    tags: {},
+    resourceAttributes: {},
+  }
+}
+
+describe('LogExplorer facets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(globalThis.window, 'innerWidth', {
+      configurable: true,
+      value: 1280,
+    })
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      configurable: true,
+      value: class {
+        observe() {}
+        disconnect() {}
+      },
+    })
+    mockApi.getLogFilters.mockResolvedValue({
+      services: [{value: 'api', count: 12}],
+      environments: [{value: 'prod', count: 7}],
+      levels: [],
+      tagKeys: ['team'],
+    })
+    mockApi.getLogs.mockResolvedValue({
+      logs: [],
+      nextCursor: null,
+      hasMore: false,
+      totalCount: 0,
+    })
+    mockApi.getLogAggregate.mockResolvedValue({
+      buckets: [],
+      totalCount: 0,
+      interval: 'auto',
+    })
+    mockApi.getLogTop.mockResolvedValue({
+      field: 'service',
+      values: [{value: 'api', count: 9}],
+      totalCount: 9,
+    })
+    mockApi.getSystemLogs.mockResolvedValue({
+      logs: [],
+      nextCursor: null,
+      hasMore: false,
+      totalCount: 0,
+    })
+    mockApi.downloadLogExport.mockResolvedValue(undefined)
+  })
+
+  it('forwards selected service environment and level filters to log queries', async () => {
+    renderLogExplorer()
+
+    fireEvent.click(await screen.findByLabelText('api'))
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        service: 'api',
+        environment: undefined,
+        levels: undefined,
+      }))
+    })
+
+    fireEvent.click(screen.getByLabelText('prod'))
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        service: 'api',
+        environment: 'prod',
+      }))
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: /All Levels/i}))
+    fireEvent.click(screen.getByRole('button', {name: /error/i}))
+
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        service: 'api',
+        environment: 'prod',
+        levels: ['trace', 'debug', 'info', 'warn', 'fatal'],
+      }))
+    })
+
+    fireEvent.click(screen.getByLabelText('Clear all filters'))
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        service: undefined,
+        environment: undefined,
+        levels: undefined,
+      }))
+    })
+  })
+
+  it('applies level tokens from the default state and keeps one level selected', async () => {
+    renderLogExplorer()
+
+    const input = screen.getByPlaceholderText('Search...')
+    fireEvent.change(input, {target: {value: 'level:error'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        levels: ['error'],
+      }))
+    })
+
+    fireEvent.click(screen.getByRole('button', {name: /Error/i}))
+    fireEvent.click(screen.getByRole('button', {name: 'error'}))
+
+    expect(screen.getByRole('button', {name: 'Error'})).toBeInTheDocument()
+    expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+      levels: ['error'],
+    }))
+  })
+
+  it('keeps excluded level tokens as search text', async () => {
+    renderLogExplorer()
+
+    const input = screen.getByPlaceholderText('Search...')
+    fireEvent.change(input, {target: {value: '-level:error'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        query: '-level:error',
+        levels: undefined,
+      }))
+    })
+  })
+
+  it('uses the filtered empty state after changing only the time range', async () => {
+    renderLogExplorer()
+
+    expect(await screen.findByText('log setup guide')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: /Last 7 days/}))
+    fireEvent.click(screen.getByRole('button', {name: 'Last 24 hours'}))
+
+    expect(await screen.findByText('No logs match your filters')).toBeInTheDocument()
+    expect(screen.queryByText('log setup guide')).toBeNull()
+  })
+
+  it('uses the system log API without org-scoped facet or aggregate queries', async () => {
+    renderLogExplorer({systemId: 'system-1'})
+
+    await waitFor(() => {
+      expect(mockApi.getSystemLogs).toHaveBeenCalledWith('system-1', expect.objectContaining({
+        from: '2026-05-27T12:00:00.000Z',
+        to: undefined,
+      }))
+    })
+    expect(mockApi.getLogFilters).not.toHaveBeenCalled()
+    expect(mockApi.getLogAggregate).not.toHaveBeenCalled()
+    expect(mockApi.getLogTop).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', {name: 'CSV'})).toBeNull()
+  })
+
+  it('loads top values and applies a selected top-list value as a facet', async () => {
+    renderLogExplorer()
+
+    fireEvent.click(await screen.findByRole('button', {name: /Top List/i}))
+
+    await waitFor(() => {
+      expect(mockApi.getLogTop).toHaveBeenCalledWith(expect.objectContaining({
+        field: 'service',
+        from: '2026-05-27T12:00:00.000Z',
+        to: undefined,
+      }))
+    })
+    expect(await screen.findByText('Top values for service')).toBeTruthy()
+    const topList = screen.getByText('Top values for service').parentElement
+    expect(topList).not.toBeNull()
+    fireEvent.click(within(topList as HTMLElement).getByRole('button', {name: /api/i}))
+
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        service: 'api',
+      }))
+    })
+    expect(screen.getByText('service:api')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', {name: /Pie Chart/i}))
+    expect(await screen.findByText('api')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Table'}))
+    expect(await screen.findByText('Count')).toBeTruthy()
+  })
+
+  it('exports csv with the current org-scoped filters', async () => {
+    renderLogExplorer()
+
+    fireEvent.click(await screen.findByLabelText('api'))
+    fireEvent.click(screen.getByLabelText('prod'))
+    fireEvent.click(screen.getByRole('button', {name: 'CSV'}))
+
+    await waitFor(() => {
+      expect(mockApi.downloadLogExport).toHaveBeenCalledWith(expect.objectContaining({
+        service: 'api',
+        environment: 'prod',
+        from: '2026-05-27T12:00:00.000Z',
+        to: undefined,
+      }))
+    })
+  })
+
+  it('hydrates url filters and forwards include and exclude filters to every org query', async () => {
+    const facetFilters = [
+      {key: 'service', value: 'api', exclude: false},
+      {key: 'environment', value: 'prod', exclude: false},
+      {key: 'container_name', value: 'worker', exclude: false},
+      {key: 'team', value: 'payments', exclude: false},
+      {key: 'service', value: 'legacy', exclude: true},
+      {key: 'environment', value: 'dev', exclude: true},
+      {key: 'container_name', value: 'old-worker', exclude: true},
+      {key: 'owner', value: 'platform', exclude: true},
+    ]
+
+    renderLogExplorer({
+      enableUrlSync: true,
+      urlSearch: {
+        q: 'timeout',
+        levels: 'error,warn',
+        facets: JSON.stringify(facetFilters),
+        timePreset: 'custom',
+        from: '2026-06-03T11:00:00.000Z',
+        to: '2026-06-03T12:00:00.000Z',
+        viz: 'table',
+        groupBy: 'service',
+        topField: 'host',
+        cursor: 'cursor-1',
+      },
+    })
+
+    const expectedFiltersWithoutCursor = {
+      query: 'timeout',
+      levels: ['error', 'warn'],
+      service: 'api',
+      environment: 'prod',
+      from: '2026-06-03T11:00:00.000Z',
+      to: '2026-06-03T12:00:00.000Z',
+      tags: {team: 'payments'},
+      excludeService: 'legacy',
+      excludeEnvironment: 'dev',
+      excludeContainerName: 'old-worker',
+      excludeTags: {owner: 'platform'},
+    }
+    const expectedLogFilters = {
+      cursor: 'cursor-1',
+      containerName: 'worker',
+      ...expectedFiltersWithoutCursor,
+    }
+
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenCalledWith(expect.objectContaining(expectedLogFilters))
+    })
+    await waitFor(() => {
+      expect(mockApi.getLogAggregate).toHaveBeenCalledWith(expect.objectContaining({
+        ...expectedFiltersWithoutCursor,
+        groupBy: 'service',
+      }))
+    })
+    await waitFor(() => {
+      expect(mockApi.getLogTop).toHaveBeenCalledWith(expect.objectContaining({
+        ...expectedFiltersWithoutCursor,
+        field: 'host',
+        limit: 20,
+      }))
+    })
+  })
+
+  it('renders log rows and can view a selected log in context', async () => {
+    mockApi.getLogs.mockResolvedValue({
+      logs: [sampleLog()],
+      nextCursor: null,
+      hasMore: false,
+      totalCount: 1,
+    })
+    mockApi.getLogAggregate.mockResolvedValue({
+      buckets: [
+        {timestamp: '2026-06-03T11:00:00.000Z', count: 1, groups: {error: 1}},
+      ],
+      totalCount: 1,
+      interval: '1h',
+    })
+
+    renderLogExplorer({enableUrlSync: true})
+
+    fireEvent.click(await screen.findByText('payment failed'))
+    fireEvent.click(await screen.findByRole('button', {name: /View context for payment failed/i}))
+
+    await waitFor(() => {
+      expect(mockApi.getLogs).toHaveBeenLastCalledWith(expect.objectContaining({
+        query: undefined,
+        levels: undefined,
+        from: '2026-06-03T11:53:00.000Z',
+        to: '2026-06-03T12:03:00.000Z',
+      }))
+    })
+  })
+
+  it('reloads lazy tag facet values when the log time range changes', async () => {
+    mockApi.getLogTagValues
+      .mockResolvedValueOnce({key: 'team', values: ['payments']})
+      .mockResolvedValueOnce({key: 'team', values: ['checkout']})
+
+    renderLogExplorer()
+
+    fireEvent.click(await screen.findByRole('button', {name: /team/i}))
+
+    await waitFor(() => {
+      expect(mockApi.getLogTagValues).toHaveBeenCalledWith('team', {
+        from: '2026-05-27T12:00:00.000Z',
+        to: undefined,
+        limit: 30,
+      })
+    })
+    expect(await screen.findByRole('button', {name: 'payments'})).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', {name: /Last 7 days/}))
+    fireEvent.click(screen.getByRole('button', {name: 'Last 24 hours'}))
+
+    await waitFor(() => {
+      expect(mockApi.getLogTagValues).toHaveBeenCalledWith('team', {
+        from: '2026-06-02T12:00:00.000Z',
+        to: undefined,
+        limit: 30,
+      })
+    })
+    expect(await screen.findByRole('button', {name: 'checkout'})).toBeTruthy()
+    expect(screen.queryByRole('button', {name: 'payments'})).toBeNull()
+  })
+})

--- a/dashboard/src/components/logs/__tests__/LogVizComponents.test.tsx
+++ b/dashboard/src/components/logs/__tests__/LogVizComponents.test.tsx
@@ -1,0 +1,273 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type React from 'react'
+import {fireEvent, render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import {LogAggregateTable} from '@/components/logs/LogAggregateTable'
+import {LogHistogram} from '@/components/logs/LogHistogram'
+import {LogPieChart} from '@/components/logs/LogPieChart'
+import {LogTopList} from '@/components/logs/LogTopList'
+import type {LogAggregateBucket} from '@/lib/api'
+
+vi.mock('@/hooks/useTimezone', () => ({
+  useTimezone: () => ({timezone: 'UTC', updateTimezone: vi.fn()}),
+}))
+
+vi.mock('recharts', () => ({
+  Bar: ({dataKey, fill}: {dataKey: string; fill: string}) => (
+    <span data-fill={fill} data-testid={`bar-${dataKey}`} />
+  ),
+  BarChart: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode
+    onClick?: (state: unknown) => void
+  }) => (
+    <div data-testid="bar-chart">
+      <button
+        type="button"
+        onClick={() => onClick?.({
+          activePayload: [{payload: {timestamp: '2026-06-03T11:00:00.000Z'}}],
+        })}
+      >
+        Use bucket
+      </button>
+      <button type="button" onClick={() => onClick?.({activePayload: []})}>
+        Empty payload
+      </button>
+      {children}
+    </div>
+  ),
+  CartesianGrid: () => <span data-testid="grid" />,
+  Cell: ({fill}: {fill: string}) => <span data-fill={fill} data-testid="pie-cell" />,
+  Legend: () => <span data-testid="legend" />,
+  Pie: ({
+    children,
+    data,
+    label,
+  }: {
+    children?: React.ReactNode
+    data: Array<{name: string; value: number}>
+    label?: (entry: {name: string; percent: number}) => string
+  }) => (
+    <div data-testid="pie">
+      {data.map((entry, index) => (
+        <span key={entry.name}>{label?.({name: entry.name, percent: index === 0 ? 0.5 : 0.125})}</span>
+      ))}
+      {children}
+    </div>
+  ),
+  PieChart: ({children}: {children?: React.ReactNode}) => <div data-testid="pie-chart">{children}</div>,
+  ResponsiveContainer: ({
+    children,
+    height,
+  }: {
+    children?: React.ReactNode
+    height?: number | string
+  }) => (
+    <div data-height={height} data-testid="responsive-container">
+      {children}
+    </div>
+  ),
+  Tooltip: ({
+    content,
+    formatter,
+    labelFormatter,
+  }: {
+    content?: React.ReactNode
+    formatter?: (value: unknown, name: unknown) => unknown
+    labelFormatter?: (value: unknown) => unknown
+  }) => (
+    <div data-testid="tooltip">
+      {String(labelFormatter?.(Date.parse('2026-06-03T11:00:00.000Z')) ?? '')}
+      {String(formatter?.(1_500_000, 'total') ?? '')}
+      {String(formatter?.('not-a-number', undefined) ?? '')}
+      {content}
+    </div>
+  ),
+  XAxis: ({tickFormatter}: {tickFormatter?: (value: number) => string}) => (
+    <div data-testid="x-axis">
+      {tickFormatter?.(Date.parse('2026-06-03T11:00:00.000Z'))}
+    </div>
+  ),
+  YAxis: ({tickFormatter}: {tickFormatter?: (value: number) => string}) => (
+    <div data-testid="y-axis">
+      {[999, 1_000, 1_500, 1_000_000, 1_500_000]
+        .map((value) => tickFormatter?.(value))
+        .join('|')}
+    </div>
+  ),
+}))
+
+const topValues = [
+  {value: 'api', count: 1_500_000_000},
+  {value: 'worker', count: 1_500_000},
+  {value: 'web', count: 1_500},
+  {value: 'cron', count: 12},
+]
+
+const histogramBuckets: LogAggregateBucket[] = [
+  {timestamp: 'not-a-date', count: 99, groups: {error: 99}},
+  {
+    timestamp: '2026-06-03T10:00:00.000Z',
+    count: 5,
+    groups: {beta: 2, error: 3},
+  },
+  {
+    timestamp: '2026-06-03T11:00:00.000Z',
+    count: 3,
+    groups: {alpha: 1, warn: 2},
+  },
+]
+
+describe('log visualization components', () => {
+  it('sorts aggregate table rows and forwards clicked values', () => {
+    const onValueClick = vi.fn()
+
+    render(
+      <LogAggregateTable
+        field="service"
+        onValueClick={onValueClick}
+        totalCount={1_501_501_512}
+        values={topValues}
+      />
+    )
+
+    expect(screen.getByText('1.5B')).toBeInTheDocument()
+    expect(screen.getByText('1.5M')).toBeInTheDocument()
+    expect(screen.getByText('1.5k')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('service'))
+    fireEvent.click(screen.getByText('service'))
+    fireEvent.click(screen.getByText('Count'))
+    fireEvent.click(screen.getByText('worker'))
+
+    expect(onValueClick).toHaveBeenCalledWith('worker')
+  })
+
+  it('renders aggregate table empty and zero-total states', () => {
+    const {rerender} = render(
+      <LogAggregateTable field="host" totalCount={0} values={[]} />
+    )
+
+    expect(screen.getByText('No data for field "host"')).toBeInTheDocument()
+
+    rerender(
+      <LogAggregateTable
+        field="host"
+        totalCount={0}
+        values={[{value: 'host-a', count: 10}]}
+      />
+    )
+    fireEvent.click(screen.getByText('host-a'))
+
+    expect(screen.getByText('0.0%')).toBeInTheDocument()
+  })
+
+  it('renders top lists including empty and zero-count variants', () => {
+    const onValueClick = vi.fn()
+    const {rerender} = render(
+      <LogTopList
+        field="service"
+        onValueClick={onValueClick}
+        totalCount={1_501_501_512}
+        values={topValues}
+      />
+    )
+
+    fireEvent.click(screen.getByText('api'))
+
+    expect(screen.getByText('Top values for service')).toBeInTheDocument()
+    expect(screen.getByText('1.5B')).toBeInTheDocument()
+    expect(onValueClick).toHaveBeenCalledWith('api')
+
+    rerender(<LogTopList field="service" totalCount={0} values={[{value: 'zero', count: 0}]} />)
+    expect(screen.getByText('0.0%')).toBeInTheDocument()
+
+    rerender(<LogTopList field="service" totalCount={0} values={[]} />)
+    expect(screen.getByText('No data for field "service"')).toBeInTheDocument()
+  })
+
+  it('renders pie chart data and empty state', () => {
+    const values = Array.from({length: 10}, (_, index) => ({
+      value: `service-${index}`,
+      count: index + 1,
+    }))
+    const {rerender} = render(<LogPieChart field="service" height={180} values={values} />)
+
+    expect(screen.getByText('Distribution by service')).toBeInTheDocument()
+    expect(screen.getByText('service-0 (50%)')).toBeInTheDocument()
+    expect(screen.getAllByTestId('pie-cell')).toHaveLength(8)
+
+    rerender(<LogPieChart field="service" values={[]} />)
+    expect(screen.getByText('No data for field "service"')).toBeInTheDocument()
+  })
+
+  it('renders grouped histograms and forwards bucket clicks', () => {
+    const onBucketClick = vi.fn()
+
+    render(
+      <LogHistogram
+        buckets={histogramBuckets}
+        interval="1h"
+        onBucketClick={onBucketClick}
+        rangeFrom="2026-06-03T09:00:00.000Z"
+        rangeTo="2026-06-03T12:00:00.000Z"
+      />
+    )
+
+    expect(screen.getByTestId('bar-error')).toBeInTheDocument()
+    expect(screen.getByTestId('bar-warn')).toBeInTheDocument()
+    expect(screen.getByTestId('bar-alpha')).toBeInTheDocument()
+    expect(screen.getByTestId('bar-beta')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Use bucket'}))
+    fireEvent.click(screen.getByRole('button', {name: 'Empty payload'}))
+
+    expect(onBucketClick).toHaveBeenCalledTimes(1)
+    expect(onBucketClick).toHaveBeenCalledWith('2026-06-03T11:00:00.000Z')
+  })
+
+  it('renders ungrouped and long-range histograms', () => {
+    const {container, rerender} = render(<LogHistogram buckets={[]} />)
+    expect(container).toBeEmptyDOMElement()
+
+    rerender(
+      <LogHistogram
+        buckets={[histogramBuckets[1]]}
+        grouped={false}
+        interval="5m"
+        rangeFrom="bad-date"
+        rangeTo="2026-06-03T12:00:00.000Z"
+      />
+    )
+    fireEvent.click(screen.getByRole('button', {name: 'Use bucket'}))
+    expect(screen.getByTestId('bar-total')).toBeInTheDocument()
+
+    rerender(
+      <LogHistogram
+        buckets={[histogramBuckets[1]]}
+        interval="1d"
+        rangeFrom="2026-05-01T00:00:00.000Z"
+        rangeTo="2026-06-03T12:00:00.000Z"
+      />
+    )
+    expect(screen.getByTestId('x-axis')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/logs/logViewUrlState.test.ts
+++ b/dashboard/src/components/logs/logViewUrlState.test.ts
@@ -23,7 +23,7 @@ import {
   resolveLogGroupBy,
   serializeLogViewState,
 } from './logViewUrlState'
-import type {FacetFilter} from './LogSearchBar'
+import type {FacetFilter} from '@/lib/filters/types'
 
 describe('logViewUrlState', () => {
   describe('parseLogViewSearch', () => {

--- a/dashboard/src/components/logs/logViewUrlState.ts
+++ b/dashboard/src/components/logs/logViewUrlState.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {type FacetFilter} from '@/components/logs/LogSearchBar'
+import {type FacetFilter} from '@/lib/filters/types'
 import {type LogVizMode} from '@/components/logs/LogVizTabs'
 
 /**


### PR DESCRIPTION
Consolidates log filter controls and keeps lazy facet values in sync with range changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced facet rail with explicit error panel and "Retry" for failed loads.
  * Reorganized logs UI with a shared explorer layout, new filter/time controls, level picker with "Reset" action, visualization panels (histogram/toplist/pie/table) and CSV export control.
  * Retains prior results while refetching to avoid jarring UI updates.

* **Bug Fixes**
  * Prevents redundant facet reloads when values are already loaded.
  * Ensures lazy-loaded facet options refresh when the time range changes.

* **Tests**
  * Added broad tests covering facet lazy-loading, retry behavior, level/filter flows, CSV export, and log visualizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->