### PR TITLE
feat: add org-wide issue reads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepository.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepository.kt
@@ -20,6 +20,7 @@ import com.moneat.events.models.EventResponse
 import com.moneat.events.models.IssueTransactionResponse
 import com.moneat.events.repositories.models.IssueDetailRow
 import com.moneat.events.repositories.models.IssueRow
+import com.moneat.events.repositories.models.IssueStatusKey
 
 /**
  * Repository for issue data access.
@@ -29,6 +30,10 @@ interface IssueRepository {
     suspend fun getProjectIdForIssue(issueId: String): Long?
     suspend fun getProjectIdForIssue(issueId: String, projectId: Long): Long?
     fun getIssueStatusOverrides(projectId: Long): Map<String, String>
+    fun getIssueStatusOverridesForOrganization(
+        organizationId: Int,
+        serviceIds: List<Long>
+    ): Map<IssueStatusKey, String>
     suspend fun getIssuesRaw(
         projectId: Long,
         offset: Int,
@@ -36,6 +41,12 @@ interface IssueRepository {
         retentionDays: Int,
         retentionClause: String,
         projectIdClause: String
+    ): List<IssueRow>
+    suspend fun getOrganizationIssuesRaw(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        overfetch: Int,
+        retentionClause: String
     ): List<IssueRow>
     suspend fun getIssueDetailRaw(
         issueId: String,

--- a/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/IssueRepositoryImpl.kt
@@ -20,10 +20,13 @@ import com.moneat.events.models.EventResponse
 import com.moneat.events.models.IssueTransactionResponse
 import com.moneat.events.repositories.models.IssueDetailRow
 import com.moneat.events.repositories.models.IssueRow
+import com.moneat.events.repositories.models.IssueStatusKey
 import com.moneat.events.services.DashboardQueryHelper
 import com.moneat.shared.models.IssueStatuses
 import com.moneat.shared.models.Projects
+import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.suspendRunCatching
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
@@ -31,12 +34,12 @@ import kotlinx.serialization.json.long
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import kotlin.time.Clock
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 
@@ -77,6 +80,31 @@ class IssueRepositoryImpl(
             }
         } else {
             emptyMap()
+        }
+
+    override fun getIssueStatusOverridesForOrganization(
+        organizationId: Int,
+        serviceIds: List<Long>
+    ): Map<IssueStatusKey, String> =
+        transaction {
+            val serviceFilterIds = normalizedServiceIds(serviceIds)
+            val orgFilter = Projects.organization_id eq organizationId
+            val statusFilter =
+                if (serviceFilterIds.isEmpty()) {
+                    orgFilter
+                } else {
+                    orgFilter and (Projects.id inList serviceFilterIds)
+                }
+
+            (IssueStatuses innerJoin Projects)
+                .selectAll()
+                .where { statusFilter }
+                .associate { row ->
+                    IssueStatusKey(
+                        projectId = row[IssueStatuses.project_id],
+                        issueId = row[IssueStatuses.issue_id]
+                    ) to row[IssueStatuses.status]
+                }
         }
 
     override suspend fun getIssuesRaw(
@@ -130,6 +158,63 @@ class IssueRepositoryImpl(
                 )
             }.getOrElse { e ->
                 logger.error(e) { "Failed to parse issue row" }
+                null
+            }
+        }
+    }
+
+    override suspend fun getOrganizationIssuesRaw(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        overfetch: Int,
+        retentionClause: String
+    ): List<IssueRow> {
+        val organizationClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val serviceClause = serviceFilterClause(serviceIds)
+        val query = """
+            SELECT
+                issue_id,
+                toInt64(project_id) as project_id,
+                any(message) as title,
+                any(exception_type) as culprit,
+                any(level) as level,
+                any(platform) as platform,
+                formatDateTime(min(timestamp), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as first_seen,
+                formatDateTime(max(timestamp), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as last_seen,
+                count() as event_count,
+                uniq(user_id) as user_count,
+                'unresolved' as status
+            FROM `$clickhouseDb`.events e
+            WHERE $organizationClause
+                $serviceClause
+                AND event_type = 'error'
+                AND issue_id != ''
+                AND $retentionClause
+            GROUP BY issue_id, project_id
+            ORDER BY max(timestamp) DESC
+            LIMIT $overfetch
+            FORMAT JSONEachRow
+        """.trimIndent()
+
+        val rows = queryHelper.executeJsonEachRowQuery(query, "Organization issues") ?: return emptyList()
+        return rows.mapNotNull { obj ->
+            suspendRunCatching {
+                IssueRow(
+                    issueId = obj["issue_id"]?.jsonPrimitive?.content ?: return@mapNotNull null,
+                    projectId = obj["project_id"]?.jsonPrimitive?.long ?: return@mapNotNull null,
+                    title = obj["title"]?.jsonPrimitive?.content ?: "",
+                    culprit = obj["culprit"]?.jsonPrimitive?.content ?: "",
+                    level = obj["level"]?.jsonPrimitive?.content ?: "error",
+                    platform = obj["platform"]?.jsonPrimitive?.content ?: "",
+                    firstSeen = obj["first_seen"]?.jsonPrimitive?.content ?: "",
+                    lastSeen = obj["last_seen"]?.jsonPrimitive?.content ?: "",
+                    eventCount = obj["event_count"]?.jsonPrimitive?.long ?: 0,
+                    userCount = obj["user_count"]?.jsonPrimitive?.long ?: 0,
+                    status = obj["status"]?.jsonPrimitive?.contentOrNull ?: "unresolved",
+                    fingerprint = null
+                )
+            }.getOrElse { e ->
+                logger.error(e) { "Failed to parse organization issue row" }
                 null
             }
         }
@@ -310,5 +395,29 @@ class IssueRepositoryImpl(
                 }
             }
         }
+    }
+
+    private fun serviceFilterClause(serviceIds: List<Long>): String {
+        val normalizedIds = normalizedServiceIds(serviceIds)
+        if (normalizedIds.isEmpty()) return ""
+        val values = normalizedIds.joinToString(", ")
+        val column = if (normalizedIds.any { it < 0 }) "toInt64(project_id)" else "project_id"
+        return "AND $column IN ($values)"
+    }
+
+    private fun normalizedServiceIds(serviceIds: List<Long>): List<Long> =
+        serviceIds
+            .flatMap { serviceId ->
+                if (serviceId == DEMO_ALL_SERVICES_ID) {
+                    DEMO_PROJECT_IDS
+                } else {
+                    listOf(serviceId)
+                }
+            }
+            .distinct()
+
+    private companion object {
+        private const val DEMO_ALL_SERVICES_ID = -1L
+        private val DEMO_PROJECT_IDS = listOf(-1L, -2L, -3L)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/events/repositories/ProjectRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/ProjectRepositoryImpl.kt
@@ -215,7 +215,7 @@ class ProjectRepositoryImpl(
                         keys = emptyList(),
                         dsn = "",
                         serviceId = row[Projects.id],
-                        serviceName = row[Projects.slug],
+                        serviceName = projectServiceName(row),
                     )
                 }
         }
@@ -288,9 +288,15 @@ class ProjectRepositoryImpl(
             keys = keys,
             dsn = firstDsn,
             serviceId = row[Projects.id],
-            serviceName = row[Projects.slug],
+            serviceName = projectServiceName(row),
         )
     }
+
+    private fun projectServiceName(row: ResultRow): String =
+        row[Projects.slug]
+            .trim()
+            .ifBlank { row[Projects.name].trim() }
+            .ifBlank { row[Projects.id].toString() }
 
     private fun buildDsn(publicKey: String, projectId: Long): String {
         val backendUrl = EnvConfig.get("BACKEND_URL", "https://api.moneat.io")

--- a/backend/src/main/kotlin/com/moneat/events/repositories/models/IssueStatusKey.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/models/IssueStatusKey.kt
@@ -1,0 +1,22 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.events.repositories.models
+
+data class IssueStatusKey(
+    val projectId: Long,
+    val issueId: String
+)

--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -40,6 +40,7 @@ import com.moneat.events.models.UpdateProjectRequest
 import com.moneat.events.models.UpdateSidebarPreferencesRequest
 import com.moneat.events.models.UserResponse
 import com.moneat.events.services.DashboardService
+import com.moneat.events.services.IssueListQuery
 import com.moneat.notifications.services.AlertNotificationPreferencesService
 import com.moneat.org.routes.integrationCallbackRoutes
 import com.moneat.org.routes.integrationRoutes
@@ -86,12 +87,14 @@ import org.jetbrains.exposed.v1.jdbc.update
 import org.koin.core.context.GlobalContext
 import kotlin.time.Clock
 
+private const val DEFAULT_PAGE = 1
 private const val DEFAULT_PAGE_LIMIT = 25
 private const val DEFAULT_EVENTS_LIMIT = 50
 private const val DEFAULT_TRANSACTIONS_LIMIT = 20
 private const val DEFAULT_REPLAYS_LIMIT = 10
 private const val DEFAULT_ALERT_FREQUENCY_MINUTES = 30
 private const val DEFAULT_ALERT_LIFECYCLE_LIMIT = 50
+private const val DEMO_ORGANIZATION_ID = -1
 private const val ERROR_NO_ORGANIZATION_ACCESS = "No organization access"
 
 @Suppress("kotlin:S3776")
@@ -573,6 +576,50 @@ fun Route.apiRoutes() {
                 }
 
                 // Issues
+                get("/issues") {
+                    val principal = call.principal<JWTPrincipal>()
+                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val isDemo = call.isDemoUser()
+                    val demoEpochMs = call.getDemoEpochMs()
+
+                    val organizationId =
+                        if (isDemo) {
+                            DEMO_ORGANIZATION_ID
+                        } else {
+                            call.resolveSubscriptionOrganizationId(userId) ?: return@get
+                        }
+                    val serviceIds = call.resolveServiceIdsQuery(projectIdResolver)
+                    if (serviceIds == null) {
+                        call.respond(HttpStatusCode.BadRequest, "Invalid serviceIds")
+                        return@get
+                    }
+
+                    val page = call.request.queryParameters["page"]?.toIntOrNull() ?: DEFAULT_PAGE
+                    val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_PAGE_LIMIT
+                    if (page < 1 || limit < 1) {
+                        call.respond(
+                            HttpStatusCode.BadRequest,
+                            ErrorResponse("page and limit must be positive integers")
+                        )
+                        return@get
+                    }
+                    val status = call.request.queryParameters["status"]
+                    val services = call.serviceNamesQuery()
+
+                    val issues = dashboardService.getIssues(
+                        IssueListQuery(
+                            organizationId = organizationId,
+                            page = page,
+                            limit = limit,
+                            status = status,
+                            serviceNames = services,
+                            serviceIds = serviceIds,
+                            demoEpochMs = demoEpochMs
+                        )
+                    )
+                    call.respond(issues)
+                }
+
                 get("/projects/{projectId}/issues") {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
@@ -1547,6 +1594,24 @@ private fun ApplicationCall.resolveProjectPathId(projectIdResolver: ProjectIdRes
 
 private fun ApplicationCall.resolveProjectQueryId(projectIdResolver: ProjectIdResolver): Long? =
     request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
+
+private fun ApplicationCall.serviceNamesQuery(): List<String> =
+    queryCsvValues("services") + queryCsvValues("service")
+
+private fun ApplicationCall.resolveServiceIdsQuery(projectIdResolver: ProjectIdResolver): List<Long>? {
+    val rawServiceIds = queryCsvValues("serviceIds") + queryCsvValues("serviceId")
+    if (rawServiceIds.isEmpty()) return emptyList()
+    return rawServiceIds.map { rawServiceId ->
+        projectIdResolver.resolve(rawServiceId) ?: return null
+    }.distinct()
+}
+
+private fun ApplicationCall.queryCsvValues(name: String): List<String> =
+    request.queryParameters.getAll(name)
+        ?.flatMap { value -> value.split(",") }
+        ?.map { value -> value.trim() }
+        ?.filter { value -> value.isNotBlank() }
+        ?: emptyList()
 
 private suspend fun ApplicationCall.resolveSubscriptionOrganizationId(userId: Int): Int? {
     val orgId = principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
@@ -254,6 +254,11 @@ class DashboardQueryHelper(
         return retentionPolicyService.getRetentionDaysForProject(projectId) ?: PricingTier.FREE.retentionDays
     }
 
+    suspend fun getOrganizationRetentionDays(organizationId: Int): Int =
+        suspendRunCatching {
+            retentionPolicyService.getRetentionDaysForOrganization(organizationId)
+        }.getOrDefault(PricingTier.FREE.retentionDays)
+
     fun timestampRetentionClause(
         column: String,
         retentionDays: Int,

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -137,6 +137,9 @@ class DashboardService(
     ): List<IssueResponse> =
         issueService.getIssues(projectId, page, limit, status, demoEpochMs)
 
+    suspend fun getIssues(query: IssueListQuery): List<IssueResponse> =
+        issueService.getIssues(query)
+
     suspend fun getIssue(
         issueId: String,
         demoEpochMs: Long? = null,

--- a/backend/src/main/kotlin/com/moneat/events/services/IssueListQuery.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IssueListQuery.kt
@@ -1,0 +1,27 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.events.services
+
+data class IssueListQuery(
+    val organizationId: Int,
+    val page: Int,
+    val limit: Int,
+    val status: String?,
+    val serviceNames: List<String> = emptyList(),
+    val serviceIds: List<Long> = emptyList(),
+    val demoEpochMs: Long? = null
+)

--- a/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IssueService.kt
@@ -24,8 +24,10 @@ import com.moneat.events.models.IssueResponse
 import com.moneat.events.models.IssueTransactionResponse
 import com.moneat.events.models.IssueUpdateRequest
 import com.moneat.events.repositories.IssueRepository
+import com.moneat.events.repositories.models.IssueStatusKey
 import com.moneat.shared.models.Projects
 import com.moneat.shared.services.ProjectIdResolver
+import com.moneat.shared.services.ServiceIdentityResolver
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.suspendRunCatching
 import io.ktor.server.plugins.BadRequestException
@@ -42,12 +44,14 @@ class IssueService(
     private val queryHelper: DashboardQueryHelper,
     private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
     private val alertEpisodeService: AlertEpisodeService = AlertEpisodeService(),
+    private val serviceIdentityResolver: ServiceIdentityResolver = ServiceIdentityResolver(),
 ) {
     companion object {
         private const val ISSUE_OVERFETCH_MULTIPLIER = 5
         private const val ERROR_ALERT_DEDUP_PREFIX = "moneat-error-"
         private const val STATUS_IGNORED = "ignored"
         private const val STATUS_RESOLVED = "resolved"
+        private const val STATUS_RESOLVED_IN_NEXT_RELEASE = "resolvedInNextRelease"
         private const val STATUS_ARCHIVED = "archived"
         private const val STATUS_UNRESOLVED = "unresolved"
     }
@@ -116,6 +120,48 @@ class IssueService(
             result
         }.getOrElse { e ->
             logger.error(e) { "Failed to fetch issues for project $projectId" }
+            emptyList()
+        }
+    }
+
+    suspend fun getIssues(query: IssueListQuery): List<IssueResponse> {
+        val offset = (query.page - 1) * query.limit
+        val retentionDays = queryHelper.getOrganizationRetentionDays(query.organizationId)
+        val retentionClause =
+            queryHelper.timestampRetentionClause("timestamp", retentionDays, query.demoEpochMs)
+        val serviceIds = resolveServiceIds(query)
+        if (query.hasServiceFilters() && serviceIds.isEmpty()) return emptyList()
+
+        val pgOverrides = issueRepository.getIssueStatusOverridesForOrganization(
+            organizationId = query.organizationId,
+            serviceIds = serviceIds
+        )
+
+        val overfetch =
+            if (query.status != null) {
+                (query.limit + offset) * ISSUE_OVERFETCH_MULTIPLIER
+            } else {
+                query.limit + offset
+            }
+        val rows = issueRepository.getOrganizationIssuesRaw(
+            organizationId = query.organizationId,
+            serviceIds = serviceIds,
+            overfetch = overfetch,
+            retentionClause = retentionClause
+        )
+
+        return suspendRunCatching {
+            paginateIssueRows(
+                rows = rows,
+                status = query.status,
+                offset = offset,
+                limit = query.limit,
+                statusForRow = { row ->
+                    pgOverrides[IssueStatusKey(row.projectId, row.issueId)] ?: row.status
+                }
+            )
+        }.getOrElse { e ->
+            logger.error(e) { "Failed to fetch issues for organization ${query.organizationId}" }
             emptyList()
         }
     }
@@ -221,12 +267,70 @@ class IssueService(
             ?: throw NotFoundException("Issue not found")
 
         if (update.status != null) {
-            val validStatuses = setOf(STATUS_UNRESOLVED, STATUS_RESOLVED, STATUS_ARCHIVED, STATUS_IGNORED)
+            val validStatuses = setOf(
+                STATUS_UNRESOLVED,
+                STATUS_RESOLVED,
+                STATUS_RESOLVED_IN_NEXT_RELEASE,
+                STATUS_ARCHIVED,
+                STATUS_IGNORED
+            )
             if (update.status !in validStatuses) throw BadRequestException("Invalid status value")
             issueRepository.upsertIssueStatus(issueId, projectId, update.status)
             updateErrorAlertEpisode(issueId, projectId, update.status)
         }
     }
+
+    private fun resolveServiceIds(query: IssueListQuery): List<Long> =
+        (query.serviceIds + resolveServiceNames(query.organizationId, query.serviceNames))
+            .distinct()
+
+    private fun resolveServiceNames(organizationId: Int, serviceNames: List<String>): List<Long> =
+        serviceNames.mapNotNull { serviceName ->
+            serviceIdentityResolver.resolveServiceId(organizationId, serviceName)
+        }
+
+    private fun IssueListQuery.hasServiceFilters(): Boolean =
+        serviceIds.isNotEmpty() || serviceNames.isNotEmpty()
+
+    private fun paginateIssueRows(
+        rows: List<com.moneat.events.repositories.models.IssueRow>,
+        status: String?,
+        offset: Int,
+        limit: Int,
+        statusForRow: (com.moneat.events.repositories.models.IssueRow) -> String
+    ): List<IssueResponse> {
+        var skipped = 0
+        val result = mutableListOf<IssueResponse>()
+        for (row in rows) {
+            val effectiveStatus = statusForRow(row)
+            if (status != null && effectiveStatus != status) continue
+            if (skipped < offset) {
+                skipped++
+                continue
+            }
+            result.add(row.toIssueResponse(effectiveStatus))
+            if (result.size >= limit) break
+        }
+        return result
+    }
+
+    private fun com.moneat.events.repositories.models.IssueRow.toIssueResponse(status: String): IssueResponse =
+        IssueResponse(
+            id = issueId,
+            projectId = projectId,
+            projectResourceId = projectResourceId(projectId),
+            title = title,
+            culprit = culprit,
+            level = level,
+            platform = platform,
+            firstSeen = firstSeen,
+            lastSeen = lastSeen,
+            eventCount = eventCount,
+            userCount = userCount,
+            status = status,
+            substatus = null,
+            statusDetail = null
+        )
 
     private suspend fun resolveProjectIdForIssue(issueId: String, explicitProjectId: Long?): Long? =
         if (explicitProjectId != null) {
@@ -252,6 +356,7 @@ class IssueService(
                     reason = "Issue ignored"
                 )
             STATUS_RESOLVED,
+            STATUS_RESOLVED_IN_NEXT_RELEASE,
             STATUS_ARCHIVED ->
                 alertEpisodeService.closeCurrentEpisode(
                     organizationId = organizationId,

--- a/backend/src/test/kotlin/com/moneat/events/repositories/IssueRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/repositories/IssueRepositoryTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.events.repositories
 
+import com.moneat.events.repositories.models.IssueStatusKey
 import com.moneat.events.services.DashboardQueryHelper
 import com.moneat.shared.models.IssueStatuses
 import com.moneat.shared.models.Organizations
@@ -39,6 +40,7 @@ class IssueRepositoryTest {
 
     private var db: Database? = null
     private lateinit var repository: IssueRepository
+    private var organizationId: Int = 0
     private var projectId: Long = 0L
 
     @BeforeTest
@@ -52,17 +54,20 @@ class IssueRepositoryTest {
         org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.defaultDatabase = db
         TestDatabaseHelper.resetSchema(Organizations, Projects, IssueStatuses)
         repository = IssueRepositoryImpl(DashboardQueryHelper())
-        projectId = transaction {
+        val seedIds = transaction {
             val orgId = Organizations.insert {
                 it[name] = "Org"
                 it[slug] = "org"
             } get Organizations.id
-            Projects.insert {
+            val seededProjectId = Projects.insert {
                 it[organization_id] = orgId
                 it[name] = "Project"
                 it[slug] = "project"
             } get Projects.id
+            orgId to seededProjectId
         }
+        organizationId = seedIds.first
+        projectId = seedIds.second
     }
 
     // ──── getIssueStatusOverrides ────
@@ -88,6 +93,30 @@ class IssueRepositoryTest {
         // projectId <= 0 is a sentinel for demo projects; should return empty without hitting DB
         val overrides = repository.getIssueStatusOverrides(-1L)
         assertTrue(overrides.isEmpty())
+    }
+
+    @Test
+    fun `getIssueStatusOverridesForOrganization keys overrides by project and issue`() {
+        val otherProjectId = transaction {
+            Projects.insert {
+                it[organization_id] = organizationId
+                it[name] = "Other Project"
+                it[slug] = "other-project"
+            } get Projects.id
+        }
+        repository.upsertIssueStatus("shared-issue", projectId, "resolved")
+        repository.upsertIssueStatus("shared-issue", otherProjectId, "ignored")
+
+        val overrides = repository.getIssueStatusOverridesForOrganization(
+            organizationId = organizationId,
+            serviceIds = emptyList()
+        )
+
+        assertEquals("resolved", overrides[IssueStatusKey(projectId, "shared-issue")])
+        assertEquals(
+            "ignored",
+            overrides[IssueStatusKey(otherProjectId, "shared-issue")]
+        )
     }
 
     // ──── getIssueStatus ────

--- a/backend/src/test/kotlin/com/moneat/routes/EventApiRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/EventApiRoutesTest.kt
@@ -31,6 +31,7 @@ import com.moneat.events.models.TransactionSummaryResponse
 import com.moneat.events.models.TransactionWithSpansResponse
 import com.moneat.events.routes.apiRoutes
 import com.moneat.events.services.DashboardService
+import com.moneat.events.services.IssueListQuery
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
@@ -124,8 +125,14 @@ class EventApiRoutesTest {
         routing { apiRoutes() }
     }
 
-    private fun token(userId: Int): String =
-        RouteTestSupport.createToken(userId)
+    private data class SeededProjectScope(
+        val userId: Int,
+        val orgId: Int,
+        val projectId: Long
+    )
+
+    private fun token(userId: Int, orgId: Int? = null): String =
+        RouteTestSupport.createToken(userId, orgId)
 
     private fun demoToken(): String =
         JWT.create().withIssuer("moneat").withAudience("moneat-users")
@@ -135,6 +142,11 @@ class EventApiRoutesTest {
             .sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
 
     private fun seedUserWithProject(): Pair<Int, Long> {
+        val scope = seedUserWithProjectScope()
+        return Pair(scope.userId, scope.projectId)
+    }
+
+    private fun seedUserWithProjectScope(): SeededProjectScope {
         val orgId = transaction {
             Organizations.insert {
                 it[name] = "Event API Test Org"
@@ -162,7 +174,7 @@ class EventApiRoutesTest {
                 it[slug] = "test-project-${System.nanoTime()}"
             } get Projects.id
         }
-        return Pair(userId, projectId)
+        return SeededProjectScope(userId, orgId, projectId)
     }
 
     // ──── Authentication ────
@@ -242,6 +254,82 @@ class EventApiRoutesTest {
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("issue-1"))
+    }
+
+    @Test
+    fun `GET org issues forwards organization and service filters`() = testApplication {
+        val scope = seedUserWithProjectScope()
+        coEvery {
+            mockDashboardService.getIssues(
+                match {
+                    it.organizationId == scope.orgId &&
+                        it.page == 2 &&
+                        it.limit == 5 &&
+                        it.status == "resolved" &&
+                        it.serviceNames == listOf("Test Project") &&
+                        it.serviceIds == listOf(scope.projectId)
+                }
+            )
+        } returns listOf(sampleIssue(scope.projectId))
+
+        application { installTestApp() }
+        val url =
+            "/v1/issues?page=2&limit=5&status=resolved" +
+                "&services=Test%20Project&serviceIds=${scope.projectId}"
+        val response = client.get(url) {
+            withAuth(token(scope.userId, scope.orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("issue-1"))
+        coVerify {
+            mockDashboardService.getIssues(any<IssueListQuery>())
+        }
+    }
+
+    @Test
+    fun `GET org issues returns 400 for invalid service id filter`() = testApplication {
+        val scope = seedUserWithProjectScope()
+
+        application { installTestApp() }
+        val response = client.get("/v1/issues?serviceIds=not-a-service-id") {
+            withAuth(token(scope.userId, scope.orgId))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) {
+            mockDashboardService.getIssues(any<IssueListQuery>())
+        }
+    }
+
+    @Test
+    fun `GET org issues returns 400 for non-positive pagination`() = testApplication {
+        val scope = seedUserWithProjectScope()
+
+        application { installTestApp() }
+        val response = client.get("/v1/issues?page=0&limit=-1") {
+            withAuth(token(scope.userId, scope.orgId))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) {
+            mockDashboardService.getIssues(any<IssueListQuery>())
+        }
+    }
+
+    @Test
+    fun `GET org issues returns 404 when user lacks organization access`() = testApplication {
+        val scope = seedUserWithProjectScope()
+
+        application { installTestApp() }
+        val response = client.get("/v1/issues") {
+            withAuth(token(scope.userId, orgId = 99999))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        coVerify(exactly = 0) {
+            mockDashboardService.getIssues(any<IssueListQuery>())
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/DashboardServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/DashboardServiceTest.kt
@@ -19,6 +19,7 @@ package com.moneat.services
 import com.moneat.billing.models.PricingTierConfigs
 import com.moneat.config.ClickHouseClient
 import com.moneat.events.services.DashboardService
+import com.moneat.events.services.IssueListQuery
 import com.moneat.shared.models.IssueStatuses
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
@@ -122,6 +123,59 @@ class DashboardServiceTest {
         }
 
     @Test
+    fun `getIssues for organization applies organization and service clauses`() =
+        runBlocking {
+            val queries = Collections.synchronizedList(mutableListOf<String>())
+            MockHttpServer { exchange ->
+                val query = exchange.requestBodyText()
+                queries += query
+                if (query.contains("events e") && query.contains("GROUP BY issue_id")) {
+                    exchange.respond(
+                        200,
+                        issueOrgRowJson(),
+                        contentType = "text/plain"
+                    )
+                } else {
+                    exchange.respond(200, "", contentType = "text/plain")
+                }
+            }.use { server ->
+                ClickHouseClient.close()
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+                org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.defaultDatabase = db
+
+                transaction {
+                    Organizations.insert {
+                        it[id] = 1
+                        it[name] = "Test Org"
+                        it[slug] = "test-org"
+                    }
+                    Projects.insert {
+                        it[id] = 123
+                        it[organization_id] = 1
+                        it[name] = "API"
+                        it[slug] = "api"
+                    }
+                }
+
+                val service = DashboardService.create()
+                val issues = service.getIssues(
+                    IssueListQuery(
+                        organizationId = 1,
+                        page = 1,
+                        limit = 10,
+                        status = null,
+                        serviceIds = listOf(123)
+                    )
+                )
+
+                assertEquals(1, issues.size)
+                assertEquals("issue-org-1", issues.first().id)
+                assertTrue(queries.any { it.contains("organization_id = 1") })
+                assertTrue(queries.any { it.contains("project_id IN (123)") })
+            }
+        }
+
+    @Test
     fun `getIssue returns detail with latest event and demo project name`() =
         runBlocking {
             MockHttpServer { exchange ->
@@ -190,6 +244,12 @@ class DashboardServiceTest {
                 assertEquals("t1", traceContext?.get("trace_id")?.jsonPrimitive?.contentOrNull)
             }
         }
+
+    private fun issueOrgRowJson(): String =
+        """{"issue_id":"issue-org-1","project_id":123,"title":"Org crash","culprit":"Api.kt",""" +
+            """"level":"error","platform":"kotlin","first_seen":"2026-02-01T01:00:00.000Z",""" +
+            """"last_seen":"2026-02-02T01:00:00.000Z","event_count":12,"user_count":4,""" +
+            """"status":"unresolved"}"""
 
     @Test
     fun `getIssueTransactions returns transactions linked by issue error trace id`() =

--- a/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
@@ -28,10 +28,13 @@ import com.moneat.events.models.IssueUpdateRequest
 import com.moneat.events.repositories.IssueRepository
 import com.moneat.events.repositories.models.IssueDetailRow
 import com.moneat.events.repositories.models.IssueRow
+import com.moneat.events.repositories.models.IssueStatusKey
 import com.moneat.events.services.DashboardQueryHelper
 import com.moneat.events.services.FeedbackService
 import com.moneat.events.services.IngestionWorker
+import com.moneat.events.services.IssueListQuery
 import com.moneat.events.services.IssueService
+import com.moneat.shared.models.OtelServiceProjectMappings
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
 import com.moneat.shared.services.ProjectIdResolver
@@ -95,7 +98,7 @@ class EventServicesExtendedTest {
             driver = "org.h2.Driver"
         )
         TransactionManager.defaultDatabase = db
-        TestDatabaseHelper.resetSchema(Organizations, Projects)
+        TestDatabaseHelper.resetSchema(Organizations, Projects, OtelServiceProjectMappings)
         transaction {
             Organizations.insert {
                 it[id] = ORGANIZATION_ID
@@ -115,6 +118,7 @@ class EventServicesExtendedTest {
         alertEpisodeService = mockk(relaxed = true)
 
         coEvery { queryHelper.getProjectRetentionDays(any()) } returns 30
+        coEvery { queryHelper.getOrganizationRetentionDays(any()) } returns 30
         every {
             queryHelper.timestampRetentionClause(any(), any(), any())
         } returns "timestamp >= now() - INTERVAL 30 DAY"
@@ -255,6 +259,119 @@ class EventServicesExtendedTest {
         assertEquals(2, result.size)
         assertEquals("i3", result[0].id)
         assertEquals("i4", result[1].id)
+    }
+
+    @Test
+    fun `getIssues for organization applies status overrides per project`() = runBlocking {
+        val otherProjectId = seedProject("Other Project")
+        val rows = listOf(
+            makeIssueRow(issueId = "shared", projectId = testProjectId, status = "unresolved"),
+            makeIssueRow(issueId = "shared", projectId = otherProjectId, status = "unresolved")
+        )
+        every {
+            issueRepository.getIssueStatusOverridesForOrganization(ORGANIZATION_ID, emptyList())
+        } returns mapOf(IssueStatusKey(otherProjectId, "shared") to "ignored")
+        coEvery {
+            issueRepository.getOrganizationIssuesRaw(
+                organizationId = ORGANIZATION_ID,
+                serviceIds = emptyList(),
+                overfetch = any(),
+                retentionClause = any()
+            )
+        } returns rows
+
+        val result = issueService.getIssues(
+            IssueListQuery(
+                organizationId = ORGANIZATION_ID,
+                page = 1,
+                limit = 10,
+                status = "ignored"
+            )
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(otherProjectId, result.single().projectId)
+    }
+
+    @Test
+    fun `getIssues for organization forwards service id filters`() = runBlocking {
+        every {
+            issueRepository.getIssueStatusOverridesForOrganization(ORGANIZATION_ID, listOf(testProjectId))
+        } returns emptyMap()
+        coEvery {
+            issueRepository.getOrganizationIssuesRaw(
+                organizationId = ORGANIZATION_ID,
+                serviceIds = listOf(testProjectId),
+                overfetch = 10,
+                retentionClause = any()
+            )
+        } returns listOf(makeIssueRow(projectId = testProjectId))
+
+        val result = issueService.getIssues(
+            IssueListQuery(
+                organizationId = ORGANIZATION_ID,
+                page = 1,
+                limit = 10,
+                status = null,
+                serviceIds = listOf(testProjectId)
+            )
+        )
+
+        assertEquals(1, result.size)
+        coVerify {
+            issueRepository.getOrganizationIssuesRaw(
+                organizationId = ORGANIZATION_ID,
+                serviceIds = listOf(testProjectId),
+                overfetch = 10,
+                retentionClause = any()
+            )
+        }
+    }
+
+    @Test
+    fun `getIssues for organization resolves service names to service ids`() = runBlocking {
+        every {
+            issueRepository.getIssueStatusOverridesForOrganization(ORGANIZATION_ID, listOf(testProjectId))
+        } returns emptyMap()
+        coEvery {
+            issueRepository.getOrganizationIssuesRaw(
+                organizationId = ORGANIZATION_ID,
+                serviceIds = listOf(testProjectId),
+                overfetch = 10,
+                retentionClause = any()
+            )
+        } returns listOf(makeIssueRow(projectId = testProjectId))
+
+        val result = issueService.getIssues(
+            IssueListQuery(
+                organizationId = ORGANIZATION_ID,
+                page = 1,
+                limit = 10,
+                status = null,
+                serviceNames = listOf("test-project")
+            )
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(testProjectId, result.single().projectId)
+    }
+
+    @Test
+    fun `getIssues for organization returns empty when service names do not resolve`() = runBlocking {
+        val result = issueService.getIssues(
+            IssueListQuery(
+                organizationId = ORGANIZATION_ID,
+                page = 1,
+                limit = 10,
+                status = null,
+                serviceNames = listOf("missing-service")
+            )
+        )
+
+        assertTrue(result.isEmpty())
+        coVerify(exactly = 0) {
+            issueRepository.getOrganizationIssuesRaw(any(), any(), any(), any())
+        }
     }
 
     // ================================================================
@@ -422,7 +539,7 @@ class EventServicesExtendedTest {
     fun `updateIssue accepts all valid statuses`() = runBlocking {
         coEvery { issueRepository.getProjectIdForIssue(testIssueId) } returns testProjectId
 
-        for (status in listOf("unresolved", "resolved", "archived", "ignored")) {
+        for (status in listOf("unresolved", "resolved", "resolvedInNextRelease", "archived", "ignored")) {
             issueService.updateIssue(testIssueId, IssueUpdateRequest(status = status))
             verify { issueRepository.upsertIssueStatus(testIssueId, testProjectId, status) }
         }
@@ -468,13 +585,14 @@ class EventServicesExtendedTest {
     }
 
     @Test
-    fun `updateIssue resolved and archived close current error alert episode`() = runBlocking {
+    fun `updateIssue resolved states and archived close current error alert episode`() = runBlocking {
         coEvery { issueRepository.getProjectIdForIssue(testIssueId) } returns testProjectId
 
         issueService.updateIssue(testIssueId, IssueUpdateRequest(status = "resolved"))
+        issueService.updateIssue(testIssueId, IssueUpdateRequest(status = "resolvedInNextRelease"))
         issueService.updateIssue(testIssueId, IssueUpdateRequest(status = "archived"))
 
-        verify(exactly = 2) {
+        verify(exactly = 3) {
             alertEpisodeService.closeCurrentEpisode(
                 organizationId = ORGANIZATION_ID,
                 source = AlertSource.ERROR_ALERT,
@@ -953,10 +1071,11 @@ class EventServicesExtendedTest {
 
     private fun makeIssueRow(
         issueId: String = ISSUE_1,
-        status: String = "unresolved"
+        status: String = "unresolved",
+        projectId: Long = testProjectId
     ): IssueRow = IssueRow(
         issueId = issueId,
-        projectId = testProjectId,
+        projectId = projectId,
         title = "Test $issueId",
         culprit = "com.example.Main",
         level = "error",
@@ -968,6 +1087,15 @@ class EventServicesExtendedTest {
         status = status,
         fingerprint = listOf("fp1")
     )
+
+    private fun seedProject(name: String): Long =
+        transaction {
+            Projects.insert {
+                it[organization_id] = ORGANIZATION_ID
+                it[Projects.name] = name
+                it[slug] = name.lowercase().replace(" ", "-")
+            } get Projects.id
+        }
 
     private fun makeIssueDetailRow(
         issueId: String = ISSUE_1,


### PR DESCRIPTION
Adds org-scoped issue listing with service filters while preserving project-scoped issue routes.

Validates org/service filtering, status overrides, and route access behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-level issue listing endpoint with service filtering, pagination, and organization-scoped status overrides
  * Added new issue status "resolvedInNextRelease"

* **Bug Fixes / Improvements**
  * Improved project/service name selection so services display a sensible fallback when missing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->