### PR TITLE
feat: add org-wide analytics reads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
@@ -17,11 +17,16 @@
 package com.moneat.analytics.routes
 
 import com.moneat.analytics.models.AnalyticsFilter
+import com.moneat.analytics.services.AnalyticsQueryScope
 import com.moneat.analytics.services.AnalyticsService
+import com.moneat.config.EnvConfig
 import com.moneat.events.services.DashboardService
+import com.moneat.plugins.isDemoUser
+import com.moneat.shared.models.Memberships
 import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
@@ -31,6 +36,10 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import mu.KotlinLogging
 import org.koin.core.context.GlobalContext
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
 
@@ -47,227 +56,367 @@ private val DEFAULT_RETENTION_PERIODS = listOf(1, 7, 14, 30)
 
 /**
  * Authenticated dashboard API routes for product analytics.
- * All endpoints are under /v1/analytics/{projectId}/...
+ * Project-scoped endpoints are under /v1/analytics/{projectId}/...
+ * Organization-scoped endpoints are under /v1/analytics/...
  */
 fun Route.analyticsRoutes(
     analyticsService: AnalyticsService = GlobalContext.get().get(),
     dashboardService: DashboardService = GlobalContext.get().get(),
     projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
 ) {
-    route("/v1/analytics/{projectId}") {
-        authenticate("auth-jwt") {
-            get("/overview") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val (compFrom, compTo) = parseComparison(call, dateFrom, dateTo)
-
-                val result = analyticsService.getOverview(projectId, dateFrom, dateTo, filters, compFrom, compTo)
-                call.respond(result)
-            }
-
-            get("/timeseries") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-
-                val result = analyticsService.getTimeseries(projectId, dateFrom, dateTo, filters)
-                call.respond(result)
-            }
-
-            get("/pages") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-
-                val result = analyticsService.getPages(projectId, dateFrom, dateTo, filters, limit)
-                call.respond(result)
-            }
-
-            get("/entry-pages") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-
-                val result = analyticsService.getEntryPages(projectId, dateFrom, dateTo, filters, limit)
-                call.respond(result)
-            }
-
-            get("/exit-pages") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-
-                val result = analyticsService.getExitPages(projectId, dateFrom, dateTo, filters, limit)
-                call.respond(result)
-            }
-
-            get("/sources") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-
-                val result = analyticsService.getBreakdown(
-                    projectId,
-                    dateFrom,
-                    dateTo,
-                    filters,
-                    "referrer_source",
-                    limit,
-                )
-                call.respond(result)
-            }
-
-            get("/utm/{param}") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val param = call.parameters["param"] ?: "source"
-                val dimension = "utm_$param"
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-
-                val result = analyticsService.getBreakdown(projectId, dateFrom, dateTo, filters, dimension, limit)
-                call.respond(result)
-            }
-
-            get("/locations") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-
-                val result = analyticsService.getBreakdown(
-                    projectId,
-                    dateFrom,
-                    dateTo,
-                    filters,
-                    "country_code",
-                    limit,
-                )
-                call.respond(result)
-            }
-
-            get("/devices") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val type = call.request.queryParameters["type"] ?: "device_type"
-                val dimension = when (type) {
-                    "browser" -> "browser"
-                    "os" -> "os"
-                    else -> "device_type"
-                }
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-
-                val result = analyticsService.getBreakdown(projectId, dateFrom, dateTo, filters, dimension, limit)
-                call.respond(result)
-            }
-
-            get("/events") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val filters = parseFilters(call)
-                val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
-                val groupBy = call.request.queryParameters["group_by"] ?: "session_id"
-                val source = call.request.queryParameters["source"]
-
-                val result = analyticsService.getEvents(projectId, dateFrom, dateTo, filters, limit, groupBy, source)
-                call.respond(result)
-            }
-
-            get("/realtime") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val result = analyticsService.getRealtime(projectId)
-                call.respond(result)
-            }
-
-            get("/funnel") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val steps = call.request.queryParameters.getAll("steps")
-                    ?: call.request.queryParameters.getAll("steps[]")
-                    ?: emptyList()
-                if (steps.size < 2) {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("At least 2 funnel steps required"))
-                    return@get
-                }
-                val groupBy = call.request.queryParameters["group_by"] ?: "session_id"
-                val source = call.request.queryParameters["source"]
-
-                val result = analyticsService.getFunnel(projectId, dateFrom, dateTo, steps, groupBy, source)
-                call.respond(result)
-            }
-
-            get("/retention") {
-                val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return@get
-                val (dateFrom, dateTo) = parseDateRange(call) ?: run {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
-                    return@get
-                }
-                val startEvent = call.request.queryParameters["start_event"]
-                val returnEvent = call.request.queryParameters["return_event"]
-                if (startEvent.isNullOrBlank() || returnEvent.isNullOrBlank()) {
-                    call.respond(HttpStatusCode.BadRequest, ErrorResponse("start_event and return_event are required"))
-                    return@get
-                }
-
-                val result = analyticsService.getRetention(
-                    projectId,
-                    dateFrom,
-                    dateTo,
-                    startEvent,
-                    returnEvent,
-                    parseRetentionPeriods(call),
-                )
-                call.respond(result)
-            }
+    route("/v1/analytics") {
+        analyticsReadRoutes(analyticsService) { call ->
+            extractOrganizationContext(call, dashboardService, projectIdResolver)
         }
     }
+
+    route("/v1/analytics/{projectId}") {
+        analyticsReadRoutes(analyticsService) { call ->
+            extractProjectContext(call, dashboardService, projectIdResolver)
+        }
+    }
+}
+
+private typealias AnalyticsContextProvider = suspend (ApplicationCall) -> AnalyticsRouteContext?
+
+private enum class PageBreakdown {
+    ALL,
+    ENTRY,
+    EXIT,
+}
+
+private fun Route.analyticsReadRoutes(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    authenticate("auth-jwt") {
+        get("/overview") {
+            call.respondOverview(analyticsService, contextProvider)
+        }
+        get("/timeseries") {
+            call.respondTimeseries(analyticsService, contextProvider)
+        }
+        get("/pages") {
+            call.respondPages(analyticsService, contextProvider, PageBreakdown.ALL)
+        }
+        get("/entry-pages") {
+            call.respondPages(analyticsService, contextProvider, PageBreakdown.ENTRY)
+        }
+        get("/exit-pages") {
+            call.respondPages(analyticsService, contextProvider, PageBreakdown.EXIT)
+        }
+        get("/sources") {
+            call.respondBreakdown(analyticsService, contextProvider, "referrer_source")
+        }
+        get("/utm/{param}") {
+            val param = call.parameters["param"] ?: "source"
+            call.respondBreakdown(analyticsService, contextProvider, "utm_$param")
+        }
+        get("/locations") {
+            call.respondBreakdown(analyticsService, contextProvider, "country_code")
+        }
+        get("/devices") {
+            call.respondDevices(analyticsService, contextProvider)
+        }
+        get("/events") {
+            call.respondEvents(analyticsService, contextProvider)
+        }
+        get("/realtime") {
+            call.respondRealtime(analyticsService, contextProvider)
+        }
+        get("/funnel") {
+            call.respondFunnel(analyticsService, contextProvider)
+        }
+        get("/retention") {
+            call.respondRetention(analyticsService, contextProvider)
+        }
+    }
+}
+
+private suspend fun ApplicationCall.respondOverview(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    val context = contextProvider(this) ?: return
+    val (dateFrom, dateTo) = parseRequiredDateRange() ?: return
+    val filters = parseFilters(this)
+    val (compFrom, compTo) = parseComparison(this, dateFrom, dateTo)
+    respond(analyticsService.getOverview(context, dateFrom, dateTo, filters, compFrom, compTo))
+}
+
+private suspend fun ApplicationCall.respondTimeseries(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    val context = contextProvider(this) ?: return
+    val (dateFrom, dateTo) = parseRequiredDateRange() ?: return
+    val filters = parseFilters(this)
+    respond(analyticsService.getTimeseries(context, dateFrom, dateTo, filters))
+}
+
+private suspend fun ApplicationCall.respondPages(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+    pageBreakdown: PageBreakdown,
+) {
+    val context = contextProvider(this) ?: return
+    val (dateFrom, dateTo) = parseRequiredDateRange() ?: return
+    val filters = parseFilters(this)
+    val limit = limitQuery()
+    val result = when (pageBreakdown) {
+        PageBreakdown.ALL -> analyticsService.getPages(context, dateFrom, dateTo, filters, limit)
+        PageBreakdown.ENTRY -> analyticsService.getEntryPages(context, dateFrom, dateTo, filters, limit)
+        PageBreakdown.EXIT -> analyticsService.getExitPages(context, dateFrom, dateTo, filters, limit)
+    }
+    respond(result)
+}
+
+private suspend fun ApplicationCall.respondBreakdown(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+    dimension: String,
+) {
+    val context = contextProvider(this) ?: return
+    val (dateFrom, dateTo) = parseRequiredDateRange() ?: return
+    val filters = parseFilters(this)
+    respond(analyticsService.getBreakdown(context, dateFrom, dateTo, filters, dimension, limitQuery()))
+}
+
+private suspend fun ApplicationCall.respondDevices(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    val dimension = when (request.queryParameters["type"]) {
+        "browser" -> "browser"
+        "os" -> "os"
+        else -> "device_type"
+    }
+    respondBreakdown(analyticsService, contextProvider, dimension)
+}
+
+private suspend fun ApplicationCall.respondEvents(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    val context = contextProvider(this) ?: return
+    val (dateFrom, dateTo) = parseRequiredDateRange() ?: return
+    val filters = parseFilters(this)
+    val groupBy = request.queryParameters["group_by"] ?: "session_id"
+    val source = request.queryParameters["source"]
+    respond(analyticsService.getEvents(context, dateFrom, dateTo, filters, limitQuery(), groupBy, source))
+}
+
+private suspend fun ApplicationCall.respondRealtime(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    val context = contextProvider(this) ?: return
+    respond(analyticsService.getRealtime(context))
+}
+
+private suspend fun ApplicationCall.respondFunnel(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    val context = contextProvider(this) ?: return
+    val (dateFrom, dateTo) = parseRequiredDateRange() ?: return
+    val steps = requiredFunnelSteps() ?: return
+    val groupBy = request.queryParameters["group_by"] ?: "session_id"
+    val source = request.queryParameters["source"]
+    respond(analyticsService.getFunnel(context, dateFrom, dateTo, steps, groupBy, source))
+}
+
+private suspend fun ApplicationCall.respondRetention(
+    analyticsService: AnalyticsService,
+    contextProvider: AnalyticsContextProvider,
+) {
+    val context = contextProvider(this) ?: return
+    val (dateFrom, dateTo) = parseRequiredDateRange() ?: return
+    val (startEvent, returnEvent) = requiredRetentionEvents() ?: return
+    respond(
+        analyticsService.getRetention(
+            context,
+            dateFrom,
+            dateTo,
+            startEvent,
+            returnEvent,
+            parseRetentionPeriods(this),
+        ),
+    )
 }
 
 // --- Helpers ---
 
 private const val DEFAULT_LIMIT = 100
+private const val ERROR_NO_ORGANIZATION_ACCESS = "No organization access"
+private const val ERROR_INVALID_SERVICE_IDS = "Invalid serviceIds"
+private val DEMO_SERVICE_IDS = listOf(-1L, -2L, -3L)
+
+private data class AnalyticsRouteContext(
+    val scope: AnalyticsQueryScope,
+    val projectId: Long? = null,
+)
+
+private suspend fun AnalyticsService.getOverview(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    filters: List<AnalyticsFilter>,
+    compFrom: LocalDate?,
+    compTo: LocalDate?,
+) = context.projectId?.let { projectId ->
+    getOverview(projectId, dateFrom, dateTo, filters, compFrom, compTo)
+} ?: getOverview(context.scope, dateFrom, dateTo, filters, compFrom, compTo)
+
+private suspend fun AnalyticsService.getTimeseries(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    filters: List<AnalyticsFilter>,
+) = context.projectId?.let { projectId ->
+    getTimeseries(projectId, dateFrom, dateTo, filters)
+} ?: getTimeseries(context.scope, dateFrom, dateTo, filters)
+
+private suspend fun AnalyticsService.getPages(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    filters: List<AnalyticsFilter>,
+    limit: Int,
+) = context.projectId?.let { projectId ->
+    getPages(projectId, dateFrom, dateTo, filters, limit)
+} ?: getPages(context.scope, dateFrom, dateTo, filters, limit)
+
+private suspend fun AnalyticsService.getEntryPages(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    filters: List<AnalyticsFilter>,
+    limit: Int,
+) = context.projectId?.let { projectId ->
+    getEntryPages(projectId, dateFrom, dateTo, filters, limit)
+} ?: getEntryPages(context.scope, dateFrom, dateTo, filters, limit)
+
+private suspend fun AnalyticsService.getExitPages(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    filters: List<AnalyticsFilter>,
+    limit: Int,
+) = context.projectId?.let { projectId ->
+    getExitPages(projectId, dateFrom, dateTo, filters, limit)
+} ?: getExitPages(context.scope, dateFrom, dateTo, filters, limit)
+
+private suspend fun AnalyticsService.getBreakdown(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    filters: List<AnalyticsFilter>,
+    dimension: String,
+    limit: Int,
+) = context.projectId?.let { projectId ->
+    getBreakdown(projectId, dateFrom, dateTo, filters, dimension, limit)
+} ?: getBreakdown(context.scope, dateFrom, dateTo, filters, dimension, limit)
+
+private fun AnalyticsService.getRealtime(context: AnalyticsRouteContext) =
+    context.projectId?.let { projectId ->
+        getRealtime(projectId)
+    } ?: getRealtime(context.scope)
+
+private suspend fun AnalyticsService.getFunnel(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    steps: List<String>,
+    groupBy: String,
+    source: String?,
+) = context.projectId?.let { projectId ->
+    getFunnel(projectId, dateFrom, dateTo, steps, groupBy, source)
+} ?: getFunnel(context.scope, dateFrom, dateTo, steps, groupBy, source)
+
+private suspend fun AnalyticsService.getRetention(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    startEvent: String,
+    returnEvent: String,
+    periods: List<Int>,
+) = context.projectId?.let { projectId ->
+    getRetention(projectId, dateFrom, dateTo, startEvent, returnEvent, periods)
+} ?: getRetention(context.scope, dateFrom, dateTo, startEvent, returnEvent, periods)
+
+private suspend fun AnalyticsService.getEvents(
+    context: AnalyticsRouteContext,
+    dateFrom: LocalDate,
+    dateTo: LocalDate,
+    filters: List<AnalyticsFilter>,
+    limit: Int,
+    groupBy: String,
+    source: String?,
+) = context.projectId?.let { projectId ->
+    getEvents(projectId, dateFrom, dateTo, filters, limit, groupBy, source)
+} ?: getEvents(context.scope, dateFrom, dateTo, filters, limit, groupBy, source)
+
+private suspend fun extractOrganizationContext(
+    call: ApplicationCall,
+    dashboardService: DashboardService,
+    projectIdResolver: ProjectIdResolver,
+): AnalyticsRouteContext? {
+    val principal = call.principal<JWTPrincipal>()
+    val userId = principal?.payload?.getClaim("userId")?.asInt()
+    if (userId == null) {
+        call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+        return null
+    }
+
+    val organizationId = if (call.isDemoUser()) {
+        EnvConfig.Demo.ORG_ID.toInt()
+    } else {
+        val orgId = principal.payload.getClaim("orgId").asInt()
+        if (orgId == null || !hasOrganizationAccess(userId, orgId)) {
+            call.respond(HttpStatusCode.NotFound, ErrorResponse(ERROR_NO_ORGANIZATION_ACCESS))
+            return null
+        }
+        orgId
+    }
+
+    val serviceIds = call.resolveServiceIdsQuery(projectIdResolver)
+    if (serviceIds == null) {
+        call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERROR_INVALID_SERVICE_IDS))
+        return null
+    }
+
+    val serviceNames = call.serviceNamesQuery()
+    val resolvedNameIds = serviceNames.mapNotNull { serviceName ->
+        dashboardService.resolveServiceId(organizationId, serviceName)
+    }
+    val requestedServiceIds = normalizeRequestedServiceIds(serviceIds + resolvedNameIds)
+    val organizationServiceIds = if (call.isDemoUser()) {
+        DEMO_SERVICE_IDS
+    } else {
+        dashboardService.getServiceIdsForOrganization(organizationId)
+    }
+
+    val scopedServiceIds = if (serviceIds.isNotEmpty() || serviceNames.isNotEmpty()) {
+        requestedServiceIds.filter { serviceId -> serviceId in organizationServiceIds }
+    } else {
+        organizationServiceIds
+    }
+
+    return AnalyticsRouteContext(AnalyticsQueryScope.services(scopedServiceIds))
+}
+
+private suspend fun extractProjectContext(
+    call: ApplicationCall,
+    dashboardService: DashboardService,
+    projectIdResolver: ProjectIdResolver,
+): AnalyticsRouteContext? {
+    val (projectId, _) = extractContext(call, dashboardService, projectIdResolver) ?: return null
+    return AnalyticsRouteContext(AnalyticsQueryScope.service(projectId), projectId)
+}
 
 private suspend fun extractContext(
-    call: io.ktor.server.application.ApplicationCall,
+    call: ApplicationCall,
     dashboardService: DashboardService,
     projectIdResolver: ProjectIdResolver,
 ): Pair<Long, Int>? {
@@ -289,7 +438,80 @@ private suspend fun extractContext(
     return projectId to userId
 }
 
-private fun parseDateRange(call: io.ktor.server.application.ApplicationCall): Pair<LocalDate, LocalDate>? {
+private fun normalizeRequestedServiceIds(serviceIds: List<Long>): List<Long> =
+    serviceIds
+        .flatMap { serviceId ->
+            if (serviceId == EnvConfig.Demo.PROJECT_ID) {
+                DEMO_SERVICE_IDS
+            } else {
+                listOf(serviceId)
+            }
+        }
+        .distinct()
+
+private fun ApplicationCall.serviceNamesQuery(): List<String> =
+    queryCsvValues("services") + queryCsvValues("service")
+
+private fun ApplicationCall.resolveServiceIdsQuery(projectIdResolver: ProjectIdResolver): List<Long>? {
+    val rawServiceIds = queryCsvValues("serviceIds") + queryCsvValues("serviceId")
+    if (rawServiceIds.isEmpty()) return emptyList()
+    return rawServiceIds.map { rawServiceId ->
+        projectIdResolver.resolve(rawServiceId) ?: return null
+    }.distinct()
+}
+
+private fun ApplicationCall.queryCsvValues(name: String): List<String> =
+    request.queryParameters.getAll(name)
+        ?.flatMap { value -> value.split(",") }
+        ?.map { value -> value.trim() }
+        ?.filter { value -> value.isNotBlank() }
+        ?: emptyList()
+
+private fun hasOrganizationAccess(userId: Int, orgId: Int): Boolean =
+    transaction {
+        Memberships
+            .selectAll()
+            .where {
+                (Memberships.user_id eq userId) and
+                    (Memberships.organization_id eq orgId)
+            }
+            .firstOrNull() != null
+    }
+
+private suspend fun ApplicationCall.parseRequiredDateRange(): Pair<LocalDate, LocalDate>? =
+    parseDateRange(this) ?: run {
+        respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_DATE_RANGE))
+        null
+    }
+
+private fun ApplicationCall.limitQuery(): Int =
+    request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT
+
+private suspend fun ApplicationCall.requiredFunnelSteps(): List<String>? {
+    val steps = request.queryParameters.getAll("steps")
+        ?: request.queryParameters.getAll("steps[]")
+        ?: emptyList()
+
+    if (steps.size < 2) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("At least 2 funnel steps required"))
+        return null
+    }
+
+    return steps
+}
+
+private suspend fun ApplicationCall.requiredRetentionEvents(): Pair<String, String>? {
+    val startEvent = request.queryParameters["start_event"]
+    val returnEvent = request.queryParameters["return_event"]
+    if (startEvent.isNullOrBlank() || returnEvent.isNullOrBlank()) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("start_event and return_event are required"))
+        return null
+    }
+
+    return startEvent to returnEvent
+}
+
+private fun parseDateRange(call: ApplicationCall): Pair<LocalDate, LocalDate>? {
     val period = call.request.queryParameters["period"] ?: "30d"
     val now = LocalDate.now()
 
@@ -315,7 +537,7 @@ private fun parseDateRange(call: io.ktor.server.application.ApplicationCall): Pa
 }
 
 private fun parseComparison(
-    call: io.ktor.server.application.ApplicationCall,
+    call: ApplicationCall,
     dateFrom: LocalDate,
     dateTo: LocalDate,
 ): Pair<LocalDate?, LocalDate?> {
@@ -336,7 +558,7 @@ private fun parseComparison(
     }
 }
 
-private fun parseFilters(call: io.ktor.server.application.ApplicationCall): List<AnalyticsFilter> {
+private fun parseFilters(call: ApplicationCall): List<AnalyticsFilter> {
     val rawFilters = call.request.queryParameters.getAll("filters")
         ?: call.request.queryParameters.getAll("filters[]")
         ?: emptyList()
@@ -350,7 +572,7 @@ private fun parseFilters(call: io.ktor.server.application.ApplicationCall): List
     }
 }
 
-private fun parseRetentionPeriods(call: io.ktor.server.application.ApplicationCall): List<Int> {
+private fun parseRetentionPeriods(call: ApplicationCall): List<Int> {
     val values = call.request.queryParameters.getAll("periods")
         ?: call.request.queryParameters.getAll("periods[]")
         ?: return DEFAULT_RETENTION_PERIODS

--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsQueryScope.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsQueryScope.kt
@@ -1,0 +1,29 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.analytics.services
+
+data class AnalyticsQueryScope(
+    val serviceIds: List<Long>
+) {
+    companion object {
+        fun service(serviceId: Long): AnalyticsQueryScope =
+            AnalyticsQueryScope(listOf(serviceId))
+
+        fun services(serviceIds: List<Long>): AnalyticsQueryScope =
+            AnalyticsQueryScope(serviceIds.distinct())
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsService.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsService.kt
@@ -62,11 +62,21 @@ class AnalyticsService {
         filters: List<AnalyticsFilter>,
         compFrom: LocalDate?,
         compTo: LocalDate?,
+    ): AnalyticsOverviewResponse =
+        getOverview(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, filters, compFrom, compTo)
+
+    suspend fun getOverview(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        filters: List<AnalyticsFilter>,
+        compFrom: LocalDate?,
+        compTo: LocalDate?,
     ): AnalyticsOverviewResponse {
-        val main = queryOverviewMetrics(projectId, dateFrom, dateTo, filters)
+        val main = queryOverviewMetrics(scope, dateFrom, dateTo, filters)
 
         val comp = if (compFrom != null && compTo != null) {
-            queryOverviewMetrics(projectId, compFrom, compTo, filters)
+            queryOverviewMetrics(scope, compFrom, compTo, filters)
         } else {
             null
         }
@@ -86,12 +96,12 @@ class AnalyticsService {
     }
 
     private suspend fun queryOverviewMetrics(
-        projectId: Long,
+        scope: AnalyticsQueryScope,
         dateFrom: LocalDate,
         dateTo: LocalDate,
         filters: List<AnalyticsFilter>,
     ): OverviewMetrics {
-        val where = buildWhere(projectId, dateFrom, dateTo, filters, "s", "hour")
+        val where = buildWhere(scope, dateFrom, dateTo, filters, "s", "hour")
         // Pre-aggregate per session_id to correctly handle SummingMergeTree (which sums pageviews
         // and is_bounce across unmerged rows). Without this, is_bounce gets summed to N (one per
         // insert) and avg(is_bounce)*100 produces values like 45000%.
@@ -104,12 +114,13 @@ class AnalyticsService {
                 if(count() > 0, toFloat64(sum(total_pageviews)) / count(), 0) AS views_per_visit
             FROM (
                 SELECT
+                    project_id,
                     session_id,
                     sum(pageviews) AS total_pageviews,
                     dateDiff('second', min(started), max(ended)) AS total_duration_sec
                 FROM analytics_sessions_hourly AS s
                 WHERE $where
-                GROUP BY session_id
+                GROUP BY project_id, session_id
             )
             FORMAT JSONEachRow
         """.trimIndent()
@@ -134,14 +145,22 @@ class AnalyticsService {
         dateFrom: LocalDate,
         dateTo: LocalDate,
         filters: List<AnalyticsFilter>,
+    ): List<TimeseriesPoint> =
+        getTimeseries(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, filters)
+
+    suspend fun getTimeseries(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        filters: List<AnalyticsFilter>,
     ): List<TimeseriesPoint> {
-        val where = buildWhere(projectId, dateFrom, dateTo, filters, "s", "hour")
+        val where = buildWhere(scope, dateFrom, dateTo, filters, "s", "hour")
         val interval = if (dateTo.toEpochDay() - dateFrom.toEpochDay() <= 2) "toStartOfHour" else "toDate"
 
         val sql = """
             SELECT
                 $interval(s.hour) AS date,
-                uniq(s.session_id) AS visitors,
+                uniq(s.project_id, s.session_id) AS visitors,
                 sum(s.pageviews) AS pageviews
             FROM analytics_sessions_hourly AS s
             WHERE $where
@@ -168,15 +187,25 @@ class AnalyticsService {
         filters: List<AnalyticsFilter>,
         dimension: String,
         limit: Int = DEFAULT_LIMIT,
+    ): BreakdownResponse =
+        getBreakdown(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, filters, dimension, limit)
+
+    suspend fun getBreakdown(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        filters: List<AnalyticsFilter>,
+        dimension: String,
+        limit: Int = DEFAULT_LIMIT,
     ): BreakdownResponse {
         val (column, table, alias) = resolveDimension(dimension)
         val timeColumn = if (alias == "s") "hour" else "timestamp"
-        val where = buildWhere(projectId, dateFrom, dateTo, filters, alias, timeColumn)
+        val where = buildWhere(scope, dateFrom, dateTo, filters, alias, timeColumn)
 
         val sql = """
             SELECT
                 $column AS name,
-                uniq($alias.session_id) AS visitors,
+                uniq($alias.project_id, $alias.session_id) AS visitors,
                 ${if (table == "analytics_sessions_hourly") "sum($alias.pageviews)" else "count()"} AS pageviews
             FROM $table AS $alias
             WHERE $where AND name != ''
@@ -204,7 +233,15 @@ class AnalyticsService {
         dateTo: LocalDate,
         filters: List<AnalyticsFilter>,
         limit: Int = DEFAULT_LIMIT,
-    ): BreakdownResponse = getBreakdown(projectId, dateFrom, dateTo, filters, "pathname", limit)
+    ): BreakdownResponse = getPages(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, filters, limit)
+
+    suspend fun getPages(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        filters: List<AnalyticsFilter>,
+        limit: Int = DEFAULT_LIMIT,
+    ): BreakdownResponse = getBreakdown(scope, dateFrom, dateTo, filters, "pathname", limit)
 
     suspend fun getEntryPages(
         projectId: Long,
@@ -212,7 +249,15 @@ class AnalyticsService {
         dateTo: LocalDate,
         filters: List<AnalyticsFilter>,
         limit: Int = DEFAULT_LIMIT,
-    ): BreakdownResponse = getBreakdown(projectId, dateFrom, dateTo, filters, "entry_page", limit)
+    ): BreakdownResponse = getEntryPages(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, filters, limit)
+
+    suspend fun getEntryPages(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        filters: List<AnalyticsFilter>,
+        limit: Int = DEFAULT_LIMIT,
+    ): BreakdownResponse = getBreakdown(scope, dateFrom, dateTo, filters, "entry_page", limit)
 
     suspend fun getExitPages(
         projectId: Long,
@@ -220,14 +265,29 @@ class AnalyticsService {
         dateTo: LocalDate,
         filters: List<AnalyticsFilter>,
         limit: Int = DEFAULT_LIMIT,
-    ): BreakdownResponse = getBreakdown(projectId, dateFrom, dateTo, filters, "exit_page", limit)
+    ): BreakdownResponse = getExitPages(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, filters, limit)
+
+    suspend fun getExitPages(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        filters: List<AnalyticsFilter>,
+        limit: Int = DEFAULT_LIMIT,
+    ): BreakdownResponse = getBreakdown(scope, dateFrom, dateTo, filters, "exit_page", limit)
 
     // --- Realtime ---
 
-    fun getRealtime(projectId: Long): RealtimeResponse {
-        val key = "${AnalyticsIngestionWorker.REALTIME_KEY_PREFIX}$projectId"
+    fun getRealtime(projectId: Long): RealtimeResponse =
+        getRealtime(AnalyticsQueryScope.service(projectId))
+
+    fun getRealtime(scope: AnalyticsQueryScope): RealtimeResponse {
+        val keys = scope.serviceIds.map { serviceId ->
+            "${AnalyticsIngestionWorker.REALTIME_KEY_PREFIX}$serviceId"
+        }
+        if (keys.isEmpty()) return RealtimeResponse(0L)
+
         val count = suspendRunCatching {
-            RedisConfig.sync().pfcount(key)
+            RedisConfig.sync().pfcount(*keys.toTypedArray())
         }.getOrElse { e ->
             val errorMsg = e.toString().take(ERROR_TRUNCATE_LENGTH)
             logger.debug { "Failed to read realtime counter: $errorMsg" }
@@ -245,8 +305,19 @@ class AnalyticsService {
         steps: List<String>,
         groupBy: String = "session_id",
         source: String? = null,
+    ): FunnelResponse =
+        getFunnel(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, steps, groupBy, source)
+
+    suspend fun getFunnel(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        steps: List<String>,
+        groupBy: String = "session_id",
+        source: String? = null,
     ): FunnelResponse {
         if (steps.size < 2) return FunnelResponse(emptyList(), 0.0)
+        val scopeWhere = serviceScopeWhere(scope)
         val dateWhere = dateRange(dateFrom, dateTo)
         val groupByColumn = resolveGroupByColumn(groupBy)
         val sourceClause = sourceWhere(source)
@@ -260,14 +331,15 @@ class AnalyticsService {
                 count() AS cnt
             FROM (
                 SELECT
+                    project_id,
                     $groupByColumn,
                     windowFunnel($FUNNEL_WINDOW_SECONDS)(toDateTime(timestamp), $events) AS level
                 FROM analytics_events
-                WHERE project_id = ${asClickHouseProjectId(projectId)}
+                WHERE $scopeWhere
                   AND $dateWhere
                   $sourceClause
                   $nonEmptyGroupClause
-                GROUP BY $groupByColumn
+                GROUP BY project_id, $groupByColumn
             )
             WHERE level > 0
             GROUP BY level
@@ -318,11 +390,29 @@ class AnalyticsService {
         startEvent: String,
         returnEvent: String,
         periods: List<Int>,
+    ): RetentionResponse =
+        getRetention(
+            AnalyticsQueryScope.service(projectId),
+            dateFrom,
+            dateTo,
+            startEvent,
+            returnEvent,
+            periods
+        )
+
+    suspend fun getRetention(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        startEvent: String,
+        returnEvent: String,
+        periods: List<Int>,
     ): RetentionResponse {
         if (startEvent.isBlank() || returnEvent.isBlank() || periods.isEmpty()) {
             return RetentionResponse(startEvent, returnEvent, emptyList())
         }
 
+        val scopeWhere = serviceScopeWhere(scope, "e")
         val dateWhere = dateRange(dateFrom, dateTo, "e", "timestamp")
         val escapedStartEvent = AnalyticsIngestionWorker.escapeCH(startEvent)
         val escapedReturnEvent = AnalyticsIngestionWorker.escapeCH(returnEvent)
@@ -338,16 +428,17 @@ class AnalyticsService {
         val sql = """
             WITH cohorts AS (
                 SELECT
+                    project_id,
                     user_id,
                     min(timestamp) AS first_seen,
                     toStartOfWeek(min(timestamp)) AS cohort_week
                 FROM analytics_events AS e
-                WHERE e.project_id = ${asClickHouseProjectId(projectId)}
+                WHERE $scopeWhere
                   AND e.source = 'server'
                   AND e.event_name = '$escapedStartEvent'
                   AND e.user_id != ''
                   AND $dateWhere
-                GROUP BY user_id
+                GROUP BY project_id, user_id
             )
             SELECT
                 toString(c.cohort_week) AS cohort_week,
@@ -355,7 +446,7 @@ class AnalyticsService {
 $retentionColumns
             FROM cohorts AS c
             LEFT JOIN analytics_events AS e
-                ON e.project_id = ${asClickHouseProjectId(projectId)}
+                ON e.project_id = c.project_id
                 AND e.source = 'server'
                 AND e.user_id = c.user_id
                 AND e.event_name = '$escapedReturnEvent'
@@ -396,15 +487,26 @@ $retentionColumns
         limit: Int = DEFAULT_LIMIT,
         groupBy: String = "session_id",
         source: String? = null,
+    ): BreakdownResponse =
+        getEvents(AnalyticsQueryScope.service(projectId), dateFrom, dateTo, filters, limit, groupBy, source)
+
+    suspend fun getEvents(
+        scope: AnalyticsQueryScope,
+        dateFrom: LocalDate,
+        dateTo: LocalDate,
+        filters: List<AnalyticsFilter>,
+        limit: Int = DEFAULT_LIMIT,
+        groupBy: String = "session_id",
+        source: String? = null,
     ): BreakdownResponse {
-        val where = buildWhere(projectId, dateFrom, dateTo, filters, "e", "timestamp")
+        val where = buildWhere(scope, dateFrom, dateTo, filters, "e", "timestamp")
         val groupByColumn = resolveGroupByColumn(groupBy)
         val sourceClause = sourceWhere(source, "e")
         val nonEmptyGroupClause = if (groupByColumn == "user_id") "AND e.user_id != ''" else ""
         val sql = """
             SELECT
                 e.event_name AS name,
-                uniq(e.$groupByColumn) AS visitors,
+                uniq(e.project_id, e.$groupByColumn) AS visitors,
                 count() AS pageviews
             FROM analytics_events AS e
             WHERE $where
@@ -430,7 +532,7 @@ $retentionColumns
     // --- Query helpers ---
 
     private fun buildWhere(
-        projectId: Long,
+        scope: AnalyticsQueryScope,
         dateFrom: LocalDate,
         dateTo: LocalDate,
         filters: List<AnalyticsFilter>,
@@ -438,7 +540,7 @@ $retentionColumns
         timeColumn: String,
     ): String {
         val parts = mutableListOf<String>()
-        parts.add("$alias.project_id = ${asClickHouseProjectId(projectId)}")
+        parts.add(serviceScopeWhere(scope, alias))
         parts.add(dateRange(dateFrom, dateTo, alias, timeColumn))
 
         for (filter in filters) {
@@ -497,9 +599,17 @@ $retentionColumns
         return "AND ${prefix}source = '$escapedSource'"
     }
 
-    private fun asClickHouseProjectId(projectId: Long): String {
-        return "toUInt64($projectId)"
+    private fun serviceScopeWhere(scope: AnalyticsQueryScope, alias: String = ""): String {
+        val prefix = if (alias.isNotEmpty()) "$alias." else ""
+        val serviceIds = scope.serviceIds
+        if (serviceIds.isEmpty()) return "0 = 1"
+        if (serviceIds.size == 1) return "${prefix}project_id = ${asClickHouseServiceId(serviceIds.first())}"
+        val values = serviceIds.joinToString(", ") { asClickHouseServiceId(it) }
+        return "${prefix}project_id IN ($values)"
     }
+
+    private fun asClickHouseServiceId(serviceId: Long): String =
+        "toUInt64($serviceId)"
 
     private fun dateRange(
         dateFrom: LocalDate,

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -108,6 +108,12 @@ class DashboardService(
         demoEpochMs: Long? = null
     ): List<ProjectResponse> = projectService.getProjects(userId, demoEpochMs)
 
+    fun getServiceIdsForOrganization(orgId: Int): List<Long> =
+        projectRepository.getProjectsForOrganizations(listOf(orgId)).map { it.projectId }
+
+    fun resolveServiceId(orgId: Int, serviceName: String): Long? =
+        projectRepository.resolveServiceId(orgId, serviceName)
+
     suspend fun getProject(projectId: Long): ProjectResponse? =
         projectService.getProject(projectId)
 

--- a/backend/src/test/kotlin/com/moneat/routes/AnalyticsRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/AnalyticsRoutesTest.kt
@@ -27,6 +27,7 @@ import com.moneat.analytics.models.RealtimeResponse
 import com.moneat.analytics.models.RetentionResponse
 import com.moneat.analytics.models.TimeseriesPoint
 import com.moneat.analytics.routes.analyticsRoutes
+import com.moneat.analytics.services.AnalyticsQueryScope
 import com.moneat.analytics.services.AnalyticsService
 import com.moneat.events.services.DashboardService
 import com.moneat.shared.models.Memberships
@@ -61,6 +62,7 @@ import kotlin.test.assertTrue
 class AnalyticsRoutesTest {
     companion object {
         private const val PROJECT_ID = 1L
+        private const val SECOND_PROJECT_ID = 2L
         private const val OVERVIEW_PERIOD_30D = "/overview?period=30d"
         private var db: Database? = null
     }
@@ -91,7 +93,8 @@ class AnalyticsRoutesTest {
         installJwtAuth()
     }
 
-    private fun token(userId: Int): String = RouteTestSupport.createToken(userId)
+    private fun token(userId: Int, orgId: Int? = null): String =
+        RouteTestSupport.createToken(userId, orgId)
 
     private fun seedUser(): Int = transaction {
         Users.insert {
@@ -99,6 +102,24 @@ class AnalyticsRoutesTest {
             it[password_hash] = "hash"
             it[email_verified] = true
         } get Users.id
+    }
+
+    private fun seedOrganizationMembership(): Pair<Int, Int> {
+        val userId = seedUser()
+        val orgId = transaction {
+            Organizations.insert {
+                it[name] = "Analytics Org"
+                it[slug] = "analytics-org-${System.nanoTime()}"
+            } get Organizations.id
+        }
+        transaction {
+            Memberships.insert {
+                it[user_id] = userId
+                it[organization_id] = orgId
+                it[role] = "owner"
+            }
+        }
+        return userId to orgId
     }
 
     private fun installRoutes(app: Application) {
@@ -198,6 +219,117 @@ class AnalyticsRoutesTest {
             withAuth(token(userId))
         }
         assertEquals(HttpStatusCode.BadRequest, r.status)
+    }
+
+    @Test
+    fun `GET org overview forwards service id and name filters`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+        every { mockDashboardService.getServiceIdsForOrganization(orgId) } returns
+            listOf(PROJECT_ID, SECOND_PROJECT_ID)
+        every { mockDashboardService.resolveServiceId(orgId, "API") } returns SECOND_PROJECT_ID
+        coEvery {
+            mockAnalyticsService.getOverview(
+                match<AnalyticsQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns overviewResponse
+
+        application { installRoutes(this) }
+        val r = client.get("/v1/analytics/overview?period=30d&serviceIds=$PROJECT_ID&services=API") {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, r.status)
+        coVerify(exactly = 1) {
+            mockAnalyticsService.getOverview(
+                match<AnalyticsQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `GET org pages uses all organization services when filters are absent`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+        every { mockDashboardService.getServiceIdsForOrganization(orgId) } returns
+            listOf(PROJECT_ID, SECOND_PROJECT_ID)
+        coEvery {
+            mockAnalyticsService.getPages(
+                match<AnalyticsQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                any(),
+                any(),
+                any(),
+                10,
+            )
+        } returns breakdownResponse
+
+        application { installRoutes(this) }
+        val r = client.get("/v1/analytics/pages?period=30d&limit=10") {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, r.status)
+        coVerify(exactly = 1) {
+            mockAnalyticsService.getPages(
+                match<AnalyticsQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                any(),
+                any(),
+                any(),
+                10,
+            )
+        }
+    }
+
+    @Test
+    fun `GET org overview returns 400 for invalid service id filter`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+
+        application { installRoutes(this) }
+        val r = client.get("/v1/analytics/overview?serviceIds=not-a-service-id") {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, r.status)
+        coVerify(exactly = 0) {
+            mockAnalyticsService.getOverview(
+                any<AnalyticsQueryScope>(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `GET org overview returns 404 when user lacks organization access`() = testApplication {
+        val userId = seedUser()
+
+        application { installRoutes(this) }
+        val r = client.get("/v1/analytics/overview") {
+            withAuth(token(userId, 99999))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, r.status)
+        coVerify(exactly = 0) {
+            mockAnalyticsService.getOverview(
+                any<AnalyticsQueryScope>(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
     }
 
     // ──── Overview ────

--- a/backend/src/test/kotlin/com/moneat/services/AnalyticsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/AnalyticsServiceTest.kt
@@ -17,6 +17,7 @@
 package com.moneat.services
 
 import com.moneat.analytics.models.AnalyticsFilter
+import com.moneat.analytics.services.AnalyticsQueryScope
 import com.moneat.analytics.services.AnalyticsService
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
@@ -328,6 +329,34 @@ class AnalyticsServiceTest {
     }
 
     @Test
+    fun `getRealtime counts visitors across services as a Redis union`() {
+        mockkObject(RedisConfig)
+        try {
+            val mockCommands = io.mockk.mockk<RedisCommands<String, String>>()
+            every { RedisConfig.sync() } returns mockCommands
+            every {
+                mockCommands.pfcount(
+                    "moneat:analytics:realtime:42",
+                    "moneat:analytics:realtime:43",
+                )
+            } returns 9L
+
+            val result = service.getRealtime(AnalyticsQueryScope.services(listOf(42L, 43L)))
+
+            assertEquals(9L, result.visitors)
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    @Test
+    fun `getRealtime returns zero for empty service scope`() {
+        val result = service.getRealtime(AnalyticsQueryScope.services(emptyList()))
+
+        assertEquals(0L, result.visitors)
+    }
+
+    @Test
     fun `getRealtime returns zero when Redis throws exception`() {
         mockkObject(RedisConfig)
         try {
@@ -424,7 +453,7 @@ class AnalyticsServiceTest {
                 source = "server"
             )
 
-            assertTrue(queries.any { it.contains("GROUP BY user_id") })
+            assertTrue(queries.any { it.contains("GROUP BY project_id, user_id") })
             assertTrue(queries.any { it.contains("source = 'server'") })
             assertTrue(queries.any { it.contains("user_id != ''") })
         }
@@ -527,7 +556,7 @@ class AnalyticsServiceTest {
                 source = "server",
             )
 
-            assertTrue(queries.any { it.contains("uniq(e.user_id)") })
+            assertTrue(queries.any { it.contains("uniq(e.project_id, e.user_id)") })
             assertTrue(queries.any { it.contains("e.source = 'server'") })
             assertTrue(queries.any { it.contains("e.user_id != ''") })
         }
@@ -708,6 +737,27 @@ class AnalyticsServiceTest {
     }
 
     @Test
+    fun `getOverview scoped query filters by multiple service ids`() = runBlocking {
+        val queries = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            queries.add(exchange.requestBodyText())
+            exchange.respond(200, "", contentType = CONTENT_TYPE_TEXT_PLAIN)
+        }) { _ ->
+
+            service.getOverview(
+                AnalyticsQueryScope.services(listOf(projectId, 43)),
+                dateFrom,
+                dateTo,
+                emptyList(),
+                null,
+                null
+            )
+
+            assertTrue(queries.any { it.contains("s.project_id IN (toUInt64(42), toUInt64(43))") })
+        }
+    }
+
+    @Test
     fun `getFunnel query includes windowFunnel`() = runBlocking {
         val queries = mutableListOf<String>()
         withClickHouseMockServer({ exchange ->
@@ -718,6 +768,49 @@ class AnalyticsServiceTest {
             service.getFunnel(projectId, dateFrom, dateTo, listOf("step1", "step2"))
 
             assertTrue(queries.any { it.contains("windowFunnel") })
+        }
+    }
+
+    @Test
+    fun `getFunnel scoped query groups by service and visitor key`() = runBlocking {
+        val queries = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            queries.add(exchange.requestBodyText())
+            exchange.respond(200, "", contentType = CONTENT_TYPE_TEXT_PLAIN)
+        }) { _ ->
+
+            service.getFunnel(
+                AnalyticsQueryScope.services(listOf(projectId, 43)),
+                dateFrom,
+                dateTo,
+                listOf("step1", "step2")
+            )
+
+            assertTrue(queries.any { it.contains("project_id IN (toUInt64(42), toUInt64(43))") })
+            assertTrue(queries.any { it.contains("GROUP BY project_id, session_id") })
+        }
+    }
+
+    @Test
+    fun `getRetention scoped query joins return events within the same service`() = runBlocking {
+        val queries = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            queries.add(exchange.requestBodyText())
+            exchange.respond(200, "", contentType = CONTENT_TYPE_TEXT_PLAIN)
+        }) { _ ->
+
+            service.getRetention(
+                AnalyticsQueryScope.services(listOf(projectId, 43)),
+                dateFrom,
+                dateTo,
+                "signup.completed",
+                "recording.started",
+                listOf(1, 7)
+            )
+
+            assertTrue(queries.any { it.contains("e.project_id IN (toUInt64(42), toUInt64(43))") })
+            assertTrue(queries.any { it.contains("GROUP BY project_id, user_id") })
+            assertTrue(queries.any { it.contains("ON e.project_id = c.project_id") })
         }
     }
 


### PR DESCRIPTION
Adds organization-scoped analytics read paths with service filters while preserving project-scoped endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics can run across multiple services in an organization; you can request specific services by name or ID and defaulting to all org services when none specified.

* **Refactor**
  * Analytics endpoints now support both organization-scoped and project-scoped queries, with organization-level access enforcement.

* **Bug Fixes**
  * Invalid service ID requests return a clear error; unauthorized org access returns a not-found response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->