### PR TITLE
feat: add org-wide llm reads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/llm/routes/LlmRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/routes/LlmRoutes.kt
@@ -16,13 +16,19 @@
 
 package com.moneat.llm.routes
 
+import com.moneat.config.EnvConfig
 import com.moneat.events.services.DashboardService
 import com.moneat.llm.services.LlmDashboardService
+import com.moneat.llm.services.LlmGenerationFilters
+import com.moneat.llm.services.LlmGenerationsQuery
+import com.moneat.llm.services.LlmQueryScope
 import com.moneat.plugins.getDemoEpochMs
 import com.moneat.plugins.isDemoUser
+import com.moneat.shared.models.Memberships
 import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
@@ -30,11 +36,23 @@ import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import org.koin.core.context.GlobalContext
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 private const val DEFAULT_PAGE_SIZE = 25
+private const val ERROR_NO_ORGANIZATION_ACCESS = "No organization access"
+private const val ERROR_INVALID_SERVICE_IDS = "Invalid serviceIds"
+private const val DEMO_PRIMARY_SERVICE_ID = -1L
+private const val DEMO_SECONDARY_SERVICE_ID = -2L
+private const val DEMO_TERTIARY_SERVICE_ID = -3L
+private val DEMO_SERVICE_IDS =
+    listOf(DEMO_PRIMARY_SERVICE_ID, DEMO_SECONDARY_SERVICE_ID, DEMO_TERTIARY_SERVICE_ID)
 
 fun Route.llmRoutes(
     dashboardService: DashboardService = GlobalContext.get().get(),
@@ -55,42 +73,111 @@ fun Route.llmRoutes(
     }
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.requireLlmProjectAccess(
-    dashboardService: DashboardService,
-    projectIdResolver: ProjectIdResolver,
-): Long? {
-    val principal = call.principal<JWTPrincipal>()
-    val userId = principal!!.payload.getClaim("userId").asInt()
-    val isDemo = call.isDemoUser()
-    val projectId = call.request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
-    if (projectId == null) {
-        call.respond(HttpStatusCode.BadRequest, ErrorResponse("projectId is required"))
-        return null
-    }
-    if (!isDemo && !dashboardService.hasProjectAccess(userId, projectId)) {
-        call.respond(HttpStatusCode.Forbidden, ErrorResponse("Access denied"))
-        return null
-    }
-    return projectId
+private data class LlmRouteContext(
+    val scope: LlmQueryScope
+)
+
+private data class RequestedLlmServices(
+    val serviceIds: List<Long>,
+    val hasExplicitFilters: Boolean
+) {
+    fun applyOrganizationAccess(organizationServiceIds: List<Long>): List<Long> =
+        if (hasExplicitFilters) {
+            serviceIds.filter { serviceId -> serviceId in organizationServiceIds }
+        } else {
+            organizationServiceIds
+        }
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleLlmOverview(
+private suspend fun RoutingContext.requireLlmScope(
+    dashboardService: DashboardService,
+    projectIdResolver: ProjectIdResolver,
+): LlmRouteContext? {
+    val principal = call.principal<JWTPrincipal>()
+    val userId = principal?.payload?.getClaim("userId")?.asInt()
+    if (userId == null) {
+        call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
+        return null
+    }
+
+    val organizationId = call.resolveLlmOrganizationId(principal, userId) ?: return null
+    val requestedServices = call.requestedLlmServices(
+        dashboardService = dashboardService,
+        projectIdResolver = projectIdResolver,
+        organizationId = organizationId
+    ) ?: return null
+    val scopedServiceIds = requestedServices.applyOrganizationAccess(
+        call.availableLlmServiceIds(dashboardService, organizationId)
+    )
+
+    return LlmRouteContext(LlmQueryScope.services(scopedServiceIds))
+}
+
+private suspend fun ApplicationCall.resolveLlmOrganizationId(
+    principal: JWTPrincipal,
+    userId: Int
+): Int? {
+    if (isDemoUser()) return EnvConfig.Demo.ORG_ID.toInt()
+
+    val organizationId = principal.payload.getClaim("orgId").asInt()
+    if (organizationId != null && hasOrganizationAccess(userId, organizationId)) {
+        return organizationId
+    }
+
+    respond(HttpStatusCode.NotFound, ErrorResponse(ERROR_NO_ORGANIZATION_ACCESS))
+    return null
+}
+
+private suspend fun ApplicationCall.requestedLlmServices(
+    dashboardService: DashboardService,
+    projectIdResolver: ProjectIdResolver,
+    organizationId: Int
+): RequestedLlmServices? {
+    val serviceIds = resolveServiceIdsQuery(projectIdResolver)
+    if (serviceIds == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse(ERROR_INVALID_SERVICE_IDS))
+        return null
+    }
+
+    val serviceNames = serviceNamesQuery()
+    val resolvedServiceIds =
+        serviceNames.mapNotNull { serviceName ->
+            dashboardService.resolveServiceId(organizationId, serviceName)
+        }
+
+    return RequestedLlmServices(
+        serviceIds = normalizeRequestedServiceIds(serviceIds + resolvedServiceIds),
+        hasExplicitFilters = serviceIds.isNotEmpty() || serviceNames.isNotEmpty()
+    )
+}
+
+private fun ApplicationCall.availableLlmServiceIds(
+    dashboardService: DashboardService,
+    organizationId: Int
+): List<Long> =
+    if (isDemoUser()) {
+        DEMO_SERVICE_IDS
+    } else {
+        dashboardService.getServiceIdsForOrganization(organizationId)
+    }
+
+private suspend fun RoutingContext.handleLlmOverview(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
     projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
+    val context = requireLlmScope(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val demoEpochMs = call.getDemoEpochMs()
-    call.respond(llmService.getOverview(projectId, range, demoEpochMs))
+    call.respond(llmService.getOverview(context.scope, range, demoEpochMs))
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerations(
+private suspend fun RoutingContext.handleLlmGenerations(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
     projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
+    val context = requireLlmScope(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val model = call.request.queryParameters["model"]
     val provider = call.request.queryParameters["provider"]
@@ -98,24 +185,35 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerations(
     val status = call.request.queryParameters["status"]
     val page = call.request.queryParameters["page"]?.toIntOrNull() ?: 1
     val pageSize = call.request.queryParameters["pageSize"]?.toIntOrNull() ?: DEFAULT_PAGE_SIZE
-    val demoEpochMs = call.getDemoEpochMs()
+    val query = LlmGenerationsQuery(
+        range = range,
+        filters = LlmGenerationFilters(
+            model = model,
+            provider = provider,
+            type = type,
+            status = status
+        ),
+        page = page,
+        pageSize = pageSize,
+        demoEpochMs = call.getDemoEpochMs()
+    )
     call.respond(
-        llmService.getGenerations(projectId, range, model, provider, type, status, page, pageSize, demoEpochMs)
+        llmService.getGenerations(context.scope, query)
     )
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerationDetail(
+private suspend fun RoutingContext.handleLlmGenerationDetail(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
     projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
+    val context = requireLlmScope(dashboardService, projectIdResolver) ?: return
     val generationId =
         call.parameters["id"] ?: run {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse("generation id is required"))
             return
         }
-    val detail = llmService.getGenerationDetail(projectId, generationId)
+    val detail = llmService.getGenerationDetail(context.scope, generationId)
     if (detail == null) {
         call.respond(HttpStatusCode.NotFound, ErrorResponse("Generation not found"))
         return
@@ -123,18 +221,18 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmGenerationDet
     call.respond(detail)
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleLlmTrace(
+private suspend fun RoutingContext.handleLlmTrace(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
     projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
+    val context = requireLlmScope(dashboardService, projectIdResolver) ?: return
     val traceId =
         call.parameters["traceId"] ?: run {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse("traceId is required"))
             return
         }
-    val trace = llmService.getTrace(projectId, traceId)
+    val trace = llmService.getTrace(context.scope, traceId)
     if (trace == null) {
         call.respond(HttpStatusCode.NotFound, ErrorResponse("Trace not found"))
         return
@@ -142,24 +240,64 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLlmTrace(
     call.respond(trace)
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleLlmModels(
+private suspend fun RoutingContext.handleLlmModels(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
     projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
+    val context = requireLlmScope(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val demoEpochMs = call.getDemoEpochMs()
-    call.respond(llmService.getModels(projectId, range, demoEpochMs))
+    call.respond(llmService.getModels(context.scope, range, demoEpochMs))
 }
 
-private suspend fun io.ktor.server.routing.RoutingContext.handleLlmCosts(
+private suspend fun RoutingContext.handleLlmCosts(
     dashboardService: DashboardService,
     llmService: LlmDashboardService,
     projectIdResolver: ProjectIdResolver,
 ) {
-    val projectId = requireLlmProjectAccess(dashboardService, projectIdResolver) ?: return
+    val context = requireLlmScope(dashboardService, projectIdResolver) ?: return
     val range = call.request.queryParameters["range"] ?: "24h"
     val demoEpochMs = call.getDemoEpochMs()
-    call.respond(llmService.getCosts(projectId, range, demoEpochMs))
+    call.respond(llmService.getCosts(context.scope, range, demoEpochMs))
 }
+
+private fun normalizeRequestedServiceIds(serviceIds: List<Long>): List<Long> =
+    serviceIds
+        .flatMap { serviceId ->
+            if (serviceId == EnvConfig.Demo.PROJECT_ID) {
+                DEMO_SERVICE_IDS
+            } else {
+                listOf(serviceId)
+            }
+        }
+        .distinct()
+
+private fun ApplicationCall.serviceNamesQuery(): List<String> =
+    queryCsvValues("services") + queryCsvValues("service")
+
+private fun ApplicationCall.resolveServiceIdsQuery(projectIdResolver: ProjectIdResolver): List<Long>? {
+    val rawServiceIds = queryCsvValues("projectId") + queryCsvValues("serviceIds") + queryCsvValues("serviceId")
+    if (rawServiceIds.isEmpty()) return emptyList()
+    return rawServiceIds.map { rawServiceId ->
+        projectIdResolver.resolve(rawServiceId) ?: return null
+    }.distinct()
+}
+
+private fun ApplicationCall.queryCsvValues(name: String): List<String> =
+    request.queryParameters.getAll(name)
+        ?.flatMap { value -> value.split(",") }
+        ?.map { value -> value.trim() }
+        ?.filter { value -> value.isNotBlank() }
+        ?: emptyList()
+
+private fun hasOrganizationAccess(userId: Int, orgId: Int): Boolean =
+    transaction {
+        Memberships
+            .selectAll()
+            .where {
+                (Memberships.user_id eq userId) and
+                    (Memberships.organization_id eq orgId)
+            }
+            .firstOrNull() != null
+    }

--- a/backend/src/main/kotlin/com/moneat/llm/services/LlmDashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/services/LlmDashboardService.kt
@@ -48,6 +48,21 @@ private val logger = KotlinLogging.logger {}
 private const val MILLIS_PER_SECOND = 1000.0
 private const val DATETIME64_PRECISION_MS = 3
 
+data class LlmGenerationFilters(
+    val model: String? = null,
+    val provider: String? = null,
+    val type: String? = null,
+    val status: String? = null
+)
+
+data class LlmGenerationsQuery(
+    val range: String,
+    val filters: LlmGenerationFilters = LlmGenerationFilters(),
+    val page: Int,
+    val pageSize: Int,
+    val demoEpochMs: Long? = null
+)
+
 class LlmDashboardService {
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
     private val json = Json { ignoreUnknownKeys = true }
@@ -65,6 +80,13 @@ class LlmDashboardService {
         } else {
             "project_id = $projectId"
         }
+    }
+
+    private fun serviceScopeClause(scope: LlmQueryScope): String {
+        val serviceIds = scope.serviceIds
+        if (serviceIds.isEmpty()) return "0 = 1"
+        if (serviceIds.size == 1) return projectIdClause(serviceIds.first())
+        return "toInt64(project_id) IN (${serviceIds.joinToString(", ")})"
     }
 
     private suspend fun extractBody(response: HttpResponse): String? {
@@ -120,9 +142,16 @@ class LlmDashboardService {
         projectId: Long,
         range: String,
         demoEpochMs: Long? = null
+    ): LlmOverviewResponse =
+        getOverview(LlmQueryScope.service(projectId), range, demoEpochMs)
+
+    suspend fun getOverview(
+        scope: LlmQueryScope,
+        range: String,
+        demoEpochMs: Long? = null
     ): LlmOverviewResponse {
         val bucket = bucketFromRange(range)
-        val projectFilter = projectIdClause(projectId)
+        val serviceFilter = serviceScopeClause(scope)
         val timeFilter = rangeClause(range, demoEpochMs)
 
         // Stats query
@@ -135,7 +164,7 @@ class LlmDashboardService {
                 avg(duration_ms) as avg_duration_ms,
                 countIf(status = 'error') * 100.0 / greatest(count(), 1) as error_rate
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter
+            WHERE $serviceFilter
               AND $timeFilter
             FORMAT JSONEachRow
             """.trimIndent()
@@ -150,7 +179,7 @@ class LlmDashboardService {
                 sum(cost_usd) as cost,
                 countIf(status = 'error') as errors
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter
+            WHERE $serviceFilter
               AND $timeFilter
             GROUP BY ts
             ORDER BY ts
@@ -169,7 +198,7 @@ class LlmDashboardService {
                 avg(duration_ms) as avg_duration_ms,
                 countIf(status = 'error') * 100.0 / greatest(count(), 1) as error_rate
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter
+            WHERE $serviceFilter
               AND $timeFilter
             GROUP BY model, provider
             ORDER BY call_count DESC
@@ -224,27 +253,26 @@ class LlmDashboardService {
 
     suspend fun getGenerations(
         projectId: Long,
-        range: String,
-        model: String?,
-        provider: String?,
-        type: String?,
-        status: String?,
-        page: Int,
-        pageSize: Int,
-        demoEpochMs: Long? = null
+        query: LlmGenerationsQuery
+    ): LlmGenerationsListResponse =
+        getGenerations(LlmQueryScope.service(projectId), query)
+
+    suspend fun getGenerations(
+        scope: LlmQueryScope,
+        query: LlmGenerationsQuery
     ): LlmGenerationsListResponse {
-        val offset = (page - 1) * pageSize
-        val projectFilter = projectIdClause(projectId)
-        val timeFilter = rangeClause(range, demoEpochMs)
+        val offset = (query.page - 1) * query.pageSize
+        val serviceFilter = serviceScopeClause(scope)
+        val timeFilter = rangeClause(query.range, query.demoEpochMs)
 
         val filters =
             buildList {
-                add(projectFilter)
+                add(serviceFilter)
                 add(timeFilter)
-                model?.let { add("model = '${ClickHouseSqlUtils.escapeSql(it)}'") }
-                provider?.let { add("provider = '${ClickHouseSqlUtils.escapeSql(it)}'") }
-                type?.let { add("type = '${ClickHouseSqlUtils.escapeSql(it)}'") }
-                status?.let { add("status = '${ClickHouseSqlUtils.escapeSql(it)}'") }
+                query.filters.model?.let { add("model = '${ClickHouseSqlUtils.escapeSql(it)}'") }
+                query.filters.provider?.let { add("provider = '${ClickHouseSqlUtils.escapeSql(it)}'") }
+                query.filters.type?.let { add("type = '${ClickHouseSqlUtils.escapeSql(it)}'") }
+                query.filters.status?.let { add("status = '${ClickHouseSqlUtils.escapeSql(it)}'") }
             }
         val where = filters.joinToString(" AND ")
 
@@ -267,7 +295,7 @@ class LlmDashboardService {
             FROM `$clickhouseDb`.llm_generations
             WHERE $where
             ORDER BY timestamp DESC
-            LIMIT $pageSize OFFSET $offset
+            LIMIT ${query.pageSize} OFFSET $offset
             FORMAT JSONEachRow
             """.trimIndent()
 
@@ -313,17 +341,23 @@ class LlmDashboardService {
         return LlmGenerationsListResponse(
             generations = generations,
             total = total,
-            page = page,
-            pageSize = pageSize
+            page = query.page,
+            pageSize = query.pageSize
         )
     }
 
     suspend fun getGenerationDetail(
         projectId: Long,
         generationId: String
+    ): LlmGenerationDetailResponse? =
+        getGenerationDetail(LlmQueryScope.service(projectId), generationId)
+
+    suspend fun getGenerationDetail(
+        scope: LlmQueryScope,
+        generationId: String
     ): LlmGenerationDetailResponse? {
         val escapedId = ClickHouseSqlUtils.escapeSql(generationId)
-        val projectFilter = projectIdClause(projectId)
+        val serviceFilter = serviceScopeClause(scope)
         val query =
             """
             SELECT
@@ -339,7 +373,7 @@ class LlmDashboardService {
                 user_id, session_id, environment, release,
                 tags, metadata
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter AND toString(generation_id) = '$escapedId'
+            WHERE $serviceFilter AND toString(generation_id) = '$escapedId'
             LIMIT 1
             FORMAT JSONEachRow
             """.trimIndent()
@@ -387,9 +421,15 @@ class LlmDashboardService {
     suspend fun getTrace(
         projectId: Long,
         traceId: String
+    ): LlmTraceResponse? =
+        getTrace(LlmQueryScope.service(projectId), traceId)
+
+    suspend fun getTrace(
+        scope: LlmQueryScope,
+        traceId: String
     ): LlmTraceResponse? {
         val escapedTraceId = ClickHouseSqlUtils.escapeSql(traceId)
-        val projectFilter = projectIdClause(projectId)
+        val serviceFilter = serviceScopeClause(scope)
         val query =
             """
             SELECT
@@ -405,7 +445,7 @@ class LlmDashboardService {
                 user_id, session_id, environment, release,
                 tags, metadata
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter AND trace_id = '$escapedTraceId'
+            WHERE $serviceFilter AND trace_id = '$escapedTraceId'
             ORDER BY timestamp ASC
             FORMAT JSONEachRow
             """.trimIndent()
@@ -469,9 +509,16 @@ class LlmDashboardService {
         projectId: Long,
         range: String,
         demoEpochMs: Long? = null
+    ): LlmCostsResponse =
+        getCosts(LlmQueryScope.service(projectId), range, demoEpochMs)
+
+    suspend fun getCosts(
+        scope: LlmQueryScope,
+        range: String,
+        demoEpochMs: Long? = null
     ): LlmCostsResponse {
         val bucket = bucketFromRange(range)
-        val projectFilter = projectIdClause(projectId)
+        val serviceFilter = serviceScopeClause(scope)
         val timeFilter = rangeClause(range, demoEpochMs)
 
         val breakdownQuery =
@@ -482,7 +529,7 @@ class LlmDashboardService {
                 sum(total_tokens) as total_tokens,
                 count() as call_count
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter AND $timeFilter
+            WHERE $serviceFilter AND $timeFilter
             GROUP BY model, provider
             ORDER BY total_cost DESC
             FORMAT JSONEachRow
@@ -497,7 +544,7 @@ class LlmDashboardService {
                 sum(cost_usd) as cost,
                 countIf(status = 'error') as errors
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter AND $timeFilter
+            WHERE $serviceFilter AND $timeFilter
             GROUP BY ts
             ORDER BY ts
             FORMAT JSONEachRow
@@ -541,8 +588,15 @@ class LlmDashboardService {
         projectId: Long,
         range: String,
         demoEpochMs: Long? = null
+    ): List<LlmModelStats> =
+        getModels(LlmQueryScope.service(projectId), range, demoEpochMs)
+
+    suspend fun getModels(
+        scope: LlmQueryScope,
+        range: String,
+        demoEpochMs: Long? = null
     ): List<LlmModelStats> {
-        val projectFilter = projectIdClause(projectId)
+        val serviceFilter = serviceScopeClause(scope)
         val timeFilter = rangeClause(range, demoEpochMs)
         val query =
             """
@@ -554,7 +608,7 @@ class LlmDashboardService {
                 avg(duration_ms) as avg_duration_ms,
                 countIf(status = 'error') * 100.0 / greatest(count(), 1) as error_rate
             FROM `$clickhouseDb`.llm_generations
-            WHERE $projectFilter AND $timeFilter
+            WHERE $serviceFilter AND $timeFilter
             GROUP BY model, provider
             ORDER BY call_count DESC
             FORMAT JSONEachRow

--- a/backend/src/main/kotlin/com/moneat/llm/services/LlmQueryScope.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/services/LlmQueryScope.kt
@@ -1,0 +1,29 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.llm.services
+
+data class LlmQueryScope(
+    val serviceIds: List<Long>
+) {
+    companion object {
+        fun service(serviceId: Long): LlmQueryScope =
+            LlmQueryScope(listOf(serviceId))
+
+        fun services(serviceIds: List<Long>): LlmQueryScope =
+            LlmQueryScope(serviceIds.distinct())
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/llm/LlmRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/llm/LlmRoutesExtendedTest.kt
@@ -112,65 +112,65 @@ class LlmRoutesExtendedTest {
             assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
-    // ──── Missing projectId (400) ────
+    // ──── Missing organization access (404) ────
 
     @Test
-    fun `generations returns 400 when projectId is missing`() =
+    fun `generations returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1, orgId = 1)
+            val token = RouteTestSupport.createToken(userId = 1)
             val response = client.get("/v1/llm/generations") {
                 withAuth(token)
             }
-            assertEquals(HttpStatusCode.BadRequest, response.status)
-            assertTrue(response.bodyAsText().contains("projectId is required"))
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("No organization access"))
         }
 
     @Test
-    fun `models returns 400 when projectId is missing`() =
+    fun `models returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1, orgId = 1)
+            val token = RouteTestSupport.createToken(userId = 1)
             val response = client.get("/v1/llm/models") {
                 withAuth(token)
             }
-            assertEquals(HttpStatusCode.BadRequest, response.status)
-            assertTrue(response.bodyAsText().contains("projectId is required"))
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("No organization access"))
         }
 
     @Test
-    fun `costs returns 400 when projectId is missing`() =
+    fun `costs returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1, orgId = 1)
+            val token = RouteTestSupport.createToken(userId = 1)
             val response = client.get("/v1/llm/costs") {
                 withAuth(token)
             }
-            assertEquals(HttpStatusCode.BadRequest, response.status)
-            assertTrue(response.bodyAsText().contains("projectId is required"))
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("No organization access"))
         }
 
     @Test
-    fun `generation detail returns 400 when projectId is missing`() =
+    fun `generation detail returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1, orgId = 1)
+            val token = RouteTestSupport.createToken(userId = 1)
             val response = client.get("/v1/llm/generations/abc-123") {
                 withAuth(token)
             }
-            assertEquals(HttpStatusCode.BadRequest, response.status)
-            assertTrue(response.bodyAsText().contains("projectId is required"))
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("No organization access"))
         }
 
     @Test
-    fun `traces returns 400 when projectId is missing`() =
+    fun `traces returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1, orgId = 1)
+            val token = RouteTestSupport.createToken(userId = 1)
             val response = client.get("/v1/llm/traces/some-trace-id") {
                 withAuth(token)
             }
-            assertEquals(HttpStatusCode.BadRequest, response.status)
-            assertTrue(response.bodyAsText().contains("projectId is required"))
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("No organization access"))
         }
 }

--- a/backend/src/test/kotlin/com/moneat/routes/LlmRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/LlmRoutesTest.kt
@@ -52,7 +52,7 @@ class LlmRoutesTest {
     }
 
     @Test
-    fun `overview endpoint returns 400 when projectId is missing`() =
+    fun `overview endpoint returns 404 when organization access is missing`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -82,8 +82,8 @@ class LlmRoutesTest {
                     header(HttpHeaders.Authorization, "Bearer ${tokenForUser(12)}")
                 }
 
-            assertEquals(HttpStatusCode.BadRequest, response.status)
-            assertTrue(response.bodyAsText().contains("projectId is required"))
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("No organization access"))
         }
 
     private fun tokenForUser(userId: Int): String {

--- a/backend/src/test/kotlin/com/moneat/routes/LlmScopedRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/LlmScopedRoutesTest.kt
@@ -1,0 +1,292 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.routes
+
+import com.moneat.events.services.DashboardService
+import com.moneat.llm.models.LlmGenerationDetailResponse
+import com.moneat.llm.models.LlmGenerationsListResponse
+import com.moneat.llm.models.LlmOverviewResponse
+import com.moneat.llm.models.LlmTraceResponse
+import com.moneat.llm.routes.llmRoutes
+import com.moneat.llm.services.LlmDashboardService
+import com.moneat.llm.services.LlmGenerationsQuery
+import com.moneat.llm.services.LlmQueryScope
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
+import com.moneat.shared.models.Users
+import com.moneat.testsupport.RouteTestSupport
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import com.moneat.testsupport.TestDatabaseHelper
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class LlmScopedRoutesTest {
+    companion object {
+        private const val PROJECT_ID = 1L
+        private const val SECOND_PROJECT_ID = 2L
+        private var db: Database? = null
+    }
+
+    private val mockDashboardService = mockk<DashboardService>(relaxed = true)
+    private val mockLlmService = mockk<LlmDashboardService>(relaxed = true)
+
+    @BeforeTest
+    fun setupDatabase() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_llm_routes_mock;" +
+                    "MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;" +
+                    "DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.resetSchema(
+            Users,
+            Organizations,
+            Memberships,
+            Projects
+        )
+    }
+
+    private fun installRoutes(app: Application) {
+        app.installJwtAuth()
+        app.install(RateLimit) {
+            register(RateLimitName("api")) {
+                requestKey { "test-user" }
+                rateLimiter(limit = 100, refillPeriod = 1.seconds)
+            }
+        }
+        app.routing {
+            llmRoutes(
+                dashboardService = mockDashboardService,
+                llmService = mockLlmService,
+            )
+        }
+    }
+
+    private fun token(userId: Int, orgId: Int? = null): String =
+        RouteTestSupport.createToken(userId, orgId)
+
+    private fun seedUser(): Int = transaction {
+        Users.insert {
+            it[email] = "llm-${System.nanoTime()}@test.com"
+            it[password_hash] = "hash"
+            it[email_verified] = true
+        } get Users.id
+    }
+
+    private fun seedOrganizationMembership(): Pair<Int, Int> {
+        val userId = seedUser()
+        val orgId = transaction {
+            Organizations.insert {
+                it[name] = "LLM Org"
+                it[slug] = "llm-org-${System.nanoTime()}"
+            } get Organizations.id
+        }
+        transaction {
+            Memberships.insert {
+                it[user_id] = userId
+                it[organization_id] = orgId
+                it[role] = "owner"
+            }
+        }
+        return userId to orgId
+    }
+
+    private fun LlmGenerationsQuery.hasExpectedFilters(): Boolean =
+        range == "7d" &&
+            filters.model == "gpt-4o" &&
+            filters.provider == "openai" &&
+            filters.type == "chat" &&
+            filters.status == "error" &&
+            page == 2 &&
+            pageSize == 10 &&
+            demoEpochMs == null
+
+    @Test
+    fun `overview uses all organization services when filters are absent`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+        every { mockDashboardService.getServiceIdsForOrganization(orgId) } returns
+            listOf(PROJECT_ID, SECOND_PROJECT_ID)
+        coEvery {
+            mockLlmService.getOverview(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                "24h",
+                null,
+            )
+        } returns LlmOverviewResponse(
+            totalGenerations = 3,
+            totalTokens = 10,
+            totalCost = 0.25,
+            avgDurationMs = 100.0,
+            errorRate = 0.0,
+            timeline = emptyList(),
+            topModels = emptyList(),
+        )
+
+        application { installRoutes(this) }
+        val response = client.get("/v1/llm/overview") {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            mockLlmService.getOverview(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                "24h",
+                null,
+            )
+        }
+    }
+
+    @Test
+    fun `generations forwards service id and service name filters`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+        every { mockDashboardService.getServiceIdsForOrganization(orgId) } returns
+            listOf(PROJECT_ID, SECOND_PROJECT_ID)
+        every { mockDashboardService.resolveServiceId(orgId, "API") } returns SECOND_PROJECT_ID
+        coEvery {
+            mockLlmService.getGenerations(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                match<LlmGenerationsQuery> { it.hasExpectedFilters() },
+            )
+        } returns LlmGenerationsListResponse(emptyList(), total = 0, page = 2, pageSize = 10)
+
+        application { installRoutes(this) }
+        val response = client.get(
+            "/v1/llm/generations?range=7d&serviceIds=$PROJECT_ID&services=API" +
+                "&model=gpt-4o&provider=openai&type=chat&status=error&page=2&pageSize=10"
+        ) {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            mockLlmService.getGenerations(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID, SECOND_PROJECT_ID) },
+                match<LlmGenerationsQuery> { it.hasExpectedFilters() },
+            )
+        }
+    }
+
+    @Test
+    fun `invalid service id filter returns 400 without calling service`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+
+        application { installRoutes(this) }
+        val response = client.get("/v1/llm/overview?serviceIds=not-a-service-id") {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) {
+            mockLlmService.getOverview(any<LlmQueryScope>(), any(), any())
+        }
+    }
+
+    @Test
+    fun `overview returns 404 when user lacks organization access`() = testApplication {
+        val userId = seedUser()
+
+        application { installRoutes(this) }
+        val response = client.get("/v1/llm/overview") {
+            withAuth(token(userId, 99999))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        coVerify(exactly = 0) {
+            mockLlmService.getOverview(any<LlmQueryScope>(), any(), any())
+        }
+    }
+
+    @Test
+    fun `generation detail uses scoped services and returns not found when absent`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+        every { mockDashboardService.getServiceIdsForOrganization(orgId) } returns listOf(PROJECT_ID)
+        coEvery {
+            mockLlmService.getGenerationDetail(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID) },
+                "gen-1",
+            )
+        } returns null
+
+        application { installRoutes(this) }
+        val response = client.get("/v1/llm/generations/gen-1") {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        coVerify(exactly = 1) {
+            mockLlmService.getGenerationDetail(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID) },
+                "gen-1",
+            )
+        }
+    }
+
+    @Test
+    fun `trace uses scoped services`() = testApplication {
+        val (userId, orgId) = seedOrganizationMembership()
+        every { mockDashboardService.getServiceIdsForOrganization(orgId) } returns listOf(PROJECT_ID)
+        coEvery {
+            mockLlmService.getTrace(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID) },
+                "trace-1",
+            )
+        } returns LlmTraceResponse(
+            traceId = "trace-1",
+            generations = emptyList<LlmGenerationDetailResponse>(),
+            totalDurationMs = 0.0,
+            totalTokens = 0,
+            totalCost = 0.0,
+        )
+
+        application { installRoutes(this) }
+        val response = client.get("/v1/llm/traces/trace-1") {
+            withAuth(token(userId, orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            mockLlmService.getTrace(
+                match<LlmQueryScope> { it.serviceIds == listOf(PROJECT_ID) },
+                "trace-1",
+            )
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/services/LlmServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LlmServiceExtendedTest.kt
@@ -19,7 +19,10 @@ package com.moneat.services
 import com.moneat.config.ClickHouseClient
 import com.moneat.llm.models.LlmGenerationIngest
 import com.moneat.llm.services.LlmDashboardService
+import com.moneat.llm.services.LlmGenerationFilters
+import com.moneat.llm.services.LlmGenerationsQuery
 import com.moneat.llm.services.LlmIngestionWorker
+import com.moneat.llm.services.LlmQueryScope
 import com.moneat.testsupport.queryBasedClickHouseHandler
 import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
@@ -54,6 +57,21 @@ class LlmServiceExtendedTest {
         ClickHouseClient.close()
     }
 
+    private fun generationsQuery(
+        range: String = "24h",
+        filters: LlmGenerationFilters = LlmGenerationFilters(),
+        page: Int = 1,
+        pageSize: Int = 25,
+        demoEpochMs: Long? = null
+    ): LlmGenerationsQuery =
+        LlmGenerationsQuery(
+            range = range,
+            filters = filters,
+            page = page,
+            pageSize = pageSize,
+            demoEpochMs = demoEpochMs
+        )
+
     // ──── LlmDashboardService: getGenerations ────
 
     @Test
@@ -71,13 +89,7 @@ class LlmServiceExtendedTest {
             withClickHouseMockServer(handler) { _ ->
                 val result = LlmDashboardService().getGenerations(
                     projectId = 5,
-                    range = "24h",
-                    model = null,
-                    provider = null,
-                    type = null,
-                    status = null,
-                    page = 1,
-                    pageSize = 25
+                    query = generationsQuery()
                 )
                 assertEquals(42L, result.total)
                 assertEquals(1, result.page)
@@ -100,13 +112,17 @@ class LlmServiceExtendedTest {
             ) { _ ->
                 LlmDashboardService().getGenerations(
                     projectId = 5,
-                    range = "7d",
-                    model = GPT_4O,
-                    provider = "openai",
-                    type = "chat",
-                    status = "error",
-                    page = 2,
-                    pageSize = 10
+                    query = generationsQuery(
+                        range = "7d",
+                        filters = LlmGenerationFilters(
+                            model = GPT_4O,
+                            provider = "openai",
+                            type = "chat",
+                            status = "error"
+                        ),
+                        page = 2,
+                        pageSize = 10
+                    )
                 )
                 val dataQuery = queries.find { it.contains("ORDER BY timestamp DESC") } ?: ""
                 assertTrue(dataQuery.contains("model = '${GPT_4O}'"), "model filter missing")
@@ -127,13 +143,7 @@ class LlmServiceExtendedTest {
             withClickHouseMockServer(handler) { _ ->
                 val result = LlmDashboardService().getGenerations(
                     projectId = 5,
-                    range = "24h",
-                    model = null,
-                    provider = null,
-                    type = null,
-                    status = null,
-                    page = 1,
-                    pageSize = 25
+                    query = generationsQuery()
                 )
                 assertEquals(0L, result.total)
                 assertTrue(result.generations.isEmpty())
@@ -322,6 +332,114 @@ class LlmServiceExtendedTest {
                 assertEquals(0.0, result.totalCost)
                 assertTrue(result.timeline.isEmpty())
                 assertTrue(result.topModels.isEmpty())
+            }
+        }
+
+    // ──── LlmDashboardService: service scopes ────
+
+    @Test
+    fun `getOverview scoped query filters by multiple service ids`() =
+        runBlocking {
+            val queries = mutableListOf<String>()
+            withClickHouseMockServer({ exchange ->
+                val query = exchange.requestBodyText()
+                queries += query
+                when {
+                    query.contains(COUNT_AS_TOTAL_GENERATIONS) -> {
+                        exchange.respond(200, EMPTY_STATS_JSON, contentType = TEXT_PLAIN)
+                    }
+                    else -> {
+                        exchange.respond(200, "\n", contentType = TEXT_PLAIN)
+                    }
+                }
+            }) { _ ->
+                LlmDashboardService().getOverview(
+                    scope = LlmQueryScope.services(listOf(10L, 11L)),
+                    range = "24h"
+                )
+                assertTrue(queries.isNotEmpty(), "Expected overview queries to be captured")
+                assertTrue(queries.all { it.contains("toInt64(project_id) IN (10, 11)") })
+            }
+        }
+
+    @Test
+    fun `getGenerations scoped query applies service scope and filters`() =
+        runBlocking {
+            val queries = mutableListOf<String>()
+            withClickHouseMockServer(
+                queryBasedClickHouseHandler(
+                    defaultBody = """{"total":0}""",
+                    captureQueries = queries
+                )
+            ) { _ ->
+                LlmDashboardService().getGenerations(
+                    scope = LlmQueryScope.services(listOf(5L, 6L)),
+                    query = LlmGenerationsQuery(
+                        range = "7d",
+                        filters = LlmGenerationFilters(
+                            model = GPT_4O,
+                            provider = "openai",
+                            type = "chat",
+                            status = "error"
+                        ),
+                        page = 1,
+                        pageSize = 25
+                    )
+                )
+                val dataQuery = queries.find { it.contains("ORDER BY timestamp DESC") } ?: ""
+                assertTrue(dataQuery.contains("toInt64(project_id) IN (5, 6)"))
+                assertTrue(dataQuery.contains("model = '${GPT_4O}'"))
+                assertTrue(dataQuery.contains("status = 'error'"))
+            }
+        }
+
+    @Test
+    fun `getGenerationDetail scoped query includes service scope and generation id`() =
+        runBlocking {
+            val queries = mutableListOf<String>()
+            withClickHouseMockServer({ exchange ->
+                queries += exchange.requestBodyText()
+                exchange.respond(500, "internal error", contentType = TEXT_PLAIN)
+            }) { _ ->
+                LlmDashboardService().getGenerationDetail(
+                    scope = LlmQueryScope.services(listOf(5L, 6L)),
+                    generationId = "gen-1"
+                )
+                val query = queries.firstOrNull() ?: ""
+                assertTrue(query.contains("toInt64(project_id) IN (5, 6)"))
+                assertTrue(query.contains("toString(generation_id) = 'gen-1'"))
+            }
+        }
+
+    @Test
+    fun `getTrace scoped query includes service scope and trace id`() =
+        runBlocking {
+            val queries = mutableListOf<String>()
+            withClickHouseMockServer(
+                queryBasedClickHouseHandler(defaultBody = "\n", captureQueries = queries)
+            ) { _ ->
+                LlmDashboardService().getTrace(
+                    scope = LlmQueryScope.services(listOf(5L, 6L)),
+                    traceId = "trace-1"
+                )
+                val query = queries.firstOrNull() ?: ""
+                assertTrue(query.contains("toInt64(project_id) IN (5, 6)"))
+                assertTrue(query.contains("trace_id = 'trace-1'"))
+            }
+        }
+
+    @Test
+    fun `getModels empty service scope uses no rows clause`() =
+        runBlocking {
+            val queries = mutableListOf<String>()
+            withClickHouseMockServer(
+                queryBasedClickHouseHandler(defaultBody = "\n", captureQueries = queries)
+            ) { _ ->
+                LlmDashboardService().getModels(
+                    scope = LlmQueryScope.services(emptyList()),
+                    range = "24h"
+                )
+                assertTrue(queries.any { it.contains("WHERE 0 = 1 AND") })
             }
         }
 


### PR DESCRIPTION
Adds organization-scoped LLM read paths with service filters while preserving project-scoped compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched LLM access from single-project checks to organization- and service-scoped access, supporting multi-service queries and demo project normalization.

* **Bug Fixes**
  * Return 404 Not Found for requests lacking organization access; improved validation for missing or malformed route/query parameters.

* **Tests**
  * Added extensive tests covering scoped routing, multi-service filtering, access denial, and query-generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->