### PR TITLE
feat: add org-wide release replay feedback reads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -95,7 +95,18 @@ private const val DEFAULT_REPLAYS_LIMIT = 10
 private const val DEFAULT_ALERT_FREQUENCY_MINUTES = 30
 private const val DEFAULT_ALERT_LIFECYCLE_LIMIT = 50
 private const val DEMO_ORGANIZATION_ID = -1
+private const val DEMO_PRIMARY_SERVICE_ID = -1L
+private const val DEMO_CHECKOUT_SERVICE_ID = -2L
+private const val DEMO_MOBILE_SERVICE_ID = -3L
 private const val ERROR_NO_ORGANIZATION_ACCESS = "No organization access"
+private const val ERROR_INVALID_SERVICE_IDS = "Invalid serviceIds"
+private val DEMO_SERVICE_IDS = listOf(DEMO_PRIMARY_SERVICE_ID, DEMO_CHECKOUT_SERVICE_ID, DEMO_MOBILE_SERVICE_ID)
+
+private data class ServiceReadContext(
+    val organizationId: Int,
+    val serviceIds: List<Long>,
+    val demoEpochMs: Long?
+)
 
 @Suppress("kotlin:S3776")
 fun Route.apiRoutes() {
@@ -590,7 +601,7 @@ fun Route.apiRoutes() {
                         }
                     val serviceIds = call.resolveServiceIdsQuery(projectIdResolver)
                     if (serviceIds == null) {
-                        call.respond(HttpStatusCode.BadRequest, "Invalid serviceIds")
+                        call.respond(HttpStatusCode.BadRequest, ERROR_INVALID_SERVICE_IDS)
                         return@get
                     }
 
@@ -977,6 +988,30 @@ fun Route.apiRoutes() {
                 }
 
                 // Replays
+                get("/replays") {
+                    val principal = call.principal<JWTPrincipal>()
+                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context =
+                        call.resolveServiceReadContext(userId, dashboardService, projectIdResolver) ?: return@get
+
+                    val page = call.request.queryParameters["page"]?.toIntOrNull() ?: 1
+                    val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_PAGE_LIMIT
+                    val environment = call.request.queryParameters["environment"]
+                    val period = call.request.queryParameters["period"] ?: "7d"
+
+                    val replays =
+                        dashboardService.getReplaysForServices(
+                            organizationId = context.organizationId,
+                            serviceIds = context.serviceIds,
+                            page = page,
+                            limit = limit,
+                            environment = environment,
+                            period = period,
+                            demoEpochMs = context.demoEpochMs
+                        )
+                    call.respond(replays)
+                }
+
                 get("/projects/{projectId}/replays") {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
@@ -1071,6 +1106,28 @@ fun Route.apiRoutes() {
 
                     val timeline = dashboardService.getReplayTimeline(replayId, demoEpochMs)
                     call.respond(timeline)
+                }
+
+                get("/feedback") {
+                    val principal = call.principal<JWTPrincipal>()
+                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context =
+                        call.resolveServiceReadContext(userId, dashboardService, projectIdResolver) ?: return@get
+
+                    val page = call.request.queryParameters["page"]?.toIntOrNull() ?: 1
+                    val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_PAGE_LIMIT
+                    val status = call.request.queryParameters["status"]
+
+                    val feedback =
+                        dashboardService.getFeedbackForServices(
+                            organizationId = context.organizationId,
+                            serviceIds = context.serviceIds,
+                            page = page,
+                            limit = limit,
+                            status = status,
+                            demoEpochMs = context.demoEpochMs
+                        )
+                    call.respond(feedback)
                 }
 
                 get("/projects/{projectId}/feedback") {
@@ -1198,6 +1255,45 @@ fun Route.apiRoutes() {
                 }
 
                 // Releases
+                get("/releases") {
+                    val principal = call.principal<JWTPrincipal>()
+                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context =
+                        call.resolveServiceReadContext(userId, dashboardService, projectIdResolver) ?: return@get
+
+                    val releases =
+                        dashboardService.getReleasesForServices(
+                            organizationId = context.organizationId,
+                            serviceIds = context.serviceIds,
+                            parentSpan = call.getSentryTransaction()
+                        )
+                    call.respond(releases)
+                }
+
+                get("/releases/{version}/stats") {
+                    val principal = call.principal<JWTPrincipal>()
+                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context =
+                        call.resolveServiceReadContext(userId, dashboardService, projectIdResolver) ?: return@get
+                    val version = call.parameters["version"]
+                    if (version == null) {
+                        call.respond(HttpStatusCode.BadRequest)
+                        return@get
+                    }
+
+                    val stats =
+                        dashboardService.getReleaseStatsForServices(
+                            organizationId = context.organizationId,
+                            serviceIds = context.serviceIds,
+                            version = version
+                        )
+                    if (stats == null) {
+                        call.respond(HttpStatusCode.NotFound)
+                    } else {
+                        call.respond(stats)
+                    }
+                }
+
                 get("/projects/{projectId}/releases") {
                     val principal = call.principal<JWTPrincipal>()
                     val userId = principal!!.payload.getClaim("userId").asInt()
@@ -1594,6 +1690,57 @@ private fun ApplicationCall.resolveProjectPathId(projectIdResolver: ProjectIdRes
 
 private fun ApplicationCall.resolveProjectQueryId(projectIdResolver: ProjectIdResolver): Long? =
     request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
+
+private suspend fun ApplicationCall.resolveServiceReadContext(
+    userId: Int,
+    dashboardService: DashboardService,
+    projectIdResolver: ProjectIdResolver
+): ServiceReadContext? {
+    val isDemo = isDemoUser()
+    val organizationId =
+        if (isDemo) {
+            DEMO_ORGANIZATION_ID
+        } else {
+            resolveSubscriptionOrganizationId(userId) ?: return null
+        }
+
+    val serviceIds = resolveServiceIdsQuery(projectIdResolver)
+    if (serviceIds == null) {
+        respond(HttpStatusCode.BadRequest, ERROR_INVALID_SERVICE_IDS)
+        return null
+    }
+
+    val serviceNames = serviceNamesQuery()
+    val resolvedNameIds = serviceNames.mapNotNull { serviceName ->
+        dashboardService.resolveServiceId(organizationId, serviceName)
+    }
+    val requestedServiceIds = normalizeRequestedServiceIds(serviceIds + resolvedNameIds)
+    val organizationServiceIds =
+        if (isDemo) {
+            DEMO_SERVICE_IDS
+        } else {
+            dashboardService.getServiceIdsForOrganization(organizationId)
+        }
+    val scopedServiceIds =
+        if (serviceIds.isNotEmpty() || serviceNames.isNotEmpty()) {
+            requestedServiceIds.filter { serviceId -> serviceId in organizationServiceIds }
+        } else {
+            organizationServiceIds
+        }
+
+    return ServiceReadContext(organizationId, scopedServiceIds, getDemoEpochMs())
+}
+
+private fun normalizeRequestedServiceIds(serviceIds: List<Long>): List<Long> =
+    serviceIds
+        .flatMap { serviceId ->
+            if (serviceId == DEMO_PRIMARY_SERVICE_ID) {
+                DEMO_SERVICE_IDS
+            } else {
+                listOf(serviceId)
+            }
+        }
+        .distinct()
 
 private fun ApplicationCall.serviceNamesQuery(): List<String> =
     queryCsvValues("services") + queryCsvValues("service")

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -229,10 +229,24 @@ class DashboardService(
         parentSpan: ISpan? = null
     ): List<ReleaseListResponse> = releaseStatsService.getReleases(projectId, parentSpan)
 
+    suspend fun getReleasesForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        parentSpan: ISpan? = null
+    ): List<ReleaseListResponse> =
+        releaseStatsService.getReleasesForServices(organizationId, serviceIds, parentSpan)
+
     suspend fun getReleaseStats(
         projectId: Long,
         version: String
     ): ReleaseDetailStats? = releaseStatsService.getReleaseStats(projectId, version)
+
+    suspend fun getReleaseStatsForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        version: String
+    ): ReleaseDetailStats? =
+        releaseStatsService.getReleaseStatsForServices(organizationId, serviceIds, version)
 
     suspend fun getReplays(
         projectId: Long,
@@ -242,6 +256,17 @@ class DashboardService(
         period: String = "7d",
         demoEpochMs: Long? = null
     ): List<ReplayListItem> = replayService.getReplays(projectId, page, limit, environment, period, demoEpochMs)
+
+    suspend fun getReplaysForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        page: Int = 1,
+        limit: Int = 25,
+        environment: String? = null,
+        period: String = "7d",
+        demoEpochMs: Long? = null
+    ): List<ReplayListItem> =
+        replayService.getReplaysForServices(organizationId, serviceIds, page, limit, environment, period, demoEpochMs)
 
     suspend fun getReplay(
         replayId: String,
@@ -268,6 +293,16 @@ class DashboardService(
         status: String? = null,
         demoEpochMs: Long? = null
     ): List<FeedbackListItem> = feedbackService.getFeedback(projectId, page, limit, status, demoEpochMs)
+
+    suspend fun getFeedbackForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        page: Int = 1,
+        limit: Int = 25,
+        status: String? = null,
+        demoEpochMs: Long? = null
+    ): List<FeedbackListItem> =
+        feedbackService.getFeedbackForServices(organizationId, serviceIds, page, limit, status, demoEpochMs)
 
     suspend fun getFeedbackDetail(feedbackId: String): FeedbackDetailResponse? =
         feedbackService.getFeedbackDetail(feedbackId)

--- a/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
@@ -60,10 +60,44 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
         limit: Int = 25,
         status: String? = null,
         demoEpochMs: Long? = null
+    ): List<FeedbackListItem> =
+        getFeedback(
+            scope = ServiceQueryScope.service(projectId),
+            retentionDays = queryHelper.getProjectRetentionDays(projectId),
+            page = page,
+            limit = limit,
+            status = status,
+            demoEpochMs = demoEpochMs
+        )
+
+    suspend fun getFeedbackForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        page: Int = 1,
+        limit: Int = 25,
+        status: String? = null,
+        demoEpochMs: Long? = null
+    ): List<FeedbackListItem> =
+        getFeedback(
+            scope = ServiceQueryScope.services(serviceIds),
+            retentionDays = queryHelper.getOrganizationRetentionDays(organizationId),
+            page = page,
+            limit = limit,
+            status = status,
+            demoEpochMs = demoEpochMs
+        )
+
+    private suspend fun getFeedback(
+        scope: ServiceQueryScope,
+        retentionDays: Int,
+        page: Int,
+        limit: Int,
+        status: String?,
+        demoEpochMs: Long?
     ): List<FeedbackListItem> {
+        if (scope.serviceIds.isEmpty()) return emptyList()
         val offset = (page - 1) * limit
-        val retentionDays = queryHelper.getProjectRetentionDays(projectId)
-        val projectIdClause = ClickHouseQueryUtils.projectIdClause(projectId)
+        val projectIdClause = scope.projectIdClause()
         val validStatuses = setOf("unresolved", "resolved", "archived")
         val statusFilter =
             if (status != null && status in validStatuses) {

--- a/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReleaseStatsService.kt
@@ -20,7 +20,6 @@ import com.moneat.config.ClickHouseClient
 import com.moneat.events.models.ReleaseDetailStats
 import com.moneat.events.models.ReleaseListResponse
 import com.moneat.shared.services.CacheService
-import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.sentry.ISpan
@@ -41,6 +40,13 @@ private data class ReleaseListRow(
     val userCount: Long
 )
 
+private data class ReleaseQueryContext(
+    val scope: ServiceQueryScope,
+    val retentionDays: Int,
+    val cacheKey: String,
+    val logLabel: String
+)
+
 class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
     private val clickhouseDb: String get() = queryHelper.clickhouseDb
     private val json get() = queryHelper.json
@@ -53,10 +59,40 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
     suspend fun getReleases(
         projectId: Long,
         parentSpan: ISpan? = null
+    ): List<ReleaseListResponse> {
+        val context =
+            ReleaseQueryContext(
+                scope = ServiceQueryScope.service(projectId),
+                retentionDays = queryHelper.getProjectRetentionDays(projectId),
+                cacheKey = "project:$projectId",
+                logLabel = "project $projectId"
+            )
+        return getReleases(context, parentSpan)
+    }
+
+    suspend fun getReleasesForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        parentSpan: ISpan? = null
+    ): List<ReleaseListResponse> {
+        val scope = ServiceQueryScope.services(serviceIds)
+        val context =
+            ReleaseQueryContext(
+                scope = scope,
+                retentionDays = queryHelper.getOrganizationRetentionDays(organizationId),
+                cacheKey = "org:$organizationId:${scope.cacheKeyPart()}",
+                logLabel = "organization $organizationId"
+            )
+        return getReleases(context, parentSpan)
+    }
+
+    private suspend fun getReleases(
+        context: ReleaseQueryContext,
+        parentSpan: ISpan? = null
     ): List<ReleaseListResponse> =
-        CacheService.cached("cache:releases:$projectId", RELEASES_CACHE_TTL_SECONDS, parentSpan) {
-            val retentionDays = queryHelper.getProjectRetentionDays(projectId)
-            val projectIdClause = ClickHouseQueryUtils.projectIdClause(projectId)
+        CacheService.cached("cache:releases:${context.cacheKey}", RELEASES_CACHE_TTL_SECONDS, parentSpan) {
+            if (context.scope.serviceIds.isEmpty()) return@cached emptyList()
+            val projectIdClause = context.scope.projectIdClause()
             val releasesQuery =
                 """
             SELECT
@@ -67,7 +103,7 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 uniq(user_id) as user_count
             FROM `$clickhouseDb`.events
             WHERE $projectIdClause AND release != ''
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
+                AND ${queryHelper.timestampRetentionClause("timestamp", context.retentionDays)}
             GROUP BY release
             ORDER BY first_seen DESC
             FORMAT JSONEachRow
@@ -76,8 +112,10 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
             suspendRunCatching {
                 val releases = executeReleasesListQuery(releasesQuery, parentSpan)
                 val versions = releases.map { it.version }
-                val newIssueCountByVersion = getNewIssueCountForReleases(projectId, versions, retentionDays, parentSpan)
-                val crashFreeRateByVersion = getCrashFreeRateForReleases(projectId, versions, retentionDays, parentSpan)
+                val newIssueCountByVersion =
+                    getNewIssueCountForReleases(context.scope, versions, context.retentionDays, parentSpan)
+                val crashFreeRateByVersion =
+                    getCrashFreeRateForReleases(context.scope, versions, context.retentionDays, parentSpan)
                 releases.map { r ->
                     ReleaseListResponse(
                         version = r.version,
@@ -90,7 +128,7 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                     )
                 }
             }.getOrElse { e ->
-                logger.error(e) { "Failed to fetch releases for project $projectId" }
+                logger.error(e) { "Failed to fetch releases for ${context.logLabel}" }
                 emptyList()
             }
         }
@@ -99,8 +137,39 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
         projectId: Long,
         version: String
     ): ReleaseDetailStats? {
-        val retentionDays = queryHelper.getProjectRetentionDays(projectId)
+        val context =
+            ReleaseQueryContext(
+                scope = ServiceQueryScope.service(projectId),
+                retentionDays = queryHelper.getProjectRetentionDays(projectId),
+                cacheKey = "project:$projectId",
+                logLabel = "project $projectId"
+            )
+        return getReleaseStats(context, version)
+    }
+
+    suspend fun getReleaseStatsForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        version: String
+    ): ReleaseDetailStats? {
+        val scope = ServiceQueryScope.services(serviceIds)
+        val context =
+            ReleaseQueryContext(
+                scope = scope,
+                retentionDays = queryHelper.getOrganizationRetentionDays(organizationId),
+                cacheKey = "org:$organizationId:${scope.cacheKeyPart()}",
+                logLabel = "organization $organizationId"
+            )
+        return getReleaseStats(context, version)
+    }
+
+    private suspend fun getReleaseStats(
+        context: ReleaseQueryContext,
+        version: String
+    ): ReleaseDetailStats? {
+        if (context.scope.serviceIds.isEmpty()) return null
         val escapedVersion = escapeSql(version)
+        val projectIdClause = context.scope.projectIdClause()
         val releasesQuery =
             """
             SELECT
@@ -109,8 +178,8 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 count() as total_events,
                 uniq(user_id) as user_count
             FROM `$clickhouseDb`.events
-            WHERE project_id = $projectId AND release = '$escapedVersion'
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
+            WHERE $projectIdClause AND release = '$escapedVersion'
+                AND ${queryHelper.timestampRetentionClause("timestamp", context.retentionDays)}
             FORMAT JSONEachRow
             """.trimIndent()
 
@@ -125,10 +194,10 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
             val totalEvents = obj["total_events"]?.jsonPrimitive?.long ?: 0
             val userCount = obj["user_count"]?.jsonPrimitive?.long ?: 0
 
-            val newIssues = getNewIssueCountForRelease(projectId, version, retentionDays)
+            val newIssues = getNewIssueCountForRelease(context.scope, version, context.retentionDays)
             val resolvedIssues = 0L
-            val crashFreeSessionRate = getCrashFreeRateForRelease(projectId, version, retentionDays)
-            val crashFreeUserRate = getCrashFreeUserRateForRelease(projectId, version, retentionDays)
+            val crashFreeSessionRate = getCrashFreeRateForRelease(context.scope, version, context.retentionDays)
+            val crashFreeUserRate = getCrashFreeUserRateForRelease(context.scope, version, context.retentionDays)
 
             val intervalMinutes = RELEASE_STATS_INTERVAL_MINUTES
             val eventsTimelineQuery =
@@ -141,8 +210,8 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                     ) as time,
                     count() as count
                 FROM `$clickhouseDb`.events
-                WHERE project_id = $projectId AND release = '$escapedVersion'
-                    AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
+                WHERE $projectIdClause AND release = '$escapedVersion'
+                    AND ${queryHelper.timestampRetentionClause("timestamp", context.retentionDays)}
                 GROUP BY time
                 ORDER BY time
                 FORMAT JSONEachRow
@@ -152,8 +221,8 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 """
                 SELECT level, count() as count
                 FROM `$clickhouseDb`.events
-                WHERE project_id = $projectId AND release = '$escapedVersion'
-                    AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
+                WHERE $projectIdClause AND release = '$escapedVersion'
+                    AND ${queryHelper.timestampRetentionClause("timestamp", context.retentionDays)}
                 GROUP BY level
                 FORMAT JSONEachRow
                 """.trimIndent()
@@ -162,8 +231,8 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 """
                 SELECT issue_id, any(message) as title, count() as count
                 FROM `$clickhouseDb`.events
-                WHERE project_id = $projectId AND release = '$escapedVersion' AND event_type = 'error'
-                    AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
+                WHERE $projectIdClause AND release = '$escapedVersion' AND event_type = 'error'
+                    AND ${queryHelper.timestampRetentionClause("timestamp", context.retentionDays)}
                 GROUP BY issue_id
                 ORDER BY count DESC
                 LIMIT 10
@@ -185,7 +254,7 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
                 topIssues = queryHelper.executeTopIssuesQuery(topIssuesQuery)
             )
         }.getOrElse { e ->
-            logger.error(e) { "Failed to fetch release stats for $version" }
+            logger.error(e) { "Failed to fetch release stats for ${context.logLabel} release $version" }
             null
         }
     }
@@ -208,20 +277,21 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
     }
 
     private suspend fun getNewIssueCountForReleases(
-        projectId: Long,
+        scope: ServiceQueryScope,
         versions: List<String>,
         retentionDays: Int,
         parentSpan: ISpan? = null
     ): Map<String, Long> {
         if (versions.isEmpty()) return emptyMap()
         val escapedVersions = versions.distinct().map { "'${escapeSql(it)}'" }.joinToString(",")
+        val projectIdClause = scope.projectIdClause()
         val query =
             """
             SELECT first_release as version, count() as total
             FROM (
                 SELECT issue_id, argMin(release, timestamp) as first_release
                 FROM `$clickhouseDb`.events
-                WHERE project_id = $projectId AND event_type = 'error' AND issue_id != ''
+                WHERE $projectIdClause AND event_type = 'error' AND issue_id != ''
                     AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
                 GROUP BY issue_id
                 HAVING first_release IN ($escapedVersions)
@@ -241,18 +311,19 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
     }
 
     private suspend fun getCrashFreeRateForReleases(
-        projectId: Long,
+        scope: ServiceQueryScope,
         versions: List<String>,
         retentionDays: Int,
         parentSpan: ISpan? = null
     ): Map<String, Double> {
         if (versions.isEmpty()) return emptyMap()
         val escapedVersions = versions.distinct().map { "'${escapeSql(it)}'" }.joinToString(",")
+        val projectIdClause = scope.projectIdClause()
         val query =
             """
             SELECT release as version, countIf(errors = 0) * 100.0 / count() as rate
             FROM `$clickhouseDb`.sessions
-            WHERE project_id = $projectId AND release IN ($escapedVersions)
+            WHERE $projectIdClause AND release IN ($escapedVersions)
                 AND ${queryHelper.timestampRetentionClause("started", retentionDays)}
             GROUP BY release
             FORMAT JSONEachRow
@@ -270,17 +341,18 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
     }
 
     private suspend fun getNewIssueCountForRelease(
-        projectId: Long,
+        scope: ServiceQueryScope,
         version: String,
         retentionDays: Int
     ): Long {
         val escapedVersion = escapeSql(version)
+        val projectIdClause = scope.projectIdClause()
         val query =
             """
             SELECT count() as total FROM (
                 SELECT issue_id, argMin(release, timestamp) as first_release
                 FROM `$clickhouseDb`.events
-                WHERE project_id = $projectId AND event_type = 'error' AND issue_id != ''
+                WHERE $projectIdClause AND event_type = 'error' AND issue_id != ''
                     AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
                 GROUP BY issue_id
                 HAVING first_release = '$escapedVersion'
@@ -291,41 +363,43 @@ class ReleaseStatsService(private val queryHelper: DashboardQueryHelper) {
     }
 
     private suspend fun getCrashFreeRateForRelease(
-        projectId: Long,
+        scope: ServiceQueryScope,
         version: String,
         retentionDays: Int
     ): Double? {
         val escapedVersion = escapeSql(version)
+        val projectIdClause = scope.projectIdClause()
         val query =
             """
             SELECT countIf(errors = 0) * 100.0 / count() as rate
             FROM `$clickhouseDb`.sessions
-            WHERE project_id = $projectId AND release = '$escapedVersion'
+            WHERE $projectIdClause AND release = '$escapedVersion'
                 AND ${queryHelper.timestampRetentionClause("started", retentionDays)}
             FORMAT JSONEachRow
             """.trimIndent()
-        return executeNullableRateQuery(query, "crash-free session rate for project $projectId release $version")
+        return executeNullableRateQuery(query, "crash-free session rate for release $version")
     }
 
     private suspend fun getCrashFreeUserRateForRelease(
-        projectId: Long,
+        scope: ServiceQueryScope,
         version: String,
         retentionDays: Int
     ): Double? {
         val escapedVersion = escapeSql(version)
+        val projectIdClause = scope.projectIdClause()
         val query =
             """
             SELECT countIf(errors = 0) * 100.0 / count() as rate
             FROM (
                 SELECT user_id, sum(errors) as errors
                 FROM `$clickhouseDb`.sessions
-                WHERE project_id = $projectId AND release = '$escapedVersion' AND user_id != ''
+                WHERE $projectIdClause AND release = '$escapedVersion' AND user_id != ''
                     AND ${queryHelper.timestampRetentionClause("started", retentionDays)}
                 GROUP BY user_id
             )
             FORMAT JSONEachRow
             """.trimIndent()
-        return executeNullableRateQuery(query, "crash-free user rate for project $projectId release $version")
+        return executeNullableRateQuery(query, "crash-free user rate for release $version")
     }
 
     private suspend fun executeNullableRateQuery(

--- a/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
@@ -51,6 +51,16 @@ import java.util.Base64
 
 private val logger = KotlinLogging.logger {}
 
+private data class ReplayListQuery(
+    val scope: ServiceQueryScope,
+    val retentionDays: Int,
+    val page: Int,
+    val limit: Int,
+    val environment: String?,
+    val period: String,
+    val demoEpochMs: Long?
+)
+
 class ReplayService(
     private val queryHelper: DashboardQueryHelper,
     private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
@@ -455,25 +465,59 @@ class ReplayService(
         environment: String? = null,
         period: String = "7d",
         demoEpochMs: Long? = null
-    ): List<ReplayListItem> {
-        val offset = (page - 1) * limit
-        val retentionDays = queryHelper.getProjectRetentionDays(projectId)
-        val projectIdClause = ClickHouseQueryUtils.projectIdClause(projectId)
+    ): List<ReplayListItem> =
+        getReplays(
+            ReplayListQuery(
+                scope = ServiceQueryScope.service(projectId),
+                retentionDays = queryHelper.getProjectRetentionDays(projectId),
+                page = page,
+                limit = limit,
+                environment = environment,
+                period = period,
+                demoEpochMs = demoEpochMs
+            )
+        )
 
-        val nowMs = demoEpochMs ?: System.currentTimeMillis()
+    suspend fun getReplaysForServices(
+        organizationId: Int,
+        serviceIds: List<Long>,
+        page: Int = 1,
+        limit: Int = 25,
+        environment: String? = null,
+        period: String = "7d",
+        demoEpochMs: Long? = null
+    ): List<ReplayListItem> =
+        getReplays(
+            ReplayListQuery(
+                scope = ServiceQueryScope.services(serviceIds),
+                retentionDays = queryHelper.getOrganizationRetentionDays(organizationId),
+                page = page,
+                limit = limit,
+                environment = environment,
+                period = period,
+                demoEpochMs = demoEpochMs
+            )
+        )
+
+    private suspend fun getReplays(queryOptions: ReplayListQuery): List<ReplayListItem> {
+        if (queryOptions.scope.serviceIds.isEmpty()) return emptyList()
+        val offset = (queryOptions.page - 1) * queryOptions.limit
+        val projectIdClause = queryOptions.scope.projectIdClause()
+
+        val nowMs = queryOptions.demoEpochMs ?: System.currentTimeMillis()
         val periodMs =
-            when (period) {
+            when (queryOptions.period) {
                 "24h" -> PERIOD_24H_MS
                 "30d" -> PERIOD_30D_MS
                 "90d" -> PERIOD_90D_MS
                 else -> PERIOD_7D_MS
             }
         val periodStartMs = nowMs - periodMs
-        val retentionStartMs = nowMs - (retentionDays * MILLIS_PER_DAY)
+        val retentionStartMs = nowMs - (queryOptions.retentionDays * MILLIS_PER_DAY)
 
         val envClause =
-            if (environment != null && environment.isNotBlank()) {
-                "AND environment = '${escapeSql(environment)}'"
+            if (queryOptions.environment != null && queryOptions.environment.isNotBlank()) {
+                "AND environment = '${escapeSql(queryOptions.environment)}'"
             } else {
                 ""
             }
@@ -505,7 +549,7 @@ class ReplayService(
                 $envClause
             GROUP BY replay_id, project_id
             ORDER BY max(timestamp) DESC
-            LIMIT $limit OFFSET $offset
+            LIMIT ${queryOptions.limit} OFFSET $offset
             FORMAT JSONEachRow
             """.trimIndent()
 
@@ -515,27 +559,29 @@ class ReplayService(
                 suspendRunCatching {
                     val startedMs = obj["started_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
                     val finishedMs = obj["finished_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
+                    val rowProjectId =
+                        obj["project_id"]?.jsonPrimitive?.long ?: queryOptions.scope.serviceIds.firstOrNull()
                     val rawErrorCount = obj["error_count"]?.jsonPrimitive?.intOrNull ?: 0
                     val fallbackErrorCount =
-                        if (rawErrorCount == 0 && startedMs != null && finishedMs != null) {
+                        if (rawErrorCount == 0 && startedMs != null && finishedMs != null && rowProjectId != null) {
                             getReplayWindowErrorCount(
-                                projectId,
+                                rowProjectId,
                                 startedMs,
                                 finishedMs,
                                 obj["user_id"]?.jsonPrimitive?.contentOrNull,
-                                retentionDays
+                                queryOptions.retentionDays
                             )
                         } else {
                             0
                         }
-                    buildReplayListItemFromJson(obj, projectId, maxOf(rawErrorCount, fallbackErrorCount))
+                    buildReplayListItemFromJson(obj, rowProjectId ?: 0L, maxOf(rawErrorCount, fallbackErrorCount))
                 }.getOrElse { e ->
                     logger.error(e) { "Failed to parse replay list row" }
                     null
                 }
             }
         }.getOrElse { e ->
-            logger.error(e) { "Failed to fetch replays for project $projectId" }
+            logger.error(e) { "Failed to fetch replays for services ${queryOptions.scope.cacheKeyPart()}" }
             emptyList()
         }
     }

--- a/backend/src/main/kotlin/com/moneat/events/services/ServiceQueryScope.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ServiceQueryScope.kt
@@ -1,0 +1,48 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.events.services
+
+import com.moneat.utils.ClickHouseQueryUtils
+
+data class ServiceQueryScope(
+    val serviceIds: List<Long>
+) {
+    fun projectIdClause(columnName: String = "project_id"): String {
+        if (serviceIds.isEmpty()) return EMPTY_SCOPE_CLAUSE
+        if (serviceIds.size == 1) return ClickHouseQueryUtils.projectIdClause(serviceIds.first(), columnName)
+
+        val values = serviceIds.joinToString(", ")
+        return if (serviceIds.any { it < 0 }) {
+            "toInt64($columnName) IN ($values)"
+        } else {
+            "$columnName IN ($values)"
+        }
+    }
+
+    fun cacheKeyPart(): String =
+        serviceIds.joinToString(",")
+
+    companion object {
+        private const val EMPTY_SCOPE_CLAUSE = "0 = 1"
+
+        fun service(serviceId: Long): ServiceQueryScope =
+            ServiceQueryScope(listOf(serviceId))
+
+        fun services(serviceIds: List<Long>): ServiceQueryScope =
+            ServiceQueryScope(serviceIds.distinct())
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
@@ -19,6 +19,7 @@ package com.moneat.events.services
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -42,6 +43,7 @@ class FeedbackServiceTest {
         every {
             queryHelper.timestampRetentionClause(any(), any(), any())
         } returns "timestamp >= now() - INTERVAL 30 DAY"
+        coEvery { queryHelper.getOrganizationRetentionDays(any()) } returns 30
         service = FeedbackService(queryHelper)
     }
 
@@ -83,5 +85,34 @@ class FeedbackServiceTest {
         assertEquals(FEEDBACK_UUID, detail?.feedbackId)
         assertEquals("2026-05-29T17:39:22.000Z", detail?.timestamp)
         assertEquals("unresolved", detail?.status)
+    }
+
+    @Test
+    fun `getFeedbackForServices scopes query to selected services`() = runBlocking {
+        val querySlot = slot<String>()
+        coEvery { queryHelper.executeJsonEachRowQuery(capture(querySlot), "Feedback list") } returns emptyList()
+
+        val result =
+            service.getFeedbackForServices(
+                organizationId = 1,
+                serviceIds = listOf(1L, 2L),
+                status = "resolved"
+            )
+
+        assertEquals(emptyList(), result)
+        assertEquals(true, querySlot.captured.contains("project_id IN (1, 2)"))
+        assertEquals(true, querySlot.captured.contains("status = 'resolved'"))
+    }
+
+    @Test
+    fun `getFeedback scopes project query through service scope`() = runBlocking {
+        val querySlot = slot<String>()
+        coEvery { queryHelper.executeJsonEachRowQuery(capture(querySlot), "Feedback list") } returns emptyList()
+
+        val result = service.getFeedback(projectId = 3L, status = "archived")
+
+        assertEquals(emptyList(), result)
+        assertEquals(true, querySlot.captured.contains("project_id = 3"))
+        assertEquals(true, querySlot.captured.contains("status = 'archived'"))
     }
 }

--- a/backend/src/test/kotlin/com/moneat/events/services/ServiceQueryScopeTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/services/ServiceQueryScopeTest.kt
@@ -1,0 +1,29 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.events.services
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ServiceQueryScopeTest {
+    @Test
+    fun `projectIdClause casts mixed demo service ids to Int64`() {
+        val clause = ServiceQueryScope.services(listOf(-1L, -2L, 3L)).projectIdClause()
+
+        assertEquals("toInt64(project_id) IN (-1, -2, 3)", clause)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
@@ -108,6 +108,12 @@ class EventRoutesExtendedTest {
     private val mockDashboardService = mockk<DashboardService>(relaxed = true)
     private val mockAlertPrefsService = mockk<AlertNotificationPreferencesService>(relaxed = true)
 
+    private data class SeededUserProject(
+        val userId: Int,
+        val orgId: Int,
+        val projectId: Long
+    )
+
     @BeforeTest
     fun setup() {
         startTestKoin()
@@ -153,6 +159,12 @@ class EventRoutesExtendedTest {
     private fun token(userId: Int): String =
         RouteTestSupport.createToken(userId)
 
+    private fun token(
+        userId: Int,
+        orgId: Int
+    ): String =
+        RouteTestSupport.createToken(userId = userId, orgId = orgId)
+
     private fun demoToken(): String =
         JWT.create().withIssuer("moneat").withAudience("moneat-users")
             .withClaim("userId", -1)
@@ -160,7 +172,10 @@ class EventRoutesExtendedTest {
             .withClaim("isDemo", true)
             .sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
 
-    private fun seedUserWithProject(): Pair<Int, Long> {
+    private fun seedUserWithProject(): Pair<Int, Long> =
+        seedUserProject().let { it.userId to it.projectId }
+
+    private fun seedUserProject(): SeededUserProject {
         val orgId = transaction {
             Organizations.insert {
                 it[name] = "Ext Test Org"
@@ -188,7 +203,7 @@ class EventRoutesExtendedTest {
                 it[slug] = "ext-project-${System.nanoTime()}"
             } get Projects.id
         }
-        return Pair(userId, projectId)
+        return SeededUserProject(userId = userId, orgId = orgId, projectId = projectId)
     }
 
     private fun projectResourceId(projectId: Long): String = transaction {
@@ -603,6 +618,56 @@ class EventRoutesExtendedTest {
     }
 
     @Test
+    fun `GET org replays filters to requested services`() = testApplication {
+        val seed = seedUserProject()
+        every { mockDashboardService.getServiceIdsForOrganization(seed.orgId) } returns
+            listOf(seed.projectId, SENTINEL_ID)
+        coEvery {
+            mockDashboardService.getReplaysForServices(
+                seed.orgId,
+                listOf(seed.projectId),
+                2,
+                10,
+                "production",
+                "30d",
+                any()
+            )
+        } returns listOf(sampleReplayListItem(seed.projectId))
+
+        application { installTestApp() }
+        val url = "/v1/replays?page=2&limit=10&environment=production&period=30d&serviceId=${seed.projectId}"
+        val response = client.get(url) {
+            withAuth(token(seed.userId, seed.orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("replay-1"))
+        coVerify {
+            mockDashboardService.getReplaysForServices(
+                seed.orgId,
+                listOf(seed.projectId),
+                2,
+                10,
+                "production",
+                "30d",
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `GET org replays returns 400 for invalid service id`() = testApplication {
+        val seed = seedUserProject()
+
+        application { installTestApp() }
+        val response = client.get("/v1/replays?serviceIds=not-a-service") {
+            withAuth(token(seed.userId, seed.orgId))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
     fun `GET replay detail returns 200`() = testApplication {
         val (userId, _) = seedUserWithProject()
         coEvery { mockDashboardService.hasReplayAccess(userId, REPLAY_D1) } returns true
@@ -732,6 +797,41 @@ class EventRoutesExtendedTest {
     }
 
     @Test
+    fun `GET org feedback resolves service names`() = testApplication {
+        val seed = seedUserProject()
+        every { mockDashboardService.resolveServiceId(seed.orgId, "checkout") } returns seed.projectId
+        every { mockDashboardService.getServiceIdsForOrganization(seed.orgId) } returns listOf(seed.projectId)
+        coEvery {
+            mockDashboardService.getFeedbackForServices(
+                seed.orgId,
+                listOf(seed.projectId),
+                1,
+                25,
+                "resolved",
+                any()
+            )
+        } returns listOf(sampleFeedbackListItem())
+
+        application { installTestApp() }
+        val response = client.get("/v1/feedback?services=checkout&status=resolved") {
+            withAuth(token(seed.userId, seed.orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("fb-1"))
+        coVerify {
+            mockDashboardService.getFeedbackForServices(
+                seed.orgId,
+                listOf(seed.projectId),
+                1,
+                25,
+                "resolved",
+                any()
+            )
+        }
+    }
+
+    @Test
     fun `GET feedback list returns 403 without access`() = testApplication {
         val (userId, _) = seedUserWithProject()
         every { mockDashboardService.hasProjectAccess(userId, SENTINEL_ID) } returns false
@@ -832,6 +932,26 @@ class EventRoutesExtendedTest {
     }
 
     @Test
+    fun `GET org releases uses all organization services`() = testApplication {
+        val seed = seedUserProject()
+        every { mockDashboardService.getServiceIdsForOrganization(seed.orgId) } returns listOf(seed.projectId)
+        coEvery {
+            mockDashboardService.getReleasesForServices(seed.orgId, listOf(seed.projectId), any())
+        } returns listOf(sampleRelease())
+
+        application { installTestApp() }
+        val response = client.get("/v1/releases") {
+            withAuth(token(seed.userId, seed.orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("1.0.0"))
+        coVerify {
+            mockDashboardService.getReleasesForServices(seed.orgId, listOf(seed.projectId), any())
+        }
+    }
+
+    @Test
     fun `GET releases returns 403 without access`() = testApplication {
         val (userId, _) = seedUserWithProject()
         every { mockDashboardService.hasProjectAccess(userId, SENTINEL_ID) } returns false
@@ -857,6 +977,42 @@ class EventRoutesExtendedTest {
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("1.0.0"))
+    }
+
+    @Test
+    fun `GET org release stats filters service ids to organization services`() = testApplication {
+        val seed = seedUserProject()
+        every { mockDashboardService.getServiceIdsForOrganization(seed.orgId) } returns listOf(seed.projectId)
+        coEvery {
+            mockDashboardService.getReleaseStatsForServices(seed.orgId, listOf(seed.projectId), "1.0.0")
+        } returns sampleReleaseStats()
+
+        application { installTestApp() }
+        val response = client.get("/v1/releases/1.0.0/stats?serviceIds=${seed.projectId},$SENTINEL_ID") {
+            withAuth(token(seed.userId, seed.orgId))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("1.0.0"))
+        coVerify {
+            mockDashboardService.getReleaseStatsForServices(seed.orgId, listOf(seed.projectId), "1.0.0")
+        }
+    }
+
+    @Test
+    fun `GET org release stats returns 404 when not found`() = testApplication {
+        val seed = seedUserProject()
+        every { mockDashboardService.getServiceIdsForOrganization(seed.orgId) } returns listOf(seed.projectId)
+        coEvery {
+            mockDashboardService.getReleaseStatsForServices(seed.orgId, listOf(seed.projectId), "9.9.9")
+        } returns null
+
+        application { installTestApp() }
+        val response = client.get("/v1/releases/9.9.9/stats") {
+            withAuth(token(seed.userId, seed.orgId))
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/DashboardServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/DashboardServiceTest.kt
@@ -40,6 +40,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DashboardServiceTest {
@@ -173,6 +174,23 @@ class DashboardServiceTest {
                 assertTrue(queries.any { it.contains("organization_id = 1") })
                 assertTrue(queries.any { it.contains("project_id IN (123)") })
             }
+        }
+
+    @Test
+    fun `org service read methods return empty results for empty service scope`() =
+        runBlocking {
+            val service = DashboardService.create()
+
+            val releases = service.getReleasesForServices(organizationId = 1, serviceIds = emptyList())
+            val releaseStats =
+                service.getReleaseStatsForServices(organizationId = 1, serviceIds = emptyList(), version = "1.0.0")
+            val replays = service.getReplaysForServices(organizationId = 1, serviceIds = emptyList())
+            val feedback = service.getFeedbackForServices(organizationId = 1, serviceIds = emptyList())
+
+            assertTrue(releases.isEmpty())
+            assertNull(releaseStats)
+            assertTrue(replays.isEmpty())
+            assertTrue(feedback.isEmpty())
         }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/ReleaseStatsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReleaseStatsServiceTest.kt
@@ -49,6 +49,7 @@ class ReleaseStatsServiceTest {
     @BeforeTest
     fun setup() {
         coEvery { retentionPolicyService.getRetentionDaysForProject(any()) } returns 30
+        coEvery { retentionPolicyService.getRetentionDaysForOrganization(any()) } returns 30
         queryHelper = DashboardQueryHelper(retentionPolicyService, pricingTierService)
         service = ReleaseStatsService(queryHelper)
     }
@@ -115,6 +116,52 @@ class ReleaseStatsServiceTest {
             val releases = service.getReleases(1L)
             assertTrue(releases.isEmpty())
         }
+    }
+
+    @Test
+    fun `getReleasesForServices scopes release queries to service ids`() = runBlocking {
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
+        MockHttpServer { exchange ->
+            val query = exchange.requestBodyText()
+            queries += query
+            when {
+                query.contains("first_release") && query.contains("GROUP BY first_release") ->
+                    exchange.respond(200, """{"version":"1.0.0","total":1}""", contentType = TEXT_PLAIN)
+
+                query.contains(COUNT_IF_ERRORS_0) && query.contains("sessions") ->
+                    exchange.respond(200, """{"version":"1.0.0","rate":99.0}""", contentType = TEXT_PLAIN)
+
+                else ->
+                    exchange.respond(
+                        200,
+                        """
+                        {
+                          "version":"1.0.0",
+                          "first_seen":"2026-01-01T00:00:00.000Z",
+                          "last_seen":"2026-01-02T00:00:00.000Z",
+                          "event_count":4,
+                          "user_count":2
+                        }
+                        """.trimIndent().replace("\n", ""),
+                        contentType = TEXT_PLAIN
+                    )
+            }
+        }.use { server ->
+            ClickHouseClient.close()
+            ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+            val releases = service.getReleasesForServices(organizationId = 1, serviceIds = listOf(1L, 2L))
+
+            assertEquals(1, releases.size)
+            assertTrue(queries.any { it.contains("project_id IN (1, 2)") })
+        }
+    }
+
+    @Test
+    fun `getReleaseStatsForServices returns null for empty service scope`() = runBlocking {
+        val stats = service.getReleaseStatsForServices(organizationId = 1, serviceIds = emptyList(), version = "1.0.0")
+
+        assertNull(stats)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
@@ -53,6 +53,7 @@ class ReplayServiceTest {
         db = OrgProjectTestFixtures.connectResetAndSeedDefaultOrgProject(db, "moneat_replay_service")
 
         coEvery { retentionPolicyService.getRetentionDaysForProject(any()) } returns 30
+        coEvery { retentionPolicyService.getRetentionDaysForOrganization(any()) } returns 30
         queryHelper = DashboardQueryHelper(retentionPolicyService, pricingTierService)
         service = ReplayService(queryHelper)
     }
@@ -104,6 +105,39 @@ class ReplayServiceTest {
             assertEquals("Chrome", result[0].browserName)
             assertEquals("macOS", result[0].osName)
             assertEquals(8, result[0].activity)
+        }
+    }
+
+    @Test
+    fun `getReplaysForServices scopes list and fallback error count by row service id`() = runBlocking {
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val replayRow = """
+{"replay_id":"$REPLAY_UUID","project_id":2,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_count":0,"user_id":"u-1","user_email":"test@test.com","user_username":"tester","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":8}
+        """.trimIndent()
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            queries += query
+            when {
+                query.contains("countDistinct(event_id)") ->
+                    exchange.respond(200, """{"count":3}""", TEXT_PLAIN)
+
+                else ->
+                    exchange.respond(200, replayRow, TEXT_PLAIN)
+            }
+        }) {
+            val result =
+                service.getReplaysForServices(
+                    organizationId = 1,
+                    serviceIds = listOf(1L, 2L),
+                    environment = "production"
+                )
+
+            assertEquals(1, result.size)
+            assertEquals(2L, result.first().projectId)
+            assertEquals(3, result.first().errorCount)
+            assertTrue(queries.any { it.contains("project_id IN (1, 2)") })
+            assertTrue(queries.any { it.contains("project_id = 2") })
+            assertTrue(queries.any { it.contains("environment = 'production'") })
         }
     }
 


### PR DESCRIPTION
Adds org-scoped read coverage for release, replay, and feedback surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoints now support organization-scoped reads: query releases, release stats, replays, and feedback filtered by one or more services (including demo service expansion) with standardized invalid-service error responses.
  * Multi-service queries respect organization service membership and return empty/null/404 when no services match.

* **Tests**
  * Added coverage for service-scoped endpoints, query scoping, pagination/fallback behaviors, demo-expansion, and empty-service results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->