### PR TITLE
feat: add service id db cutover

### DIFF
--- a/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
@@ -129,13 +129,14 @@ class AnalyticsIngestionWorker(
 
         val sql = """
             INSERT INTO analytics_events (
-                project_id, session_id, user_id, event_name, source, hostname, pathname,
+                service_id, project_id, session_id, user_id, event_name, source, hostname, pathname,
                 referrer, referrer_source,
                 utm_source, utm_medium, utm_campaign, utm_term, utm_content,
                 country_code, subdivision, city,
                 browser, browser_version, os, os_version, device_type,
                 screen_width, props, timestamp
             ) VALUES (
+                ${event.projectId},
                 ${event.projectId},
                 '${escapeCH(event.sessionId)}',
                 '${escapeCH(event.userId)}',

--- a/backend/src/main/kotlin/com/moneat/auth/services/AccountDeletionService.kt
+++ b/backend/src/main/kotlin/com/moneat/auth/services/AccountDeletionService.kt
@@ -26,6 +26,7 @@ import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Subscriptions
 import com.moneat.shared.models.UsageRecords
 import com.moneat.shared.models.Users
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -39,9 +40,11 @@ import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
+
+private const val PROJECT_ID_COLUMN = "project_id"
+private const val SERVICE_ID_COLUMN = "service_id"
 
 class AccountDeletionService(
     private val stripeService: StripeService,
@@ -343,23 +346,23 @@ class AccountDeletionService(
                 // Delete from all ClickHouse tables (including LLM and analytics)
                 val tables =
                     listOf(
-                        "events",
-                        "spans",
-                        "sessions",
-                        "replay_events",
-                        "replay_segments",
-                        "user_feedback",
-                        "logs",
-                        "llm_generations",
-                        "llm_generations_hourly_mv",
-                        "analytics_events",
-                        "analytics_sessions_hourly",
-                        "issues"
+                        "events" to SERVICE_ID_COLUMN,
+                        "spans" to SERVICE_ID_COLUMN,
+                        "sessions" to SERVICE_ID_COLUMN,
+                        "replay_events" to SERVICE_ID_COLUMN,
+                        "replay_segments" to SERVICE_ID_COLUMN,
+                        "user_feedback" to SERVICE_ID_COLUMN,
+                        "logs" to SERVICE_ID_COLUMN,
+                        "llm_generations" to SERVICE_ID_COLUMN,
+                        "llm_generations_hourly_mv" to PROJECT_ID_COLUMN,
+                        "analytics_events" to SERVICE_ID_COLUMN,
+                        "analytics_sessions_hourly" to SERVICE_ID_COLUMN,
+                        "issues" to SERVICE_ID_COLUMN
                     )
 
-                tables.forEach { table ->
+                tables.forEach { (table, idColumn) ->
                     suspendRunCatching {
-                        val query = "ALTER TABLE $table DELETE WHERE project_id IN ($projectIdsList)"
+                        val query = "ALTER TABLE $table DELETE WHERE $idColumn IN ($projectIdsList)"
                         val response = ClickHouseClient.execute(query)
 
                         if (response.status == HttpStatusCode.OK) {

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedAnalytics.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedAnalytics.kt
@@ -27,7 +27,7 @@ internal suspend fun checkFreshAnalyticsDataCount(): Long {
         """
         SELECT count() as cnt
         FROM analytics_events
-        WHERE project_id IN ($P1, $P2, $P3)
+        WHERE service_id IN ($P1, $P2, $P3)
             AND timestamp >= now() - INTERVAL 7 DAY
         """.trimIndent()
     return suspendRunCatching {
@@ -46,7 +46,7 @@ internal suspend fun checkFreshAnalyticsDataCount(): Long {
 internal suspend fun purgeAnalyticsDemoData() {
     suspendRunCatching {
         requireClickHouse2xx(
-            ClickHouseClient.execute("ALTER TABLE analytics_events DELETE WHERE project_id IN ($P1, $P2, $P3)"),
+            ClickHouseClient.execute("ALTER TABLE analytics_events DELETE WHERE service_id IN ($P1, $P2, $P3)"),
             "Purge analytics_events"
         )
     }.onFailure { logger.warn { "Purge analytics_events failed (non-fatal): ${it.message}" } }
@@ -54,7 +54,7 @@ internal suspend fun purgeAnalyticsDemoData() {
     suspendRunCatching {
         requireClickHouse2xx(
             ClickHouseClient.execute(
-                "ALTER TABLE analytics_sessions_hourly DELETE WHERE project_id IN ($P1, $P2, $P3)"
+                "ALTER TABLE analytics_sessions_hourly DELETE WHERE service_id IN ($P1, $P2, $P3)"
             ),
             "Purge analytics_sessions_hourly"
         )
@@ -65,6 +65,7 @@ internal suspend fun reseedAnalyticsEvents() {
         """
         INSERT INTO analytics_events (
             event_id,
+            service_id,
             project_id,
             session_id,
             event_name,
@@ -86,6 +87,11 @@ internal suspend fun reseedAnalyticsEvents() {
         )
         SELECT
             generateUUIDv4() AS event_id,
+            CASE intDiv(number, 5) % 3
+                WHEN 0 THEN $P1
+                WHEN 1 THEN $P2
+                ELSE $P3
+            END AS service_id,
             CASE intDiv(number, 5) % 3
                 WHEN 0 THEN $P1
                 WHEN 1 THEN $P2

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedCore.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedCore.kt
@@ -49,12 +49,12 @@ private fun demoIssueInsertSql(envExpr: String, spec: DemoIssueInsertSpec): Stri
     with(spec) {
         """
         INSERT INTO events (
-            event_id, project_id, issue_id, timestamp, received_at, event_type,
+            event_id, service_id, project_id, issue_id, timestamp, received_at, event_type,
             platform, level, message, exception_type, exception_value,
             stack_trace, environment, release, user_id, user_email,
             device_model, os_name, os_version, fingerprint
         )
-        SELECT generateUUIDv4(), $project, '${escapeSql(issueId)}',
+        SELECT generateUUIDv4(), $project, $project, '${escapeSql(issueId)}',
             now() - INTERVAL (number % $hours) HOUR, now() - INTERVAL (number % $hours) HOUR,
             'error', '${escapeSql(platform)}', '${escapeSql(level)}',
             '${escapeSql(message)}', '${escapeSql(exType)}', '${escapeSql(exValue)}', '${escapeSql(stack)}',
@@ -72,7 +72,7 @@ internal suspend fun checkFreshDataCount(): Long {
         """
         SELECT count() as cnt
         FROM events
-        WHERE project_id IN ($P1, $P2, $P3)
+        WHERE service_id IN ($P1, $P2, $P3)
             AND timestamp >= now() - INTERVAL 7 DAY
         """.trimIndent()
     return suspendRunCatching {
@@ -88,11 +88,11 @@ internal suspend fun checkFreshDataCount(): Long {
 internal suspend fun purgeOldDemoData() {
     val tables =
         listOf(
-            "events" to "project_id",
-            "sessions" to "project_id",
-            "spans" to "project_id",
-            "replay_events" to "project_id",
-            "replay_segments" to "project_id"
+            "events" to "service_id",
+            "sessions" to "service_id",
+            "spans" to "service_id",
+            "replay_events" to "service_id",
+            "replay_segments" to "service_id"
         )
     for ((table, col) in tables) {
         val query = "ALTER TABLE $table DELETE WHERE $col IN ($P1, $P2, $P3)"
@@ -101,7 +101,7 @@ internal suspend fun purgeOldDemoData() {
     }
     // Also purge issues materialized from demo events
     suspendRunCatching {
-        ClickHouseClient.execute("ALTER TABLE issues DELETE WHERE project_id IN ($P1, $P2, $P3)")
+        ClickHouseClient.execute("ALTER TABLE issues DELETE WHERE service_id IN ($P1, $P2, $P3)")
     }.onFailure { logger.warn { "Purge issues failed (non-fatal): ${it.message}" } }
 }
 internal suspend fun reseedEvents() {
@@ -1739,12 +1739,13 @@ internal suspend fun reseedEvents() {
         // ── Transactions (all 3 projects) ────────────────────────────────────
         """
         INSERT INTO events (
-            event_id, project_id, issue_id, timestamp, received_at, event_type,
+            event_id, service_id, project_id, issue_id, timestamp, received_at, event_type,
             platform, level, transaction_name, transaction_op, duration_ms,
             environment, release, user_id, contexts
         )
         SELECT
             generateUUIDv4(),
+            CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END,
             CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END,
             '',
             now() - INTERVAL (number % 168) HOUR, now() - INTERVAL (number % 168) HOUR,
@@ -1781,9 +1782,13 @@ internal suspend fun reseedEvents() {
 internal suspend fun reseedSessions() {
     val sql =
         """
-        INSERT INTO sessions (session_id, project_id, started, duration_ms, status, errors, release, environment, user_id, received_at)
+        INSERT INTO sessions (
+            session_id, service_id, project_id, started, duration_ms, status, errors,
+            release, environment, user_id, received_at
+        )
         SELECT
             generateUUIDv4(),
+            CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END,
             CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END,
             now() - INTERVAL (number * 2) HOUR,
             1000 + (number * 123) % 300000,
@@ -1803,7 +1808,7 @@ internal suspend fun reseedReplays() {
     val replayEventsSql =
         """
         INSERT INTO replay_events (
-            replay_id, project_id, segment_id, timestamp, replay_start_timestamp,
+            replay_id, service_id, project_id, segment_id, timestamp, replay_start_timestamp,
             urls, error_ids, trace_ids, environment, release, platform,
             user_id, user_email, user_username, browser_name, browser_version,
             os_name, os_version, activity, tags
@@ -1813,6 +1818,7 @@ internal suspend fun reseedReplays() {
                 'aaaaaaaa-bbbb-cccc-dddd-',
                 lpad(toString(number), 12, '0')
             )),
+            CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END,
             CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END,
             0,
             now() - INTERVAL (number * 4) HOUR,
@@ -1841,13 +1847,14 @@ internal suspend fun reseedReplays() {
     val segmentsSql =
         """
         INSERT INTO replay_segments (
-            replay_id, project_id, segment_id, timestamp, recording_data
+            replay_id, service_id, project_id, segment_id, timestamp, recording_data
         )
         SELECT
             toUUID(concat(
                 'aaaaaaaa-bbbb-cccc-dddd-',
                 lpad(toString(number), 12, '0')
             )) as replay_id,
+            CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END as service_id,
             CASE number % 3 WHEN 0 THEN $P1 WHEN 1 THEN $P2 ELSE $P3 END as project_id,
             0 as segment_id,
             now() - INTERVAL (number * 4) HOUR as timestamp,

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedFeedback.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedFeedback.kt
@@ -34,7 +34,7 @@ private val logger = KotlinLogging.logger {}
 internal suspend fun checkFreshFeedbackCount(): Long {
     val query = """
         SELECT count() FROM user_feedback
-        WHERE project_id IN ($P1, $P2, $P3)
+        WHERE service_id IN ($P1, $P2, $P3)
             AND timestamp >= now() - INTERVAL 7 DAY
     """.trimIndent()
     return suspendRunCatching {
@@ -53,7 +53,7 @@ internal suspend fun checkFreshFeedbackCount(): Long {
 internal suspend fun purgeFeedbackDemoData() {
     suspendRunCatching {
         requireClickHouse2xx(
-            ClickHouseClient.execute("ALTER TABLE user_feedback DELETE WHERE project_id IN ($P1, $P2, $P3)"),
+            ClickHouseClient.execute("ALTER TABLE user_feedback DELETE WHERE service_id IN ($P1, $P2, $P3)"),
             "Purge user_feedback"
         )
     }.onFailure { logger.warn { "Purge user_feedback failed (non-fatal): ${it.message}" } }
@@ -69,12 +69,13 @@ internal suspend fun reseedFeedback() {
 private fun buildFeedbackInsertSql(): String =
     """
         INSERT INTO user_feedback (
-            feedback_id, project_id, timestamp, received_at, message, contact_email, name, url,
+            feedback_id, service_id, project_id, timestamp, received_at, message, contact_email, name, url,
             associated_event_id, replay_id, environment, release, platform, user_id, user_email,
             user_username, user_ip_address, sdk_name, sdk_version, tags, status, updated_at
         )
         SELECT
             generateUUIDv4(),
+            arrayElement([$P1, $P2, $P3], number % 3 + 1),
             arrayElement([$P1, $P2, $P3], number % 3 + 1),
             now64(3) - INTERVAL (number * 67 % 20160) MINUTE,
             now64(3) - INTERVAL (number * 67 % 20160) MINUTE,

--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedLlm.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedLlm.kt
@@ -27,7 +27,7 @@ internal suspend fun checkFreshLlmDataCount(): Long {
         """
         SELECT count() as cnt
         FROM llm_generations
-        WHERE project_id IN ($P1, $P2, $P3)
+        WHERE service_id IN ($P1, $P2, $P3)
             AND timestamp >= now() - INTERVAL 12 HOUR
         """.trimIndent()
     return suspendRunCatching {
@@ -44,7 +44,7 @@ internal suspend fun checkFreshLlmDataCount(): Long {
 }
 internal suspend fun purgeLlmDemoData() {
     suspendRunCatching {
-        ClickHouseClient.execute("ALTER TABLE llm_generations DELETE WHERE project_id IN ($P1, $P2, $P3)")
+        ClickHouseClient.execute("ALTER TABLE llm_generations DELETE WHERE service_id IN ($P1, $P2, $P3)")
     }.onFailure { logger.warn { "Purge llm_generations failed (non-fatal): ${it.message}" } }
 
     // SummingMergeTree materialized rows need explicit cleanup.
@@ -57,6 +57,7 @@ internal suspend fun reseedLlmGenerations() {
         """
         INSERT INTO llm_generations (
             generation_id,
+            service_id,
             project_id,
             trace_id,
             span_id,
@@ -89,6 +90,11 @@ internal suspend fun reseedLlmGenerations() {
         )
         SELECT
             generateUUIDv4() AS generation_id,
+            CASE intDiv(number, 4) % 3
+                WHEN 0 THEN $P1
+                WHEN 1 THEN $P2
+                ELSE $P3
+            END AS service_id,
             CASE intDiv(number, 4) % 3
                 WHEN 0 THEN $P1
                 WHEN 1 THEN $P2

--- a/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/DatadogMetricService.kt
@@ -68,7 +68,8 @@ private data class MetricInsertRow(
 @Serializable
 private data class MetricJsonEachRow(
     @SerialName("organization_id") val organizationId: Long,
-    @SerialName("project_id") val projectId: Long,
+    @SerialName("service_id") val projectId: Long,
+    @SerialName("project_id") val deprecatedProjectId: Long,
     @SerialName("metric_name") val metricName: String,
     @SerialName("metric_type") val metricType: String,
     val timestamp: String,
@@ -219,7 +220,7 @@ object DatadogMetricService {
 
         val insert = """
             INSERT INTO `$db`.metrics (
-                organization_id, project_id, metric_name, metric_type, timestamp,
+                organization_id, service_id, project_id, metric_name, metric_type, timestamp,
                 value, host, tags, unit, source_type_name,
                 source
             ) FORMAT JSONEachRow
@@ -248,6 +249,7 @@ object DatadogMetricService {
         MetricJsonEachRow(
             organizationId = organizationId,
             projectId = projectId ?: 0L,
+            deprecatedProjectId = projectId ?: 0L,
             metricName = metric.name,
             metricType = metric.type,
             timestamp = formatClickHouseDateTime64MillisUtc(metric.timestampMs),
@@ -272,6 +274,7 @@ object DatadogMetricService {
             """(
                 ${batch.organizationId},
                 ${batch.projectId ?: 0L},
+                ${batch.projectId ?: 0L},
                 '${escapeSql(s.name)}',
                 fromUnixTimestamp64Milli(${s.timestampMs}),
                 '${escapeSql(s.host)}',
@@ -288,7 +291,7 @@ object DatadogMetricService {
 
         val insert = """
             INSERT INTO `$db`.metric_sketches (
-                organization_id, project_id, metric_name, timestamp, host, tags,
+                organization_id, service_id, project_id, metric_name, timestamp, host, tags,
                 sketch_count, sketch_min, sketch_max, sketch_avg,
                 sketch_sum, sketch_k, sketch_n
             ) VALUES $rows

--- a/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
@@ -111,7 +111,7 @@ class EventRepositoryImpl(
         val tagsMap = tagsToMap(data.tags)
         val sql = """
             INSERT INTO `$db`.events (
-                event_id, project_id, organization_id, timestamp, event_type, level,
+                event_id, service_id, project_id, organization_id, timestamp, event_type, level,
                 message, platform, environment, release, dist, server_name,
                 user_id, user_email, user_username, user_ip_address,
                 exception_type, exception_value, stack_trace,
@@ -119,6 +119,7 @@ class EventRepositoryImpl(
                 sdk_name, sdk_version
             ) VALUES (
                 toUUID('${escapeSql(data.eventId)}'),
+                ${data.projectId},
                 ${data.projectId},
                 ${data.organizationId},
                 fromUnixTimestamp64Milli(${data.timestampMs}),
@@ -158,7 +159,7 @@ class EventRepositoryImpl(
         val tagsMap = tagsToMap(data.tags)
         val sql = """
             INSERT INTO `$db`.events (
-                event_id, project_id, organization_id, timestamp, event_type, level,
+                event_id, service_id, project_id, organization_id, timestamp, event_type, level,
                 message, platform, environment, release, dist, server_name,
                 user_id, user_email, user_username, user_ip_address,
                 exception_type, exception_value, stack_trace,
@@ -167,6 +168,7 @@ class EventRepositoryImpl(
                 sdk_name, sdk_version
             ) VALUES (
                 toUUID('${escapeSql(data.eventId)}'),
+                ${data.projectId},
                 ${data.projectId},
                 ${data.organizationId},
                 fromUnixTimestamp64Milli(${data.timestampMs}),
@@ -207,6 +209,7 @@ class EventRepositoryImpl(
             """(
                 toUUID('${escapeSql(session.sessionId)}'),
                 ${session.projectId},
+                ${session.projectId},
                 ${session.organizationId},
                 fromUnixTimestamp64Milli(${session.startedMs}),
                 ${session.durationMs},
@@ -220,7 +223,7 @@ class EventRepositoryImpl(
         }
         val sql = """
             INSERT INTO `$db`.sessions (
-                session_id, project_id, organization_id, started, duration_ms, status, errors,
+                session_id, service_id, project_id, organization_id, started, duration_ms, status, errors,
                 release, environment, user_id, received_at
             ) VALUES
             $valueRows
@@ -237,6 +240,7 @@ class EventRepositoryImpl(
                 '${escapeSql(span.traceId)}',
                 toUUID('${escapeSql(span.transactionId)}'),
                 ${span.projectId},
+                ${span.projectId},
                 ${span.organizationId},
                 '${escapeSql(span.op)}',
                 '${escapeSql(span.description)}',
@@ -250,7 +254,7 @@ class EventRepositoryImpl(
         }
         val sql = """
             INSERT INTO `$db`.spans (
-                span_id, parent_span_id, trace_id, transaction_id, project_id, organization_id,
+                span_id, parent_span_id, trace_id, transaction_id, service_id, project_id, organization_id,
                 op, description, start_timestamp, end_timestamp, duration_ms, status, tags, data
             ) VALUES
             $valueRows
@@ -262,12 +266,13 @@ class EventRepositoryImpl(
         val tagsMap = tagsToMap(data.tags)
         val sql = """
             INSERT INTO `$db`.user_feedback (
-                feedback_id, project_id, organization_id, timestamp, message, contact_email, name, url,
+                feedback_id, service_id, project_id, organization_id, timestamp, message, contact_email, name, url,
                 associated_event_id, replay_id, environment, release, platform,
                 user_id, user_email, user_username, user_ip_address,
                 sdk_name, sdk_version, tags, status
             ) VALUES (
                 toUUID('${escapeSql(data.feedbackId)}'),
+                ${data.projectId},
                 ${data.projectId},
                 ${data.organizationId},
                 fromUnixTimestamp64Milli(${data.timestampMs}),
@@ -299,13 +304,14 @@ class EventRepositoryImpl(
         val traceIdsArray = "[${data.traceIds.joinToString(",") { "'${escapeSql(it)}'" }}]"
         val sql = """
             INSERT INTO `$db`.replay_events (
-                replay_id, project_id, organization_id, segment_id, timestamp, replay_start_timestamp,
+                replay_id, service_id, project_id, organization_id, segment_id, timestamp, replay_start_timestamp,
                 urls, error_ids, trace_ids, environment, release, platform,
                 user_id, user_email, user_username, user_ip_address,
                 sdk_name, sdk_version, browser_name, browser_version,
                 os_name, os_version, device_name, device_family, activity, tags
             ) VALUES (
                 toUUID('${escapeSql(data.replayId)}'),
+                ${data.projectId},
                 ${data.projectId},
                 ${data.organizationId},
                 ${data.segmentId},
@@ -339,9 +345,10 @@ class EventRepositoryImpl(
     override suspend fun insertReplayRecording(data: ReplayRecordingInsertData) {
         val sql = """
             INSERT INTO `$db`.replay_segments (
-                replay_id, project_id, organization_id, segment_id, timestamp, recording_data
+                replay_id, service_id, project_id, organization_id, segment_id, timestamp, recording_data
             ) VALUES (
                 toUUID('${escapeSql(data.replayId)}'),
+                ${data.projectId},
                 ${data.projectId},
                 ${data.organizationId},
                 ${data.segmentId},
@@ -357,6 +364,7 @@ class EventRepositoryImpl(
         val valueRows = rows.joinToString(",\n") { g ->
             """(
                 toUUID('${escapeSql(g.generationId)}'),
+                ${g.projectId},
                 ${g.projectId},
                 ${g.organizationId},
                 '${escapeSql(g.traceId)}',
@@ -387,7 +395,7 @@ class EventRepositoryImpl(
         }
         val sql = """
             INSERT INTO `$db`.llm_generations (
-                generation_id, project_id, organization_id, trace_id, span_id, parent_span_id,
+                generation_id, service_id, project_id, organization_id, trace_id, span_id, parent_span_id,
                 timestamp, duration_ms, name, model, provider, type,
                 input, output, input_tokens, output_tokens, total_tokens, cost_usd,
                 temperature, max_tokens, top_p,
@@ -454,9 +462,10 @@ class EventRepositoryImpl(
     private suspend fun insertErrorEventRollups(data: ErrorEventInsertData) {
         val projectRollup = """
             INSERT INTO `$db`.event_project_rollup_1h (
-                project_id, organization_id, bucket_start, level, platform, browser_name,
+                service_id, project_id, organization_id, bucket_start, level, platform, browser_name,
                 environment, event_count
             ) VALUES (
+                ${data.projectId},
                 ${data.projectId},
                 ${data.organizationId},
                 toStartOfHour(fromUnixTimestamp64Milli(${data.timestampMs})),
@@ -469,8 +478,9 @@ class EventRepositoryImpl(
         """.trimIndent()
         val issueRollup = """
             INSERT INTO `$db`.event_issue_rollup_1h (
-                project_id, organization_id, issue_id, bucket_start, title, event_count
+                service_id, project_id, organization_id, issue_id, bucket_start, title, event_count
             ) VALUES (
+                ${data.projectId},
                 ${data.projectId},
                 ${data.organizationId},
                 '${escapeSql(data.issueId)}',

--- a/backend/src/main/kotlin/com/moneat/events/services/SentrySpanBackfill.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/SentrySpanBackfill.kt
@@ -50,7 +50,7 @@ object SentrySpanBackfill {
                 span_id, span_id_high,
                 trace_id, trace_id_high,
                 parent_id, parent_id_high,
-                organization_id,
+                organization_id, service_id, project_id,
                 name, service, resource, type,
                 start, duration, error,
                 meta, metrics, host, env, version,
@@ -64,6 +64,8 @@ object SentrySpanBackfill {
                 reinterpretAsUInt64(reverse(unhex(lpad(parent_span_id, 16, '0')))),
                 0,
                 $orgExpr,
+                service_id,
+                project_id,
                 '' AS name,
                 '' AS service,
                 description AS resource,
@@ -75,7 +77,7 @@ object SentrySpanBackfill {
                     tags,
                     map(
                         'sentry.transaction_id', toString(transaction_id),
-                        'sentry.project_id', toString(project_id)
+                        'sentry.project_id', toString(service_id)
                     )
                 ) AS meta,
                 map() AS metrics,
@@ -87,7 +89,7 @@ object SentrySpanBackfill {
                 parent_span_id AS parent_id_hex,
                 'sentry' AS source
             FROM `$db`.spans
-            WHERE project_id IN (${mapping.keys.joinToString(",")})
+            WHERE service_id IN (${mapping.keys.joinToString(",")})
         """.trimIndent()
 
         logger.info { "Starting spans -> apm_spans backfill for ${mapping.size} projects..." }
@@ -117,7 +119,7 @@ object SentrySpanBackfill {
             return mapping.values.first().toString()
         }
         val cases = mapping.entries.joinToString(", ") { (pid, oid) ->
-            "project_id = $pid, $oid"
+            "service_id = $pid, $oid"
         }
         return "multiIf($cases, NULL)"
     }

--- a/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
@@ -156,6 +156,7 @@ class LlmIngestionWorker(
                     """(
                     toUUID('$generationId'),
                     $projectId,
+                    $projectId,
                     '${esc(gen.traceId)}',
                     '${esc(gen.spanId)}',
                     '${esc(gen.parentSpanId)}',
@@ -199,7 +200,7 @@ class LlmIngestionWorker(
         val query =
             """
             INSERT INTO `$clickhouseDb`.llm_generations (
-                generation_id, project_id, trace_id, span_id, parent_span_id,
+                generation_id, service_id, project_id, trace_id, span_id, parent_span_id,
                 timestamp, duration_ms, name, model, provider, type,
                 input, output, input_tokens, output_tokens, total_tokens, cost_usd,
                 temperature, max_tokens, top_p,

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
@@ -192,6 +192,7 @@ class LogService(private val logRepository: LogRepository) {
                 toUUID('${escapeSql(entry.logId)}'),
                 ${batch.effectiveOrganizationId},
                 ${entry.projectId ?: 0L},
+                ${entry.projectId ?: 0L},
                 toUUID('${escapeSql(systemIdValue)}'),
                 fromUnixTimestamp64Milli(${entry.timestampMs}),
                 '${escapeSql(entry.level)}',
@@ -218,6 +219,7 @@ class LogService(private val logRepository: LogRepository) {
             INSERT INTO `$clickhouseDb`.logs (
                 log_id,
                 organization_id,
+                service_id,
                 project_id,
                 system_id,
                 timestamp,

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpMetricsService.kt
@@ -87,7 +87,8 @@ data class QueuedOtlpMetricsBatch(
 @Serializable
 private data class OtlpMetricJsonEachRow(
     @SerialName("organization_id") val organizationId: Long,
-    @SerialName("project_id") val projectId: Long,
+    @SerialName("service_id") val projectId: Long,
+    @SerialName("project_id") val deprecatedProjectId: Long,
     @SerialName("metric_name") val metricName: String,
     @SerialName("metric_type") val metricType: String,
     val timestamp: String,
@@ -658,7 +659,7 @@ class OtlpMetricsService(
 
         val insert = """
             INSERT INTO `$clickhouseDb`.metrics (
-                organization_id, project_id, metric_name, metric_type,
+                organization_id, service_id, project_id, metric_name, metric_type,
                 timestamp, value, host, tags, unit, source_type_name,
                 source, is_monotonic, aggregation_temporality,
                 hist_count, hist_sum, hist_min, hist_max,
@@ -698,6 +699,7 @@ class OtlpMetricsService(
         OtlpMetricJsonEachRow(
             organizationId = organizationId,
             projectId = projectId ?: 0L,
+            deprecatedProjectId = projectId ?: 0L,
             metricName = metricName,
             metricType = metricType,
             timestamp = formatClickHouseDateTime64MillisUtc(timestampMs),

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpTraceService.kt
@@ -344,6 +344,7 @@ class OtlpTraceService(
                 $parentIdHigh,
                 ${s.organizationId},
                 ${s.projectId ?: 0L},
+                ${s.projectId ?: 0L},
                 '${escapeSql(s.name)}',
                 '${escapeSql(s.service)}',
                 '${escapeSql(s.resource)}',
@@ -374,7 +375,7 @@ class OtlpTraceService(
         val insert = """
             INSERT INTO `$clickhouseDb`.apm_spans (
                 span_id, span_id_high, trace_id, trace_id_high, parent_id, parent_id_high,
-                organization_id, project_id,
+                organization_id, service_id, project_id,
                 name, service, resource, type,
                 start, duration, error,
                 meta, metrics, host, env, version,

--- a/backend/src/main/kotlin/com/moneat/shared/services/RetentionBackgroundService.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/services/RetentionBackgroundService.kt
@@ -35,6 +35,16 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 private val logger = KotlinLogging.logger {}
 
+private const val PROJECT_ID_COLUMN = "project_id"
+private const val SERVICE_ID_COLUMN = "service_id"
+private const val LLM_GENERATIONS_HOURLY_TABLE = "llm_generations_hourly_mv"
+
+private data class ProjectScopedRetentionTable(
+    val name: String,
+    val timeColumn: String,
+    val idColumn: String = SERVICE_ID_COLUMN
+)
+
 class RetentionBackgroundService(
     private val retentionPolicyService: RetentionPolicyService = RetentionPolicyService()
 ) {
@@ -164,11 +174,11 @@ class RetentionBackgroundService(
         if (projectIds.isEmpty()) return 0
         val tables =
             listOf(
-                "events" to "timestamp",
-                "spans" to "start_timestamp",
-                "sessions" to "started",
-                "user_feedback" to "timestamp",
-                "issues" to "last_seen"
+                ProjectScopedRetentionTable("events", "timestamp"),
+                ProjectScopedRetentionTable("spans", "start_timestamp"),
+                ProjectScopedRetentionTable("sessions", "started"),
+                ProjectScopedRetentionTable("user_feedback", "timestamp"),
+                ProjectScopedRetentionTable("issues", "last_seen")
             )
         return submitProjectScopedDeletes(projectIds, tables, retentionDays)
     }
@@ -179,8 +189,8 @@ class RetentionBackgroundService(
     ): Int {
         if (projectIds.isEmpty()) return 0
         val tables = listOf(
-            "replay_events" to "timestamp",
-            "replay_segments" to "timestamp"
+            ProjectScopedRetentionTable("replay_events", "timestamp"),
+            ProjectScopedRetentionTable("replay_segments", "timestamp")
         )
         return submitProjectScopedDeletes(projectIds, tables, replayRetentionDays)
     }
@@ -191,8 +201,8 @@ class RetentionBackgroundService(
     ): Int {
         if (projectIds.isEmpty()) return 0
         val tables = listOf(
-            "llm_generations" to "timestamp",
-            "llm_generations_hourly_mv" to "hour"
+            ProjectScopedRetentionTable("llm_generations", "timestamp"),
+            ProjectScopedRetentionTable(LLM_GENERATIONS_HOURLY_TABLE, "hour", PROJECT_ID_COLUMN)
         )
         return submitProjectScopedDeletes(projectIds, tables, llmRetentionDays)
     }
@@ -203,8 +213,8 @@ class RetentionBackgroundService(
     ): Int {
         if (projectIds.isEmpty()) return 0
         val tables = listOf(
-            "analytics_events" to "timestamp",
-            "analytics_sessions_hourly" to "hour"
+            ProjectScopedRetentionTable("analytics_events", "timestamp"),
+            ProjectScopedRetentionTable("analytics_sessions_hourly", "hour")
         )
         return submitProjectScopedDeletes(projectIds, tables, analyticsRetentionDays)
     }
@@ -227,20 +237,20 @@ class RetentionBackgroundService(
 
     private suspend fun submitProjectScopedDeletes(
         projectIds: List<Long>,
-        tables: List<Pair<String, String>>,
+        tables: List<ProjectScopedRetentionTable>,
         retentionDays: Int
     ): Int {
         var mutations = 0
         for (chunk in projectIds.chunked(idChunkSize)) {
             val projectList = chunk.joinToString(",")
-            for ((table, timeColumn) in tables) {
+            for (table in tables) {
                 val query =
                     """
-                    ALTER TABLE `$clickhouseDb`.`$table`
-                    DELETE WHERE project_id IN ($projectList)
-                        AND $timeColumn < now() - INTERVAL $retentionDays DAY
+                    ALTER TABLE `$clickhouseDb`.`${table.name}`
+                    DELETE WHERE ${table.idColumn} IN ($projectList)
+                        AND ${table.timeColumn} < now() - INTERVAL $retentionDays DAY
                     """.trimIndent()
-                if (submitMutation(query, "$table(project)")) {
+                if (submitMutation(query, "${table.name}(project)")) {
                     mutations++
                 }
             }
@@ -298,7 +308,7 @@ class RetentionBackgroundService(
             val query =
                 """
                 ALTER TABLE `$clickhouseDb`.logs
-                DELETE WHERE project_id IN ($projectList)
+                DELETE WHERE service_id IN ($projectList)
                     AND timestamp < now() - INTERVAL $logRetentionDays DAY
                 """.trimIndent()
             if (submitMutation(query, "logs(project)")) {

--- a/backend/src/main/resources/db/clickhouse_migration/V51__service_id_column_cutover.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V51__service_id_column_cutover.sql
@@ -1,0 +1,90 @@
+DROP TABLE IF EXISTS issues_mv;
+DROP TABLE IF EXISTS analytics_sessions_hourly_mv;
+
+ALTER TABLE events DROP COLUMN IF EXISTS service_id;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE issues DROP COLUMN IF EXISTS service_id;
+ALTER TABLE issues ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS issues_mv TO issues AS
+SELECT
+    issue_id,
+    project_id,
+    service_id,
+    organization_id,
+    fingerprint,
+    min(timestamp) as first_seen,
+    max(timestamp) as last_seen,
+    count() as event_count,
+    uniq(user_id) as user_count,
+    any(message) as title,
+    any(exception_type) as culprit,
+    any(level) as level,
+    any(platform) as platform,
+    CAST('unresolved' AS Enum8('unresolved' = 1, 'resolved' = 2, 'ignored' = 3)) as status,
+    max(timestamp) as updated_at
+FROM events
+WHERE event_type = 'error'
+GROUP BY issue_id, project_id, service_id, organization_id, fingerprint;
+
+ALTER TABLE sessions DROP COLUMN IF EXISTS service_id;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE spans DROP COLUMN IF EXISTS service_id;
+ALTER TABLE spans ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE replay_events DROP COLUMN IF EXISTS service_id;
+ALTER TABLE replay_events ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE replay_segments DROP COLUMN IF EXISTS service_id;
+ALTER TABLE replay_segments ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE user_feedback DROP COLUMN IF EXISTS service_id;
+ALTER TABLE user_feedback ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE llm_generations DROP COLUMN IF EXISTS service_id;
+ALTER TABLE llm_generations ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE event_project_rollup_1h DROP COLUMN IF EXISTS service_id;
+ALTER TABLE event_project_rollup_1h ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE event_issue_rollup_1h DROP COLUMN IF EXISTS service_id;
+ALTER TABLE event_issue_rollup_1h ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE analytics_events ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE analytics_sessions_hourly ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_sessions_hourly_mv
+TO analytics_sessions_hourly AS
+SELECT
+    project_id,
+    service_id,
+    session_id,
+    toStartOfHour(min(timestamp)) AS hour,
+    min(timestamp) AS started,
+    max(timestamp) AS ended,
+    countIf(event_name = 'pageview') AS pageviews,
+    count() AS events,
+    argMin(pathname, timestamp) AS entry_page,
+    argMax(pathname, timestamp) AS exit_page,
+    argMin(referrer_source, timestamp) AS referrer_source,
+    argMin(utm_source, timestamp) AS utm_source,
+    argMin(utm_medium, timestamp) AS utm_medium,
+    argMin(utm_campaign, timestamp) AS utm_campaign,
+    argMin(country_code, timestamp) AS country_code,
+    argMin(browser, timestamp) AS browser,
+    argMin(os, timestamp) AS os,
+    argMin(device_type, timestamp) AS device_type,
+    if(countIf(event_name = 'pageview') = 1, 1, 0) AS is_bounce
+FROM analytics_events
+GROUP BY project_id, service_id, session_id;
+
+ALTER TABLE logs ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE apm_spans ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE metrics ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;
+
+ALTER TABLE metric_sketches ADD COLUMN IF NOT EXISTS service_id UInt64 DEFAULT project_id AFTER project_id;

--- a/backend/src/main/resources/db/migration/V125__rename_projects_to_services.sql
+++ b/backend/src/main/resources/db/migration/V125__rename_projects_to_services.sql
@@ -1,0 +1,20 @@
+ALTER TABLE projects RENAME TO services;
+
+ALTER TABLE services RENAME CONSTRAINT projects_pkey TO services_pkey;
+ALTER TABLE services RENAME CONSTRAINT projects_organization_id_fkey TO services_organization_id_fkey;
+ALTER TABLE services RENAME CONSTRAINT projects_organization_id_slug_key TO services_organization_id_slug_key;
+
+ALTER INDEX IF EXISTS idx_projects_org RENAME TO idx_services_org;
+ALTER INDEX IF EXISTS idx_projects_resource_id RENAME TO idx_services_resource_id;
+
+CREATE VIEW projects AS
+SELECT
+    id,
+    resource_id,
+    organization_id,
+    name,
+    slug,
+    framework,
+    created_at,
+    updated_at
+FROM services;

--- a/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -344,6 +344,7 @@ class DatadogMetricServiceTest {
             val row = jsonRows(query).single()
             assertNull(row["metric_id"])
             assertEquals("42", row["organization_id"]?.jsonPrimitive?.content)
+            assertEquals("0", row["service_id"]?.jsonPrimitive?.content)
             assertEquals("0", row["project_id"]?.jsonPrimitive?.content)
             assertEquals("2023-11-14 22:13:20.123", row["timestamp"]?.jsonPrimitive?.content)
             assertEquals("O'Brien \"prod\"\nline", row["tags"]?.jsonObject?.get("odd")?.jsonPrimitive?.content)
@@ -379,6 +380,7 @@ class DatadogMetricServiceTest {
 
             val query = queries.single { it.contains("INSERT INTO `test_db`.metrics ") }
             val row = jsonRows(query).single()
+            assertEquals("7", row["service_id"]?.jsonPrimitive?.content)
             assertEquals("7", row["project_id"]?.jsonPrimitive?.content)
         } finally {
             unmockkObject(ClickHouseClient)
@@ -412,8 +414,8 @@ class DatadogMetricServiceTest {
             )
 
             val query = queries.single { it.contains("INSERT INTO `test_db`.metric_sketches ") }
-            assertTrue(query.contains("organization_id, project_id, metric_name"))
-            assertTrue(Regex("""(?s)\(\s*42,\s*7,\s*'latency'""").containsMatchIn(query))
+            assertTrue(query.contains("organization_id, service_id, project_id, metric_name"))
+            assertTrue(Regex("""(?s)\(\s*42,\s*7,\s*7,\s*'latency'""").containsMatchIn(query))
         } finally {
             unmockkObject(ClickHouseClient)
         }

--- a/backend/src/test/kotlin/com/moneat/demo/DemoDataSeeder.kt
+++ b/backend/src/test/kotlin/com/moneat/demo/DemoDataSeeder.kt
@@ -1317,10 +1317,11 @@ object DemoDataSeeder {
         val issueQuery =
             """
             INSERT INTO `$db`.issues (
-                issue_id, project_id, fingerprint, title, culprit, level,
+                issue_id, service_id, project_id, fingerprint, title, culprit, level,
                 first_seen, last_seen, event_count, user_count, status
             ) VALUES (
                 '$issueId',
+                $projectId,
                 $projectId,
                 '${UUID.randomUUID().toString().replace("-", "")}',
                 '${template.title.replace("'", "''")}',
@@ -1447,12 +1448,13 @@ object DemoDataSeeder {
             val eventQuery =
                 """
                 INSERT INTO `$db`.events (
-                    event_id, project_id, issue_id, timestamp, received_at, event_type,
+                    event_id, service_id, project_id, issue_id, timestamp, received_at, event_type,
                     platform, level, message, exception_type, exception_value,
                     stack_trace, environment, release, user_id, user_email, user_username, user_ip_address,
                     device_model, os_name, os_version, breadcrumbs, contexts, tags, sdk_name, sdk_version, request
                 ) VALUES (
                     '$eventId',
+                    $projectId,
                     $projectId,
                     '$issueId',
                     toDateTime64(${timestamp.epochSecond}, 3, 'UTC'),
@@ -1786,13 +1788,14 @@ object DemoDataSeeder {
                 val eventQuery =
                     """
                     INSERT INTO `$db`.events (
-                        event_id, project_id, timestamp, received_at, event_type,
+                        event_id, service_id, project_id, timestamp, received_at, event_type,
                         level, platform, environment, release, 
                         transaction_name, transaction_op, duration_ms,
                         user_id, user_email, device_model, os_name, os_version,
                         browser_name, browser_version, message
                     ) VALUES (
                         '$eventId',
+                        $androidProjectId,
                         $androidProjectId,
                         toDateTime64(${timestamp.epochSecond}, 3, 'UTC'),
                         toDateTime64(${timestamp.epochSecond}, 3, 'UTC'),
@@ -1958,13 +1961,14 @@ object DemoDataSeeder {
                 val replayQuery =
                     """
                     INSERT INTO `$db`.replay_events (
-                        replay_id, project_id, segment_id, timestamp, replay_start_timestamp,
+                        replay_id, service_id, project_id, segment_id, timestamp, replay_start_timestamp,
                         urls, error_ids, trace_ids, environment, release, platform,
                         user_id, user_email, user_username, user_ip_address,
                         sdk_name, sdk_version, browser_name, browser_version,
                         os_name, os_version, device_name, device_family, activity, tags
                     ) VALUES (
                         '$replayId',
+                        $androidProjectId,
                         $androidProjectId,
                         $segmentId,
                         toDateTime64(${segmentTime.epochSecond}, 3, 'UTC'),
@@ -2136,13 +2140,14 @@ object DemoDataSeeder {
             val feedbackQuery =
                 """
                 INSERT INTO `$db`.user_feedback (
-                    feedback_id, project_id, timestamp, received_at,
+                    feedback_id, service_id, project_id, timestamp, received_at,
                     message, contact_email, name, url,
                     associated_event_id, replay_id, environment, release,
                     platform, user_id, user_email, user_username, user_ip_address,
                     sdk_name, sdk_version, tags, status, updated_at
                 ) VALUES (
                     '$feedbackId',
+                    $androidProjectId,
                     $androidProjectId,
                     toDateTime64(${timestamp.epochSecond}, 3, 'UTC'),
                     toDateTime64(${timestamp.epochSecond}, 3, 'UTC'),
@@ -3913,14 +3918,14 @@ object DemoDataSeeder {
 
             val clickhouseQueries =
                 listOf(
-                    "ALTER TABLE issues DELETE WHERE project_id IN ($projectIdList)",
-                    "ALTER TABLE events DELETE WHERE project_id IN ($projectIdList)",
-                    "ALTER TABLE logs DELETE WHERE project_id IN ($projectIdList)",
-                    "ALTER TABLE user_feedback DELETE WHERE project_id IN ($projectIdList)",
-                    "ALTER TABLE replay_events DELETE WHERE project_id IN ($projectIdList)",
-                    "ALTER TABLE replay_segments DELETE WHERE project_id IN ($projectIdList)",
-                    "ALTER TABLE sessions DELETE WHERE project_id IN ($projectIdList)",
-                    "ALTER TABLE spans DELETE WHERE project_id IN ($projectIdList)"
+                    "ALTER TABLE issues DELETE WHERE service_id IN ($projectIdList)",
+                    "ALTER TABLE events DELETE WHERE service_id IN ($projectIdList)",
+                    "ALTER TABLE logs DELETE WHERE service_id IN ($projectIdList)",
+                    "ALTER TABLE user_feedback DELETE WHERE service_id IN ($projectIdList)",
+                    "ALTER TABLE replay_events DELETE WHERE service_id IN ($projectIdList)",
+                    "ALTER TABLE replay_segments DELETE WHERE service_id IN ($projectIdList)",
+                    "ALTER TABLE sessions DELETE WHERE service_id IN ($projectIdList)",
+                    "ALTER TABLE spans DELETE WHERE service_id IN ($projectIdList)"
                 )
 
             for (query in clickhouseQueries) {

--- a/backend/src/test/kotlin/com/moneat/events/repositories/EventRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/repositories/EventRepositoryTest.kt
@@ -190,9 +190,9 @@ class EventRepositoryTest {
         val sql = queries.single()
         val compactSql = sql.replace(Regex("\\s+"), " ")
         assertTrue(sql.contains("INSERT INTO `test`.sessions"))
-        assertTrue(sql.contains("session_id, project_id, organization_id"))
+        assertTrue(sql.contains("session_id, service_id, project_id, organization_id"))
         assertTrue(sql.contains("toUUID('11111111-1111-1111-1111-111111111111')"))
-        assertTrue(compactSql.contains("42, 7, fromUnixTimestamp64Milli(1767225600000)"))
+        assertTrue(compactSql.contains("42, 42, 7, fromUnixTimestamp64Milli(1767225600000)"))
         assertTrue(sql.contains("fromUnixTimestamp64Milli(1767225600000)"))
         assertTrue(sql.contains("1500.0"))
         assertTrue(sql.contains("'ok'"))
@@ -225,19 +225,19 @@ class EventRepositoryTest {
         }
 
         val compactSql = queries.joinToString("\n").replace(Regex("\\s+"), " ")
-        assertTrue(compactSql.contains("event_id, project_id, organization_id"))
-        assertTrue(compactSql.contains("transaction_id, project_id, organization_id"))
+        assertTrue(compactSql.contains("event_id, service_id, project_id, organization_id"))
+        assertTrue(compactSql.contains("transaction_id, service_id, project_id, organization_id"))
         assertTrue(
             compactSql.contains(
-                "span_id, parent_span_id, trace_id, transaction_id, project_id, organization_id"
+                "span_id, parent_span_id, trace_id, transaction_id, service_id, project_id, organization_id"
             )
         )
-        assertTrue(compactSql.contains("feedback_id, project_id, organization_id"))
-        assertTrue(compactSql.contains("replay_id, project_id, organization_id"))
-        assertTrue(compactSql.contains("generation_id, project_id, organization_id"))
+        assertTrue(compactSql.contains("feedback_id, service_id, project_id, organization_id"))
+        assertTrue(compactSql.contains("replay_id, service_id, project_id, organization_id"))
+        assertTrue(compactSql.contains("generation_id, service_id, project_id, organization_id"))
         assertTrue(compactSql.contains("42, 7"))
-        assertTrue(compactSql.contains("project_id, organization_id, bucket_start"))
-        assertTrue(compactSql.contains("project_id, organization_id, issue_id"))
+        assertTrue(compactSql.contains("service_id, project_id, organization_id, bucket_start"))
+        assertTrue(compactSql.contains("service_id, project_id, organization_id, issue_id"))
     }
 
     private fun errorEventData(): ErrorEventInsertData =

--- a/backend/src/test/kotlin/com/moneat/events/services/SentrySpanBackfillTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/services/SentrySpanBackfillTest.kt
@@ -1,0 +1,110 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.events.services
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Projects
+import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.testsupport.requestBodyText
+import com.moneat.testsupport.respond
+import com.moneat.testsupport.withClickHouseMockServer
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SentrySpanBackfillTest {
+
+    companion object {
+        private var db: Database? = null
+    }
+
+    @BeforeTest
+    fun setUp() {
+        if (db == null) {
+            db = Database.connect(
+                url = "jdbc:h2:mem:moneat_sentry_span_backfill;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+        }
+        TransactionManager.defaultDatabase = db
+        TestDatabaseHelper.resetSchema(Organizations, Projects)
+        ClickHouseClient.close()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        ClickHouseClient.close()
+    }
+
+    @Test
+    fun `run backfills spans using service id routing columns`() = runBlocking {
+        val orgId = seedOrg()
+        val checkoutServiceId = seedProject(orgId, "checkout")
+        val workerServiceId = seedProject(orgId, "worker")
+        val queries = CopyOnWriteArrayList<String>()
+
+        withClickHouseMockServer(
+            { exchange ->
+                queries += exchange.requestBodyText()
+                exchange.respond(200, "")
+            },
+            database = "test_db"
+        ) {
+            runBlocking { SentrySpanBackfill.run() }
+        }
+
+        val query = queries.single()
+        assertTrue(query.contains("INSERT INTO `test_db`.apm_spans"))
+        assertTrue(query.contains("organization_id, service_id, project_id"))
+        assertTrue(query.contains("service_id,"))
+        assertTrue(query.contains("project_id,"))
+        assertTrue(query.contains("'sentry.project_id', toString(service_id)"))
+        assertTrue(query.contains("WHERE service_id IN ("))
+        assertTrue(query.contains(checkoutServiceId.toString()))
+        assertTrue(query.contains(workerServiceId.toString()))
+        assertTrue(query.contains("service_id = $checkoutServiceId, $orgId"))
+        assertTrue(query.contains("service_id = $workerServiceId, $orgId"))
+    }
+
+    private fun seedOrg(): Int =
+        transaction {
+            Organizations.insert {
+                it[name] = "Backfill Org"
+                it[slug] = "backfill-org"
+            } get Organizations.id
+        }
+
+    private fun seedProject(
+        orgId: Int,
+        slug: String
+    ): Long =
+        transaction {
+            Projects.insert {
+                it[organization_id] = orgId
+                it[name] = slug
+                it[Projects.slug] = slug
+            } get Projects.id
+        }
+}

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpMetricsServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpMetricsServiceTest.kt
@@ -697,6 +697,7 @@ class OtlpMetricsServiceTest {
 
         val row = jsonRows(query).single()
         assertEquals("42", row["organization_id"]?.jsonPrimitive?.content)
+        assertEquals("123", row["service_id"]?.jsonPrimitive?.content)
         assertEquals("123", row["project_id"]?.jsonPrimitive?.content)
         assertEquals("2023-11-14 22:13:20.123", row["timestamp"]?.jsonPrimitive?.content)
         assertEquals("O'Brien \"prod\"\nline", row["tags"]?.jsonObject?.get("odd")?.jsonPrimitive?.content)

--- a/backend/src/test/kotlin/com/moneat/services/AccountDeletionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/AccountDeletionServiceTest.kt
@@ -1,18 +1,25 @@
 package com.moneat.services
 
 import com.moneat.auth.services.AccountDeletionService
+import com.moneat.config.ClickHouseClient
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.OrgInvitations
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
 import com.moneat.shared.models.RefreshTokens
 import com.moneat.shared.models.Subscriptions
+import com.moneat.shared.models.UsageRecords
 import com.moneat.shared.models.Users
 import com.moneat.testsupport.TestDatabaseHelper
+import com.moneat.testsupport.requestBodyText
+import com.moneat.testsupport.respond
+import com.moneat.testsupport.withClickHouseMockServer
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.*
 import kotlin.time.Clock
 
@@ -44,8 +51,14 @@ class AccountDeletionServiceTest {
             Projects,
             RefreshTokens,
             Subscriptions,
+            UsageRecords,
             OrgInvitations
         )
+    }
+
+    @AfterTest
+    fun closeClickHouse() {
+        ClickHouseClient.close()
     }
 
     private fun seedUser(
@@ -91,6 +104,18 @@ class AccountDeletionServiceTest {
             it[plan] = "pro"
         }
     }
+
+    private fun seedProject(
+        orgId: Int,
+        name: String = "delete-service"
+    ): Long =
+        transaction {
+            Projects.insert {
+                it[organization_id] = orgId
+                it[Projects.name] = name
+                it[slug] = name
+            } get Projects.id
+        }
 
     // ──── validateUserDeletion ────
 
@@ -233,5 +258,36 @@ class AccountDeletionServiceTest {
 
         val result = service.validateOrganizationDeletion(orgId, userId)
         assertTrue(result.canDelete)
+    }
+
+    @Test
+    fun `deleteOrganization deletes ClickHouse service data by compatible id column`() = runBlocking {
+        val userId = seedUser()
+        val orgId = seedOrg("Delete Service Org")
+        val projectId = seedProject(orgId)
+        seedMembership(userId, orgId, "owner")
+        val queries = CopyOnWriteArrayList<String>()
+
+        withClickHouseMockServer(
+            { exchange ->
+                queries += exchange.requestBodyText()
+                exchange.respond(200, "")
+            }
+        ) {
+            assertTrue(service.deleteOrganization(orgId, userId))
+        }
+
+        assertTrue(
+            queries.any { it == "ALTER TABLE events DELETE WHERE service_id IN ($projectId)" },
+            "events should delete by service_id"
+        )
+        assertTrue(
+            queries.any { it == "ALTER TABLE llm_generations DELETE WHERE service_id IN ($projectId)" },
+            "llm_generations should delete by service_id"
+        )
+        assertTrue(
+            queries.any { it == "ALTER TABLE llm_generations_hourly_mv DELETE WHERE project_id IN ($projectId)" },
+            "llm_generations_hourly_mv should keep deprecated project_id"
+        )
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/RetentionBackgroundServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/RetentionBackgroundServiceTest.kt
@@ -214,7 +214,7 @@ class RetentionBackgroundServiceTest {
                 )
                 assertTrue(
                     logQ[0].contains(
-                        "project_id IN ($projectId)"
+                        "service_id IN ($projectId)"
                     ),
                     "Log query scoped to project"
                 )
@@ -237,13 +237,12 @@ class RetentionBackgroundServiceTest {
     @Test
     fun `runSweep submits LLM deletes`() = runBlocking {
         val orgId = seedOrg()
-        seedProject(orgId)
+        val projectId = seedProject(orgId)
         mockAllRetention(orgId)
 
         withSweep { queries ->
-            listOf("llm_generations", "llm_generations_hourly_mv").forEach {
-                assertTableDeleteWithRetention(queries, it, LLM_RETENTION)
-            }
+            assertProjectScopedDelete(queries, "llm_generations", projectId, LLM_RETENTION)
+            assertDeprecatedProjectScopedDelete(queries, "llm_generations_hourly_mv", projectId, LLM_RETENTION)
         }
     }
 
@@ -350,7 +349,7 @@ class RetentionBackgroundServiceTest {
 
             withSweep { queries ->
                 val projQ = queries.filter {
-                    it.contains("project_id")
+                    it.contains("service_id")
                 }
                 assertTrue(
                     projQ.isEmpty(),
@@ -399,6 +398,22 @@ class RetentionBackgroundServiceTest {
     }
 
     private fun assertProjectScopedDelete(
+        queries: List<String>,
+        table: String,
+        projectId: Long,
+        retentionDays: Int
+    ) {
+        assertTrue(
+            queries.any {
+                it.contains("`testdb`.`$table`") &&
+                    it.contains("service_id IN ($projectId)") &&
+                    it.contains("INTERVAL $retentionDays DAY")
+            },
+            "Missing DELETE for $table"
+        )
+    }
+
+    private fun assertDeprecatedProjectScopedDelete(
         queries: List<String>,
         table: String,
         projectId: Long,


### PR DESCRIPTION
## Summary
- add service_id cutover migrations
- preserve project_id compatibility
- update writers and cleanup paths

## Tests
- ./gradlew test
- ./gradlew detekt
- ./gradlew jacocoTestCoverageVerification
- ./gradlew testClasses integrationTestClasses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a distinct service identifier across analytics, logs, metrics, traces, and demo data; retention and deletion routines updated to use service scoping.
  * Projects renamed to Services; a compatibility view preserves existing project-based access.
* **Chore**
  * Database migration added to add and populate service identifiers and refresh related aggregations.
* **Tests**
  * Test coverage updated/added to validate service-id behavior and migration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->