### PR TITLE
feat: add release replay feedback service facets

### DIFF
--- a/dashboard/src/lib/api/modules/__tests__/release-replay-feedback-service-scope.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/release-replay-feedback-service-scope.test.ts
@@ -1,0 +1,103 @@
+import {describe, expect, it, beforeEach} from 'vitest'
+import {http, HttpResponse} from 'msw'
+import {server} from '@/test/mocks/server'
+import {api} from '@/lib/api'
+
+const API_BASE = 'http://localhost:8080'
+
+describe('release replay feedback service scope API', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    sessionStorage.setItem('authenticated', 'true')
+  })
+
+  it('fetches organization releases with service scope params', async () => {
+    const releases = [{version: '1.0.0'}]
+
+    server.use(
+      http.get(`${API_BASE}/v1/releases`, ({request}) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.getAll('services')).toEqual(['API', 'Worker'])
+        expect(url.searchParams.getAll('serviceIds')).toEqual(['1', 'svc-worker'])
+        expect(url.searchParams.get('projectId')).toBeNull()
+        return HttpResponse.json(releases)
+      })
+    )
+
+    const result = await api.getOrganizationReleases({
+      services: ['API', 'Worker'],
+      serviceIds: [1, 'svc-worker'],
+    })
+
+    expect(result).toEqual(releases)
+  })
+
+  it('fetches organization release stats with service scope params', async () => {
+    const stats = {version: '1.0.0', totalEvents: 10}
+
+    server.use(
+      http.get(`${API_BASE}/v1/releases/1.0.0/stats`, ({request}) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.getAll('services')).toEqual(['API'])
+        expect(url.searchParams.get('projectId')).toBeNull()
+        return HttpResponse.json(stats)
+      })
+    )
+
+    const result = await api.getOrganizationReleaseStats('1.0.0', {services: ['API']})
+    expect(result).toEqual(stats)
+  })
+
+  it('fetches organization replays with paging and service scope params', async () => {
+    const replays = [{replayId: 'replay-1'}]
+
+    server.use(
+      http.get(`${API_BASE}/v1/replays`, ({request}) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('page')).toBe('2')
+        expect(url.searchParams.get('limit')).toBe('5')
+        expect(url.searchParams.get('period')).toBe('24h')
+        expect(url.searchParams.get('environment')).toBe('production')
+        expect(url.searchParams.getAll('services')).toEqual(['API'])
+        expect(url.searchParams.get('projectId')).toBeNull()
+        return HttpResponse.json(replays)
+      })
+    )
+
+    const result = await api.getOrganizationReplays({
+      page: 2,
+      limit: 5,
+      period: '24h',
+      environment: 'production',
+      services: ['API'],
+    })
+
+    expect(result).toEqual(replays)
+  })
+
+  it('fetches organization feedback with status and service scope params', async () => {
+    const feedback = [{feedbackId: 'fb-1'}]
+
+    server.use(
+      http.get(`${API_BASE}/v1/feedback`, ({request}) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('page')).toBe('3')
+        expect(url.searchParams.get('limit')).toBe('10')
+        expect(url.searchParams.get('status')).toBe('resolved')
+        expect(url.searchParams.getAll('services')).toEqual(['API'])
+        expect(url.searchParams.get('projectId')).toBeNull()
+        return HttpResponse.json(feedback)
+      })
+    )
+
+    const result = await api.getOrganizationFeedback({
+      page: 3,
+      limit: 10,
+      status: 'resolved',
+      services: ['API'],
+    })
+
+    expect(result).toEqual(feedback)
+  })
+})

--- a/dashboard/src/lib/api/modules/feedback.ts
+++ b/dashboard/src/lib/api/modules/feedback.ts
@@ -16,6 +16,23 @@
 
 import type { ApiClientCore } from '../client'
 import type { Feedback, FeedbackDetail } from '../types'
+import { urlWithQuery } from '../utils'
+import { appendServiceScopeParams, type ServiceScopeParams } from './service-scope'
+
+interface FeedbackListOptions extends ServiceScopeParams {
+  page?: number
+  limit?: number
+  status?: string
+}
+
+function feedbackQuery(options: FeedbackListOptions = {}): string {
+  const params = new URLSearchParams()
+  params.set('page', String(options.page ?? 1))
+  params.set('limit', String(options.limit ?? 25))
+  if (options.status) params.set('status', options.status)
+  appendServiceScopeParams(params, options)
+  return params.toString()
+}
 
 export function feedbackMethods(core: ApiClientCore) {
   const base = core.API_BASE
@@ -23,16 +40,17 @@ export function feedbackMethods(core: ApiClientCore) {
   return {
     getFeedback: (
       projectId: string | number,
-      options: { page?: number; limit?: number; status?: string } = {}
+      options: FeedbackListOptions = {}
     ) => {
-      const params = new URLSearchParams()
-      params.set('page', String(options.page ?? 1))
-      params.set('limit', String(options.limit ?? 25))
-      if (options.status) params.set('status', options.status)
       return core.request<Feedback[]>(
-        `${base}/projects/${projectId}/feedback?${params.toString()}`
+        `${base}/projects/${projectId}/feedback?${feedbackQuery(options)}`
       )
     },
+
+    getOrganizationFeedback: (options: FeedbackListOptions = {}) =>
+      core.request<Feedback[]>(
+        urlWithQuery(`${base}/feedback`, feedbackQuery(options))
+      ),
 
     getFeedbackDetail: (feedbackId: string) =>
       core.request<FeedbackDetail>(

--- a/dashboard/src/lib/api/modules/releases.ts
+++ b/dashboard/src/lib/api/modules/releases.ts
@@ -16,6 +16,8 @@
 
 import type { ApiClientCore } from '../client'
 import type { Release, ReleaseStats } from '../types'
+import { urlWithQuery } from '../utils'
+import { serviceScopeQuery, type ServiceScopeParams } from './service-scope'
 
 export function releasesMethods(core: ApiClientCore) {
   const base = core.API_BASE
@@ -24,9 +26,19 @@ export function releasesMethods(core: ApiClientCore) {
     getReleases: (projectId: string | number) =>
       core.request<Release[]>(`${base}/projects/${projectId}/releases`),
 
+    getOrganizationReleases: (params: ServiceScopeParams = {}) =>
+      core.request<Release[]>(
+        urlWithQuery(`${base}/releases`, serviceScopeQuery(params))
+      ),
+
     getReleaseStats: (projectId: string | number, version: string) =>
       core.request<ReleaseStats>(
         `${base}/projects/${projectId}/releases/${encodeURIComponent(version)}/stats`
+      ),
+
+    getOrganizationReleaseStats: (version: string, params: ServiceScopeParams = {}) =>
+      core.request<ReleaseStats>(
+        urlWithQuery(`${base}/releases/${encodeURIComponent(version)}/stats`, serviceScopeQuery(params))
       ),
   }
 }

--- a/dashboard/src/lib/api/modules/replays.ts
+++ b/dashboard/src/lib/api/modules/replays.ts
@@ -22,6 +22,25 @@ import type {
   ReplayRecordingResponse,
   ReplayTimelineResponse,
 } from '../types'
+import { urlWithQuery } from '../utils'
+import { appendServiceScopeParams, type ServiceScopeParams } from './service-scope'
+
+interface ReplaysListOptions extends ServiceScopeParams {
+  page?: number
+  limit?: number
+  environment?: string
+  period?: '24h' | '7d' | '30d' | '90d'
+}
+
+function replaysQuery(options: ReplaysListOptions = {}): string {
+  const params = new URLSearchParams()
+  params.set('page', String(options.page ?? 1))
+  params.set('limit', String(options.limit ?? 25))
+  params.set('period', options.period ?? '7d')
+  if (options.environment) params.set('environment', options.environment)
+  appendServiceScopeParams(params, options)
+  return params.toString()
+}
 
 export function replaysMethods(core: ApiClientCore) {
   const base = core.API_BASE
@@ -38,20 +57,17 @@ export function replaysMethods(core: ApiClientCore) {
   return {
     getReplays: (
       projectId: string | number,
-      options: {
-        page?: number
-        limit?: number
-        environment?: string
-        period?: '24h' | '7d' | '30d' | '90d'
-      } = {}
+      options: ReplaysListOptions = {}
     ) => {
-      const params = new URLSearchParams()
-      params.set('page', String(options.page ?? 1))
-      params.set('limit', String(options.limit ?? 25))
-      params.set('period', options.period ?? '7d')
-      if (options.environment) params.set('environment', options.environment)
-      return core.request<Replay[]>(`${base}/projects/${projectId}/replays?${params.toString()}`)
+      return core.request<Replay[]>(
+        `${base}/projects/${projectId}/replays?${replaysQuery(options)}`
+      )
     },
+
+    getOrganizationReplays: (options: ReplaysListOptions = {}) =>
+      core.request<Replay[]>(
+        urlWithQuery(`${base}/replays`, replaysQuery(options))
+      ),
 
     getReplay: (replayId: string) =>
       core.request<ReplayDetail>(`${base}/replays/${encodeURIComponent(replayId)}`),

--- a/dashboard/src/lib/api/modules/service-scope.ts
+++ b/dashboard/src/lib/api/modules/service-scope.ts
@@ -1,0 +1,17 @@
+export type ServiceScopeId = string | number
+
+export interface ServiceScopeParams {
+  services?: readonly string[]
+  serviceIds?: readonly ServiceScopeId[]
+}
+
+export function appendServiceScopeParams(qs: URLSearchParams, params?: ServiceScopeParams) {
+  params?.services?.forEach((service) => qs.append('services', service))
+  params?.serviceIds?.forEach((serviceId) => qs.append('serviceIds', String(serviceId)))
+}
+
+export function serviceScopeQuery(params?: ServiceScopeParams): string {
+  const qs = new URLSearchParams()
+  appendServiceScopeParams(qs, params)
+  return qs.toString()
+}

--- a/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
+++ b/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
@@ -1,0 +1,469 @@
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {fireEvent, screen, waitFor} from '@testing-library/react'
+import {clearAuthStorage, renderRoute} from '@/test/utils'
+
+const {mockApi, mockRouteParams} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    checkAuth: vi.fn(),
+    getCurrentUser: vi.fn(),
+    updateUserTimezone: vi.fn(),
+    getProjects: vi.fn(),
+    getOrganizationReleases: vi.fn(),
+    getOrganizationReleaseStats: vi.fn(),
+    getOrganizationReplays: vi.fn(),
+    getBillingUsage: vi.fn(),
+    getOrganizationFeedback: vi.fn(),
+    updateFeedback: vi.fn(),
+  },
+  mockRouteParams: {
+    current: {version: '1.0.0'},
+  },
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+  formatErrorForLogging: (error: unknown) => String(error),
+}))
+
+vi.mock('@/hooks/useTimezone', () => ({
+  useTimezone: () => ({timezone: 'UTC'}),
+}))
+
+vi.mock('@/components/charts/StatsCard', () => ({
+  StatsCard: ({title, value}: {title: string; value: string | number}) => <div>{title}:{value}</div>,
+}))
+
+vi.mock('@/components/charts/EventsChart', () => ({
+  EventsChart: ({title}: {title: string}) => <div>{title}</div>,
+}))
+
+vi.mock('@/components/charts/BarChart', () => ({
+  BarChart: ({title}: {title: string}) => <div>{title}</div>,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    options,
+    useParams: () => mockRouteParams.current,
+    useSearch: () => ({}),
+  }),
+  Link: ({children, ...props}: {children: React.ReactNode}) => React.createElement('a', props, children),
+  Outlet: () => null,
+  redirect: (opts: Record<string, unknown>) => ({...opts, __redirect: true}),
+  useMatches: () => [],
+  useNavigate: () => vi.fn(),
+}))
+
+import {Route as FeedbackRoute} from '../feedback'
+import {Route as ReleaseDetailRoute} from '../releases.$version'
+import {Route as ReleasesRoute} from '../releases'
+import {Route as ReplaysRoute} from '../replays'
+
+const mockProjects = [
+  {
+    id: 1,
+    resourceId: 'svc-api',
+    name: 'API Service',
+    slug: 'api-service',
+    keys: [],
+    dsn: 'https://public@example.com/api/1',
+  },
+  {
+    id: 2,
+    resourceId: 'svc-worker',
+    name: 'Worker Service',
+    slug: 'worker-service',
+    keys: [],
+    dsn: 'https://worker@example.com/api/2',
+  },
+]
+
+const release = {
+  version: '1.0.0',
+  firstSeen: '2026-06-01T00:00:00.000Z',
+  lastSeen: '2026-06-02T00:00:00.000Z',
+  eventCount: 42,
+  newIssueCount: 1,
+  crashFreeRate: 99.5,
+  userCount: 12,
+}
+
+const releaseWithoutCrashRate = {
+  ...release,
+  version: '1.1.0',
+  firstSeen: '',
+  lastSeen: 'not-a-date',
+  eventCount: 100,
+  newIssueCount: 3,
+  crashFreeRate: null,
+  userCount: 20,
+}
+
+const healthyRelease = {
+  ...release,
+  version: '1.2.0',
+  eventCount: 7,
+  newIssueCount: 0,
+  crashFreeRate: 99.9,
+  userCount: 3,
+}
+
+const releaseStats = {
+  version: '1.0.0',
+  firstSeen: '2026-06-01T00:00:00.000Z',
+  lastSeen: '2026-06-02T00:00:00.000Z',
+  totalEvents: 42,
+  newIssues: 1,
+  resolvedIssues: 0,
+  crashFreeSessionRate: 99.5,
+  crashFreeUserRate: 99.1,
+  userCount: 12,
+  eventsTimeline: [{timestamp: '2026-06-01T00:00:00.000Z', count: 42}],
+  eventsByLevel: {error: 42},
+  topIssues: [{issueId: 'issue-1', title: 'Worker failed', count: 4}],
+}
+
+const replay = {
+  replayId: 'replay-1',
+  projectId: 1,
+  projectResourceId: 'svc-api',
+  startedAt: '2026-06-01T00:00:00.000Z',
+  finishedAt: '2026-06-01T00:01:00.000Z',
+  durationMs: 60000,
+  urls: ['https://app.example.com/dashboard'],
+  errorCount: 1,
+  user: {email: 'user@example.com'},
+  browserName: 'Chrome',
+  osName: 'macOS',
+  activity: 80,
+}
+
+const replayVariants = [
+  replay,
+  {
+    ...replay,
+    replayId: 'replay-2',
+    durationMs: 500,
+    urls: [],
+    errorCount: 0,
+    user: {username: 'Worker User'},
+    browserName: undefined,
+    osName: undefined,
+    activity: 0,
+  },
+  {
+    ...replay,
+    replayId: 'replay-3',
+    durationMs: 12000,
+    urls: ['https://app.example.com/a', 'https://app.example.com/b'],
+    errorCount: 2,
+    user: {id: 'anon-1'},
+    activity: 20,
+  },
+  {
+    ...replay,
+    replayId: 'replay-4',
+    durationMs: 300000,
+    errorCount: 0,
+    user: undefined,
+    activity: 50,
+  },
+]
+
+const feedback = {
+  feedbackId: 'feedback-1',
+  message: 'Checkout is confusing',
+  contactEmail: 'user@example.com',
+  name: 'User Example',
+  url: 'https://app.example.com/checkout',
+  status: 'unresolved',
+  timestamp: '2026-06-01T00:00:00.000Z',
+  environment: 'production',
+  release: '1.0.0',
+  platform: 'javascript',
+  associatedEventId: null,
+  replayId: 'replay-1',
+}
+
+const resolvedFeedback = {
+  ...feedback,
+  feedbackId: 'feedback-2',
+  message: '',
+  contactEmail: '',
+  name: '',
+  status: 'resolved',
+  environment: '',
+  platform: '',
+  url: '',
+  associatedEventId: 'event-1',
+  replayId: null,
+}
+
+describe('release, replay, and feedback service facets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearAuthStorage()
+    mockRouteParams.current = {version: '1.0.0'}
+    mockApi.isAuthenticated.mockReturnValue(true)
+    mockApi.checkAuth.mockResolvedValue(true)
+    mockApi.getCurrentUser.mockResolvedValue(null)
+    mockApi.updateUserTimezone.mockResolvedValue(undefined)
+    mockApi.getProjects.mockResolvedValue(mockProjects)
+    mockApi.getOrganizationReleases.mockResolvedValue([release])
+    mockApi.getOrganizationReleaseStats.mockResolvedValue(releaseStats)
+    mockApi.getOrganizationReplays.mockResolvedValue([replay])
+    mockApi.getBillingUsage.mockResolvedValue({retentionDays: 30})
+    mockApi.getOrganizationFeedback.mockResolvedValue([feedback])
+    mockApi.updateFeedback.mockResolvedValue(feedback)
+  })
+
+  it('loads releases organization-wide by default', async () => {
+    mockApi.getOrganizationReleases.mockResolvedValue([
+      release,
+      releaseWithoutCrashRate,
+      healthyRelease,
+    ])
+
+    renderRoute(ReleasesRoute)
+
+    expect(await screen.findByText('1.0.0')).toBeInTheDocument()
+    expect(await screen.findByText('1.1.0')).toBeInTheDocument()
+    expect(await screen.findByText('1.2.0')).toBeInTheDocument()
+    expect(mockApi.getOrganizationReleases).toHaveBeenCalledWith({})
+  })
+
+  it('adds selected services to release calls', async () => {
+    renderRoute(ReleasesRoute)
+
+    await screen.findByText('1.0.0')
+    fireEvent.click(screen.getByRole('checkbox', {name: 'Worker Service'}))
+
+    await waitFor(() => {
+      expect(mockApi.getOrganizationReleases).toHaveBeenLastCalledWith({
+        services: ['Worker Service'],
+      })
+    })
+  })
+
+  it('loads release detail stats without project scoping', async () => {
+    renderRoute(ReleaseDetailRoute)
+
+    expect(await screen.findByText('Top Issues in this Release')).toBeInTheDocument()
+    expect(mockApi.getOrganizationReleaseStats).toHaveBeenCalledWith('1.0.0')
+  })
+
+  it('renders release empty, error, and not-found states', async () => {
+    mockApi.getOrganizationReleases.mockResolvedValueOnce([])
+
+    const emptyRender = renderRoute(ReleasesRoute)
+
+    expect(await screen.findByText('No releases detected')).toBeInTheDocument()
+    emptyRender.unmount()
+
+    mockApi.getProjects.mockRejectedValueOnce(new Error('services down'))
+
+    const errorRender = renderRoute(ReleasesRoute)
+
+    expect(await screen.findByText('Failed to load services: services down')).toBeInTheDocument()
+    errorRender.unmount()
+
+    mockApi.getProjects.mockResolvedValue(mockProjects)
+    mockApi.getOrganizationReleaseStats.mockResolvedValueOnce(null)
+
+    renderRoute(ReleaseDetailRoute)
+
+    expect(await screen.findByText('Release not found')).toBeInTheDocument()
+  })
+
+  it('shows no matching release services when filters cancel out', async () => {
+    renderRoute(ReleasesRoute)
+
+    await screen.findByText('1.0.0')
+    fireEvent.click(screen.getByRole('checkbox', {name: 'API Service'}))
+    fireEvent.click(screen.getAllByTitle('Exclude this value')[0])
+    fireEvent.click(screen.getAllByTitle('Exclude this value')[0])
+
+    expect(await screen.findByText('No services match filters')).toBeInTheDocument()
+  })
+
+  it('loads replays with service facet filters', async () => {
+    mockApi.getOrganizationReplays.mockResolvedValue(replayVariants)
+
+    renderRoute(ReplaysRoute)
+
+    expect(await screen.findByText('user@example.com')).toBeInTheDocument()
+    expect(await screen.findByText('Worker User')).toBeInTheDocument()
+    expect(await screen.findByText('Anonymous')).toBeInTheDocument()
+    expect(mockApi.getOrganizationReplays).toHaveBeenCalledWith({
+      page: 1,
+      limit: 25,
+      period: '7d',
+      environment: undefined,
+    })
+
+    fireEvent.click(screen.getByRole('checkbox', {name: 'Worker Service'}))
+
+    await waitFor(() => {
+      expect(mockApi.getOrganizationReplays).toHaveBeenLastCalledWith({
+        page: 1,
+        limit: 25,
+        period: '7d',
+        environment: undefined,
+        services: ['Worker Service'],
+      })
+    })
+  })
+
+  it('renders replay empty and search-empty states', async () => {
+    mockApi.getOrganizationReplays.mockResolvedValueOnce([])
+
+    const emptyRender = renderRoute(ReplaysRoute)
+
+    expect(await screen.findByText('No replays yet')).toBeInTheDocument()
+    emptyRender.unmount()
+
+    mockApi.getOrganizationReplays.mockResolvedValue(replayVariants)
+
+    renderRoute(ReplaysRoute)
+
+    await screen.findByText('user@example.com')
+    fireEvent.change(screen.getByPlaceholderText('Search by user, URL, or browser...'), {
+      target: {value: 'does-not-exist'},
+    })
+
+    expect(await screen.findByText('No replays match your search')).toBeInTheDocument()
+  })
+
+  it('handles replay service and retention edge states', async () => {
+    mockApi.getProjects.mockResolvedValueOnce([])
+
+    const noServicesRender = renderRoute(ReplaysRoute)
+
+    expect(await screen.findByText('No services yet')).toBeInTheDocument()
+    expect(mockApi.getOrganizationReplays).not.toHaveBeenCalled()
+    noServicesRender.unmount()
+
+    mockApi.getProjects.mockRejectedValueOnce(new Error('service load failed'))
+
+    const errorRender = renderRoute(ReplaysRoute)
+
+    expect(await screen.findByText('Failed to load services: service load failed')).toBeInTheDocument()
+    errorRender.unmount()
+
+    mockApi.getProjects.mockResolvedValue(mockProjects)
+    mockApi.getBillingUsage.mockResolvedValueOnce({retentionDays: 1})
+
+    renderRoute(ReplaysRoute)
+
+    await screen.findByText('user@example.com')
+    expect(mockApi.getOrganizationReplays).toHaveBeenLastCalledWith({
+      page: 1,
+      limit: 25,
+      period: '24h',
+      environment: undefined,
+    })
+  })
+
+  it('loads feedback with service facet filters', async () => {
+    mockApi.getOrganizationFeedback.mockResolvedValue([feedback, resolvedFeedback])
+
+    renderRoute(FeedbackRoute)
+
+    expect(await screen.findByText('Checkout is confusing')).toBeInTheDocument()
+    expect(mockApi.getOrganizationFeedback).toHaveBeenCalledWith({page: 1, limit: 500})
+    expect(mockApi.getOrganizationFeedback).toHaveBeenCalledWith({
+      page: 1,
+      limit: 100,
+      status: 'unresolved',
+    })
+
+    fireEvent.click(screen.getByRole('checkbox', {name: 'Worker Service'}))
+
+    await waitFor(() => {
+      expect(mockApi.getOrganizationFeedback).toHaveBeenLastCalledWith({
+        page: 1,
+        limit: 100,
+        status: 'unresolved',
+        services: ['Worker Service'],
+      })
+    })
+  })
+
+  it('filters and resolves selected feedback', async () => {
+    mockApi.getOrganizationFeedback.mockResolvedValue([feedback, resolvedFeedback])
+
+    renderRoute(FeedbackRoute)
+
+    expect(await screen.findByText('Checkout is confusing')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', {name: /Resolved/}))
+
+    await waitFor(() => {
+      expect(mockApi.getOrganizationFeedback).toHaveBeenLastCalledWith({
+        page: 1,
+        limit: 100,
+        status: 'resolved',
+      })
+    })
+
+    fireEvent.click(await screen.findByRole('checkbox', {name: 'Select all feedback'}))
+    fireEvent.click(screen.getByRole('button', {name: 'Resolve'}))
+
+    await waitFor(() => {
+      expect(mockApi.updateFeedback).toHaveBeenCalledWith('feedback-1', {status: 'resolved'})
+    })
+  })
+
+  it('renders feedback empty and search-empty states', async () => {
+    mockApi.getOrganizationFeedback.mockResolvedValueOnce([])
+    mockApi.getOrganizationFeedback.mockResolvedValueOnce([])
+
+    const emptyRender = renderRoute(FeedbackRoute)
+
+    expect(await screen.findByText('No feedback yet')).toBeInTheDocument()
+    emptyRender.unmount()
+
+    mockApi.getOrganizationFeedback.mockResolvedValue([feedback])
+
+    renderRoute(FeedbackRoute)
+
+    await screen.findByText('Checkout is confusing')
+    fireEvent.change(screen.getByPlaceholderText('Search by message, name, or email...'), {
+      target: {value: 'not-present'},
+    })
+
+    expect(await screen.findByText('No feedback match your search')).toBeInTheDocument()
+  })
+
+  it('handles feedback no-services and no matching service filters', async () => {
+    mockApi.getProjects.mockResolvedValueOnce([])
+
+    const noServicesRender = renderRoute(FeedbackRoute)
+
+    expect(await screen.findByText('No services yet')).toBeInTheDocument()
+    expect(mockApi.getOrganizationFeedback).not.toHaveBeenCalled()
+    noServicesRender.unmount()
+
+    mockApi.getProjects.mockResolvedValue(mockProjects)
+
+    renderRoute(FeedbackRoute)
+
+    await screen.findByText('Checkout is confusing')
+    fireEvent.click(screen.getByRole('checkbox', {name: 'API Service'}))
+    fireEvent.click(screen.getAllByTitle('Exclude this value')[0])
+    fireEvent.click(screen.getAllByTitle('Exclude this value')[0])
+
+    expect(await screen.findByText('No services match filters')).toBeInTheDocument()
+  })
+
+  it('does not query scoped release data when there are no services', async () => {
+    mockApi.getProjects.mockResolvedValue([])
+
+    renderRoute(ReleasesRoute)
+
+    expect(await screen.findByText('No services yet')).toBeInTheDocument()
+    expect(mockApi.getOrganizationReleases).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -17,8 +17,8 @@
 import {createFileRoute, Outlet, redirect, useMatches, useNavigate} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
-import {useProject} from '@/contexts/ProjectContext'
 import {formatRelativeTime, cn} from '@/lib/utils'
+import {FacetRail} from '@/components/filters/FacetRail'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
@@ -43,8 +43,15 @@ import {
   Search,
   Video,
 } from 'lucide-react'
-import {useEffect, useMemo, useState} from 'react'
+import {useMemo, useState} from 'react'
 import {useToast} from '@/hooks/useToast'
+import {
+  facetValues,
+  serviceNamesForQuery,
+  serviceRailSections,
+  serviceScopeKey,
+} from '@/lib/service-facet-scope'
+import type {FacetFilter} from '@/lib/filters/types'
 
 export const Route = createFileRoute('/feedback')({
   beforeLoad: async ({ location }) => {
@@ -156,7 +163,7 @@ function FeedbackPage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>('unresolved')
   const [selectedFeedback, setSelectedFeedback] = useState<Set<string>>(new Set())
-  const { selectedProjectId, setSelectedProjectId } = useProject()
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
@@ -166,35 +173,47 @@ function FeedbackPage() {
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.resourceId
-
-  useEffect(() => {
-    if (!selectedProjectId && projects?.[0]?.resourceId) {
-      setSelectedProjectId(projects[0].resourceId)
-    }
-  }, [selectedProjectId, projects, setSelectedProjectId])
+  const projectList = projects ?? []
+  const includedServices = useMemo(
+    () => facetValues(facetFilters, 'service', false),
+    [facetFilters]
+  )
+  const excludedServices = useMemo(
+    () => facetValues(facetFilters, 'service', true),
+    [facetFilters]
+  )
+  const hasServiceFilters = includedServices.length > 0 || excludedServices.length > 0
+  const serviceNames = useMemo(
+    () => serviceNamesForQuery(projectList, includedServices, excludedServices),
+    [projectList, includedServices, excludedServices]
+  )
+  const scopeKey = serviceScopeKey(serviceNames, hasServiceFilters)
+  const hasFeedbackScope = projectList.length > 0 && (!hasServiceFilters || serviceNames.length > 0)
+  const serviceScopeParams = useMemo(() => (
+    serviceNames.length > 0 ? {services: [...serviceNames]} : {}
+  ), [serviceNames])
+  const railSections = useMemo(() => serviceRailSections(projectList), [projectList])
+  const handleFacetFiltersChange = (nextFilters: FacetFilter[]) => {
+    setFacetFilters(nextFilters)
+    setSelectedFeedback(new Set())
+  }
 
   // Fetch all feedback for stats (unfiltered)
   const { data: allFeedback = [] } = useQuery({
-    queryKey: ['feedback', projectId, 'all'],
-    queryFn: () =>
-      projectId
-        ? api.getFeedback(projectId, { page: 1, limit: 500 })
-        : [],
-    enabled: !!projectId,
+    queryKey: ['feedback', 'organization', scopeKey, 'all', serviceScopeParams],
+    queryFn: () => api.getOrganizationFeedback({ page: 1, limit: 500, ...serviceScopeParams }),
+    enabled: hasFeedbackScope,
   })
 
   const { data: feedbackList = [] } = useQuery({
-    queryKey: ['feedback', projectId, statusFilter],
-    queryFn: () =>
-      projectId
-        ? api.getFeedback(projectId, {
-            page: 1,
-            limit: 100,
-            status: statusFilter === 'all' ? undefined : statusFilter,
-          })
-        : [],
-    enabled: !!projectId,
+    queryKey: ['feedback', 'organization', scopeKey, statusFilter, serviceScopeParams],
+    queryFn: () => api.getOrganizationFeedback({
+      page: 1,
+      limit: 100,
+      status: statusFilter === 'all' ? undefined : statusFilter,
+      ...serviceScopeParams,
+    }),
+    enabled: hasFeedbackScope,
   })
 
   const stats = useMemo(() => {
@@ -212,7 +231,7 @@ function FeedbackPage() {
       )
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['feedback', projectId] })
+      queryClient.invalidateQueries({ queryKey: ['feedback'] })
       toast({
         title: 'Success',
         description: `${selectedFeedback.size} feedback item${selectedFeedback.size === 1 ? '' : 's'} resolved`,
@@ -267,54 +286,70 @@ function FeedbackPage() {
           description="Review and manage feedback from your users"
         />
 
-        {!projects || projects.length === 0 ? (
-          <EmptyState
-            icon={MessageSquare}
-            title="No projects yet"
-            description="Create a project and integrate the feedback widget to see user feedback here."
+        <div className="grid gap-2 lg:grid-cols-[220px_minmax(0,1fr)]">
+          <FacetRail
+            sections={railSections}
+            facetFilters={facetFilters}
+            onFacetFiltersChange={handleFacetFiltersChange}
+            title="Feedback"
+            className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
           />
-        ) : (
-          <>
-            {/* Stats Cards (also act as status filters) */}
-            {allFeedback.length > 0 && (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                <FeedbackStatCard
-                  label="Total"
-                  value={stats.total}
-                  icon={Inbox}
-                  tone="accent"
-                  active={statusFilter === 'all'}
-                  onClick={() => setStatusFilter('all')}
-                />
-                <FeedbackStatCard
-                  label="Unresolved"
-                  value={stats.unresolved}
-                  icon={CircleDot}
-                  tone="warning"
-                  active={statusFilter === 'unresolved'}
-                  onClick={() => setStatusFilter('unresolved')}
-                />
-                <FeedbackStatCard
-                  label="Resolved"
-                  value={stats.resolved}
-                  icon={CheckCircle2}
-                  tone="success"
-                  active={statusFilter === 'resolved'}
-                  onClick={() => setStatusFilter('resolved')}
-                />
-                <FeedbackStatCard
-                  label="Archived"
-                  value={stats.archived}
-                  icon={Archive}
-                  tone="neutral"
-                  active={statusFilter === 'archived'}
-                  onClick={() => setStatusFilter('archived')}
-                />
-              </div>
-            )}
 
-            {/* Toolbar */}
-            <div className="mb-3 flex gap-2 items-center flex-wrap">
+          <div className="min-w-0">
+            {projectList.length === 0 ? (
+              <EmptyState
+                icon={MessageSquare}
+                title="No services yet"
+                description="Create a service and integrate the feedback widget to see user feedback here."
+              />
+            ) : !hasFeedbackScope ? (
+              <EmptyState
+                icon={MessageSquare}
+                title="No services match filters"
+                description="Adjust the selected services to view feedback."
+              />
+            ) : (
+              <>
+                {/* Stats Cards (also act as status filters) */}
+                {allFeedback.length > 0 && (
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                    <FeedbackStatCard
+                      label="Total"
+                      value={stats.total}
+                      icon={Inbox}
+                      tone="accent"
+                      active={statusFilter === 'all'}
+                      onClick={() => setStatusFilter('all')}
+                    />
+                    <FeedbackStatCard
+                      label="Unresolved"
+                      value={stats.unresolved}
+                      icon={CircleDot}
+                      tone="warning"
+                      active={statusFilter === 'unresolved'}
+                      onClick={() => setStatusFilter('unresolved')}
+                    />
+                    <FeedbackStatCard
+                      label="Resolved"
+                      value={stats.resolved}
+                      icon={CheckCircle2}
+                      tone="success"
+                      active={statusFilter === 'resolved'}
+                      onClick={() => setStatusFilter('resolved')}
+                    />
+                    <FeedbackStatCard
+                      label="Archived"
+                      value={stats.archived}
+                      icon={Archive}
+                      tone="neutral"
+                      active={statusFilter === 'archived'}
+                      onClick={() => setStatusFilter('archived')}
+                    />
+                  </div>
+                )}
+
+                {/* Toolbar */}
+                <div className="mb-3 flex gap-2 items-center flex-wrap">
               {filteredFeedback.length > 0 && (
                 <div className="flex items-center gap-2">
                   <Checkbox
@@ -350,9 +385,9 @@ function FeedbackPage() {
                   className="pl-8 h-8 text-xs"
                 />
               </div>
-            </div>
+                </div>
 
-            {filteredFeedback.length === 0 ? (
+                {filteredFeedback.length === 0 ? (
               <EmptyState
                 icon={searchQuery ? Search : MessageSquare}
                 title={searchQuery ? 'No feedback match your search' : 'No feedback yet'}
@@ -362,7 +397,7 @@ function FeedbackPage() {
                     : 'Use the feedback widget in your app to collect user feedback. It will appear here.'
                 }
               />
-            ) : (
+                ) : (
               <TooltipProvider>
                 <div className="space-y-1.5">
                   {filteredFeedback.map((f) => {
@@ -473,19 +508,21 @@ function FeedbackPage() {
                   })}
                 </div>
               </TooltipProvider>
-            )}
+                )}
 
-            {/* Footer count */}
-            {filteredFeedback.length > 0 && (
+                {/* Footer count */}
+                {filteredFeedback.length > 0 && (
               <div className="mt-3 text-center">
                 <p className="text-xs text-muted-foreground">
                   Showing {filteredFeedback.length} feedback item{filteredFeedback.length === 1 ? '' : 's'}
                   {searchQuery && ' matching your search'}
                 </p>
               </div>
+                )}
+              </>
             )}
-          </>
-        )}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/dashboard/src/routes/releases.$version.tsx
+++ b/dashboard/src/routes/releases.$version.tsx
@@ -17,7 +17,6 @@
 import {createFileRoute, Link, redirect} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
-import {useProject} from '@/contexts/ProjectContext'
 import {EventsChart} from '@/components/charts/EventsChart'
 import {BarChart} from '@/components/charts/BarChart'
 import {StatsCard} from '@/components/charts/StatsCard'
@@ -38,23 +37,11 @@ export const Route = createFileRoute('/releases/$version')({
 
 function ReleaseDetailPage() {
   const { version } = Route.useParams()
-  const { selectedProjectId } = useProject()
   const releaseVersion = version
 
-  const { data: projects } = useQuery({
-    queryKey: ['projects'],
-    queryFn: () => api.getProjects(),
-  })
-
-  const projectId = selectedProjectId || projects?.[0]?.resourceId
-
   const { data: stats, isLoading } = useQuery({
-    queryKey: ['releaseStats', projectId, releaseVersion],
-    queryFn: () =>
-      projectId
-        ? api.getReleaseStats(projectId, releaseVersion)
-        : Promise.reject(new Error('No project')),
-    enabled: !!projectId,
+    queryKey: ['releaseStats', 'organization', releaseVersion],
+    queryFn: () => api.getOrganizationReleaseStats(releaseVersion),
   })
 
   return (
@@ -75,13 +62,7 @@ function ReleaseDetailPage() {
           }
         />
 
-        {!projectId ? (
-          <EmptyState
-            icon={Package}
-            title="No project selected"
-            description="Select a project to view release details."
-          />
-        ) : isLoading ? (
+        {isLoading ? (
           <div className="p-8 text-center">Loading release stats...</div>
         ) : !stats ? (
           <EmptyState
@@ -148,7 +129,7 @@ function ReleaseDetailPage() {
                       key={issue.issueId}
                       to="/issues/$issueId"
                       params={{ issueId: issue.issueId }}
-                      search={{ projectId }}
+                      search={{ projectId: undefined }}
                       className="flex items-center justify-between p-2 rounded-lg border hover:bg-accent/40 transition-colors"
                     >
                       <div className="flex items-center gap-2 min-w-0">

--- a/dashboard/src/routes/releases.tsx
+++ b/dashboard/src/routes/releases.tsx
@@ -17,8 +17,8 @@
 import {createFileRoute, Link, Outlet, redirect, useMatches} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api, formatErrorForLogging} from '@/lib/api'
-import {useProject} from '@/contexts/ProjectContext'
 import {useMemo, useState} from 'react'
+import {FacetRail} from '@/components/filters/FacetRail'
 import {Card, CardContent} from '@/components/ui/card'
 import {Input} from '@/components/ui/input'
 import {Badge} from '@/components/ui/badge'
@@ -28,6 +28,13 @@ import {PageHeader} from '@/components/ui/page-header'
 import {EmptyState} from '@/components/ui/empty-state'
 import {StatusDot} from '@/components/ui/status-dot'
 import {Activity, AlertCircle, Flame, Package, Search, ShieldCheck, Users} from 'lucide-react'
+import {
+  facetValues,
+  serviceNamesForQuery,
+  serviceRailSections,
+  serviceScopeKey,
+} from '@/lib/service-facet-scope'
+import type {FacetFilter} from '@/lib/filters/types'
 
 export const Route = createFileRoute('/releases')({
   beforeLoad: async ({ location }) => {
@@ -54,22 +61,38 @@ type SortBy = 'latest' | 'events' | 'issues' | 'stability'
 function ReleasesPage() {
   const [searchQuery, setSearchQuery] = useState('')
   const [sortBy, setSortBy] = useState<SortBy>('latest')
-  const { selectedProjectId } = useProject()
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
 
-  const { data: projects } = useQuery({
+  const { data: projects, isLoading: projectsLoading, error: projectsError } = useQuery({
     queryKey: ['projects'],
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.resourceId
+  const projectList = projects ?? []
+  const includedServices = useMemo(
+    () => facetValues(facetFilters, 'service', false),
+    [facetFilters]
+  )
+  const excludedServices = useMemo(
+    () => facetValues(facetFilters, 'service', true),
+    [facetFilters]
+  )
+  const hasServiceFilters = includedServices.length > 0 || excludedServices.length > 0
+  const serviceNames = useMemo(
+    () => serviceNamesForQuery(projectList, includedServices, excludedServices),
+    [projectList, includedServices, excludedServices]
+  )
+  const scopeKey = serviceScopeKey(serviceNames, hasServiceFilters)
+  const hasReleaseScope = projectList.length > 0 && (!hasServiceFilters || serviceNames.length > 0)
+  const serviceScopeParams = useMemo(() => (
+    serviceNames.length > 0 ? {services: [...serviceNames]} : {}
+  ), [serviceNames])
+  const railSections = useMemo(() => serviceRailSections(projectList), [projectList])
 
   const { data: releases, isLoading, error } = useQuery({
-    queryKey: ['releases', projectId],
-    queryFn: async () => {
-      if (!projectId) return []
-      return api.getReleases(projectId)
-    },
-    enabled: !!projectId,
+    queryKey: ['releases', 'organization', scopeKey, serviceScopeParams],
+    queryFn: () => api.getOrganizationReleases(serviceScopeParams),
+    enabled: hasReleaseScope,
   })
   
   if (error) {
@@ -148,19 +171,40 @@ function ReleasesPage() {
   }
 
   return (
-    <div>
-      <div className="container mx-auto px-4 py-4 space-y-3">
-        <PageHeader
-          icon={Package}
-          title="Releases"
-          description="Track release health, new issues, and crash-free rates"
-        />
+    <div className="grid gap-2 p-3 lg:grid-cols-[220px_minmax(0,1fr)]">
+      <FacetRail
+        sections={railSections}
+        facetFilters={facetFilters}
+        onFacetFiltersChange={setFacetFilters}
+        title="Releases"
+        className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
+      />
 
-        {!projects || projects.length === 0 ? (
+      <div className="min-w-0">
+        <div className="container mx-auto px-4 py-4 space-y-3">
+          <PageHeader
+            icon={Package}
+            title="Releases"
+            description="Track release health, new issues, and crash-free rates"
+          />
+
+          {projectsLoading ? (
+          <div className="p-6 text-center text-sm">Loading services...</div>
+        ) : projectsError ? (
+          <div className="p-8 text-destructive">
+            Failed to load services: {projectsError instanceof Error ? projectsError.message : 'Unknown error'}
+          </div>
+        ) : projectList.length === 0 ? (
           <EmptyState
             icon={Package}
-            title="No projects yet"
-            description="Create a project to view releases."
+            title="No services yet"
+            description="Create a service to view releases."
+          />
+        ) : !hasReleaseScope ? (
+          <EmptyState
+            icon={Package}
+            title="No services match filters"
+            description="Adjust the selected services to view releases."
           />
         ) : isLoading ? (
           <div className="p-6 text-center text-sm">Loading releases...</div>
@@ -170,7 +214,7 @@ function ReleasesPage() {
             title="No releases detected"
             description="Releases are auto-detected when events include a release version. Configure your SDK with a release version to start tracking."
           />
-        ) : (
+          ) : (
           <div className="space-y-3">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
               <StatsCard
@@ -326,7 +370,8 @@ function ReleasesPage() {
               </Link>
             ))}
           </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   )

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -17,11 +17,11 @@
 import {createFileRoute, Outlet, redirect, useMatches, useNavigate} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
-import {useProject} from '@/contexts/ProjectContext'
 import {formatRelativeTime} from '@/lib/utils'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDate as formatDateUtil} from '@/lib/date-format'
 import {useMemo, useState} from 'react'
+import {FacetRail} from '@/components/filters/FacetRail'
 import {Badge} from '@/components/ui/badge'
 import {Input} from '@/components/ui/input'
 import {PageHeader} from '@/components/ui/page-header'
@@ -32,19 +32,26 @@ import {Button} from '@/components/ui/button'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue,} from '@/components/ui/select'
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from '@/components/ui/tooltip'
 import {
-    AlertCircle,
-    ChevronLeft,
-    ChevronRight,
-    Clock,
-    Globe,
-    Monitor,
-    MousePointerClick,
-    Play,
-    Search,
-    Timer,
-    User,
-    Video,
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Globe,
+  Monitor,
+  MousePointerClick,
+  Play,
+  Search,
+  Timer,
+  User,
+  Video,
 } from 'lucide-react'
+import {
+  facetValues,
+  serviceNamesForQuery,
+  serviceRailSections,
+  serviceScopeKey,
+} from '@/lib/service-facet-scope'
+import type {FacetFilter} from '@/lib/filters/types'
 
 export const Route = createFileRoute('/replays')({
   beforeLoad: async ({ location }) => {
@@ -132,18 +139,41 @@ function getDurationColor(ms: number): string {
 function ReplaysPage() {
   const navigate = useNavigate()
   const { timezone } = useTimezone()
-  const { selectedProjectId } = useProject()
   const [period, setPeriod] = useState<'24h' | '7d' | '30d' | '90d'>('7d')
   const [environment, setEnvironment] = useState('all')
   const [page, setPage] = useState(1)
   const [searchQuery, setSearchQuery] = useState('')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
 
-  const { data: projects } = useQuery({
+  const { data: projects, isLoading: projectsLoading, error: projectsError } = useQuery({
     queryKey: ['projects'],
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = selectedProjectId || projects?.[0]?.resourceId
+  const projectList = projects ?? []
+  const includedServices = useMemo(
+    () => facetValues(facetFilters, 'service', false),
+    [facetFilters]
+  )
+  const excludedServices = useMemo(
+    () => facetValues(facetFilters, 'service', true),
+    [facetFilters]
+  )
+  const hasServiceFilters = includedServices.length > 0 || excludedServices.length > 0
+  const serviceNames = useMemo(
+    () => serviceNamesForQuery(projectList, includedServices, excludedServices),
+    [projectList, includedServices, excludedServices]
+  )
+  const scopeKey = serviceScopeKey(serviceNames, hasServiceFilters)
+  const hasReplayScope = projectList.length > 0 && (!hasServiceFilters || serviceNames.length > 0)
+  const serviceScopeParams = useMemo(() => (
+    serviceNames.length > 0 ? {services: [...serviceNames]} : {}
+  ), [serviceNames])
+  const railSections = useMemo(() => serviceRailSections(projectList), [projectList])
+  const handleFacetFiltersChange = (nextFilters: FacetFilter[]) => {
+    setFacetFilters(nextFilters)
+    setPage(1)
+  }
   const { data: billingUsage } = useQuery({
     queryKey: ['billing-usage'],
     queryFn: () => api.getBillingUsage(),
@@ -165,17 +195,15 @@ function ReplaysPage() {
     : availablePeriods[availablePeriods.length - 1]?.value ?? '7d') as '24h' | '7d' | '30d' | '90d'
 
   const { data: replays = [], isLoading } = useQuery({
-    queryKey: ['replays', projectId, effectivePeriod, environment, page],
-    queryFn: () =>
-      projectId
-        ? api.getReplays(projectId, {
-            page,
-            limit: 25,
-            period: effectivePeriod,
-            environment: environment === 'all' ? undefined : environment,
-          })
-        : [],
-    enabled: !!projectId,
+    queryKey: ['replays', 'organization', scopeKey, effectivePeriod, environment, page, serviceScopeParams],
+    queryFn: () => api.getOrganizationReplays({
+      page,
+      limit: 25,
+      period: effectivePeriod,
+      environment: environment === 'all' ? undefined : environment,
+      ...serviceScopeParams,
+    }),
+    enabled: hasReplayScope,
   })
 
   const stats = useMemo(() => {
@@ -211,39 +239,60 @@ function ReplaysPage() {
     })
   }, [replays, searchQuery])
 
-  if (!projects || projects.length === 0) {
+  if (projectsLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading services...</div>
+  }
+
+  if (projectsError) {
+    return (
+      <div className="p-8 text-destructive">
+        Failed to load services: {projectsError instanceof Error ? projectsError.message : 'Unknown error'}
+      </div>
+    )
+  }
+
+  if (projectList.length === 0) {
     return (
       <div className="min-h-screen p-6">
         <EmptyState
           icon={Video}
-          title="No projects yet"
-          description="Create a project to start capturing session replays."
+          title="No services yet"
+          description="Create a service to start capturing session replays."
         />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen">
-      <div className="container mx-auto px-4 py-4 space-y-4">
-        <PageHeader
-          icon={Video}
-          title="Session Replays"
-          description="Watch real user sessions to understand behavior and debug issues"
-        />
+    <div className="grid min-h-screen gap-2 p-3 lg:grid-cols-[220px_minmax(0,1fr)]">
+      <FacetRail
+        sections={railSections}
+        facetFilters={facetFilters}
+        onFacetFiltersChange={handleFacetFiltersChange}
+        title="Replays"
+        className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
+      />
 
-        {/* Stats Cards */}
-        {replays.length > 0 && (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <StatCard label="Sessions" value={stats.total} icon={Play} tone="info" />
-            <StatCard label="Errors" value={stats.totalErrors} icon={AlertCircle} tone="danger" />
-            <StatCard label="Avg Duration" value={formatDuration(stats.avgDuration)} icon={Timer} tone="success" />
-            <StatCard label="Unique Users" value={stats.uniqueUsers} icon={User} tone="accent" />
-          </div>
-        )}
+      <div className="min-w-0">
+        <div className="container mx-auto px-4 py-4 space-y-4">
+          <PageHeader
+            icon={Video}
+            title="Session Replays"
+            description="Watch real user sessions to understand behavior and debug issues"
+          />
 
-        {/* Toolbar */}
-        <div className="mb-3 flex flex-wrap items-center gap-2">
+          {/* Stats Cards */}
+          {replays.length > 0 && (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <StatCard label="Sessions" value={stats.total} icon={Play} tone="info" />
+              <StatCard label="Errors" value={stats.totalErrors} icon={AlertCircle} tone="danger" />
+              <StatCard label="Avg Duration" value={formatDuration(stats.avgDuration)} icon={Timer} tone="success" />
+              <StatCard label="Unique Users" value={stats.uniqueUsers} icon={User} tone="accent" />
+            </div>
+          )}
+
+          {/* Toolbar */}
+          <div className="mb-3 flex flex-wrap items-center gap-2">
           <div className="relative flex-1 min-w-[200px]">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
@@ -276,10 +325,16 @@ function ReplaysPage() {
               <SelectItem value="development">Development</SelectItem>
             </SelectContent>
           </Select>
-        </div>
+          </div>
 
-        {/* Content */}
-        {isLoading ? (
+          {/* Content */}
+          {!hasReplayScope ? (
+          <EmptyState
+            icon={Play}
+            title="No services match filters"
+            description="Adjust the selected services to view session replays."
+          />
+        ) : isLoading ? (
           <div className="space-y-2">
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="rounded-xl border border-border/60 bg-card p-4 animate-pulse">
@@ -434,10 +489,10 @@ function ReplaysPage() {
               })}
             </div>
           </TooltipProvider>
-        )}
+          )}
 
-        {/* Pagination */}
-        {filteredReplays.length > 0 && (
+          {/* Pagination */}
+          {filteredReplays.length > 0 && (
           <div className="mt-4 flex items-center justify-between">
             <p className="text-xs text-muted-foreground">
               Showing {filteredReplays.length} replay{filteredReplays.length === 1 ? '' : 's'}
@@ -470,7 +525,8 @@ function ReplaysPage() {
               </Button>
             </div>
           </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Moves releases, replays, and feedback views to organization-scoped service facets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-based filtering across Releases, Replays, and Feedback pages
  * Enabled organization-wide views of releases, replays, and feedback with service facet selection

* **Tests**
  * Added comprehensive test coverage for service scope filtering and organization-level data queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->