### PR TITLE
feat: reframe sources ingestion setup

### DIFF
--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -335,7 +335,7 @@ export function CommandPalette() {
             <div className="relative">
               <CommandInput
                 className="pr-24"
-                placeholder="Search dashboards, projects, pages..."
+                placeholder="Search dashboards, services, pages..."
                 value={search}
                 onValueChange={handleSearchChange}
                 onKeyDown={handleInputKeyDown}
@@ -431,7 +431,7 @@ export function CommandPalette() {
                 </CommandGroup>
               )}
               {searchResult?.projects && searchResult.projects.length > 0 && (
-                <CommandGroup heading="Projects">
+                <CommandGroup heading="Services">
                   {searchResult.projects.map((p) => (
                     <CommandItem
                       key={p.id}

--- a/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
+++ b/dashboard/src/components/projects/ProjectTelemetrySetupHub.tsx
@@ -338,7 +338,7 @@ function TargetPlatformSection({
   return (
     <FlatSetupSection
       title="Target platforms"
-      description="Each target platform gets its own DSN for separate error monitoring."
+      description="Each target platform gets its own Sentry-compatible DSN for separate error monitoring."
       action={availableTargets.length > 0 && !showAddPlatform ? (
         <Button
           type="button"
@@ -445,8 +445,8 @@ function DsnSection({
   if (project.keys.length > 1) {
     return (
       <FlatSetupSection
-        title="Project DSNs"
-        description="Use the matching DSN for each target platform in your SDK."
+        title="Service DSNs"
+        description="Use the matching DSN for each target platform in your Sentry-compatible SDK."
       >
         <Tabs value={selectedTarget ?? 'default'} onValueChange={onSelectedTargetChange}>
           <TabsList className="mb-4 flex h-auto flex-wrap gap-1">
@@ -486,7 +486,7 @@ function DsnSection({
   }
 
   return (
-    <FlatSetupSection title="Project DSN" description="Use this DSN in a Sentry-compatible SDK.">
+    <FlatSetupSection title="Service DSN" description="Use this DSN in a Sentry-compatible SDK.">
       <div className="flex items-center gap-2">
         <code className="min-w-0 flex-1 break-all rounded-lg bg-muted px-3 py-2.5 text-sm">
           {project.dsn}
@@ -820,9 +820,9 @@ export function ProjectTelemetrySetupHub({
       setCopiedResourceId(true)
       setTimeout(() => setCopiedResourceId(false), COPY_RESET_MS)
     } catch (error) {
-      console.error('Failed to copy project resource ID:', error)
+      console.error('Failed to copy service ID:', error)
       toast({
-        title: 'Could not copy resource ID',
+        title: 'Could not copy service ID',
         description: 'Check browser clipboard permissions and try again.',
         variant: 'destructive',
       })
@@ -938,9 +938,13 @@ export function ProjectTelemetrySetupHub({
               ) : null}
               <Badge variant={statusVariant(activeStatus.state)}>{activeStatus.label}</Badge>
             </div>
-            <h1 className="text-3xl font-bold">{project.name}</h1>
+            <p className="text-sm font-medium text-muted-foreground">{project.name}</p>
+            <h1 className="text-3xl font-bold">Sources / Ingestion</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Connect telemetry sources and manage this service's stable ID, DSNs, and ingestion keys.
+            </p>
             <div className="mt-1 flex max-w-full items-center gap-2 text-xs text-muted-foreground">
-              <span>Project ID</span>
+              <span>Service ID</span>
               <code className="max-w-[min(28rem,70vw)] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-foreground">
                 {project.resourceId}
               </code>
@@ -949,14 +953,14 @@ export function ProjectTelemetrySetupHub({
                 variant="ghost"
                 size="icon"
                 className="h-6 w-6 shrink-0"
-                aria-label="Copy project ID"
+                aria-label="Copy service ID"
                 onClick={copyResourceId}
               >
                 {copiedResourceId ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
               </Button>
             </div>
           </div>
-          <Button asChild variant="outline" size="icon" aria-label="Project settings">
+          <Button asChild variant="outline" size="icon" aria-label="Service settings">
             <Link to="/projects/$projectId/settings" params={{projectId: project.resourceId}}>
               <Settings className="h-4 w-4" />
             </Link>

--- a/dashboard/src/components/projects/ServiceSettingsCard.tsx
+++ b/dashboard/src/components/projects/ServiceSettingsCard.tsx
@@ -430,7 +430,7 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
             <Link to="/projects/$projectId" params={{projectId}}>
               <Button variant="outline" size="sm">
                 <ExternalLink className="h-4 w-4" />
-                View setup guide
+                View ingestion setup
               </Button>
             </Link>
           </CardContent>
@@ -447,7 +447,7 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
             <Link to="/projects/$projectId" params={{projectId}}>
               <Button variant="outline" size="sm">
                 <ExternalLink className="h-4 w-4" />
-                View setup guide
+                View ingestion setup
               </Button>
             </Link>
           </CardContent>

--- a/dashboard/src/components/projects/__tests__/ProjectTelemetrySetupHub.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ProjectTelemetrySetupHub.test.tsx
@@ -73,7 +73,7 @@ function renderHub(project: Project = baseProject, selectedSourcesParam?: string
 describe('ProjectTelemetrySetupHub', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    localStorage.clear()
+    globalThis.localStorage.clear()
     mockApi.isAuthenticated.mockReturnValue(true)
     mockApi.getSdkVersions.mockResolvedValue({versions: {}})
     mockApi.getCurrentUser.mockResolvedValue({organizationSlug: 'acme'})

--- a/dashboard/src/components/projects/__tests__/ProjectTelemetrySetupHub.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ProjectTelemetrySetupHub.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {ProjectTelemetrySetupHub} from '@/components/projects/ProjectTelemetrySetupHub'
+import type {Project} from '@/lib/api'
+
+const {mockApi, mockNavigate, mockRouterInvalidate, mockToast} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    getSdkVersions: vi.fn(),
+    getCurrentUser: vi.fn(),
+    getProjectStats: vi.fn(),
+    getOtlpApiKeys: vi.fn(),
+    getAgentApiKeys: vi.fn(),
+    getMonitorHosts: vi.fn(),
+    createOtlpApiKey: vi.fn(),
+    createAgentApiKey: vi.fn(),
+    addProjectTarget: vi.fn(),
+  },
+  mockNavigate: vi.fn(),
+  mockRouterInvalidate: vi.fn(),
+  mockToast: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({api: mockApi}))
+vi.mock('@/hooks/useToast', () => ({useToast: () => ({toast: mockToast})}))
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (opts: Record<string, unknown>) => ({...opts, options: opts}),
+  redirect: (opts: Record<string, unknown>) => ({...opts, __redirect: true}),
+  Link: ({children, ...props}: {children: React.ReactNode}) => React.createElement('a', props, children),
+  useNavigate: () => mockNavigate,
+  useRouter: () => ({invalidate: mockRouterInvalidate}),
+}))
+
+const baseProject: Project = {
+  id: 1,
+  resourceId: 'svc-checkout',
+  name: 'Checkout API',
+  slug: 'checkout-api',
+  framework: 'react',
+  dsn: 'https://public@example.test/1',
+  keys: [
+    {
+      platformTarget: null,
+      dsn: 'https://public@example.test/1',
+    },
+  ],
+}
+
+const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, 'clipboard')
+
+function stubClipboard(writeText = vi.fn()) {
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    configurable: true,
+    value: {writeText},
+  })
+  return writeText
+}
+
+function renderHub(project: Project = baseProject, selectedSourcesParam?: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false}, mutations: {retry: false}},
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProjectTelemetrySetupHub project={project} selectedSourcesParam={selectedSourcesParam} />
+    </QueryClientProvider>
+  )
+}
+
+describe('ProjectTelemetrySetupHub', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockApi.isAuthenticated.mockReturnValue(true)
+    mockApi.getSdkVersions.mockResolvedValue({versions: {}})
+    mockApi.getCurrentUser.mockResolvedValue({organizationSlug: 'acme'})
+    mockApi.getProjectStats.mockResolvedValue({totalEvents: 0})
+    mockApi.getOtlpApiKeys.mockResolvedValue({keys: []})
+    mockApi.getAgentApiKeys.mockResolvedValue({keys: []})
+    mockApi.getMonitorHosts.mockResolvedValue([])
+    mockApi.createOtlpApiKey.mockResolvedValue({key: 'otlp-secret'})
+    mockApi.createAgentApiKey.mockResolvedValue({key: 'agent-secret'})
+    mockApi.addProjectTarget.mockResolvedValue({platformTarget: 'ios', dsn: 'https://public@example.test/ios'})
+    if (originalClipboard) {
+      Object.defineProperty(globalThis.navigator, 'clipboard', originalClipboard)
+    } else {
+      delete (globalThis.navigator as {clipboard?: unknown}).clipboard
+    }
+  })
+
+  it('frames the project route as the sources and ingestion home for a service', async () => {
+    renderHub()
+
+    expect(screen.getByRole('heading', {name: 'Sources / Ingestion'})).toBeInTheDocument()
+    expect(screen.getByText('Checkout API')).toBeInTheDocument()
+    expect(screen.getByText('Service ID')).toBeInTheDocument()
+    expect(screen.getByText('svc-checkout')).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Copy service ID'})).toBeInTheDocument()
+    expect(screen.getByLabelText('Service settings')).toBeInTheDocument()
+
+    expect(screen.getAllByRole('button', {name: /OpenTelemetry/}).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('button', {name: /Sentry SDK/}).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('button', {name: /Datadog Agent/}).length).toBeGreaterThan(0)
+    expect(screen.getByRole('heading', {name: 'Connect OpenTelemetry'})).toBeInTheDocument()
+    expect(await screen.findByText('OTLP API key')).toBeInTheDocument()
+    expect(screen.getByText(/\/v1\/traces\/otlp/)).toBeInTheDocument()
+    expect(screen.getByText(/\/v1\/metrics\/otlp/)).toBeInTheDocument()
+    expect(screen.getAllByText(/\/v1\/logs\/otlp/).length).toBeGreaterThan(0)
+  })
+
+  it('shows the service DSN for the Sentry-compatible setup path and copies it', async () => {
+    const writeText = stubClipboard()
+    mockApi.getProjectStats.mockResolvedValueOnce({totalEvents: 12})
+
+    renderHub(baseProject, 'sentry-sdk')
+
+    expect(screen.getByRole('heading', {name: 'Connect a Sentry-compatible SDK'})).toBeInTheDocument()
+    expect((await screen.findAllByText('Receiving')).length).toBeGreaterThan(0)
+    expect(await screen.findByText('Service DSN')).toBeInTheDocument()
+    expect(screen.getByText('https://public@example.test/1')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', {name: 'Copy DSN'}))
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('https://public@example.test/1')
+    })
+  })
+
+  it('creates an OTLP key and shows the one-time secret in the ingestion snippets', async () => {
+    const user = userEvent.setup()
+
+    renderHub(baseProject, 'opentelemetry')
+
+    await user.click(screen.getByRole('button', {name: 'Create OTLP key'}))
+
+    await waitFor(() => {
+      expect(mockApi.createOtlpApiKey).toHaveBeenCalledWith('Checkout API OTLP')
+    })
+    expect(await screen.findByText('otlp-secret')).toBeInTheDocument()
+    expect(screen.getAllByText(/Authorization=Bearer otlp-secret/).length).toBeGreaterThan(0)
+  })
+
+  it('shows service DSNs for target platforms and can add another platform', async () => {
+    const user = userEvent.setup()
+    const targetProject: Project = {
+      ...baseProject,
+      framework: 'unity',
+      keys: [
+        {platformTarget: null, dsn: 'https://public@example.test/default'},
+        {platformTarget: 'android', dsn: 'https://public@example.test/android'},
+      ],
+    }
+
+    renderHub(targetProject, 'sentry-sdk')
+
+    expect(await screen.findByText('Target platforms')).toBeInTheDocument()
+    expect(screen.getByText('Service DSNs')).toBeInTheDocument()
+    expect(screen.getByRole('tab', {name: 'Default'})).toBeInTheDocument()
+    expect(screen.getByRole('tab', {name: 'Android'})).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', {name: 'Add Platform'}))
+    await user.click(screen.getByRole('button', {name: 'iOS'}))
+
+    await waitFor(() => {
+      expect(mockApi.addProjectTarget).toHaveBeenCalledWith('svc-checkout', 'ios')
+    })
+    expect(mockRouterInvalidate).toHaveBeenCalled()
+  })
+
+  it('creates a Datadog Agent key from an already configured source state', async () => {
+    const user = userEvent.setup()
+    mockApi.getAgentApiKeys.mockResolvedValueOnce({keys: [{lastUsedAt: null}]})
+
+    renderHub(baseProject, 'datadog-agent')
+
+    expect(screen.getByRole('heading', {name: 'Connect a Datadog Agent'})).toBeInTheDocument()
+    expect((await screen.findAllByText('Key created')).length).toBeGreaterThan(0)
+    expect(screen.getByText('A reusable key already exists. Existing keys cannot reveal the full secret again.'))
+      .toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /Full instructions/})).toHaveAttribute(
+      'href',
+      '/docs/datadog-agent/agent-setup'
+    )
+
+    await user.click(screen.getByRole('button', {name: 'Create another agent key'}))
+
+    await waitFor(() => {
+      expect(mockApi.createAgentApiKey).toHaveBeenCalledWith('Checkout API Agent')
+    })
+    expect((await screen.findAllByText('agent-secret')).length).toBeGreaterThan(0)
+    expect(screen.getByText('datadog.yaml')).toBeInTheDocument()
+    expect(screen.getByText('Run the agent')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/lib/telemetry-sources.ts
+++ b/dashboard/src/lib/telemetry-sources.ts
@@ -67,7 +67,7 @@ export const TELEMETRY_SOURCES: TelemetrySource[] = [
     shortLabel: 'Sentry SDK',
     description: 'Keep an existing Sentry SDK and send error, replay, and performance events to Moneat.',
     setupTitle: 'Connect a Sentry-compatible SDK',
-    setupDescription: 'Use the project DSN with the SDK for your selected platform.',
+    setupDescription: 'Use the service DSN with the SDK for your selected platform.',
     productHref: '/issues',
     productLabel: 'View issues',
   },
@@ -172,7 +172,7 @@ export function getTelemetrySourceStatus(
     return {
       state: 'waiting',
       label: 'Waiting',
-      detail: 'The project DSN is ready. Send a test event to verify setup.',
+      detail: 'The service DSN is ready. Send a test event to verify setup.',
     }
   }
 

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -69,7 +69,7 @@ const STATIC_TITLES: Record<string, string> = {
   '/signoz-alternative': 'SigNoz Alternative 2026',
   '/docs': 'Documentation',
   '/blog': 'Blog',
-  '/projects': 'Projects',
+  '/projects': 'Sources / Ingestion',
   '/feedback': 'Feedback',
   '/performance': 'Traces',
   '/performance/traces': 'Traces',
@@ -165,8 +165,8 @@ function getDocumentTitle(pathname: string, isPublicLandingPage: boolean): strin
   }
 
   const dynamicMatchers: Array<[RegExp, (matches: RegExpMatchArray) => string]> = [
-    [/^\/projects\/([^/]+)\/settings$/, (match) => `Project ${formatEntityId(match[1])} Settings`],
-    [/^\/projects\/([^/]+)$/, (match) => `Project ${formatEntityId(match[1])}`],
+    [/^\/projects\/([^/]+)\/settings$/, (match) => `Service ${formatEntityId(match[1])} Settings`],
+    [/^\/projects\/([^/]+)$/, (match) => `Sources / Ingestion ${formatEntityId(match[1])}`],
     [/^\/issues\/([^/]+)$/, (match) => `Issue ${formatEntityId(match[1])}`],
     [/^\/feedback\/([^/]+)$/, (match) => `Feedback ${formatEntityId(match[1])}`],
     [/^\/performance\/traces\/([^/]+)$/, (match) => `Trace ${formatEntityId(match[1])}`],

--- a/dashboard/src/routes/projects.$projectId.settings.tsx
+++ b/dashboard/src/routes/projects.$projectId.settings.tsx
@@ -51,7 +51,7 @@ function ProjectSettingsPage() {
             className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
             <ArrowLeft className="h-4 w-4" />
-            Back to setup guide
+            Back to ingestion setup
           </Link>
           <div>
             <h1 className="text-2xl font-bold">Service settings</h1>

--- a/dashboard/src/routes/projects.$projectId.tsx
+++ b/dashboard/src/routes/projects.$projectId.tsx
@@ -31,10 +31,10 @@ export const Route = createFileRoute('/projects/$projectId')({
     const project = await api.getProject(params.projectId)
     return { project }
   },
-  component: SetupPage,
+  component: SourcesIngestionPage,
 })
 
-function SetupPage() {
+function SourcesIngestionPage() {
   const routerState = useRouterState()
   const showingChildPage = /^\/projects\/[^/]+\/(settings|traces|spans)\/?/.test(routerState.location.pathname)
   const { project } = Route.useLoaderData()

--- a/dashboard/src/routes/projects.tsx
+++ b/dashboard/src/routes/projects.tsx
@@ -459,7 +459,7 @@ export const platforms: PlatformType[] = [
   {
     id: 'other',
     name: 'Other Platform',
-    description: 'Generic project setup',
+    description: 'Generic source setup',
     icon: Code2,
     color: '#4b5563',
     category: 'backend',


### PR DESCRIPTION
Reframes the service setup route as Sources / Ingestion and keeps service ID, DSNs, and ingestion keys visible there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test coverage for the telemetry setup hub, including copy/clipboard and key-creation flows.

* **Refactor**
  * Updated UI terminology from “project” to “service” and rebranded pages/headers to “Sources / Ingestion”.
  * Updated search placeholder and result group label to reference services.
  * Adjusted button/link labels (e.g., “View ingestion setup”, “Back to ingestion setup”) and document titles/navigation to match wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->