### PR TITLE
feat: complete service terminology cleanup

### DIFF
--- a/dashboard/src/blog/posts/all-in-one-observability.mdx
+++ b/dashboard/src/blog/posts/all-in-one-observability.mdx
@@ -93,8 +93,8 @@ In one dashboard:
 
 | Moneat Plan | Monthly | What's included |
 |---|---|---|
-| **Free** | $0 | 1 GB unified ingestion, 3 monitors, 1 project, 3-day retention |
-| **Pro** | $29 | 50 GB ingestion, 10 monitors, unlimited projects, 30-day retention |
+| **Free** | $0 | 1 GB unified ingestion, 3 monitors, 1 service, 3-day retention |
+| **Pro** | $29 | 50 GB ingestion, 10 monitors, unlimited services, 30-day retention |
 | **Team** | $79 | 200 GB ingestion, 25 monitors, status pages, SSO, 30-day retention |
 | **Business** | $199 | 1 TB ingestion, unlimited monitors, 90-day retention |
 | **On-call** | +$5/user/mo | Schedules, escalation policies, push notifications, Slack DM |

--- a/dashboard/src/blog/posts/keep-your-existing-sdks.mdx
+++ b/dashboard/src/blog/posts/keep-your-existing-sdks.mdx
@@ -24,7 +24,7 @@ Sentry.init({
 });
 ```
 
-Your DSN is available in **Projects → [Your Project] → Settings**. All 90+ Sentry SDK platforms (JavaScript, Python, Java, Kotlin, Swift, Go, Ruby, etc.) work out of the box.
+Your DSN is available in **Sources / Ingestion → Service settings**. All 90+ Sentry SDK platforms (JavaScript, Python, Java, Kotlin, Swift, Go, Ruby, etc.) work out of the box.
 
 ## Datadog Agent
 

--- a/dashboard/src/blog/posts/migrate-from-sentry.mdx
+++ b/dashboard/src/blog/posts/migrate-from-sentry.mdx
@@ -43,7 +43,7 @@ Nothing in your application code changes.
 
 ### Option A: Moneat Cloud
 
-Sign up at [moneat.io](https://moneat.io), create an organization and project, and copy your DSN:
+Sign up at [moneat.io](https://moneat.io), create an organization and service, and copy your DSN:
 
 ```
 https://{public_key}@app.moneat.io/api/{project_id}
@@ -93,9 +93,9 @@ Point DNS at your server, configure SSL, and you're live. Full guide: [moneat.io
 
 ---
 
-## Step 2: Create Projects and Get DSNs (2 minutes)
+## Step 2: Create Services and Get DSNs (2 minutes)
 
-In the Moneat dashboard, go to **Settings → Projects → New Project**, select your platform, and copy the DSN. Create one project per Sentry project you're migrating.
+In the Moneat dashboard, go to **Sources / Ingestion**, select your platform, and copy the DSN. Create one service per Sentry project you're migrating.
 
 ---
 
@@ -245,7 +245,7 @@ After deploying with the new DSN:
 
 ## What About Historical Data?
 
-Moneat doesn't import historical Sentry data, but error monitoring data has a short half-life — teams rarely reference errors older than 30 days. Run both platforms in parallel for 1–2 weeks before canceling Sentry, migrating one service at a time since the DSN is per-project.
+Moneat doesn't import historical Sentry data, but error monitoring data has a short half-life — teams rarely reference errors older than 30 days. Run both platforms in parallel for 1–2 weeks before canceling Sentry, migrating one service at a time since the DSN is per-service.
 
 ```javascript
 // Temporarily send to both Sentry and Moneat during transition
@@ -270,7 +270,7 @@ Sentry.init({
 | Step | Time |
 |---|---|
 | Set up Moneat instance | 5-10 minutes |
-| Create projects and copy DSNs | 2 minutes |
+| Create services and copy DSNs | 2 minutes |
 | Update DSN in each service | 1 minute per service |
 | Configure source maps | 5-10 minutes |
 | Set up alerts | 5-10 minutes |

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -75,7 +75,7 @@ const PAGE_ITEMS: Array<{
 }> = [
   {
     label: 'Overview',
-    description: 'Project metrics and key stats',
+    description: 'Service metrics and key stats',
     href: APP_OVERVIEW_HREF,
     icon: Home,
     keywords: ['home'],

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -73,12 +73,12 @@ import {APP_OVERVIEW_HREF, APP_OVERVIEW_SEARCH, isAppOverviewSearch} from '@/lib
 import {hasEnterpriseModule, useEnterpriseFeatures} from '@/hooks/useEnterpriseFeatures'
 import {useCommandPalette} from '@/hooks/useCommandPalette'
 import {
-  ProjectSetupForm,
-  type ProjectSetupSubmission,
-} from '@/components/projects/ProjectSetupForm'
+  ServiceSetupForm,
+  type ServiceSetupSubmission,
+} from '@/components/projects/ServiceSetupForm'
 import {
   serializeTelemetrySourceIds,
-  storeTelemetrySourceIdsForProject,
+  storeTelemetrySourceIdsForService,
 } from '@/lib/telemetry-sources'
 import {primaryServiceResourceId} from '@/lib/service-facet-scope'
 
@@ -105,13 +105,13 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
   const { data: features } = useEnterpriseFeatures()
   const { openPalette } = useCommandPalette() ?? {}
 
-  // Create project dialog state
+  // Create service dialog state
   const [showCreateDialog, setShowCreateDialog] = useState(false)
 
   useEffect(() => {
     const handler = () => setShowCreateDialog(true)
-    globalThis.addEventListener('open-create-project-dialog', handler)
-    return () => globalThis.removeEventListener('open-create-project-dialog', handler)
+    globalThis.addEventListener('open-create-service-dialog', handler)
+    return () => globalThis.removeEventListener('open-create-service-dialog', handler)
   }, [])
   const { data: user } = useQuery({
     queryKey: ['currentUser'],
@@ -126,48 +126,48 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
   })
   const primaryServiceId = primaryServiceResourceId(projects)
 
-  const createProjectMutation = useMutation({
-    mutationFn: (data: ProjectSetupSubmission) =>
+  const createServiceMutation = useMutation({
+    mutationFn: (data: ServiceSetupSubmission) =>
       api.createProject(data.name, data.framework, data.targets),
-    onSuccess: (project, submission) => {
-      storeTelemetrySourceIdsForProject(project.resourceId, submission.sourceIds)
-      trackEvent('Project Create', {
-        framework: project.framework || 'none',
+    onSuccess: (service, submission) => {
+      storeTelemetrySourceIdsForService(service.resourceId, submission.sourceIds)
+      trackEvent('Service Create', {
+        framework: service.framework || 'none',
         sources: serializeTelemetrySourceIds(submission.sourceIds),
       })
       queryClient.invalidateQueries({ queryKey: ['projects'] })
       resetCreateForm()
       navigate({
         to: '/projects/$projectId',
-        params: { projectId: project.resourceId },
+        params: { projectId: service.resourceId },
         search: { sources: serializeTelemetrySourceIds(submission.sourceIds) },
       })
     },
     onError: (error: Error) => {
       if (error.message.includes('project_limit_reached')) {
         toast({
-          title: 'Project Limit Reached',
+          title: 'Service Limit Reached',
           description: (
             <>
-              You've reached the maximum number of projects for your plan.{' '}
+              You've reached the maximum number of services for your plan.{' '}
               <Link to="/settings" search={{tab: 'billing'}} className="underline font-medium">
                 Upgrade your plan
               </Link>{' '}
-              to add more projects.
+              to add more services.
             </>
           ),
           variant: 'destructive',
         })
       } else if (error.message.includes('already exists')) {
         toast({
-          title: 'Project Already Exists',
-          description: 'A project with this name already exists. Please choose a different name.',
+          title: 'Service Already Exists',
+          description: 'A service with this name already exists. Please choose a different name.',
           variant: 'destructive',
         })
       } else {
         toast({
           title: 'Error',
-          description: error.message || 'Failed to create project. Please try again.',
+          description: error.message || 'Failed to create service. Please try again.',
           variant: 'destructive',
         })
       }
@@ -176,7 +176,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
 
   const resetCreateForm = () => {
     setShowCreateDialog(false)
-    createProjectMutation.reset()
+    createServiceMutation.reset()
   }
 
   type NavGroupId = 'core' | 'infrastructure' | 'insights' | 'operations' | 'analytics' | 'management'
@@ -620,11 +620,11 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
             </DialogDescription>
           </DialogHeader>
 
-          <ProjectSetupForm
+          <ServiceSetupForm
             autoFocus
-            isSubmitting={createProjectMutation.isPending}
+            isSubmitting={createServiceMutation.isPending}
             onCancel={resetCreateForm}
-            onSubmit={(submission) => createProjectMutation.mutate(submission)}
+            onSubmit={(submission) => createServiceMutation.mutate(submission)}
           />
         </DialogContent>
       </Dialog>

--- a/dashboard/src/components/analytics/AnalyticsRealtimeBadge.tsx
+++ b/dashboard/src/components/analytics/AnalyticsRealtimeBadge.tsx
@@ -1,10 +1,10 @@
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 
-export function AnalyticsRealtimeBadge({projectId}: {projectId: string | number}) {
+export function AnalyticsRealtimeBadge({serviceId}: {serviceId: string | number}) {
   const {data} = useQuery({
-    queryKey: ['analytics-realtime', projectId],
-    queryFn: () => api.getAnalyticsRealtime(projectId),
+    queryKey: ['analytics-realtime', serviceId],
+    queryFn: () => api.getAnalyticsRealtime(serviceId),
     refetchInterval: 30_000,
   })
 

--- a/dashboard/src/components/landing/competitorComparisonData.ts
+++ b/dashboard/src/components/landing/competitorComparisonData.ts
@@ -342,11 +342,11 @@ export const competitorPages: CompetitorPageData[] = [
     migrationSteps: [
       {
         title: 'Start with one DSN swap',
-        detail: 'Point one project at Moneat and verify grouping, release context, source maps, and alert behavior.',
+        detail: 'Point one service at Moneat and verify grouping, release context, source maps, and alert behavior.',
       },
       {
         title: 'Add operating context',
-        detail: 'Bring in logs, traces, hosts, and uptime checks around the same project before changing broader SDK rollout.',
+        detail: 'Bring in logs, traces, hosts, and uptime checks around the same service before changing broader SDK rollout.',
       },
       {
         title: 'Move response workflows last',
@@ -504,7 +504,7 @@ export const competitorPages: CompetitorPageData[] = [
       },
       {
         title: 'Test telemetry compatibility',
-        detail: 'Send one Sentry SDK project, one Datadog Agent host, and one OTLP service to Moneat.',
+        detail: 'Send one Sentry SDK service, one Datadog Agent host, and one OTLP service to Moneat.',
       },
       {
         title: 'Decide hosted vs controlled',
@@ -662,7 +662,7 @@ export const competitorPages: CompetitorPageData[] = [
       },
       {
         title: 'Add non-OTel migration paths',
-        detail: 'Test a Sentry SDK project and a Datadog Agent host if your estate is not purely OpenTelemetry.',
+        detail: 'Test a Sentry SDK service and a Datadog Agent host if your estate is not purely OpenTelemetry.',
       },
       {
         title: 'Validate response workflows',

--- a/dashboard/src/components/projects/ServiceSettingsCard.tsx
+++ b/dashboard/src/components/projects/ServiceSettingsCard.tsx
@@ -56,8 +56,8 @@ const platformFilterTabs: Array<{id: PlatformFilter; label: string; icon: React.
 ]
 
 interface ServiceSettingsCardProps {
-  /** Internal project resource id of the service to edit. */
-  readonly projectId: string
+  /** Stable service resource id used by the legacy project API contract. */
+  readonly serviceId: string
   /** The service's enabled telemetry sources — gates which config sections show. */
   readonly sourceIds: TelemetrySourceId[]
   /** Called after a successful delete. When omitted, navigates to the overview. */
@@ -70,19 +70,19 @@ interface ServiceSettingsCardProps {
  * enabled telemetry sources: Sentry slug/CLI/DSN-targets only with the Sentry SDK
  * source; short OTLP/Datadog pointers with those sources. General + Danger always.
  *
- * Loads its own project by id, so callers that switch services should pass a
- * `key={projectId}` to reset local edits on change.
+ * Loads its own service by id, so callers that switch services should pass a
+ * `key={serviceId}` to reset local edits on change.
  */
-export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSettingsCardProps) {
+export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSettingsCardProps) {
   const router = useRouter()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const {toast} = useToast()
 
   const {data: project, isLoading} = useQuery({
-    queryKey: ['project', projectId],
-    queryFn: () => api.getProject(projectId),
-    enabled: !!projectId,
+    queryKey: ['project', serviceId],
+    queryFn: () => api.getProject(serviceId),
+    enabled: !!serviceId,
   })
 
   const [localName, setName] = useState<string | undefined>(undefined)
@@ -123,12 +123,12 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
     })
   }, [platformFilter])
 
-  const updateProjectMutation = useMutation({
-    mutationFn: (updates: {name?: string; framework?: string}) => api.updateProject(projectId, updates),
+  const updateServiceMutation = useMutation({
+    mutationFn: (updates: {name?: string; framework?: string}) => api.updateProject(serviceId, updates),
     onSuccess: async () => {
-      trackEvent('Project Update')
+      trackEvent('Service Update')
       await queryClient.invalidateQueries({queryKey: ['projects']})
-      await queryClient.invalidateQueries({queryKey: ['project', projectId]})
+      await queryClient.invalidateQueries({queryKey: ['project', serviceId]})
       await router.invalidate()
       toast({title: 'Service updated', description: 'Service settings were saved successfully.'})
     },
@@ -137,10 +137,10 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
     },
   })
 
-  const deleteProjectMutation = useMutation({
-    mutationFn: () => api.deleteProject(projectId),
+  const deleteServiceMutation = useMutation({
+    mutationFn: () => api.deleteProject(serviceId),
     onSuccess: async () => {
-      trackEvent('Project Delete')
+      trackEvent('Service Delete')
       await queryClient.invalidateQueries({queryKey: ['projects']})
       toast({title: 'Service deleted', description: `"${project?.name ?? 'Service'}" has been deleted.`})
       if (onDeleted) {
@@ -155,10 +155,10 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
   })
 
   const addTargetMutation = useMutation({
-    mutationFn: (target: string) => api.addProjectTarget(projectId, target),
+    mutationFn: (target: string) => api.addProjectTarget(serviceId, target),
     onSuccess: async () => {
       await queryClient.invalidateQueries({queryKey: ['projects']})
-      await queryClient.invalidateQueries({queryKey: ['project', projectId]})
+      await queryClient.invalidateQueries({queryKey: ['project', serviceId]})
       await router.invalidate()
       toast({title: 'Target added', description: 'A new platform target and DSN were created.'})
     },
@@ -204,7 +204,7 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
     if (frameworkChanged) updates.framework = framework
 
     if (Object.keys(updates).length === 0) return
-    updateProjectMutation.mutate(updates)
+    updateServiceMutation.mutate(updates)
   }
 
   const copySlug = () => {
@@ -231,9 +231,9 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
           </div>
           <Button
             onClick={handleSave}
-            disabled={!trimmedName || (!nameChanged && !frameworkChanged) || updateProjectMutation.isPending}
+            disabled={!trimmedName || (!nameChanged && !frameworkChanged) || updateServiceMutation.isPending}
           >
-            {updateProjectMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            {updateServiceMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
             Save Changes
           </Button>
         </CardHeader>
@@ -427,7 +427,7 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <Link to="/projects/$projectId" params={{projectId}}>
+            <Link to="/projects/$projectId" params={{projectId: serviceId}}>
               <Button variant="outline" size="sm">
                 <ExternalLink className="h-4 w-4" />
                 View ingestion setup
@@ -444,7 +444,7 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
             <CardDescription>Point a compatible agent at Moneat and tag it with this service.</CardDescription>
           </CardHeader>
           <CardContent>
-            <Link to="/projects/$projectId" params={{projectId}}>
+            <Link to="/projects/$projectId" params={{projectId: serviceId}}>
               <Button variant="outline" size="sm">
                 <ExternalLink className="h-4 w-4" />
                 View ingestion setup
@@ -482,15 +482,15 @@ export function ServiceSettingsCard({projectId, sourceIds, onDeleted}: ServiceSe
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={deleteProjectMutation.isPending}>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={deleteServiceMutation.isPending}>
               Cancel
             </Button>
             <Button
               variant="destructive"
-              onClick={() => deleteProjectMutation.mutate()}
-              disabled={deleteProjectMutation.isPending}
+              onClick={() => deleteServiceMutation.mutate()}
+              disabled={deleteServiceMutation.isPending}
             >
-              {deleteProjectMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+              {deleteServiceMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
               Delete Service
             </Button>
           </DialogFooter>

--- a/dashboard/src/components/projects/ServiceSetupForm.tsx
+++ b/dashboard/src/components/projects/ServiceSetupForm.tsx
@@ -29,15 +29,15 @@ import {
 
 type PlatformFilter = 'all' | 'mobile' | 'frontend' | 'backend' | 'desktop-gaming'
 
-export interface ProjectSetupSubmission {
+export interface ServiceSetupSubmission {
   name: string
   framework: string
   targets?: string[]
   sourceIds: TelemetrySourceId[]
 }
 
-interface ProjectSetupFormProps {
-  readonly onSubmit: (submission: ProjectSetupSubmission) => void
+interface ServiceSetupFormProps {
+  readonly onSubmit: (submission: ServiceSetupSubmission) => void
   readonly isSubmitting?: boolean
   readonly submitLabel?: string
   readonly submittingLabel?: string
@@ -64,7 +64,7 @@ function getDefaultTargets(platformId: string): string[] {
   return []
 }
 
-export function ProjectSetupForm({
+export function ServiceSetupForm({
   onSubmit,
   isSubmitting = false,
   submitLabel = 'Create Service',
@@ -74,8 +74,8 @@ export function ProjectSetupForm({
   error,
   autoFocus = false,
   initialSourceIds = DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS,
-}: ProjectSetupFormProps) {
-  const [projectName, setProjectName] = useState('')
+}: ServiceSetupFormProps) {
+  const [serviceName, setServiceName] = useState('')
   const [selectedPlatform, setSelectedPlatform] = useState<string | null>(null)
   const [selectedTargets, setSelectedTargets] = useState<string[]>([])
   const [platformFilter, setPlatformFilter] = useState<PlatformFilter>('all')
@@ -100,7 +100,7 @@ export function ProjectSetupForm({
   const requiresTargets = Boolean(selectedPlatformInfo?.targets)
   const hasValidTargets = !requiresTargets || selectedTargets.length > 0
   const canSubmit =
-    projectName.trim().length > 0 &&
+    serviceName.trim().length > 0 &&
     Boolean(selectedPlatform) &&
     hasValidTargets &&
     selectedSourceIds.length > 0 &&
@@ -124,7 +124,7 @@ export function ProjectSetupForm({
     if (!canSubmit || !selectedPlatform) return
 
     onSubmit({
-      name: projectName.trim(),
+      name: serviceName.trim(),
       framework: selectedPlatform,
       targets: requiresTargets ? selectedTargets : undefined,
       sourceIds: selectedSourceIds,
@@ -140,12 +140,12 @@ export function ProjectSetupForm({
       ) : null}
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="project-name">Service name</Label>
+        <Label htmlFor="service-name">Service name</Label>
         <Input
-          id="project-name"
+          id="service-name"
           placeholder="Checkout API"
-          value={projectName}
-          onChange={(event) => setProjectName(event.target.value)}
+          value={serviceName}
+          onChange={(event) => setServiceName(event.target.value)}
           autoFocus={autoFocus}
         />
       </div>

--- a/dashboard/src/components/projects/ServiceTelemetrySetupHub.tsx
+++ b/dashboard/src/components/projects/ServiceTelemetrySetupHub.tsx
@@ -45,17 +45,17 @@ import {
   TELEMETRY_SOURCES,
   getTelemetrySource,
   getTelemetrySourceStatus,
-  loadTelemetrySourceIdsForProject,
+  loadTelemetrySourceIdsForService,
   parseTelemetrySourceIds,
   serializeTelemetrySourceIds,
-  storeTelemetrySourceIdsForProject,
+  storeTelemetrySourceIdsForService,
   toggleTelemetrySourceId,
   type TelemetrySourceId,
   type TelemetrySourceStatusState,
 } from '@/lib/telemetry-sources'
 
-interface ProjectTelemetrySetupHubProps {
-  readonly project: Project
+interface ServiceTelemetrySetupHubProps {
+  readonly service: Project
   readonly selectedSourcesParam?: string
 }
 
@@ -117,7 +117,7 @@ function getInitialSourceIds(projectId: string | number, selectedSourcesParam?: 
   const sourceIdsFromSearch = parseTelemetrySourceIds(selectedSourcesParam)
   if (sourceIdsFromSearch.length > 0) return sourceIdsFromSearch
 
-  const storedSourceIds = loadTelemetrySourceIdsForProject(projectId)
+  const storedSourceIds = loadTelemetrySourceIdsForService(projectId)
   if (storedSourceIds.length > 0) return storedSourceIds
 
   return ALL_TELEMETRY_SOURCE_IDS
@@ -127,29 +127,29 @@ function getTargetLabel(target: string): string {
   return target.split('-').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
 }
 
-function getProjectKey(project: Project, targetId: string | null): ProjectKey {
-  if (!targetId || targetId === 'default') return project.keys[0]
-  return project.keys.find((key) => key.platformTarget === targetId) ?? project.keys[0]
+function getServiceKey(service: Project, targetId: string | null): ProjectKey {
+  if (!targetId || targetId === 'default') return service.keys[0]
+  return service.keys.find((key) => key.platformTarget === targetId) ?? service.keys[0]
 }
 
 function getDocsForTarget(
-  project: Project,
+  service: Project,
   selectedTarget: string | null,
   sdkVersions: Record<string, string> | undefined,
   setupOptions: {orgSlug?: string; projectSlug: string; backendUrl: string}
 ): PlatformSetupDocs | null {
-  const key = getProjectKey(project, selectedTarget)
+  const key = getServiceKey(service, selectedTarget)
   if (!selectedTarget || selectedTarget === 'default') {
-    return getSetupDocs(project.framework, project.dsn, sdkVersions, setupOptions)
+    return getSetupDocs(service.framework, service.dsn, sdkVersions, setupOptions)
   }
 
   const targetDocs = getSetupDocs(
-    `${project.framework}-${selectedTarget}`,
+    `${service.framework}-${selectedTarget}`,
     key.dsn,
     sdkVersions,
     setupOptions
   )
-  return targetDocs || getSetupDocs(project.framework, key.dsn, sdkVersions, setupOptions)
+  return targetDocs || getSetupDocs(service.framework, key.dsn, sdkVersions, setupOptions)
 }
 
 function keyPlaceholder(createdKey: string | null, fallback: string): string {
@@ -306,25 +306,25 @@ function httpLogsSnippet(apiKey: string): string {
 }
 
 function TargetPlatformSection({
-  project,
+  service,
   selectedTarget,
   onSelectedTargetChange,
 }: {
-  readonly project: Project
+  readonly service: Project
   readonly selectedTarget: string | null
   readonly onSelectedTargetChange: (target: string | null) => void
 }) {
   const queryClient = useQueryClient()
   const router = useRouter()
-  const platformInfo = getPlatformInfo(project.framework)
-  const existingTargets = project.keys
+  const platformInfo = getPlatformInfo(service.framework)
+  const existingTargets = service.keys
     .map((key) => key.platformTarget)
     .filter(Boolean) as string[]
   const availableTargets = platformInfo?.targets?.filter((target) => !existingTargets.includes(target.id)) ?? []
   const [showAddPlatform, setShowAddPlatform] = useState(false)
 
   const addTargetMutation = useMutation({
-    mutationFn: (target: string) => api.addProjectTarget(project.resourceId, target),
+    mutationFn: (target: string) => api.addProjectTarget(service.resourceId, target),
     onSuccess: (_key, target) => {
       queryClient.invalidateQueries({queryKey: ['projects']})
       router.invalidate()
@@ -333,7 +333,7 @@ function TargetPlatformSection({
     },
   })
 
-  if (project.keys.length <= 1 && availableTargets.length === 0) return null
+  if (service.keys.length <= 1 && availableTargets.length === 0) return null
 
   return (
     <FlatSetupSection
@@ -354,7 +354,7 @@ function TargetPlatformSection({
     >
       <div className="flex flex-col gap-4">
         <div className="flex flex-wrap gap-2">
-          {project.keys.map((key) => {
+          {service.keys.map((key) => {
             const target = key.platformTarget ?? 'default'
             const isSelected = (selectedTarget ?? 'default') === target
             return (
@@ -426,11 +426,11 @@ function TargetPlatformSection({
 }
 
 function DsnSection({
-  project,
+  service,
   selectedTarget,
   onSelectedTargetChange,
 }: {
-  readonly project: Project
+  readonly service: Project
   readonly selectedTarget: string | null
   readonly onSelectedTargetChange: (target: string | null) => void
 }) {
@@ -442,7 +442,7 @@ function DsnSection({
     setTimeout(() => setCopiedTarget(null), COPY_RESET_MS)
   }
 
-  if (project.keys.length > 1) {
+  if (service.keys.length > 1) {
     return (
       <FlatSetupSection
         title="Service DSNs"
@@ -450,7 +450,7 @@ function DsnSection({
       >
         <Tabs value={selectedTarget ?? 'default'} onValueChange={onSelectedTargetChange}>
           <TabsList className="mb-4 flex h-auto flex-wrap gap-1">
-            {project.keys.map((key) => {
+            {service.keys.map((key) => {
               const target = key.platformTarget ?? 'default'
               return (
                 <TabsTrigger key={target} value={target}>
@@ -459,7 +459,7 @@ function DsnSection({
               )
             })}
           </TabsList>
-          {project.keys.map((key) => {
+          {service.keys.map((key) => {
             const target = key.platformTarget ?? 'default'
             return (
               <TabsContent key={target} value={target}>
@@ -489,13 +489,13 @@ function DsnSection({
     <FlatSetupSection title="Service DSN" description="Use this DSN in a Sentry-compatible SDK.">
       <div className="flex items-center gap-2">
         <code className="min-w-0 flex-1 break-all rounded-lg bg-muted px-3 py-2.5 text-sm">
-          {project.dsn}
+          {service.dsn}
         </code>
         <Button
           type="button"
           variant="outline"
           size="icon"
-          onClick={() => handleCopyDsn(project.dsn, 'default')}
+          onClick={() => handleCopyDsn(service.dsn, 'default')}
           aria-label="Copy DSN"
         >
           {copiedTarget === 'default' ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
@@ -506,12 +506,12 @@ function DsnSection({
 }
 
 function SentrySetupPanel({
-  project,
+  service,
   selectedTarget,
   onSelectedTargetChange,
   docs,
 }: {
-  readonly project: Project
+  readonly service: Project
   readonly selectedTarget: string | null
   readonly onSelectedTargetChange: (target: string | null) => void
   readonly docs: PlatformSetupDocs | null
@@ -527,12 +527,12 @@ function SentrySetupPanel({
   return (
     <div className="flex flex-col gap-4">
       <TargetPlatformSection
-        project={project}
+        service={service}
         selectedTarget={selectedTarget}
         onSelectedTargetChange={onSelectedTargetChange}
       />
       <DsnSection
-        project={project}
+        service={service}
         selectedTarget={selectedTarget}
         onSelectedTargetChange={onSelectedTargetChange}
       />
@@ -788,10 +788,10 @@ function DatadogAgentPanel({
   )
 }
 
-export function ProjectTelemetrySetupHub({
-  project,
+export function ServiceTelemetrySetupHub({
+  service,
   selectedSourcesParam,
-}: ProjectTelemetrySetupHubProps) {
+}: ServiceTelemetrySetupHubProps) {
   const navigate = useNavigate({from: '/projects/$projectId'})
   const queryClient = useQueryClient()
   const {toast} = useToast()
@@ -800,7 +800,7 @@ export function ProjectTelemetrySetupHub({
     [selectedSourcesParam]
   )
   const [storedSourceIds, setStoredSourceIds] = useState<TelemetrySourceId[]>(
-    () => getInitialSourceIds(project.resourceId)
+    () => getInitialSourceIds(service.resourceId)
   )
   const selectedSourceIds = sourceIdsFromSearch.length > 0 ? sourceIdsFromSearch : storedSourceIds
   const [requestedActiveSourceId, setRequestedActiveSourceId] = useState<TelemetrySourceId>(selectedSourceIds[0])
@@ -808,7 +808,7 @@ export function ProjectTelemetrySetupHub({
     ? requestedActiveSourceId
     : selectedSourceIds[0]
   const [selectedTarget, setSelectedTarget] = useState<string | null>(
-    () => project.keys[0]?.platformTarget ?? 'default'
+    () => service.keys[0]?.platformTarget ?? 'default'
   )
   const [copiedResourceId, setCopiedResourceId] = useState(false)
   const [createdOtlpKey, setCreatedOtlpKey] = useState<string | null>(null)
@@ -816,7 +816,7 @@ export function ProjectTelemetrySetupHub({
 
   const copyResourceId = async () => {
     try {
-      await navigator.clipboard.writeText(project.resourceId)
+      await navigator.clipboard.writeText(service.resourceId)
       setCopiedResourceId(true)
       setTimeout(() => setCopiedResourceId(false), COPY_RESET_MS)
     } catch (error) {
@@ -830,8 +830,8 @@ export function ProjectTelemetrySetupHub({
   }
 
   useEffect(() => {
-    storeTelemetrySourceIdsForProject(project.resourceId, selectedSourceIds)
-  }, [project.resourceId, selectedSourceIds])
+    storeTelemetrySourceIdsForService(service.resourceId, selectedSourceIds)
+  }, [service.resourceId, selectedSourceIds])
 
   const {data: sdkVersionsResponse} = useQuery({
     queryKey: ['sdk-versions'],
@@ -844,8 +844,8 @@ export function ProjectTelemetrySetupHub({
     staleTime: 30 * 60 * 1000,
   })
   const {data: projectStats} = useQuery({
-    queryKey: ['projectStats', project.resourceId, '24h'],
-    queryFn: () => api.getProjectStats(project.resourceId, '24h'),
+    queryKey: ['serviceStats', service.resourceId, '24h'],
+    queryFn: () => api.getProjectStats(service.resourceId, '24h'),
   })
   const {data: otlpKeyResponse} = useQuery({
     queryKey: ['otlpApiKeys'],
@@ -865,19 +865,19 @@ export function ProjectTelemetrySetupHub({
 
   const setupOptions = {
     orgSlug: currentUser?.organizationSlug,
-    projectSlug: project.slug,
+    projectSlug: service.slug,
     backendUrl: backendBaseUrl,
   }
   const sentryDocs = getDocsForTarget(
-    project,
+    service,
     selectedTarget,
     sdkVersionsResponse?.versions,
     setupOptions
   )
-  const platformInfo = getPlatformInfo(project.framework)
+  const platformInfo = getPlatformInfo(service.framework)
   const PlatformIcon = platformInfo?.icon
   const sourceStatusInput = useMemo(() => ({
-    projectEventCount: projectStats?.totalEvents,
+    serviceEventCount: projectStats?.totalEvents,
     otlpKeys: otlpKeyResponse?.keys,
     agentKeys: agentKeyResponse?.keys,
     monitorHosts,
@@ -886,7 +886,7 @@ export function ProjectTelemetrySetupHub({
   const hasExistingAgentKey = (agentKeyResponse?.keys.length ?? 0) > 0
 
   const createOtlpKeyMutation = useMutation({
-    mutationFn: () => api.createOtlpApiKey(`${project.name} OTLP`),
+    mutationFn: () => api.createOtlpApiKey(`${service.name} OTLP`),
     onSuccess: (response) => {
       setCreatedOtlpKey(response.key)
       queryClient.invalidateQueries({queryKey: ['otlpApiKeys']})
@@ -895,7 +895,7 @@ export function ProjectTelemetrySetupHub({
   })
 
   const createAgentKeyMutation = useMutation({
-    mutationFn: () => api.createAgentApiKey(`${project.name} Agent`),
+    mutationFn: () => api.createAgentApiKey(`${service.name} Agent`),
     onSuccess: (response) => {
       setCreatedAgentKey(response.key)
       queryClient.invalidateQueries({queryKey: ['agentApiKeys']})
@@ -905,7 +905,7 @@ export function ProjectTelemetrySetupHub({
 
   const updateSelectedSources = (sourceIds: TelemetrySourceId[]) => {
     setStoredSourceIds(sourceIds)
-    storeTelemetrySourceIdsForProject(project.resourceId, sourceIds)
+    storeTelemetrySourceIdsForService(service.resourceId, sourceIds)
     navigate({
       search: (previous) => ({
         ...previous,
@@ -938,7 +938,7 @@ export function ProjectTelemetrySetupHub({
               ) : null}
               <Badge variant={statusVariant(activeStatus.state)}>{activeStatus.label}</Badge>
             </div>
-            <p className="text-sm font-medium text-muted-foreground">{project.name}</p>
+            <p className="text-sm font-medium text-muted-foreground">{service.name}</p>
             <h1 className="text-3xl font-bold">Sources / Ingestion</h1>
             <p className="mt-1 text-sm text-muted-foreground">
               Connect telemetry sources and manage this service's stable ID, DSNs, and ingestion keys.
@@ -946,7 +946,7 @@ export function ProjectTelemetrySetupHub({
             <div className="mt-1 flex max-w-full items-center gap-2 text-xs text-muted-foreground">
               <span>Service ID</span>
               <code className="max-w-[min(28rem,70vw)] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-foreground">
-                {project.resourceId}
+                {service.resourceId}
               </code>
               <Button
                 type="button"
@@ -961,7 +961,7 @@ export function ProjectTelemetrySetupHub({
             </div>
           </div>
           <Button asChild variant="outline" size="icon" aria-label="Service settings">
-            <Link to="/projects/$projectId/settings" params={{projectId: project.resourceId}}>
+            <Link to="/projects/$projectId/settings" params={{projectId: service.resourceId}}>
               <Settings className="h-4 w-4" />
             </Link>
           </Button>
@@ -1042,7 +1042,7 @@ export function ProjectTelemetrySetupHub({
 
             <TabsContent value="sentry-sdk" className="mt-0">
               <SentrySetupPanel
-                project={project}
+                service={service}
                 selectedTarget={selectedTarget}
                 onSelectedTargetChange={setSelectedTarget}
                 docs={sentryDocs}

--- a/dashboard/src/components/projects/TelemetrySourcePicker.tsx
+++ b/dashboard/src/components/projects/TelemetrySourcePicker.tsx
@@ -39,7 +39,7 @@ interface TelemetrySourcePickerProps {
 
 /**
  * Controlled grid of telemetry sources (OpenTelemetry / Sentry SDK / Datadog Agent).
- * Extracted from ProjectSetupForm so the same picker drives both service creation
+ * Extracted from ServiceSetupForm so the same picker drives both service creation
  * and per-service configuration. Toggling keeps at least one source selected
  * (via toggleTelemetrySourceId).
  */

--- a/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
@@ -51,7 +51,7 @@ function renderCard(sourceIds: TelemetrySourceId[], onDeleted?: () => void) {
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <ServiceSettingsCard projectId="proj-1" sourceIds={sourceIds} onDeleted={onDeleted} />
+      <ServiceSettingsCard serviceId="proj-1" sourceIds={sourceIds} onDeleted={onDeleted} />
     </QueryClientProvider>
   )
 }

--- a/dashboard/src/components/projects/__tests__/ServiceSetupForm.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ServiceSetupForm.test.tsx
@@ -1,14 +1,14 @@
 import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {describe, expect, it, vi} from 'vitest'
-import {ProjectSetupForm, type ProjectSetupSubmission} from '@/components/projects/ProjectSetupForm'
+import {ServiceSetupForm, type ServiceSetupSubmission} from '@/components/projects/ServiceSetupForm'
 
-describe('ProjectSetupForm', () => {
-  it('submits project, platform, targets, and selected telemetry sources', async () => {
+describe('ServiceSetupForm', () => {
+  it('submits service, platform, targets, and selected telemetry sources', async () => {
     const user = userEvent.setup()
-    const onSubmit = vi.fn<(submission: ProjectSetupSubmission) => void>()
+    const onSubmit = vi.fn<(submission: ServiceSetupSubmission) => void>()
 
-    render(<ProjectSetupForm onSubmit={onSubmit} />)
+    render(<ServiceSetupForm onSubmit={onSubmit} />)
 
     await user.type(screen.getByLabelText('Service name'), 'Checkout API')
     await user.click(screen.getByRole('button', {name: /React$/}))
@@ -24,11 +24,11 @@ describe('ProjectSetupForm', () => {
     })
   })
 
-  it('keeps submit disabled until a project name and platform are selected', async () => {
+  it('keeps submit disabled until a service name and platform are selected', async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()
 
-    render(<ProjectSetupForm onSubmit={onSubmit} />)
+    render(<ServiceSetupForm onSubmit={onSubmit} />)
 
     expect(screen.getByRole('button', {name: 'Create Service'})).toBeDisabled()
 
@@ -43,7 +43,7 @@ describe('ProjectSetupForm', () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()
 
-    render(<ProjectSetupForm onSubmit={onSubmit} />)
+    render(<ServiceSetupForm onSubmit={onSubmit} />)
 
     await user.click(screen.getByRole('button', {name: 'Backend'}))
     expect(screen.getByRole('button', {name: 'Node.js'})).toBeInTheDocument()
@@ -57,9 +57,9 @@ describe('ProjectSetupForm', () => {
 
   it('requires at least one target platform for multi-target apps', async () => {
     const user = userEvent.setup()
-    const onSubmit = vi.fn<(submission: ProjectSetupSubmission) => void>()
+    const onSubmit = vi.fn<(submission: ServiceSetupSubmission) => void>()
 
-    render(<ProjectSetupForm onSubmit={onSubmit} />)
+    render(<ServiceSetupForm onSubmit={onSubmit} />)
 
     await user.type(screen.getByLabelText('Service name'), 'Game client')
     await user.click(screen.getByRole('button', {name: 'Desktop & Gaming'}))
@@ -89,29 +89,29 @@ describe('ProjectSetupForm', () => {
     const onCancel = vi.fn()
 
     const {rerender} = render(
-      <ProjectSetupForm
+      <ServiceSetupForm
         onSubmit={onSubmit}
         onCancel={onCancel}
         cancelLabel="Back"
-        error="Unable to create project"
+        error="Unable to create service"
       />
     )
 
-    expect(screen.getByText('Unable to create project')).toBeInTheDocument()
+    expect(screen.getByText('Unable to create service')).toBeInTheDocument()
     await user.click(screen.getByRole('button', {name: 'Back'}))
     expect(onCancel).toHaveBeenCalledTimes(1)
 
     rerender(
-      <ProjectSetupForm
+      <ServiceSetupForm
         onSubmit={onSubmit}
         onCancel={onCancel}
         cancelLabel="Back"
         isSubmitting
-        submittingLabel="Saving project..."
+        submittingLabel="Saving service..."
       />
     )
 
-    expect(screen.getByRole('button', {name: 'Saving project...'})).toBeDisabled()
+    expect(screen.getByRole('button', {name: 'Saving service...'})).toBeDisabled()
     expect(screen.getByRole('button', {name: 'Back'})).toBeDisabled()
   })
 })

--- a/dashboard/src/components/projects/__tests__/ServiceTelemetrySetupHub.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ServiceTelemetrySetupHub.test.tsx
@@ -3,7 +3,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {fireEvent, render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
-import {ProjectTelemetrySetupHub} from '@/components/projects/ProjectTelemetrySetupHub'
+import {ServiceTelemetrySetupHub} from '@/components/projects/ServiceTelemetrySetupHub'
 import type {Project} from '@/lib/api'
 
 const {mockApi, mockNavigate, mockRouterInvalidate, mockToast} = vi.hoisted(() => ({
@@ -34,7 +34,7 @@ vi.mock('@tanstack/react-router', () => ({
   useRouter: () => ({invalidate: mockRouterInvalidate}),
 }))
 
-const baseProject: Project = {
+const baseService: Project = {
   id: 1,
   resourceId: 'svc-checkout',
   name: 'Checkout API',
@@ -59,18 +59,18 @@ function stubClipboard(writeText = vi.fn()) {
   return writeText
 }
 
-function renderHub(project: Project = baseProject, selectedSourcesParam?: string) {
+function renderHub(service: Project = baseService, selectedSourcesParam?: string) {
   const queryClient = new QueryClient({
     defaultOptions: {queries: {retry: false}, mutations: {retry: false}},
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <ProjectTelemetrySetupHub project={project} selectedSourcesParam={selectedSourcesParam} />
+      <ServiceTelemetrySetupHub service={service} selectedSourcesParam={selectedSourcesParam} />
     </QueryClientProvider>
   )
 }
 
-describe('ProjectTelemetrySetupHub', () => {
+describe('ServiceTelemetrySetupHub', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     globalThis.localStorage.clear()
@@ -91,7 +91,7 @@ describe('ProjectTelemetrySetupHub', () => {
     }
   })
 
-  it('frames the project route as the sources and ingestion home for a service', async () => {
+  it('frames sources and ingestion as the home for a service', async () => {
     renderHub()
 
     expect(screen.getByRole('heading', {name: 'Sources / Ingestion'})).toBeInTheDocument()
@@ -115,7 +115,7 @@ describe('ProjectTelemetrySetupHub', () => {
     const writeText = stubClipboard()
     mockApi.getProjectStats.mockResolvedValueOnce({totalEvents: 12})
 
-    renderHub(baseProject, 'sentry-sdk')
+    renderHub(baseService, 'sentry-sdk')
 
     expect(screen.getByRole('heading', {name: 'Connect a Sentry-compatible SDK'})).toBeInTheDocument()
     expect((await screen.findAllByText('Receiving')).length).toBeGreaterThan(0)
@@ -132,7 +132,7 @@ describe('ProjectTelemetrySetupHub', () => {
   it('creates an OTLP key and shows the one-time secret in the ingestion snippets', async () => {
     const user = userEvent.setup()
 
-    renderHub(baseProject, 'opentelemetry')
+    renderHub(baseService, 'opentelemetry')
 
     await user.click(screen.getByRole('button', {name: 'Create OTLP key'}))
 
@@ -145,8 +145,8 @@ describe('ProjectTelemetrySetupHub', () => {
 
   it('shows service DSNs for target platforms and can add another platform', async () => {
     const user = userEvent.setup()
-    const targetProject: Project = {
-      ...baseProject,
+    const targetService: Project = {
+      ...baseService,
       framework: 'unity',
       keys: [
         {platformTarget: null, dsn: 'https://public@example.test/default'},
@@ -154,7 +154,7 @@ describe('ProjectTelemetrySetupHub', () => {
       ],
     }
 
-    renderHub(targetProject, 'sentry-sdk')
+    renderHub(targetService, 'sentry-sdk')
 
     expect(await screen.findByText('Target platforms')).toBeInTheDocument()
     expect(screen.getByText('Service DSNs')).toBeInTheDocument()
@@ -174,7 +174,7 @@ describe('ProjectTelemetrySetupHub', () => {
     const user = userEvent.setup()
     mockApi.getAgentApiKeys.mockResolvedValueOnce({keys: [{lastUsedAt: null}]})
 
-    renderHub(baseProject, 'datadog-agent')
+    renderHub(baseService, 'datadog-agent')
 
     expect(screen.getByRole('heading', {name: 'Connect a Datadog Agent'})).toBeInTheDocument()
     expect((await screen.findAllByText('Key created')).length).toBeGreaterThan(0)

--- a/dashboard/src/components/settings/OtlpApiKeysTab.tsx
+++ b/dashboard/src/components/settings/OtlpApiKeysTab.tsx
@@ -25,7 +25,7 @@ import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/c
 import {useToast} from '@/hooks/useToast'
 import {ApiKeysTabBase} from './ApiKeysTabBase'
 
-const UNMAPPED_PROJECT_VALUE = '__unmapped__'
+const UNMAPPED_SERVICE_VALUE = '__unmapped__'
 
 function serviceLabel(service: OtlpObservedService) {
   if (!service.serviceNamespace) return service.serviceName
@@ -48,7 +48,7 @@ export function OtlpApiKeysTab() {
         cardTitle="OTLP API Keys"
         cardDescription={
           'Create organization credentials for OpenTelemetry ingestion. ' +
-          'Services route to projects by service.name mappings below.'
+          'Services route to Moneat services by service.name mappings below.'
         }
         docsHref="/docs/logging"
         icon={ScrollText}
@@ -94,22 +94,22 @@ function OtlpServiceRoutingPanel() {
     queryFn: () => api.getOtlpObservedServices(),
     enabled: api.isAuthenticated(),
   })
-  const {data: projects = []} = useQuery({
+  const {data: moneatServices = []} = useQuery({
     queryKey: ['projects'],
     queryFn: () => api.getProjects(),
     enabled: api.isAuthenticated(),
   })
 
   const upsertMapping = useMutation({
-    mutationFn: (input: {service: OtlpObservedService; projectId: string | number}) =>
+    mutationFn: (input: {service: OtlpObservedService; serviceId: string | number}) =>
       api.upsertOtlpServiceMapping(
         input.service.serviceName,
-        input.projectId,
+        input.serviceId,
         input.service.serviceNamespace
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: ['otlpObservedServices']})
-      toast({title: 'Service mapped', description: 'OTLP telemetry will route to the selected project.'})
+      toast({title: 'Service mapped', description: 'OTLP telemetry will route to the selected service.'})
     },
     onError: (error: Error) => {
       toast({title: 'Failed to map service', description: error.message, variant: 'destructive'})
@@ -134,7 +134,7 @@ function OtlpServiceRoutingPanel() {
       <CardHeader>
         <CardTitle className="text-base">Service routing</CardTitle>
         <CardDescription>
-          Map OpenTelemetry services to Moneat projects. Unmapped services continue ingesting at
+          Map OpenTelemetry services to Moneat services. Unmapped services continue ingesting at
           organization scope.
         </CardDescription>
       </CardHeader>
@@ -155,7 +155,7 @@ function OtlpServiceRoutingPanel() {
                 <TableHead>Service</TableHead>
                 <TableHead>Signals</TableHead>
                 <TableHead>Environment</TableHead>
-                <TableHead>Project</TableHead>
+                <TableHead>Moneat service</TableHead>
                 <TableHead className="w-[80px]">
                   <span className="sr-only">Actions</span>
                 </TableHead>
@@ -166,8 +166,8 @@ function OtlpServiceRoutingPanel() {
                 <OtlpServiceRoutingRow
                   key={service.id}
                   service={service}
-                  projects={projects}
-                  upsertMapping={(projectId) => upsertMapping.mutate({service, projectId})}
+                  moneatServices={moneatServices}
+                  upsertMapping={(serviceId) => upsertMapping.mutate({service, serviceId})}
                   deleteMapping={() => {
                     if (service.mappingId != null) deleteMapping.mutate(service.mappingId)
                   }}
@@ -184,13 +184,13 @@ function OtlpServiceRoutingPanel() {
 
 function OtlpServiceRoutingRow(props: {
   readonly service: OtlpObservedService
-  readonly projects: Project[]
-  readonly upsertMapping: (projectId: string | number) => void
+  readonly moneatServices: Project[]
+  readonly upsertMapping: (serviceId: string | number) => void
   readonly deleteMapping: () => void
   readonly isPending: boolean
 }) {
-  const {service, projects, upsertMapping, deleteMapping, isPending} = props
-  const selectedProject = service.projectResourceId ?? UNMAPPED_PROJECT_VALUE
+  const {service, moneatServices, upsertMapping, deleteMapping, isPending} = props
+  const selectedMoneatService = service.projectResourceId ?? UNMAPPED_SERVICE_VALUE
 
   return (
     <TableRow>
@@ -218,10 +218,10 @@ function OtlpServiceRoutingRow(props: {
       </TableCell>
       <TableCell className="min-w-[220px]">
         <Select
-          value={selectedProject}
-          disabled={isPending || projects.length === 0}
+          value={selectedMoneatService}
+          disabled={isPending || moneatServices.length === 0}
           onValueChange={(value) => {
-            if (value === UNMAPPED_PROJECT_VALUE) {
+            if (value === UNMAPPED_SERVICE_VALUE) {
               if (service.mappingId != null) deleteMapping()
               return
             }
@@ -229,14 +229,14 @@ function OtlpServiceRoutingRow(props: {
           }}
         >
           <SelectTrigger>
-            <SelectValue placeholder="Select project" />
+            <SelectValue placeholder="Select service" />
           </SelectTrigger>
           <SelectContent>
             <SelectGroup>
-              <SelectItem value={UNMAPPED_PROJECT_VALUE}>Unmapped</SelectItem>
-              {projects.map((project) => (
-                <SelectItem key={project.id} value={project.resourceId}>
-                  {project.name}
+              <SelectItem value={UNMAPPED_SERVICE_VALUE}>Unmapped</SelectItem>
+              {moneatServices.map((moneatService) => (
+                <SelectItem key={moneatService.id} value={moneatService.resourceId}>
+                  {moneatService.name}
                 </SelectItem>
               ))}
             </SelectGroup>

--- a/dashboard/src/components/settings/__tests__/OtlpApiKeysTab.test.tsx
+++ b/dashboard/src/components/settings/__tests__/OtlpApiKeysTab.test.tsx
@@ -173,7 +173,7 @@ describe('OtlpApiKeysTab', () => {
     })
   })
 
-  it('maps an unmapped service from the project selector', async () => {
+  it('maps an unmapped service from the service selector', async () => {
     let capturedBody: Record<string, unknown> | null = null
     const user = userEvent.setup()
     server.use(

--- a/dashboard/src/docs/pages/ai-observability.mdx
+++ b/dashboard/src/docs/pages/ai-observability.mdx
@@ -31,7 +31,7 @@ If your application uses a Sentry SDK with AI integrations, point your DSN to yo
     },
     {
       title: 'Point the DSN to Moneat',
-      content: 'Instead of using a Sentry DSN, configure the SDK to point to your Moneat instance. You can find your project DSN in your project settings. It follows this format:',
+      content: 'Instead of using a Sentry DSN, configure the SDK to point to your Moneat instance. You can find your service DSN in your service settings. It follows this format:',
     },
   ]}
 />
@@ -54,7 +54,7 @@ If you're not using a Sentry SDK, you can send LLM generation events directly to
 POST /api/{projectId}/llm/
 ```
 
-Authenticate using either the `X-Sentry-Auth` header or the `sentry_key` query parameter with your project's public key. The endpoint accepts gzip-compressed payloads via the `Content-Encoding: gzip` header.
+Authenticate using either the `X-Sentry-Auth` header or the `sentry_key` query parameter with your service public key. The endpoint accepts gzip-compressed payloads via the `Content-Encoding: gzip` header.
 
 ### Payload Format
 
@@ -142,7 +142,7 @@ LLM generation data is stored in ClickHouse with plan-specific retention. Check 
 
 ## Next Steps
 
-- [Getting Started](/docs/getting-started) - Set up your account and first project
+- [Getting Started](/docs/getting-started) - Set up your account and first service
 - [SDK Setup](/docs/sdk-setup) - Platform-specific SDK configuration
 - [Error Monitoring](/docs/error-monitoring) - Error capture and issue grouping
 - [Billing & Plans](/docs/billing) - Usage quotas and billing

--- a/dashboard/src/docs/pages/billing.mdx
+++ b/dashboard/src/docs/pages/billing.mdx
@@ -30,7 +30,7 @@ OIDC SSO is available on all self-hosted deployments at no cost. SAML SSO and SS
 Monitor your data usage in real-time from **Settings & Billing**. The usage dashboard shows:
 
 - **Current period usage** - Data ingested this billing cycle
-- **Usage breakdown** - By project, event type, and day
+- **Usage breakdown** - By service, event type, and day
 - **Quota remaining** - Capacity left
 - **Historical trends** - Usage patterns over previous months
 

--- a/dashboard/src/docs/pages/getting-started.mdx
+++ b/dashboard/src/docs/pages/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Create your account, set up a project, and capture your first error in minutes.
+description: Create your account, set up a service, and capture your first error in minutes.
 ---
 
 # Getting Started
@@ -15,11 +15,11 @@ description: Create your account, set up a project, and capture your first error
     },
     {
       title: 'Complete onboarding',
-      content: 'After signing up, follow the onboarding flow to create your organization and first project.',
+      content: 'After signing up, follow the onboarding flow to create your organization and first service.',
     },
     {
       title: 'Get your DSN',
-      content: "Once your project is created, you'll receive a DSN (Data Source Name). This is the connection string your SDK uses to send events to Moneat. It looks like:",
+      content: "Once your service is created, you'll receive a DSN (Data Source Name). This is the connection string your SDK uses to send events to Moneat. It looks like:",
     },
   ]}
 />
@@ -53,7 +53,7 @@ implementation("io.sentry:sentry-android:7.0.0")
 
 ## Configure the SDK
 
-Point the SDK to your Moneat instance by setting the DSN from your project settings.
+Point the SDK to your Moneat instance by setting the DSN from your service settings.
 
 **JavaScript**
 

--- a/dashboard/src/docs/pages/issue-tracking.mdx
+++ b/dashboard/src/docs/pages/issue-tracking.mdx
@@ -36,7 +36,7 @@ Clicking on an issue in the dashboard opens the detail view, which includes:
 The issues list supports several filtering options to help you focus on what matters:
 
 - **Status** - Filter by new, acknowledged, resolved, or ignored
-- **Project** - Show issues from specific projects
+- **Service** - Show issues from specific services
 - **Time range** - Filter by when issues were first or last seen
 - **Sort** - Sort by last seen, first seen, event count, or user count
 

--- a/dashboard/src/docs/pages/logging.mdx
+++ b/dashboard/src/docs/pages/logging.mdx
@@ -35,7 +35,7 @@ POST /api/{projectId}/logs/
 
 ## Searching Logs
 
-Navigate to your project's **Logs** tab to search and filter logs. The search interface supports:
+Navigate to **Logs** to search and filter logs for your services. The search interface supports:
 
 - **Full-text search** - Search across log messages
 - **Level filtering** - Filter by log level (debug, info, warn, error, fatal)

--- a/dashboard/src/docs/pages/product-analytics/funnels.mdx
+++ b/dashboard/src/docs/pages/product-analytics/funnels.mdx
@@ -15,7 +15,7 @@ A funnel is an ordered sequence of events (pageviews or custom events). Moneat c
 Step 1: Visit /pricing         →  1,200 visitors  (100%)
 Step 2: Click "Start Trial"    →    840 visitors   (70%)
 Step 3: Complete Signup        →    504 visitors   (42%)
-Step 4: First Project Created  →    302 visitors   (25.2%)
+Step 4: First Service Created  →    302 visitors   (25.2%)
 ```
 
 ### Key Concepts
@@ -111,7 +111,7 @@ Measures: Cart-to-purchase conversion rate and where buyers abandon.
 
 ```
 Step 1: Complete Signup
-Step 2: Create Project
+Step 2: Create Service
 Step 3: Install SDK
 Step 4: First Event Received
 ```

--- a/dashboard/src/docs/pages/product-analytics/index.mdx
+++ b/dashboard/src/docs/pages/product-analytics/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Privacy-focused, cookie-free web analytics for your projects. Track pageviews, visitors, and custom events without compromising user privacy.
+description: Privacy-focused, cookie-free web analytics for your services. Track pageviews, visitors, and custom events without compromising user privacy.
 ---
 
 # Product Analytics
@@ -53,9 +53,9 @@ Events are processed on ingestion: IP and User-Agent are used to derive the sess
 
 Get analytics running on your site in under a minute:
 
-### 1. Get your project key
+### 1. Get your service key
 
-Navigate to your project's **Settings** page in the Moneat dashboard. Your project's public key (the same one used for error monitoring) authenticates analytics events.
+Navigate to your service's **Settings** page in the Moneat dashboard. Your service public key (the same one used for error monitoring) authenticates analytics events.
 
 ### 2. Add the tracking script
 
@@ -63,7 +63,7 @@ Navigate to your project's **Settings** page in the Moneat dashboard. Your proje
 <script
   defer
   data-domain="yoursite.com"
-  data-key="your-project-public-key"
+  data-key="your-service-public-key"
   src="https://your-moneat-instance.com/js/m.js"
 ></script>
 ```

--- a/dashboard/src/docs/pages/product-analytics/setup.mdx
+++ b/dashboard/src/docs/pages/product-analytics/setup.mdx
@@ -15,7 +15,7 @@ Add the following to your website's `<head>`:
 <script
   defer
   data-domain="yoursite.com"
-  data-key="your-project-public-key"
+  data-key="your-service-public-key"
   src="https://your-moneat-instance.com/js/m.js"
 ></script>
 ```
@@ -27,7 +27,7 @@ That's it. The script automatically tracks pageviews, including client-side navi
 | Attribute | Required | Description |
 |-----------|----------|-------------|
 | `data-domain` | Yes | Your website's domain (e.g., `example.com`). Must match the domain you're tracking. |
-| `data-key` | Yes | Your Moneat project's public key. Found in **Project Settings**. |
+| `data-key` | Yes | Your Moneat service public key. Found in **Service settings**. |
 | `data-api` | No | Override the API host if the analytics API runs on a different domain than the script origin. |
 | `src` | Yes | URL to the tracking script served by your Moneat instance. |
 
@@ -57,7 +57,7 @@ import { init } from '@moneat/analytics'
 init({
   domain: 'yoursite.com',
   apiHost: 'https://your-moneat-instance.com',
-  key: 'your-project-public-key',
+  key: 'your-service-public-key',
 })
 ```
 
@@ -67,7 +67,7 @@ init({
 |--------|------|----------|-------------|
 | `domain` | `string` | Yes | Your website's domain |
 | `apiHost` | `string` | Yes | Your Moneat instance URL |
-| `key` | `string` | Yes | Project public key |
+| `key` | `string` | Yes | Service public key |
 | `trackLocalhost` | `boolean` | No | Track events on `localhost` (default: `false`) |
 | `hashMode` | `boolean` | No | Use hash-based routing instead of History API (default: `false`) |
 
@@ -82,7 +82,7 @@ import { init } from '@moneat/analytics'
 init({
   domain: 'yoursite.com',
   apiHost: 'https://your-moneat-instance.com',
-  key: 'your-project-public-key',
+  key: 'your-service-public-key',
 })
 ```
 
@@ -99,7 +99,7 @@ export default function RootLayout({ children }) {
         <Script
           defer
           data-domain="yoursite.com"
-          data-key="your-project-public-key"
+          data-key="your-service-public-key"
           src="https://your-moneat-instance.com/js/m.js"
           strategy="afterInteractive"
         />
@@ -120,15 +120,15 @@ export default defineNuxtPlugin(() => {
   init({
     domain: 'yoursite.com',
     apiHost: 'https://your-moneat-instance.com',
-    key: 'your-project-public-key',
+    key: 'your-service-public-key',
   })
 })
 ```
 
-## Finding Your Project Key
+## Finding Your Service Key
 
 1. Open the Moneat dashboard
-2. Navigate to your project's **Settings** page
+2. Navigate to your service's **Settings** page
 3. Copy the **Public Key** (also called the Sentry key)
 
 This is the same key used for error monitoring - one key for both features.

--- a/dashboard/src/docs/pages/sdk-setup.mdx
+++ b/dashboard/src/docs/pages/sdk-setup.mdx
@@ -17,7 +17,7 @@ Any platform with a Sentry SDK works with Moneat. This includes all major langua
 
 ## Finding Your DSN
 
-Your DSN (Data Source Name) is available in your project settings. Navigate to **Projects → [Your Project] → Settings** to find it. The DSN format is:
+Your DSN (Data Source Name) is available in your service settings. Navigate to **Sources / Ingestion → Service settings** to find it. The DSN format is:
 
 ```text
 https://<public_key>@api.moneat.io/api/<project_id>
@@ -25,7 +25,7 @@ https://<public_key>@api.moneat.io/api/<project_id>
 
 ## Platform-Specific Setup
 
-Select your platform below to see the setup steps. Replace `YOUR_DSN_HERE` with your project's DSN from the dashboard.
+Select your platform below to see the setup steps. Replace `YOUR_DSN_HERE` with your service DSN from the dashboard.
 
 <SdkSetup />
 
@@ -37,7 +37,7 @@ Moneat works with any Sentry SDK. For platforms not listed above, refer to the [
 
 These SDK options work across all platforms:
 
-- `dsn` - Your Moneat project DSN (required)
+- `dsn` - Your Moneat service DSN (required)
 - `release` - Your app version for release tracking
 - `environment` - Deployment environment (production, staging, etc.)
 - `tracesSampleRate` - Percentage of transactions to capture (0.0 to 1.0)

--- a/dashboard/src/docs/pages/sso-authentication.mdx
+++ b/dashboard/src/docs/pages/sso-authentication.mdx
@@ -30,7 +30,7 @@ GitHub OAuth lets your team sign in using their GitHub accounts. This is the eas
     },
     {
       title: 'Complete onboarding',
-      content: "If this is your first time, you'll be guided through creating your organization and first project.",
+      content: "If this is your first time, you'll be guided through creating your organization and first service.",
     },
   ]}
 />

--- a/dashboard/src/lib/__tests__/pricing-display-ext.test.ts
+++ b/dashboard/src/lib/__tests__/pricing-display-ext.test.ts
@@ -90,19 +90,19 @@ describe('pricing-display', () => {
       expect(model.includedLimits.some(l => l.includes('2 TB'))).toBe(true)
     })
 
-    it('shows unlimited projects when maxProjects is null', () => {
+    it('shows unlimited services when maxProjects is null', () => {
       const model = buildPricingCardModel(makeTier({ maxProjects: null }), 'monthly')
-      expect(model.includedLimits.some(l => l.includes('Unlimited projects'))).toBe(true)
+      expect(model.includedLimits.some(l => l.includes('Unlimited services'))).toBe(true)
     })
 
-    it('shows project count when maxProjects is set', () => {
+    it('shows service count when maxProjects is set', () => {
       const model = buildPricingCardModel(makeTier({ maxProjects: 5 }), 'monthly')
-      expect(model.includedLimits.some(l => l.includes('5 projects'))).toBe(true)
+      expect(model.includedLimits.some(l => l.includes('5 services'))).toBe(true)
     })
 
-    it('shows singular project for 1', () => {
+    it('shows singular service for 1', () => {
       const model = buildPricingCardModel(makeTier({ maxProjects: 1 }), 'monthly')
-      expect(model.includedLimits.some(l => l.includes('1 project') && !l.includes('projects'))).toBe(true)
+      expect(model.includedLimits.some(l => l.includes('1 service') && !l.includes('services'))).toBe(true)
     })
 
     it('shows monitor count and interval', () => {

--- a/dashboard/src/lib/__tests__/pricing-display.test.ts
+++ b/dashboard/src/lib/__tests__/pricing-display.test.ts
@@ -119,26 +119,26 @@ describe('pricing-display', () => {
     })
   })
 
-  describe('Project limit formatting', () => {
-    it('formats single project correctly', () => {
+  describe('Service limit formatting', () => {
+    it('formats single service correctly', () => {
       const tier = createBaseTier({ maxProjects: 1 })
       const model = buildPricingCardModel(tier, 'monthly')
 
-      expect(model.features).toContain('1 project')
+      expect(model.features).toContain('1 service')
     })
 
-    it('formats multiple projects correctly', () => {
+    it('formats multiple services correctly', () => {
       const tier = createBaseTier({ maxProjects: 10 })
       const model = buildPricingCardModel(tier, 'monthly')
 
-      expect(model.features).toContain('10 projects')
+      expect(model.features).toContain('10 services')
     })
 
-    it('formats unlimited projects when null', () => {
+    it('formats unlimited services when null', () => {
       const tier = createBaseTier({ maxProjects: null })
       const model = buildPricingCardModel(tier, 'monthly')
 
-      expect(model.features).toContain('Unlimited projects')
+      expect(model.features).toContain('Unlimited services')
     })
   })
 
@@ -215,7 +215,7 @@ describe('pricing-display', () => {
       // Included limits come first, then platform features
       expect(model.features[0]).toMatch(/GB ingestion/)
       expect(model.features[1]).toMatch(/day retention/)
-      expect(model.features[2]).toMatch(/project/)
+      expect(model.features[2]).toMatch(/service/)
       expect(model.features[3]).toMatch(/monitor/)
     })
   })

--- a/dashboard/src/lib/__tests__/service-facet-scope.test.ts
+++ b/dashboard/src/lib/__tests__/service-facet-scope.test.ts
@@ -14,7 +14,7 @@ import {
   serviceScopeKey,
 } from '../service-facet-scope'
 
-const projects = [
+const services = [
   {
     id: 1,
     resourceId: 'svc-api',
@@ -47,7 +47,7 @@ describe('service facet scope', () => {
 
   it('uses explicit included services minus exclusions', () => {
     expect(serviceNamesForQuery(
-      projects,
+      services,
       ['Worker Service', 'API Service', 'Worker Service'],
       ['API Service']
     )).toEqual(['Worker Service'])
@@ -55,22 +55,22 @@ describe('service facet scope', () => {
 
   it('deduplicates and sorts included services', () => {
     expect(serviceNamesForQuery(
-      projects,
+      services,
       ['Worker Service', 'API Service', 'Worker Service'],
       []
     )).toEqual(['API Service', 'Worker Service'])
   })
 
-  it('uses all projects when only exclusions are selected', () => {
+  it('uses all services when only exclusions are selected', () => {
     expect(serviceNamesForQuery(
-      projects,
+      services,
       [],
       ['Worker Service']
     )).toEqual(['API Service'])
   })
 
   it('returns no query services when no service filters are active', () => {
-    expect(serviceNamesForQuery(projects, [], [])).toEqual([])
+    expect(serviceNamesForQuery(services, [], [])).toEqual([])
   })
 
   it('builds stable scope keys', () => {
@@ -79,8 +79,8 @@ describe('service facet scope', () => {
     expect(serviceScopeKey(['API Service', 'Worker|Service'], true)).toBe('["API Service","Worker|Service"]')
   })
 
-  it('builds service rail options from projects', () => {
-    expect(serviceRailSections(projects)).toEqual([
+  it('builds service rail options from services', () => {
+    expect(serviceRailSections(services)).toEqual([
       {
         key: 'service',
         label: 'Service',
@@ -91,8 +91,8 @@ describe('service facet scope', () => {
   })
 
   it('resolves the first accessible service for legacy home queries', () => {
-    expect(primaryServiceResourceId(projects)).toBe('svc-api')
-    expect(hasAccessibleServices(projects)).toBe(true)
+    expect(primaryServiceResourceId(services)).toBe('svc-api')
+    expect(hasAccessibleServices(services)).toBe(true)
     expect(primaryServiceResourceId([])).toBeUndefined()
     expect(hasAccessibleServices([])).toBe(false)
   })

--- a/dashboard/src/lib/__tests__/telemetry-sources.test.ts
+++ b/dashboard/src/lib/__tests__/telemetry-sources.test.ts
@@ -2,10 +2,10 @@ import {describe, expect, it} from 'vitest'
 import {
   ALL_TELEMETRY_SOURCE_IDS,
   getTelemetrySourceStatus,
-  loadTelemetrySourceIdsForProject,
+  loadTelemetrySourceIdsForService,
   parseTelemetrySourceIds,
   serializeTelemetrySourceIds,
-  storeTelemetrySourceIdsForProject,
+  storeTelemetrySourceIdsForService,
   toggleTelemetrySourceId,
 } from '@/lib/telemetry-sources'
 
@@ -29,15 +29,15 @@ describe('telemetry-sources', () => {
     expect(toggleTelemetrySourceId(['opentelemetry'], 'opentelemetry')).toEqual(['opentelemetry'])
   })
 
-  it('stores source selections per project', () => {
-    storeTelemetrySourceIdsForProject(42, ['sentry-sdk', 'opentelemetry'])
-    expect(loadTelemetrySourceIdsForProject(42)).toEqual(['sentry-sdk', 'opentelemetry'])
-    expect(loadTelemetrySourceIdsForProject(43)).toEqual([])
+  it('stores source selections per service', () => {
+    storeTelemetrySourceIdsForService(42, ['sentry-sdk', 'opentelemetry'])
+    expect(loadTelemetrySourceIdsForService(42)).toEqual(['sentry-sdk', 'opentelemetry'])
+    expect(loadTelemetrySourceIdsForService(43)).toEqual([])
   })
 
-  it('reports Sentry-compatible SDK progress from project events', () => {
-    expect(getTelemetrySourceStatus('sentry-sdk', {projectEventCount: 0}).state).toBe('waiting')
-    expect(getTelemetrySourceStatus('sentry-sdk', {projectEventCount: 1}).state).toBe('receiving')
+  it('reports Sentry-compatible SDK progress from service events', () => {
+    expect(getTelemetrySourceStatus('sentry-sdk', {serviceEventCount: 0}).state).toBe('waiting')
+    expect(getTelemetrySourceStatus('sentry-sdk', {serviceEventCount: 1}).state).toBe('receiving')
   })
 
   it('reports OTLP-style progress from API key usage', () => {

--- a/dashboard/src/lib/pricing-display.ts
+++ b/dashboard/src/lib/pricing-display.ts
@@ -195,7 +195,7 @@ function buildIncludedLimits(tier: PricingCardTierInput): string[] {
     )
   }
 
-  limits.push(tier.maxProjects == null ? 'Unlimited projects' : `${tier.maxProjects} project${tier.maxProjects === 1 ? '' : 's'}`)
+  limits.push(tier.maxProjects == null ? 'Unlimited services' : `${tier.maxProjects} service${tier.maxProjects === 1 ? '' : 's'}`)
   limits.push(`${formatMonitorLimit(tier.maxSystems)} (${tier.monitorIntervalSeconds}s interval)`)
 
   // Analytics limits

--- a/dashboard/src/lib/service-facet-scope.ts
+++ b/dashboard/src/lib/service-facet-scope.ts
@@ -1,6 +1,8 @@
 import type {Issue, IssueListParams, Project} from '@/lib/api'
 import type {FacetFilter, FacetRailSection} from '@/lib/filters/types'
 
+type ServiceList = readonly Project[] | null | undefined
+
 export const HOME_OVERVIEW_ISSUES_QUERY = {
   page: 1,
   limit: 100,
@@ -22,11 +24,11 @@ export function facetValues(filters: readonly FacetFilter[], key: string, exclud
     .map((filter) => filter.value)
 }
 
-export function hasAccessibleServices(services: readonly Project[] | null | undefined): boolean {
+export function hasAccessibleServices(services: ServiceList): boolean {
   return (services?.length ?? 0) > 0
 }
 
-export function primaryServiceResourceId(services: readonly Project[] | null | undefined): string | undefined {
+export function primaryServiceResourceId(services: ServiceList): string | undefined {
   return services?.[0]?.resourceId
 }
 

--- a/dashboard/src/lib/service-facet-scope.ts
+++ b/dashboard/src/lib/service-facet-scope.ts
@@ -22,12 +22,12 @@ export function facetValues(filters: readonly FacetFilter[], key: string, exclud
     .map((filter) => filter.value)
 }
 
-export function hasAccessibleServices(projects: readonly Project[] | null | undefined): boolean {
-  return (projects?.length ?? 0) > 0
+export function hasAccessibleServices(services: readonly Project[] | null | undefined): boolean {
+  return (services?.length ?? 0) > 0
 }
 
-export function primaryServiceResourceId(projects: readonly Project[] | null | undefined): string | undefined {
-  return projects?.[0]?.resourceId
+export function primaryServiceResourceId(services: readonly Project[] | null | undefined): string | undefined {
+  return services?.[0]?.resourceId
 }
 
 export function issueDetailSearch(issue: Pick<Issue, 'projectResourceId'>): {projectId: string} {
@@ -35,7 +35,7 @@ export function issueDetailSearch(issue: Pick<Issue, 'projectResourceId'>): {pro
 }
 
 export function serviceNamesForQuery(
-  projects: readonly Project[],
+  services: readonly Project[],
   includedServices: readonly string[],
   excludedServices: readonly string[]
 ): string[] {
@@ -44,7 +44,7 @@ export function serviceNamesForQuery(
   const excluded = new Set(excludedServices)
   const candidates = includedServices.length > 0
     ? includedServices
-    : projects.map((project) => project.name)
+    : services.map((service) => service.name)
 
   return [...new Set(candidates)]
     .filter((service) => !excluded.has(service))
@@ -57,13 +57,13 @@ export function serviceScopeKey(serviceNames: readonly string[], hasServiceFilte
   return JSON.stringify(serviceNames)
 }
 
-export function serviceRailSections(projects: readonly Project[]): FacetRailSection[] {
+export function serviceRailSections(services: readonly Project[]): FacetRailSection[] {
   return [
     {
       key: 'service',
       label: 'Service',
       color: 'bg-primary',
-      options: projects.map((project) => ({value: project.name})),
+      options: services.map((service) => ({value: service.name})),
     },
   ]
 }

--- a/dashboard/src/lib/telemetry-sources.ts
+++ b/dashboard/src/lib/telemetry-sources.ts
@@ -38,7 +38,7 @@ export interface MonitorHostUsage {
 }
 
 export interface TelemetrySourceStatusInput {
-  projectEventCount?: number
+  serviceEventCount?: number
   otlpKeys?: KeyUsage[]
   agentKeys?: KeyUsage[]
   monitorHosts?: MonitorHostUsage[]
@@ -141,20 +141,25 @@ export function toggleTelemetrySourceId(
   return [...selectedSourceIds, sourceId]
 }
 
-export function telemetrySourcesStorageKey(projectId: string | number): string {
-  return `moneat:project:${projectId}:telemetry-sources`
+export function telemetrySourcesStorageKey(serviceId: string | number): string {
+  return `moneat:service:${serviceId}:telemetry-sources`
 }
 
-export function loadTelemetrySourceIdsForProject(projectId: string | number): TelemetrySourceId[] {
-  const rawValue = globalThis.localStorage?.getItem(telemetrySourcesStorageKey(projectId))
+function legacyTelemetrySourcesStorageKey(serviceId: string | number): string {
+  return `moneat:project:${serviceId}:telemetry-sources`
+}
+
+export function loadTelemetrySourceIdsForService(serviceId: string | number): TelemetrySourceId[] {
+  const rawValue = globalThis.localStorage?.getItem(telemetrySourcesStorageKey(serviceId)) ??
+    globalThis.localStorage?.getItem(legacyTelemetrySourcesStorageKey(serviceId))
   return parseTelemetrySourceIds(rawValue)
 }
 
-export function storeTelemetrySourceIdsForProject(
-  projectId: string | number,
+export function storeTelemetrySourceIdsForService(
+  serviceId: string | number,
   sourceIds: TelemetrySourceId[]
 ): void {
-  globalThis.localStorage?.setItem(telemetrySourcesStorageKey(projectId), serializeTelemetrySourceIds(sourceIds))
+  globalThis.localStorage?.setItem(telemetrySourcesStorageKey(serviceId), serializeTelemetrySourceIds(sourceIds))
 }
 
 export function getTelemetrySourceStatus(
@@ -162,11 +167,11 @@ export function getTelemetrySourceStatus(
   input: TelemetrySourceStatusInput
 ): TelemetrySourceStatus {
   if (sourceId === 'sentry-sdk') {
-    if ((input.projectEventCount ?? 0) > 0) {
+    if ((input.serviceEventCount ?? 0) > 0) {
       return {
         state: 'receiving',
         label: 'Receiving',
-        detail: 'Moneat has received project events.',
+        detail: 'Moneat has received service events.',
       }
     }
     return {

--- a/dashboard/src/routes/__tests__/analytics-index-service-facets.test.tsx
+++ b/dashboard/src/routes/__tests__/analytics-index-service-facets.test.tsx
@@ -216,7 +216,7 @@ describe('Analytics index service facets', () => {
     expect(screen.getByText('View Full Documentation')).toBeInTheDocument()
   })
 
-  it('renders the web setup state with fallback project identifiers', async () => {
+  it('renders the web setup state with fallback service identifiers', async () => {
     mockApi.getProjects.mockResolvedValue([{...mockProjects[0], dsn: 'not a valid url'}])
     mockApi.getAnalyticsOverview.mockResolvedValue({
       uniqueVisitors: 0,

--- a/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
@@ -60,7 +60,7 @@ import { Route as IssuesIndexRoute } from '../issues.index'
 const mockProject = {
   id: 1,
   resourceId: 'proj-1',
-  name: 'Test Project',
+  name: 'Test Service',
   slug: 'test-project',
   platform: 'javascript',
 }
@@ -378,8 +378,8 @@ describe('Issues Index - data coverage', () => {
 
     await screen.findByRole('textbox')
     // Creation/config moved to the sidebar + Configuration page.
-    expect(screen.queryByText('New Project')).not.toBeInTheDocument()
     expect(screen.queryByText('New Service')).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Project settings')).not.toBeInTheDocument()
+    expect(screen.queryByText('New Service')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Service settings')).not.toBeInTheDocument()
   })
 })

--- a/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
@@ -379,7 +379,7 @@ describe('Issues Index - data coverage', () => {
     await screen.findByRole('textbox')
     // Creation/config moved to the sidebar + Configuration page.
     expect(screen.queryByText('New Service')).not.toBeInTheDocument()
-    expect(screen.queryByText('New Service')).not.toBeInTheDocument()
+    expect(screen.queryByText('New Project')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Service settings')).not.toBeInTheDocument()
   })
 })

--- a/dashboard/src/routes/admin.billing.tsx
+++ b/dashboard/src/routes/admin.billing.tsx
@@ -1137,8 +1137,8 @@ function AdminBillingPage() {
               {/* Specs */}
               <div className="space-y-1.5">
                 <Label htmlFor="maxProjects">
-                  Max Projects
-                  <HelpTip text="Maximum number of projects an organization on this tier can create. Leave blank for unlimited." />
+                  Max Services
+                  <HelpTip text="Maximum number of services an organization on this tier can create. Leave blank for unlimited." />
                 </Label>
                 <Input
                   id="maxProjects"
@@ -1150,7 +1150,7 @@ function AdminBillingPage() {
                     setCreateForm((p) => ({...p, maxProjects: val}))
                   }}
                 />
-                <FieldHint>{createForm.maxProjects ? `${createForm.maxProjects} projects` : 'Unlimited projects'}</FieldHint>
+                <FieldHint>{createForm.maxProjects ? `${createForm.maxProjects} services` : 'Unlimited services'}</FieldHint>
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="maxSystems">
@@ -1909,7 +1909,7 @@ function AdminBillingPage() {
                 <p>Monthly Data Limit: {Math.round(targetTierConfig.monthlyGbLimit / BYTES_PER_GB)} GB</p>
                 <p>LLM Events: {formatQuotaLimit(targetTierConfig.monthlyLlmEventLimit ?? 0)}</p>
                 <p>Retention: {retentionSummary(targetTierConfig)}</p>
-                <p>Max Projects: {targetTierConfig.maxProjects ?? 'Unlimited'}</p>
+                <p>Max Services: {targetTierConfig.maxProjects ?? 'Unlimited'}</p>
                 <p>Max Systems: {targetTierConfig.maxSystems}</p>
                 <p>PAYG: {targetTierConfig.paygEnabled ? 'Enabled' : 'Disabled'}</p>
               </div>
@@ -2113,7 +2113,7 @@ function CreateConfigSummary({tier, form}: {tier: string; form: CreateFormState}
       <p><strong>Trial:</strong> {form.trialDays} day(s)</p>
       <p><strong>LLM Events:</strong> {formatQuotaLimit(form.monthlyLlmEventLimit)}</p>
       <p><strong>Retention:</strong> {createFormRetentionSummary(form)}</p>
-      <p><strong>Max Projects:</strong> {form.maxProjects || 'Unlimited'}</p>
+      <p><strong>Max Services:</strong> {form.maxProjects || 'Unlimited'}</p>
       <p><strong>Max Systems:</strong> {form.maxSystems}</p>
       <p><strong>Monitor Interval:</strong> {formatInterval(form.monitorIntervalSeconds)}</p>
       <p>
@@ -2242,7 +2242,7 @@ function ChangeSummary({
   const formMaxProjects = form.maxProjects.trim() ? Number(form.maxProjects) : null
   if (current.maxProjects !== formMaxProjects) {
     changes.push({
-      field: 'Max Projects',
+      field: 'Max Services',
       from: current.maxProjects != null ? String(current.maxProjects) : 'Unlimited',
       to: formMaxProjects != null ? String(formMaxProjects) : 'Unlimited',
     })

--- a/dashboard/src/routes/admin.notifications.tsx
+++ b/dashboard/src/routes/admin.notifications.tsx
@@ -96,7 +96,7 @@ const notificationTypes: Array<{
   {
     type: 'error_alert',
     label: 'Error Alert',
-    description: 'New error or exception detected in a project',
+    description: 'New error or exception detected in a service',
     icon: AlertCircle,
     supportsEmail: true,
     supportsSlack: true,

--- a/dashboard/src/routes/admin.organizations.$orgId.tsx
+++ b/dashboard/src/routes/admin.organizations.$orgId.tsx
@@ -526,7 +526,7 @@ function AdminOrgDetailPage() {
         </Card>
       )}
 
-      {/* Members & Projects */}
+      {/* Members & Services */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card>
           <CardHeader>
@@ -608,9 +608,9 @@ function AdminOrgDetailPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Projects</CardTitle>
+            <CardTitle className="text-base">Services</CardTitle>
             <CardDescription>
-              {org.projectCount} project{org.projectCount !== 1 ? 's' : ''}
+              {org.projectCount} service{org.projectCount !== 1 ? 's' : ''}
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -642,7 +642,7 @@ function AdminOrgDetailPage() {
                 </TableBody>
               </Table>
             ) : (
-              <EmptyState message="No projects" icon={FolderKanban} />
+              <EmptyState message="No services" icon={FolderKanban} />
             )}
           </CardContent>
         </Card>

--- a/dashboard/src/routes/admin.organizations.tsx
+++ b/dashboard/src/routes/admin.organizations.tsx
@@ -190,7 +190,7 @@ function AdminOrganizationsPage() {
                     <SortIndicator column="quota" sortBy={sortBy} sortDir={sortDir} />
                   </TableHead>
                   <TableHead className="text-right">Members</TableHead>
-                  <TableHead className="text-right">Projects</TableHead>
+                  <TableHead className="text-right">Services</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/dashboard/src/routes/admin.telemetry.tsx
+++ b/dashboard/src/routes/admin.telemetry.tsx
@@ -123,7 +123,7 @@ function AdminTelemetryPage() {
                   <TableHead className="text-xs">SSL</TableHead>
                   <TableHead className="text-xs text-right">CPU</TableHead>
                   <TableHead className="text-xs text-right">Memory</TableHead>
-                  <TableHead className="text-xs text-right">Projects</TableHead>
+                  <TableHead className="text-xs text-right">Services</TableHead>
                   <TableHead className="text-xs text-right">Users</TableHead>
                   <TableHead className="text-xs text-right">Events</TableHead>
                   <TableHead className="text-xs text-right">Issues</TableHead>

--- a/dashboard/src/routes/admin.users.tsx
+++ b/dashboard/src/routes/admin.users.tsx
@@ -411,7 +411,7 @@ function AdminUsersPage() {
               This action cannot be undone. This will permanently delete the selected {selectedUsers.size === 1 ? 'user' : 'users'} and all associated data including:
               <ul className="list-disc list-inside mt-2 space-y-1">
                 <li>Organizations (if they are the sole member)</li>
-                <li>Projects and project keys</li>
+                <li>Services and service keys</li>
                 <li>Auth tokens and sessions</li>
                 <li>Notification preferences</li>
                 <li>All related events and data</li>

--- a/dashboard/src/routes/alerting.tsx
+++ b/dashboard/src/routes/alerting.tsx
@@ -128,7 +128,7 @@ const config: FeaturePageConfig = {
     {icon: Mail, title: 'Email Alerts', description: 'Detailed email notifications with error context, stack traces, and direct links to investigate.', iconColor: 'text-blue-400'},
     {icon: Phone, title: 'Phone & SMS', description: 'Critical alerts that call or text the on-call responder when immediate attention is needed.', iconColor: 'text-amber-400'},
     {icon: Filter, title: 'Alert Rules', description: 'Configure alert thresholds on error rates, log patterns, uptime, or any metric you track.', iconColor: 'text-violet-400'},
-    {icon: Workflow, title: 'Routing Rules', description: 'Route different alert types to different channels and teams based on project, severity, or tags.', iconColor: 'text-cyan-400'},
+    {icon: Workflow, title: 'Routing Rules', description: 'Route different alert types to different channels and teams based on service, severity, or tags.', iconColor: 'text-cyan-400'},
     {icon: Bell, title: 'Digest & Dedup', description: 'Group related alerts together to avoid notification fatigue during incident storms.', iconColor: 'text-green-400'},
   ],
   heroVisual: <AlertingHero />,

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -3,6 +3,7 @@ import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {useAnalyticsParams} from '@/contexts/UseAnalyticsParams'
+import {serviceNamesForQuery} from '@/lib/service-facet-scope'
 import {AnalyticsFilterBar} from '@/components/analytics/AnalyticsFilterBar'
 import {AnalyticsKpiCards, AnalyticsKpiCardsSkeleton} from '@/components/analytics/AnalyticsKpiCards'
 import {AnalyticsChart} from '@/components/analytics/AnalyticsChart'
@@ -44,21 +45,6 @@ function facetValues(filters: readonly FacetFilter[], key: string, exclude: bool
   return filters
     .filter((filter) => filter.key === key && Boolean(filter.exclude) === exclude)
     .map((filter) => filter.value)
-}
-
-function serviceNamesForQuery(
-  services: readonly Project[],
-  includedServices: readonly string[],
-  excludedServices: readonly string[]
-): string[] {
-  if (includedServices.length === 0 && excludedServices.length === 0) return []
-
-  const excluded = new Set(excludedServices)
-  const candidates = includedServices.length > 0
-    ? includedServices
-    : services.map((service) => service.name)
-
-  return candidates.filter((service) => !excluded.has(service))
 }
 
 function analyticsScopeKey(serviceNames: readonly string[], hasServiceFilters: boolean): string {

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -47,7 +47,7 @@ function facetValues(filters: readonly FacetFilter[], key: string, exclude: bool
 }
 
 function serviceNamesForQuery(
-  projects: readonly Project[],
+  services: readonly Project[],
   includedServices: readonly string[],
   excludedServices: readonly string[]
 ): string[] {
@@ -56,7 +56,7 @@ function serviceNamesForQuery(
   const excluded = new Set(excludedServices)
   const candidates = includedServices.length > 0
     ? includedServices
-    : projects.map((project) => project.name)
+    : services.map((service) => service.name)
 
   return candidates.filter((service) => !excluded.has(service))
 }
@@ -71,9 +71,9 @@ function analyticsServiceParams(serviceNames: readonly string[]): Pick<Analytics
   return serviceNames.length > 0 ? {services: [...serviceNames]} : {}
 }
 
-function findSetupProject(projects: readonly Project[], serviceNames: readonly string[]): Project | undefined {
-  if (serviceNames.length === 0) return projects[0]
-  return projects.find((project) => project.name === serviceNames[0]) ?? projects[0]
+function findSetupService(services: readonly Project[], serviceNames: readonly string[]): Project | undefined {
+  if (serviceNames.length === 0) return services[0]
+  return services.find((service) => service.name === serviceNames[0]) ?? services[0]
 }
 
 function AnalyticsOverview() {
@@ -83,12 +83,12 @@ function AnalyticsOverview() {
   const [breakdownTab, setBreakdownTab] = useState('pages')
   const [analyticsTab, setAnalyticsTab] = useState('web')
 
-  const {data: projects, isLoading: projectsLoading, error: projectsError} = useQuery({
+  const {data: services, isLoading: servicesLoading, error: servicesError} = useQuery({
     queryKey: ['projects'],
     queryFn: () => api.getProjects(),
   })
 
-  const projectList = projects ?? []
+  const serviceList = services ?? []
   const includedServices = useMemo(
     () => facetValues(facetFilters, 'service', false),
     [facetFilters]
@@ -99,13 +99,13 @@ function AnalyticsOverview() {
   )
   const hasServiceFilters = includedServices.length > 0 || excludedServices.length > 0
   const serviceNames = useMemo(
-    () => serviceNamesForQuery(projectList, includedServices, excludedServices),
-    [projectList, includedServices, excludedServices]
+    () => serviceNamesForQuery(serviceList, includedServices, excludedServices),
+    [serviceList, includedServices, excludedServices]
   )
   const scopeKey = analyticsScopeKey(serviceNames, hasServiceFilters)
-  const hasAnalyticsScope = projectList.length > 0 && (!hasServiceFilters || serviceNames.length > 0)
+  const hasAnalyticsScope = serviceList.length > 0 && (!hasServiceFilters || serviceNames.length > 0)
   const serviceParams = useMemo(() => analyticsServiceParams(serviceNames), [serviceNames])
-  const setupProject = findSetupProject(projectList, serviceNames)
+  const setupService = findSetupService(serviceList, serviceNames)
 
   const dateParams = useMemo((): AnalyticsParams => ({
     period,
@@ -135,10 +135,10 @@ function AnalyticsOverview() {
         key: 'service',
         label: 'Service',
         color: 'bg-primary',
-        options: projectList.map((project) => ({value: project.name})),
+        options: serviceList.map((service) => ({value: service.name})),
       },
     ],
-    [projectList]
+    [serviceList]
   )
 
   const {data: overview, isLoading: overviewLoading} = useQuery({
@@ -232,19 +232,19 @@ function AnalyticsOverview() {
     setFilters([...filters, {property, operator: 'is', value: item.name}])
   }
 
-  if (projectsLoading) {
+  if (servicesLoading) {
     return <div className="p-8 text-sm text-muted-foreground">Loading analytics...</div>
   }
 
-  if (projectsError) {
+  if (servicesError) {
     return (
       <div className="p-8 text-destructive">
-        Failed to load services: {projectsError instanceof Error ? projectsError.message : 'Unknown error'}
+        Failed to load services: {servicesError instanceof Error ? servicesError.message : 'Unknown error'}
       </div>
     )
   }
 
-  if (projectList.length === 0) {
+  if (serviceList.length === 0) {
     return (
       <div className="py-10">
         <EmptyState
@@ -288,7 +288,7 @@ function AnalyticsOverview() {
 
             <TabsContent value="web" className="mt-2 space-y-2">
               {!overviewLoading && !hasWebAnalytics ? (
-                <WebAnalyticsEmptyState project={setupProject} />
+                <WebAnalyticsEmptyState service={setupService} />
               ) : (
                 <>
                   <AnalyticsFilterBar filters={filters} onFiltersChange={setFilters} />
@@ -447,8 +447,8 @@ function AnalyticsOverview() {
                 <ProductAnalyticsTab scopeId={ORGANIZATION_ANALYTICS_SCOPE} params={productParams} />
               ) : (
                 <ProductAnalyticsEmptyState
-                  project={setupProject}
-                  projectId={setupProject?.resourceId ?? 'your-service-id'}
+                  service={setupService}
+                  serviceId={setupService?.resourceId ?? 'your-service-id'}
                 />
               )}
             </TabsContent>
@@ -459,9 +459,9 @@ function AnalyticsOverview() {
   )
 }
 
-function WebAnalyticsEmptyState({project}: {project?: Project}) {
-  const scriptHost = getProjectApiHost(project)
-  const publicKey = getProjectPublicKey(project)
+function WebAnalyticsEmptyState({service}: {service?: Project}) {
+  const scriptHost = getServiceApiHost(service)
+  const publicKey = getServicePublicKey(service)
   const scriptCode = `<script
   defer
   data-domain="yoursite.com"
@@ -511,14 +511,14 @@ function WebAnalyticsEmptyState({project}: {project?: Project}) {
   )
 }
 
-function getProjectPublicKey(project?: Project): string {
-  if (!project?.dsn) return 'your-project-public-key'
+function getServicePublicKey(service?: Project): string {
+  if (!service?.dsn) return 'your-service-public-key'
 
   try {
-    const url = new URL(project.dsn)
-    return url.username || 'your-project-public-key'
+    const url = new URL(service.dsn)
+    return url.username || 'your-service-public-key'
   } catch {
-    return 'your-project-public-key'
+    return 'your-service-public-key'
   }
 }
 
@@ -677,9 +677,9 @@ function ProductFunnelResults({
   )
 }
 
-function ProductAnalyticsEmptyState({project, projectId}: {project?: Project; projectId: string}) {
-  const apiHost = getProjectApiHost(project)
-  const endpoint = `${apiHost}/v1/analytics/${projectId}/events`
+function ProductAnalyticsEmptyState({service, serviceId}: {service?: Project; serviceId: string}) {
+  const apiHost = getServiceApiHost(service)
+  const endpoint = `${apiHost}/v1/analytics/${serviceId}/events`
   const nodeCode = `await fetch('${endpoint}', {
   method: 'POST',
   headers: {
@@ -754,11 +754,11 @@ function ProductAnalyticsEmptyState({project, projectId}: {project?: Project; pr
   )
 }
 
-function getProjectApiHost(project?: Project): string {
-  if (!project?.dsn) return 'https://your-moneat-instance.com'
+function getServiceApiHost(service?: Project): string {
+  if (!service?.dsn) return 'https://your-moneat-instance.com'
 
   try {
-    const url = new URL(project.dsn)
+    const url = new URL(service.dsn)
     return `${url.protocol}//${url.host}`
   } catch {
     return 'https://your-moneat-instance.com'

--- a/dashboard/src/routes/analytics.tsx
+++ b/dashboard/src/routes/analytics.tsx
@@ -15,13 +15,13 @@ export const Route = createFileRoute('/analytics')({
 function AnalyticsLayoutInner() {
   const {period, setPeriod, customFrom, customTo, onCustomRangeChange} = useAnalyticsParams()
 
-  const {data: projects} = useQuery({
+  const {data: services} = useQuery({
     queryKey: ['projects'],
     queryFn: () => api.getProjects(),
   })
 
-  const projectId = primaryServiceResourceId(projects)
-  const project = projects?.find(p => p.resourceId === projectId)
+  const serviceId = primaryServiceResourceId(services)
+  const service = services?.find((candidate) => candidate.resourceId === serviceId)
 
   return (
     <div className="p-3 space-y-2">
@@ -33,7 +33,7 @@ function AnalyticsLayoutInner() {
           <div>
             <h1 className="text-lg font-semibold leading-tight">Analytics</h1>
             <p className="text-muted-foreground text-xs">
-              {project ? `${project.name} — ` : ''}Privacy-focused web analytics
+              {service ? `${service.name} — ` : ''}Privacy-focused web analytics
             </p>
           </div>
         </div>
@@ -46,7 +46,7 @@ function AnalyticsLayoutInner() {
             customTo={customTo}
             onCustomRangeChange={onCustomRangeChange}
           />
-          {projectId && <AnalyticsRealtimeBadge projectId={projectId} />}
+          {serviceId && <AnalyticsRealtimeBadge serviceId={serviceId} />}
         </div>
       </div>
 

--- a/dashboard/src/routes/configuration.tsx
+++ b/dashboard/src/routes/configuration.tsx
@@ -28,8 +28,8 @@ import {TelemetrySourcePicker} from '@/components/projects/TelemetrySourcePicker
 import {ServiceSettingsCard} from '@/components/projects/ServiceSettingsCard'
 import {
   DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS,
-  loadTelemetrySourceIdsForProject,
-  storeTelemetrySourceIdsForProject,
+  loadTelemetrySourceIdsForService,
+  storeTelemetrySourceIdsForService,
   type TelemetrySourceId,
 } from '@/lib/telemetry-sources'
 
@@ -44,17 +44,17 @@ export const Route = createFileRoute('/configuration')({
 
 // Creation is owned by the sidebar's shared dialog — Configuration just opens it.
 function openCreateServiceDialog() {
-  globalThis.dispatchEvent(new CustomEvent('open-create-project-dialog'))
+  globalThis.dispatchEvent(new CustomEvent('open-create-service-dialog'))
 }
 
 function loadSourcesForService(serviceId: string | null): TelemetrySourceId[] {
   if (!serviceId) return DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS
-  const stored = loadTelemetrySourceIdsForProject(serviceId)
+  const stored = loadTelemetrySourceIdsForService(serviceId)
   return stored.length > 0 ? stored : DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS
 }
 
 function ConfigurationPage() {
-  const {data: projects, isLoading} = useQuery({
+  const {data: services, isLoading} = useQuery({
     queryKey: ['projects'],
     queryFn: () => api.getProjects(),
     enabled: api.isAuthenticated(),
@@ -63,11 +63,11 @@ function ConfigurationPage() {
   // Local service selection for this page only.
   const [chosenId, setChosenId] = useState<string | null>(null)
   const selectedId = useMemo(() => {
-    if (!projects || projects.length === 0) return null
-    const ids = projects.map((project) => project.resourceId)
+    if (!services || services.length === 0) return null
+    const ids = services.map((service) => service.resourceId)
     if (chosenId && ids.includes(chosenId)) return chosenId
-    return projects[0].resourceId
-  }, [projects, chosenId])
+    return services[0].resourceId
+  }, [services, chosenId])
 
   // Telemetry-source selection for the chosen service, persisted to localStorage.
   // Reload (without an effect) whenever the selected service changes.
@@ -80,7 +80,7 @@ function ConfigurationPage() {
 
   const handleSourcesChange = (next: TelemetrySourceId[]) => {
     setSources(next)
-    if (selectedId) storeTelemetrySourceIdsForProject(selectedId, next)
+    if (selectedId) storeTelemetrySourceIdsForService(selectedId, next)
   }
 
   return (
@@ -99,7 +99,7 @@ function ConfigurationPage() {
 
       {isLoading ? (
         <p className="text-sm text-muted-foreground">Loading services…</p>
-      ) : !projects || projects.length === 0 ? (
+      ) : !services || services.length === 0 ? (
         <EmptyState
           icon={SlidersHorizontal}
           title="No services yet"
@@ -121,9 +121,9 @@ function ConfigurationPage() {
               onChange={(event) => setChosenId(event.target.value)}
               className="h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
             >
-              {projects.map((project) => (
-                <option key={project.resourceId} value={project.resourceId}>
-                  {project.name}
+              {services.map((service) => (
+                <option key={service.resourceId} value={service.resourceId}>
+                  {service.name}
                 </option>
               ))}
             </select>
@@ -145,7 +145,7 @@ function ConfigurationPage() {
 
               <ServiceSettingsCard
                 key={selectedId}
-                projectId={selectedId}
+                serviceId={selectedId}
                 sourceIds={sources}
                 onDeleted={() => setChosenId(null)}
               />

--- a/dashboard/src/routes/error-tracking.tsx
+++ b/dashboard/src/routes/error-tracking.tsx
@@ -89,7 +89,7 @@ const config: FeaturePageConfig = {
   tagline: 'Triage production exceptions',
   description:
     'Catch, group, and triage errors with smart fingerprinting. See full stack traces, breadcrumbs, and user ' +
-    'context for every exception across all your projects. Works with Sentry-compatible SDKs.',
+    'context for every exception across all your services. Works with Sentry-compatible SDKs.',
   metaDescription: pageSeo.metaDescription,
   icon: Activity,
   iconColor: 'text-sky-400',

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -146,7 +146,7 @@ function facetValues(filters: readonly FacetFilter[], key: string, exclude: bool
 }
 
 function serviceNamesForQuery(
-  projects: readonly Project[],
+  services: readonly Project[],
   includedServices: readonly string[],
   excludedServices: readonly string[]
 ): string[] {
@@ -155,7 +155,7 @@ function serviceNamesForQuery(
   const excluded = new Set(excludedServices)
   const candidates = includedServices.length > 0
     ? includedServices
-    : projects.map((project) => project.name)
+    : services.map((service) => service.name)
 
   return candidates.filter((service) => !excluded.has(service))
 }
@@ -164,20 +164,20 @@ function serverStatusFilter(statusIncludes: readonly string[], statusExcludes: r
   return statusIncludes.length === 1 && statusExcludes.length === 0 ? statusIncludes[0] : undefined
 }
 
-function projectMaps(projects: readonly Project[]): {
+function serviceNameMaps(services: readonly Project[]): {
   byResourceId: Map<string, string>
   byId: Map<string, string>
 } {
   return {
-    byResourceId: new Map(projects.map((project) => [project.resourceId, project.name])),
-    byId: new Map(projects.map((project) => [String(project.id), project.name])),
+    byResourceId: new Map(services.map((service) => [service.resourceId, service.name])),
+    byId: new Map(services.map((service) => [String(service.id), service.name])),
   }
 }
 
 function toSafeIssue(
   issue: Issue,
-  projectsByResourceId: ReadonlyMap<string, string>,
-  projectsById: ReadonlyMap<string, string>
+  servicesByResourceId: ReadonlyMap<string, string>,
+  servicesById: ReadonlyMap<string, string>
 ): SafeIssue | null {
   const id = toSafeId(issue.id)
   if (!id) return null
@@ -186,8 +186,8 @@ function toSafeIssue(
   if (!projectResourceId) return null
 
   const service =
-    projectsByResourceId.get(projectResourceId) ??
-    projectsById.get(toSafeId(issue.projectId)) ??
+    servicesByResourceId.get(projectResourceId) ??
+    servicesById.get(toSafeId(issue.projectId)) ??
     projectResourceId
 
   return {
@@ -315,11 +315,11 @@ function DashboardPage() {
   const { toast } = useToast()
   const queryClient = useQueryClient()
 
-  const { data: projects, isLoading, isError: projectsError, error: projectsErrorObj } = useQuery({
+  const { data: services, isLoading, isError: servicesError, error: servicesErrorObj } = useQuery({
     queryKey: ['projects'],
     queryFn: () => api.getProjects(),
   })
-  const hasProjects = (projects?.length ?? 0) > 0
+  const hasServices = (services?.length ?? 0) > 0
 
   const effectiveFacetFilters = facetFilters
   const includedServices = useMemo(
@@ -348,10 +348,10 @@ function DashboardPage() {
   )
   const serviceFiltersActive = includedServices.length > 0 || excludedServices.length > 0
   const selectedServices = useMemo(
-    () => serviceNamesForQuery(projects ?? [], includedServices, excludedServices),
-    [excludedServices, includedServices, projects]
+    () => serviceNamesForQuery(services ?? [], includedServices, excludedServices),
+    [excludedServices, includedServices, services]
   )
-  const issuesQueryEnabled = hasProjects && (!serviceFiltersActive || selectedServices.length > 0)
+  const issuesQueryEnabled = hasServices && (!serviceFiltersActive || selectedServices.length > 0)
   const statusParam = serverStatusFilter(statusIncludes, statusExcludes)
 
   const {
@@ -509,15 +509,15 @@ function DashboardPage() {
     resolveNextReleaseMutation.mutate(selectedIssueTargets)
   }
 
-  const {byResourceId: projectNameByResourceId, byId: projectNameById} = useMemo(
-    () => projectMaps(projects ?? []),
-    [projects]
+  const {byResourceId: serviceNameByResourceId, byId: serviceNameById} = useMemo(
+    () => serviceNameMaps(services ?? []),
+    [services]
   )
   const safeIssues = useMemo(
     () => organizationIssues
-      .map((issue) => toSafeIssue(issue, projectNameByResourceId, projectNameById))
+      .map((issue) => toSafeIssue(issue, serviceNameByResourceId, serviceNameById))
       .filter((issue): issue is SafeIssue => issue !== null),
-    [organizationIssues, projectNameById, projectNameByResourceId]
+    [organizationIssues, serviceNameById, serviceNameByResourceId]
   )
 
   const safeIssuesByKey = useMemo(() => {
@@ -570,17 +570,17 @@ function DashboardPage() {
     setPage(1)
   }
 
-  const projectNames = useMemo(() => (projects ?? []).map((p) => p.name), [projects])
+  const serviceNames = useMemo(() => (services ?? []).map((service) => service.name), [services])
   const issueSchema: FacetSchema = useMemo(
     () => [
-      {key: 'service', suggestions: projectNames},
+      {key: 'service', suggestions: serviceNames},
       {
         key: 'status',
         suggestions: ['unresolved', 'resolved', 'ignored', 'resolvedInNextRelease'],
       },
       {key: 'level', suggestions: ['error', 'warning', 'fatal', 'info', 'debug']},
     ],
-    [projectNames]
+    [serviceNames]
   )
   const issueRailSections: FacetRailSection[] = useMemo(
     () => [
@@ -588,7 +588,7 @@ function DashboardPage() {
         key: 'service',
         label: 'Service',
         color: 'bg-primary',
-        options: (projects ?? []).map((p) => ({value: p.name})),
+        options: (services ?? []).map((service) => ({value: service.name})),
       },
       {
         key: 'status',
@@ -614,18 +614,18 @@ function DashboardPage() {
         ],
       },
     ],
-    [projects]
+    [services]
   )
 
   if (isLoading) return <div className="p-8">Loading...</div>
 
-  if (projectsError) return (
+  if (servicesError) return (
     <div className="p-8 text-destructive">
-      Failed to load projects: {projectsErrorObj instanceof Error ? projectsErrorObj.message : 'Unknown error'}
+      Failed to load services: {servicesErrorObj instanceof Error ? servicesErrorObj.message : 'Unknown error'}
     </div>
   )
 
-  if (!hasProjects) {
+  if (!hasServices) {
     return (
       <div className="px-6 py-4">
         <Card className="p-12 text-center border-primary/20 bg-gradient-to-b from-card to-primary/5">
@@ -645,7 +645,7 @@ function DashboardPage() {
               <Button
                 size="lg"
                 className="w-full max-w-sm sm:w-auto sm:mx-auto"
-                onClick={() => globalThis.dispatchEvent(new CustomEvent('open-create-project-dialog'))}
+                onClick={() => globalThis.dispatchEvent(new CustomEvent('open-create-service-dialog'))}
               >
                 <Plus className="h-4 w-4" />
                 Create your first service

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -20,6 +20,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import type {ApmErrorGroup, ApmTimeRange, Issue, Project} from '@/lib/api'
 import {trackEvent} from '@/lib/analytics'
+import {serviceNamesForQuery} from '@/lib/service-facet-scope'
 import {formatRelativeTime, cn} from '@/lib/utils'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
@@ -143,21 +144,6 @@ function facetValues(filters: readonly FacetFilter[], key: string, exclude: bool
   return filters
     .filter((filter) => filter.key === key && Boolean(filter.exclude) === exclude)
     .map((filter) => filter.value)
-}
-
-function serviceNamesForQuery(
-  services: readonly Project[],
-  includedServices: readonly string[],
-  excludedServices: readonly string[]
-): string[] {
-  if (includedServices.length === 0 && excludedServices.length === 0) return []
-
-  const excluded = new Set(excludedServices)
-  const candidates = includedServices.length > 0
-    ? includedServices
-    : services.map((service) => service.name)
-
-  return candidates.filter((service) => !excluded.has(service))
 }
 
 function serverStatusFilter(statusIncludes: readonly string[], statusExcludes: readonly string[]): string | undefined {

--- a/dashboard/src/routes/onboarding.tsx
+++ b/dashboard/src/routes/onboarding.tsx
@@ -27,12 +27,12 @@ import {Logo} from '@/components/Logo'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
 import {Copy, Check, AlertCircle, Loader2, ArrowRight} from 'lucide-react'
 import {
-  ProjectSetupForm,
-  type ProjectSetupSubmission,
-} from '@/components/projects/ProjectSetupForm'
+  ServiceSetupForm,
+  type ServiceSetupSubmission,
+} from '@/components/projects/ServiceSetupForm'
 import {
   serializeTelemetrySourceIds,
-  storeTelemetrySourceIdsForProject,
+  storeTelemetrySourceIdsForService,
 } from '@/lib/telemetry-sources'
 import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
 
@@ -74,7 +74,7 @@ function generateSlug(name: string): string {
     .substring(0, 100)
 }
 
-type OnboardingStep = 'org' | 'project'
+type OnboardingStep = 'org' | 'service'
 
 const ONBOARDING_SHELL_CLASS_NAME = 'flex min-h-dvh justify-center overflow-y-auto bg-background px-4 py-8 sm:py-12'
 const ONBOARDING_CARD_CLASS_NAME = 'my-auto w-full'
@@ -96,8 +96,8 @@ function OnboardingPage() {
   const [checkingSlug, setCheckingSlug] = useState(false)
   const [slugAvailable, setSlugAvailable] = useState<boolean | null>(null)
 
-  // Project step state
-  const [projectError, setProjectError] = useState('')
+  // Service step state
+  const [serviceError, setServiceError] = useState('')
 
   // Auto-generate slug from org name
   useEffect(() => {
@@ -178,13 +178,13 @@ function OnboardingPage() {
     setLoading(true)
     try {
       // Retrieve UTM parameters from localStorage
-      const utmParamsStr = localStorage.getItem('utm_params')
+      const utmParamsStr = globalThis.localStorage.getItem('utm_params')
       let utmParams: Record<string, string | undefined> = {}
       if (utmParamsStr) {
         try {
           utmParams = JSON.parse(utmParamsStr) as Record<string, string | undefined>
         } catch {
-          localStorage.removeItem('utm_params')
+          globalThis.localStorage.removeItem('utm_params')
         }
       }
       
@@ -201,42 +201,42 @@ function OnboardingPage() {
       })
       
       // Clean up UTM params after successful onboarding
-      localStorage.removeItem('utm_params')
+      globalThis.localStorage.removeItem('utm_params')
       trackEvent('Onboarding Complete', { company_size: companySize })
       
-      setStep('project')
+      setStep('service')
     } catch {
       setError('Failed to complete onboarding. Please try again.')
       setLoading(false)
     }
   }
 
-  const createProjectMutation = useMutation({
-    mutationFn: (data: ProjectSetupSubmission) =>
+  const createServiceMutation = useMutation({
+    mutationFn: (data: ServiceSetupSubmission) =>
       api.createProject(data.name, data.framework, data.targets),
-    onSuccess: (project, submission) => {
-      storeTelemetrySourceIdsForProject(project.resourceId, submission.sourceIds)
-      trackEvent('Onboarding Project Create', {
-        framework: project.framework || 'none',
+    onSuccess: (service, submission) => {
+      storeTelemetrySourceIdsForService(service.resourceId, submission.sourceIds)
+      trackEvent('Onboarding Service Create', {
+        framework: service.framework || 'none',
         sources: serializeTelemetrySourceIds(submission.sourceIds),
       })
       queryClient.invalidateQueries({ queryKey: ['projects'] })
       navigate({
         to: '/projects/$projectId',
-        params: { projectId: project.resourceId },
+        params: { projectId: service.resourceId },
         search: { sources: serializeTelemetrySourceIds(submission.sourceIds) },
       })
     },
     onError: (error: Error) => {
       if (error.message.includes('already exists')) {
-        setProjectError('A project with this name already exists. Please choose a different name.')
+        setServiceError('A service with this name already exists. Please choose a different name.')
       } else {
-        setProjectError(error.message || 'Failed to create project. Please try again.')
+        setServiceError(error.message || 'Failed to create service. Please try again.')
       }
     },
   })
 
-  if (step === 'project') {
+  if (step === 'service') {
     return (
       <div className={ONBOARDING_SHELL_CLASS_NAME}>
         <Card className={`${ONBOARDING_CARD_CLASS_NAME} max-w-3xl`}>
@@ -245,24 +245,24 @@ function OnboardingPage() {
               <Logo className="h-10" />
             </div>
             <div>
-              <CardTitle className="text-2xl">Create Your First Project</CardTitle>
+              <CardTitle className="text-2xl">Create Your First Service</CardTitle>
               <CardDescription className="mt-1">
                 Pick the application and telemetry sources you want to connect first.
               </CardDescription>
             </div>
           </CardHeader>
           <CardContent>
-            <ProjectSetupForm
+            <ServiceSetupForm
               autoFocus
-              error={projectError}
-              isSubmitting={createProjectMutation.isPending}
+              error={serviceError}
+              isSubmitting={createServiceMutation.isPending}
               submittingLabel="Creating..."
-              submitLabel="Create Project"
+              submitLabel="Create Service"
               cancelLabel="Skip for now"
               onCancel={() => navigate({ to: '/', search: APP_OVERVIEW_SEARCH })}
               onSubmit={(submission) => {
-                setProjectError('')
-                createProjectMutation.mutate(submission)
+                setServiceError('')
+                createServiceMutation.mutate(submission)
               }}
             />
           </CardContent>

--- a/dashboard/src/routes/projects.$projectId.settings.tsx
+++ b/dashboard/src/routes/projects.$projectId.settings.tsx
@@ -20,7 +20,7 @@ import {api} from '@/lib/api'
 import {ServiceSettingsCard} from '@/components/projects/ServiceSettingsCard'
 import {
   DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS,
-  loadTelemetrySourceIdsForProject,
+  loadTelemetrySourceIdsForService,
 } from '@/lib/telemetry-sources'
 
 export const Route = createFileRoute('/projects/$projectId/settings')({
@@ -30,15 +30,15 @@ export const Route = createFileRoute('/projects/$projectId/settings')({
     }
   },
   loader: async ({params}) => {
-    const project = await api.getProject(params.projectId)
-    return {project}
+    const service = await api.getProject(params.projectId)
+    return {service}
   },
-  component: ProjectSettingsPage,
+  component: ServiceSettingsPage,
 })
 
-function ProjectSettingsPage() {
-  const {project} = Route.useLoaderData()
-  const stored = loadTelemetrySourceIdsForProject(project.resourceId)
+function ServiceSettingsPage() {
+  const {service} = Route.useLoaderData()
+  const stored = loadTelemetrySourceIdsForService(service.resourceId)
   const sourceIds = stored.length > 0 ? stored : DEFAULT_SELECTED_TELEMETRY_SOURCE_IDS
 
   return (
@@ -47,7 +47,7 @@ function ProjectSettingsPage() {
         <div className="space-y-2">
           <Link
             to="/projects/$projectId"
-            params={{projectId: project.resourceId}}
+            params={{projectId: service.resourceId}}
             className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
             <ArrowLeft className="h-4 w-4" />
@@ -59,7 +59,7 @@ function ProjectSettingsPage() {
           </div>
         </div>
 
-        <ServiceSettingsCard projectId={project.resourceId} sourceIds={sourceIds} />
+        <ServiceSettingsCard serviceId={service.resourceId} sourceIds={sourceIds} />
       </div>
     </div>
   )

--- a/dashboard/src/routes/projects.$projectId.spans.$spanId.tsx
+++ b/dashboard/src/routes/projects.$projectId.spans.$spanId.tsx
@@ -48,7 +48,7 @@ function SpanDetailPage() {
       <div className="p-6 space-y-4">
         <div className="text-destructive font-semibold">Span not found</div>
         <p className="text-muted-foreground text-sm">
-          The span <span className="font-mono">{spanId}</span> could not be found in project {projectId}.
+          The span <span className="font-mono">{spanId}</span> could not be found in service {projectId}.
         </p>
         <p className="text-muted-foreground text-sm">
           This could happen if:

--- a/dashboard/src/routes/projects.$projectId.tsx
+++ b/dashboard/src/routes/projects.$projectId.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute, Outlet, redirect, useRouterState} from '@tanstack/react-router'
 import {api} from '@/lib/api'
-import {ProjectTelemetrySetupHub} from '@/components/projects/ProjectTelemetrySetupHub'
+import {ServiceTelemetrySetupHub} from '@/components/projects/ServiceTelemetrySetupHub'
 
 export const Route = createFileRoute('/projects/$projectId')({
   validateSearch: (search: Record<string, unknown>): {sources?: string} => {
@@ -28,8 +28,8 @@ export const Route = createFileRoute('/projects/$projectId')({
     }
   },
   loader: async ({ params }) => {
-    const project = await api.getProject(params.projectId)
-    return { project }
+    const service = await api.getProject(params.projectId)
+    return { service }
   },
   component: SourcesIngestionPage,
 })
@@ -37,12 +37,12 @@ export const Route = createFileRoute('/projects/$projectId')({
 function SourcesIngestionPage() {
   const routerState = useRouterState()
   const showingChildPage = /^\/projects\/[^/]+\/(settings|traces|spans)\/?/.test(routerState.location.pathname)
-  const { project } = Route.useLoaderData()
+  const { service } = Route.useLoaderData()
   const { sources } = Route.useSearch()
 
   if (showingChildPage) {
     return <Outlet />
   }
 
-  return <ProjectTelemetrySetupHub project={project} selectedSourcesParam={sources} />
+  return <ServiceTelemetrySetupHub service={service} selectedSourcesParam={sources} />
 }

--- a/dashboard/src/routes/projects.tsx
+++ b/dashboard/src/routes/projects.tsx
@@ -478,13 +478,13 @@ export const Route = createFileRoute('/projects')({
 
 function ProjectsLayout() {
   const matches = useMatches()
-  // Check if we're showing a child route (project detail)
+  // Check if we're showing a child route (service detail)
   const showingChild = matches.some(match => match.id.includes('projectId'))
 
   if (showingChild) {
     return <Outlet />
   }
 
-  // /projects base path now redirects to dashboard - project list is in the sidebar
+  // /projects base path now redirects to the overview; service setup lives under child routes.
   return <Navigate to="/" search={APP_OVERVIEW_SEARCH} />
 }

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -354,7 +354,7 @@ function ReplaysPage() {
           <EmptyState
             icon={Play}
             title="No replays yet"
-            description="Session replays are recorded when you enable replay capture in a compatible SDK. Configure replays in your project setup to start capturing user sessions."
+            description="Session replays are recorded when you enable replay capture in a compatible SDK. Configure replays in your service setup to start capturing user sessions."
           />
         ) : filteredReplays.length === 0 ? (
           <EmptyState

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -95,7 +95,7 @@ import {TIMEZONES} from '@/lib/timezones'
 import {formatDate as formatDateUtil, formatDateTime as formatDateTimeUtil} from '@/lib/date-format'
 
 const AUTH_TOKEN_SCOPES = [
-  { group: 'Project', scopes: ['project:read', 'project:write'] },
+  { group: 'Service', scopes: ['project:read', 'project:write'] },
   { group: 'Releases', scopes: ['releases:read', 'releases:write'] },
   { group: 'Source Maps', scopes: ['sourcemaps:read', 'sourcemaps:write'] },
   { group: 'Events', scopes: ['event:read'] },
@@ -104,8 +104,8 @@ const AUTH_TOKEN_SCOPES = [
 ] as const
 
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
-  'project:read': 'List and view project details.',
-  'project:write': 'Create, update, and delete projects.',
+  'project:read': 'List and view service details.',
+  'project:write': 'Create, update, and delete services.',
   'releases:read': 'List releases and view release metadata.',
   'releases:write': 'Create and manage releases (e.g. for version tracking).',
   'sourcemaps:read': 'List and download source map files.',
@@ -2514,34 +2514,34 @@ function NotificationsTab() {
     },
   })
 
-  const updateProjectMutation = useMutation({
-    mutationFn: ({ projectId, prefs }: {
-      projectId: string
+  const updateServiceMutation = useMutation({
+    mutationFn: ({ serviceId, prefs }: {
+      serviceId: string
       prefs: Partial<{
         issueAlerts: boolean
         errorAlerts: boolean
         weeklySummary: boolean
         alertFrequencyMinutes: number
       }>
-    }) => api.updateProjectNotificationPreferences(projectId, prefs),
+    }) => api.updateProjectNotificationPreferences(serviceId, prefs),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['notificationPreferences'] })
-      toast({ title: 'Project preferences updated' })
+      toast({ title: 'Service preferences updated' })
     },
     onError: (err: Error) => {
       toast({
-        title: 'Failed to update project preferences',
+        title: 'Failed to update service preferences',
         description: err.message,
         variant: 'destructive',
       })
     },
   })
 
-  const deleteProjectMutation = useMutation({
-    mutationFn: (projectId: string) => api.deleteProjectNotificationPreferences(projectId),
+  const deleteServiceMutation = useMutation({
+    mutationFn: (serviceId: string) => api.deleteProjectNotificationPreferences(serviceId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['notificationPreferences'] })
-      toast({ title: 'Project override removed', description: 'Using global preferences for this project.' })
+      toast({ title: 'Service override removed', description: 'Using global preferences for this service.' })
     },
     onError: (err: Error) => {
       toast({
@@ -2604,7 +2604,7 @@ function NotificationsTab() {
     alertFrequencyMinutes: 30,
   }
 
-  const projects = preferences?.projects || []
+  const servicePreferences = preferences?.projects || []
 
   return (
     <div className="space-y-6">
@@ -2666,7 +2666,7 @@ function NotificationsTab() {
               Error Alert Frequency
             </Label>
             <p className="text-sm text-muted-foreground mb-2">
-              Minimum time between alerts for the same project
+              Minimum time between alerts for the same service
             </p>
             <Select
               value={global.alertFrequencyMinutes.toString()}
@@ -2694,23 +2694,23 @@ function NotificationsTab() {
               <Layers className="h-5 w-5 text-primary" />
             </div>
             <div>
-              <CardTitle>Per-Project Overrides</CardTitle>
+              <CardTitle>Per-Service Overrides</CardTitle>
               <CardDescription>
-                Customize notification settings for specific projects
+                Customize notification settings for specific services
               </CardDescription>
             </div>
           </div>
         </CardHeader>
         <CardContent>
-          {projects.length === 0 ? (
+          {servicePreferences.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              No project-specific overrides configured. All projects use the global preferences above.
+              No service-specific overrides configured. All services use the global preferences above.
             </p>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Project</TableHead>
+                  <TableHead>Service</TableHead>
                   <TableHead className="text-center">Issues</TableHead>
                   <TableHead className="text-center">Errors</TableHead>
                   <TableHead className="text-center">Weekly</TableHead>
@@ -2719,15 +2719,15 @@ function NotificationsTab() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {projects.map((project) => (
-                  <TableRow key={project.projectResourceId}>
-                    <TableCell className="font-medium">{project.projectName}</TableCell>
+                {servicePreferences.map((servicePreference) => (
+                  <TableRow key={servicePreference.projectResourceId}>
+                    <TableCell className="font-medium">{servicePreference.projectName}</TableCell>
                     <TableCell className="text-center">
                       <Checkbox
-                        checked={project.issueAlerts}
+                        checked={servicePreference.issueAlerts}
                         onCheckedChange={(checked) =>
-                          updateProjectMutation.mutate({
-                            projectId: project.projectResourceId,
+                          updateServiceMutation.mutate({
+                            serviceId: servicePreference.projectResourceId,
                             prefs: { issueAlerts: checked === true },
                           })
                         }
@@ -2735,10 +2735,10 @@ function NotificationsTab() {
                     </TableCell>
                     <TableCell className="text-center">
                       <Checkbox
-                        checked={project.errorAlerts}
+                        checked={servicePreference.errorAlerts}
                         onCheckedChange={(checked) =>
-                          updateProjectMutation.mutate({
-                            projectId: project.projectResourceId,
+                          updateServiceMutation.mutate({
+                            serviceId: servicePreference.projectResourceId,
                             prefs: { errorAlerts: checked === true },
                           })
                         }
@@ -2746,25 +2746,25 @@ function NotificationsTab() {
                     </TableCell>
                     <TableCell className="text-center">
                       <Checkbox
-                        checked={project.weeklySummary}
+                        checked={servicePreference.weeklySummary}
                         onCheckedChange={(checked) =>
-                          updateProjectMutation.mutate({
-                            projectId: project.projectResourceId,
+                          updateServiceMutation.mutate({
+                            serviceId: servicePreference.projectResourceId,
                             prefs: { weeklySummary: checked === true },
                           })
                         }
                       />
                     </TableCell>
                     <TableCell className="text-center text-sm text-muted-foreground">
-                      {project.alertFrequencyMinutes >= 60
-                        ? `${project.alertFrequencyMinutes / 60}h`
-                        : `${project.alertFrequencyMinutes}m`}
+                      {servicePreference.alertFrequencyMinutes >= 60
+                        ? `${servicePreference.alertFrequencyMinutes / 60}h`
+                        : `${servicePreference.alertFrequencyMinutes}m`}
                     </TableCell>
                     <TableCell>
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => deleteProjectMutation.mutate(project.projectResourceId)}
+                        onClick={() => deleteServiceMutation.mutate(servicePreference.projectResourceId)}
                       >
                         Reset
                       </Button>
@@ -3475,7 +3475,7 @@ function AccountTab() {
                 What will be deleted:
               </h4>
               <ul className="text-sm text-danger-fg/90 space-y-1 list-disc list-inside">
-                <li>All projects and their events</li>
+                <li>All services and their events</li>
                 <li>All error data, transactions, sessions, and replays</li>
                 <li>All monitoring data and uptime checks</li>
                 <li>All team members will be removed</li>

--- a/dashboard/src/routes/usage-insights.tsx
+++ b/dashboard/src/routes/usage-insights.tsx
@@ -229,7 +229,7 @@ function UsageInsightsPage() {
                     <TableHead>Source</TableHead>
                     <TableHead>Service</TableHead>
                     <TableHead>Operation</TableHead>
-                    <TableHead>Project</TableHead>
+                    <TableHead>Moneat service</TableHead>
                     <TableHead className="text-right">Spans</TableHead>
                     <TableHead className="text-right">Share</TableHead>
                     <TableHead className="text-right">Errors</TableHead>

--- a/emails/README.md
+++ b/emails/README.md
@@ -45,7 +45,7 @@ Sends notifications when new errors are detected.
 - `{{ issueMessage }}` - Full error message
 - `{{ issueCount }}` - Number of occurrences
 - `{{ issueUrl }}` - Link to issue in dashboard
-- `{{ projectName }}` - Project name
+- `{{ projectName }}` - Service name
 - `{{ environment }}` - Environment (production, staging, etc)
 - `{{ timestamp }}` - When error first occurred
 - `{{ stackTrace }}` - Stack trace

--- a/emails/src/templates/error-alert.html
+++ b/emails/src/templates/error-alert.html
@@ -92,7 +92,7 @@ stackTrace: |-
       <td class="px-8 pb-6 bg-white">
         <table class="w-full" cellpadding="0" cellspacing="0" role="presentation">
           <tr>
-            <!-- Project Card -->
+            <!-- Service Card -->
             <td class="w-1/2 pr-2">
               <table class="w-full" cellpadding="0" cellspacing="0" role="presentation" style="border-radius: 8px; border: 1px solid #e5e5e5; overflow: hidden;">
                 <tr>
@@ -100,7 +100,7 @@ stackTrace: |-
                 </tr>
                 <tr>
                   <td class="p-3">
-                    <p class="m-0 text-xs font-medium mb-1" style="color: #737373;">Project</p>
+                    <p class="m-0 text-xs font-medium mb-1" style="color: #737373;">Service</p>
                     <p class="m-0 text-sm font-semibold" style="color: #0a0a0a;">[[ page.projectName ]]</p>
                   </td>
                 </tr>

--- a/emails/src/templates/weekly-summary.html
+++ b/emails/src/templates/weekly-summary.html
@@ -128,10 +128,10 @@ projects: []
       </td>
     </tr>
 
-    <!-- Per-Project Breakdown -->
+    <!-- Per-Service Breakdown -->
     <tr>
       <td class="px-8 pb-6 bg-white">
-        <p class="m-0 text-sm font-semibold mb-3" style="color: #0a0a0a;">Project Breakdown</p>
+        <p class="m-0 text-sm font-semibold mb-3" style="color: #0a0a0a;">Service Breakdown</p>
 
         PROJECTS_PLACEHOLDER
       </td>


### PR DESCRIPTION
## Summary
- complete the service-first terminology sweep across dashboard, docs, and email copy
- rename service setup components and event names while preserving project API/route compatibility
- update related tests for service-oriented labels and helpers

## Validation
- npm test
- COVERAGE_GATE_PHASE=hard CI=true npm run test:coverage
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guides and help to use "service" terminology and to point DSN/setup instructions to "Sources / Ingestion → Service settings."

* **Style**
  * Dashboard UI and emails: "projects" relabeled as "services" across settings, onboarding, pricing, analytics, and creation flows. Pricing table now references service limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->