### PR TITLE
fix: sync demo banner state

### DIFF
--- a/dashboard/src/components/demo/DemoBanner.tsx
+++ b/dashboard/src/components/demo/DemoBanner.tsx
@@ -18,8 +18,12 @@ import {Link} from '@tanstack/react-router'
 import {isDemo} from '@/lib/demo'
 import {Info} from 'lucide-react'
 
-export function DemoBanner() {
-  if (!isDemo() || localStorage.getItem('screenshot-mode') === 'true') {
+type DemoBannerProps = {
+  isDemoMode?: boolean
+}
+
+export function DemoBanner({isDemoMode = isDemo()}: DemoBannerProps) {
+  if (!isDemoMode || globalThis.localStorage?.getItem('screenshot-mode') === 'true') {
     return null
   }
 

--- a/dashboard/src/lib/__tests__/demo.test.ts
+++ b/dashboard/src/lib/__tests__/demo.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { setDemoEpoch, isDemo, getNow, getNowDate, getDemoEpochMs } from '@/lib/demo'
+import {
+  setDemoEpoch,
+  syncDemoEpochFromUser,
+  isDemo,
+  getNow,
+  getNowDate,
+  getDemoEpochMs,
+} from '@/lib/demo'
 
 describe('demo', () => {
   beforeEach(() => {
@@ -34,6 +41,21 @@ describe('demo', () => {
       sessionStorage.setItem('demoEpochMs', '1700000000000')
       // Module state is null but sessionStorage has value
       expect(isDemo()).toBe(true)
+    })
+  })
+
+  describe('syncDemoEpochFromUser', () => {
+    it('clears demo mode when the user is not a demo user', () => {
+      setDemoEpoch(1700000000000)
+      syncDemoEpochFromUser({demoEpochMs: null})
+      expect(isDemo()).toBe(false)
+      expect(sessionStorage.getItem('demoEpochMs')).toBeNull()
+    })
+
+    it('sets demo mode when the user is a demo user', () => {
+      syncDemoEpochFromUser({demoEpochMs: 1700000000000})
+      expect(isDemo()).toBe(true)
+      expect(getDemoEpochMs()).toBe(1700000000000)
     })
   })
 

--- a/dashboard/src/lib/api/__tests__/client-branches.test.ts
+++ b/dashboard/src/lib/api/__tests__/client-branches.test.ts
@@ -261,6 +261,7 @@ describe('client – branch coverage', () => {
 
   describe('checkAuth – 403 response', () => {
     it('removes authenticated flag and returns false on 403', async () => {
+      sessionStorage.setItem('demoEpochMs', '1700000000000')
       server.use(
         http.get(`${API_BASE}/v1/user`, () => {
           return new HttpResponse(null, { status: 403 })
@@ -270,6 +271,7 @@ describe('client – branch coverage', () => {
       const result = await api.checkAuth()
       expect(result).toBe(false)
       expect(sessionStorage.getItem('authenticated')).toBeNull()
+      expect(sessionStorage.getItem('demoEpochMs')).toBeNull()
     })
   })
 

--- a/dashboard/src/lib/api/__tests__/client.test.ts
+++ b/dashboard/src/lib/api/__tests__/client.test.ts
@@ -156,6 +156,7 @@ describe('client', () => {
   describe('checkAuth() success', () => {
     it('returns true and sets authenticated flag on 200', async () => {
       sessionStorage.removeItem('authenticated')
+      sessionStorage.setItem('demoEpochMs', '1700000000000')
       server.use(
         http.get(`${API_BASE}/v1/user`, () =>
           HttpResponse.json({ id: 1, email: 'a@b.com' })
@@ -165,6 +166,7 @@ describe('client', () => {
       const result = await api.checkAuth()
       expect(result).toBe(true)
       expect(sessionStorage.getItem('authenticated')).toBe('true')
+      expect(sessionStorage.getItem('demoEpochMs')).toBeNull()
     })
   })
 
@@ -172,6 +174,7 @@ describe('client', () => {
 
   describe('checkAuth() 401', () => {
     it('returns false and removes authenticated flag on 401', async () => {
+      sessionStorage.setItem('demoEpochMs', '1700000000000')
       server.use(
         http.get(`${API_BASE}/v1/user`, () =>
           new HttpResponse(null, { status: 401 })
@@ -183,6 +186,7 @@ describe('client', () => {
 
       const result = await api.checkAuth()
       expect(result).toBe(false)
+      expect(sessionStorage.getItem('demoEpochMs')).toBeNull()
     })
   })
 

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import { isDemo, setDemoEpoch } from '../demo'
+import { isDemo, setDemoEpoch, syncDemoEpochFromUser } from '../demo'
 
 export const API_BASE = `${import.meta.env.VITE_BACKEND_URL || ''}/v1`
 const AUTH_PAGE_PATHS = new Set([
@@ -293,9 +293,14 @@ export function createApiClientCore(): ApiClientCore {
       if (!response.ok) {
         if (response.status === 401 || response.status === 403) {
           globalThis.sessionStorage?.removeItem('authenticated')
+          setDemoEpoch(null)
         }
         return false
       }
+      const user = await response
+        .json()
+        .catch(() => null) as { demoEpochMs?: number | null } | null
+      syncDemoEpochFromUser(user)
       globalThis.sessionStorage?.setItem('authenticated', 'true')
       return true
     } catch {

--- a/dashboard/src/lib/api/modules/__tests__/user.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/user.test.ts
@@ -49,6 +49,47 @@ describe('User API', () => {
     expect(result).toEqual(mock)
   })
 
+  it('clears stale demo epoch when the current user is not demo', async () => {
+    sessionStorage.setItem('demoEpochMs', '1700000000000')
+    const mock = {
+      id: 1,
+      email: 'user@example.com',
+      name: 'Test User',
+      emailVerified: true,
+      onboardingCompleted: true,
+      demoEpochMs: null,
+    }
+
+    server.use(
+      http.get(`${API_BASE}/v1/user`, () => {
+        return HttpResponse.json(mock)
+      })
+    )
+
+    await api.getCurrentUser()
+    expect(sessionStorage.getItem('demoEpochMs')).toBeNull()
+  })
+
+  it('stores demo epoch when the current user is demo', async () => {
+    const mock = {
+      id: -1,
+      email: 'demo@moneat.dev',
+      name: 'Demo User',
+      emailVerified: true,
+      onboardingCompleted: true,
+      demoEpochMs: 1700000000000,
+    }
+
+    server.use(
+      http.get(`${API_BASE}/v1/user`, () => {
+        return HttpResponse.json(mock)
+      })
+    )
+
+    await api.getCurrentUser()
+    expect(sessionStorage.getItem('demoEpochMs')).toBe('1700000000000')
+  })
+
   // ──── updateSidebarPreferences ────
 
   it('updates sidebar preferences', async () => {

--- a/dashboard/src/lib/api/modules/user.ts
+++ b/dashboard/src/lib/api/modules/user.ts
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+import { syncDemoEpochFromUser } from '../../demo'
 import type { ApiClientCore } from '../client'
 import type {
   AccountDeletionValidation,
@@ -21,24 +22,29 @@ import type {
   OrganizationDeletionValidation,
 } from '../types'
 
+type CurrentUserResponse = {
+  id: number
+  email: string
+  name?: string
+  emailVerified: boolean
+  onboardingCompleted: boolean
+  isAdmin?: boolean
+  organizationSlug?: string
+  orgRole?: string
+  demoEpochMs?: number | null
+  sidebarHiddenItems?: string[]
+  timezone?: string | null
+}
+
 export function userMethods(core: ApiClientCore) {
   const base = core.API_BASE
 
   return {
-    getCurrentUser: () =>
-      core.request<{
-        id: number
-        email: string
-        name?: string
-        emailVerified: boolean
-        onboardingCompleted: boolean
-        isAdmin?: boolean
-        organizationSlug?: string
-        orgRole?: string
-        demoEpochMs?: number
-        sidebarHiddenItems?: string[]
-        timezone?: string | null
-      }>(`${base}/user`),
+    getCurrentUser: async (): Promise<CurrentUserResponse> => {
+      const user = await core.request<CurrentUserResponse>(`${base}/user`)
+      syncDemoEpochFromUser(user)
+      return user
+    },
 
     updateSidebarPreferences: (hiddenItems: string[]) =>
       core.request<{ hiddenItems: string[] }>(

--- a/dashboard/src/lib/demo.ts
+++ b/dashboard/src/lib/demo.ts
@@ -20,7 +20,35 @@
  * instead of the actual current time.
  */
 
+type DemoEpochSource = {
+  demoEpochMs?: number | null
+}
+
 let demoEpochMs: number | null = null;
+
+function readStoredDemoEpoch(): number | null {
+  const stored = globalThis.sessionStorage?.getItem('demoEpochMs') ?? null;
+  if (stored === null) return null;
+
+  const storedEpochMs = Number(stored);
+  if (!Number.isFinite(storedEpochMs)) {
+    setDemoEpoch(null);
+    return null;
+  }
+
+  return storedEpochMs;
+}
+
+function getActiveDemoEpoch(): number | null {
+  if (demoEpochMs !== null) return demoEpochMs;
+
+  const storedEpochMs = readStoredDemoEpoch();
+  if (storedEpochMs !== null) {
+    demoEpochMs = storedEpochMs;
+  }
+
+  return storedEpochMs;
+}
 
 /**
  * Set the demo epoch. Call this after demo login or when loading user data.
@@ -28,24 +56,24 @@ let demoEpochMs: number | null = null;
 export function setDemoEpoch(ms: number | null) {
   demoEpochMs = ms;
   if (ms !== null) {
-    sessionStorage.setItem('demoEpochMs', String(ms));
+    globalThis.sessionStorage?.setItem('demoEpochMs', String(ms));
   } else {
-    sessionStorage.removeItem('demoEpochMs');
+    globalThis.sessionStorage?.removeItem('demoEpochMs');
   }
+}
+
+/**
+ * Sync local demo state from the authenticated user response.
+ */
+export function syncDemoEpochFromUser(user: DemoEpochSource | null | undefined) {
+  setDemoEpoch(user?.demoEpochMs ?? null);
 }
 
 /**
  * Check if currently in demo mode.
  */
 export function isDemo(): boolean {
-  if (demoEpochMs !== null) return true;
-  // Recover from sessionStorage if module state was lost (e.g. HMR)
-  const stored = sessionStorage.getItem('demoEpochMs');
-  if (stored) {
-    demoEpochMs = Number(stored);
-    return true;
-  }
-  return false;
+  return getActiveDemoEpoch() !== null;
 }
 
 /**
@@ -53,13 +81,9 @@ export function isDemo(): boolean {
  * In demo mode, returns the demo epoch; otherwise returns actual current time.
  */
 export function getNow(): number {
-  if (demoEpochMs !== null) return demoEpochMs;
-  // Recover from sessionStorage if needed
-  const stored = sessionStorage.getItem('demoEpochMs');
-  if (stored) {
-    demoEpochMs = Number(stored);
-    return demoEpochMs;
-  }
+  const activeDemoEpoch = getActiveDemoEpoch();
+  if (activeDemoEpoch !== null) return activeDemoEpoch;
+
   return Date.now();
 }
 
@@ -75,5 +99,5 @@ export function getNowDate(): Date {
  * Get the demo epoch timestamp (for debugging/display).
  */
 export function getDemoEpochMs(): number | null {
-  return demoEpochMs;
+  return getActiveDemoEpoch();
 }

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -22,7 +22,7 @@ import {CommandPalette} from '../components/CommandPalette'
 import {CommandPaletteProvider} from '../contexts/CommandPaletteProvider'
 import {Toaster} from '../components/ui/toaster'
 import {api} from '../lib/api'
-import {setDemoEpoch} from '../lib/demo'
+import {isDemo} from '../lib/demo'
 import {APP_OVERVIEW_SEARCH, isPublicLandingRoute} from '../lib/overview-route'
 import {DemoBanner} from '../components/demo/DemoBanner'
 import {AiFloatingPanel} from '../components/AiFloatingPanel'
@@ -264,11 +264,13 @@ function RootComponent() {
     return () => observer.disconnect()
   }, [])
 
-  const { data: user } = useQuery({
+  const { data: user, isFetching: isUserFetching } = useQuery({
     queryKey: ['currentUser'],
     queryFn: () => api.getCurrentUser(),
     enabled: isAuthenticated,
   })
+  const demoEpochMs = user?.demoEpochMs ?? null
+  const showDemoBanner = demoEpochMs !== null && !isUserFetching && isDemo()
   const isLandingPage = isPublicLandingRoute(currentPath, router.location.search)
   const isPublicRoute = (
     isLandingPage ||
@@ -278,13 +280,6 @@ function RootComponent() {
     currentPath.startsWith('/legal/') ||
     currentPath.startsWith('/docs')
   )
-
-  // Initialize demo mode when user data is loaded
-  useEffect(() => {
-    if (user?.demoEpochMs) {
-      setDemoEpoch(user.demoEpochMs)
-    }
-  }, [user?.demoEpochMs])
 
   useEffect(() => {
     document.title = getDocumentTitle(currentPath, isLandingPage)
@@ -368,7 +363,7 @@ function RootComponent() {
         <CommandPaletteProvider>
           {/* Fixed header: optional demo banner */}
           <div ref={headerRef} className="fixed top-0 left-0 right-0 z-50 w-full">
-            <DemoBanner />
+            <DemoBanner isDemoMode={showDemoBanner} />
           </div>
           <Sidebar
             isExpanded={isSidebarExpanded}
@@ -385,7 +380,7 @@ function RootComponent() {
           className="transition-[margin-left] duration-300"
           style={{ marginLeft: 0 }}
         >
-          {isAuthenticated && !isPublicRoute && <DemoBanner />}
+          {isAuthenticated && !isPublicRoute && <DemoBanner isDemoMode={showDemoBanner} />}
           <Outlet />
         </div>
       )}

--- a/dashboard/src/routes/auth.oauth.callback.tsx
+++ b/dashboard/src/routes/auth.oauth.callback.tsx
@@ -18,6 +18,7 @@ import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useEffect, useMemo} from 'react'
 import {Logo} from '@/components/Logo'
 import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
+import {setDemoEpoch} from '@/lib/demo'
 
 export const Route = createFileRoute('/auth/oauth/callback')({
   component: OAuthCallbackPage,
@@ -43,7 +44,8 @@ function OAuthCallbackPage() {
     }
 
     // Auth token is now set as httpOnly cookie by the backend redirect
-    sessionStorage.setItem('authenticated', 'true')
+    setDemoEpoch(null)
+    globalThis.sessionStorage?.setItem('authenticated', 'true')
     const timer = setTimeout(() => {
       navigate({ to: '/', search: APP_OVERVIEW_SEARCH })
     }, 500)

--- a/dashboard/src/routes/auth.sso.callback.tsx
+++ b/dashboard/src/routes/auth.sso.callback.tsx
@@ -18,6 +18,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useEffect, useMemo } from 'react'
 import { Logo } from '@/components/Logo'
 import { APP_OVERVIEW_SEARCH } from '@/lib/overview-route'
+import { setDemoEpoch } from '@/lib/demo'
 
 export const Route = createFileRoute('/auth/sso/callback')({
   component: SsoCallbackPage,
@@ -40,7 +41,8 @@ function SsoCallbackPage() {
     }
 
     // Auth token is now set as httpOnly cookie by the backend redirect
-    sessionStorage.setItem('authenticated', 'true')
+    setDemoEpoch(null)
+    globalThis.sessionStorage?.setItem('authenticated', 'true')
     const timer = setTimeout(() => {
       navigate({ to: '/', search: APP_OVERVIEW_SEARCH })
     }, 100)

--- a/dashboard/src/routes/impersonate-callback.tsx
+++ b/dashboard/src/routes/impersonate-callback.tsx
@@ -17,6 +17,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { APP_OVERVIEW_SEARCH } from '@/lib/overview-route'
+import { setDemoEpoch } from '@/lib/demo'
 
 export const Route = createFileRoute('/impersonate-callback')({
   component: ImpersonateCallback,
@@ -42,7 +43,8 @@ function ImpersonateCallback() {
       if (event.data?.type !== 'MONEAT_IMPERSONATION_TOKEN') return
       if (typeof event.data?.token !== 'string' || event.data.token.length === 0) return
 
-      sessionStorage.setItem('impersonate_token', event.data.token)
+      setDemoEpoch(null)
+      globalThis.sessionStorage?.setItem('impersonate_token', event.data.token)
       window.clearTimeout(timeoutId)
       window.removeEventListener('message', handleTokenMessage)
       navigate({ to: '/', search: APP_OVERVIEW_SEARCH })


### PR DESCRIPTION
## Summary
- sync demo state with the active user session
- keep stale demo state from affecting normal sessions
- cover recent demo navigation and landing flows

## Validation
- npm test -- src/lib/__tests__/overview-route.test.ts src/routes/__tests__/-signup-route.test.tsx src/lib/__tests__/demo.test.ts src/lib/api/modules/__tests__/user.test.ts src/lib/api/__tests__/client.test.ts src/lib/api/__tests__/client-branches.test.ts
- npm run typecheck
- npm run lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced demo mode to synchronize state with current user data.

* **Bug Fixes**
  * Improved demo epoch state cleanup during authentication flows and impersonation.
  * More resilient storage access using optional chaining to prevent errors when localStorage/sessionStorage is unavailable.

* **Tests**
  * Added coverage for demo epoch synchronization and authentication state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->