### PR TITLE
docs: align telemetry source copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Moneat is Sentry SDK, Datadog Agent, and OpenTelemetry (OTLP) compatible. Point 
 | Performance Monitoring | Distributed tracing with transaction and span breakdowns | [Docs](https://moneat.io/docs) |
 | Continuous Profiling | Flamegraph visualization (pprof, JFR, Sentry formats) | [Docs](https://moneat.io/docs) |
 | Logging | Centralized, searchable log management via OTLP and ClickHouse | [Docs](https://moneat.io/docs) |
-| OpenTelemetry (OTLP) | Ingest logs, traces, and metrics via standard OTLP/HTTP endpoints | [Docs](https://moneat.io/docs) |
+| OpenTelemetry Ingestion | Send logs, traces, and metrics from any OTLP exporter or Collector | [Docs](https://moneat.io/docs) |
 | Uptime & Status Pages | HTTP/TCP/ping checks with public status pages | [Docs](https://moneat.io/docs) |
 | Synthetics | API, multi-step, SSL, DNS, TCP, and UDP synthetic tests | [Docs](https://moneat.io/docs) |
 | Custom Dashboards | Drag-and-drop widgets, Grafana dashboard import | [Docs](https://moneat.io/docs) |
@@ -100,7 +100,7 @@ Moneat is Sentry SDK, Datadog Agent, and OpenTelemetry (OTLP) compatible. Point 
 | AI Observability | Trace and debug LLM calls | [Docs](https://moneat.io/docs) |
 | MCP Server | Model Context Protocol endpoint for AI coding assistants | [Docs](https://moneat.io/docs) |
 | User Feedback | Sentry-compatible feedback ingestion with status workflows | [Docs](https://moneat.io/docs) |
-| Datadog Compatibility | Ingest from existing Datadog agents with no code changes | [Docs](https://moneat.io/docs) |
+| Datadog Agent Compatibility | Ingest from existing Datadog agents with no code changes | [Docs](https://moneat.io/docs) |
 | On-Call & Incidents | PagerDuty-style escalations *(Enterprise)* | [Pricing](https://moneat.io/pricing) |
 | SSO (OIDC) | Sign in with any OpenID Connect provider | [Docs](https://moneat.io/docs) |
 | SSO (SAML) & Enforcement | SAML 2.0 and mandatory SSO *(Enterprise)* | [Pricing](https://moneat.io/pricing) |

--- a/dashboard/src/components/apm/SourceBadge.tsx
+++ b/dashboard/src/components/apm/SourceBadge.tsx
@@ -22,9 +22,21 @@ const SOURCE_CONFIG: Record<string, {label: string; className: string}> = {
     label: 'Datadog',
     className: 'text-chart-6 border-chart-6/30',
   },
+  'datadog-agent': {
+    label: 'Datadog Agent',
+    className: 'text-chart-6 border-chart-6/30',
+  },
   otlp: {
     label: 'OTEL',
     className: 'text-chart-3 border-chart-3/30',
+  },
+  opentelemetry: {
+    label: 'OpenTelemetry',
+    className: 'text-chart-3 border-chart-3/30',
+  },
+  'sentry-sdk': {
+    label: 'Sentry SDK',
+    className: 'text-muted-foreground border-border/50',
   },
   sdk: {
     label: 'SDK',

--- a/dashboard/src/components/apm/SourceBadge.tsx
+++ b/dashboard/src/components/apm/SourceBadge.tsx
@@ -44,13 +44,14 @@ const SOURCE_CONFIG: Record<string, {label: string; className: string}> = {
   },
 }
 
-export function SourceBadge({source, className}: {source: string; className?: string}) {
-  const key = source.trim().toLowerCase()
+export function SourceBadge({source, className}: {source?: string | null; className?: string}) {
+  const rawSource = source?.trim() ?? ''
+  const key = rawSource.toLowerCase()
   const config =
     key === ''
       ? {label: 'Unknown', className: 'text-muted-foreground border-border/50'}
       : SOURCE_CONFIG[key] ?? {
-          label: source.charAt(0).toUpperCase() + source.slice(1),
+          label: rawSource.charAt(0).toUpperCase() + rawSource.slice(1),
           className: 'text-muted-foreground border-border/50',
         }
 

--- a/dashboard/src/components/monitoring/ContainerList.tsx
+++ b/dashboard/src/components/monitoring/ContainerList.tsx
@@ -8,6 +8,7 @@
 
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
+import {SourceBadge} from '@/components/apm/SourceBadge'
 
 export interface MergedContainer {
   id: string
@@ -379,9 +380,7 @@ export function ContainerList() {
                       </TableCell>
 
                       <TableCell>
-                        <Badge variant="neutral" className="text-[10px] font-medium">
-                          Datadog
-                        </Badge>
+                        <SourceBadge source={c.source} className="max-w-[100px] truncate" />
                       </TableCell>
 
                       <TableCell>

--- a/dashboard/src/components/monitoring/ContainerList.tsx
+++ b/dashboard/src/components/monitoring/ContainerList.tsx
@@ -22,7 +22,7 @@ export interface MergedContainer {
   memLimit: number
   netRxBytes: number
   netTxBytes: number
-  source: 'datadog-agent'
+  source?: string | null
   timestamp?: string
 }
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
@@ -127,7 +127,7 @@ export function ContainerList() {
     queryFn: async () => {
       const res = await api.getContainers({limit: 200})
       const mapped = res.containers.map((c) => ({
-        id: `dd-${c.host}-${c.containerId}`,
+        id: `${c.source ?? 'container'}-${c.host}-${c.containerId}`,
         host: c.host,
         containerId: c.containerId,
         name: c.name,
@@ -138,7 +138,7 @@ export function ContainerList() {
         memLimit: c.memLimit,
         netRxBytes: c.netRxBytes,
         netTxBytes: c.netTxBytes,
-        source: 'datadog-agent' as const,
+        source: c.source,
         timestamp: c.timestamp,
       } satisfies MergedContainer))
       // Deduplicate by (host, containerId), keeping the most recent entry

--- a/dashboard/src/docs/pages/ai-observability.mdx
+++ b/dashboard/src/docs/pages/ai-observability.mdx
@@ -15,7 +15,9 @@ Moneat captures LLM calls, traces multi-step agent executions, and tracks token 
 - **Error monitoring** - LLM failures, timeouts, and rate limits
 - **Model analytics** - Performance, cost, and error rates across models
 
-## Getting Started with Sentry SDKs
+## Getting Started
+
+### Sentry-Compatible SDKs
 
 If your application uses a Sentry SDK with AI integrations, point your DSN to your Moneat instance to start sending LLM observability data.
 

--- a/dashboard/src/docs/pages/infrastructure-monitoring.mdx
+++ b/dashboard/src/docs/pages/infrastructure-monitoring.mdx
@@ -1,11 +1,11 @@
 ---
 title: Infrastructure Monitoring
-description: Monitor hosts, containers, processes, and network connections via the Datadog Agent.
+description: Monitor hosts, containers, processes, and network connections from connected infrastructure telemetry sources.
 ---
 
 # Infrastructure Monitoring
 
-Infrastructure monitoring collects host metrics, container stats, process details, and network connections from machines running the Datadog Agent. Data is ingested via Datadog-compatible endpoints and stored in ClickHouse.
+Infrastructure monitoring collects host metrics, container stats, process details, and network connections from connected agents and collectors. Data is normalized into Moneat infrastructure telemetry and stored in ClickHouse.
 
 ## Setup
 

--- a/dashboard/src/docs/pages/infrastructure-monitoring.mdx
+++ b/dashboard/src/docs/pages/infrastructure-monitoring.mdx
@@ -1,15 +1,15 @@
 ---
 title: Infrastructure Monitoring
-description: Monitor hosts, containers, processes, and network connections from connected infrastructure telemetry sources.
+description: Monitor hosts, containers, processes, and network connections from configured infrastructure telemetry agents.
 ---
 
 # Infrastructure Monitoring
 
-Infrastructure monitoring collects host metrics, container stats, process details, and network connections from connected agents and collectors. Data is normalized into Moneat infrastructure telemetry and stored in ClickHouse.
+Infrastructure monitoring collects host metrics, container stats, process details, and network connections from configured infrastructure agents. The Datadog Agent setup below is the currently documented path for these signals; additional collectors or agents should be documented separately as they are supported. Data is normalized into Moneat infrastructure telemetry and stored in ClickHouse.
 
 ## Setup
 
-Install and configure the Datadog Agent pointed at your Moneat instance. See the [Datadog Agent setup](/docs/datadog-agent/agent-setup) page for instructions.
+The Datadog Agent is the currently documented setup path for infrastructure monitoring. Install and configure the agent pointed at your Moneat instance. See the [Datadog Agent setup](/docs/datadog-agent/agent-setup) page for instructions.
 
 The Process Agent must be enabled to collect container, process, and network data. Add to your `datadog.yaml`:
 

--- a/dashboard/src/docs/pages/intro.mdx
+++ b/dashboard/src/docs/pages/intro.mdx
@@ -1,7 +1,7 @@
 
 # Moneat Documentation
 
-Moneat is a Sentry-compatible observability platform for error monitoring, performance tracing, session replay, logging, uptime tracking, and incident management. Use any existing Sentry SDK, Datadog Agent, or OpenTelemetry (OTLP) exporter to get started.
+Moneat is an OpenTelemetry-native observability platform for error monitoring, performance tracing, session replay, logging, uptime tracking, and incident management. It supports popular open-source collectors and SDKs, including Sentry-compatible SDKs, the Datadog Agent, and any OTLP exporter.
 
 <Link to="/docs/getting-started" className="inline-block px-6 py-3 bg-sky-500 hover:bg-sky-600 !text-white font-semibold rounded-lg transition-colors no-underline">Get Started</Link>
 
@@ -12,17 +12,17 @@ Moneat is a Sentry-compatible observability platform for error monitoring, perfo
 - [Session Replay](/docs/session-replay) - Record and replay user sessions linked to errors
 - [Performance Monitoring](/docs/performance-monitoring) - Distributed tracing, transactions, spans, and service maps
 - [Structured Logging](/docs/logging) - Ingest, search, and tail logs via OTLP
-- [OpenTelemetry (OTLP)](/docs/logging) - Ingest logs, traces, and metrics via standard OTLP/HTTP endpoints
+- [OpenTelemetry Ingestion](/docs/logging) - Send logs, traces, and metrics from any OTLP exporter or Collector
 - [Releases & Source Maps](/docs/releases) - Track deployments and upload source maps
 - [AI Observability](/docs/ai-observability) - Monitor LLM applications and trace agent executions
 - [Custom Dashboards](/docs/custom-dashboards) - Build dashboards with drag-and-drop widgets and custom data sources
 - [User Feedback](/docs/user-feedback) - Collect and manage user-submitted feedback
-- [Infrastructure Monitoring](/docs/infrastructure-monitoring) - Monitor hosts, containers, processes, and network via the Datadog Agent
+- [Infrastructure Monitoring](/docs/infrastructure-monitoring) - Monitor hosts, containers, processes, and network telemetry
 - [On-Call & Incidents](/docs/on-call) - Schedules, escalation policies, and incident management
 - [Uptime Monitoring](/docs/uptime-monitoring) - HTTP checks and heartbeat monitors
 - [Status Pages](/docs/status-pages) - Public status pages for communicating incidents
 - [Product Analytics](/docs/product-analytics) - Funnels, retention, and event tracking
-- [Datadog Agent](/docs/datadog-agent) - Ingest metrics, traces, logs, and profiles from the Datadog Agent
+- [Datadog Agent Compatibility](/docs/datadog-agent) - Connect existing Datadog Agent fleets to Moneat without code changes
 
 ## Configuration & Account
 

--- a/dashboard/src/docs/pages/performance-monitoring.mdx
+++ b/dashboard/src/docs/pages/performance-monitoring.mdx
@@ -5,7 +5,7 @@ description: Distributed tracing, transaction tracking, and service maps.
 
 # Performance Monitoring
 
-Moneat supports three performance monitoring paths: Sentry-compatible transactions, Datadog-compatible APM traces, and OpenTelemetry (OTLP) traces. All store data in ClickHouse and are accessible from the **Performance** section in the sidebar.
+Moneat ingests distributed traces and spans from Sentry-compatible SDKs, the Datadog Agent, and any OTLP exporter, then shows them in one Performance view.
 
 ## Sentry Transactions
 
@@ -58,7 +58,7 @@ Metrics are stored in ClickHouse and available for querying via custom dashboard
 
 ## Service Map
 
-The service map is built from APM spans (Datadog and OTLP). It shows services as nodes and inter-service calls as edges, with error rates and average durations per edge. The map uses automatic layout via Dagre.
+The service map is built from APM spans across all telemetry sources. It shows services as nodes and inter-service calls as edges, with error rates and average durations per edge. The map uses automatic layout via Dagre.
 
 Available at **Performance > Service Map**.
 

--- a/dashboard/src/docs/sidebar.ts
+++ b/dashboard/src/docs/sidebar.ts
@@ -29,22 +29,6 @@ export const docsSidebar: SidebarCategory[] = [
       'user-feedback',
       'infrastructure-monitoring',
       {
-        label: 'Datadog Agent',
-        link: 'datadog-agent',
-        items: [
-          'datadog-agent/agent-setup',
-          'datadog-agent/continuous-profiling',
-          'datadog-agent/log-collection',
-          'datadog-agent/dashboard-import',
-          'datadog-agent/kubernetes',
-          'datadog-agent/database-monitoring',
-          'datadog-agent/debugger',
-          'datadog-agent/network-devices',
-          'datadog-agent/sbom',
-          'datadog-agent/synthetics',
-        ],
-      },
-      {
         label: 'Product Analytics',
         link: 'product-analytics',
         items: [
@@ -68,6 +52,28 @@ export const docsSidebar: SidebarCategory[] = [
     label: 'Configuration',
     collapsed: false,
     items: ['sdk-setup', 'integrations', 'sso-authentication', 'api-tokens'],
+  },
+  {
+    label: 'Source Setup',
+    collapsed: false,
+    items: [
+      {
+        label: 'Datadog Agent Compatibility',
+        link: 'datadog-agent',
+        items: [
+          'datadog-agent/agent-setup',
+          'datadog-agent/continuous-profiling',
+          'datadog-agent/log-collection',
+          'datadog-agent/dashboard-import',
+          'datadog-agent/kubernetes',
+          'datadog-agent/database-monitoring',
+          'datadog-agent/debugger',
+          'datadog-agent/network-devices',
+          'datadog-agent/sbom',
+          'datadog-agent/synthetics',
+        ],
+      },
+    ],
   },
   {
     label: 'MCP Server',

--- a/dashboard/src/lib/api/types/infrastructure.ts
+++ b/dashboard/src/lib/api/types/infrastructure.ts
@@ -48,6 +48,7 @@ export interface DdContainerResponse {
   memLimit: number
   netRxBytes: number
   netTxBytes: number
+  source?: string | null
   tags: Record<string, string>
   timestamp: string
 }


### PR DESCRIPTION
## Summary
- align docs copy around telemetry sources
- move Datadog Agent docs under source setup
- render container source from source metadata

## Validation
- npm run lint
- npm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container monitoring and APM badges now surface each event’s data source (e.g., Datadog Agent, OpenTelemetry, Sentry).

* **Documentation**
  * Repositioned platform as OpenTelemetry-native and clarified OTLP exporter/Collector ingestion.
  * Renamed feature entries to emphasize “OpenTelemetry Ingestion” and “Datadog Agent Compatibility.”
  * Reworked intro, performance, and infrastructure pages and reorganized sidebar under a new “Source Setup” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->