### PR TITLE
feat: add service map metrics contract

### DIFF
--- a/backend/src/main/kotlin/com/moneat/datadog/models/DatadogTraceModels.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/models/DatadogTraceModels.kt
@@ -221,8 +221,27 @@ data class DdServiceMapEntry(
 )
 
 @Serializable
+data class DdServiceEdge(
+    val fromService: String,
+    val toService: String,
+    val callCount: Long,
+    val errorCount: Long,
+    val avgDurationNs: Double,
+)
+
+@Serializable
 data class DdServiceMapResponse(
     val services: List<DdServiceMapEntry>,
+    val edges: List<DdServiceEdge> = emptyList(),
+)
+
+@Serializable
+data class DdServiceLatencyResponse(
+    val service: String,
+    val p50DurationNs: Long,
+    val p90DurationNs: Long,
+    val p99DurationNs: Long,
+    val sampleCount: Long,
 )
 
 // --- APM Resource Stats Models ---

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -40,11 +40,14 @@ private const val INVALID_TOKEN_ERROR = "Invalid token"
 private const val INVALID_TIME_RANGE_ERROR = "Invalid timeRange"
 private const val INVALID_STATUS_ERROR = "Invalid status"
 private const val INVALID_SERVICES_ERROR = "Invalid services"
+private const val INVALID_SERVICE_ERROR = "Invalid service"
+private const val INVALID_SERVICE_MAP_FILTER_ERROR = "Invalid service map filter"
 private const val STATUS_ERROR = "error"
 private const val STATUS_OK = "ok"
 private const val MAX_TRACE_SEARCH_LENGTH = 200
 private const val MAX_SERVICE_FILTERS = 50
 private const val MAX_SERVICE_FILTER_LENGTH = 200
+private const val MAX_SERVICE_PARAM_LENGTH = 200
 private val hexTraceIdPattern = Regex("^[0-9a-fA-F]+$")
 
 private val apmTimeRanges = mapOf(
@@ -140,7 +143,38 @@ fun Route.traceDashboardRoutes() {
         get("/v1/services/map") {
             val orgId = call.organizationId()
                 ?: return@get call.respondUnauthorized()
-            val result = TraceIngestionService.getServiceMap(orgId, call.getSentryTransaction())
+            val timeRange = call.apmTimeRange()
+                ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
+            val scope = call.serviceMapScope()
+                ?: return@get call.respondBadRequest(INVALID_SERVICE_MAP_FILTER_ERROR)
+            val result = TraceIngestionService.getServiceMap(
+                orgId,
+                timeRange,
+                scope.env,
+                scope.source,
+                call.getSentryTransaction(),
+            )
+            call.respond(result)
+        }
+
+        // GET /v1/services/{service}/latency - focused-service latency percentiles
+        get("/v1/services/{service}/latency") {
+            val orgId = call.organizationId()
+                ?: return@get call.respondUnauthorized()
+            val service = call.requiredServiceMapParam("service")
+                ?: return@get call.respondBadRequest(INVALID_SERVICE_ERROR)
+            val timeRange = call.apmTimeRange()
+                ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
+            val scope = call.serviceMapScope()
+                ?: return@get call.respondBadRequest(INVALID_SERVICE_MAP_FILTER_ERROR)
+            val result = TraceIngestionService.getServiceLatencyPercentiles(
+                orgId,
+                service,
+                timeRange,
+                scope.env,
+                scope.source,
+                call.getSentryTransaction(),
+            )
             call.respond(result)
         }
 
@@ -259,6 +293,34 @@ private fun ApplicationCall.apmTimeRange(): DdApmQueryTimeRange? {
     val rawValue = parameters["timeRange"] ?: parameters["range"] ?: DEFAULT_APM_TIME_RANGE
     return apmTimeRanges[rawValue]
 }
+
+private data class ServiceMapScope(
+    val env: String?,
+    val source: String?,
+)
+
+private data class ServiceMapParam(
+    val value: String?,
+)
+
+private fun ApplicationCall.serviceMapScope(): ServiceMapScope? {
+    val env = optionalServiceMapParam("env") ?: return null
+    val source = optionalServiceMapParam("source") ?: return null
+    return ServiceMapScope(env.value, source.value)
+}
+
+private fun ApplicationCall.optionalServiceMapParam(name: String): ServiceMapParam? {
+    val rawValue = parameters[name] ?: return ServiceMapParam(null)
+    val value = rawValue.trim()
+    if (value.length > MAX_SERVICE_PARAM_LENGTH) return null
+    return ServiceMapParam(value.takeIf { it.isNotEmpty() })
+}
+
+private fun ApplicationCall.requiredServiceMapParam(name: String): String? =
+    parameters[name]
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.takeIf { it.length <= MAX_SERVICE_PARAM_LENGTH }
 
 private fun ApplicationCall.apmStatus(): String? {
     val rawValue = parameters["status"] ?: return ""

--- a/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/services/TraceIngestionService.kt
@@ -40,6 +40,8 @@ import com.moneat.datadog.models.DdApmServiceFacet
 import com.moneat.datadog.models.DdApmServiceHealthItem
 import com.moneat.datadog.models.DdResourceStatsItem
 import com.moneat.datadog.models.DdResourceStatsResponse
+import com.moneat.datadog.models.DdServiceEdge
+import com.moneat.datadog.models.DdServiceLatencyResponse
 import com.moneat.datadog.models.DdServiceMapEntry
 import com.moneat.datadog.models.DdServiceMapResponse
 import com.moneat.datadog.models.DdSpan
@@ -92,6 +94,8 @@ private const val APM_ERROR_GROUPS_TABLE = "apm_error_groups_hourly"
 private const val APM_RESOURCE_STATS_TABLE = "apm_resource_stats_hourly"
 private const val APM_SERVICE_STATS_TABLE = "apm_service_stats_hourly"
 private const val APM_SERVICE_EDGES_TABLE = "apm_service_edges_hourly"
+private const val SERVICE_MAP_SERVICE_LIMIT = 100
+private const val SERVICE_MAP_EDGE_LIMIT = 500
 private const val MAX_META_VALUE_LENGTH = 5000
 private const val DEFAULT_QUERY_LIMIT = 50
 private const val MAX_QUERY_LIMIT = 200
@@ -973,86 +977,142 @@ object TraceIngestionService {
 
     suspend fun getServiceMap(
         organizationId: Int,
+        timeRange: DdApmQueryTimeRange = defaultApmQueryTimeRange,
+        env: String? = null,
+        source: String? = null,
         parentSpan: ISpan? = null,
     ): DdServiceMapResponse {
-        val query = """
+        val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val windowClause = timeRange.bucketStartClause()
+        val filterClause = serviceMapFilterClause(env, source)
+
+        val statsQuery = """
             SELECT
                 service,
                 sum(span_count) as span_count,
                 sum(error_count) as error_count,
                 if(sum(duration_count) = 0, 0, sum(duration_sum) / sum(duration_count)) as avg_duration_ns
             FROM `$clickhouseDb`.$APM_SERVICE_STATS_TABLE
-            WHERE ${ClickHouseQueryUtils.orgIdClause(organizationId.toLong())}
-              AND bucket_start >= toStartOfHour(now() - INTERVAL 1 HOUR)
+            WHERE $orgClause
+              AND $windowClause$filterClause
             GROUP BY service
             ORDER BY span_count DESC
-            LIMIT 100
+            LIMIT $SERVICE_MAP_SERVICE_LIMIT
             FORMAT JSONEachRow
         """.trimIndent()
+        val services = parseServiceMapStats(executeDashboardQuery(statsQuery, "", parentSpan))
 
-        val result = executeDashboardQuery(query, "", parentSpan)
-        val services = if (result.isBlank()) {
-            emptyList()
-        } else {
-            result.trim().lines()
-                .filter { it.isNotBlank() }
-                .mapNotNull { line ->
-                    val obj = parseRowOrNull(line) ?: return@mapNotNull null
-                    DdServiceMapEntry(
-                        service = obj["service"]!!
-                            .jsonPrimitive.content,
-                        spanCount = obj["span_count"]!!
-                            .jsonPrimitive.long,
-                        errorCount = obj["error_count"]!!
-                            .jsonPrimitive.long,
-                        avgDurationNs = obj["avg_duration_ns"]!!
-                            .jsonPrimitive.double,
-                        callsTo = emptyList(),
-                    )
-                }
-        }
-
-        // Build service relationships from parent-child spans
-        val callsQuery = """
+        // Edges carry their own throughput, error, and latency aggregates so the
+        // map can weight and color each dependency, not just draw an arrow.
+        val edgesQuery = """
             SELECT
                 from_service,
-                to_service
+                to_service,
+                sum(call_count) as call_count,
+                sum(error_count) as error_count,
+                if(sum(duration_count) = 0, 0, sum(duration_sum) / sum(duration_count)) as avg_duration_ns
             FROM `$clickhouseDb`.$APM_SERVICE_EDGES_TABLE
-            WHERE ${ClickHouseQueryUtils.orgIdClause(organizationId.toLong())}
-              AND bucket_start >= toStartOfHour(now() - INTERVAL 1 HOUR)
+            WHERE $orgClause
+              AND $windowClause$filterClause
             GROUP BY from_service, to_service
-            HAVING sum(call_count) > 0
-            ORDER BY sum(call_count) DESC
+            -- `call_count` is the SELECT alias (sum(call_count)); reference it directly
+            -- so we don't nest aggregates (sum(sum(...)) -> ILLEGAL_AGGREGATION).
+            HAVING call_count > 0
+            ORDER BY call_count DESC
+            LIMIT $SERVICE_MAP_EDGE_LIMIT
             FORMAT JSONEachRow
         """.trimIndent()
+        val edges = parseServiceMapEdges(executeDashboardQuery(edgesQuery, "", parentSpan))
 
-        val callsResult = executeDashboardQuery(
-            callsQuery,
-            "",
-            parentSpan,
-        )
         val callsMap = mutableMapOf<String, MutableSet<String>>()
-        if (callsResult.isNotBlank()) {
-            callsResult.trim().lines()
-                .filter { it.isNotBlank() }
-                .forEach { line ->
-                    val obj = parseRowOrNull(line) ?: return@forEach
-                    val from = obj["from_service"]!!
-                        .jsonPrimitive.content
-                    val to = obj["to_service"]!!
-                        .jsonPrimitive.content
-                    callsMap.getOrPut(from) { mutableSetOf() }.add(to)
-                }
+        edges.forEach { edge ->
+            callsMap.getOrPut(edge.fromService) { mutableSetOf() }.add(edge.toService)
+        }
+        val enriched = services.map { service ->
+            service.copy(callsTo = callsMap[service.service]?.toList() ?: emptyList())
         }
 
-        val enriched = services.map { svc ->
-            svc.copy(
-                callsTo = callsMap[svc.service]?.toList()
-                    ?: emptyList()
-            )
-        }
+        return DdServiceMapResponse(services = enriched, edges = edges)
+    }
 
-        return DdServiceMapResponse(services = enriched)
+    /**
+     * On-demand trace latency percentiles for a single focused service. This uses
+     * the same finalized/live trace-summary read path as the APM overview so the
+     * detail dock's latency matches the rest of the APM experience.
+     */
+    suspend fun getServiceLatencyPercentiles(
+        organizationId: Int,
+        service: String,
+        timeRange: DdApmQueryTimeRange = defaultApmQueryTimeRange,
+        env: String? = null,
+        source: String? = null,
+        parentSpan: ISpan? = null,
+    ): DdServiceLatencyResponse {
+        val subquery = traceSummarySubquery(
+            organizationId = organizationId,
+            query = DdTraceListQuery(
+                service = service,
+                env = env,
+                source = source,
+                timeRange = timeRange,
+            ),
+        )
+        val query = """
+            SELECT
+                if(count() > 0, toUInt64(quantile(0.50)(duration_ns)), 0) as p50_duration_ns,
+                if(count() > 0, toUInt64(quantile(0.90)(duration_ns)), 0) as p90_duration_ns,
+                if(count() > 0, toUInt64(quantile(0.99)(duration_ns)), 0) as p99_duration_ns,
+                count() as sample_count
+            FROM ($subquery)
+            FORMAT JSONEachRow
+        """.trimIndent()
+        val obj = firstJsonRow(query, parentSpan)
+        return DdServiceLatencyResponse(
+            service = service,
+            p50DurationNs = obj?.longValue("p50_duration_ns") ?: 0,
+            p90DurationNs = obj?.longValue("p90_duration_ns") ?: 0,
+            p99DurationNs = obj?.longValue("p99_duration_ns") ?: 0,
+            sampleCount = obj?.longValue("sample_count") ?: 0,
+        )
+    }
+
+    private fun parseServiceMapStats(result: String): List<DdServiceMapEntry> {
+        if (result.isBlank()) return emptyList()
+        return result.trim().lines()
+            .filter { it.isNotBlank() }
+            .mapNotNull { line ->
+                val obj = parseRowOrNull(line) ?: return@mapNotNull null
+                DdServiceMapEntry(
+                    service = obj["service"]!!.jsonPrimitive.content,
+                    spanCount = obj["span_count"]!!.jsonPrimitive.long,
+                    errorCount = obj["error_count"]!!.jsonPrimitive.long,
+                    avgDurationNs = obj["avg_duration_ns"]!!.jsonPrimitive.double,
+                    callsTo = emptyList(),
+                )
+            }
+    }
+
+    private fun parseServiceMapEdges(result: String): List<DdServiceEdge> {
+        if (result.isBlank()) return emptyList()
+        return result.trim().lines()
+            .filter { it.isNotBlank() }
+            .mapNotNull { line ->
+                val obj = parseRowOrNull(line) ?: return@mapNotNull null
+                DdServiceEdge(
+                    fromService = obj["from_service"]!!.jsonPrimitive.content,
+                    toService = obj["to_service"]!!.jsonPrimitive.content,
+                    callCount = obj["call_count"]!!.jsonPrimitive.long,
+                    errorCount = obj["error_count"]!!.jsonPrimitive.long,
+                    avgDurationNs = obj["avg_duration_ns"]!!.jsonPrimitive.double,
+                )
+            }
+    }
+
+    private fun serviceMapFilterClause(env: String?, source: String?): String {
+        val clauses = mutableListOf<String>()
+        if (!env.isNullOrBlank()) clauses.add("env = '${escapeSql(env)}'")
+        if (!source.isNullOrBlank()) clauses.add("source = '${escapeSql(source)}'")
+        return if (clauses.isEmpty()) "" else " AND " + clauses.joinToString(" AND ")
     }
 
     suspend fun getApmErrors(

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DatadogQueryRoutesTest.kt
@@ -86,7 +86,7 @@ class DatadogQueryRoutesTest {
         coEvery { TraceIngestionService.getApmOverview(any(), any<DdTraceListQuery>(), any()) } returns
             emptyApmOverview()
         coEvery { TraceIngestionService.getTraceDetail(any(), any(), any()) } returns null
-        coEvery { TraceIngestionService.getServiceMap(any(), any()) } returns
+        coEvery { TraceIngestionService.getServiceMap(any(), any(), any(), any(), any()) } returns
             DdServiceMapResponse(emptyList())
         coEvery { TraceIngestionService.getApmErrors(any(), any(), any(), any(), any(), any()) } returns
             DdApmErrorsResponse(emptyList(), 0L)

--- a/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DatadogRoutesExtendedTest.kt
@@ -29,6 +29,7 @@ import com.moneat.datadog.models.DatadogProcessPayload
 import com.moneat.datadog.models.DdApiKeys
 import com.moneat.datadog.models.DdApmErrorsResponse
 import com.moneat.datadog.models.DdResourceStatsResponse
+import com.moneat.datadog.models.DdServiceLatencyResponse
 import com.moneat.datadog.models.DdServiceMapResponse
 import com.moneat.datadog.models.DdStatsPayload
 import com.moneat.datadog.models.DdTraceListResponse
@@ -2302,7 +2303,7 @@ class DatadogRoutesExtendedTest {
     fun `GET v1 services map returns 200`() = testApplication {
         val (userId, orgId) = seedUserAndOrg()
         coEvery {
-            TraceIngestionService.getServiceMap(orgId)
+            TraceIngestionService.getServiceMap(any(), any(), any(), any(), any())
         } returns DdServiceMapResponse(emptyList())
         application {
             installAuth()
@@ -2312,6 +2313,87 @@ class DatadogRoutesExtendedTest {
             withAuth(jwtToken(userId, orgId))
         }
         assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `GET v1 services map forwards scope filters`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        coEvery {
+            TraceIngestionService.getServiceMap(orgId, any(), "prod", "otel", any())
+        } returns DdServiceMapResponse(emptyList())
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val response = client.get("/v1/services/map?timeRange=6h&env=prod&source=otel") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            TraceIngestionService.getServiceMap(orgId, any(), "prod", "otel", any())
+        }
+    }
+
+    @Test
+    fun `GET v1 services map rejects oversized scope filter`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val response = client.get("/v1/services/map?env=${"p".repeat(201)}") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `GET v1 services service latency returns percentiles`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        coEvery {
+            TraceIngestionService.getServiceLatencyPercentiles(orgId, "checkout", any(), "prod", "otel", any())
+        } returns DdServiceLatencyResponse(
+            service = "checkout",
+            p50DurationNs = 1_000L,
+            p90DurationNs = 5_000L,
+            p99DurationNs = 9_000L,
+            sampleCount = 42L,
+        )
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val response = client.get("/v1/services/checkout/latency?timeRange=24h&env=prod&source=otel") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"sampleCount\":42"))
+    }
+
+    @Test
+    fun `GET v1 services service latency rejects oversized service`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val response = client.get("/v1/services/${"s".repeat(201)}/latency") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `GET v1 services service latency rejects oversized scope filter`() = testApplication {
+        val (userId, orgId) = seedUserAndOrg()
+        application {
+            installAuth()
+            routing { traceDashboardRoutes() }
+        }
+        val response = client.get("/v1/services/checkout/latency?source=${"s".repeat(201)}") {
+            withAuth(jwtToken(userId, orgId))
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TraceIngestionServiceCoverageTest.kt
@@ -582,6 +582,7 @@ class TraceIngestionServiceCoverageTest {
 
         val result = TraceIngestionService.getServiceMap(1)
         assertTrue(result.services.isEmpty())
+        assertTrue(result.edges.isEmpty())
     }
 
     @Test
@@ -598,7 +599,7 @@ class TraceIngestionServiceCoverageTest {
                 """.trimIndent()
             } else {
                 """
-                {"from_service":"web","to_service":"db"}
+                {"from_service":"web","to_service":"db","call_count":42,"error_count":2,"avg_duration_ns":300000.0}
                 """.trimIndent()
             }
         }
@@ -608,6 +609,12 @@ class TraceIngestionServiceCoverageTest {
         assertEquals("web", result.services[0].service)
         assertEquals(listOf("db"), result.services[0].callsTo)
         assertTrue(result.services[1].callsTo.isEmpty())
+        assertEquals(1, result.edges.size)
+        assertEquals("web", result.edges[0].fromService)
+        assertEquals("db", result.edges[0].toService)
+        assertEquals(42L, result.edges[0].callCount)
+        assertEquals(2L, result.edges[0].errorCount)
+        assertEquals(300000.0, result.edges[0].avgDurationNs, 0.001)
         assertTrue(capturedQueries.any { it.contains("apm_service_stats_hourly") })
         assertTrue(capturedQueries.any { it.contains("apm_service_edges_hourly") })
         assertTrue(capturedQueries.none { it.contains("INNER JOIN") })
@@ -619,11 +626,71 @@ class TraceIngestionServiceCoverageTest {
         val span = mockk<ISpan>(relaxed = true)
         coEvery { ClickHouseClient.executeWithFormat(any(), any(), span) } returns ""
 
-        TraceIngestionService.getServiceMap(1, span)
+        TraceIngestionService.getServiceMap(1, parentSpan = span)
 
         coVerify(exactly = 2) {
             ClickHouseClient.executeWithFormat(any(), any(), span)
         }
+    }
+
+    @Test
+    fun `getServiceMap applies env and source filters`() = runBlocking {
+        val capturedQueries = mutableListOf<String>()
+        coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
+            capturedQueries.add(firstArg())
+            ""
+        }
+
+        TraceIngestionService.getServiceMap(
+            1,
+            DdApmQueryTimeRange(6, DdApmQueryTimeUnit.HOUR),
+            env = "prod",
+            source = "otel",
+        )
+
+        assertTrue(capturedQueries.isNotEmpty())
+        assertTrue(capturedQueries.all { it.contains("env = 'prod'") })
+        assertTrue(capturedQueries.all { it.contains("source = 'otel'") })
+        assertTrue(capturedQueries.all { it.contains("INTERVAL 6 HOUR") })
+    }
+
+    @Test
+    fun `getServiceLatencyPercentiles parses percentile row`() = runBlocking {
+        val capturedQueries = mutableListOf<String>()
+        coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
+            capturedQueries.add(firstArg())
+            """{"p50_duration_ns":1000,"p90_duration_ns":5000,"p99_duration_ns":9000,"sample_count":420}"""
+        }
+
+        val result = TraceIngestionService.getServiceLatencyPercentiles(
+            1,
+            "web",
+            DdApmQueryTimeRange(6, DdApmQueryTimeUnit.HOUR),
+            env = "prod",
+            source = "otlp",
+        )
+
+        assertEquals("web", result.service)
+        assertEquals(1000L, result.p50DurationNs)
+        assertEquals(5000L, result.p90DurationNs)
+        assertEquals(9000L, result.p99DurationNs)
+        assertEquals(420L, result.sampleCount)
+        assertTrue(capturedQueries.single().contains("apm_traces_final"))
+        assertTrue(capturedQueries.single().contains("apm_trace_summaries"))
+        assertTrue(capturedQueries.single().contains("root_service = 'web'"))
+        assertTrue(capturedQueries.single().contains("env = 'prod'"))
+        assertTrue(capturedQueries.single().contains("source = 'otlp'"))
+        assertTrue(capturedQueries.single().contains("INTERVAL 6 HOUR"))
+    }
+
+    @Test
+    fun `getServiceLatencyPercentiles returns zeros for blank response`() = runBlocking {
+        coEvery { ClickHouseClient.executeWithFormat(any(), any()) } returns ""
+
+        val result = TraceIngestionService.getServiceLatencyPercentiles(1, "web")
+
+        assertEquals(0L, result.p50DurationNs)
+        assertEquals(0L, result.sampleCount)
     }
 
     // ===================== getApmErrors =====================

--- a/dashboard/src/lib/api/modules/__tests__/apm.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/apm.test.ts
@@ -276,16 +276,42 @@ describe('APM API', () => {
   // ──── getApmServiceMap ────
 
   it('fetches APM service map', async () => {
-    const mockMap = { nodes: [], edges: [] }
+    const mockMap = { services: [], edges: [] }
 
     server.use(
-      http.get(`${API_BASE}/v1/services/map`, () => {
+      http.get(`${API_BASE}/v1/services/map`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('timeRange')).toBe('6h')
+        expect(url.searchParams.get('env')).toBe('prod')
+        expect(url.searchParams.get('source')).toBe('otlp')
         return HttpResponse.json(mockMap)
       })
     )
 
-    const result = await api.getApmServiceMap()
+    const result = await api.getApmServiceMap({ timeRange: '6h', env: 'prod', source: 'otlp' })
     expect(result).toEqual(mockMap)
+  })
+
+  it('fetches APM service latency', async () => {
+    const mockLatency = {
+      service: 'checkout',
+      p50DurationNs: 1_000,
+      p90DurationNs: 5_000,
+      p99DurationNs: 9_000,
+      sampleCount: 42,
+    }
+
+    server.use(
+      http.get(`${API_BASE}/v1/services/checkout/latency`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('timeRange')).toBe('24h')
+        expect(url.searchParams.get('env')).toBe('prod')
+        return HttpResponse.json(mockLatency)
+      })
+    )
+
+    const result = await api.getApmServiceLatency('checkout', { timeRange: '24h', env: 'prod' })
+    expect(result).toEqual(mockLatency)
   })
 
   // ──── getApmErrors ────

--- a/dashboard/src/lib/api/modules/apm.ts
+++ b/dashboard/src/lib/api/modules/apm.ts
@@ -21,6 +21,7 @@ import type {
   ApmTraceListResponse,
   ApmTraceDetailResponse,
   ApmServiceMapResponse,
+  ApmServiceLatency,
   ApmErrorsResponse,
   ApmResourceStatsResponse,
   ApmStatusFilter,
@@ -51,6 +52,18 @@ function appendApmListParams(searchParams: URLSearchParams, params: ApmListParam
   if (params.limit != null) searchParams.set('limit', String(params.limit))
   if (params.offset != null) searchParams.set('offset', String(params.offset))
   if (params.timeRange) searchParams.set('timeRange', params.timeRange)
+}
+
+type ApmServiceMapParams = {
+  timeRange?: ApmTimeRange
+  env?: string
+  source?: string
+}
+
+function appendServiceMapParams(searchParams: URLSearchParams, params: ApmServiceMapParams): void {
+  if (params.timeRange) searchParams.set('timeRange', params.timeRange)
+  if (params.env) searchParams.set('env', params.env)
+  if (params.source) searchParams.set('source', params.source)
 }
 
 function normalizeStringMap(raw: unknown): Record<string, string> {
@@ -143,8 +156,21 @@ export function apmMethods(core: ApiClientCore) {
       }
     },
 
-    getApmServiceMap: () =>
-      core.request<ApmServiceMapResponse>(`${base}/services/map`),
+    getApmServiceMap: (params: ApmServiceMapParams = {}) => {
+      const searchParams = new URLSearchParams()
+      appendServiceMapParams(searchParams, params)
+      return core.request<ApmServiceMapResponse>(
+        urlWithQuery(`${base}/services/map`, searchParams.toString())
+      )
+    },
+
+    getApmServiceLatency: (service: string, params: ApmServiceMapParams = {}) => {
+      const searchParams = new URLSearchParams()
+      appendServiceMapParams(searchParams, params)
+      return core.request<ApmServiceLatency>(
+        urlWithQuery(`${base}/services/${encodeURIComponent(service)}/latency`, searchParams.toString())
+      )
+    },
 
     getApmErrors: (
       params: ApmListParams = {}

--- a/dashboard/src/lib/api/types/apm.ts
+++ b/dashboard/src/lib/api/types/apm.ts
@@ -143,8 +143,25 @@ export interface ApmServiceMapEntry {
   callsTo: string[]
 }
 
+export interface ApmServiceEdge {
+  fromService: string
+  toService: string
+  callCount: number
+  errorCount: number
+  avgDurationNs: number
+}
+
 export interface ApmServiceMapResponse {
   services: ApmServiceMapEntry[]
+  edges?: ApmServiceEdge[]
+}
+
+export interface ApmServiceLatency {
+  service: string
+  p50DurationNs: number
+  p90DurationNs: number
+  p99DurationNs: number
+  sampleCount: number
 }
 
 export interface ApmErrorGroup {


### PR DESCRIPTION
Adds service map edge metrics, scoped map reads, and focused latency data for the monitoring map experience.

Validation:
- backend targeted route/service tests
- dashboard APM API test
- backend detekt
- dashboard lint
- dashboard build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service map now includes service relationship data with throughput and error metrics
  * Service map queries support time-range and scope filtering (environment/source)
  * New endpoint for fetching per-service latency percentiles (p50, p90, p99) with filtering capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->