### PR TITLE
feat: add log management backend APIs

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -142,9 +142,15 @@ class DashboardAlertService(
         val alertPriority = normalizeAlertPriority(request.alertPriority ?: request.legacyIncidentSeverity)
 
         return transaction {
-            DashboardWidgets.selectAll().where {
-                (DashboardWidgets.id eq request.widgetId) and (DashboardWidgets.dashboardId eq dashboardId)
-            }.firstOrNull() ?: throw IllegalArgumentException("Widget not found in this dashboard")
+            DashboardWidgets.innerJoin(Dashboards)
+                .selectAll()
+                .where {
+                    (DashboardWidgets.id eq request.widgetId) and
+                        (DashboardWidgets.dashboardId eq dashboardId) and
+                        (Dashboards.id eq dashboardId) and
+                        (Dashboards.orgId eq orgId)
+                }
+                .firstOrNull() ?: throw IllegalArgumentException("Widget not found in this dashboard")
 
             val id = DashboardWidgetAlerts.insert {
                 it[DashboardWidgetAlerts.widgetId] = request.widgetId

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
@@ -27,24 +27,26 @@ import com.moneat.dashboards.models.FilterOp
 import com.moneat.dashboards.models.GroupByType
 import com.moneat.dashboards.models.QueryDsl
 import com.moneat.dashboards.models.TimeRangeDef
+import com.moneat.logs.services.LogQueryParser
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.TimeConstants.MILLIS_PER_DAY
+import com.moneat.utils.TimeConstants.MILLIS_PER_HOUR
+import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import mu.KotlinLogging
 import kotlin.collections.filter
-import com.moneat.utils.suspendRunCatching
-import com.moneat.utils.TimeConstants.MILLIS_PER_DAY
-import com.moneat.utils.TimeConstants.MILLIS_PER_HOUR
-import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 
 private val logger = KotlinLogging.logger {}
 
 class DashboardQueryEngine {
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
     private val json = Json { ignoreUnknownKeys = true }
+    private val logQueryParser = LogQueryParser()
 
     private val allowedTables = setOf(
         "events",
@@ -91,6 +93,7 @@ class DashboardQueryEngine {
         private const val EPOCH_MS_TO_SECONDS_DIVISOR = 1000.0
         private const val DATETIME64_MILLIS_PRECISION = 3
         private const val QUERY_PREVIEW_LENGTH = 80
+        private const val LOGS_TABLE_NAME = "logs"
 
         fun resolveTimeInterval(from: String, to: String): String {
             val rangeMs = parseRelativeTime(to) - parseRelativeTime(from)
@@ -286,8 +289,19 @@ class DashboardQueryEngine {
         for (filter in dsl.filters) {
             clauses.add(buildFilterClause(filter))
         }
+        buildLogRawQueryClause(dsl)?.let { clauses.add(it) }
 
         return clauses
+    }
+
+    internal fun buildLogRawQueryClause(dsl: QueryDsl): String? {
+        val rawQuery = dsl.rawQuery?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        if (!dsl.isLogsDataSource()) return null
+        val root = logQueryParser.parse(rawQuery).rootNode ?: return null
+        val condition = logQueryParser.toClickHouseSql(root) { value -> ClickHouseSqlUtils.escapeSql(value) }
+        return condition
+            .takeIf { it.isNotBlank() && it != "1=1" }
+            ?.let { "($it)" }
     }
 
     internal fun buildScopeClause(dsl: QueryDsl, projectId: Long, orgId: Long?): String {
@@ -392,7 +406,7 @@ class DashboardQueryEngine {
         retentionDays: Int = 90,
         orgId: Long? = null
     ): List<Map<String, JsonElement>> {
-        if (dsl.rawQuery != null) {
+        if (dsl.rawQuery != null && !dsl.isLogsDataSource()) {
             logger.warn { "Skipping raw query execution for security - use query DSL" }
             return emptyList()
         }
@@ -442,6 +456,9 @@ class DashboardQueryEngine {
 
     fun parseCustomDataSourceId(dataSource: String): Long? =
         if (dataSource.startsWith("custom:")) dataSource.removePrefix("custom:").toLongOrNull() else null
+
+    private fun QueryDsl.isLogsDataSource(): Boolean =
+        DataSource.fromString(dataSource)?.tableName == LOGS_TABLE_NAME
 
     private fun getBuiltInDataSources(): List<DataSourceInfo> = listOf(
         DataSourceInfo(

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -66,6 +66,7 @@ import com.moneat.llm.services.LlmDashboardService
 import com.moneat.logs.repositories.LogRepository
 import com.moneat.logs.repositories.LogRepositoryImpl
 import com.moneat.logs.services.LogIndexService
+import com.moneat.logs.services.LogManagementService
 import com.moneat.logs.services.LogService
 import com.moneat.monitor.repositories.HostAlertRepository
 import com.moneat.monitor.repositories.HostAlertRepositoryImpl
@@ -259,6 +260,7 @@ val logsModule = module {
     single { OtlpApiKeyService() }
     single { OtlpServiceRoutingService() }
     single { LogIndexService() }
+    single { LogManagementService() }
 }
 
 /** Uptime monitoring and status pages. */

--- a/backend/src/main/kotlin/com/moneat/logs/LogPermissions.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/LogPermissions.kt
@@ -1,0 +1,30 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs
+
+/**
+ * Permission keys owned by the logs domain. When advanced RBAC is available
+ * these keys are resolved by the shared permission bridge; otherwise routes
+ * fall back to coarse organization roles.
+ */
+object LogPermissions {
+    const val READ = "logs:read"
+    const val MANAGE = "logs:manage"
+    const val LIVE_TAIL = "logs:live-tail"
+    const val METRICS = "logs:metrics"
+    const val MONITORS = "logs:monitors"
+}

--- a/backend/src/main/kotlin/com/moneat/logs/models/LogModels.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/models/LogModels.kt
@@ -175,7 +175,13 @@ data class LogTailFilters(
     val query: String? = null,
     val levels: Set<String> = emptySet(),
     val service: String? = null,
-    val environment: String? = null
+    val environment: String? = null,
+    @SerialName("container_name") val containerName: String? = null,
+    val tags: Map<String, String> = emptyMap(),
+    @SerialName("exclude_service") val excludeService: String? = null,
+    @SerialName("exclude_environment") val excludeEnvironment: String? = null,
+    @SerialName("exclude_container_name") val excludeContainerName: String? = null,
+    @SerialName("exclude_tags") val excludeTags: Map<String, String> = emptyMap()
 )
 
 @Serializable
@@ -258,4 +264,220 @@ data class UpdateLogIndexRequest(
 data class LogIndexTestResponse(
     @SerialName("match_count") val matchCount: Long,
     @SerialName("total_count") val totalCount: Long
+)
+
+@Serializable
+data class LogIndexUsageResponse(
+    @SerialName("index_name") val indexName: String,
+    @SerialName("bytes_today") val bytesToday: Long,
+    @SerialName("count_today") val countToday: Long,
+    @SerialName("quota_gb") val quotaGb: Float? = null,
+    @SerialName("retention_days") val retentionDays: Int? = null
+)
+
+@Serializable
+data class LogPipelineStep(
+    val type: String,
+    val enabled: Boolean = true,
+    val condition: String = "",
+    @SerialName("source_field") val sourceField: String = "",
+    @SerialName("target_field") val targetField: String = "",
+    val pattern: String = "",
+    val replacement: String = "",
+    val value: String = "",
+    val tags: Map<String, String> = emptyMap()
+)
+
+@Serializable
+data class LogPipelineResponse(
+    val id: Int,
+    val name: String,
+    val description: String = "",
+    val steps: List<LogPipelineStep> = emptyList(),
+    val priority: Int,
+    @SerialName("is_active") val isActive: Boolean,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+@Serializable
+data class CreateLogPipelineRequest(
+    val name: String,
+    val description: String = "",
+    val steps: List<LogPipelineStep> = emptyList(),
+    val priority: Int = 0,
+    @SerialName("is_active") val isActive: Boolean = true
+)
+
+@Serializable
+data class UpdateLogPipelineRequest(
+    val name: String? = null,
+    val description: String? = null,
+    val steps: List<LogPipelineStep>? = null,
+    val priority: Int? = null,
+    @SerialName("is_active") val isActive: Boolean? = null
+)
+
+@Serializable
+data class LogPipelinePreviewEntry(
+    val level: String = "info",
+    val message: String = "",
+    val body: String = "",
+    val service: String = "",
+    val environment: String = "",
+    val host: String = "",
+    val tags: Map<String, String> = emptyMap(),
+    @SerialName("resource_attributes") val resourceAttributes: Map<String, String> = emptyMap()
+)
+
+@Serializable
+data class LogPipelinePreviewRequest(
+    val steps: List<LogPipelineStep> = emptyList(),
+    @SerialName("sample_logs") val sampleLogs: List<LogPipelinePreviewEntry> = emptyList()
+)
+
+@Serializable
+data class LogPipelinePreviewResult(
+    val before: LogPipelinePreviewEntry,
+    val after: LogPipelinePreviewEntry? = null,
+    val dropped: Boolean = false
+)
+
+@Serializable
+data class LogSavedViewState(
+    val query: String = "",
+    val levels: List<String> = emptyList(),
+    val facets: Map<String, String> = emptyMap(),
+    @SerialName("time_preset") val timePreset: String = "1h",
+    val from: String? = null,
+    val to: String? = null,
+    val visualization: String = "timeline",
+    @SerialName("group_by") val groupBy: String? = null,
+    @SerialName("top_field") val topField: String? = null
+)
+
+@Serializable
+data class LogSavedViewResponse(
+    val id: Int,
+    val name: String,
+    val state: LogSavedViewState,
+    @SerialName("is_shared") val isShared: Boolean,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+@Serializable
+data class CreateLogSavedViewRequest(
+    val name: String,
+    val state: LogSavedViewState,
+    @SerialName("is_shared") val isShared: Boolean = true
+)
+
+@Serializable
+data class UpdateLogSavedViewRequest(
+    val name: String? = null,
+    val state: LogSavedViewState? = null,
+    @SerialName("is_shared") val isShared: Boolean? = null
+)
+
+@Serializable
+data class LogMetricRuleResponse(
+    val id: Int,
+    val name: String,
+    val query: String = "",
+    val levels: List<String> = emptyList(),
+    @SerialName("group_by") val groupBy: String? = null,
+    val interval: String = "5m",
+    @SerialName("is_active") val isActive: Boolean,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+@Serializable
+data class CreateLogMetricRuleRequest(
+    val name: String,
+    val query: String = "",
+    val levels: List<String> = emptyList(),
+    @SerialName("group_by") val groupBy: String? = null,
+    val interval: String = "5m",
+    @SerialName("is_active") val isActive: Boolean = true
+)
+
+@Serializable
+data class UpdateLogMetricRuleRequest(
+    val name: String? = null,
+    val query: String? = null,
+    val levels: List<String>? = null,
+    @SerialName("group_by") val groupBy: String? = null,
+    val interval: String? = null,
+    @SerialName("is_active") val isActive: Boolean? = null
+)
+
+@Serializable
+data class LogMonitorResponse(
+    val id: Int,
+    val name: String,
+    val query: String = "",
+    val levels: List<String> = emptyList(),
+    @SerialName("group_by") val groupBy: String? = null,
+    val condition: String = ">",
+    val threshold: Double,
+    @SerialName("warning_threshold") val warningThreshold: Double? = null,
+    @SerialName("window_minutes") val windowMinutes: Int,
+    @SerialName("is_active") val isActive: Boolean,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String
+)
+
+@Serializable
+data class CreateLogMonitorRequest(
+    val name: String,
+    val query: String = "",
+    val levels: List<String> = emptyList(),
+    @SerialName("group_by") val groupBy: String? = null,
+    val condition: String = ">",
+    val threshold: Double,
+    @SerialName("warning_threshold") val warningThreshold: Double? = null,
+    @SerialName("window_minutes") val windowMinutes: Int = 5,
+    @SerialName("is_active") val isActive: Boolean = true
+)
+
+@Serializable
+data class UpdateLogMonitorRequest(
+    val name: String? = null,
+    val query: String? = null,
+    val levels: List<String>? = null,
+    @SerialName("group_by") val groupBy: String? = null,
+    val condition: String? = null,
+    val threshold: Double? = null,
+    @SerialName("warning_threshold") val warningThreshold: Double? = null,
+    @SerialName("window_minutes") val windowMinutes: Int? = null,
+    @SerialName("is_active") val isActive: Boolean? = null
+)
+
+@Serializable
+data class LogMonitorDraftRequest(
+    val name: String,
+    val query: String = "",
+    val levels: List<String> = emptyList(),
+    @SerialName("group_by") val groupBy: String? = null,
+    val condition: String = ">",
+    val threshold: Double,
+    @SerialName("warning_threshold") val warningThreshold: Double? = null,
+    @SerialName("duration_seconds") val durationSeconds: Int = 0,
+    @SerialName("dashboard_id") val dashboardId: Long? = null,
+    @SerialName("widget_id") val widgetId: Long? = null
+)
+
+@Serializable
+data class LogMonitorDraftResponse(
+    val name: String,
+    val query: String,
+    val levels: List<String> = emptyList(),
+    @SerialName("group_by") val groupBy: String? = null,
+    val condition: String,
+    val threshold: Double,
+    @SerialName("warning_threshold") val warningThreshold: Double? = null,
+    @SerialName("dashboard_alert_created") val dashboardAlertCreated: Boolean = false,
+    @SerialName("dashboard_alert_id") val dashboardAlertId: Long? = null
 )

--- a/backend/src/main/kotlin/com/moneat/logs/routes/LogManagementRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/routes/LogManagementRoutes.kt
@@ -1,0 +1,457 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs.routes
+
+import com.moneat.dashboards.models.CreateDashboardAlertRequest
+import com.moneat.dashboards.services.DashboardAlertService
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.logs.LogPermissions
+import com.moneat.logs.models.CreateLogMetricRuleRequest
+import com.moneat.logs.models.CreateLogMonitorRequest
+import com.moneat.logs.models.LogAggregateResponse
+import com.moneat.logs.models.LogMonitorDraftRequest
+import com.moneat.logs.models.LogMonitorDraftResponse
+import com.moneat.logs.models.LogPipelinePreviewRequest
+import com.moneat.logs.models.UpdateLogMetricRuleRequest
+import com.moneat.logs.models.UpdateLogMonitorRequest
+import com.moneat.logs.models.UpdateLogPipelineRequest
+import com.moneat.logs.models.UpdateLogSavedViewRequest
+import com.moneat.logs.services.LogIndexService
+import com.moneat.logs.services.LogManagementService
+import com.moneat.logs.services.LogService
+import com.moneat.org.services.OrgMembershipService
+import com.moneat.org.services.OrgRole
+import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+private const val LOG_FORBIDDEN_MESSAGE = "Insufficient permissions"
+private const val PIPELINE_NOT_FOUND_MESSAGE = "Pipeline not found"
+private const val SAVED_VIEW_NOT_FOUND_MESSAGE = "Saved view not found"
+private const val METRIC_RULE_NOT_FOUND_MESSAGE = "Metric rule not found"
+private const val LOG_MONITOR_NOT_FOUND_MESSAGE = "Log monitor not found"
+private const val DEFAULT_METRIC_ROLLUP_MINUTES = 5L
+private const val MAX_METRIC_ROLLUP_DAYS = 1L
+
+fun Route.registerLogManagementRoutes(
+    logManagementService: LogManagementService,
+    logIndexService: LogIndexService,
+    logService: LogService,
+    membershipService: OrgMembershipService,
+    dashboardAlertService: DashboardAlertService
+) {
+    registerLogIndexManagementRoutes(logIndexService, membershipService)
+    registerLogPipelineManagementRoutes(logManagementService, membershipService)
+    registerLogSavedViewManagementRoutes(logManagementService, membershipService)
+    registerLogMetricManagementRoutes(logManagementService, logService, membershipService)
+    registerLogMonitorManagementRoutes(logManagementService, membershipService, dashboardAlertService)
+}
+
+private fun Route.registerLogIndexManagementRoutes(
+    logIndexService: LogIndexService,
+    membershipService: OrgMembershipService
+) {
+    get("/logs/permissions") {
+        call.respondLogPermissions(membershipService)
+    }
+    get("/logs/indexes/usage") {
+        call.respond(HttpStatusCode.OK, mapOf("usage" to logIndexService.usageStats(call.logOrgId())))
+    }
+    post("/logs/indexes/retention/run") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
+        val applied = logIndexService.enforceRetention(call.logOrgId())
+        call.respond(HttpStatusCode.OK, mapOf("indexes_processed" to applied))
+    }
+}
+
+private fun Route.registerLogPipelineManagementRoutes(
+    logManagementService: LogManagementService,
+    membershipService: OrgMembershipService
+) {
+    get("/logs/pipelines") {
+        call.respond(HttpStatusCode.OK, mapOf("pipelines" to logManagementService.listPipelines(call.logOrgId())))
+    }
+    post("/logs/pipelines") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
+        call.respondCreatedOrBadRequest {
+            logManagementService.createPipeline(call.logOrgId(), call.logUserId(), call.receive())
+        }
+    }
+    put("/logs/pipelines/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@put
+        val id = call.logPathId("id") ?: return@put
+        val updated = logManagementService.updatePipeline(call.logOrgId(), id, call.receive<UpdateLogPipelineRequest>())
+        call.respondNullable(updated, PIPELINE_NOT_FOUND_MESSAGE)
+    }
+    delete("/logs/pipelines/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@delete
+        val id = call.logPathId("id") ?: return@delete
+        call.respondDeleted(logManagementService.deletePipeline(call.logOrgId(), id), PIPELINE_NOT_FOUND_MESSAGE)
+    }
+    post("/logs/pipelines/preview") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
+        val result = logManagementService.previewPipeline(call.receive<LogPipelinePreviewRequest>())
+        call.respond(HttpStatusCode.OK, mapOf("results" to result))
+    }
+}
+
+private fun Route.registerLogSavedViewManagementRoutes(
+    logManagementService: LogManagementService,
+    membershipService: OrgMembershipService
+) {
+    get("/logs/saved-views") {
+        call.respond(
+            HttpStatusCode.OK,
+            mapOf("views" to logManagementService.listSavedViews(call.logOrgId(), call.logUserId()))
+        )
+    }
+    post("/logs/saved-views") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
+        call.respondCreatedOrBadRequest {
+            logManagementService.createSavedView(call.logOrgId(), call.logUserId(), call.receive())
+        }
+    }
+    put("/logs/saved-views/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@put
+        val id = call.logPathId("id") ?: return@put
+        val updated = logManagementService.updateSavedView(
+            call.logOrgId(),
+            id,
+            call.logUserId(),
+            call.receive<UpdateLogSavedViewRequest>()
+        )
+        call.respondNullable(updated, SAVED_VIEW_NOT_FOUND_MESSAGE)
+    }
+    delete("/logs/saved-views/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@delete
+        val id = call.logPathId("id") ?: return@delete
+        call.respondDeleted(
+            logManagementService.deleteSavedView(call.logOrgId(), id, call.logUserId()),
+            SAVED_VIEW_NOT_FOUND_MESSAGE
+        )
+    }
+}
+
+private fun Route.registerLogMetricManagementRoutes(
+    logManagementService: LogManagementService,
+    logService: LogService,
+    membershipService: OrgMembershipService
+) {
+    get("/logs/metrics/rules") {
+        call.respond(HttpStatusCode.OK, mapOf("rules" to logManagementService.listMetricRules(call.logOrgId())))
+    }
+    post("/logs/metrics/rules") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@post
+        call.respondCreatedOrBadRequest {
+            logManagementService.createMetricRule(call.logOrgId(), call.logUserId(), call.receive())
+        }
+    }
+    put("/logs/metrics/rules/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@put
+        val id = call.logPathId("id") ?: return@put
+        val updated = logManagementService.updateMetricRule(
+            call.logOrgId(),
+            id,
+            call.receive<UpdateLogMetricRuleRequest>()
+        )
+        call.respondNullable(updated, METRIC_RULE_NOT_FOUND_MESSAGE)
+    }
+    delete("/logs/metrics/rules/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@delete
+        val id = call.logPathId("id") ?: return@delete
+        call.respondDeleted(logManagementService.deleteMetricRule(call.logOrgId(), id), METRIC_RULE_NOT_FOUND_MESSAGE)
+    }
+    post("/logs/metrics/preview") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@post
+        val request = call.receive<CreateLogMetricRuleRequest>()
+        val aggregate = logService.aggregateForMetricPreview(call.logOrgId().toLong(), request)
+        call.respond(HttpStatusCode.OK, aggregate)
+    }
+    post("/logs/metrics/rules/{id}/rollup") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@post
+        val id = call.logPathId("id") ?: return@post
+        val rule = logManagementService.getMetricRule(call.logOrgId(), id)
+            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse(METRIC_RULE_NOT_FOUND_MESSAGE))
+        val aggregate = logService.aggregateForMetricPreview(call.logOrgId().toLong(), rule.toCreateRequest())
+        val inserted = logManagementService.recordMetricPoints(call.logOrgId().toLong(), rule, aggregate)
+        call.respond(HttpStatusCode.OK, mapOf("points_inserted" to inserted))
+    }
+}
+
+private fun Route.registerLogMonitorManagementRoutes(
+    logManagementService: LogManagementService,
+    membershipService: OrgMembershipService,
+    dashboardAlertService: DashboardAlertService
+) {
+    get("/logs/monitors") {
+        call.respond(HttpStatusCode.OK, mapOf("monitors" to logManagementService.listLogMonitors(call.logOrgId())))
+    }
+    post("/logs/monitors") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@post
+        call.respondCreatedOrBadRequest {
+            logManagementService.createLogMonitor(
+                call.logOrgId(),
+                call.logUserId(),
+                call.receive<CreateLogMonitorRequest>()
+            )
+        }
+    }
+    put("/logs/monitors/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@put
+        val id = call.logPathId("id") ?: return@put
+        call.respondNullableOrBadRequest(LOG_MONITOR_NOT_FOUND_MESSAGE) {
+            logManagementService.updateLogMonitor(
+                call.logOrgId(),
+                id,
+                call.receive<UpdateLogMonitorRequest>()
+            )
+        }
+    }
+    delete("/logs/monitors/{id}") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@delete
+        val id = call.logPathId("id") ?: return@delete
+        call.respondDeleted(logManagementService.deleteLogMonitor(call.logOrgId(), id), LOG_MONITOR_NOT_FOUND_MESSAGE)
+    }
+    post("/logs/monitors/from-query") {
+        if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@post
+        val request = call.receive<LogMonitorDraftRequest>()
+        val response = call.createLogMonitorDraftOrBadRequest(request, dashboardAlertService) ?: return@post
+        call.respond(HttpStatusCode.OK, response)
+    }
+}
+
+private suspend fun ApplicationCall.respondLogPermissions(membershipService: OrgMembershipService) {
+    respond(
+        HttpStatusCode.OK,
+        mapOf(
+            "can_manage" to isLogAllowed(membershipService, LogPermissions.MANAGE),
+            "can_live_tail" to isLogAllowed(membershipService, LogPermissions.LIVE_TAIL),
+            "can_create_metrics" to isLogAllowed(membershipService, LogPermissions.METRICS),
+            "can_create_monitors" to isLogAllowed(membershipService, LogPermissions.MONITORS)
+        )
+    )
+}
+
+private suspend fun ApplicationCall.createLogMonitorDraft(
+    request: LogMonitorDraftRequest,
+    dashboardAlertService: DashboardAlertService
+): LogMonitorDraftResponse {
+    val dashboardId = request.dashboardId
+    val widgetId = request.widgetId
+    if (dashboardId != null && widgetId != null) {
+        val alert = dashboardAlertService.createAlert(
+            dashboardId = dashboardId,
+            orgId = logOrgId().toLong(),
+            createdBy = logUserId().toLong(),
+            request = CreateDashboardAlertRequest(
+                widgetId = widgetId,
+                name = request.name,
+                condition = request.condition,
+                threshold = request.threshold,
+                warningThreshold = request.warningThreshold,
+                durationSeconds = request.durationSeconds
+            )
+        )
+        return request.toDraftResponse(dashboardAlertCreated = true, dashboardAlertId = alert.id)
+    }
+    return request.toDraftResponse(dashboardAlertCreated = false, dashboardAlertId = null)
+}
+
+private suspend fun ApplicationCall.createLogMonitorDraftOrBadRequest(
+    request: LogMonitorDraftRequest,
+    dashboardAlertService: DashboardAlertService
+): LogMonitorDraftResponse? =
+    suspendRunCatching {
+        createLogMonitorDraft(request, dashboardAlertService)
+    }.getOrElse { error ->
+        if (error is IllegalArgumentException) {
+            respond(HttpStatusCode.BadRequest, ErrorResponse(error.message ?: "Invalid monitor draft"))
+            null
+        } else {
+            throw error
+        }
+    }
+
+private suspend fun ApplicationCall.ensureLogAccess(
+    membershipService: OrgMembershipService,
+    permission: String
+): Boolean {
+    val allowed = isLogAllowed(membershipService, permission)
+    if (!allowed) {
+        respond(HttpStatusCode.Forbidden, ErrorResponse(LOG_FORBIDDEN_MESSAGE))
+    }
+    return allowed
+}
+
+private suspend fun ApplicationCall.isLogAllowed(
+    membershipService: OrgMembershipService,
+    permission: String
+): Boolean {
+    val granular = FeatureRegistry.getPermissionBridge()?.hasPermission(logOrgId(), logUserId(), permission)
+    return granular ?: suspendRunCatching {
+        membershipService.requireRole(logOrgId(), logUserId(), OrgRole.ADMIN)
+        true
+    }.getOrElse { false }
+}
+
+private suspend fun <T> ApplicationCall.respondCreatedOrBadRequest(block: suspend () -> T) {
+    suspendRunCatching {
+        val value = block()
+        respond(HttpStatusCode.Created, value as Any)
+    }.getOrElse { error ->
+        if (error is IllegalArgumentException) {
+            respond(HttpStatusCode.BadRequest, ErrorResponse(error.message ?: "Invalid request"))
+        } else {
+            throw error
+        }
+    }
+}
+
+private suspend fun ApplicationCall.respondNullable(
+    value: Any?,
+    missingMessage: String
+) {
+    if (value == null) {
+        respond(HttpStatusCode.NotFound, ErrorResponse(missingMessage))
+    } else {
+        respond(HttpStatusCode.OK, value)
+    }
+}
+
+private suspend fun ApplicationCall.respondNullableOrBadRequest(
+    missingMessage: String,
+    block: suspend () -> Any?
+) {
+    suspendRunCatching {
+        respondNullable(block(), missingMessage)
+    }.getOrElse { error ->
+        if (error is IllegalArgumentException) {
+            respond(HttpStatusCode.BadRequest, ErrorResponse(error.message ?: "Invalid request"))
+        } else {
+            throw error
+        }
+    }
+}
+
+private suspend fun ApplicationCall.respondDeleted(
+    deleted: Boolean,
+    missingMessage: String
+) {
+    if (deleted) {
+        respond(HttpStatusCode.NoContent)
+    } else {
+        respond(HttpStatusCode.NotFound, ErrorResponse(missingMessage))
+    }
+}
+
+private suspend fun ApplicationCall.logPathId(name: String): Int? {
+    val id = parameters[name]?.toIntOrNull()
+    if (id == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid ID"))
+        return null
+    }
+    return id
+}
+
+private fun ApplicationCall.logUserId(): Int =
+    principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
+
+private fun ApplicationCall.logOrgId(): Int =
+    principal<JWTPrincipal>()!!.payload.getClaim("orgId").asInt()
+
+private suspend fun LogService.aggregateForMetricPreview(
+    organizationId: Long,
+    request: CreateLogMetricRuleRequest
+): LogAggregateResponse {
+    val (from, to) = metricRollupWindow(request.interval)
+    return aggregateLogs(
+        organizationId = organizationId,
+        from = from,
+        to = to,
+        interval = request.interval,
+        query = request.query,
+        levels = request.levels,
+        service = null,
+        environment = null,
+        tags = emptyMap(),
+        excludeService = null,
+        excludeEnvironment = null,
+        excludeContainerName = null,
+        excludeTags = emptyMap(),
+        groupBy = LogManagementService.normalizeMetricGroupBy(request.groupBy)
+    )
+}
+
+private fun metricRollupWindow(interval: String): Pair<String, String> {
+    val to = Clock.System.now()
+    val from = to - metricIntervalDuration(interval)
+    return from.toString() to to.toString()
+}
+
+private fun metricIntervalDuration(interval: String): Duration {
+    val trimmed = interval.trim().lowercase()
+    val amount = trimmed.dropLast(1).toLongOrNull() ?: DEFAULT_METRIC_ROLLUP_MINUTES
+    val duration = when (trimmed.lastOrNull()) {
+        'm' -> amount.minutes
+        'h' -> amount.hours
+        'd' -> amount.days
+        else -> DEFAULT_METRIC_ROLLUP_MINUTES.minutes
+    }
+    val bounded = duration.coerceAtMost(MAX_METRIC_ROLLUP_DAYS.days)
+    return if (bounded > Duration.ZERO) bounded else DEFAULT_METRIC_ROLLUP_MINUTES.minutes
+}
+
+private fun com.moneat.logs.models.LogMetricRuleResponse.toCreateRequest(): CreateLogMetricRuleRequest =
+    CreateLogMetricRuleRequest(
+        name = name,
+        query = query,
+        levels = levels,
+        groupBy = groupBy,
+        interval = interval,
+        isActive = isActive
+    )
+
+private fun LogMonitorDraftRequest.toDraftResponse(
+    dashboardAlertCreated: Boolean,
+    dashboardAlertId: Long?
+): LogMonitorDraftResponse =
+    LogMonitorDraftResponse(
+        name = name,
+        query = query,
+        levels = levels,
+        groupBy = groupBy,
+        condition = condition,
+        threshold = threshold,
+        warningThreshold = warningThreshold,
+        dashboardAlertCreated = dashboardAlertCreated,
+        dashboardAlertId = dashboardAlertId
+    )

--- a/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
@@ -25,12 +25,16 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.billing.services.QuotaExceededResponse
 import com.moneat.datadog.decompression.DecompressionService
+import com.moneat.dashboards.services.DashboardAlertService
 import com.moneat.events.services.EventService
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.logs.LogPermissions
 import com.moneat.logs.models.CreateLogIndexRequest
 import com.moneat.logs.models.LogQueryRequest
 import com.moneat.logs.models.LogTailFilters
 import com.moneat.logs.models.UpdateLogIndexRequest
 import com.moneat.logs.services.LogIndexService
+import com.moneat.logs.services.LogManagementService
 import com.moneat.logs.services.LogService
 import com.moneat.otlp.OtlpAuth
 import com.moneat.otlp.models.CreateOtlpApiKeyRequest
@@ -39,6 +43,8 @@ import com.moneat.otlp.services.OtlpApiKeyService
 import com.moneat.otlp.services.OtlpServiceDescriptor
 import com.moneat.otlp.services.OtlpServiceRoutingService
 import com.moneat.otlp.services.OtlpSignalType
+import com.moneat.org.services.OrgMembershipService
+import com.moneat.org.services.OrgRole
 import com.moneat.plugins.getDemoEpochMs
 import com.moneat.plugins.isDemoUser
 import com.moneat.shared.services.ProjectIdResolver
@@ -83,15 +89,25 @@ fun Route.logRoutes(
     otlpApiKeyService: OtlpApiKeyService = GlobalContext.get().get(),
     logIndexService: LogIndexService = GlobalContext.get().get(),
     otlpServiceRoutingService: OtlpServiceRoutingService = GlobalContext.get().get(),
+    logManagementService: LogManagementService = GlobalContext.get().get(),
+    membershipService: OrgMembershipService = GlobalContext.get().get(),
+    dashboardAlertService: DashboardAlertService = GlobalContext.get().get(),
 ) {
     route("/v1") {
         authenticate("auth-jwt") {
             registerOtlpApiKeyRoutes(otlpApiKeyService)
             registerOtlpServiceRoutingRoutes(otlpServiceRoutingService)
-            registerLogIndexRoutes(logIndexService)
+            registerLogIndexRoutes(logIndexService, membershipService)
             registerLogQueryRoutes(logService)
+            registerLogManagementRoutes(
+                logManagementService = logManagementService,
+                logIndexService = logIndexService,
+                logService = logService,
+                membershipService = membershipService,
+                dashboardAlertService = dashboardAlertService
+            )
         }
-        registerLogTailRoute(logService)
+        registerLogTailRoute(logService, membershipService)
     }
 }
 
@@ -190,12 +206,23 @@ private suspend fun ApplicationCall.deleteOtlpServiceMapping(
     respond(HttpStatusCode.NoContent)
 }
 
-private fun Route.registerLogIndexRoutes(logIndexService: LogIndexService) {
+private fun Route.registerLogIndexRoutes(
+    logIndexService: LogIndexService,
+    membershipService: OrgMembershipService
+) {
     get("/logs/indexes") { call.listLogIndexes(logIndexService) }
-    post("/logs/indexes") { call.createLogIndex(logIndexService) }
-    put("/logs/indexes/{id}") { call.updateLogIndex(logIndexService) }
-    delete("/logs/indexes/{id}") { call.deleteLogIndex(logIndexService) }
-    post("/logs/indexes/test") { call.testLogIndex(logIndexService) }
+    post("/logs/indexes") {
+        if (call.ensureLogIndexAccess(membershipService)) call.createLogIndex(logIndexService)
+    }
+    put("/logs/indexes/{id}") {
+        if (call.ensureLogIndexAccess(membershipService)) call.updateLogIndex(logIndexService)
+    }
+    delete("/logs/indexes/{id}") {
+        if (call.ensureLogIndexAccess(membershipService)) call.deleteLogIndex(logIndexService)
+    }
+    post("/logs/indexes/test") {
+        if (call.ensureLogIndexAccess(membershipService)) call.testLogIndex(logIndexService)
+    }
 }
 
 private suspend fun ApplicationCall.listLogIndexes(logIndexService: LogIndexService) {
@@ -388,14 +415,25 @@ private suspend fun ApplicationCall.exportLogs(logService: LogService) {
     respondText(csv, ContentType.Text.CSV)
 }
 
-private fun Route.registerLogTailRoute(logService: LogService) {
-    get("/logs/tail") { call.tailLogs(logService) }
+private fun Route.registerLogTailRoute(
+    logService: LogService,
+    membershipService: OrgMembershipService
+) {
+    get("/logs/tail") { call.tailLogs(logService, membershipService) }
 }
 
-private suspend fun ApplicationCall.tailLogs(logService: LogService) {
-    val orgId = resolveTailOrganizationId()
-    if (orgId == null) {
+private suspend fun ApplicationCall.tailLogs(
+    logService: LogService,
+    membershipService: OrgMembershipService
+) {
+    val identity = resolveTailIdentity()
+    if (identity == null) {
         respond(HttpStatusCode.Unauthorized, ErrorResponse("Unauthorized"))
+        return
+    }
+    val (userId, orgId) = identity
+    if (!hasLogAccess(membershipService, orgId.toInt(), userId, LogPermissions.LIVE_TAIL)) {
+        respond(HttpStatusCode.Forbidden, ErrorResponse("Insufficient permissions"))
         return
     }
 
@@ -404,7 +442,14 @@ private suspend fun ApplicationCall.tailLogs(logService: LogService) {
             query = request.queryParameters["q"] ?: request.queryParameters["query"],
             levels = parseLevelQueryParams(this).map { it.lowercase() }.toSet(),
             service = request.queryParameters["service"],
-            environment = request.queryParameters["environment"]
+            environment = request.queryParameters["environment"],
+            containerName = request.queryParameters["containerName"] ?: request.queryParameters["container_name"],
+            tags = parseTagQueryParams(this),
+            excludeService = request.queryParameters["excludeService"],
+            excludeEnvironment = request.queryParameters["excludeEnvironment"],
+            excludeContainerName = request.queryParameters["excludeContainerName"]
+                ?: request.queryParameters["exclude_container_name"],
+            excludeTags = parseExcludeTagQueryParams(this)
         )
     val redisUrl = application.environment.config.property("redis.url").getString()
     val channel = logService.liveChannel(orgId)
@@ -520,10 +565,41 @@ private fun ApplicationCall.requiredUserId(): Int =
 private fun ApplicationCall.requiredOrganizationId(): Int =
     principal<JWTPrincipal>()!!.payload.getClaim("orgId").asInt()
 
-private fun ApplicationCall.resolveTailOrganizationId(): Long? {
+private suspend fun ApplicationCall.ensureLogIndexAccess(membershipService: OrgMembershipService): Boolean {
+    val allowed = hasLogAccess(
+        membershipService = membershipService,
+        organizationId = requiredOrganizationId(),
+        userId = requiredUserId(),
+        permission = LogPermissions.MANAGE
+    )
+    if (!allowed) {
+        respond(HttpStatusCode.Forbidden, ErrorResponse("Insufficient permissions"))
+    }
+    return allowed
+}
+
+private suspend fun hasLogAccess(
+    membershipService: OrgMembershipService,
+    organizationId: Int,
+    userId: Int,
+    permission: String
+): Boolean {
+    val granular = FeatureRegistry.getPermissionBridge()?.hasPermission(organizationId, userId, permission)
+    return granular ?: suspendRunCatching {
+        membershipService.requireRole(organizationId, userId, OrgRole.ADMIN)
+        true
+    }.getOrElse { false }
+}
+
+private fun ApplicationCall.resolveTailIdentity(): Pair<Int, Long>? {
     val principal = principal<JWTPrincipal>()
-    return principal?.payload?.getClaim("orgId")?.asInt()?.toLong()
-        ?: authenticateTailRequest(this)?.second
+    val principalUserId = principal?.payload?.getClaim("userId")?.asInt()
+    val principalOrgId = principal?.payload?.getClaim("orgId")?.asInt()?.toLong()
+    return if (principalUserId != null && principalOrgId != null) {
+        principalUserId to principalOrgId
+    } else {
+        authenticateTailRequest(this)
+    }
 }
 
 private fun parseLevelQueryParams(call: ApplicationCall): List<String> {

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogEntryFilterEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogEntryFilterEvaluator.kt
@@ -1,0 +1,176 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs.services
+
+import com.moneat.utils.suspendRunCatching
+
+private val searchableFields = listOf(
+    "message",
+    "body",
+    "service",
+    "environment",
+    "host",
+    "container_name"
+)
+
+class LogEntryFilterEvaluator(
+    private val parser: LogQueryParser = LogQueryParser()
+) {
+    fun matches(
+        filterQuery: String,
+        entry: Map<String, String>
+    ): Boolean {
+        if (filterQuery.isBlank()) return true
+        val parsed = parser.parse(filterQuery)
+        val root = parsed.rootNode ?: return true
+        return evaluate(root, entry)
+    }
+
+    fun evaluate(
+        node: LogQueryParser.QueryNode,
+        entry: Map<String, String>
+    ): Boolean {
+        return when (node) {
+            is LogQueryParser.QueryNode.FieldNode -> evaluateFieldNode(node, entry)
+            is LogQueryParser.QueryNode.FullTextNode -> evaluateFullTextNode(node, entry)
+            is LogQueryParser.QueryNode.AndNode ->
+                evaluate(node.left, entry) && evaluate(node.right, entry)
+            is LogQueryParser.QueryNode.OrNode ->
+                evaluate(node.left, entry) || evaluate(node.right, entry)
+            is LogQueryParser.QueryNode.NotNode ->
+                !evaluate(node.node, entry)
+            is LogQueryParser.QueryNode.ExistsNode ->
+                !entry[node.field].isNullOrEmpty()
+            is LogQueryParser.QueryNode.TagExistsNode ->
+                entry.containsKey(node.tagKey)
+            is LogQueryParser.QueryNode.TermNode -> evaluateTermNode(node, entry)
+            is LogQueryParser.QueryNode.RangeNode -> evaluateRangeNode(node, entry)
+            is LogQueryParser.QueryNode.ComparisonNode -> evaluateComparisonNode(node, entry)
+        }
+    }
+
+    private fun evaluateFullTextNode(
+        node: LogQueryParser.QueryNode.FullTextNode,
+        entry: Map<String, String>
+    ): Boolean {
+        return searchableFields.any { field ->
+            val value = entry[field] ?: return@any false
+            matchesFullText(value, node)
+        }
+    }
+
+    private fun evaluateTermNode(
+        node: LogQueryParser.QueryNode.TermNode,
+        entry: Map<String, String>
+    ): Boolean {
+        return entry.values.any { value ->
+            if (node.isWildcard) {
+                matchesWildcard(value, node.term, partial = true)
+            } else {
+                value.contains(node.term, ignoreCase = true)
+            }
+        }
+    }
+
+    private fun evaluateFieldNode(
+        node: LogQueryParser.QueryNode.FieldNode,
+        entry: Map<String, String>
+    ): Boolean {
+        val value = entry[node.field] ?: return false
+        if (!node.isWildcard) {
+            return value.lowercase() == node.value.lowercase()
+        }
+
+        return matchesWildcard(value, node.value, partial = false)
+    }
+
+    private fun matchesFullText(
+        value: String,
+        node: LogQueryParser.QueryNode.FullTextNode
+    ): Boolean {
+        if (node.isWildcard) {
+            return matchesWildcard(value, node.term, partial = true)
+        }
+
+        if (node.isPhrase) {
+            return containsPhrase(value, node.term)
+        }
+
+        return value.contains(node.term, ignoreCase = true)
+    }
+
+    private fun containsPhrase(
+        value: String,
+        phrase: String
+    ): Boolean {
+        return value.contains(phrase, ignoreCase = true)
+    }
+
+    private fun matchesWildcard(
+        value: String,
+        pattern: String,
+        partial: Boolean
+    ): Boolean {
+        val matcher = wildcardMatcher(pattern) ?: return false
+        return if (partial) {
+            matcher.containsMatchIn(value)
+        } else {
+            value.matches(matcher)
+        }
+    }
+
+    private fun wildcardMatcher(pattern: String): Regex? {
+        val regexPattern = buildString {
+            pattern.forEach { character ->
+                when (character) {
+                    '*' -> append(".*")
+                    '?' -> append('.')
+                    else -> append(Regex.escape(character.toString()))
+                }
+            }
+        }
+
+        return suspendRunCatching {
+            Regex(regexPattern, RegexOption.IGNORE_CASE)
+        }.getOrNull()
+    }
+
+    private fun evaluateRangeNode(
+        node: LogQueryParser.QueryNode.RangeNode,
+        entry: Map<String, String>
+    ): Boolean {
+        val value = entry[node.field]?.toDoubleOrNull() ?: return false
+        val min = node.min.toDoubleOrNull() ?: return false
+        val max = node.max.toDoubleOrNull() ?: return false
+        return value in min..max
+    }
+
+    private fun evaluateComparisonNode(
+        node: LogQueryParser.QueryNode.ComparisonNode,
+        entry: Map<String, String>
+    ): Boolean {
+        val value = entry[node.field]?.toDoubleOrNull() ?: return false
+        val target = node.value.toDoubleOrNull() ?: return false
+        return when (node.operator) {
+            ">" -> value > target
+            ">=" -> value >= target
+            "<" -> value < target
+            "<=" -> value <= target
+            else -> false
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogIndexService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogIndexService.kt
@@ -21,11 +21,14 @@ import com.moneat.config.isClickHouseError
 import com.moneat.logs.models.CreateLogIndexRequest
 import com.moneat.logs.models.LogIndexResponse
 import com.moneat.logs.models.LogIndexTestResponse
+import com.moneat.logs.models.LogIndexUsageResponse
+import com.moneat.logs.models.QueuedLogEntry
 import com.moneat.logs.models.UpdateLogIndexRequest
 import com.moneat.shared.models.LogIndexes
 import com.moneat.shared.services.CacheService
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -34,25 +37,33 @@ import kotlinx.serialization.json.longOrNull
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.text.Charsets
 import kotlin.time.Clock
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
 private val json = Json { ignoreUnknownKeys = true }
 private const val CACHE_TTL_SECONDS = 60L
+private const val QUOTA_USAGE_CACHE_TTL_MILLIS = 30_000L
 private const val MAX_SAMPLING_RATE = 1.0f
 private const val MIN_SAMPLING_RATE = 0.0f
 private const val MAX_RETENTION_DAYS = 365
+private const val BYTES_PER_GB = 1024L * 1024L * 1024L
+private const val ERROR_BODY_SHORT_CHARS = 500
+private const val POSTGRES_UNIQUE_VIOLATION_SQLSTATE = "23505"
 
 class LogIndexService {
 
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
     private val queryParser = LogQueryParser()
+    private val filterEvaluator = LogEntryFilterEvaluator(queryParser)
+    private val quotaUsageCache = ConcurrentHashMap<Int, QuotaUsageCacheEntry>()
 
     fun create(
         organizationId: Int,
@@ -60,22 +71,25 @@ class LogIndexService {
     ): LogIndexResponse {
         val name = request.name.trim()
         if (name.isEmpty()) throw IllegalArgumentException("Index name cannot be empty")
+        ensureIndexNameAvailable(organizationId, name)
         val now = Clock.System.now()
-        val id = transaction {
-            LogIndexes.insert {
-                it[LogIndexes.organizationId] = organizationId
-                it[LogIndexes.name] = name
-                it[LogIndexes.filterQuery] = request.filterQuery
-                it[LogIndexes.retentionDays] = request.retentionDays
-                    .coerceIn(1, MAX_RETENTION_DAYS)
-                it[LogIndexes.samplingRate] = request.samplingRate
-                    .coerceIn(MIN_SAMPLING_RATE, MAX_SAMPLING_RATE)
-                it[LogIndexes.priority] = request.priority
-                it[LogIndexes.isActive] = true
-                it[LogIndexes.dailyQuotaGb] = request.dailyQuotaGb
-                it[LogIndexes.createdAt] = now
-                it[LogIndexes.updatedAt] = now
-            }[LogIndexes.id]
+        val id = mapDuplicateIndexName {
+            transaction {
+                LogIndexes.insert {
+                    it[LogIndexes.organizationId] = organizationId
+                    it[LogIndexes.name] = name
+                    it[LogIndexes.filterQuery] = request.filterQuery
+                    it[LogIndexes.retentionDays] = request.retentionDays
+                        .coerceIn(1, MAX_RETENTION_DAYS)
+                    it[LogIndexes.samplingRate] = request.samplingRate
+                        .coerceIn(MIN_SAMPLING_RATE, MAX_SAMPLING_RATE)
+                    it[LogIndexes.priority] = request.priority
+                    it[LogIndexes.isActive] = true
+                    it[LogIndexes.dailyQuotaGb] = request.dailyQuotaGb
+                    it[LogIndexes.createdAt] = now
+                    it[LogIndexes.updatedAt] = now
+                }[LogIndexes.id]
+            }
         }
         invalidateCache(organizationId)
         return getById(organizationId, id)!!
@@ -86,38 +100,43 @@ class LogIndexService {
         indexId: Int,
         request: UpdateLogIndexRequest
     ): LogIndexResponse? {
+        request.name?.trim()?.takeIf { it.isNotEmpty() }?.let { name ->
+            ensureIndexNameAvailable(organizationId, name, indexId)
+        }
         val now = Clock.System.now()
-        val updated = transaction {
-            LogIndexes.update({
-                (LogIndexes.id eq indexId) and
-                    (LogIndexes.organizationId eq organizationId)
-            }) {
-                request.name?.let { v ->
-                    val trimmed = v.trim()
-                    if (trimmed.isEmpty()) throw IllegalArgumentException("Index name cannot be empty")
-                    it[LogIndexes.name] = trimmed
+        val updated = mapDuplicateIndexName {
+            transaction {
+                LogIndexes.update({
+                    (LogIndexes.id eq indexId) and
+                        (LogIndexes.organizationId eq organizationId)
+                }) {
+                    request.name?.let { v ->
+                        val trimmed = v.trim()
+                        if (trimmed.isEmpty()) throw IllegalArgumentException("Index name cannot be empty")
+                        it[LogIndexes.name] = trimmed
+                    }
+                    request.filterQuery?.let { v ->
+                        it[LogIndexes.filterQuery] = v
+                    }
+                    request.retentionDays?.let { v ->
+                        it[LogIndexes.retentionDays] =
+                            v.coerceIn(1, MAX_RETENTION_DAYS)
+                    }
+                    request.samplingRate?.let { v ->
+                        it[LogIndexes.samplingRate] =
+                            v.coerceIn(MIN_SAMPLING_RATE, MAX_SAMPLING_RATE)
+                    }
+                    request.priority?.let { v ->
+                        it[LogIndexes.priority] = v
+                    }
+                    request.isActive?.let { v ->
+                        it[LogIndexes.isActive] = v
+                    }
+                    request.dailyQuotaGb?.let { v ->
+                        it[LogIndexes.dailyQuotaGb] = v
+                    }
+                    it[LogIndexes.updatedAt] = now
                 }
-                request.filterQuery?.let { v ->
-                    it[LogIndexes.filterQuery] = v
-                }
-                request.retentionDays?.let { v ->
-                    it[LogIndexes.retentionDays] =
-                        v.coerceIn(1, MAX_RETENTION_DAYS)
-                }
-                request.samplingRate?.let { v ->
-                    it[LogIndexes.samplingRate] =
-                        v.coerceIn(MIN_SAMPLING_RATE, MAX_SAMPLING_RATE)
-                }
-                request.priority?.let { v ->
-                    it[LogIndexes.priority] = v
-                }
-                request.isActive?.let { v ->
-                    it[LogIndexes.isActive] = v
-                }
-                request.dailyQuotaGb?.let { v ->
-                    it[LogIndexes.dailyQuotaGb] = v
-                }
-                it[LogIndexes.updatedAt] = now
             }
         }
         if (updated == 0) return null
@@ -211,6 +230,87 @@ class LogIndexService {
         return ""
     }
 
+    suspend fun usageStats(organizationId: Int): List<LogIndexUsageResponse> {
+        val indexes = list(organizationId).associateBy { it.name }
+        val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val sql = """
+            SELECT
+                index_name,
+                count() AS cnt,
+                sum(length(message) + length(body)) AS bytes
+            FROM `$clickhouseDb`.logs
+            WHERE $orgClause
+              AND timestamp >= toStartOfDay(now())
+              AND index_name != ''
+            GROUP BY index_name
+            FORMAT JSONEachRow
+        """.trimIndent()
+
+        val rows = executeUsageQuery(sql)
+        return indexes.values.map { index ->
+            val row = rows[index.name]
+            LogIndexUsageResponse(
+                indexName = index.name,
+                bytesToday = row?.bytes ?: 0L,
+                countToday = row?.count ?: 0L,
+                quotaGb = index.dailyQuotaGb,
+                retentionDays = index.retentionDays
+            )
+        }
+    }
+
+    suspend fun enforceRetention(organizationId: Int): Int {
+        var applied = 0
+        for (index in list(organizationId)) {
+            val sql = """
+                ALTER TABLE `$clickhouseDb`.logs
+                DELETE WHERE organization_id = ${organizationId.toLong()}
+                  AND index_name = '${escapeSql(index.name)}'
+                  AND timestamp < now() - INTERVAL ${index.retentionDays} DAY
+            """.trimIndent()
+            val response = ClickHouseClient.execute(sql)
+            val body = response.bodyAsText()
+            if (response.isClickHouseError(body)) {
+                logger.warn {
+                    "Retention delete failed for log index '${index.name}': " +
+                        body.take(ERROR_BODY_SHORT_CHARS)
+                }
+            } else {
+                applied += 1
+            }
+        }
+        return applied
+    }
+
+    suspend fun filterWithinDailyQuota(
+        organizationId: Int,
+        entries: List<QueuedLogEntry>,
+        indexes: List<LogIndexResponse>
+    ): List<QueuedLogEntry> {
+        if (entries.isEmpty()) return entries
+        val quotaIndexes = indexes
+            .filter { it.dailyQuotaGb != null && it.dailyQuotaGb > 0f }
+            .associateBy { it.name }
+        if (quotaIndexes.isEmpty()) return entries
+
+        val usedBytes = cachedQuotaUsageBytes(organizationId)
+
+        return synchronized(usedBytes) {
+            entries.filter { entry ->
+                val index = quotaIndexes[entry.indexName] ?: return@filter true
+                val quotaBytes = ((index.dailyQuotaGb ?: return@filter true) * BYTES_PER_GB).toLong()
+                val entryBytes = entry.quotaBytes()
+                val current = usedBytes[entry.indexName] ?: 0L
+                if (current + entryBytes > quotaBytes) {
+                    false
+                } else {
+                    usedBytes[entry.indexName] = current + entryBytes
+                    true
+                }
+            }
+        }
+    }
+
     /**
      * Test a filter query against the last hour of logs and return
      * match/total counts.
@@ -273,87 +373,7 @@ class LogIndexService {
         filterQuery: String,
         logEntry: Map<String, String>
     ): Boolean {
-        val parsed = queryParser.parse(filterQuery)
-        if (parsed.rootNode == null) return true
-        return evaluateNode(parsed.rootNode, logEntry)
-    }
-
-    private fun evaluateNode(
-        node: LogQueryParser.QueryNode,
-        entry: Map<String, String>
-    ): Boolean {
-        return when (node) {
-            is LogQueryParser.QueryNode.FieldNode -> {
-                val value = entry[node.field] ?: return false
-                if (node.isWildcard) {
-                    val escaped = Regex.escape(node.value)
-                    val pattern = escaped
-                        .replace("\\*", ".*")
-                        .replace("\\?", ".")
-                    suspendRunCatching {
-                        value.matches(Regex(pattern, RegexOption.IGNORE_CASE))
-                    }.getOrElse { _ ->
-                        false
-                    }
-                } else {
-                    value.equals(node.value, ignoreCase = true)
-                }
-            }
-            is LogQueryParser.QueryNode.FullTextNode -> {
-                val searchFields = listOf(
-                    "message",
-                    "body",
-                    "service",
-                    "environment",
-                    "host",
-                    "container_name"
-                )
-                searchFields.any { field ->
-                    val v = entry[field] ?: return@any false
-                    v.contains(node.term, ignoreCase = true)
-                }
-            }
-            is LogQueryParser.QueryNode.AndNode ->
-                evaluateNode(node.left, entry) &&
-                    evaluateNode(node.right, entry)
-            is LogQueryParser.QueryNode.OrNode ->
-                evaluateNode(node.left, entry) ||
-                    evaluateNode(node.right, entry)
-            is LogQueryParser.QueryNode.NotNode ->
-                !evaluateNode(node.node, entry)
-            is LogQueryParser.QueryNode.ExistsNode -> {
-                val v = entry[node.field]
-                v != null && v.isNotEmpty()
-            }
-            is LogQueryParser.QueryNode.TagExistsNode -> {
-                entry.containsKey(node.tagKey)
-            }
-            is LogQueryParser.QueryNode.TermNode -> {
-                entry.values.any {
-                    it.contains(node.term, ignoreCase = true)
-                }
-            }
-            is LogQueryParser.QueryNode.RangeNode -> {
-                val v = entry[node.field]?.toDoubleOrNull()
-                    ?: return false
-                val min = node.min.toDoubleOrNull() ?: return false
-                val max = node.max.toDoubleOrNull() ?: return false
-                v in min..max
-            }
-            is LogQueryParser.QueryNode.ComparisonNode -> {
-                val v = entry[node.field]?.toDoubleOrNull()
-                    ?: return false
-                val target = node.value.toDoubleOrNull()
-                    ?: return false
-                when (node.operator) {
-                    ">" -> v > target
-                    ">=" -> v >= target
-                    "<" -> v < target
-                    "<=" -> v <= target
-                    else -> false
-                }
-            }
-        }
+        return filterEvaluator.matches(filterQuery, logEntry)
     }
 
     private suspend fun executeCountQuery(sql: String): Long {
@@ -374,6 +394,60 @@ class LogIndexService {
         }
     }
 
+    private suspend fun executeUsageQuery(sql: String): Map<String, UsageRow> {
+        return suspendRunCatching {
+            val response = ClickHouseClient.execute(sql)
+            val body = response.bodyAsText()
+            if (response.isClickHouseError(body)) {
+                logger.warn { "Usage query failed: ${body.take(ERROR_BODY_SHORT_CHARS)}" }
+                emptyMap()
+            } else {
+                body.lineSequence()
+                    .filter { it.isNotBlank() }
+                    .mapNotNull { line ->
+                        val obj = json.parseToJsonElement(line).jsonObject
+                        val name = obj["index_name"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                        val count = obj["cnt"]?.jsonPrimitive?.longOrNull ?: 0L
+                        val bytes = obj["bytes"]?.jsonPrimitive?.longOrNull ?: 0L
+                        name to UsageRow(count = count, bytes = bytes)
+                    }
+                    .toMap()
+            }
+        }.getOrElse { e ->
+            logger.warn(e) { "Usage query failed: $sql" }
+            emptyMap()
+        }
+    }
+
+    private data class UsageRow(
+        val count: Long,
+        val bytes: Long
+    )
+
+    private data class QuotaUsageCacheEntry(
+        val expiresAtMillis: Long,
+        val bytesByIndex: MutableMap<String, Long>
+    )
+
+    private suspend fun cachedQuotaUsageBytes(organizationId: Int): MutableMap<String, Long> {
+        val nowMillis = Clock.System.now().toEpochMilliseconds()
+        val cached = quotaUsageCache[organizationId]
+        if (cached != null && cached.expiresAtMillis > nowMillis) {
+            return cached.bytesByIndex
+        }
+        val fresh = usageStats(organizationId).associate { usage ->
+            usage.indexName to usage.bytesToday
+        }.toMutableMap()
+        quotaUsageCache[organizationId] = QuotaUsageCacheEntry(
+            expiresAtMillis = nowMillis + QUOTA_USAGE_CACHE_TTL_MILLIS,
+            bytesByIndex = fresh
+        )
+        return fresh
+    }
+
+    private fun QueuedLogEntry.quotaBytes(): Long =
+        (message.toByteArray(Charsets.UTF_8).size + body.toByteArray(Charsets.UTF_8).size).toLong()
+
     private fun toResponse(
         row: org.jetbrains.exposed.v1.core.ResultRow
     ): LogIndexResponse {
@@ -391,7 +465,35 @@ class LogIndexService {
         )
     }
 
+    private fun ensureIndexNameAvailable(
+        organizationId: Int,
+        name: String,
+        excludeId: Int? = null
+    ) {
+        val duplicate = transaction {
+            LogIndexes
+                .selectAll()
+                .where {
+                    (LogIndexes.organizationId eq organizationId) and
+                        (LogIndexes.name eq name)
+                }
+                .firstOrNull()
+                ?.let { excludeId == null || it[LogIndexes.id] != excludeId }
+                ?: false
+        }
+        require(!duplicate) { "Index name already exists" }
+    }
+
+    private fun <T> mapDuplicateIndexName(block: () -> T): T =
+        try {
+            block()
+        } catch (error: ExposedSQLException) {
+            require(error.sqlState != POSTGRES_UNIQUE_VIOLATION_SQLSTATE) { "Index name already exists" }
+            throw error
+        }
+
     private fun invalidateCache(organizationId: Int) {
         CacheService.invalidate("logindex:active:$organizationId")
+        quotaUsageCache.remove(organizationId)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
@@ -45,9 +45,11 @@ class LogIngestionWorker(
     private val workerCount: Int,
     private val logService: LogService = LogService(LogRepositoryImpl()),
     private val logIndexService: LogIndexService = LogIndexService(),
+    private val logManagementService: LogManagementService = LogManagementService(),
 ) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var jobs: List<Job> = emptyList()
+    private val filterEvaluator = LogEntryFilterEvaluator()
 
     fun start() {
         logger.info { "Starting LogIngestionWorker with $workerCount workers, queue=$queueKey" }
@@ -105,18 +107,29 @@ class LogIngestionWorker(
             } else {
                 emptyList()
             }
+            val pipelines = if (orgId in Int.MIN_VALUE..Int.MAX_VALUE) {
+                logManagementService.getActivePipelinesCached(orgId.toInt())
+            } else {
+                emptyList()
+            }
+            val processedLogs = logManagementService.applyPipelines(batch.logs, pipelines)
 
             val taggedLogs = if (indexes.isEmpty()) {
-                batch.logs
+                processedLogs
             } else {
-                batch.logs.mapNotNull { entry ->
+                processedLogs.mapNotNull { entry ->
                     applyIndexRouting(entry, indexes)
                 }
             }
+            val quotaFilteredLogs = if (orgId in Int.MIN_VALUE..Int.MAX_VALUE) {
+                logIndexService.filterWithinDailyQuota(orgId.toInt(), taggedLogs, indexes)
+            } else {
+                taggedLogs
+            }
 
-            if (taggedLogs.isEmpty()) return
+            if (quotaFilteredLogs.isEmpty()) return
 
-            val taggedBatch = batch.copy(logs = taggedLogs)
+            val taggedBatch = batch.copy(logs = quotaFilteredLogs)
             val inserted = logService.insertBatch(taggedBatch)
             logService.publishLiveLogs(orgId, inserted)
             OperationalMetrics.recordWorkerMessageProcessed("Log", workerId)
@@ -157,22 +170,12 @@ class LogIngestionWorker(
             "span_id" to entry.spanId
         ) + entry.tags + entry.resourceAttributes
 
-        val parser = LogQueryParser()
         for (index in indexes) {
             val matches = if (index.filterQuery.isBlank()) {
                 true
             } else {
                 suspendRunCatching {
-                    val parsed = parser.parse(index.filterQuery)
-                    if (parsed.rootNode == null) {
-                        logger.debug {
-                            "Filter '${index.filterQuery}' for index '${index.name}' " +
-                                "produced null AST; treating as non-match"
-                        }
-                        false
-                    } else {
-                        evaluateFilter(parsed.rootNode, entryMap)
-                    }
+                    filterEvaluator.matches(index.filterQuery, entryMap)
                 }.getOrElse { _ ->
                     false
                 }
@@ -188,76 +191,5 @@ class LogIngestionWorker(
             }
         }
         return entry
-    }
-
-    private fun evaluateFilter(
-        node: LogQueryParser.QueryNode,
-        entry: Map<String, String>
-    ): Boolean {
-        return when (node) {
-            is LogQueryParser.QueryNode.FieldNode -> {
-                val value = entry[node.field] ?: return false
-                if (node.isWildcard) {
-                    val escaped = Regex.escape(node.value)
-                    val pattern = escaped
-                        .replace("\\*", ".*")
-                        .replace("\\?", ".")
-                    suspendRunCatching {
-                        value.matches(Regex(pattern, RegexOption.IGNORE_CASE))
-                    }.getOrElse { _ ->
-                        false
-                    }
-                } else {
-                    value.equals(node.value, ignoreCase = true)
-                }
-            }
-            is LogQueryParser.QueryNode.FullTextNode -> {
-                val fields = listOf(
-                    "message",
-                    "body",
-                    "service",
-                    "environment",
-                    "host",
-                    "container_name"
-                )
-                fields.any { f ->
-                    val v = entry[f] ?: return@any false
-                    v.contains(node.term, ignoreCase = true)
-                }
-            }
-            is LogQueryParser.QueryNode.AndNode ->
-                evaluateFilter(node.left, entry) &&
-                    evaluateFilter(node.right, entry)
-            is LogQueryParser.QueryNode.OrNode ->
-                evaluateFilter(node.left, entry) ||
-                    evaluateFilter(node.right, entry)
-            is LogQueryParser.QueryNode.NotNode ->
-                !evaluateFilter(node.node, entry)
-            is LogQueryParser.QueryNode.ExistsNode ->
-                !entry[node.field].isNullOrEmpty()
-            is LogQueryParser.QueryNode.TagExistsNode ->
-                entry.containsKey(node.tagKey)
-            is LogQueryParser.QueryNode.TermNode ->
-                entry.values.any {
-                    it.contains(node.term, ignoreCase = true)
-                }
-            is LogQueryParser.QueryNode.RangeNode -> {
-                val v = entry[node.field]?.toDoubleOrNull() ?: return false
-                val min = node.min.toDoubleOrNull() ?: return false
-                val max = node.max.toDoubleOrNull() ?: return false
-                v in min..max
-            }
-            is LogQueryParser.QueryNode.ComparisonNode -> {
-                val v = entry[node.field]?.toDoubleOrNull() ?: return false
-                val target = node.value.toDoubleOrNull() ?: return false
-                when (node.operator) {
-                    ">" -> v > target
-                    ">=" -> v >= target
-                    "<" -> v < target
-                    "<=" -> v <= target
-                    else -> false
-                }
-            }
-        }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogManagementService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogManagementService.kt
@@ -1,0 +1,1086 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs.services
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.config.isClickHouseError
+import com.moneat.logs.models.CreateLogMetricRuleRequest
+import com.moneat.logs.models.CreateLogMonitorRequest
+import com.moneat.logs.models.CreateLogPipelineRequest
+import com.moneat.logs.models.CreateLogSavedViewRequest
+import com.moneat.logs.models.LogAggregateResponse
+import com.moneat.logs.models.LogMetricRuleResponse
+import com.moneat.logs.models.LogMonitorResponse
+import com.moneat.logs.models.LogPipelinePreviewEntry
+import com.moneat.logs.models.LogPipelinePreviewRequest
+import com.moneat.logs.models.LogPipelinePreviewResult
+import com.moneat.logs.models.LogPipelineResponse
+import com.moneat.logs.models.LogPipelineStep
+import com.moneat.logs.models.LogSavedViewResponse
+import com.moneat.logs.models.LogSavedViewState
+import com.moneat.logs.models.QueuedLogEntry
+import com.moneat.logs.models.UpdateLogMetricRuleRequest
+import com.moneat.logs.models.UpdateLogMonitorRequest
+import com.moneat.logs.models.UpdateLogPipelineRequest
+import com.moneat.logs.models.UpdateLogSavedViewRequest
+import com.moneat.shared.models.LogMetricRules
+import com.moneat.shared.models.LogMonitors
+import com.moneat.shared.models.LogPipelines
+import com.moneat.shared.models.LogSavedViews
+import com.moneat.shared.services.CacheService
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.suspendRunCatching
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+
+private val logManagementLogger = KotlinLogging.logger {}
+private val logManagementJson = Json { ignoreUnknownKeys = true }
+private const val LOG_MANAGEMENT_CACHE_TTL_SECONDS = 60L
+private const val DEFAULT_METRIC_GROUP_KEY = ""
+private const val DEFAULT_METRIC_GROUP_VALUE = ""
+private const val KEY_VALUE_PATTERN = """([A-Za-z0-9_.-]+)=([^\s]+)"""
+private const val CLICKHOUSE_ERROR_PREVIEW_CHARS = 500
+private const val POSTGRES_UNIQUE_VIOLATION_SQLSTATE = "23505"
+private const val PIPELINE_NAME_REQUIRED_MESSAGE = "Pipeline name is required"
+private const val PIPELINE_NAME_EXISTS_MESSAGE = "Pipeline name already exists"
+private const val SAVED_VIEW_NAME_REQUIRED_MESSAGE = "Saved view name is required"
+private const val SAVED_VIEW_NAME_EXISTS_MESSAGE = "Saved view name already exists"
+private const val METRIC_RULE_NAME_REQUIRED_MESSAGE = "Metric rule name is required"
+private const val METRIC_RULE_NAME_EXISTS_MESSAGE = "Metric rule name already exists"
+private const val LOG_MONITOR_NAME_REQUIRED_MESSAGE = "Log monitor name is required"
+private const val LOG_MONITOR_NAME_EXISTS_MESSAGE = "Log monitor name already exists"
+private const val LOG_MONITOR_THRESHOLD_MESSAGE = "Log monitor threshold must be finite"
+private const val LOG_MONITOR_WINDOW_MINUTES_MESSAGE = "Log monitor window_minutes must be at least 1"
+private const val DROP_STEP_CONDITION_REQUIRED_MESSAGE = "Drop pipeline steps require a condition"
+private const val PIPELINE_PATTERN_TOO_LONG_MESSAGE = "Pipeline regex pattern is too long"
+private const val PIPELINE_PATTERN_UNSAFE_MESSAGE = "Pipeline regex pattern uses unsupported high-cost constructs"
+private const val PIPELINE_PATTERN_INVALID_MESSAGE = "Pipeline regex pattern is invalid"
+private const val MAX_PIPELINE_PATTERN_LENGTH = 512
+private const val MIN_LOG_MONITOR_WINDOW_MINUTES = 1
+private val unsafeNestedQuantifierPattern = Regex("""\((?:\\.|[^()\\])*[+*](?:\\.|[^()\\])*\)\s*[+*{]""")
+private val unsafeBackreferencePattern = Regex("""\\[1-9]""")
+
+class LogManagementService {
+    private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
+    private val filterEvaluator = LogEntryFilterEvaluator()
+
+    companion object {
+        private val validMetricGroupFields = setOf("level", "service", "environment")
+        private val validMonitorConditions = setOf(">", ">=", "<", "<=", "==")
+
+        fun normalizeMetricGroupBy(value: String?): String? {
+            val normalized = value?.trim()?.takeIf { it.isNotBlank() } ?: return null
+            require(normalized in validMetricGroupFields) {
+                "Metric group_by must be one of: ${validMetricGroupFields.joinToString()}"
+            }
+            return normalized
+        }
+
+        fun normalizeMonitorCondition(value: String?): String {
+            val normalized = value?.trim()?.takeIf { it.isNotBlank() } ?: ">"
+            require(normalized in validMonitorConditions) {
+                "Log monitor condition must be one of: ${validMonitorConditions.joinToString()}"
+            }
+            return normalized
+        }
+    }
+
+    fun listPipelines(organizationId: Int): List<LogPipelineResponse> =
+        transaction {
+            LogPipelines
+                .selectAll()
+                .where { LogPipelines.organizationId eq organizationId }
+                .orderBy(LogPipelines.priority)
+                .map { toPipelineResponse(it) }
+        }
+
+    fun createPipeline(
+        organizationId: Int,
+        createdBy: Int,
+        request: CreateLogPipelineRequest
+    ): LogPipelineResponse {
+        val name = requireTrimmedName(request.name, PIPELINE_NAME_REQUIRED_MESSAGE)
+        ensurePipelineNameAvailable(organizationId, name)
+        validatePipelineSteps(request.steps)
+        val now = Clock.System.now()
+        val id = mapDuplicateName(PIPELINE_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogPipelines.insert {
+                    it[LogPipelines.organizationId] = organizationId
+                    it[LogPipelines.name] = name
+                    it[LogPipelines.description] = request.description.trim()
+                    it[LogPipelines.stepsJson] = encodeSteps(request.steps)
+                    it[LogPipelines.priority] = request.priority
+                    it[LogPipelines.isActive] = request.isActive
+                    it[LogPipelines.createdBy] = createdBy
+                    it[LogPipelines.createdAt] = now
+                    it[LogPipelines.updatedAt] = now
+                }[LogPipelines.id]
+            }
+        }
+        invalidatePipelineCache(organizationId)
+        return getPipeline(organizationId, id)!!
+    }
+
+    fun updatePipeline(
+        organizationId: Int,
+        pipelineId: Int,
+        request: UpdateLogPipelineRequest
+    ): LogPipelineResponse? {
+        val nameUpdate = request.name?.let { requireTrimmedName(it, PIPELINE_NAME_REQUIRED_MESSAGE) }
+        nameUpdate?.let { name -> ensurePipelineNameAvailable(organizationId, name, pipelineId) }
+        request.steps?.let { validatePipelineSteps(it) }
+        val now = Clock.System.now()
+        val updated = mapDuplicateName(PIPELINE_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogPipelines.update({
+                    (LogPipelines.id eq pipelineId) and
+                        (LogPipelines.organizationId eq organizationId)
+                }) {
+                    nameUpdate?.let { name ->
+                        it[LogPipelines.name] = name
+                    }
+                    request.description?.let { value ->
+                        it[LogPipelines.description] = value.trim()
+                    }
+                    request.steps?.let { steps ->
+                        it[LogPipelines.stepsJson] = encodeSteps(steps)
+                    }
+                    request.priority?.let { value ->
+                        it[LogPipelines.priority] = value
+                    }
+                    request.isActive?.let { value ->
+                        it[LogPipelines.isActive] = value
+                    }
+                    it[LogPipelines.updatedAt] = now
+                }
+            }
+        }
+        if (updated == 0) return null
+        invalidatePipelineCache(organizationId)
+        return getPipeline(organizationId, pipelineId)
+    }
+
+    fun deletePipeline(organizationId: Int, pipelineId: Int): Boolean {
+        val deleted = transaction {
+            LogPipelines.deleteWhere {
+                (LogPipelines.id eq pipelineId) and
+                    (LogPipelines.organizationId eq organizationId)
+            }
+        }
+        if (deleted > 0) invalidatePipelineCache(organizationId)
+        return deleted > 0
+    }
+
+    suspend fun getActivePipelinesCached(organizationId: Int): List<LogPipelineResponse> =
+        CacheService.cached("logpipeline:active:$organizationId", LOG_MANAGEMENT_CACHE_TTL_SECONDS) {
+            transaction {
+                LogPipelines
+                    .selectAll()
+                    .where {
+                        (LogPipelines.organizationId eq organizationId) and
+                            (LogPipelines.isActive eq true)
+                    }
+                    .orderBy(LogPipelines.priority)
+                    .map { toPipelineResponse(it) }
+            }
+        }
+
+    fun previewPipeline(request: LogPipelinePreviewRequest): List<LogPipelinePreviewResult> {
+        validatePipelineSteps(request.steps)
+        return request.sampleLogs.map { sample ->
+            val state = PipelineEntryState.fromPreview(sample)
+            val transformed = applySteps(state, request.steps)
+            LogPipelinePreviewResult(
+                before = sample,
+                after = transformed?.toPreview(),
+                dropped = transformed == null
+            )
+        }
+    }
+
+    fun applyPipelines(
+        entries: List<QueuedLogEntry>,
+        pipelines: List<LogPipelineResponse>
+    ): List<QueuedLogEntry> {
+        if (entries.isEmpty() || pipelines.isEmpty()) return entries
+        val steps = pipelines.flatMap { pipeline -> pipeline.steps }
+        if (steps.isEmpty()) return entries
+
+        return entries.mapNotNull { entry ->
+            val state = PipelineEntryState.fromQueued(entry)
+            applySteps(state, steps)?.toQueued(entry)
+        }
+    }
+
+    fun listSavedViews(
+        organizationId: Int,
+        userId: Int
+    ): List<LogSavedViewResponse> =
+        transaction {
+            LogSavedViews
+                .selectAll()
+                .where {
+                    (LogSavedViews.organizationId eq organizationId) and
+                        ((LogSavedViews.isShared eq true) or (LogSavedViews.createdBy eq userId))
+                }
+                .orderBy(LogSavedViews.name)
+                .map { toSavedViewResponse(it) }
+        }
+
+    fun createSavedView(
+        organizationId: Int,
+        createdBy: Int,
+        request: CreateLogSavedViewRequest
+    ): LogSavedViewResponse {
+        val name = requireTrimmedName(request.name, SAVED_VIEW_NAME_REQUIRED_MESSAGE)
+        ensureSavedViewNameAvailable(organizationId, name)
+        val now = Clock.System.now()
+        val id = mapDuplicateName(SAVED_VIEW_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogSavedViews.insert {
+                    it[LogSavedViews.organizationId] = organizationId
+                    it[LogSavedViews.name] = name
+                    it[LogSavedViews.viewStateJson] = encodeViewState(request.state)
+                    it[LogSavedViews.isShared] = request.isShared
+                    it[LogSavedViews.createdBy] = createdBy
+                    it[LogSavedViews.createdAt] = now
+                    it[LogSavedViews.updatedAt] = now
+                }[LogSavedViews.id]
+            }
+        }
+        return getSavedView(organizationId, id, createdBy)!!
+    }
+
+    fun updateSavedView(
+        organizationId: Int,
+        viewId: Int,
+        userId: Int,
+        request: UpdateLogSavedViewRequest
+    ): LogSavedViewResponse? {
+        val nameUpdate = request.name?.let { requireTrimmedName(it, SAVED_VIEW_NAME_REQUIRED_MESSAGE) }
+        nameUpdate?.let { name -> ensureSavedViewNameAvailable(organizationId, name, viewId) }
+        val now = Clock.System.now()
+        val updated = mapDuplicateName(SAVED_VIEW_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogSavedViews.update({
+                    savedViewAccessCondition(organizationId, viewId, userId)
+                }) {
+                    nameUpdate?.let { name ->
+                        it[LogSavedViews.name] = name
+                    }
+                    request.state?.let { state ->
+                        it[LogSavedViews.viewStateJson] = encodeViewState(state)
+                    }
+                    request.isShared?.let { value ->
+                        it[LogSavedViews.isShared] = value
+                    }
+                    it[LogSavedViews.updatedAt] = now
+                }
+            }
+        }
+        if (updated == 0) return null
+        return getSavedView(organizationId, viewId, userId)
+    }
+
+    fun deleteSavedView(
+        organizationId: Int,
+        viewId: Int,
+        userId: Int
+    ): Boolean =
+        transaction {
+            LogSavedViews.deleteWhere {
+                savedViewAccessCondition(organizationId, viewId, userId)
+            }
+        } > 0
+
+    fun listMetricRules(organizationId: Int): List<LogMetricRuleResponse> =
+        transaction {
+            LogMetricRules
+                .selectAll()
+                .where { LogMetricRules.organizationId eq organizationId }
+                .orderBy(LogMetricRules.name)
+                .map { toMetricRuleResponse(it) }
+        }
+
+    fun createMetricRule(
+        organizationId: Int,
+        createdBy: Int,
+        request: CreateLogMetricRuleRequest
+    ): LogMetricRuleResponse {
+        val name = requireTrimmedName(request.name, METRIC_RULE_NAME_REQUIRED_MESSAGE)
+        ensureMetricRuleNameAvailable(organizationId, name)
+        val groupBy = normalizeMetricGroupBy(request.groupBy)
+        val now = Clock.System.now()
+        val id = mapDuplicateName(METRIC_RULE_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogMetricRules.insert {
+                    it[LogMetricRules.organizationId] = organizationId
+                    it[LogMetricRules.name] = name
+                    it[LogMetricRules.query] = request.query.trim()
+                    it[LogMetricRules.levelsJson] = encodeLevels(request.levels)
+                    it[LogMetricRules.groupBy] = groupBy
+                    it[LogMetricRules.interval] = request.interval
+                    it[LogMetricRules.isActive] = request.isActive
+                    it[LogMetricRules.createdBy] = createdBy
+                    it[LogMetricRules.createdAt] = now
+                    it[LogMetricRules.updatedAt] = now
+                }[LogMetricRules.id]
+            }
+        }
+        return getMetricRule(organizationId, id)!!
+    }
+
+    fun updateMetricRule(
+        organizationId: Int,
+        ruleId: Int,
+        request: UpdateLogMetricRuleRequest
+    ): LogMetricRuleResponse? {
+        val nameUpdate = request.name?.let { requireTrimmedName(it, METRIC_RULE_NAME_REQUIRED_MESSAGE) }
+        nameUpdate?.let { name -> ensureMetricRuleNameAvailable(organizationId, name, ruleId) }
+        val now = Clock.System.now()
+        val updated = mapDuplicateName(METRIC_RULE_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogMetricRules.update({
+                    (LogMetricRules.id eq ruleId) and
+                        (LogMetricRules.organizationId eq organizationId)
+                }) {
+                    nameUpdate?.let { name ->
+                        it[LogMetricRules.name] = name
+                    }
+                    request.query?.let { value ->
+                        it[LogMetricRules.query] = value.trim()
+                    }
+                    request.levels?.let { levels ->
+                        it[LogMetricRules.levelsJson] = encodeLevels(levels)
+                    }
+                    request.groupBy?.let { value ->
+                        it[LogMetricRules.groupBy] = normalizeMetricGroupBy(value)
+                    }
+                    request.interval?.let { value ->
+                        it[LogMetricRules.interval] = value
+                    }
+                    request.isActive?.let { value ->
+                        it[LogMetricRules.isActive] = value
+                    }
+                    it[LogMetricRules.updatedAt] = now
+                }
+            }
+        }
+        if (updated == 0) return null
+        return getMetricRule(organizationId, ruleId)
+    }
+
+    fun deleteMetricRule(organizationId: Int, ruleId: Int): Boolean =
+        transaction {
+            LogMetricRules.deleteWhere {
+                (LogMetricRules.id eq ruleId) and
+                    (LogMetricRules.organizationId eq organizationId)
+            }
+        } > 0
+
+    fun listLogMonitors(organizationId: Int): List<LogMonitorResponse> =
+        transaction {
+            LogMonitors
+                .selectAll()
+                .where { LogMonitors.organizationId eq organizationId }
+                .orderBy(LogMonitors.name)
+                .map { toLogMonitorResponse(it) }
+        }
+
+    fun createLogMonitor(
+        organizationId: Int,
+        createdBy: Int,
+        request: CreateLogMonitorRequest
+    ): LogMonitorResponse {
+        val name = requireTrimmedName(request.name, LOG_MONITOR_NAME_REQUIRED_MESSAGE)
+        ensureLogMonitorNameAvailable(organizationId, name)
+        val groupBy = normalizeMetricGroupBy(request.groupBy)
+        val condition = normalizeMonitorCondition(request.condition)
+        val threshold = requireFiniteThreshold(request.threshold)
+        val warningThreshold = request.warningThreshold?.let { requireFiniteThreshold(it) }
+        val windowMinutes = normalizeMonitorWindowMinutes(request.windowMinutes)
+        val now = Clock.System.now()
+        val id = mapDuplicateName(LOG_MONITOR_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogMonitors.insert {
+                    it[LogMonitors.organizationId] = organizationId
+                    it[LogMonitors.name] = name
+                    it[LogMonitors.query] = request.query.trim()
+                    it[LogMonitors.levelsJson] = encodeLevels(request.levels)
+                    it[LogMonitors.groupBy] = groupBy
+                    it[LogMonitors.condition] = condition
+                    it[LogMonitors.threshold] = threshold
+                    it[LogMonitors.warningThreshold] = warningThreshold
+                    it[LogMonitors.windowMinutes] = windowMinutes
+                    it[LogMonitors.isActive] = request.isActive
+                    it[LogMonitors.createdBy] = createdBy
+                    it[LogMonitors.createdAt] = now
+                    it[LogMonitors.updatedAt] = now
+                }[LogMonitors.id]
+            }
+        }
+        return getLogMonitor(organizationId, id)!!
+    }
+
+    fun updateLogMonitor(
+        organizationId: Int,
+        monitorId: Int,
+        request: UpdateLogMonitorRequest
+    ): LogMonitorResponse? {
+        val nameUpdate = request.name?.let { requireTrimmedName(it, LOG_MONITOR_NAME_REQUIRED_MESSAGE) }
+        nameUpdate?.let { name -> ensureLogMonitorNameAvailable(organizationId, name, monitorId) }
+        val groupByUpdate = request.groupBy?.let { normalizeMetricGroupBy(it) }
+        val conditionUpdate = request.condition?.let { normalizeMonitorCondition(it) }
+        val thresholdUpdate = request.threshold?.let { requireFiniteThreshold(it) }
+        val warningThresholdUpdate = request.warningThreshold?.let { requireFiniteThreshold(it) }
+        val windowMinutesUpdate = request.windowMinutes?.let { normalizeMonitorWindowMinutes(it) }
+        val now = Clock.System.now()
+        val updated = mapDuplicateName(LOG_MONITOR_NAME_EXISTS_MESSAGE) {
+            transaction {
+                LogMonitors.update({
+                    (LogMonitors.id eq monitorId) and
+                        (LogMonitors.organizationId eq organizationId)
+                }) {
+                    nameUpdate?.let { name ->
+                        it[LogMonitors.name] = name
+                    }
+                    request.query?.let { value ->
+                        it[LogMonitors.query] = value.trim()
+                    }
+                    request.levels?.let { levels ->
+                        it[LogMonitors.levelsJson] = encodeLevels(levels)
+                    }
+                    groupByUpdate?.let { value ->
+                        it[LogMonitors.groupBy] = value
+                    }
+                    conditionUpdate?.let { value ->
+                        it[LogMonitors.condition] = value
+                    }
+                    thresholdUpdate?.let { value ->
+                        it[LogMonitors.threshold] = value
+                    }
+                    warningThresholdUpdate?.let { value ->
+                        it[LogMonitors.warningThreshold] = value
+                    }
+                    windowMinutesUpdate?.let { value ->
+                        it[LogMonitors.windowMinutes] = value
+                    }
+                    request.isActive?.let { value ->
+                        it[LogMonitors.isActive] = value
+                    }
+                    it[LogMonitors.updatedAt] = now
+                }
+            }
+        }
+        if (updated == 0) return null
+        return getLogMonitor(organizationId, monitorId)
+    }
+
+    fun deleteLogMonitor(organizationId: Int, monitorId: Int): Boolean =
+        transaction {
+            LogMonitors.deleteWhere {
+                (LogMonitors.id eq monitorId) and
+                    (LogMonitors.organizationId eq organizationId)
+            }
+        } > 0
+
+    suspend fun recordMetricPoints(
+        organizationId: Long,
+        rule: LogMetricRuleResponse,
+        aggregate: LogAggregateResponse
+    ): Int {
+        val rows = aggregate.buckets.flatMap { bucket ->
+            if (bucket.groups.isEmpty()) {
+                listOf(metricRow(organizationId, rule, bucket.timestamp, DEFAULT_METRIC_GROUP_VALUE, bucket.count))
+            } else {
+                bucket.groups.map { (groupValue, count) ->
+                    metricRow(organizationId, rule, bucket.timestamp, groupValue, count)
+                }
+            }
+        }
+        if (rows.isEmpty()) return 0
+
+        val sql = """
+            INSERT INTO `$clickhouseDb`.log_metric_points
+            (organization_id, metric_name, rule_id, timestamp, group_key, group_value, value, source_query)
+            VALUES
+            ${rows.joinToString(",\n")}
+        """.trimIndent()
+
+        val response = ClickHouseClient.execute(sql)
+        val body = response.bodyAsText()
+        if (response.isClickHouseError(body)) {
+            logManagementLogger.warn {
+                "Failed to record log metric points: ${body.take(CLICKHOUSE_ERROR_PREVIEW_CHARS)}"
+            }
+            throw IllegalStateException("Failed to record log metric points")
+        }
+        return rows.size
+    }
+
+    fun getMetricRule(
+        organizationId: Int,
+        ruleId: Int
+    ): LogMetricRuleResponse? =
+        transaction {
+            LogMetricRules
+                .selectAll()
+                .where {
+                    (LogMetricRules.id eq ruleId) and
+                        (LogMetricRules.organizationId eq organizationId)
+                }
+                .firstOrNull()
+                ?.let { toMetricRuleResponse(it) }
+        }
+
+    private fun getLogMonitor(
+        organizationId: Int,
+        monitorId: Int
+    ): LogMonitorResponse? =
+        transaction {
+            LogMonitors
+                .selectAll()
+                .where {
+                    (LogMonitors.id eq monitorId) and
+                        (LogMonitors.organizationId eq organizationId)
+                }
+                .firstOrNull()
+                ?.let { toLogMonitorResponse(it) }
+        }
+
+    private fun getPipeline(
+        organizationId: Int,
+        pipelineId: Int
+    ): LogPipelineResponse? =
+        transaction {
+            LogPipelines
+                .selectAll()
+                .where {
+                    (LogPipelines.id eq pipelineId) and
+                        (LogPipelines.organizationId eq organizationId)
+                }
+                .firstOrNull()
+                ?.let { toPipelineResponse(it) }
+        }
+
+    private fun getSavedView(
+        organizationId: Int,
+        viewId: Int,
+        userId: Int
+    ): LogSavedViewResponse? =
+        transaction {
+            LogSavedViews
+                .selectAll()
+                .where { savedViewAccessCondition(organizationId, viewId, userId) }
+                .firstOrNull()
+                ?.let { toSavedViewResponse(it) }
+        }
+
+    private fun applySteps(
+        initial: PipelineEntryState,
+        steps: List<LogPipelineStep>
+    ): PipelineEntryState? {
+        return steps.fold(initial as PipelineEntryState?) { current, step ->
+            if (current == null || !step.enabled || !matchesCondition(step, current)) {
+                current
+            } else {
+                applyStep(current, step)
+            }
+        }
+    }
+
+    private fun matchesCondition(
+        step: LogPipelineStep,
+        state: PipelineEntryState
+    ): Boolean {
+        return step.condition.isBlank() ||
+            suspendRunCatching {
+                filterEvaluator.matches(step.condition, state.toFilterMap())
+            }.getOrElse { false }
+    }
+
+    private fun applyStep(
+        state: PipelineEntryState,
+        step: LogPipelineStep
+    ): PipelineEntryState? {
+        return when (step.type.trim().lowercase()) {
+            "drop" -> null
+            "redact" -> applyRedaction(state, step)
+            "remap" -> applyRemap(state, step)
+            "enrich" -> applyEnrichment(state, step)
+            "parse" -> applyParsing(state, step)
+            else -> state
+        }
+    }
+
+    private fun applyRedaction(
+        state: PipelineEntryState,
+        step: LogPipelineStep
+    ): PipelineEntryState {
+        if (step.pattern.isBlank()) return state
+        val regex = suspendRunCatching { Regex(step.pattern) }.getOrNull() ?: return state
+        val replacement = step.replacement.ifBlank { "[redacted]" }
+        return when (step.sourceField.ifBlank { "message" }) {
+            "message" -> state.copy(message = regex.replace(state.message, replacement))
+            "body" -> state.copy(body = regex.replace(state.body, replacement))
+            else -> state.copy(
+                message = regex.replace(state.message, replacement),
+                body = regex.replace(state.body, replacement)
+            )
+        }
+    }
+
+    private fun applyRemap(
+        state: PipelineEntryState,
+        step: LogPipelineStep
+    ): PipelineEntryState {
+        val sourceValue = state.get(step.sourceField)
+        if (sourceValue.isNullOrBlank() || step.targetField.isBlank()) return state
+        return state.set(step.targetField, sourceValue)
+    }
+
+    private fun applyEnrichment(
+        state: PipelineEntryState,
+        step: LogPipelineStep
+    ): PipelineEntryState {
+        val withTags = state.copy(tags = state.tags + step.tags)
+        if (step.targetField.isBlank() || step.value.isBlank()) return withTags
+        return withTags.set(step.targetField, step.value)
+    }
+
+    private fun applyParsing(
+        state: PipelineEntryState,
+        step: LogPipelineStep
+    ): PipelineEntryState {
+        val sourceValue = state.get(step.sourceField.ifBlank { "message" }) ?: return state
+        val regex = suspendRunCatching {
+            Regex(step.pattern.ifBlank { KEY_VALUE_PATTERN })
+        }.getOrElse { e ->
+            logManagementLogger.warn(e) { "Invalid log pipeline parse pattern" }
+            return state
+        }
+        val extracted = regex.findAll(sourceValue)
+            .mapNotNull { match ->
+                val key = match.groups[1]?.value ?: return@mapNotNull null
+                val value = match.groups[2]?.value ?: return@mapNotNull null
+                key to value
+            }
+            .toMap()
+        if (extracted.isEmpty()) return state
+        return state.copy(tags = state.tags + extracted)
+    }
+
+    private fun metricRow(
+        organizationId: Long,
+        rule: LogMetricRuleResponse,
+        timestamp: String,
+        groupValue: String,
+        value: Long
+    ): String {
+        val groupKey = rule.groupBy ?: DEFAULT_METRIC_GROUP_KEY
+        return "($organizationId, '${escapeSql(rule.name)}', ${rule.id}, " +
+            "parseDateTime64BestEffort('${escapeSql(timestamp)}'), " +
+            "'${escapeSql(groupKey)}', '${escapeSql(groupValue)}', $value, '${escapeSql(rule.query)}')"
+    }
+
+    private fun toPipelineResponse(row: ResultRow): LogPipelineResponse =
+        LogPipelineResponse(
+            id = row[LogPipelines.id],
+            name = row[LogPipelines.name],
+            description = row[LogPipelines.description],
+            steps = decodeSteps(row[LogPipelines.stepsJson]),
+            priority = row[LogPipelines.priority],
+            isActive = row[LogPipelines.isActive],
+            createdAt = row[LogPipelines.createdAt].toString(),
+            updatedAt = row[LogPipelines.updatedAt].toString()
+        )
+
+    private fun toSavedViewResponse(row: ResultRow): LogSavedViewResponse =
+        LogSavedViewResponse(
+            id = row[LogSavedViews.id],
+            name = row[LogSavedViews.name],
+            state = decodeViewState(row[LogSavedViews.viewStateJson]),
+            isShared = row[LogSavedViews.isShared],
+            createdAt = row[LogSavedViews.createdAt].toString(),
+            updatedAt = row[LogSavedViews.updatedAt].toString()
+        )
+
+    private fun toMetricRuleResponse(row: ResultRow): LogMetricRuleResponse =
+        LogMetricRuleResponse(
+            id = row[LogMetricRules.id],
+            name = row[LogMetricRules.name],
+            query = row[LogMetricRules.query],
+            levels = decodeLevels(row[LogMetricRules.levelsJson]),
+            groupBy = row[LogMetricRules.groupBy],
+            interval = row[LogMetricRules.interval],
+            isActive = row[LogMetricRules.isActive],
+            createdAt = row[LogMetricRules.createdAt].toString(),
+            updatedAt = row[LogMetricRules.updatedAt].toString()
+        )
+
+    private fun toLogMonitorResponse(row: ResultRow): LogMonitorResponse =
+        LogMonitorResponse(
+            id = row[LogMonitors.id],
+            name = row[LogMonitors.name],
+            query = row[LogMonitors.query],
+            levels = decodeLevels(row[LogMonitors.levelsJson]),
+            groupBy = row[LogMonitors.groupBy],
+            condition = row[LogMonitors.condition],
+            threshold = row[LogMonitors.threshold],
+            warningThreshold = row[LogMonitors.warningThreshold],
+            windowMinutes = row[LogMonitors.windowMinutes],
+            isActive = row[LogMonitors.isActive],
+            createdAt = row[LogMonitors.createdAt].toString(),
+            updatedAt = row[LogMonitors.updatedAt].toString()
+        )
+
+    private fun validatePipelineSteps(steps: List<LogPipelineStep>) {
+        steps.forEach { step ->
+            val type = step.type.trim().lowercase()
+            val unconditionalDrop = step.enabled &&
+                type == "drop" &&
+                step.condition.isBlank()
+            require(!unconditionalDrop) {
+                DROP_STEP_CONDITION_REQUIRED_MESSAGE
+            }
+            if (type == "redact" || type == "parse") {
+                validatePipelineRegex(step.pattern)
+            }
+        }
+    }
+
+    private fun validatePipelineRegex(pattern: String) {
+        val trimmed = pattern.trim()
+        if (trimmed.isBlank()) return
+        require(trimmed.length <= MAX_PIPELINE_PATTERN_LENGTH) {
+            PIPELINE_PATTERN_TOO_LONG_MESSAGE
+        }
+        require(!unsafeNestedQuantifierPattern.containsMatchIn(trimmed)) {
+            PIPELINE_PATTERN_UNSAFE_MESSAGE
+        }
+        require(!unsafeBackreferencePattern.containsMatchIn(trimmed)) {
+            PIPELINE_PATTERN_UNSAFE_MESSAGE
+        }
+        runCatching { Regex(trimmed) }.getOrElse {
+            throw IllegalArgumentException(PIPELINE_PATTERN_INVALID_MESSAGE)
+        }
+    }
+
+    private fun requireTrimmedName(value: String, message: String): String {
+        val trimmed = value.trim()
+        require(trimmed.isNotBlank()) { message }
+        return trimmed
+    }
+
+    private fun requireFiniteThreshold(value: Double): Double {
+        require(value.isFinite()) { LOG_MONITOR_THRESHOLD_MESSAGE }
+        return value
+    }
+
+    private fun normalizeMonitorWindowMinutes(value: Int): Int {
+        require(value >= MIN_LOG_MONITOR_WINDOW_MINUTES) { LOG_MONITOR_WINDOW_MINUTES_MESSAGE }
+        return value
+    }
+
+    private fun ensurePipelineNameAvailable(
+        organizationId: Int,
+        name: String,
+        excludeId: Int? = null
+    ) {
+        val duplicate = transaction {
+            LogPipelines
+                .selectAll()
+                .where {
+                    (LogPipelines.organizationId eq organizationId) and
+                        (LogPipelines.name eq name)
+                }
+                .firstOrNull()
+                ?.let { excludeId == null || it[LogPipelines.id] != excludeId }
+                ?: false
+        }
+        require(!duplicate) { PIPELINE_NAME_EXISTS_MESSAGE }
+    }
+
+    private fun ensureSavedViewNameAvailable(
+        organizationId: Int,
+        name: String,
+        excludeId: Int? = null
+    ) {
+        val duplicate = transaction {
+            LogSavedViews
+                .selectAll()
+                .where {
+                    (LogSavedViews.organizationId eq organizationId) and
+                        (LogSavedViews.name eq name)
+                }
+                .firstOrNull()
+                ?.let { excludeId == null || it[LogSavedViews.id] != excludeId }
+                ?: false
+        }
+        require(!duplicate) { SAVED_VIEW_NAME_EXISTS_MESSAGE }
+    }
+
+    private fun ensureMetricRuleNameAvailable(
+        organizationId: Int,
+        name: String,
+        excludeId: Int? = null
+    ) {
+        val duplicate = transaction {
+            LogMetricRules
+                .selectAll()
+                .where {
+                    (LogMetricRules.organizationId eq organizationId) and
+                        (LogMetricRules.name eq name)
+                }
+                .firstOrNull()
+                ?.let { excludeId == null || it[LogMetricRules.id] != excludeId }
+                ?: false
+        }
+        require(!duplicate) { METRIC_RULE_NAME_EXISTS_MESSAGE }
+    }
+
+    private fun ensureLogMonitorNameAvailable(
+        organizationId: Int,
+        name: String,
+        excludeId: Int? = null
+    ) {
+        val duplicate = transaction {
+            LogMonitors
+                .selectAll()
+                .where {
+                    (LogMonitors.organizationId eq organizationId) and
+                        (LogMonitors.name eq name)
+                }
+                .firstOrNull()
+                ?.let { excludeId == null || it[LogMonitors.id] != excludeId }
+                ?: false
+        }
+        require(!duplicate) { LOG_MONITOR_NAME_EXISTS_MESSAGE }
+    }
+
+    private fun savedViewAccessCondition(
+        organizationId: Int,
+        viewId: Int,
+        userId: Int
+    ): Op<Boolean> =
+        (LogSavedViews.id eq viewId) and
+            (LogSavedViews.organizationId eq organizationId) and
+            ((LogSavedViews.isShared eq true) or (LogSavedViews.createdBy eq userId))
+
+    private fun <T> mapDuplicateName(message: String, block: () -> T): T =
+        try {
+            block()
+        } catch (error: ExposedSQLException) {
+            require(error.sqlState != POSTGRES_UNIQUE_VIOLATION_SQLSTATE) { message }
+            throw error
+        }
+
+    private fun encodeSteps(steps: List<LogPipelineStep>): String =
+        logManagementJson.encodeToString(ListSerializer(LogPipelineStep.serializer()), steps)
+
+    private fun decodeSteps(value: String): List<LogPipelineStep> =
+        suspendRunCatching {
+            logManagementJson.decodeFromString(ListSerializer(LogPipelineStep.serializer()), value)
+        }.getOrElse { emptyList() }
+
+    private fun encodeViewState(state: LogSavedViewState): String =
+        logManagementJson.encodeToString(LogSavedViewState.serializer(), state)
+
+    private fun decodeViewState(value: String): LogSavedViewState =
+        suspendRunCatching {
+            logManagementJson.decodeFromString(LogSavedViewState.serializer(), value)
+        }.getOrElse { LogSavedViewState() }
+
+    private fun encodeLevels(levels: List<String>): String =
+        logManagementJson.encodeToString(ListSerializer(String.serializer()), levels)
+
+    private fun decodeLevels(value: String): List<String> =
+        suspendRunCatching {
+            logManagementJson.decodeFromString(ListSerializer(String.serializer()), value)
+        }.getOrElse { emptyList() }
+
+    private fun invalidatePipelineCache(organizationId: Int) {
+        CacheService.invalidate("logpipeline:active:$organizationId")
+    }
+}
+
+private data class PipelineEntryState(
+    val level: String,
+    val message: String,
+    val body: String,
+    val service: String,
+    val environment: String,
+    val host: String,
+    val source: String,
+    val containerName: String,
+    val containerId: String,
+    val containerImage: String,
+    val traceId: String,
+    val spanId: String,
+    val tags: Map<String, String>,
+    val resourceAttributes: Map<String, String>
+) {
+    fun get(field: String): String? {
+        return when (field) {
+            "level" -> level
+            "message" -> message
+            "body" -> body
+            "service" -> service
+            "environment" -> environment
+            "host" -> host
+            "source" -> source
+            "container_name" -> containerName
+            "container_id" -> containerId
+            "container_image" -> containerImage
+            "trace_id" -> traceId
+            "span_id" -> spanId
+            else -> getNestedField(field)
+        }
+    }
+
+    private fun getNestedField(field: String): String? {
+        val tagKey = field.removePrefix("tags.").takeIf { it != field }
+        if (tagKey != null) return tags[tagKey]
+
+        val resourceAttributeKey = field.removePrefix("resource_attributes.").takeIf { it != field }
+        if (resourceAttributeKey != null) return resourceAttributes[resourceAttributeKey]
+
+        return tags[field] ?: resourceAttributes[field]
+    }
+
+    fun set(
+        field: String,
+        value: String
+    ): PipelineEntryState {
+        return when (field) {
+            "level" -> copy(level = value)
+            "message" -> copy(message = value)
+            "body" -> copy(body = value)
+            "service" -> copy(service = value)
+            "environment" -> copy(environment = value)
+            "host" -> copy(host = value)
+            "container_name" -> copy(containerName = value)
+            "container_id" -> copy(containerId = value)
+            "container_image" -> copy(containerImage = value)
+            "trace_id" -> copy(traceId = value)
+            "span_id" -> copy(spanId = value)
+            else -> {
+                val tagKey = field.removePrefix("tags.").takeIf { it != field } ?: field
+                copy(tags = tags + (tagKey to value))
+            }
+        }
+    }
+
+    fun toFilterMap(): Map<String, String> =
+        mapOf(
+            "level" to level,
+            "message" to message,
+            "body" to body,
+            "service" to service,
+            "environment" to environment,
+            "host" to host,
+            "source" to source,
+            "container_name" to containerName,
+            "container_id" to containerId,
+            "container_image" to containerImage,
+            "trace_id" to traceId,
+            "span_id" to spanId
+        ) + tags + resourceAttributes
+
+    fun toQueued(original: QueuedLogEntry): QueuedLogEntry =
+        original.copy(
+            level = level,
+            message = message,
+            body = body,
+            service = service,
+            environment = environment,
+            host = host,
+            containerName = containerName,
+            containerId = containerId,
+            containerImage = containerImage,
+            traceId = traceId,
+            spanId = spanId,
+            tags = tags,
+            resourceAttributes = resourceAttributes
+        )
+
+    fun toPreview(): LogPipelinePreviewEntry =
+        LogPipelinePreviewEntry(
+            level = level,
+            message = message,
+            body = body,
+            service = service,
+            environment = environment,
+            host = host,
+            tags = tags,
+            resourceAttributes = resourceAttributes
+        )
+
+    companion object {
+        fun fromQueued(entry: QueuedLogEntry): PipelineEntryState =
+            PipelineEntryState(
+                level = entry.level,
+                message = entry.message,
+                body = entry.body,
+                service = entry.service,
+                environment = entry.environment,
+                host = entry.host,
+                source = entry.source,
+                containerName = entry.containerName,
+                containerId = entry.containerId,
+                containerImage = entry.containerImage,
+                traceId = entry.traceId,
+                spanId = entry.spanId,
+                tags = entry.tags,
+                resourceAttributes = entry.resourceAttributes
+            )
+
+        fun fromPreview(entry: LogPipelinePreviewEntry): PipelineEntryState =
+            PipelineEntryState(
+                level = entry.level,
+                message = entry.message,
+                body = entry.body,
+                service = entry.service,
+                environment = entry.environment,
+                host = entry.host,
+                source = "",
+                containerName = "",
+                containerId = "",
+                containerImage = "",
+                traceId = "",
+                spanId = "",
+                tags = entry.tags,
+                resourceAttributes = entry.resourceAttributes
+            )
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogService.kt
@@ -281,25 +281,75 @@ class LogService(private val logRepository: LogRepository) {
     fun matchesTailFilters(
         log: LogEntryResponse,
         filters: LogTailFilters
+    ): Boolean =
+        matchesIncludedTailFilters(log, filters) &&
+            matchesExcludedTailFilters(log, filters) &&
+            matchesTailTagFilters(log, filters) &&
+            matchesTailQueryFilter(log, filters)
+
+    private fun matchesIncludedTailFilters(
+        log: LogEntryResponse,
+        filters: LogTailFilters
     ): Boolean {
         if (filters.levels.isNotEmpty() && log.level.lowercase() !in filters.levels) {
             return false
         }
-        if (!filters.service.isNullOrBlank() && !log.service.equals(filters.service, ignoreCase = true)) {
+        if (!matchesOptionalIgnoreCase(log.service, filters.service)) {
             return false
         }
-        if (!filters.environment.isNullOrBlank() && !log.environment.equals(filters.environment, ignoreCase = true)) {
+        if (!matchesOptionalIgnoreCase(log.environment, filters.environment)) {
             return false
         }
-        if (!filters.query.isNullOrBlank()) {
-            val query = filters.query.lowercase()
-            val haystack = "${log.message}\n${log.body}".lowercase()
-            if (!haystack.contains(query)) {
-                return false
-            }
+        if (!matchesOptionalIgnoreCase(log.containerName, filters.containerName)) {
+            return false
         }
         return true
     }
+
+    private fun matchesExcludedTailFilters(
+        log: LogEntryResponse,
+        filters: LogTailFilters
+    ): Boolean {
+        if (matchesExcludedIgnoreCase(log.service, filters.excludeService)) {
+            return false
+        }
+        if (matchesExcludedIgnoreCase(log.environment, filters.excludeEnvironment)) {
+            return false
+        }
+        if (matchesExcludedIgnoreCase(log.containerName, filters.excludeContainerName)) {
+            return false
+        }
+        return true
+    }
+
+    private fun matchesTailTagFilters(
+        log: LogEntryResponse,
+        filters: LogTailFilters
+    ): Boolean {
+        if (filters.tags.any { (key, value) -> log.tags[key] != value }) {
+            return false
+        }
+        if (filters.excludeTags.any { (key, value) -> log.tags[key] == value }) {
+            return false
+        }
+        return true
+    }
+
+    private fun matchesTailQueryFilter(
+        log: LogEntryResponse,
+        filters: LogTailFilters
+    ): Boolean {
+        if (filters.query.isNullOrBlank()) return true
+        val query = filters.query.lowercase()
+        val haystack = "${log.message}\n${log.body}".lowercase()
+        return haystack.contains(query)
+    }
+
+    private fun matchesOptionalIgnoreCase(actual: String, expected: String?): Boolean =
+        expected.isNullOrBlank() || actual.lowercase() == expected.lowercase()
+
+    private fun matchesExcludedIgnoreCase(actual: String, excluded: String?): Boolean =
+        !excluded.isNullOrBlank() && actual.lowercase() == excluded.lowercase()
 
     suspend fun queryLogs(
         organizationId: Long,

--- a/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
@@ -289,6 +289,65 @@ object LogIndexes : Table("log_indexes") {
     override val primaryKey = PrimaryKey(id)
 }
 
+object LogPipelines : Table("log_pipelines") {
+    val id = integer("id").autoIncrement()
+    val organizationId = integer("organization_id").references(Organizations.id)
+    val name = varchar("name", 255)
+    val description = text("description").default("")
+    val stepsJson = text("steps_json").default("[]")
+    val priority = integer("priority").default(0)
+    val isActive = bool("is_active").default(true)
+    val createdBy = integer("created_by").references(Users.id).nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object LogSavedViews : Table("log_saved_views") {
+    val id = integer("id").autoIncrement()
+    val organizationId = integer("organization_id").references(Organizations.id)
+    val name = varchar("name", 255)
+    val viewStateJson = text("view_state_json")
+    val isShared = bool("is_shared").default(true)
+    val createdBy = integer("created_by").references(Users.id).nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object LogMetricRules : Table("log_metric_rules") {
+    val id = integer("id").autoIncrement()
+    val organizationId = integer("organization_id").references(Organizations.id)
+    val name = varchar("name", 255)
+    val query = text("query").default("")
+    val levelsJson = text("levels_json").default("[]")
+    val groupBy = varchar("group_by", 128).nullable()
+    val interval = varchar("interval", 16).default("5m")
+    val isActive = bool("is_active").default(true)
+    val createdBy = integer("created_by").references(Users.id).nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object LogMonitors : Table("log_monitors") {
+    val id = integer("id").autoIncrement()
+    val organizationId = integer("organization_id").references(Organizations.id)
+    val name = varchar("name", 255)
+    val query = text("query").default("")
+    val levelsJson = text("levels_json").default("[]")
+    val groupBy = varchar("group_by", 128).nullable()
+    val condition = varchar("condition", 8).default(">")
+    val threshold = double("threshold")
+    val warningThreshold = double("warning_threshold").nullable()
+    val windowMinutes = integer("window_minutes").default(5)
+    val isActive = bool("is_active").default(true)
+    val createdBy = integer("created_by").references(Users.id).nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+    override val primaryKey = PrimaryKey(id)
+}
+
 object AgentApiKeys : Table("agent_api_keys") {
     val id = integer("id").autoIncrement()
     val organization_id = integer("organization_id").references(Organizations.id)

--- a/backend/src/main/resources/db/clickhouse_migration/V52__add_log_metric_points.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V52__add_log_metric_points.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS log_metric_points (
+    organization_id UInt64,
+    metric_name LowCardinality(String),
+    rule_id UInt32,
+    timestamp DateTime64(3, 'UTC'),
+    group_key LowCardinality(String),
+    group_value String,
+    value Float64,
+    source_query String,
+    created_at DateTime64(3, 'UTC') DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree(created_at)
+PARTITION BY (organization_id, toYYYYMM(timestamp))
+ORDER BY (organization_id, metric_name, rule_id, timestamp, group_key, group_value)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;

--- a/backend/src/main/resources/db/migration/V128__add_log_management_tables.sql
+++ b/backend/src/main/resources/db/migration/V128__add_log_management_tables.sql
@@ -1,0 +1,49 @@
+CREATE TABLE log_pipelines (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    steps_json TEXT NOT NULL DEFAULT '[]',
+    priority INTEGER NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(organization_id, name)
+);
+
+CREATE TABLE log_saved_views (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    view_state_json TEXT NOT NULL,
+    is_shared BOOLEAN NOT NULL DEFAULT true,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(organization_id, name)
+);
+
+CREATE TABLE log_metric_rules (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    query TEXT NOT NULL DEFAULT '',
+    levels_json TEXT NOT NULL DEFAULT '[]',
+    group_by VARCHAR(128),
+    interval VARCHAR(16) NOT NULL DEFAULT '5m',
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(organization_id, name)
+);
+
+CREATE INDEX idx_log_pipelines_org_active_priority
+    ON log_pipelines (organization_id, is_active, priority);
+
+CREATE INDEX idx_log_saved_views_org_shared
+    ON log_saved_views (organization_id, is_shared);
+
+CREATE INDEX idx_log_metric_rules_org_active
+    ON log_metric_rules (organization_id, is_active);

--- a/backend/src/main/resources/db/migration/V129__add_log_monitors_table.sql
+++ b/backend/src/main/resources/db/migration/V129__add_log_monitors_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS log_monitors (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    query TEXT NOT NULL DEFAULT '',
+    levels_json TEXT NOT NULL DEFAULT '[]',
+    group_by VARCHAR(128),
+    condition VARCHAR(8) NOT NULL DEFAULT '>',
+    threshold DOUBLE PRECISION NOT NULL,
+    warning_threshold DOUBLE PRECISION,
+    window_minutes INTEGER NOT NULL DEFAULT 5,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    UNIQUE (organization_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_log_monitors_org_active
+    ON log_monitors(organization_id, is_active);

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -89,6 +89,7 @@ class DashboardAlertServiceTest {
     companion object {
         private var db: Database? = null
         private const val ORG_ID = 1L
+        private const val OTHER_ORG_ID = 2L
         private const val CREATED_BY = 100L
         private const val DEFAULT_PROJECT_ID = 1L
         private const val RECOVERY_RETENTION_DAYS = 90
@@ -229,12 +230,13 @@ class DashboardAlertServiceTest {
 
     private fun seedDashboard(
         title: String = "Test Dashboard",
-        projectId: Long? = DEFAULT_PROJECT_ID
+        projectId: Long? = DEFAULT_PROJECT_ID,
+        orgId: Long = ORG_ID
     ): Long =
         transaction {
             val now = Clock.System.now()
             Dashboards.insert {
-                it[orgId] = ORG_ID
+                it[Dashboards.orgId] = orgId
                 it[Dashboards.projectId] = projectId
                 it[Dashboards.title] = title
                 it[createdBy] = CREATED_BY
@@ -496,6 +498,23 @@ class DashboardAlertServiceTest {
                 request = buildCreateRequest(widgetId),
             )
         }
+    }
+
+    @Test
+    fun `createAlert fails when dashboard belongs to another org`() {
+        val dashboardId = seedDashboard(orgId = OTHER_ORG_ID)
+        val widgetId = seedWidget(dashboardId)
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            service.createAlert(
+                dashboardId = dashboardId,
+                orgId = ORG_ID,
+                createdBy = CREATED_BY,
+                request = buildCreateRequest(widgetId),
+            )
+        }
+
+        assertEquals("Widget not found in this dashboard", error.message)
     }
 
     // ──── listAlerts tests ────

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DashboardQueryEngineTest {
@@ -421,6 +422,26 @@ class DashboardQueryEngineTest {
         )
         val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90)
         assertTrue(clauses.any { it.contains("level = 'error'") })
+    }
+
+    @Test
+    fun `buildWhereClauses applies log raw query through explorer parser`() {
+        val dsl = QueryDsl(
+            dataSource = "logs",
+            rawQuery = "level:error service:api timeout"
+        )
+
+        val clauses = engine.buildWhereClauses(dsl, 123, "timestamp", null, 90, orgId = 456)
+        val rawClause = clauses.single { it.contains("toString(level) = 'error'") }
+
+        assertContains(rawClause, "service = 'api'")
+        assertContains(rawClause, "hasTokenCaseInsensitive(message, 'timeout')")
+    }
+
+    @Test
+    fun `buildLogRawQueryClause ignores non log and blank raw queries`() {
+        assertNull(engine.buildLogRawQueryClause(QueryDsl(dataSource = "events", rawQuery = "level:error")))
+        assertNull(engine.buildLogRawQueryClause(QueryDsl(dataSource = "logs", rawQuery = " ")))
     }
 
     // ──── buildQuery (integration / full SQL) ────

--- a/backend/src/test/kotlin/com/moneat/logs/LogManagementRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/logs/LogManagementRoutesTest.kt
@@ -1,0 +1,528 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs
+
+import com.moneat.dashboards.models.DashboardAlertResponse
+import com.moneat.dashboards.services.DashboardAlertService
+import com.moneat.logs.models.LogAggregateBucket
+import com.moneat.logs.models.LogAggregateResponse
+import com.moneat.logs.models.LogIndexUsageResponse
+import com.moneat.logs.models.LogMetricRuleResponse
+import com.moneat.logs.models.LogMonitorResponse
+import com.moneat.logs.models.LogPipelinePreviewEntry
+import com.moneat.logs.models.LogPipelinePreviewResult
+import com.moneat.logs.models.LogPipelineResponse
+import com.moneat.logs.models.LogPipelineStep
+import com.moneat.logs.models.LogSavedViewResponse
+import com.moneat.logs.models.LogSavedViewState
+import com.moneat.logs.routes.logRoutes as installLogRoutes
+import com.moneat.logs.services.LogIndexService
+import com.moneat.logs.services.LogManagementService
+import com.moneat.logs.services.LogService
+import com.moneat.org.services.OrgMembershipService
+import com.moneat.org.services.OrgRole
+import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.otlp.services.OtlpServiceRoutingService
+import com.moneat.testsupport.RouteTestSupport
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.application.Application
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val TEST_ORG_ID = 7
+private const val TEST_USER_ID = 42
+private const val TEST_CREATED_AT = "2026-06-04T00:00:00Z"
+private const val TEST_UPDATED_AT = "2026-06-04T00:01:00Z"
+
+class LogManagementRoutesTest {
+    private val logService = mockk<LogService>(relaxed = true)
+    private val otlpApiKeyService = mockk<OtlpApiKeyService>(relaxed = true)
+    private val logIndexService = mockk<LogIndexService>(relaxed = true)
+    private val otlpServiceRoutingService = mockk<OtlpServiceRoutingService>(relaxed = true)
+    private val logManagementService = mockk<LogManagementService>(relaxed = true)
+    private val membershipService = mockk<OrgMembershipService>(relaxed = true)
+    private val dashboardAlertService = mockk<DashboardAlertService>(relaxed = true)
+
+    @BeforeTest
+    fun setup() {
+        clearMocks(
+            logService,
+            otlpApiKeyService,
+            logIndexService,
+            otlpServiceRoutingService,
+            logManagementService,
+            membershipService,
+            dashboardAlertService
+        )
+        every { membershipService.requireRole(TEST_ORG_ID, TEST_USER_ID, OrgRole.ADMIN) } just Runs
+    }
+
+    // ──── Index management ────
+
+    @Test
+    fun `GET log permissions returns coarse fallback permissions`() =
+        testApplication {
+            application { installLogManagementRoutes() }
+
+            val response = client.get("/v1/logs/permissions") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("can_manage"))
+            assertTrue(body.contains("can_live_tail"))
+            assertTrue(body.contains("can_create_metrics"))
+            assertTrue(body.contains("can_create_monitors"))
+        }
+
+    @Test
+    fun `GET log index usage and POST retention run return index management payloads`() =
+        testApplication {
+            coEvery { logIndexService.usageStats(TEST_ORG_ID) } returns listOf(
+                LogIndexUsageResponse(
+                    indexName = "errors",
+                    bytesToday = 1024,
+                    countToday = 12,
+                    quotaGb = 1.5f,
+                    retentionDays = 14
+                )
+            )
+            coEvery { logIndexService.enforceRetention(TEST_ORG_ID) } returns 2
+            application { installLogManagementRoutes() }
+
+            val usage = client.get("/v1/logs/indexes/usage") { withAuth(token()) }
+            val retention = client.post("/v1/logs/indexes/retention/run") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.OK, usage.status)
+            assertTrue(usage.bodyAsText().contains("errors"))
+            assertEquals(HttpStatusCode.OK, retention.status)
+            assertTrue(retention.bodyAsText().contains("indexes_processed"))
+        }
+
+    @Test
+    fun `POST retention run returns forbidden when admin fallback rejects`() =
+        testApplication {
+            every {
+                membershipService.requireRole(TEST_ORG_ID, TEST_USER_ID, OrgRole.ADMIN)
+            } throws IllegalStateException("no")
+            application { installLogManagementRoutes() }
+
+            val response = client.post("/v1/logs/indexes/retention/run") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertTrue(response.bodyAsText().contains("Insufficient permissions"))
+        }
+
+    // ──── Pipelines ────
+
+    @Test
+    fun `pipeline routes list create update delete and preview`() =
+        testApplication {
+            val pipeline = pipelineResponse(id = 11, name = "Cleanup")
+            every { logManagementService.listPipelines(TEST_ORG_ID) } returns listOf(pipeline)
+            every { logManagementService.createPipeline(eq(TEST_ORG_ID), eq(TEST_USER_ID), any()) } returns pipeline
+            every { logManagementService.updatePipeline(eq(TEST_ORG_ID), eq(11), any()) } returns pipeline
+            every { logManagementService.deletePipeline(TEST_ORG_ID, 11) } returns true
+            every { logManagementService.previewPipeline(any()) } returns listOf(
+                LogPipelinePreviewResult(
+                    before = LogPipelinePreviewEntry(message = "token=secret"),
+                    after = LogPipelinePreviewEntry(message = "token=[redacted]"),
+                    dropped = false
+                )
+            )
+            application { installLogManagementRoutes() }
+
+            val list = client.get("/v1/logs/pipelines") { withAuth(token()) }
+            val create = client.postJson("/v1/logs/pipelines", """{"name":"Cleanup","steps":[]}""")
+            val update = client.putJson("/v1/logs/pipelines/11", """{"name":"Cleanup v2"}""")
+            val preview = client.postJson(
+                "/v1/logs/pipelines/preview",
+                """{"steps":[],"sample_logs":[{"message":"token=secret"}]}"""
+            )
+            val deleted = client.delete("/v1/logs/pipelines/11") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.OK, list.status)
+            assertTrue(list.bodyAsText().contains("Cleanup"))
+            assertEquals(HttpStatusCode.Created, create.status)
+            assertEquals(HttpStatusCode.OK, update.status)
+            assertEquals(HttpStatusCode.OK, preview.status)
+            assertTrue(preview.bodyAsText().contains("token=[redacted]"))
+            assertEquals(HttpStatusCode.NoContent, deleted.status)
+        }
+
+    @Test
+    fun `pipeline routes map invalid id not found and bad request`() =
+        testApplication {
+            every { logManagementService.createPipeline(eq(TEST_ORG_ID), eq(TEST_USER_ID), any()) } throws
+                IllegalArgumentException("Pipeline name is required")
+            every { logManagementService.updatePipeline(eq(TEST_ORG_ID), eq(99), any()) } returns null
+            every { logManagementService.deletePipeline(TEST_ORG_ID, 99) } returns false
+            application { installLogManagementRoutes() }
+
+            val invalidId = client.putJson("/v1/logs/pipelines/bad", """{"name":"x"}""")
+            val notFound = client.putJson("/v1/logs/pipelines/99", """{"name":"x"}""")
+            val deleteMissing = client.delete("/v1/logs/pipelines/99") { withAuth(token()) }
+            val badRequest = client.postJson("/v1/logs/pipelines", """{"name":""}""")
+
+            assertEquals(HttpStatusCode.BadRequest, invalidId.status)
+            assertEquals(HttpStatusCode.NotFound, notFound.status)
+            assertEquals(HttpStatusCode.NotFound, deleteMissing.status)
+            assertEquals(HttpStatusCode.BadRequest, badRequest.status)
+        }
+
+    // ──── Saved views ────
+
+    @Test
+    fun `saved view routes list create update and delete`() =
+        testApplication {
+            val view = savedViewResponse(id = 21, name = "Errors")
+            every { logManagementService.listSavedViews(TEST_ORG_ID, TEST_USER_ID) } returns listOf(view)
+            every { logManagementService.createSavedView(eq(TEST_ORG_ID), eq(TEST_USER_ID), any()) } returns view
+            every {
+                logManagementService.updateSavedView(eq(TEST_ORG_ID), eq(21), eq(TEST_USER_ID), any())
+            } returns view
+            every { logManagementService.deleteSavedView(TEST_ORG_ID, 21, TEST_USER_ID) } returns true
+            application { installLogManagementRoutes() }
+
+            val list = client.get("/v1/logs/saved-views") { withAuth(token()) }
+            val create = client.postJson(
+                "/v1/logs/saved-views",
+                """{"name":"Errors","state":{"query":"level:error"},"is_shared":true}"""
+            )
+            val update = client.putJson("/v1/logs/saved-views/21", """{"name":"Errors v2"}""")
+            val deleted = client.delete("/v1/logs/saved-views/21") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.OK, list.status)
+            assertEquals(HttpStatusCode.Created, create.status)
+            assertEquals(HttpStatusCode.OK, update.status)
+            assertEquals(HttpStatusCode.NoContent, deleted.status)
+        }
+
+    @Test
+    fun `saved view routes map invalid id and missing view`() =
+        testApplication {
+            every {
+                logManagementService.updateSavedView(eq(TEST_ORG_ID), eq(404), eq(TEST_USER_ID), any())
+            } returns null
+            every { logManagementService.deleteSavedView(TEST_ORG_ID, 404, TEST_USER_ID) } returns false
+            application { installLogManagementRoutes() }
+
+            val invalidId = client.putJson("/v1/logs/saved-views/nope", """{"name":"x"}""")
+            val notFound = client.putJson("/v1/logs/saved-views/404", """{"name":"x"}""")
+            val deleteMissing = client.delete("/v1/logs/saved-views/404") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.BadRequest, invalidId.status)
+            assertEquals(HttpStatusCode.NotFound, notFound.status)
+            assertEquals(HttpStatusCode.NotFound, deleteMissing.status)
+        }
+
+    // ──── Metrics and monitors ────
+
+    @Test
+    fun `metric routes list create update delete preview and rollup`() =
+        testApplication {
+            val rule = metricRuleResponse(id = 31, name = "Errors")
+            val aggregate = LogAggregateResponse(
+                buckets = listOf(LogAggregateBucket(timestamp = TEST_CREATED_AT, count = 3)),
+                totalCount = 3,
+                interval = "5m"
+            )
+            every { logManagementService.listMetricRules(TEST_ORG_ID) } returns listOf(rule)
+            every { logManagementService.createMetricRule(eq(TEST_ORG_ID), eq(TEST_USER_ID), any()) } returns rule
+            every { logManagementService.updateMetricRule(eq(TEST_ORG_ID), eq(31), any()) } returns rule
+            every { logManagementService.deleteMetricRule(TEST_ORG_ID, 31) } returns true
+            every { logManagementService.getMetricRule(TEST_ORG_ID, 31) } returns rule
+            coEvery {
+                logService.aggregateLogs(
+                    organizationId = any(),
+                    from = any(),
+                    to = any(),
+                    interval = any(),
+                    query = any(),
+                    levels = any(),
+                    service = any(),
+                    environment = any(),
+                    tags = any(),
+                    excludeService = any(),
+                    excludeEnvironment = any(),
+                    excludeContainerName = any(),
+                    excludeTags = any(),
+                    groupBy = any()
+                )
+            } returns aggregate
+            coEvery { logManagementService.recordMetricPoints(TEST_ORG_ID.toLong(), rule, aggregate) } returns 3
+            application { installLogManagementRoutes() }
+
+            val list = client.get("/v1/logs/metrics/rules") { withAuth(token()) }
+            val create = client.postJson("/v1/logs/metrics/rules", """{"name":"Errors","group_by":"service"}""")
+            val update = client.putJson("/v1/logs/metrics/rules/31", """{"name":"Errors v2"}""")
+            val preview = client.postJson("/v1/logs/metrics/preview", """{"name":"Preview","interval":"2h"}""")
+            val rollup = client.post("/v1/logs/metrics/rules/31/rollup") { withAuth(token()) }
+            val deleted = client.delete("/v1/logs/metrics/rules/31") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.OK, list.status)
+            assertEquals(HttpStatusCode.Created, create.status)
+            assertEquals(HttpStatusCode.OK, update.status)
+            assertEquals(HttpStatusCode.OK, preview.status)
+            assertTrue(preview.bodyAsText().contains("total_count"))
+            assertEquals(HttpStatusCode.OK, rollup.status)
+            assertTrue(rollup.bodyAsText().contains("points_inserted"))
+            assertEquals(HttpStatusCode.NoContent, deleted.status)
+        }
+
+    @Test
+    fun `metric routes map invalid id missing rule and bad request`() =
+        testApplication {
+            every { logManagementService.createMetricRule(eq(TEST_ORG_ID), eq(TEST_USER_ID), any()) } throws
+                IllegalArgumentException("Metric rule name is required")
+            every { logManagementService.updateMetricRule(eq(TEST_ORG_ID), eq(404), any()) } returns null
+            every { logManagementService.deleteMetricRule(TEST_ORG_ID, 404) } returns false
+            every { logManagementService.getMetricRule(TEST_ORG_ID, 404) } returns null
+            application { installLogManagementRoutes() }
+
+            val badCreate = client.postJson("/v1/logs/metrics/rules", """{"name":""}""")
+            val invalidId = client.putJson("/v1/logs/metrics/rules/bad", """{"name":"x"}""")
+            val updateMissing = client.putJson("/v1/logs/metrics/rules/404", """{"name":"x"}""")
+            val rollupMissing = client.post("/v1/logs/metrics/rules/404/rollup") { withAuth(token()) }
+            val deleteMissing = client.delete("/v1/logs/metrics/rules/404") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.BadRequest, badCreate.status)
+            assertEquals(HttpStatusCode.BadRequest, invalidId.status)
+            assertEquals(HttpStatusCode.NotFound, updateMissing.status)
+            assertEquals(HttpStatusCode.NotFound, rollupMissing.status)
+            assertEquals(HttpStatusCode.NotFound, deleteMissing.status)
+        }
+
+    @Test
+    fun `monitor route creates drafts with and without dashboard alerts`() =
+        testApplication {
+            every {
+                dashboardAlertService.createAlert(
+                    dashboardId = 12,
+                    orgId = TEST_ORG_ID.toLong(),
+                    createdBy = TEST_USER_ID.toLong(),
+                    request = any()
+                )
+            } returns dashboardAlertResponse()
+            application { installLogManagementRoutes() }
+
+            val draftOnly = client.postJson(
+                "/v1/logs/monitors/from-query",
+                """{"name":"Errors","query":"level:error","threshold":10.0}"""
+            )
+            val dashboardDraft = client.postJson(
+                "/v1/logs/monitors/from-query",
+                """{"name":"Errors","threshold":10.0,"dashboard_id":12,"widget_id":34}"""
+            )
+
+            assertEquals(HttpStatusCode.OK, draftOnly.status)
+            assertTrue(draftOnly.bodyAsText().contains(""""dashboard_alert_created":false"""))
+            assertEquals(HttpStatusCode.OK, dashboardDraft.status)
+            assertTrue(dashboardDraft.bodyAsText().contains(""""dashboard_alert_id":55"""))
+        }
+
+    @Test
+    fun `monitor route maps dashboard alert validation errors to bad request`() =
+        testApplication {
+            every {
+                dashboardAlertService.createAlert(
+                    dashboardId = 12,
+                    orgId = TEST_ORG_ID.toLong(),
+                    createdBy = TEST_USER_ID.toLong(),
+                    request = any()
+                )
+            } throws IllegalArgumentException("Widget not found in this dashboard")
+            application { installLogManagementRoutes() }
+
+            val response = client.postJson(
+                "/v1/logs/monitors/from-query",
+                """{"name":"Errors","threshold":10.0,"dashboard_id":12,"widget_id":34}"""
+            )
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertTrue(response.bodyAsText().contains("Widget not found"))
+        }
+
+    @Test
+    fun `monitor routes list create update and delete standalone monitors`() =
+        testApplication {
+            val monitor = logMonitorResponse(id = 41, name = "Error burst")
+            every { logManagementService.listLogMonitors(TEST_ORG_ID) } returns listOf(monitor)
+            every { logManagementService.createLogMonitor(eq(TEST_ORG_ID), eq(TEST_USER_ID), any()) } returns monitor
+            every { logManagementService.updateLogMonitor(eq(TEST_ORG_ID), eq(41), any()) } returns
+                monitor.copy(isActive = false)
+            every { logManagementService.deleteLogMonitor(TEST_ORG_ID, 41) } returns true
+            application { installLogManagementRoutes() }
+
+            val list = client.get("/v1/logs/monitors") { withAuth(token()) }
+            val create = client.postJson(
+                "/v1/logs/monitors",
+                """{"name":"Error burst","threshold":10.0,"group_by":"service"}"""
+            )
+            val update = client.putJson("/v1/logs/monitors/41", """{"is_active":false}""")
+            val deleted = client.delete("/v1/logs/monitors/41") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.OK, list.status)
+            assertTrue(list.bodyAsText().contains("Error burst"))
+            assertEquals(HttpStatusCode.Created, create.status)
+            assertEquals(HttpStatusCode.OK, update.status)
+            assertTrue(update.bodyAsText().contains(""""is_active":false"""))
+            assertEquals(HttpStatusCode.NoContent, deleted.status)
+        }
+
+    @Test
+    fun `monitor routes map invalid id missing monitor and bad request`() =
+        testApplication {
+            every { logManagementService.createLogMonitor(eq(TEST_ORG_ID), eq(TEST_USER_ID), any()) } throws
+                IllegalArgumentException("Log monitor name is required")
+            every { logManagementService.updateLogMonitor(eq(TEST_ORG_ID), eq(404), any()) } returns null
+            every { logManagementService.deleteLogMonitor(TEST_ORG_ID, 404) } returns false
+            every { logManagementService.updateLogMonitor(eq(TEST_ORG_ID), eq(42), any()) } throws
+                IllegalArgumentException("Log monitor condition must be one of: >, >=, <, <=, ==")
+            application { installLogManagementRoutes() }
+
+            val badCreate = client.postJson("/v1/logs/monitors", """{"name":"","threshold":10.0}""")
+            val invalidId = client.putJson("/v1/logs/monitors/bad", """{"name":"x"}""")
+            val updateMissing = client.putJson("/v1/logs/monitors/404", """{"name":"x"}""")
+            val badUpdate = client.putJson("/v1/logs/monitors/42", """{"condition":"!="}""")
+            val deleteMissing = client.delete("/v1/logs/monitors/404") { withAuth(token()) }
+
+            assertEquals(HttpStatusCode.BadRequest, badCreate.status)
+            assertEquals(HttpStatusCode.BadRequest, invalidId.status)
+            assertEquals(HttpStatusCode.NotFound, updateMissing.status)
+            assertEquals(HttpStatusCode.BadRequest, badUpdate.status)
+            assertEquals(HttpStatusCode.NotFound, deleteMissing.status)
+        }
+
+    private fun Application.installLogManagementRoutes() {
+        installJwtAuth()
+        routing {
+            installLogRoutes(
+                logService = logService,
+                otlpApiKeyService = otlpApiKeyService,
+                logIndexService = logIndexService,
+                otlpServiceRoutingService = otlpServiceRoutingService,
+                logManagementService = logManagementService,
+                membershipService = membershipService,
+                dashboardAlertService = dashboardAlertService
+            )
+        }
+    }
+
+    private suspend fun io.ktor.client.HttpClient.postJson(
+        path: String,
+        body: String
+    ) = post(path) {
+        withAuth(token())
+        contentType(ContentType.Application.Json)
+        setBody(body)
+    }
+
+    private suspend fun io.ktor.client.HttpClient.putJson(
+        path: String,
+        body: String
+    ) = put(path) {
+        withAuth(token())
+        contentType(ContentType.Application.Json)
+        setBody(body)
+    }
+
+    private fun token(): String =
+        RouteTestSupport.createToken(userId = TEST_USER_ID, orgId = TEST_ORG_ID)
+
+    private fun pipelineResponse(id: Int, name: String): LogPipelineResponse =
+        LogPipelineResponse(
+            id = id,
+            name = name,
+            description = "",
+            steps = listOf(LogPipelineStep(type = "redact", pattern = "secret")),
+            priority = 10,
+            isActive = true,
+            createdAt = TEST_CREATED_AT,
+            updatedAt = TEST_UPDATED_AT
+        )
+
+    private fun savedViewResponse(id: Int, name: String): LogSavedViewResponse =
+        LogSavedViewResponse(
+            id = id,
+            name = name,
+            state = LogSavedViewState(query = "level:error", levels = listOf("error")),
+            isShared = true,
+            createdAt = TEST_CREATED_AT,
+            updatedAt = TEST_UPDATED_AT
+        )
+
+    private fun metricRuleResponse(id: Int, name: String): LogMetricRuleResponse =
+        LogMetricRuleResponse(
+            id = id,
+            name = name,
+            query = "level:error",
+            levels = listOf("error"),
+            groupBy = "service",
+            interval = "5m",
+            isActive = true,
+            createdAt = TEST_CREATED_AT,
+            updatedAt = TEST_UPDATED_AT
+        )
+
+    private fun logMonitorResponse(id: Int, name: String): LogMonitorResponse =
+        LogMonitorResponse(
+            id = id,
+            name = name,
+            query = "level:error",
+            levels = listOf("error"),
+            groupBy = "service",
+            condition = ">",
+            threshold = 10.0,
+            warningThreshold = 5.0,
+            windowMinutes = 5,
+            isActive = true,
+            createdAt = TEST_CREATED_AT,
+            updatedAt = TEST_UPDATED_AT
+        )
+
+    private fun dashboardAlertResponse(): DashboardAlertResponse =
+        DashboardAlertResponse(
+            id = 55,
+            widgetId = 34,
+            dashboardId = 12,
+            name = "Errors",
+            condition = ">",
+            threshold = 10.0,
+            createdAt = TEST_CREATED_AT,
+            updatedAt = TEST_UPDATED_AT
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
@@ -16,11 +16,12 @@
 
 package com.moneat.logs
 
-import com.moneat.logs.routes.logRoutes
 import com.moneat.logs.models.LogIndexResponse
 import com.moneat.logs.models.LogIndexTestResponse
+import com.moneat.logs.routes.logRoutes as installLogRoutes
 import com.moneat.logs.services.LogIndexService
 import com.moneat.logs.services.LogService
+import com.moneat.org.services.OrgMembershipService
 import com.moneat.otlp.models.CreateOtlpApiKeyResponse
 import com.moneat.otlp.models.OtlpApiKeyResponse
 import com.moneat.otlp.models.OtlpObservedServiceResponse
@@ -41,6 +42,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.server.routing.Route
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
@@ -57,6 +59,7 @@ class LogRoutesExtendedTest {
     private val mockLogService = mockk<LogService>(relaxed = true)
     private val mockOtlpApiKeyService = mockk<OtlpApiKeyService>(relaxed = true)
     private val mockLogIndexService = mockk<LogIndexService>(relaxed = true)
+    private val mockMembershipService = mockk<OrgMembershipService>(relaxed = true)
     private val mockOtlpServiceRoutingService = mockk<OtlpServiceRoutingService>(relaxed = true)
 
     @BeforeTest
@@ -67,6 +70,34 @@ class LogRoutesExtendedTest {
     @AfterTest
     fun teardown() {
         stopTestKoin()
+    }
+
+    private fun Route.logRoutes(
+        logService: LogService,
+        otlpApiKeyService: OtlpApiKeyService,
+        logIndexService: LogIndexService
+    ) {
+        installLogRoutes(
+            logService = logService,
+            otlpApiKeyService = otlpApiKeyService,
+            logIndexService = logIndexService,
+            membershipService = mockMembershipService
+        )
+    }
+
+    private fun Route.logRoutes(
+        logService: LogService,
+        otlpApiKeyService: OtlpApiKeyService,
+        logIndexService: LogIndexService,
+        otlpServiceRoutingService: OtlpServiceRoutingService
+    ) {
+        installLogRoutes(
+            logService = logService,
+            otlpApiKeyService = otlpApiKeyService,
+            logIndexService = logIndexService,
+            otlpServiceRoutingService = otlpServiceRoutingService,
+            membershipService = mockMembershipService
+        )
     }
 
     // ──── Auth checks (401 without JWT) ────

--- a/backend/src/test/kotlin/com/moneat/logs/services/LogEntryFilterEvaluatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/logs/services/LogEntryFilterEvaluatorTest.kt
@@ -1,0 +1,103 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs.services
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LogEntryFilterEvaluatorTest {
+    // ──── setup ────
+
+    private val evaluator = LogEntryFilterEvaluator()
+    private val entry = mapOf(
+        "message" to "Checkout timeout on shard a",
+        "body" to "request failed with status 503",
+        "service" to "api",
+        "environment" to "prod",
+        "host" to "host-1",
+        "container_name" to "worker-api",
+        "team" to "payments",
+        "duration" to "125",
+        "status_code" to "503"
+    )
+
+    // ──── matches ────
+
+    @Test
+    fun `matches treats blank and parsed queries as expected`() {
+        assertTrue(evaluator.matches("", entry))
+        assertTrue(evaluator.matches("service:api timeout", entry))
+        assertFalse(evaluator.matches("service:worker timeout", entry))
+    }
+
+    // ──── evaluate text, existence, and boolean nodes ────
+
+    @Test
+    fun `evaluate covers text field existence and boolean nodes`() {
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.FullTextNode("timeout"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.FullTextNode("time*", true), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.FullTextNode("timeout on shard", false, true), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.FullTextNode("missing"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.TermNode("checkout"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.TermNode("check*", true), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.TermNode("absent"), entry))
+
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.ExistsNode("host"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.ExistsNode("missing"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.TagExistsNode("team"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.TagExistsNode("missing"), entry))
+
+        val serviceNode = LogQueryParser.QueryNode.FieldNode("service", "api")
+        val prodNode = LogQueryParser.QueryNode.FieldNode("environment", "prod")
+        val workerNode = LogQueryParser.QueryNode.FieldNode("service", "worker")
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.AndNode(serviceNode, prodNode), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.AndNode(serviceNode, workerNode), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.OrNode(workerNode, prodNode), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.NotNode(workerNode), entry))
+    }
+
+    // ──── evaluate field wildcard nodes ────
+
+    @Test
+    fun `evaluate covers field wildcard nodes`() {
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.FieldNode("service", "API"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.FieldNode("missing", "value"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.FieldNode("service", "api", true), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.FieldNode("service", "a?i", true), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.FieldNode("service", "web-*", true), entry))
+    }
+
+    // ──── evaluate range and comparison nodes ────
+
+    @Test
+    fun `evaluate covers range and comparison nodes`() {
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.RangeNode("duration", "100", "200"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.RangeNode("duration", "200", "300"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.RangeNode("missing", "100", "200"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.RangeNode("duration", "low", "200"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.RangeNode("duration", "100", "high"), entry))
+
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.ComparisonNode("status_code", ">", "500"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.ComparisonNode("status_code", ">=", "503"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.ComparisonNode("duration", "<", "200"), entry))
+        assertTrue(evaluator.evaluate(LogQueryParser.QueryNode.ComparisonNode("duration", "<=", "125"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.ComparisonNode("duration", "=", "125"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.ComparisonNode("duration", ">", "slow"), entry))
+        assertFalse(evaluator.evaluate(LogQueryParser.QueryNode.ComparisonNode("missing", ">", "10"), entry))
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/logs/services/LogManagementServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/logs/services/LogManagementServiceTest.kt
@@ -1,0 +1,707 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.logs.services
+
+import com.moneat.logs.models.CreateLogMetricRuleRequest
+import com.moneat.logs.models.CreateLogMonitorRequest
+import com.moneat.logs.models.CreateLogPipelineRequest
+import com.moneat.logs.models.CreateLogSavedViewRequest
+import com.moneat.logs.models.LogPipelinePreviewEntry
+import com.moneat.logs.models.LogPipelinePreviewRequest
+import com.moneat.logs.models.LogPipelineResponse
+import com.moneat.logs.models.LogPipelineStep
+import com.moneat.logs.models.LogSavedViewState
+import com.moneat.logs.models.QueuedLogEntry
+import com.moneat.logs.models.UpdateLogMetricRuleRequest
+import com.moneat.logs.models.UpdateLogMonitorRequest
+import com.moneat.logs.models.UpdateLogPipelineRequest
+import com.moneat.logs.models.UpdateLogSavedViewRequest
+import com.moneat.shared.models.LogMetricRules
+import com.moneat.shared.models.LogMonitors
+import com.moneat.shared.models.LogPipelines
+import com.moneat.shared.models.LogSavedViews
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import com.moneat.testsupport.TestDatabaseHelper
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val TEST_ORGANIZATION_ID = 1
+private const val TEST_USER_ID = 1
+private const val OTHER_USER_ID = 2
+private const val DEFAULT_TEST_TIMESTAMP_MS = 1_720_000_000_000L
+
+class LogManagementServiceTest {
+    private val service = LogManagementService()
+
+    @BeforeEach
+    fun setup() {
+        Database.connect(
+            "jdbc:h2:mem:log_management_service;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+            driver = "org.h2.Driver"
+        )
+        TestDatabaseHelper.resetSchema(
+            Users,
+            Organizations,
+            LogPipelines,
+            LogSavedViews,
+            LogMetricRules,
+            LogMonitors
+        )
+        seedUser(TEST_USER_ID, "owner@example.com")
+        seedUser(OTHER_USER_ID, "other@example.com")
+        seedOrganization(TEST_ORGANIZATION_ID, "Test Org")
+    }
+
+    // ──── Pipeline transforms ────
+
+    @Test
+    fun `previewPipeline applies parse remap enrich redact and conditional drop steps`() {
+        val steps = listOf(
+            LogPipelineStep(type = "unknown"),
+            LogPipelineStep(
+                type = "parse",
+                sourceField = "message",
+                pattern = """([a-z_]+)=([A-Za-z0-9-]+)"""
+            ),
+            LogPipelineStep(type = "remap", sourceField = "tags.request_id", targetField = "trace_id"),
+            LogPipelineStep(
+                type = "enrich",
+                targetField = "environment",
+                value = "prod",
+                tags = mapOf("team" to "payments")
+            ),
+            LogPipelineStep(
+                type = "redact",
+                sourceField = "message",
+                pattern = """token=[A-Za-z0-9-]+""",
+                replacement = "token=[redacted]"
+            ),
+            LogPipelineStep(type = "drop", enabled = false),
+            LogPipelineStep(type = "drop", condition = "level:error service:checkout")
+        )
+        val keepSample = previewEntry(
+            level = "info",
+            message = "request_id=req-1 token=secret-123",
+            service = "checkout"
+        )
+        val dropSample = previewEntry(
+            level = "error",
+            message = "request_id=req-2 token=secret-456",
+            service = "checkout"
+        )
+
+        val result = service.previewPipeline(
+            LogPipelinePreviewRequest(steps = steps, sampleLogs = listOf(keepSample, dropSample))
+        )
+
+        assertFalse(result[0].dropped)
+        val transformed = assertNotNull(result[0].after)
+        assertEquals("request_id=req-1 token=[redacted]", transformed.message)
+        assertEquals("prod", transformed.environment)
+        assertEquals("req-1", transformed.tags["request_id"])
+        assertEquals("payments", transformed.tags["team"])
+        assertTrue(result[1].dropped)
+        assertNull(result[1].after)
+    }
+
+    @Test
+    fun `previewPipeline redacts body and tolerates missing fields`() {
+        val sample = previewEntry(message = "visible secret=123", body = "body secret=456")
+
+        val result = service.previewPipeline(
+            LogPipelinePreviewRequest(
+                steps = listOf(
+                    LogPipelineStep(type = "redact", sourceField = "body", pattern = """secret=\d+"""),
+                    LogPipelineStep(type = "redact", sourceField = "tags.any", pattern = """secret=\d+"""),
+                    LogPipelineStep(type = "remap", sourceField = "tags.missing", targetField = "service"),
+                    LogPipelineStep(type = "enrich", tags = mapOf("release" to "2026.06"))
+                ),
+                sampleLogs = listOf(sample)
+            )
+        )
+
+        val transformed = assertNotNull(result.single().after)
+        assertEquals("visible [redacted]", transformed.message)
+        assertEquals("body [redacted]", transformed.body)
+        assertEquals("api", transformed.service)
+        assertEquals("2026.06", transformed.tags["release"])
+    }
+
+    @Test
+    fun `previewPipeline rejects malformed regex patterns before ingestion`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            service.previewPipeline(
+                LogPipelinePreviewRequest(
+                    steps = listOf(LogPipelineStep(type = "parse", pattern = "[")),
+                    sampleLogs = listOf(previewEntry())
+                )
+            )
+        }
+
+        assertEquals("Pipeline regex pattern is invalid", error.message)
+    }
+
+    @Test
+    fun `previewPipeline rejects enabled unconditional drop steps`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            service.previewPipeline(
+                LogPipelinePreviewRequest(
+                    steps = listOf(LogPipelineStep(type = " drop ")),
+                    sampleLogs = listOf(previewEntry())
+                )
+            )
+        }
+
+        assertEquals("Drop pipeline steps require a condition", error.message)
+    }
+
+    @Test
+    fun `previewPipeline rejects unsafe regex patterns before ingestion`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            service.previewPipeline(
+                LogPipelinePreviewRequest(
+                    steps = listOf(LogPipelineStep(type = "redact", pattern = "(a+)+$")),
+                    sampleLogs = listOf(previewEntry(message = "aaaaaaaaaaaaaaaa"))
+                )
+            )
+        }
+
+        assertEquals("Pipeline regex pattern uses unsupported high-cost constructs", error.message)
+    }
+
+    @Test
+    fun `applyPipelines transforms queued entries and drops matching entries`() {
+        val pipelines = listOf(
+            pipelineResponse(
+                steps = listOf(
+                    LogPipelineStep(
+                        type = "redact",
+                        sourceField = "body",
+                        pattern = """password=\S+""",
+                        replacement = "password=[redacted]"
+                    ),
+                    LogPipelineStep(type = "remap", sourceField = "resource_attributes.k8s.pod", targetField = "host"),
+                    LogPipelineStep(type = "remap", sourceField = "service", targetField = "tags.original_service"),
+                    LogPipelineStep(type = "remap", sourceField = "tags.tenant", targetField = "service"),
+                    LogPipelineStep(type = "enrich", targetField = "container_name", value = "app-container"),
+                    LogPipelineStep(type = "drop", condition = "drop:true")
+                )
+            )
+        )
+
+        val kept = queuedEntry(
+            logId = "keep",
+            body = "password=swordfish",
+            service = "checkout",
+            tags = mapOf("tenant" to "enterprise"),
+            resourceAttributes = mapOf("k8s.pod" to "pod-a")
+        )
+        val dropped = queuedEntry(logId = "drop", tags = mapOf("drop" to "true"))
+
+        val result = service.applyPipelines(listOf(kept, dropped), pipelines)
+
+        assertEquals(1, result.size)
+        val transformed = result.single()
+        assertEquals("keep", transformed.logId)
+        assertEquals("password=[redacted]", transformed.body)
+        assertEquals("enterprise", transformed.service)
+        assertEquals("pod-a", transformed.host)
+        assertEquals("app-container", transformed.containerName)
+        assertEquals("checkout", transformed.tags["original_service"])
+    }
+
+    @Test
+    fun `applyPipelines returns original entries when there are no active steps`() {
+        val entry = queuedEntry()
+
+        assertEquals(listOf(entry), service.applyPipelines(listOf(entry), emptyList()))
+        assertEquals(
+            listOf(entry),
+            service.applyPipelines(
+                entries = listOf(entry),
+                pipelines = listOf(pipelineResponse(steps = emptyList()))
+            )
+        )
+        assertEquals(emptyList(), service.applyPipelines(emptyList(), listOf(pipelineResponse())))
+    }
+
+    // ──── Pipeline persistence ────
+
+    @Test
+    fun `pipeline CRUD trims stores orders updates and deletes organization pipelines`() {
+        val first = service.createPipeline(
+            organizationId = TEST_ORGANIZATION_ID,
+            createdBy = TEST_USER_ID,
+            request = CreateLogPipelineRequest(
+                name = "  Error cleanup  ",
+                description = "  remove noisy lines  ",
+                steps = listOf(LogPipelineStep(type = "redact", pattern = "secret")),
+                priority = 20,
+                isActive = true
+            )
+        )
+        val second = service.createPipeline(
+            organizationId = TEST_ORGANIZATION_ID,
+            createdBy = TEST_USER_ID,
+            request = CreateLogPipelineRequest(name = "Parser", priority = 10, isActive = false)
+        )
+
+        assertEquals(listOf(second.id, first.id), service.listPipelines(TEST_ORGANIZATION_ID).map { it.id })
+        assertEquals("Error cleanup", first.name)
+        assertEquals("remove noisy lines", first.description)
+
+        val updated = service.updatePipeline(
+            organizationId = TEST_ORGANIZATION_ID,
+            pipelineId = first.id,
+            request = UpdateLogPipelineRequest(
+                name = "  Cleanup v2  ",
+                description = "  updated  ",
+                steps = listOf(LogPipelineStep(type = "parse")),
+                priority = 5,
+                isActive = false
+            )
+        )
+
+        assertNotNull(updated)
+        assertEquals("Cleanup v2", updated.name)
+        assertEquals("updated", updated.description)
+        assertEquals(5, updated.priority)
+        assertFalse(updated.isActive)
+        assertEquals(listOf("parse"), updated.steps.map { it.type })
+        assertNull(service.updatePipeline(TEST_ORGANIZATION_ID, 999, UpdateLogPipelineRequest(name = "missing")))
+        assertTrue(service.deletePipeline(TEST_ORGANIZATION_ID, second.id))
+        assertFalse(service.deletePipeline(TEST_ORGANIZATION_ID, second.id))
+    }
+
+    @Test
+    fun `pipeline CRUD rejects blank duplicate and unsafe drop requests`() {
+        service.createPipeline(TEST_ORGANIZATION_ID, TEST_USER_ID, CreateLogPipelineRequest(name = "Cleanup"))
+
+        assertEquals(
+            "Pipeline name is required",
+            assertFailsWith<IllegalArgumentException> {
+                service.createPipeline(TEST_ORGANIZATION_ID, TEST_USER_ID, CreateLogPipelineRequest(name = " "))
+            }.message
+        )
+        assertEquals(
+            "Pipeline name already exists",
+            assertFailsWith<IllegalArgumentException> {
+                service.createPipeline(TEST_ORGANIZATION_ID, TEST_USER_ID, CreateLogPipelineRequest(name = "Cleanup"))
+            }.message
+        )
+        assertEquals(
+            "Drop pipeline steps require a condition",
+            assertFailsWith<IllegalArgumentException> {
+                service.createPipeline(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogPipelineRequest(name = "Drop all", steps = listOf(LogPipelineStep(type = "drop")))
+                )
+            }.message
+        )
+    }
+
+    // ──── Saved views and metrics ────
+
+    @Test
+    fun `saved view CRUD keeps private views scoped to the creator`() {
+        val shared = service.createSavedView(
+            organizationId = TEST_ORGANIZATION_ID,
+            createdBy = TEST_USER_ID,
+            request = CreateLogSavedViewRequest(
+                name = "  Errors  ",
+                state = LogSavedViewState(query = "level:error", levels = listOf("error")),
+                isShared = true
+            )
+        )
+        val private = service.createSavedView(
+            organizationId = TEST_ORGANIZATION_ID,
+            createdBy = TEST_USER_ID,
+            request = CreateLogSavedViewRequest(
+                name = "Mine",
+                state = LogSavedViewState(groupBy = "service", topField = "host"),
+                isShared = false
+            )
+        )
+
+        assertEquals(
+            listOf("Errors", "Mine"),
+            service.listSavedViews(TEST_ORGANIZATION_ID, TEST_USER_ID).map { it.name }
+        )
+        assertEquals(
+            listOf("Errors"),
+            service.listSavedViews(TEST_ORGANIZATION_ID, OTHER_USER_ID).map { it.name }
+        )
+        assertNull(
+            service.updateSavedView(
+                organizationId = TEST_ORGANIZATION_ID,
+                viewId = private.id,
+                userId = OTHER_USER_ID,
+                request = UpdateLogSavedViewRequest()
+            )
+        )
+
+        val updated = service.updateSavedView(
+            organizationId = TEST_ORGANIZATION_ID,
+            viewId = private.id,
+            userId = TEST_USER_ID,
+            request = UpdateLogSavedViewRequest(
+                name = "  Mine updated  ",
+                state = LogSavedViewState(query = "service:api", timePreset = "24h"),
+                isShared = true
+            )
+        )
+
+        assertNotNull(updated)
+        assertEquals("Mine updated", updated.name)
+        assertEquals("service:api", updated.state.query)
+        assertTrue(updated.isShared)
+        assertTrue(service.deleteSavedView(TEST_ORGANIZATION_ID, shared.id, OTHER_USER_ID))
+        assertFalse(service.deleteSavedView(TEST_ORGANIZATION_ID, shared.id, OTHER_USER_ID))
+    }
+
+    @Test
+    fun `saved view CRUD rejects blank and duplicate names`() {
+        service.createSavedView(
+            TEST_ORGANIZATION_ID,
+            TEST_USER_ID,
+            CreateLogSavedViewRequest(name = "Errors", state = LogSavedViewState())
+        )
+
+        assertEquals(
+            "Saved view name is required",
+            assertFailsWith<IllegalArgumentException> {
+                service.createSavedView(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogSavedViewRequest(name = " ", state = LogSavedViewState())
+                )
+            }.message
+        )
+        assertEquals(
+            "Saved view name already exists",
+            assertFailsWith<IllegalArgumentException> {
+                service.createSavedView(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogSavedViewRequest(name = "Errors", state = LogSavedViewState())
+                )
+            }.message
+        )
+    }
+
+    @Test
+    fun `metric rule CRUD normalizes group by stores levels updates and deletes rules`() {
+        val created = service.createMetricRule(
+            organizationId = TEST_ORGANIZATION_ID,
+            createdBy = TEST_USER_ID,
+            request = CreateLogMetricRuleRequest(
+                name = "  Error rate  ",
+                query = " level:error ",
+                levels = listOf("error"),
+                groupBy = " service ",
+                interval = "1m",
+                isActive = true
+            )
+        )
+
+        assertEquals("Error rate", created.name)
+        assertEquals("level:error", created.query)
+        assertEquals(listOf("error"), created.levels)
+        assertEquals("service", created.groupBy)
+        assertEquals(listOf(created.id), service.listMetricRules(TEST_ORGANIZATION_ID).map { it.id })
+
+        val updated = service.updateMetricRule(
+            organizationId = TEST_ORGANIZATION_ID,
+            ruleId = created.id,
+            request = UpdateLogMetricRuleRequest(
+                name = "  Warnings  ",
+                query = "level:warn",
+                levels = listOf("warn", "error"),
+                groupBy = "environment",
+                interval = "5m",
+                isActive = false
+            )
+        )
+
+        assertNotNull(updated)
+        assertEquals("Warnings", updated.name)
+        assertEquals("level:warn", updated.query)
+        assertEquals(listOf("warn", "error"), updated.levels)
+        assertEquals("environment", updated.groupBy)
+        assertEquals("5m", updated.interval)
+        assertFalse(updated.isActive)
+        assertNull(service.updateMetricRule(TEST_ORGANIZATION_ID, 999, UpdateLogMetricRuleRequest(name = "missing")))
+        assertTrue(service.deleteMetricRule(TEST_ORGANIZATION_ID, created.id))
+        assertFalse(service.deleteMetricRule(TEST_ORGANIZATION_ID, created.id))
+    }
+
+    @Test
+    fun `metric rule CRUD rejects invalid names duplicates and group by fields`() {
+        service.createMetricRule(TEST_ORGANIZATION_ID, TEST_USER_ID, CreateLogMetricRuleRequest(name = "Errors"))
+
+        assertNull(LogManagementService.normalizeMetricGroupBy(" "))
+        assertEquals("level", LogManagementService.normalizeMetricGroupBy("level"))
+        assertEquals(
+            "Metric rule name is required",
+            assertFailsWith<IllegalArgumentException> {
+                service.createMetricRule(TEST_ORGANIZATION_ID, TEST_USER_ID, CreateLogMetricRuleRequest(name = " "))
+            }.message
+        )
+        assertEquals(
+            "Metric rule name already exists",
+            assertFailsWith<IllegalArgumentException> {
+                service.createMetricRule(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMetricRuleRequest(name = "Errors")
+                )
+            }.message
+        )
+        assertEquals(
+            "Metric group_by must be one of: level, service, environment",
+            assertFailsWith<IllegalArgumentException> {
+                service.createMetricRule(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMetricRuleRequest(name = "Bad group", groupBy = "trace_id")
+                )
+            }.message
+        )
+    }
+
+    @Test
+    fun `log monitor CRUD normalizes query group by condition window and deletes monitors`() {
+        val created = service.createLogMonitor(
+            organizationId = TEST_ORGANIZATION_ID,
+            createdBy = TEST_USER_ID,
+            request = CreateLogMonitorRequest(
+                name = "  Error burst  ",
+                query = " service:api level:error ",
+                levels = listOf("error"),
+                groupBy = " service ",
+                condition = ">=",
+                threshold = 10.0,
+                warningThreshold = 5.0,
+                windowMinutes = 15,
+                isActive = true
+            )
+        )
+
+        assertEquals("Error burst", created.name)
+        assertEquals("service:api level:error", created.query)
+        assertEquals(listOf("error"), created.levels)
+        assertEquals("service", created.groupBy)
+        assertEquals(">=", created.condition)
+        assertEquals(10.0, created.threshold)
+        assertEquals(5.0, created.warningThreshold)
+        assertEquals(15, created.windowMinutes)
+        assertEquals(listOf(created.id), service.listLogMonitors(TEST_ORGANIZATION_ID).map { it.id })
+
+        val updated = service.updateLogMonitor(
+            organizationId = TEST_ORGANIZATION_ID,
+            monitorId = created.id,
+            request = UpdateLogMonitorRequest(
+                name = "  Warnings  ",
+                query = "level:warn",
+                levels = listOf("warn", "error"),
+                groupBy = "environment",
+                condition = "<",
+                threshold = 2.5,
+                warningThreshold = 1.5,
+                windowMinutes = 30,
+                isActive = false
+            )
+        )
+
+        assertNotNull(updated)
+        assertEquals("Warnings", updated.name)
+        assertEquals("level:warn", updated.query)
+        assertEquals(listOf("warn", "error"), updated.levels)
+        assertEquals("environment", updated.groupBy)
+        assertEquals("<", updated.condition)
+        assertEquals(2.5, updated.threshold)
+        assertEquals(1.5, updated.warningThreshold)
+        assertEquals(30, updated.windowMinutes)
+        assertFalse(updated.isActive)
+        assertNull(service.updateLogMonitor(TEST_ORGANIZATION_ID, 999, UpdateLogMonitorRequest(name = "missing")))
+        assertTrue(service.deleteLogMonitor(TEST_ORGANIZATION_ID, created.id))
+        assertFalse(service.deleteLogMonitor(TEST_ORGANIZATION_ID, created.id))
+    }
+
+    @Test
+    fun `log monitor CRUD rejects invalid names duplicates group by condition threshold and window`() {
+        service.createLogMonitor(
+            TEST_ORGANIZATION_ID,
+            TEST_USER_ID,
+            CreateLogMonitorRequest(name = "Errors", threshold = 1.0)
+        )
+
+        assertEquals(">", LogManagementService.normalizeMonitorCondition(" "))
+        assertEquals("<=", LogManagementService.normalizeMonitorCondition("<="))
+        assertEquals(
+            "Log monitor name is required",
+            assertFailsWith<IllegalArgumentException> {
+                service.createLogMonitor(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMonitorRequest(name = " ", threshold = 1.0)
+                )
+            }.message
+        )
+        assertEquals(
+            "Log monitor name already exists",
+            assertFailsWith<IllegalArgumentException> {
+                service.createLogMonitor(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMonitorRequest(name = "Errors", threshold = 1.0)
+                )
+            }.message
+        )
+        assertEquals(
+            "Metric group_by must be one of: level, service, environment",
+            assertFailsWith<IllegalArgumentException> {
+                service.createLogMonitor(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMonitorRequest(name = "Bad group", threshold = 1.0, groupBy = "trace_id")
+                )
+            }.message
+        )
+        assertEquals(
+            "Log monitor condition must be one of: >, >=, <, <=, ==",
+            assertFailsWith<IllegalArgumentException> {
+                service.createLogMonitor(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMonitorRequest(name = "Bad condition", threshold = 1.0, condition = "!=")
+                )
+            }.message
+        )
+        assertEquals(
+            "Log monitor threshold must be finite",
+            assertFailsWith<IllegalArgumentException> {
+                service.createLogMonitor(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMonitorRequest(name = "Bad threshold", threshold = Double.NaN)
+                )
+            }.message
+        )
+        assertEquals(
+            "Log monitor window_minutes must be at least 1",
+            assertFailsWith<IllegalArgumentException> {
+                service.createLogMonitor(
+                    TEST_ORGANIZATION_ID,
+                    TEST_USER_ID,
+                    CreateLogMonitorRequest(name = "Bad window", threshold = 1.0, windowMinutes = 0)
+                )
+            }.message
+        )
+    }
+
+    private fun previewEntry(
+        level: String = "info",
+        message: String = "request_id=req-1",
+        body: String = "",
+        service: String = "api",
+        environment: String = "dev",
+        host: String = "host-a",
+        tags: Map<String, String> = emptyMap(),
+        resourceAttributes: Map<String, String> = emptyMap()
+    ): LogPipelinePreviewEntry =
+        LogPipelinePreviewEntry(
+            level = level,
+            message = message,
+            body = body,
+            service = service,
+            environment = environment,
+            host = host,
+            tags = tags,
+            resourceAttributes = resourceAttributes
+        )
+
+    private fun queuedEntry(
+        logId: String = "log-1",
+        body: String = "",
+        service: String = "api",
+        tags: Map<String, String> = emptyMap(),
+        resourceAttributes: Map<String, String> = emptyMap()
+    ): QueuedLogEntry =
+        QueuedLogEntry(
+            logId = logId,
+            timestampMs = DEFAULT_TEST_TIMESTAMP_MS,
+            level = "info",
+            message = "message",
+            body = body,
+            service = service,
+            environment = "dev",
+            host = "host-a",
+            source = "agent",
+            containerName = "container",
+            containerId = "container-id",
+            containerImage = "image",
+            traceId = "trace-id",
+            spanId = "span-id",
+            tags = tags,
+            resourceAttributes = resourceAttributes
+        )
+
+    private fun pipelineResponse(
+        steps: List<LogPipelineStep> = listOf(LogPipelineStep(type = "parse"))
+    ): LogPipelineResponse =
+        LogPipelineResponse(
+            id = 1,
+            name = "Pipeline",
+            steps = steps,
+            priority = 0,
+            isActive = true,
+            createdAt = "2026-06-04T00:00:00Z",
+            updatedAt = "2026-06-04T00:00:00Z"
+        )
+
+    private fun seedUser(id: Int, email: String) {
+        transaction {
+            Users.insert {
+                it[Users.id] = id
+                it[Users.email] = email
+                it[Users.password_hash] = "hash"
+            }
+        }
+    }
+
+    private fun seedOrganization(id: Int, name: String) {
+        transaction {
+            Organizations.insert {
+                it[Organizations.id] = id
+                it[Organizations.name] = name
+                it[Organizations.slug] = name.lowercase().replace(" ", "-")
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/services/LogIndexServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogIndexServiceTest.kt
@@ -20,6 +20,7 @@ package com.moneat.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.logs.models.CreateLogIndexRequest
+import com.moneat.logs.models.QueuedLogEntry
 import com.moneat.logs.models.UpdateLogIndexRequest
 import com.moneat.logs.services.LogIndexService
 import com.moneat.shared.models.LogIndexes
@@ -54,6 +55,7 @@ class LogIndexServiceTest {
         private const val SERVICE_API = "service:api"
         private const val API_INDEX = "api-index"
         private const val TEXT_PLAIN = "text/plain"
+        private const val TEST_TIMESTAMP_MS = 1_720_000_000_000L
     }
 
     @BeforeTest
@@ -596,6 +598,160 @@ class LogIndexServiceTest {
         assertEquals("", noMatch)
     }
 
+    // ──── usage, retention, and quota ────
+
+    @Test
+    fun `usageStats maps ClickHouse usage onto configured indexes`() =
+        runBlocking {
+            createIndex(name = "errors", dailyQuotaGb = 1.5f)
+            createIndex(name = "empty", retentionDays = 14)
+
+            MockHttpServer { exchange ->
+                val body = exchange.requestBodyText()
+                assertTrue(body.contains("GROUP BY index_name"))
+                exchange.respond(
+                    200,
+                    """
+                    {"index_name":"errors","cnt":12,"bytes":1024}
+                    {"index_name":"unknown","cnt":99,"bytes":4096}
+                    """.trimIndent(),
+                    contentType = TEXT_PLAIN
+                )
+            }.use { server ->
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+                val stats = service.usageStats(ORG_ID)
+
+                val errors = stats.first { it.indexName == "errors" }
+                assertEquals(1024L, errors.bytesToday)
+                assertEquals(12L, errors.countToday)
+                assertEquals(1.5f, errors.quotaGb)
+
+                val empty = stats.first { it.indexName == "empty" }
+                assertEquals(0L, empty.bytesToday)
+                assertEquals(0L, empty.countToday)
+                assertEquals(14, empty.retentionDays)
+            }
+        }
+
+    @Test
+    fun `usageStats returns zero usage when ClickHouse errors`() =
+        runBlocking {
+            createIndex(name = "errors", dailyQuotaGb = 2.0f)
+
+            MockHttpServer { exchange ->
+                exchange.respond(500, "Code: 60. Table does not exist", contentType = TEXT_PLAIN)
+            }.use { server ->
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+                val usage = service.usageStats(ORG_ID).single()
+
+                assertEquals("errors", usage.indexName)
+                assertEquals(0L, usage.bytesToday)
+                assertEquals(0L, usage.countToday)
+                assertEquals(2.0f, usage.quotaGb)
+            }
+        }
+
+    @Test
+    fun `enforceRetention counts successful deletes and skips ClickHouse failures`() =
+        runBlocking {
+            createIndex(name = "audit's", retentionDays = 7, priority = 0)
+            createIndex(name = "errors", retentionDays = 30, priority = 1)
+            val statements = mutableListOf<String>()
+
+            MockHttpServer { exchange ->
+                val body = exchange.requestBodyText()
+                statements.add(body)
+                if (statements.size == 1) {
+                    exchange.respond(200, "", contentType = TEXT_PLAIN)
+                } else {
+                    exchange.respond(500, "Code: 241. Memory limit", contentType = TEXT_PLAIN)
+                }
+            }.use { server ->
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+                val applied = service.enforceRetention(ORG_ID)
+
+                assertEquals(1, applied)
+                assertEquals(2, statements.size)
+                assertTrue(statements.first().contains("INTERVAL 7 DAY"))
+                assertTrue(statements.first().contains("index_name = 'audit\\'s'"))
+            }
+        }
+
+    @Test
+    fun `filterWithinDailyQuota returns immediately for empty and unmetered inputs`() =
+        runBlocking {
+            val unmetered = createIndex(name = "unmetered", dailyQuotaGb = null)
+            val entry = queuedLog(indexName = "unmetered")
+
+            assertEquals(
+                emptyList(),
+                service.filterWithinDailyQuota(ORG_ID, emptyList(), listOf(unmetered))
+            )
+            assertEquals(
+                listOf(entry),
+                service.filterWithinDailyQuota(ORG_ID, listOf(entry), listOf(unmetered))
+            )
+        }
+
+    @Test
+    fun `filterWithinDailyQuota enforces daily quota cumulatively`() =
+        runBlocking {
+            val quotaIndex = createIndex(name = "quota", dailyQuotaGb = 0.000001f)
+            val unmetered = createIndex(name = "unmetered", dailyQuotaGb = null)
+            val allowed = queuedLog(indexName = "quota", message = "1234567890", body = "1234567890")
+            val dropped = queuedLog(indexName = "quota", message = "x".repeat(80), body = "")
+            val withoutQuota = queuedLog(indexName = "unmetered", message = "x".repeat(200), body = "")
+            val unknown = queuedLog(indexName = "unknown", message = "x".repeat(200), body = "")
+
+            MockHttpServer { exchange ->
+                exchange.respond(
+                    200,
+                    """{"index_name":"quota","cnt":50,"bytes":1000}""",
+                    contentType = TEXT_PLAIN
+                )
+            }.use { server ->
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+                val result = service.filterWithinDailyQuota(
+                    ORG_ID,
+                    listOf(allowed, dropped, withoutQuota, unknown),
+                    listOf(quotaIndex, unmetered)
+                )
+
+                assertEquals(listOf(allowed, withoutQuota, unknown), result)
+            }
+        }
+
+    @Test
+    fun `filterWithinDailyQuota caches usage and counts utf8 bytes`() =
+        runBlocking {
+            val quotaIndex = createIndex(name = "quota", dailyQuotaGb = 0.000001f)
+            val first = queuedLog(indexName = "quota", message = "éé", body = "")
+            val second = queuedLog(indexName = "quota", message = "é", body = "")
+            var usageQueries = 0
+
+            MockHttpServer { exchange ->
+                usageQueries += 1
+                exchange.respond(
+                    200,
+                    """{"index_name":"quota","cnt":50,"bytes":1068}""",
+                    contentType = TEXT_PLAIN
+                )
+            }.use { server ->
+                ClickHouseClient.init(server.baseUrl, "test", "default", "")
+
+                val allowed = service.filterWithinDailyQuota(ORG_ID, listOf(first), listOf(quotaIndex))
+                val rejected = service.filterWithinDailyQuota(ORG_ID, listOf(second), listOf(quotaIndex))
+
+                assertEquals(listOf(first), allowed)
+                assertEquals(emptyList(), rejected)
+                assertEquals(1, usageQueries)
+            }
+        }
+
     // ──── testFilter (ClickHouse) ────
 
     @Test
@@ -693,4 +849,27 @@ class LogIndexServiceTest {
                 assertEquals(0L, result.matchCount)
             }
         }
+
+    private fun queuedLog(
+        indexName: String,
+        message: String = "hello",
+        body: String = "body"
+    ): QueuedLogEntry =
+        QueuedLogEntry(
+            logId = "log-$indexName-$message",
+            timestampMs = TEST_TIMESTAMP_MS,
+            level = "info",
+            message = message,
+            body = body,
+            service = "api",
+            environment = "prod",
+            host = "host-1",
+            source = "sdk",
+            containerName = "",
+            containerId = "",
+            containerImage = "",
+            traceId = "",
+            spanId = "",
+            indexName = indexName
+        )
 }

--- a/backend/src/test/kotlin/com/moneat/services/LogIngestionWorkerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogIngestionWorkerTest.kt
@@ -18,10 +18,19 @@ package com.moneat.services
 
 import com.moneat.logs.models.QueuedLogBatch
 import com.moneat.logs.models.QueuedLogEntry
+import com.moneat.logs.models.LogEntryResponse
+import com.moneat.logs.models.LogIndexResponse
+import com.moneat.logs.models.LogPipelineResponse
 import com.moneat.logs.repositories.LogRepositoryImpl
+import com.moneat.logs.services.LogIndexService
 import com.moneat.logs.services.LogIngestionWorker
+import com.moneat.logs.services.LogManagementService
 import com.moneat.logs.services.LogService
 import com.moneat.monitoring.OperationalMetrics
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -91,6 +100,123 @@ class LogIngestionWorkerTest {
         }
 
     @Test
+    fun `processMessageForTest applies pipelines indexes quota and publishes live logs`() =
+        runBlocking {
+            val logService = mockk<LogService>()
+            val logIndexService = mockk<LogIndexService>()
+            val logManagementService = mockk<LogManagementService>()
+            val originalEntry = queuedEntry(logId = "route-me", level = "error", message = "before")
+            val pipedEntry = originalEntry.copy(message = "after")
+            val inserted = listOf(logEntryResponse(logId = "route-me", message = "after"))
+            val batch = QueuedLogBatch(organizationId = 99L, source = "sdk", logs = listOf(originalEntry))
+            val payload = LogService(LogRepositoryImpl()).encodeQueueMessage(batch)
+            val index = logIndexResponse(name = "errors", filterQuery = "level:error")
+            val pipeline = logPipelineResponse(name = "Cleanup")
+            val dlq = mutableListOf<String>()
+
+            every { logService.decodeQueueMessage(payload) } returns batch
+            coEvery { logIndexService.getActiveIndexesCached(99) } returns listOf(index)
+            coEvery { logManagementService.getActivePipelinesCached(99) } returns listOf(pipeline)
+            every { logManagementService.applyPipelines(listOf(originalEntry), listOf(pipeline)) } returns
+                listOf(pipedEntry)
+            coEvery {
+                logIndexService.filterWithinDailyQuota(99, any(), listOf(index))
+            } answers {
+                secondArg()
+            }
+            coEvery { logService.insertBatch(any()) } returns inserted
+            coEvery { logService.publishLiveLogs(99L, inserted) } returns Unit
+
+            val worker = LogIngestionWorker(
+                queueKey = "log:q",
+                dlqKey = "log:dlq",
+                workerCount = 1,
+                logService = logService,
+                logIndexService = logIndexService,
+                logManagementService = logManagementService
+            )
+
+            worker.processMessageForTest(workerId = 4, payload = payload) { dlq.add(it) }
+
+            assertEquals(emptyList(), dlq)
+            coVerify {
+                logService.insertBatch(
+                    match { insertedBatch ->
+                        insertedBatch.logs.single().indexName == "errors" &&
+                            insertedBatch.logs.single().message == "after"
+                    }
+                )
+            }
+            coVerify { logService.publishLiveLogs(99L, inserted) }
+        }
+
+    @Test
+    fun `processMessageForTest skips org scoped lookups when org id is outside Int range`() =
+        runBlocking {
+            val logService = mockk<LogService>()
+            val logIndexService = mockk<LogIndexService>(relaxed = true)
+            val logManagementService = mockk<LogManagementService>(relaxed = true)
+            val entry = queuedEntry(logId = "large-org", level = "info", message = "hello")
+            val orgId = Int.MAX_VALUE.toLong() + 1L
+            val batch = QueuedLogBatch(organizationId = orgId, source = "sdk", logs = listOf(entry))
+            val payload = LogService(LogRepositoryImpl()).encodeQueueMessage(batch)
+            val inserted = listOf(logEntryResponse(logId = "large-org", message = "hello"))
+
+            every { logService.decodeQueueMessage(payload) } returns batch
+            every { logManagementService.applyPipelines(listOf(entry), emptyList()) } returns listOf(entry)
+            coEvery { logService.insertBatch(batch) } returns inserted
+            coEvery { logService.publishLiveLogs(orgId, inserted) } returns Unit
+
+            val worker = LogIngestionWorker(
+                queueKey = "log:q",
+                dlqKey = "log:dlq",
+                workerCount = 1,
+                logService = logService,
+                logIndexService = logIndexService,
+                logManagementService = logManagementService
+            )
+
+            worker.processMessageForTest(workerId = 5, payload = payload)
+
+            coVerify(exactly = 0) { logIndexService.getActiveIndexesCached(any()) }
+            coVerify(exactly = 0) { logManagementService.getActivePipelinesCached(any()) }
+            coVerify(exactly = 0) { logIndexService.filterWithinDailyQuota(any(), any(), any()) }
+            coVerify { logService.publishLiveLogs(orgId, inserted) }
+        }
+
+    @Test
+    fun `processMessageForTest returns before insert when quota filtering drops all logs`() =
+        runBlocking {
+            val logService = mockk<LogService>()
+            val logIndexService = mockk<LogIndexService>()
+            val logManagementService = mockk<LogManagementService>()
+            val entry = queuedEntry(logId = "quota", level = "info", message = "hello")
+            val batch = QueuedLogBatch(organizationId = 100L, source = "sdk", logs = listOf(entry))
+            val payload = LogService(LogRepositoryImpl()).encodeQueueMessage(batch)
+            val index = logIndexResponse(name = "main", filterQuery = "")
+
+            every { logService.decodeQueueMessage(payload) } returns batch
+            coEvery { logIndexService.getActiveIndexesCached(100) } returns listOf(index)
+            coEvery { logManagementService.getActivePipelinesCached(100) } returns emptyList()
+            every { logManagementService.applyPipelines(listOf(entry), emptyList()) } returns listOf(entry)
+            coEvery { logIndexService.filterWithinDailyQuota(100, any(), listOf(index)) } returns emptyList()
+
+            val worker = LogIngestionWorker(
+                queueKey = "log:q",
+                dlqKey = "log:dlq",
+                workerCount = 1,
+                logService = logService,
+                logIndexService = logIndexService,
+                logManagementService = logManagementService
+            )
+
+            worker.processMessageForTest(workerId = 6, payload = payload)
+
+            coVerify(exactly = 0) { logService.insertBatch(any()) }
+            coVerify(exactly = 0) { logService.publishLiveLogs(any(), any()) }
+        }
+
+    @Test
     fun `processMessageForTest records DLQ failure when callback throws`() =
         runBlocking {
             val worker = LogIngestionWorker("log:q", "log:dlq", 1)
@@ -108,4 +234,75 @@ class LogIngestionWorkerTest {
             assertContains(rendered, "dlq_key=\"log:dlq\"")
             assertContains(rendered, "status=\"failure\"")
         }
+
+    private fun queuedEntry(
+        logId: String,
+        level: String,
+        message: String
+    ): QueuedLogEntry =
+        QueuedLogEntry(
+            logId = logId,
+            timestampMs = 1_738_372_400_000,
+            level = level,
+            message = message,
+            body = message,
+            service = "api",
+            environment = "prod",
+            host = "host-1",
+            source = "sdk",
+            containerName = "",
+            containerId = "",
+            containerImage = "",
+            traceId = "",
+            spanId = ""
+        )
+
+    private fun logIndexResponse(
+        name: String,
+        filterQuery: String
+    ): LogIndexResponse =
+        LogIndexResponse(
+            id = 1,
+            name = name,
+            filterQuery = filterQuery,
+            retentionDays = 30,
+            samplingRate = 1.0f,
+            priority = 0,
+            isActive = true,
+            createdAt = "2026-06-04T00:00:00Z",
+            updatedAt = "2026-06-04T00:00:00Z"
+        )
+
+    private fun logPipelineResponse(name: String): LogPipelineResponse =
+        LogPipelineResponse(
+            id = 1,
+            name = name,
+            description = "",
+            steps = emptyList(),
+            priority = 0,
+            isActive = true,
+            createdAt = "2026-06-04T00:00:00Z",
+            updatedAt = "2026-06-04T00:00:00Z"
+        )
+
+    private fun logEntryResponse(
+        logId: String,
+        message: String
+    ): LogEntryResponse =
+        LogEntryResponse(
+            logId = logId,
+            timestamp = "2026-06-04T00:00:00Z",
+            level = "info",
+            message = message,
+            body = message,
+            service = "api",
+            environment = "prod",
+            host = "host-1",
+            source = "sdk",
+            containerName = "",
+            containerId = "",
+            containerImage = "",
+            traceId = "",
+            spanId = ""
+        )
 }


### PR DESCRIPTION
Adds backend support for log management workflows from the explorer: management permissions, pipelines, saved views, index usage and quota enforcement, log metric rules, live-tail filtering, and log monitors.

Validation:
- git diff --check
- migration version scan
- ./gradlew test detekt