### PR TITLE
feat: enhance service map visuals

### DIFF
--- a/dashboard/src/components/apm/ServiceMap.tsx
+++ b/dashboard/src/components/apm/ServiceMap.tsx
@@ -16,62 +16,44 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from 'react'
 import {useQuery} from '@tanstack/react-query'
+import {Link} from '@tanstack/react-router'
 import {
   Handle,
   Position,
-  MarkerType,
   type Node,
-  type Edge,
   type NodeProps,
 } from '@xyflow/react'
-import Dagre from '@dagrejs/dagre'
-import {api, type ApmServiceMapEntry} from '@/lib/api'
+import {api, type ApmServiceEdge, type ApmTimeRange} from '@/lib/api'
+import type {FacetFilter} from '@/lib/filters/types'
 import {Badge} from '@/components/ui/badge'
-import {Database, Globe, Server, Layers} from 'lucide-react'
+import {Button} from '@/components/ui/button'
+import {Database, Globe, Server, Layers, FileText, Flame, ListTree} from 'lucide-react'
 import {MapCanvas} from '@/components/maps/MapCanvas'
-import {MapDetailPanel} from '@/components/maps/MapDetailPanel'
+import {MapDetailDock} from '@/components/maps/MapDetailDock'
 import {MapLegend} from '@/components/maps/MapLegend'
 import {MapNodeCard} from '@/components/maps/MapNodeCard'
-
-type ServiceType = 'database' | 'cache' | 'queue' | 'web' | 'service'
-
-type ServiceNodeData = {
-  label: string
-  spanCount: number
-  errorCount: number
-  avgDurationNs: number
-  serviceType: ServiceType
-  isExternal: boolean
-  dimmed: boolean
-  selected: boolean
-}
-
-type ServiceGraphSelection = Readonly<{
-  connectedServices: Set<string>
-  connectedEdges: Set<string>
-}>
-
-type ServiceNodeBuildOptions = Readonly<{
-  services: ApmServiceMapEntry[]
-  graph: Dagre.graphlib.Graph
-  selectedId: string | null
-  connectedServices: Set<string>
-}>
-
-type ExternalNodeBuildOptions = Readonly<{
-  externalServices: Set<string>
-  graph: Dagre.graphlib.Graph
-  selectedId: string | null
-  connectedServices: Set<string>
-}>
-
-type ServiceEdgeBuildOptions = Readonly<{
-  services: ApmServiceMapEntry[]
-  selectedId: string | null
-  connectedEdges: Set<string>
-}>
-
-const SERVICE_TYPES: ServiceType[] = ['database', 'cache', 'queue', 'web', 'service']
+import {cn} from '@/lib/utils'
+import {
+  buildServiceMapGraph,
+  formatCount,
+  formatDurationNs,
+  formatPercent,
+  formatRatePerMin,
+  timeRangeSeconds,
+  type HealthTone,
+  type ServiceMapEdgeModel,
+  type ServiceMapNodeModel,
+  type ServiceType,
+} from './serviceMapModel'
+import {
+  layoutPositions,
+  timeRangeSecondsForNode,
+  toFlowEdges,
+  toFlowNodes,
+  DEFAULT_TIME_RANGE,
+  TONE_COLOR,
+  type ServiceNodeData,
+} from './serviceMapFlow'
 
 const SERVICE_CHART_VAR: Record<ServiceType, string> = {
   database: '--chart-2',
@@ -79,14 +61,6 @@ const SERVICE_CHART_VAR: Record<ServiceType, string> = {
   queue: '--chart-6',
   web: '--chart-4',
   service: '--chart-1',
-}
-
-function serviceColor(type: ServiceType): string {
-  return `hsl(var(${SERVICE_CHART_VAR[type]}))`
-}
-
-function serviceTint(type: ServiceType): string {
-  return `hsl(var(${SERVICE_CHART_VAR[type]}) / 0.15)`
 }
 
 const SERVICE_ICONS: Record<ServiceType, ComponentType<{className?: string}>> = {
@@ -97,249 +71,24 @@ const SERVICE_ICONS: Record<ServiceType, ComponentType<{className?: string}>> = 
   service: Server,
 }
 
-const SERVICE_LEGEND_ITEMS = SERVICE_TYPES.map((type) => ({
-  label: type.charAt(0).toUpperCase() + type.slice(1),
-  color: serviceColor(type),
-}))
-
-function formatDuration(ns: number): string {
-  if (ns < 1_000_000) return `${(ns / 1000).toFixed(0)}µs`
-  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(1)}ms`
-  return `${(ns / 1_000_000_000).toFixed(2)}s`
+// Node health borders use the soft status-border tokens (matching the sibling
+// infrastructure map), so healthy nodes stay calm and warning/error nodes draw
+// the eye. Selection is conveyed by the primary ring, not the border color.
+const TONE_BORDER_CLASS: Record<HealthTone, string> = {
+  success: 'border-success-border hover:border-success-fg',
+  warning: 'border-warning-border hover:border-warning-fg',
+  danger: 'border-danger-border hover:border-danger-fg',
+  neutral: 'border-border hover:border-foreground/30',
 }
 
-function inferServiceType(name: string): ServiceType {
-  const lower = name.toLowerCase()
-  if (/postgres|mysql|mongo|clickhouse|sqlite|mariadb|cockroach|\bdb\b/.test(lower)) return 'database'
-  if (/redis|cache|memcached|varnish/.test(lower)) return 'cache'
-  if (/kafka|rabbitmq|queue|sqs|sns|nats|pulsar/.test(lower)) return 'queue'
-  if (/web|api|gateway|nginx|envoy|proxy|frontend/.test(lower)) return 'web'
-  return 'service'
+const PIVOT_BUTTON_CLASS = 'h-auto flex-col gap-1 px-1 py-1.5 text-[10px]'
+
+function serviceColor(type: ServiceType): string {
+  return `hsl(var(${SERVICE_CHART_VAR[type]}))`
 }
 
-// --- Layout ---
-
-const NODE_W = 200
-const NODE_H = 80
-const EXT_W = 160
-const EXT_H = 56
-
-function buildGraph(
-  services: ApmServiceMapEntry[],
-  selectedId: string | null,
-): {nodes: Node[]; edges: Edge[]} {
-  const knownServices = new Set(services.map((service) => service.service))
-  const externalServices = getExternalServices(services, knownServices)
-  const selection = getServiceSelection(services, selectedId)
-  const graph = createServiceLayoutGraph(services, externalServices)
-  const nodes = [
-    ...createServiceNodes({
-      services,
-      graph,
-      selectedId,
-      connectedServices: selection.connectedServices,
-    }),
-    ...createExternalNodes({
-      externalServices,
-      graph,
-      selectedId,
-      connectedServices: selection.connectedServices,
-    }),
-  ]
-  const edges = createServiceEdges({
-    services,
-    selectedId,
-    connectedEdges: selection.connectedEdges,
-  })
-
-  return {nodes, edges}
-}
-
-function getExternalServices(services: ApmServiceMapEntry[], knownServices: Set<string>): Set<string> {
-  const external = new Set<string>()
-  for (const service of services) {
-    for (const target of service.callsTo) {
-      if (!knownServices.has(target)) external.add(target)
-    }
-  }
-  return external
-}
-
-function getServiceSelection(
-  services: ApmServiceMapEntry[],
-  selectedId: string | null,
-): ServiceGraphSelection {
-  const connectedServices = new Set<string>()
-  const connectedEdges = new Set<string>()
-  if (selectedId) {
-    connectedServices.add(selectedId)
-    addSelectedServiceConnections({
-      services,
-      selectedId,
-      connectedServices,
-      connectedEdges,
-    })
-  }
-  return {connectedServices, connectedEdges}
-}
-
-function addSelectedServiceConnections({
-  services,
-  selectedId,
-  connectedServices,
-  connectedEdges,
-}: Readonly<{
-  services: ApmServiceMapEntry[]
-  selectedId: string
-  connectedServices: Set<string>
-  connectedEdges: Set<string>
-}>) {
-  for (const service of services) {
-    for (const target of service.callsTo) {
-      if (service.service === selectedId || target === selectedId) {
-        connectedServices.add(service.service)
-        connectedServices.add(target)
-        connectedEdges.add(getServiceEdgeId(service.service, target))
-      }
-    }
-  }
-}
-
-function isSelectionInVisibleGraph(
-  services: ApmServiceMapEntry[],
-  selectedId: string,
-): boolean {
-  return services.some(
-    (service) => service.service === selectedId || service.callsTo.includes(selectedId),
-  )
-}
-
-function createServiceLayoutGraph(
-  services: ApmServiceMapEntry[],
-  externalServices: Set<string>,
-): Dagre.graphlib.Graph {
-  const graph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
-  graph.setGraph({rankdir: 'LR', nodesep: 50, ranksep: 160, marginx: 40, marginy: 40})
-
-  for (const service of services) graph.setNode(service.service, {width: NODE_W, height: NODE_H})
-  for (const name of externalServices) graph.setNode(name, {width: EXT_W, height: EXT_H})
-  for (const service of services) {
-    for (const target of service.callsTo) graph.setEdge(service.service, target)
-  }
-
-  Dagre.layout(graph)
-  return graph
-}
-
-function createServiceNodes({
-  services,
-  graph,
-  selectedId,
-  connectedServices,
-}: ServiceNodeBuildOptions): Node[] {
-  return services.map((service) => {
-    const position = graph.node(service.service)
-    return {
-      id: service.service,
-      type: 'service',
-      position: {x: position.x - NODE_W / 2, y: position.y - NODE_H / 2},
-      data: {
-        label: service.service,
-        spanCount: service.spanCount,
-        errorCount: service.errorCount,
-        avgDurationNs: service.avgDurationNs,
-        serviceType: inferServiceType(service.service),
-        isExternal: false,
-        dimmed: isServiceDimmed(service.service, selectedId, connectedServices),
-        selected: selectedId === service.service,
-      } satisfies ServiceNodeData,
-    }
-  })
-}
-
-function createExternalNodes({
-  externalServices,
-  graph,
-  selectedId,
-  connectedServices,
-}: ExternalNodeBuildOptions): Node[] {
-  const nodes: Node[] = []
-  for (const name of externalServices) {
-    const position = graph.node(name)
-    nodes.push({
-      id: name,
-      type: 'service',
-      position: {x: position.x - EXT_W / 2, y: position.y - EXT_H / 2},
-      data: {
-        label: name,
-        spanCount: 0,
-        errorCount: 0,
-        avgDurationNs: 0,
-        serviceType: inferServiceType(name),
-        isExternal: true,
-        dimmed: isServiceDimmed(name, selectedId, connectedServices),
-        selected: selectedId === name,
-      } satisfies ServiceNodeData,
-    })
-  }
-  return nodes
-}
-
-function createServiceEdges({
-  services,
-  selectedId,
-  connectedEdges,
-}: ServiceEdgeBuildOptions): Edge[] {
-  const edges: Edge[] = []
-  for (const service of services) {
-    for (const target of service.callsTo) {
-      const id = getServiceEdgeId(service.service, target)
-      const isDimmed = isServiceEdgeDimmed(id, selectedId, connectedEdges)
-      edges.push({
-        id,
-        source: service.service,
-        target,
-        type: 'smoothstep',
-        animated: !isDimmed && selectedId !== null,
-        style: {
-          stroke: isDimmed
-            ? 'hsl(var(--muted-foreground) / 0.2)'
-            : 'hsl(var(--muted-foreground) / 0.6)',
-          strokeWidth: isDimmed ? 1 : 2,
-        },
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          color: isDimmed
-            ? 'hsl(var(--muted-foreground) / 0.2)'
-            : 'hsl(var(--muted-foreground) / 0.6)',
-          width: 14,
-          height: 14,
-        },
-      })
-    }
-  }
-
-  return edges
-}
-
-function getServiceEdgeId(source: string, target: string): string {
-  return `${source}->${target}`
-}
-
-function isServiceDimmed(
-  serviceId: string,
-  selectedId: string | null,
-  connectedServices: Set<string>,
-): boolean {
-  return selectedId !== null && !connectedServices.has(serviceId)
-}
-
-function isServiceEdgeDimmed(
-  edgeId: string,
-  selectedId: string | null,
-  connectedEdges: Set<string>,
-): boolean {
-  return selectedId !== null && !connectedEdges.has(edgeId)
+function serviceTint(type: ServiceType): string {
+  return `hsl(var(${SERVICE_CHART_VAR[type]}) / 0.15)`
 }
 
 // --- Custom node ---
@@ -354,14 +103,20 @@ const handleStyle: CSSProperties = {
 const ServiceNode = memo(function ServiceNode({data}: Readonly<NodeProps<Node<ServiceNodeData>>>) {
   const accent = serviceColor(data.serviceType)
   const Icon = SERVICE_ICONS[data.serviceType]
-  const hasErrors = data.errorCount > 0
-  const metrics = data.isExternal ? undefined : (
+  const borderClassName = data.isInferred ? 'border-border' : TONE_BORDER_CLASS[data.healthTone]
+
+  const metrics = data.isInferred ? (
     <>
-      <span>{data.spanCount.toLocaleString()} spans</span>
-      <span>{formatDuration(data.avgDurationNs)}</span>
-      {hasErrors && (
-        <span className="font-semibold text-destructive">
-          {data.errorCount} err
+      <span>{formatRatePerMin(data.spanCount, timeRangeSecondsForNode(data))} in</span>
+      <span>{formatDurationNs(data.avgDurationNs)}</span>
+    </>
+  ) : (
+    <>
+      <span>{formatRatePerMin(data.spanCount, timeRangeSecondsForNode(data))}</span>
+      <span>{formatDurationNs(data.avgDurationNs)}</span>
+      {data.errorRate > 0 && (
+        <span className={data.healthTone === 'danger' ? 'font-semibold text-danger-fg' : 'text-warning-fg'}>
+          {formatPercent(data.errorRate)} err
         </span>
       )}
     </>
@@ -372,16 +127,19 @@ const ServiceNode = memo(function ServiceNode({data}: Readonly<NodeProps<Node<Se
       <Handle type="target" position={Position.Left} style={handleStyle} />
       <MapNodeCard
         title={data.label}
-        subtitle={data.isExternal ? 'External dependency' : undefined}
+        subtitle={data.isInferred ? 'Inferred dependency' : undefined}
         icon={<Icon className="h-4 w-4" />}
         iconContainerStyle={{backgroundColor: serviceTint(data.serviceType), color: accent}}
-        borderColor={getServiceBorderColor({color: accent, hasErrors, selected: data.selected})}
-        minWidth={data.isExternal ? 140 : 180}
+        borderClassName={borderClassName}
+        minWidth={data.isInferred ? 148 : 188}
         selected={data.selected}
         dimmed={data.dimmed}
-        dashed={data.isExternal}
-        statusIndicator={hasErrors ? (
-          <span className="h-2.5 w-2.5 shrink-0 animate-pulse rounded-full bg-destructive" />
+        dashed={data.isInferred}
+        statusIndicator={data.healthTone === 'danger' ? (
+          <span
+            className="h-2.5 w-2.5 shrink-0 animate-pulse rounded-full"
+            style={{backgroundColor: TONE_COLOR.danger}}
+          />
         ) : null}
         metrics={metrics}
       />
@@ -394,133 +152,272 @@ const nodeTypes = {service: ServiceNode}
 
 // --- Main component ---
 
+const EMPTY_FACET_FILTERS: FacetFilter[] = []
+
 type ServiceMapProps = Readonly<{
   className?: string
   searchQuery?: string
+  timeRange?: ApmTimeRange
+  env?: string
+  source?: string
+  facetFilters?: FacetFilter[]
 }>
 
-export function ServiceMap({className, searchQuery = ''}: ServiceMapProps = {}) {
+export function ServiceMap({
+  className,
+  searchQuery = '',
+  timeRange = DEFAULT_TIME_RANGE,
+  env,
+  source,
+  facetFilters = EMPTY_FACET_FILTERS,
+}: ServiceMapProps = {}) {
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
   const {data, isError, isLoading} = useQuery({
-    queryKey: ['apmServiceMap'],
-    queryFn: () => api.getApmServiceMap(),
+    queryKey: ['apmServiceMap', timeRange, env ?? '', source ?? ''],
+    queryFn: () => api.getApmServiceMap({timeRange, env, source}),
     enabled: api.isAuthenticated(),
     refetchInterval: 30000,
   })
 
-  const services = data?.services ?? []
-  const normalizedSearch = searchQuery.trim().toLowerCase()
-  const visibleServices = useMemo(() => {
-    if (!normalizedSearch) return services
-    return services.filter((service) => {
-      const calls = service.callsTo.join(' ').toLowerCase()
-      return service.service.toLowerCase().includes(normalizedSearch) || calls.includes(normalizedSearch)
-    })
-  }, [normalizedSearch, services])
+  const services = useMemo(() => data?.services ?? [], [data])
+  const edges = useMemo<ApmServiceEdge[]>(() => data?.edges ?? [], [data])
+  const windowSeconds = timeRangeSeconds(timeRange)
 
-  const effectiveSelectedId = useMemo(() => {
-    if (selectedId === null) return null
-    return isSelectionInVisibleGraph(visibleServices, selectedId) ? selectedId : null
-  }, [selectedId, visibleServices])
+  const graph = useMemo(
+    () => buildServiceMapGraph({services, edges, windowSeconds, search: searchQuery, selectedId, facetFilters}),
+    [services, edges, windowSeconds, searchQuery, selectedId, facetFilters],
+  )
 
-  const {nodes, edges} = useMemo(
-    () => buildGraph(visibleServices, effectiveSelectedId),
-    [visibleServices, effectiveSelectedId],
+  const flowNodes = useMemo(() => {
+    const positions = layoutPositions(graph.nodes, graph.edges)
+    return toFlowNodes(graph.nodes, positions).map((node) => ({
+      ...node,
+      data: {...node.data, windowSeconds},
+    }))
+  }, [graph.nodes, graph.edges, windowSeconds])
+
+  const flowEdges = useMemo(() => toFlowEdges(graph.edges), [graph.edges])
+
+  const selectedNode = useMemo(
+    () => graph.nodes.find((node) => node.id === selectedId) ?? null,
+    [graph.nodes, selectedId],
   )
 
   const onNodeClick = useCallback((_event: ReactMouseEvent, node: Node) => {
     setSelectedId((previousId) => (previousId === node.id ? null : node.id))
-  }, [setSelectedId])
+  }, [])
 
-  const onPaneClick = useCallback(() => setSelectedId(null), [setSelectedId])
+  const onPaneClick = useCallback(() => setSelectedId(null), [])
 
-  const selected = effectiveSelectedId
-    ? visibleServices.find((service) => service.service === effectiveSelectedId)
-    : null
-  const isFilteredEmpty = services.length > 0 && visibleServices.length === 0
+  const isFilteredEmpty = services.length > 0 && graph.visibleServiceCount === 0
 
   return (
-    <MapCanvas
-      nodes={nodes}
-      edges={edges}
-      nodeTypes={nodeTypes}
-      onNodeClick={onNodeClick}
-      onPaneClick={onPaneClick}
-      isLoading={isLoading}
-      isEmpty={!isError && visibleServices.length === 0}
-      emptyTitle={isFilteredEmpty ? 'No services match your search' : 'No services found'}
-      emptyDescription={isFilteredEmpty
-        ? 'Adjust search to show more service nodes.'
-        : 'Service map populates automatically as trace telemetry is ingested.'}
-      fallback={isError ? (
-        <div className="max-w-sm text-center">
-          <p className="text-sm font-medium text-muted-foreground">Map data unavailable</p>
-          <p className="mt-1 text-xs text-muted-foreground/75">
-            Refresh the page or try again after the telemetry API responds.
-          </p>
-        </div>
-      ) : undefined}
-      className={className ?? 'service-map h-[calc(100vh-260px)] min-h-[420px]'}
-      fitSignature={`services-${visibleServices.map((service) => service.service).join('|')}`}
-    >
-      <MapLegend
-        items={[
-          ...SERVICE_LEGEND_ITEMS,
-          {
-            label: 'External',
-            color: 'hsl(var(--muted-foreground) / 0.4)',
-            dashed: true,
-          },
-        ]}
-      />
+    <div className={cn('relative flex min-h-0', className ?? 'service-map h-[calc(100vh-260px)] min-h-[420px]')}>
+      <MapCanvas
+        nodes={flowNodes}
+        edges={flowEdges}
+        nodeTypes={nodeTypes}
+        onNodeClick={onNodeClick}
+        onPaneClick={onPaneClick}
+        isLoading={isLoading}
+        isEmpty={!isError && graph.nodes.length === 0}
+        emptyTitle={isFilteredEmpty ? 'No services match your filters' : 'No services found'}
+        emptyDescription={isFilteredEmpty
+          ? 'Adjust search or facets to show more service nodes.'
+          : 'Service map populates automatically as trace telemetry is ingested.'}
+        fallback={isError ? (
+          <div className="max-w-sm text-center">
+            <p className="text-sm font-medium text-muted-foreground">Map data unavailable</p>
+            <p className="mt-1 text-xs text-muted-foreground/75">
+              Refresh the page or try again after the telemetry API responds.
+            </p>
+          </div>
+        ) : undefined}
+        className="min-w-0 flex-1 rounded-none border-0"
+        fitSignature={`services-${timeRange}-${graph.nodes.map((node) => node.id).join('|')}`}
+      >
+        <MapLegend
+          items={[
+            {label: 'Healthy', color: TONE_COLOR.success},
+            {label: 'Elevated', color: TONE_COLOR.warning},
+            {label: 'Errors', color: TONE_COLOR.danger},
+            {label: 'Inferred', color: 'hsl(var(--muted-foreground) / 0.4)', dashed: true},
+          ]}
+          trailing={
+            <span className="flex items-center gap-1.5 border-l border-border/60 pl-3 font-mono">
+              <span>{formatCount(graph.visibleServiceCount)} services</span>
+              {graph.inferredCount > 0 && (
+                <span className="text-muted-foreground/70">· {formatCount(graph.inferredCount)} inferred</span>
+              )}
+            </span>
+          }
+        />
+      </MapCanvas>
 
-      {selected && (
-        <MapDetailPanel title={selected.service} onClose={() => setSelectedId(null)}>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Spans</span>
-            <span className="font-mono text-xs">{selected.spanCount.toLocaleString()}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Avg Duration</span>
-            <span className="font-mono text-xs">{formatDuration(selected.avgDurationNs)}</span>
-          </div>
-          {selected.errorCount > 0 && (
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground">Errors</span>
-              <Badge variant="destructive" className="h-5 text-[10px]">
-                {selected.errorCount}
-              </Badge>
-            </div>
-          )}
-          {selected.callsTo.length > 0 && (
-            <div className="border-t pt-1">
-              <span className="text-[11px] text-muted-foreground">Downstream</span>
-              <div className="mt-1 flex flex-wrap gap-1">
-                {selected.callsTo.map((target) => (
-                  <Badge key={target} variant="secondary" className="h-5 text-[10px]">
-                    {target}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-        </MapDetailPanel>
+      {selectedNode && (
+        <ServiceDetailPanel
+          node={selectedNode}
+          upstream={graph.neighbors?.upstream ?? []}
+          downstream={graph.neighbors?.downstream ?? []}
+          windowSeconds={windowSeconds}
+          timeRange={timeRange}
+          env={env}
+          source={source}
+          onClose={() => setSelectedId(null)}
+        />
       )}
-    </MapCanvas>
+    </div>
   )
 }
 
-function getServiceBorderColor({
-  color,
-  hasErrors,
-  selected,
-}: {
-  color: string
-  hasErrors: boolean
-  selected: boolean
-}): string {
-  if (hasErrors && !selected) return 'hsl(var(--destructive))'
-  if (selected) return 'hsl(var(--primary))'
-  return color
+type ServiceDetailPanelProps = Readonly<{
+  node: ServiceMapNodeModel
+  upstream: ServiceMapEdgeModel[]
+  downstream: ServiceMapEdgeModel[]
+  windowSeconds: number
+  timeRange: ApmTimeRange
+  env?: string
+  source?: string
+  onClose: () => void
+}>
+
+function ServiceDetailPanel({
+  node,
+  upstream,
+  downstream,
+  windowSeconds,
+  timeRange,
+  env,
+  source,
+  onClose,
+}: ServiceDetailPanelProps) {
+  const {data: latency, isLoading: latencyLoading} = useQuery({
+    queryKey: ['apmServiceLatency', node.id, timeRange, env ?? '', source ?? ''],
+    queryFn: () => api.getApmServiceLatency(node.id, {timeRange, env, source}),
+    enabled: api.isAuthenticated() && !node.isInferred,
+  })
+
+  return (
+    <MapDetailDock
+      title={node.label}
+      subtitle={node.isInferred ? `inferred · ${node.serviceType}` : `service · ${node.serviceType}`}
+      onClose={onClose}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-muted-foreground">{node.isInferred ? 'Type' : 'Health'}</span>
+        <Badge variant={node.isInferred ? 'neutral' : healthBadgeVariant(node.healthTone)} className="h-5 text-[10px] capitalize">
+          {node.isInferred ? 'Inferred dependency' : node.healthTone}
+        </Badge>
+      </div>
+      <DetailRow label="Throughput" value={formatRatePerMin(node.spanCount, windowSeconds)} />
+      <DetailRow label="Error rate" value={formatPercent(node.errorRate)} />
+      <DetailRow label="Avg latency" value={formatDurationNs(node.avgDurationNs)} />
+      {!node.isInferred && (
+        <div className="grid grid-cols-3 gap-1.5 border-t pt-2">
+          <Percentile label="p50" value={latency?.p50DurationNs} loading={latencyLoading} />
+          <Percentile label="p90" value={latency?.p90DurationNs} loading={latencyLoading} />
+          <Percentile label="p99" value={latency?.p99DurationNs} loading={latencyLoading} />
+        </div>
+      )}
+
+      <NeighborList title="Upstream" emptyLabel="No callers" edges={upstream} endpoint="source" />
+      <NeighborList title="Downstream" emptyLabel="No dependencies" edges={downstream} endpoint="target" />
+
+      {!node.isInferred && (
+        <div className="grid grid-cols-3 gap-1.5 border-t pt-2">
+          <Button asChild variant="outline" size="sm" className={PIVOT_BUTTON_CLASS}>
+            <Link to="/performance/traces">
+              <ListTree className="h-3.5 w-3.5" />
+              Traces
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="sm" className={PIVOT_BUTTON_CLASS}>
+            <Link to="/logs" search={{q: `service:${node.id}`}}>
+              <FileText className="h-3.5 w-3.5" />
+              Logs
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="sm" className={PIVOT_BUTTON_CLASS}>
+            <Link to="/profiles/service/$service" params={{service: node.id}}>
+              <Flame className="h-3.5 w-3.5" />
+              Profiles
+            </Link>
+          </Button>
+        </div>
+      )}
+    </MapDetailDock>
+  )
+}
+
+function DetailRow({label, value}: Readonly<{label: string; value: string}>) {
+  return (
+    <div className="flex justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="truncate font-mono text-xs">{value}</span>
+    </div>
+  )
+}
+
+function Percentile({
+  label,
+  value,
+  loading,
+}: Readonly<{label: string; value?: number; loading: boolean}>) {
+  const displayValue = percentileDisplayValue(value, loading)
+
+  return (
+    <div className="rounded-md border bg-card/40 px-1.5 py-1 text-center">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="font-mono text-[11px]">{displayValue}</div>
+    </div>
+  )
+}
+
+function percentileDisplayValue(value: number | undefined, loading: boolean): string {
+  if (loading) return '…'
+  if (value == null) return '—'
+  return formatDurationNs(value)
+}
+
+function NeighborList({
+  title,
+  emptyLabel,
+  edges,
+  endpoint,
+}: Readonly<{
+  title: string
+  emptyLabel: string
+  edges: ServiceMapEdgeModel[]
+  endpoint: 'source' | 'target'
+}>) {
+  return (
+    <div className="border-t pt-1.5">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-[11px] font-medium text-muted-foreground">{title}</span>
+        <span className="text-[10px] text-muted-foreground/70">{edges.length}</span>
+      </div>
+      {edges.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground/60">{emptyLabel}</p>
+      ) : (
+        <div className="space-y-1">
+          {edges.map((edge) => (
+            <div key={edge.id} className="flex items-center justify-between gap-2 text-[11px]">
+              <span className="truncate font-medium">{endpoint === 'source' ? edge.source : edge.target}</span>
+              <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                {formatCount(edge.callCount)} · {formatDurationNs(edge.avgDurationNs)}
+                {edge.errorRate > 0 && (
+                  <span className="ml-1 text-danger-fg">{formatPercent(edge.errorRate)}</span>
+                )}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function healthBadgeVariant(tone: HealthTone): 'success' | 'warning' | 'danger' | 'neutral' {
+  return tone
 }

--- a/dashboard/src/components/apm/__tests__/ServiceMap.test.tsx
+++ b/dashboard/src/components/apm/__tests__/ServiceMap.test.tsx
@@ -5,66 +5,71 @@
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useState, type MouseEvent as ReactMouseEvent, type ReactNode} from 'react'
+import {type MouseEvent as ReactMouseEvent, type ReactNode} from 'react'
 import {fireEvent, screen, within} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {http, HttpResponse} from 'msw'
 import {server} from '@/test/mocks/server'
 import {clearAuthStorage, renderWithQueryClient} from '@/test/utils'
 import {ServiceMap} from '../ServiceMap'
+import {
+  layoutPositions,
+  toFlowEdges,
+  toFlowNodes,
+  timeRangeSecondsForNode,
+} from '../serviceMapFlow'
+import type {ServiceMapEdgeModel, ServiceMapNodeModel} from '../serviceMapModel'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    Link: ({to, children}: {to?: unknown; children: ReactNode}) => (
+      <a href={typeof to === 'string' ? to : '#'}>{children}</a>
+    ),
+  }
+})
 
 type MockMapNode = Readonly<{
   id: string
-  data?: {
-    dimmed?: boolean
-    label?: string
-    selected?: boolean
-  }
+  data?: {dimmed?: boolean; label?: string; selected?: boolean}
 }>
 
 type MockMapCanvasProps = Readonly<{
   nodes: MockMapNode[]
   isEmpty?: boolean
+  isLoading?: boolean
   emptyTitle?: string
   fallback?: ReactNode
   children?: ReactNode
   onNodeClick?: (event: ReactMouseEvent, node: MockMapNode) => void
 }>
 
+// Mirrors the real MapCanvas branching: while the query is loading it shows a
+// loading frame and does not render the flow-node container, so findByTestId
+// blocks until data arrives instead of resolving against an empty graph.
 vi.mock('@/components/maps/MapCanvas', () => ({
-  MapCanvas: ({
-    nodes,
-    isEmpty = false,
-    emptyTitle,
-    fallback,
-    children,
-    onNodeClick,
-  }: MockMapCanvasProps) => (
+  MapCanvas: ({nodes, isEmpty = false, isLoading = false, emptyTitle, fallback, children, onNodeClick}: MockMapCanvasProps) => (
     <section>
+      {isLoading && <p>Loading map...</p>}
       {fallback}
       {isEmpty && !fallback && <p>{emptyTitle}</p>}
-      <div data-testid="map-nodes">
-        {nodes.map((node) => (
-          <button
-            key={node.id}
-            type="button"
-            data-dimmed={String(node.data?.dimmed ?? false)}
-            data-selected={String(node.data?.selected ?? false)}
-            onClick={(event) => onNodeClick?.(event, node)}
-          >
-            {node.data?.label ?? node.id}
-          </button>
-        ))}
-      </div>
+      {!isLoading && (
+        <div data-testid="map-nodes">
+          {nodes.map((node) => (
+            <button
+              key={node.id}
+              type="button"
+              data-dimmed={String(node.data?.dimmed ?? false)}
+              data-selected={String(node.data?.selected ?? false)}
+              onClick={(event) => onNodeClick?.(event, node)}
+            >
+              {node.data?.label ?? node.id}
+            </button>
+          ))}
+        </div>
+      )}
       {children}
     </section>
   ),
@@ -72,79 +77,118 @@ vi.mock('@/components/maps/MapCanvas', () => ({
 
 const API_BASE = 'http://localhost:8080'
 
+function serviceEntry(service: string, spanCount: number, errorCount: number, avgDurationNs = 12_000_000) {
+  return {service, spanCount, errorCount, avgDurationNs, callsTo: []}
+}
+
+function edgeEntry(fromService: string, toService: string, callCount: number, errorCount = 0, avgDurationNs = 3_000_000) {
+  return {fromService, toService, callCount, errorCount, avgDurationNs}
+}
+
+const DEMO_MAP = {
+  services: [serviceEntry('web', 1_000, 60), serviceEntry('api', 500, 2)],
+  edges: [edgeEntry('web', 'api', 400, 40, 3_000_000), edgeEntry('api', 'postgres', 300, 0, 1_000_000)],
+}
+
+function mapHandler(body: Record<string, unknown>) {
+  return http.get(`${API_BASE}/v1/services/map`, () => HttpResponse.json(body))
+}
+
+function latencyHandler(p50: number, p90: number, p99: number) {
+  return http.get(`${API_BASE}/v1/services/:service/latency`, ({params}) =>
+    HttpResponse.json({service: String(params.service), p50DurationNs: p50, p90DurationNs: p90, p99DurationNs: p99, sampleCount: 25}),
+  )
+}
+
 describe('ServiceMap', () => {
   beforeEach(() => {
     clearAuthStorage()
   })
 
-  it('filters services by node and downstream dependency search', async () => {
-    server.use(
-      http.get(`${API_BASE}/v1/services/map`, () =>
-        HttpResponse.json({
-          services: [
-            serviceEntry('api-gateway', ['order-service', 'redis'], 120, 0),
-            serviceEntry('order-service', ['postgres'], 82, 3),
-            serviceEntry('user-service', [], 42, 0),
-          ],
-        })
-      )
-    )
+  it('renders instrumented services and inferred peers from edges', async () => {
+    server.use(mapHandler(DEMO_MAP))
+    renderWithQueryClient(<ServiceMap />)
 
-    renderWithQueryClient(<ServiceMap searchQuery="order" />)
-
-    await screen.findByText('api-gateway')
     const nodes = await screen.findByTestId('map-nodes')
-    expect(within(nodes).getByText('api-gateway')).toBeInTheDocument()
-    expect(within(nodes).getByText('order-service')).toBeInTheDocument()
-    expect(within(nodes).getByText('redis')).toBeInTheDocument()
+    expect(within(nodes).getByText('web')).toBeInTheDocument()
+    expect(within(nodes).getByText('api')).toBeInTheDocument()
+    // postgres never emits its own spans — it appears as an inferred dependency.
     expect(within(nodes).getByText('postgres')).toBeInTheDocument()
-    expect(within(nodes).queryByText('user-service')).not.toBeInTheDocument()
-
-    fireEvent.click(within(nodes).getByText('order-service'))
-
-    expect(screen.getByText('82')).toBeInTheDocument()
-    expect(screen.getByText('3')).toBeInTheDocument()
-    expect(screen.getAllByText('postgres')).toHaveLength(2)
   })
 
-  it('ignores a stale selected service after search filters it out', async () => {
+  it('keeps matched services and their neighbors when searching', async () => {
     server.use(
-      http.get(`${API_BASE}/v1/services/map`, () =>
-        HttpResponse.json({
-          services: [
-            serviceEntry('api-gateway', ['order-service', 'redis'], 120, 0),
-            serviceEntry('order-service', ['postgres'], 82, 3),
-            serviceEntry('user-service', [], 42, 0),
-          ],
-        })
-      )
+      mapHandler({
+        services: [serviceEntry('web', 100, 0), serviceEntry('api', 100, 0), serviceEntry('billing', 100, 0)],
+        edges: [edgeEntry('web', 'api', 50)],
+      }),
+    )
+    renderWithQueryClient(<ServiceMap searchQuery="web" />)
+
+    const nodes = await screen.findByTestId('map-nodes')
+    expect(within(nodes).getByText('web')).toBeInTheDocument()
+    expect(within(nodes).getByText('api')).toBeInTheDocument()
+    expect(within(nodes).queryByText('billing')).not.toBeInTheDocument()
+  })
+
+  it('focuses a service and shows metrics, percentiles, neighbors, and pivots', async () => {
+    server.use(mapHandler(DEMO_MAP), latencyHandler(1_000_000, 5_000_000, 9_000_000))
+    renderWithQueryClient(<ServiceMap />)
+
+    const nodes = await screen.findByTestId('map-nodes')
+    fireEvent.click(within(nodes).getByText('api'))
+
+    expect(screen.getByText('Throughput')).toBeInTheDocument()
+    expect(screen.getByText('Error rate')).toBeInTheDocument()
+    expect(screen.getByText('Upstream')).toBeInTheDocument()
+    expect(screen.getByText('Downstream')).toBeInTheDocument()
+
+    // Percentiles arrive from the focused-service latency endpoint.
+    expect(await screen.findByText('1.0ms')).toBeInTheDocument()
+    expect(screen.getByText('5.0ms')).toBeInTheDocument()
+    expect(screen.getByText('9.0ms')).toBeInTheDocument()
+
+    // Upstream (web) and downstream (postgres) both appear in the panel.
+    expect(within(nodes).getByText('web')).toBeInTheDocument()
+    expect(screen.getAllByText('web').length).toBeGreaterThan(1)
+    expect(screen.getAllByText('postgres').length).toBeGreaterThan(1)
+
+    expect(screen.getByText('Traces').closest('a')).toHaveAttribute('href', '/performance/traces')
+    expect(screen.getByText('Logs').closest('a')).toHaveAttribute('href', '/logs')
+    expect(screen.getByText('Profiles').closest('a')).toHaveAttribute('href', '/profiles/service/$service')
+  })
+
+  it('omits percentiles and pivots for an inferred dependency', async () => {
+    server.use(mapHandler(DEMO_MAP))
+    renderWithQueryClient(<ServiceMap />)
+
+    const nodes = await screen.findByTestId('map-nodes')
+    fireEvent.click(within(nodes).getByText('postgres'))
+
+    expect(screen.getByText('Inferred dependency')).toBeInTheDocument()
+    expect(screen.queryByText('p50')).not.toBeInTheDocument()
+    expect(screen.queryByText('Traces')).not.toBeInTheDocument()
+  })
+
+  it('passes time range, env, and source as query params', async () => {
+    let captured: URL | null = null
+    server.use(
+      http.get(`${API_BASE}/v1/services/map`, ({request}) => {
+        captured = new URL(request.url)
+        return HttpResponse.json(DEMO_MAP)
+      }),
     )
 
-    renderWithQueryClient(<ServiceMapSearchHarness />)
+    renderWithQueryClient(<ServiceMap timeRange="6h" env="prod" source="otel" />)
+    await screen.findByText('web')
 
-    await screen.findByText('api-gateway')
-    const nodes = await screen.findByTestId('map-nodes')
-    fireEvent.click(within(nodes).getByText('user-service'))
-
-    expect(within(nodes).getByText('user-service')).toHaveAttribute('data-selected', 'true')
-    expect(within(nodes).getByText('api-gateway')).toHaveAttribute('data-dimmed', 'true')
-
-    fireEvent.click(screen.getByRole('button', {name: 'Filter order'}))
-
-    const filteredNodes = await screen.findByTestId('map-nodes')
-    expect(within(filteredNodes).queryByText('user-service')).not.toBeInTheDocument()
-    expect(within(filteredNodes).getByText('api-gateway')).toHaveAttribute('data-dimmed', 'false')
-    expect(within(filteredNodes).getByText('order-service')).toHaveAttribute('data-dimmed', 'false')
-    expect(within(filteredNodes).getByText('postgres')).toHaveAttribute('data-dimmed', 'false')
+    expect(captured!.searchParams.get('timeRange')).toBe('6h')
+    expect(captured!.searchParams.get('env')).toBe('prod')
+    expect(captured!.searchParams.get('source')).toBe('otel')
   })
 
   it('shows an explicit fallback when service map data cannot load', async () => {
-    server.use(
-      http.get(`${API_BASE}/v1/services/map`, () =>
-        HttpResponse.json({error: 'unavailable'}, {status: 500})
-      )
-    )
-
+    server.use(http.get(`${API_BASE}/v1/services/map`, () => HttpResponse.json({error: 'unavailable'}, {status: 500})))
     renderWithQueryClient(<ServiceMap />)
 
     expect(await screen.findByText('Map data unavailable')).toBeInTheDocument()
@@ -152,30 +196,66 @@ describe('ServiceMap', () => {
   })
 })
 
-function ServiceMapSearchHarness() {
-  const [searchQuery, setSearchQuery] = useState('')
-
-  return (
-    <>
-      <button type="button" onClick={() => setSearchQuery('order')}>
-        Filter order
-      </button>
-      <ServiceMap searchQuery={searchQuery} />
-    </>
-  )
-}
-
-function serviceEntry(
-  service: string,
-  callsTo: string[],
-  spanCount: number,
-  errorCount: number,
-) {
-  return {
-    service,
-    callsTo,
-    spanCount,
-    errorCount,
-    avgDurationNs: 12_000_000,
+describe('ServiceMap flow mappers', () => {
+  function nodeModel(id: string, overrides: Partial<ServiceMapNodeModel> = {}): ServiceMapNodeModel {
+    return {
+      id,
+      label: id,
+      serviceType: 'service',
+      isInferred: false,
+      spanCount: 100,
+      errorCount: 0,
+      errorRate: 0,
+      throughputPerMin: 10,
+      avgDurationNs: 1_000_000,
+      healthTone: 'success',
+      selected: false,
+      dimmed: false,
+      ...overrides,
+    }
   }
-}
+
+  function edgeModel(overrides: Partial<ServiceMapEdgeModel> = {}): ServiceMapEdgeModel {
+    return {
+      id: 'a->b',
+      source: 'a',
+      target: 'b',
+      callCount: 100,
+      errorCount: 0,
+      errorRate: 0,
+      avgDurationNs: 1_000_000,
+      tone: 'neutral',
+      widthPx: 2,
+      connected: true,
+      dimmed: false,
+      animated: true,
+      label: '100 · 1.0ms',
+      ...overrides,
+    }
+  }
+
+  it('lays out every node and maps them to flow nodes', () => {
+    const nodes = [nodeModel('a'), nodeModel('b', {isInferred: true})]
+    const positions = layoutPositions(nodes, [edgeModel()])
+    expect(positions.has('a')).toBe(true)
+    expect(positions.has('b')).toBe(true)
+    expect(typeof positions.get('a')!.x).toBe('number')
+
+    const flowNodes = toFlowNodes(nodes, positions)
+    expect(flowNodes).toHaveLength(2)
+    expect(flowNodes[0]).toMatchObject({id: 'a', type: 'service'})
+    expect((flowNodes[0].data as {label: string}).label).toBe('a')
+  })
+
+  it('maps edge models to styled flow edges', () => {
+    const [flowEdge] = toFlowEdges([edgeModel({tone: 'danger', widthPx: 4})])
+    expect(flowEdge).toMatchObject({id: 'a->b', source: 'a', target: 'b', animated: true})
+    expect((flowEdge.style as {strokeWidth: number}).strokeWidth).toBe(4)
+    expect(flowEdge.label).toBe('100 · 1.0ms')
+  })
+
+  it('reads window seconds off node data with a default', () => {
+    expect(timeRangeSecondsForNode({...nodeModel('a'), windowSeconds: 120})).toBe(120)
+    expect(timeRangeSecondsForNode({...nodeModel('a')})).toBe(86_400)
+  })
+})

--- a/dashboard/src/components/apm/__tests__/serviceMapModel.test.ts
+++ b/dashboard/src/components/apm/__tests__/serviceMapModel.test.ts
@@ -1,0 +1,280 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {describe, expect, it} from 'vitest'
+import type {ApmServiceEdge, ApmServiceMapEntry, ApmTimeRange} from '@/lib/api/types/apm'
+import {
+  buildServiceFacetSections,
+  buildServiceMapGraph,
+  edgeTone,
+  formatCount,
+  formatDurationNs,
+  formatPercent,
+  formatRatePerMin,
+  healthTone,
+  inferServiceType,
+  timeRangeSeconds,
+} from '../serviceMapModel'
+
+const DAY_SECONDS = 86_400
+
+function service(
+  name: string,
+  spanCount: number,
+  errorCount: number,
+  avgDurationNs = 5_000_000,
+): ApmServiceMapEntry {
+  return {service: name, spanCount, errorCount, avgDurationNs, callsTo: []}
+}
+
+function edge(
+  fromService: string,
+  toService: string,
+  callCount: number,
+  errorCount = 0,
+  avgDurationNs = 1_000_000,
+  extra: Partial<ApmServiceEdge> = {},
+): ApmServiceEdge {
+  return {fromService, toService, callCount, errorCount, avgDurationNs, ...extra}
+}
+
+describe('serviceMapModel formatters', () => {
+  it('formats durations across unit boundaries', () => {
+    expect(formatDurationNs(0)).toBe('0µs')
+    expect(formatDurationNs(500_000)).toBe('500µs')
+    expect(formatDurationNs(2_500_000)).toBe('2.5ms')
+    expect(formatDurationNs(3_000_000_000)).toBe('3.00s')
+  })
+
+  it('formats counts with k/M suffixes', () => {
+    expect(formatCount(42)).toBe('42')
+    expect(formatCount(1_500)).toBe('1.5k')
+    expect(formatCount(2_400_000)).toBe('2.4M')
+  })
+
+  it('formats per-minute rates', () => {
+    expect(formatRatePerMin(0, DAY_SECONDS)).toBe('0/min')
+    expect(formatRatePerMin(100, 0)).toBe('0/min')
+    expect(formatRatePerMin(6_000, 3_600)).toBe('100/min')
+    expect(formatRatePerMin(6, 3_600)).toBe('0.10/min')
+  })
+
+  it('formats percentages with adaptive precision', () => {
+    expect(formatPercent(0.1)).toBe('10%')
+    expect(formatPercent(0.004)).toBe('0.4%')
+  })
+
+  it('maps known time ranges to seconds and falls back to 24h', () => {
+    expect(timeRangeSeconds('1h')).toBe(3_600)
+    expect(timeRangeSeconds('7d')).toBe(604_800)
+    expect(timeRangeSeconds('nope' as ApmTimeRange)).toBe(DAY_SECONDS)
+  })
+})
+
+describe('inferServiceType', () => {
+  it('classifies services by name and peer-kind hints', () => {
+    expect(inferServiceType('orders-postgres')).toBe('database')
+    expect(inferServiceType('session-redis')).toBe('cache')
+    expect(inferServiceType('events-kafka')).toBe('queue')
+    expect(inferServiceType('edge-gateway')).toBe('web')
+    expect(inferServiceType('billing')).toBe('service')
+    expect(inferServiceType('pg-main', 'db')).toBe('database')
+  })
+})
+
+describe('healthTone / edgeTone', () => {
+  it('grades node health by error rate with a neutral no-traffic state', () => {
+    expect(healthTone(0, 0)).toBe('neutral')
+    expect(healthTone(0.06, 100)).toBe('danger')
+    expect(healthTone(0.02, 100)).toBe('warning')
+    expect(healthTone(0, 100)).toBe('success')
+  })
+
+  it('grades edges, staying neutral below the warning threshold', () => {
+    expect(edgeTone(0.5, 0)).toBe('neutral')
+    expect(edgeTone(0.06, 10)).toBe('danger')
+    expect(edgeTone(0.02, 10)).toBe('warning')
+    expect(edgeTone(0, 10)).toBe('neutral')
+  })
+})
+
+describe('buildServiceFacetSections', () => {
+  it('tallies health and type values in worst-first / canonical order', () => {
+    const services = [
+      service('web-gateway', 1_000, 0), // success / web
+      service('payments', 1_000, 20), // warning / service
+      service('orders', 1_000, 60), // danger / service
+      service('sessions-redis', 1_000, 0), // success / cache
+      service('idle', 0, 0), // neutral / service
+    ]
+
+    const {health, type} = buildServiceFacetSections(services)
+
+    expect(health).toEqual([
+      {value: 'errors', count: 1},
+      {value: 'elevated', count: 1},
+      {value: 'healthy', count: 2},
+      {value: 'no data', count: 1},
+    ])
+    expect(type).toEqual([
+      {value: 'web', count: 1},
+      {value: 'service', count: 3},
+      {value: 'cache', count: 1},
+    ])
+  })
+})
+
+describe('buildServiceMapGraph', () => {
+  it('returns an empty graph for no input', () => {
+    const graph = buildServiceMapGraph({services: [], edges: [], windowSeconds: DAY_SECONDS})
+    expect(graph.nodes).toHaveLength(0)
+    expect(graph.edges).toHaveLength(0)
+    expect(graph.neighbors).toBeNull()
+    expect(graph.totalServiceCount).toBe(0)
+    expect(graph.inferredCount).toBe(0)
+  })
+
+  it('builds service + inferred nodes with weighted, colored edges', () => {
+    const services = [service('web', 1_000, 60), service('api', 500, 2)]
+    const edges = [
+      edge('web', 'api', 400, 40, 3_000_000),
+      edge('api', 'postgres', 300, 0, 1_000_000),
+    ]
+
+    const graph = buildServiceMapGraph({services, edges, windowSeconds: DAY_SECONDS})
+
+    expect(graph.nodes.map((n) => n.id).sort()).toEqual(['api', 'postgres', 'web'])
+    expect(graph.visibleServiceCount).toBe(2)
+    expect(graph.inferredCount).toBe(1)
+
+    const web = graph.nodes.find((n) => n.id === 'web')!
+    expect(web.healthTone).toBe('danger')
+    expect(web.errorRate).toBeCloseTo(0.06)
+
+    const postgres = graph.nodes.find((n) => n.id === 'postgres')!
+    expect(postgres.isInferred).toBe(true)
+    expect(postgres.healthTone).toBe('neutral')
+    expect(postgres.serviceType).toBe('database')
+    expect(postgres.spanCount).toBe(300)
+    expect(postgres.avgDurationNs).toBe(1_000_000)
+
+    const webApi = graph.edges.find((e) => e.id === 'web->api')!
+    const apiPg = graph.edges.find((e) => e.id === 'api->postgres')!
+    expect(webApi.tone).toBe('danger')
+    expect(apiPg.tone).toBe('neutral')
+    // The highest-throughput edge is the widest.
+    expect(webApi.widthPx).toBeGreaterThan(apiPg.widthPx)
+    // Unselected: no labels, no animation.
+    expect(webApi.label).toBeUndefined()
+    expect(webApi.animated).toBe(false)
+  })
+
+  it('aggregates repeated edges into a single inferred peer', () => {
+    const services = [service('a', 100, 0), service('b', 100, 0)]
+    const edges = [
+      edge('a', 'stripe', 50, 5, 2_000_000),
+      edge('b', 'stripe', 50, 0, 4_000_000),
+    ]
+
+    const graph = buildServiceMapGraph({services, edges, windowSeconds: DAY_SECONDS})
+    const stripe = graph.nodes.find((n) => n.id === 'stripe')!
+    expect(stripe.spanCount).toBe(100)
+    expect(stripe.errorCount).toBe(5)
+    // Call-weighted average of 2ms and 4ms.
+    expect(stripe.avgDurationNs).toBe(3_000_000)
+  })
+
+  it('keeps matched services and their immediate neighbors when searching', () => {
+    const services = [service('web', 100, 0), service('api', 100, 0), service('lonely', 100, 0)]
+    const edges = [edge('web', 'api', 10), edge('api', 'postgres', 10)]
+
+    const graph = buildServiceMapGraph({
+      services,
+      edges,
+      windowSeconds: DAY_SECONDS,
+      search: 'web',
+    })
+
+    const ids = graph.nodes.map((n) => n.id)
+    expect(ids).toContain('web')
+    expect(ids).toContain('api')
+    expect(ids).not.toContain('lonely')
+  })
+
+  it('hard-filters known services by Health and Type facets', () => {
+    const services = [
+      service('web-gateway', 1_000, 0), // success / web
+      service('orders', 1_000, 60), // danger / service
+      service('payments', 1_000, 20), // warning / service
+      service('sessions-redis', 1_000, 0), // success / cache
+    ]
+    const edges = [edge('web-gateway', 'orders', 100), edge('orders', 'sessions-redis', 100)]
+
+    const onlyErrors = buildServiceMapGraph({
+      services,
+      edges,
+      windowSeconds: DAY_SECONDS,
+      facetFilters: [{key: 'health', value: 'errors'}],
+    })
+    expect(onlyErrors.nodes.map((n) => n.id)).toEqual(['orders'])
+    expect(onlyErrors.visibleServiceCount).toBe(1)
+
+    const onlyCache = buildServiceMapGraph({
+      services,
+      edges,
+      windowSeconds: DAY_SECONDS,
+      facetFilters: [{key: 'type', value: 'cache'}],
+    })
+    expect(onlyCache.nodes.map((n) => n.id)).toEqual(['sessions-redis'])
+
+    const notHealthy = buildServiceMapGraph({
+      services,
+      edges,
+      windowSeconds: DAY_SECONDS,
+      facetFilters: [{key: 'health', value: 'healthy', exclude: true}],
+    })
+    expect(notHealthy.nodes.map((n) => n.id).sort()).toEqual(['orders', 'payments'])
+  })
+
+  it('ignores non-client facet keys like env (applied server-side)', () => {
+    const services = [service('web-gateway', 1_000, 0), service('orders', 1_000, 60)]
+    const graph = buildServiceMapGraph({
+      services,
+      edges: [],
+      windowSeconds: DAY_SECONDS,
+      facetFilters: [{key: 'env', value: 'prod'}],
+    })
+    expect(graph.nodes.map((n) => n.id).sort()).toEqual(['orders', 'web-gateway'])
+  })
+
+  it('resolves the focused neighborhood with dimming, labels, and neighbor lists', () => {
+    const services = [service('web', 100, 0), service('api', 100, 0), service('lonely', 100, 0)]
+    const edges = [edge('web', 'api', 400, 40, 3_000_000), edge('api', 'postgres', 200)]
+
+    const graph = buildServiceMapGraph({
+      services,
+      edges,
+      windowSeconds: DAY_SECONDS,
+      selectedId: 'api',
+    })
+
+    const lonely = graph.nodes.find((n) => n.id === 'lonely')!
+    const web = graph.nodes.find((n) => n.id === 'web')!
+    expect(lonely.dimmed).toBe(true)
+    expect(web.dimmed).toBe(false)
+
+    const webApi = graph.edges.find((e) => e.id === 'web->api')!
+    expect(webApi.connected).toBe(true)
+    expect(webApi.animated).toBe(true)
+    expect(webApi.label).toContain('40')
+
+    expect(graph.neighbors).not.toBeNull()
+    expect(graph.neighbors!.upstream.map((e) => e.source)).toEqual(['web'])
+    expect(graph.neighbors!.downstream.map((e) => e.target)).toEqual(['postgres'])
+  })
+})

--- a/dashboard/src/components/apm/serviceMapFlow.ts
+++ b/dashboard/src/components/apm/serviceMapFlow.ts
@@ -1,0 +1,135 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import Dagre from '@dagrejs/dagre'
+import {MarkerType, type Edge, type Node} from '@xyflow/react'
+import type {ApmTimeRange} from '@/lib/api/types/apm'
+import {
+  timeRangeSeconds,
+  type HealthTone,
+  type ServiceMapEdgeModel,
+  type ServiceMapNodeModel,
+} from './serviceMapModel'
+
+// React Flow node payload: the render-ready model plus the active window seconds
+// (so the node renderer stays a pure function of its props).
+export type ServiceNodeData = ServiceMapNodeModel & {[key: string]: unknown}
+
+export const DEFAULT_TIME_RANGE: ApmTimeRange = '24h'
+
+// Health → color. Borders and edges share one status language with the rest of
+// the app; neutral is a muted foreground so no-traffic edges recede.
+export const TONE_COLOR: Record<HealthTone, string> = {
+  success: 'hsl(var(--success-solid))',
+  warning: 'hsl(var(--warning-solid))',
+  danger: 'hsl(var(--danger-solid))',
+  neutral: 'hsl(var(--muted-foreground) / 0.55)',
+}
+
+const NODE_W = 208
+const NODE_H = 86
+const EXT_W = 168
+const EXT_H = 60
+
+export function layoutPositions(
+  nodes: ServiceMapNodeModel[],
+  edges: ServiceMapEdgeModel[],
+): Map<string, {x: number; y: number}> {
+  const graph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
+  graph.setGraph({rankdir: 'LR', nodesep: 48, ranksep: 168, marginx: 40, marginy: 40})
+
+  for (const node of nodes) {
+    graph.setNode(node.id, {
+      width: node.isInferred ? EXT_W : NODE_W,
+      height: node.isInferred ? EXT_H : NODE_H,
+    })
+  }
+  for (const edge of edges) {
+    if (graph.hasNode(edge.source) && graph.hasNode(edge.target)) {
+      graph.setEdge(edge.source, edge.target)
+    }
+  }
+
+  Dagre.layout(graph)
+  const positions = new Map<string, {x: number; y: number}>()
+  for (const node of nodes) {
+    const laid = graph.node(node.id)
+    const width = node.isInferred ? EXT_W : NODE_W
+    const height = node.isInferred ? EXT_H : NODE_H
+    positions.set(node.id, {x: laid.x - width / 2, y: laid.y - height / 2})
+  }
+  return positions
+}
+
+export function toFlowNodes(
+  nodes: ServiceMapNodeModel[],
+  positions: Map<string, {x: number; y: number}>,
+): Node[] {
+  return nodes.map((node) => ({
+    id: node.id,
+    type: 'service',
+    position: positions.get(node.id) ?? {x: 0, y: 0},
+    data: {...node} satisfies ServiceNodeData,
+  }))
+}
+
+// Edge color follows the mockup's flow language rather than node health: a
+// connected edge lights up cyan to trace the selected service's flow, error
+// edges stay red so problems read at a glance, and the rest recede to a hairline.
+function edgeColor(edge: ServiceMapEdgeModel): string {
+  if (edge.tone === 'danger') return 'hsl(var(--danger-solid))'
+  if (edge.connected) return 'hsl(var(--primary))'
+  return 'hsl(var(--muted-foreground) / 0.55)'
+}
+
+export function toFlowEdges(edges: ServiceMapEdgeModel[]): Edge[] {
+  return edges.map((edge) => {
+    const color = edgeColor(edge)
+    const opacity = edgeOpacity(edge)
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      type: 'default',
+      animated: edge.animated,
+      label: edge.label,
+      labelShowBg: true,
+      labelBgPadding: [6, 3] as [number, number],
+      labelBgBorderRadius: 4,
+      labelStyle: {
+        fill: 'hsl(var(--foreground))',
+        fontSize: 10,
+        fontWeight: 600,
+      },
+      labelBgStyle: {
+        fill: 'hsl(var(--popover))',
+        stroke: 'hsl(var(--border))',
+        strokeWidth: 0.5,
+      },
+      style: {stroke: color, strokeWidth: edge.widthPx, opacity},
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color,
+        width: 13,
+        height: 13,
+      },
+    }
+  })
+}
+
+function edgeOpacity(edge: ServiceMapEdgeModel): number {
+  if (edge.dimmed) return 0.12
+  if (edge.connected) return 1
+  return 0.6
+}
+
+// Throughput is computed from the active window; the window seconds ride along on
+// node data so the node renderer stays a pure function of its props.
+export function timeRangeSecondsForNode(data: ServiceNodeData): number {
+  return (data.windowSeconds as number) ?? timeRangeSeconds(DEFAULT_TIME_RANGE)
+}

--- a/dashboard/src/components/apm/serviceMapModel.ts
+++ b/dashboard/src/components/apm/serviceMapModel.ts
@@ -1,0 +1,544 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import type {ApmServiceEdge, ApmServiceMapEntry, ApmTimeRange} from '@/lib/api/types/apm'
+import type {FacetFilter, FacetValue} from '@/lib/filters/types'
+
+export type ServiceType = 'database' | 'cache' | 'queue' | 'web' | 'service'
+export type HealthTone = 'success' | 'warning' | 'danger' | 'neutral'
+
+// Health-facet labels shown in the rail (and matched by the graph filter).
+// Ordered worst-first to match the mockup: errors, elevated, healthy, no data.
+export const HEALTH_TONE_LABEL: Record<HealthTone, string> = {
+  danger: 'errors',
+  warning: 'elevated',
+  success: 'healthy',
+  neutral: 'no data',
+}
+
+const HEALTH_FACET_ORDER: HealthTone[] = ['danger', 'warning', 'success', 'neutral']
+const TYPE_FACET_ORDER: ServiceType[] = ['web', 'service', 'database', 'cache', 'queue']
+
+const HEALTH_FACET_KEY = 'health'
+const TYPE_FACET_KEY = 'type'
+
+// Error-rate thresholds shared by node health borders and edge coloring. The map
+// has no monitor/SLO state to read, so error rate is the honest health proxy.
+const WARNING_ERROR_RATE = 0.01
+const DANGER_ERROR_RATE = 0.05
+
+const MIN_EDGE_WIDTH = 1.5
+const MAX_EDGE_WIDTH = 5
+const SECONDS_PER_MINUTE = 60
+
+const NS_PER_MICRO = 1_000
+const NS_PER_MILLI = 1_000_000
+const NS_PER_SECOND = 1_000_000_000
+
+const TIME_RANGE_SECONDS: Record<ApmTimeRange, number> = {
+  '1h': 3_600,
+  '6h': 21_600,
+  '24h': 86_400,
+  '7d': 604_800,
+  '30d': 2_592_000,
+  '90d': 7_776_000,
+}
+
+export interface ServiceMapNodeModel {
+  id: string
+  label: string
+  serviceType: ServiceType
+  isInferred: boolean
+  spanCount: number
+  errorCount: number
+  errorRate: number
+  throughputPerMin: number
+  avgDurationNs: number
+  healthTone: HealthTone
+  selected: boolean
+  dimmed: boolean
+}
+
+export interface ServiceMapEdgeModel {
+  id: string
+  source: string
+  target: string
+  callCount: number
+  errorCount: number
+  errorRate: number
+  avgDurationNs: number
+  tone: HealthTone
+  widthPx: number
+  connected: boolean
+  dimmed: boolean
+  animated: boolean
+  label?: string
+}
+
+export interface ServiceMapNeighbors {
+  upstream: ServiceMapEdgeModel[]
+  downstream: ServiceMapEdgeModel[]
+}
+
+export interface ServiceMapGraph {
+  nodes: ServiceMapNodeModel[]
+  edges: ServiceMapEdgeModel[]
+  neighbors: ServiceMapNeighbors | null
+  visibleServiceCount: number
+  totalServiceCount: number
+  inferredCount: number
+}
+
+interface BuildServiceMapGraphOptions {
+  services: ApmServiceMapEntry[]
+  edges: ApmServiceEdge[]
+  windowSeconds: number
+  search?: string
+  selectedId?: string | null
+  facetFilters?: FacetFilter[]
+}
+
+export function timeRangeSeconds(range: ApmTimeRange): number {
+  return TIME_RANGE_SECONDS[range] ?? TIME_RANGE_SECONDS['24h']
+}
+
+export function inferServiceType(name: string, peerKind?: string): ServiceType {
+  const hint = `${peerKind ?? ''} ${name}`.toLowerCase()
+  if (/postgres|mysql|mongo|clickhouse|sqlite|mariadb|cockroach|\bdb\b|sql|dynamo|cassandra|database/.test(hint)) {
+    return 'database'
+  }
+  if (/redis|cache|memcached|varnish/.test(hint)) return 'cache'
+  if (/kafka|rabbitmq|queue|sqs|sns|nats|pulsar|amqp|messaging/.test(hint)) return 'queue'
+  if (/web|api|gateway|nginx|envoy|proxy|frontend|http|grpc/.test(hint)) return 'web'
+  return 'service'
+}
+
+export function healthTone(errorRate: number, spanCount: number): HealthTone {
+  if (spanCount <= 0) return 'neutral'
+  if (errorRate >= DANGER_ERROR_RATE) return 'danger'
+  if (errorRate >= WARNING_ERROR_RATE) return 'warning'
+  return 'success'
+}
+
+function serviceTone(service: ApmServiceMapEntry): HealthTone {
+  return healthTone(safeRate(service.errorCount, service.spanCount), service.spanCount)
+}
+
+/**
+ * Tally the Health and Type facet values (with counts) over the known services,
+ * for the service-map rail. Counts reflect the full fetched set so a value never
+ * vanishes just because it is currently filtered out.
+ */
+export function buildServiceFacetSections(
+  services: ApmServiceMapEntry[],
+): {health: FacetValue[]; type: FacetValue[]} {
+  const healthCounts = new Map<HealthTone, number>()
+  const typeCounts = new Map<ServiceType, number>()
+  for (const service of services) {
+    const tone = serviceTone(service)
+    healthCounts.set(tone, (healthCounts.get(tone) ?? 0) + 1)
+    const type = inferServiceType(service.service)
+    typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1)
+  }
+  return {
+    health: HEALTH_FACET_ORDER.filter((tone) => healthCounts.has(tone)).map((tone) => ({
+      value: HEALTH_TONE_LABEL[tone],
+      count: healthCounts.get(tone) ?? 0,
+    })),
+    type: TYPE_FACET_ORDER.filter((type) => typeCounts.has(type)).map((type) => ({
+      value: type,
+      count: typeCounts.get(type) ?? 0,
+    })),
+  }
+}
+
+interface FacetMatchGroup {
+  include: Set<string>
+  exclude: Set<string>
+}
+
+function collectFacetGroup(filters: FacetFilter[], key: string): FacetMatchGroup | null {
+  let group: FacetMatchGroup | null = null
+  for (const filter of filters) {
+    if (filter.key !== key) continue
+    group ??= {include: new Set<string>(), exclude: new Set<string>()}
+    if (filter.exclude) group.exclude.add(filter.value)
+    else group.include.add(filter.value)
+  }
+  return group
+}
+
+function matchesFacetGroup(group: FacetMatchGroup | null, value: string): boolean {
+  if (!group) return true
+  if (group.exclude.has(value)) return false
+  return group.include.size === 0 || group.include.has(value)
+}
+
+// Returns a predicate over known services, or null when no Health/Type facet is
+// active (so the caller can skip the pass entirely).
+function buildServiceFacetMatcher(
+  filters: FacetFilter[],
+): ServiceFacetMatcher | null {
+  const health = collectFacetGroup(filters, HEALTH_FACET_KEY)
+  const type = collectFacetGroup(filters, TYPE_FACET_KEY)
+  if (!health && !type) return null
+  return (service) =>
+    matchesFacetGroup(health, HEALTH_TONE_LABEL[serviceTone(service)]) &&
+    matchesFacetGroup(type, inferServiceType(service.service))
+}
+
+export function edgeTone(errorRate: number, callCount: number): HealthTone {
+  if (callCount <= 0) return 'neutral'
+  if (errorRate >= DANGER_ERROR_RATE) return 'danger'
+  if (errorRate >= WARNING_ERROR_RATE) return 'warning'
+  return 'neutral'
+}
+
+export function formatDurationNs(ns: number): string {
+  if (ns <= 0) return '0µs'
+  if (ns < NS_PER_MILLI) return `${(ns / NS_PER_MICRO).toFixed(0)}µs`
+  if (ns < NS_PER_SECOND) return `${(ns / NS_PER_MILLI).toFixed(1)}ms`
+  return `${(ns / NS_PER_SECOND).toFixed(2)}s`
+}
+
+export function formatCount(value: number): string {
+  if (value < 1_000) return `${Math.round(value)}`
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(1)}k`
+  return `${(value / 1_000_000).toFixed(1)}M`
+}
+
+export function formatRatePerMin(count: number, windowSeconds: number): string {
+  if (windowSeconds <= 0 || count <= 0) return '0/min'
+  const perMinute = count / (windowSeconds / SECONDS_PER_MINUTE)
+  if (perMinute >= 1) return `${formatCount(perMinute)}/min`
+  return `${perMinute.toFixed(2)}/min`
+}
+
+export function formatPercent(rate: number): string {
+  return `${(rate * 100).toFixed(rate >= 0.1 ? 0 : 1)}%`
+}
+
+function safeRate(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0
+  return numerator / denominator
+}
+
+function edgeId(source: string, target: string): string {
+  return `${source}->${target}`
+}
+
+function buildEdgeLabel(callCount: number, avgDurationNs: number, errorRate: number): string {
+  const parts = [formatCount(callCount), formatDurationNs(avgDurationNs)]
+  if (errorRate > 0) parts.push(formatPercent(errorRate))
+  return parts.join(' · ')
+}
+
+interface InferredAccumulator {
+  callCount: number
+  errorCount: number
+  durationWeighted: number
+}
+
+type ServiceFacetMatcher = (service: ApmServiceMapEntry) => boolean
+
+interface NodeBuildContext {
+  windowSeconds: number
+  selectedId: string | null
+  connectedServices: Set<string>
+}
+
+interface EdgeBuildContext {
+  maxCall: number
+  selectedId: string | null
+  connectedEdges: Set<string>
+}
+
+/**
+ * Pure transform from the raw service-map payload into render-ready nodes and
+ * edges: derives inferred peer nodes from edges whose target never emitted its
+ * own spans, computes per-service throughput/error-rate/health, weights each
+ * edge by throughput, colors it by error rate, and resolves the focused
+ * neighborhood (dim/animate/label) when a node is selected.
+ */
+export function buildServiceMapGraph({
+  services,
+  edges,
+  windowSeconds,
+  search = '',
+  selectedId = null,
+  facetFilters = [],
+}: BuildServiceMapGraphOptions): ServiceMapGraph {
+  const query = search.trim().toLowerCase()
+  const knownServices = new Set(services.map((service) => service.service))
+
+  const visibleServices = buildVisibleServices({services, edges, knownServices, query})
+  applyServiceFacetFilters(visibleServices, services, facetFilters)
+
+  const includedEdges = filterRenderableEdges(edges, visibleServices, knownServices)
+  const inferredAccumulators = collectInferredAccumulators(includedEdges, knownServices)
+
+  const connected = resolveConnected(selectedId, includedEdges)
+  const maxCall = includedEdges.reduce((max, edge) => Math.max(max, edge.callCount), 0)
+  const nodeContext = {windowSeconds, selectedId, connectedServices: connected.services}
+  const edgeContext = {maxCall, selectedId, connectedEdges: connected.edges}
+
+  const serviceNodes = buildKnownServiceNodes(services, visibleServices, nodeContext)
+  const inferredNodes = buildInferredServiceNodes(inferredAccumulators, nodeContext)
+  const edgeModels = includedEdges.map((edge) => buildServiceEdgeModel(edge, edgeContext))
+  const neighbors = buildNeighbors(edgeModels, selectedId)
+
+  return {
+    nodes: [...serviceNodes, ...inferredNodes],
+    edges: edgeModels,
+    neighbors,
+    visibleServiceCount: serviceNodes.length,
+    totalServiceCount: services.length,
+    inferredCount: inferredNodes.length,
+  }
+}
+
+function buildVisibleServices({
+  services,
+  edges,
+  knownServices,
+  query,
+}: Readonly<{
+  services: ApmServiceMapEntry[]
+  edges: ApmServiceEdge[]
+  knownServices: Set<string>
+  query: string
+}>): Set<string> {
+  if (query === '') return new Set(services.map((service) => service.service))
+
+  const directlyVisible = new Set(
+    services.filter((service) => service.service.toLowerCase().includes(query)).map((service) => service.service),
+  )
+  const visibleServices = new Set(directlyVisible)
+  addQueryNeighborServices(edges, knownServices, directlyVisible, visibleServices)
+  return visibleServices
+}
+
+function addQueryNeighborServices(
+  edges: ApmServiceEdge[],
+  knownServices: Set<string>,
+  directlyVisible: Set<string>,
+  visibleServices: Set<string>,
+) {
+  for (const edge of edges) {
+    if (directlyVisible.has(edge.fromService) && knownServices.has(edge.toService)) {
+      visibleServices.add(edge.toService)
+    }
+    if (directlyVisible.has(edge.toService) && knownServices.has(edge.fromService)) {
+      visibleServices.add(edge.fromService)
+    }
+  }
+}
+
+function applyServiceFacetFilters(
+  visibleServices: Set<string>,
+  services: ApmServiceMapEntry[],
+  facetFilters: FacetFilter[],
+) {
+  const facetMatch = buildServiceFacetMatcher(facetFilters)
+  if (facetMatch === null) return
+
+  for (const service of services) {
+    if (facetMatch(service)) continue
+    visibleServices.delete(service.service)
+  }
+}
+
+function filterRenderableEdges(
+  edges: ApmServiceEdge[],
+  visibleServices: Set<string>,
+  knownServices: Set<string>,
+): ApmServiceEdge[] {
+  return edges.filter(
+    (edge) => visibleServices.has(edge.fromService) && targetIsRenderable(edge.toService, visibleServices, knownServices),
+  )
+}
+
+function targetIsRenderable(
+  name: string,
+  visibleServices: Set<string>,
+  knownServices: Set<string>,
+): boolean {
+  return visibleServices.has(name) || !knownServices.has(name)
+}
+
+function collectInferredAccumulators(
+  edges: ApmServiceEdge[],
+  knownServices: Set<string>,
+): Map<string, InferredAccumulator> {
+  const inferredAccumulators = new Map<string, InferredAccumulator>()
+  for (const edge of edges) {
+    if (knownServices.has(edge.toService)) continue
+    const accumulator = inferredAccumulators.get(edge.toService) ?? newInferredAccumulator()
+    accumulator.callCount += edge.callCount
+    accumulator.errorCount += edge.errorCount
+    accumulator.durationWeighted += edge.avgDurationNs * edge.callCount
+    inferredAccumulators.set(edge.toService, accumulator)
+  }
+  return inferredAccumulators
+}
+
+function newInferredAccumulator(): InferredAccumulator {
+  return {callCount: 0, errorCount: 0, durationWeighted: 0}
+}
+
+function buildKnownServiceNodes(
+  services: ApmServiceMapEntry[],
+  visibleServices: Set<string>,
+  context: NodeBuildContext,
+): ServiceMapNodeModel[] {
+  return services
+    .filter((service) => visibleServices.has(service.service))
+    .map((service) => buildKnownServiceNode(service, context))
+}
+
+function buildKnownServiceNode(
+  service: ApmServiceMapEntry,
+  context: NodeBuildContext,
+): ServiceMapNodeModel {
+  const errorRate = safeRate(service.errorCount, service.spanCount)
+  return {
+    id: service.service,
+    label: service.service,
+    serviceType: inferServiceType(service.service),
+    isInferred: false,
+    spanCount: service.spanCount,
+    errorCount: service.errorCount,
+    errorRate,
+    throughputPerMin: ratePerMin(service.spanCount, context.windowSeconds),
+    avgDurationNs: service.avgDurationNs,
+    healthTone: healthTone(errorRate, service.spanCount),
+    selected: context.selectedId === service.service,
+    dimmed: isDimmedNode(service.service, context.selectedId, context.connectedServices),
+  }
+}
+
+function buildInferredServiceNodes(
+  inferredAccumulators: Map<string, InferredAccumulator>,
+  context: NodeBuildContext,
+): ServiceMapNodeModel[] {
+  return Array.from(inferredAccumulators.entries()).map(([name, accumulator]) =>
+    buildInferredServiceNode(name, accumulator, context),
+  )
+}
+
+function buildInferredServiceNode(
+  name: string,
+  accumulator: InferredAccumulator,
+  context: NodeBuildContext,
+): ServiceMapNodeModel {
+  const errorRate = safeRate(accumulator.errorCount, accumulator.callCount)
+  return {
+    id: name,
+    label: name,
+    serviceType: inferServiceType(name),
+    isInferred: true,
+    spanCount: accumulator.callCount,
+    errorCount: accumulator.errorCount,
+    errorRate,
+    throughputPerMin: ratePerMin(accumulator.callCount, context.windowSeconds),
+    avgDurationNs: inferredAvgDurationNs(accumulator),
+    healthTone: 'neutral',
+    selected: context.selectedId === name,
+    dimmed: isDimmedNode(name, context.selectedId, context.connectedServices),
+  }
+}
+
+function inferredAvgDurationNs(accumulator: InferredAccumulator): number {
+  if (accumulator.callCount <= 0) return 0
+  return accumulator.durationWeighted / accumulator.callCount
+}
+
+function buildServiceEdgeModel(
+  edge: ApmServiceEdge,
+  context: EdgeBuildContext,
+): ServiceMapEdgeModel {
+  const id = edgeId(edge.fromService, edge.toService)
+  const errorRate = safeRate(edge.errorCount, edge.callCount)
+  const isConnected = context.connectedEdges.has(id)
+  const isSelectedPath = context.selectedId !== null && isConnected
+  return {
+    id,
+    source: edge.fromService,
+    target: edge.toService,
+    callCount: edge.callCount,
+    errorCount: edge.errorCount,
+    errorRate,
+    avgDurationNs: edge.avgDurationNs,
+    tone: edgeTone(errorRate, edge.callCount),
+    widthPx: edgeWidth(edge.callCount, context.maxCall),
+    connected: isConnected,
+    dimmed: context.selectedId !== null && !isConnected,
+    animated: isSelectedPath,
+    label: buildSelectedEdgeLabel(edge, errorRate, isSelectedPath),
+  }
+}
+
+function buildSelectedEdgeLabel(
+  edge: ApmServiceEdge,
+  errorRate: number,
+  isSelectedPath: boolean,
+): string | undefined {
+  if (!isSelectedPath) return undefined
+  return buildEdgeLabel(edge.callCount, edge.avgDurationNs, errorRate)
+}
+
+function buildNeighbors(
+  edgeModels: ServiceMapEdgeModel[],
+  selectedId: string | null,
+): ServiceMapNeighbors | null {
+  if (selectedId === null) return null
+  return {
+    upstream: edgeModels.filter((edge) => edge.target === selectedId),
+    downstream: edgeModels.filter((edge) => edge.source === selectedId),
+  }
+}
+
+function ratePerMin(count: number, windowSeconds: number): number {
+  if (windowSeconds <= 0) return 0
+  return count / (windowSeconds / SECONDS_PER_MINUTE)
+}
+
+function edgeWidth(callCount: number, maxCall: number): number {
+  if (maxCall <= 0 || callCount <= 0) return MIN_EDGE_WIDTH
+  const normalized = Math.sqrt(Math.min(callCount / maxCall, 1))
+  return MIN_EDGE_WIDTH + normalized * (MAX_EDGE_WIDTH - MIN_EDGE_WIDTH)
+}
+
+function isDimmedNode(
+  nodeId: string,
+  selectedId: string | null,
+  connectedServices: Set<string>,
+): boolean {
+  return selectedId !== null && !connectedServices.has(nodeId)
+}
+
+interface ConnectedSets {
+  services: Set<string>
+  edges: Set<string>
+}
+
+function resolveConnected(selectedId: string | null, edges: ApmServiceEdge[]): ConnectedSets {
+  const services = new Set<string>()
+  const edgeIds = new Set<string>()
+  if (selectedId === null) return {services, edges: edgeIds}
+
+  services.add(selectedId)
+  for (const edge of edges) {
+    if (edge.fromService === selectedId || edge.toService === selectedId) {
+      services.add(edge.fromService)
+      services.add(edge.toService)
+      edgeIds.add(edgeId(edge.fromService, edge.toService))
+    }
+  }
+  return {services, edges: edgeIds}
+}

--- a/dashboard/src/components/maps/MapDetailDock.tsx
+++ b/dashboard/src/components/maps/MapDetailDock.tsx
@@ -1,0 +1,63 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+import {X} from 'lucide-react'
+import type {ReactNode} from 'react'
+import {Button} from '@/components/ui/button'
+import {cn} from '@/lib/utils'
+
+type MapDetailDockProps = Readonly<{
+  title: string
+  subtitle?: string
+  onClose: () => void
+  children: ReactNode
+  className?: string
+}>
+
+/**
+ * Detail panel that docks as a column beside the map on md+ (so the graph stays
+ * visible) and becomes a right slide-over on small screens. Replaces the old
+ * floating MapDetailPanel that covered the canvas. The parent map area must be
+ * `relative` for the small-screen overlay to anchor correctly.
+ */
+export function MapDetailDock({title, subtitle, onClose, children, className}: MapDetailDockProps) {
+  return (
+    <aside
+      className={cn(
+        'flex flex-col border-l bg-card',
+        'absolute inset-y-0 right-0 z-20 w-[88%] max-w-[340px] shadow-lg',
+        'md:static md:z-auto md:w-[320px] md:flex-none md:shadow-none',
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between gap-2 border-b px-3 py-2.5">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold" title={title}>
+            {title}
+          </h3>
+          {subtitle && (
+            <p className="mt-0.5 truncate text-[11px] text-muted-foreground" title={subtitle}>
+              {subtitle}
+            </p>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label="Close detail"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div className="flex-1 space-y-3 overflow-y-auto px-3 py-3 text-sm">{children}</div>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary
- refine the service map graph model and node rendering
- add a docked service detail panel with telemetry pivots
- cover graph derivation and service-map UI behavior

## Validation
- npm test -- --run src/components/apm/__tests__/ServiceMap.test.tsx src/components/apm/__tests__/serviceMapModel.test.ts
- npm run lint
- npm run build
- git diff --check