### PR TITLE
feat: polish monitoring tab navigation

### DIFF
--- a/dashboard/src/routes/__tests__/-monitoring-route.test.tsx
+++ b/dashboard/src/routes/__tests__/-monitoring-route.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {render, screen, waitFor} from '@testing-library/react'
+
+const {mockApi, mockRouteState, mockFeatures} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    checkAuth: vi.fn(),
+  },
+  mockRouteState: {
+    pathname: '/monitoring',
+  },
+  mockFeatures: {
+    modules: [] as string[],
+  },
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+}))
+
+vi.mock('@/hooks/useEnterpriseFeatures', () => ({
+  useEnterpriseFeatures: () => ({data: mockFeatures}),
+  hasEnterpriseModule: (features: {modules?: string[]} | undefined, moduleName: string) =>
+    features?.modules?.includes(moduleName) ?? false,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({...options, options}),
+  Link: ({children, to, ...props}: {children: React.ReactNode; to?: string}) =>
+    React.createElement('a', {href: to, ...props}, children),
+  Outlet: () => <div data-testid="monitoring-outlet" />,
+  redirect: (options: Record<string, unknown>) => ({...options, __redirect: true}),
+  useRouterState: () => ({location: {pathname: mockRouteState.pathname}}),
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+  DropdownMenuTrigger: ({children}: {children: React.ReactNode}) => <>{children}</>,
+  DropdownMenuContent: ({children}: {children: React.ReactNode}) => <div role="menu">{children}</div>,
+  DropdownMenuItem: ({children}: {children: React.ReactNode}) => <div role="menuitem">{children}</div>,
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({children}: {children: React.ReactNode}) => <>{children}</>,
+  Tooltip: ({children}: {children: React.ReactNode}) => <>{children}</>,
+  TooltipTrigger: ({children}: {children: React.ReactNode}) => <>{children}</>,
+  TooltipContent: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+
+import {Route as MonitoringRoute} from '../monitoring'
+
+let monitoringNavWidth = 900
+
+const tabWidths: Record<string, number> = {
+  Hosts: 78,
+  Map: 66,
+  Containers: 112,
+  Processes: 106,
+  Network: 98,
+  Events: 88,
+  Kubernetes: 118,
+  Databases: 106,
+  Debugger: 104,
+  'Network Devices': 146,
+  SBOM: 74,
+  More: 76,
+}
+
+function getElementWidth(element: HTMLElement): number {
+  const label = element.textContent?.trim() ?? ''
+  return tabWidths[label] ?? 72
+}
+
+function renderMonitoringRoute() {
+  const Component = (MonitoringRoute as unknown as {component: React.ComponentType}).component
+  return render(<Component />)
+}
+
+describe('monitoring route shell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.isAuthenticated.mockReturnValue(true)
+    mockApi.checkAuth.mockResolvedValue(true)
+    mockRouteState.pathname = '/monitoring'
+    mockFeatures.modules = []
+    monitoringNavWidth = 900
+
+    Object.defineProperty(globalThis.HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        return this.getAttribute('aria-label') === 'Monitoring tabs' ? monitoringNavWidth : 0
+      },
+    })
+    Object.defineProperty(globalThis.HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return getElementWidth(this)
+      },
+    })
+    vi.stubGlobal('ResizeObserver', class {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    })
+  })
+
+  it('redirects unauthenticated sessions before loading monitoring', async () => {
+    mockApi.isAuthenticated.mockReturnValue(false)
+    mockApi.checkAuth.mockResolvedValue(false)
+
+    const beforeLoad = (MonitoringRoute as unknown as {beforeLoad: () => Promise<void>}).beforeLoad
+
+    await expect(beforeLoad()).rejects.toMatchObject({
+      __redirect: true,
+      to: '/login',
+    })
+    expect(mockApi.checkAuth).toHaveBeenCalled()
+  })
+
+  it('renders core monitoring tabs and hides Datadog tabs without the module', () => {
+    renderMonitoringRoute()
+
+    expect(screen.getByRole('link', {name: /Hosts/})).toHaveAttribute('href', '/monitoring')
+    expect(screen.getByRole('link', {name: /Map/})).toHaveAttribute('href', '/monitoring/map')
+    expect(screen.getByRole('link', {name: /Containers/})).toHaveAttribute('href', '/monitoring/containers')
+    expect(screen.queryByRole('link', {name: /Processes/})).not.toBeInTheDocument()
+    expect(screen.getByLabelText('View docs')).toHaveAttribute('href', '/docs/datadog-agent/agent-setup')
+    expect(screen.getByTestId('monitoring-outlet')).toBeInTheDocument()
+  })
+
+  it('moves overflowing monitoring tabs into the More menu and keeps overflow routes active', async () => {
+    mockFeatures.modules = ['datadog']
+    mockRouteState.pathname = '/monitoring/debugger'
+    monitoringNavWidth = 230
+
+    renderMonitoringRoute()
+
+    const moreButton = await screen.findByRole('button', {name: /More/})
+    await waitFor(() => expect(screen.queryByRole('link', {name: /Debugger/})).toBeInTheDocument())
+
+    expect(moreButton).toHaveClass('text-primary')
+    expect(screen.getByRole('link', {name: /Hosts/})).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /Map/})).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /Debugger/})).toHaveClass('text-primary')
+    expect(screen.getByRole('link', {name: /Network Devices/})).toHaveAttribute(
+      'href',
+      '/monitoring/network-devices',
+    )
+    expect(screen.getByLabelText('View docs')).toHaveAttribute('href', '/docs/datadog-agent/debugger')
+  })
+
+  it('uses detail shells instead of the monitoring tab strip for nested inventory pages', () => {
+    mockRouteState.pathname = '/monitoring/hosts/i-123'
+    const Component = (MonitoringRoute as unknown as {component: React.ComponentType}).component
+
+    const {rerender} = render(<Component />)
+
+    expect(screen.queryByLabelText('Monitoring tabs')).not.toBeInTheDocument()
+    expect(screen.getByTestId('monitoring-outlet')).toBeInTheDocument()
+
+    mockRouteState.pathname = '/monitoring/system-42'
+    rerender(<Component />)
+
+    expect(screen.getByRole('link', {name: /Back to Monitoring/})).toHaveAttribute('href', '/monitoring')
+    expect(screen.queryByLabelText('Monitoring tabs')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/routes/monitoring.debugger.tsx
+++ b/dashboard/src/routes/monitoring.debugger.tsx
@@ -12,10 +12,9 @@ import {api} from '@/lib/api'
 import CreateProbeDialog from '@/components/debugger/CreateProbeDialog'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
-import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip'
 import {EmptyState} from '@/components/ui/empty-state'
 import {SectionCard} from '@/components/ui/section-card'
-import {Activity, Bug, HelpCircle, Loader2, Plus} from 'lucide-react'
+import {Activity, Bug, Loader2, Plus} from 'lucide-react'
 import {useState} from 'react'
 
 export const Route = createFileRoute('/monitoring/debugger')({
@@ -65,7 +64,7 @@ function formatStatusLabel(status: string): string {
   }
 }
 
-export function DebuggerHeaderActions() {
+function DebuggerHeaderActions() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   return (
     <>
@@ -73,26 +72,10 @@ export function DebuggerHeaderActions() {
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
       />
-      <div className="flex items-center gap-2">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <a href="/docs/datadog-agent/debugger" target="_blank" rel="noreferrer"
-                className="inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                aria-label="View docs">
-                <HelpCircle className="h-4 w-4" />
-              </a>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>View docs</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <Button onClick={() => setCreateDialogOpen(true)}>
-          <Plus className="h-4 w-4 mr-1.5" />
-          Create Probe
-        </Button>
-      </div>
+      <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+        <Plus className="h-4 w-4 mr-1.5" />
+        Create Probe
+      </Button>
     </>
   )
 }
@@ -136,6 +119,9 @@ function DebuggerDashboard() {
           <Bug className="h-3.5 w-3.5 text-muted-foreground" />
           <span className="font-semibold tabular-nums">{logs.length}</span>
           <span className="text-muted-foreground text-xs">log entries</span>
+        </div>
+        <div className="ml-auto">
+          <DebuggerHeaderActions />
         </div>
       </div>
 

--- a/dashboard/src/routes/monitoring.index.tsx
+++ b/dashboard/src/routes/monitoring.index.tsx
@@ -48,7 +48,6 @@ import {
   Copy,
   Cpu,
   HardDrive,
-  HelpCircle,
   LayoutGrid,
   List,
   Loader2,
@@ -713,7 +712,7 @@ function AddHostDialog({
   )
 }
 
-function AddHostButton({onClick}: {onClick: () => void}) {
+function AddHostButton({onClick}: Readonly<{onClick: () => void}>) {
   return (
     <Button className="gap-2" onClick={onClick}>
       <Plus className="h-4 w-4" />
@@ -722,14 +721,7 @@ function AddHostButton({onClick}: {onClick: () => void}) {
   )
 }
 
-export function HostsHeaderActions() {
-  const [addDialogOpen, setAddDialogOpen] = useState(false)
-  const {data: ddHostsData} = useQuery({
-    queryKey: ['hosts'],
-    queryFn: () => api.getHosts(),
-    enabled: api.isAuthenticated(),
-  })
-  const hosts = ddHostsData?.hosts ?? []
+function HostsHeaderActions({hosts, onAddHost}: Readonly<{hosts: DdHostResponse[]; onAddHost: () => void}>) {
   const {data: billingUsage} = useQuery({
     queryKey: ['billingUsage'],
     queryFn: () => api.getBillingUsage(),
@@ -741,44 +733,27 @@ export function HostsHeaderActions() {
   const isAtLimit = !isSelfHosted && hosts.length >= hostLimit
 
   return (
-    <>
-      <AddHostDialog isOpen={addDialogOpen} setIsOpen={setAddDialogOpen} />
-      <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2">
+      {isAtLimit ? (
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <a href="/docs/datadog-agent/agent-setup" target="_blank" rel="noreferrer"
-                className="inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                aria-label="View docs">
-                <HelpCircle className="h-4 w-4" />
-              </a>
+              <Link to="/settings" search={{tab: 'billing'}}>
+                <Button variant="default" size="sm" className="gap-2">
+                  <Plus className="h-4 w-4" />
+                  Upgrade to Add More
+                </Button>
+              </Link>
             </TooltipTrigger>
             <TooltipContent>
-              <p>View docs</p>
+              <p>You&apos;ve reached the limit for your {currentPlan} plan</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        {isAtLimit ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Link to="/settings" search={{tab: 'billing'}}>
-                  <Button variant="default" size="sm" className="gap-2">
-                    <Plus className="h-4 w-4" />
-                    Upgrade to Add More
-                  </Button>
-                </Link>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>You&apos;ve reached the limit for your {currentPlan} plan</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        ) : (
-          <AddHostButton onClick={() => setAddDialogOpen(true)} />
-        )}
-      </div>
-    </>
+      ) : (
+        <AddHostButton onClick={onAddHost} />
+      )}
+    </div>
   )
 }
 
@@ -1089,6 +1064,11 @@ function MonitoringHostsPage() {
                 <span className="font-semibold tabular-nums">{formatBytes(totalMemoryKb)}</span>
                 <span className="text-muted-foreground text-xs">memory</span>
               </div>
+            </div>
+          )}
+          {!isLoadingHosts && hosts.length > 0 && (
+            <div className="sm:ml-auto">
+              <HostsHeaderActions hosts={hosts} onAddHost={() => setAddDialogOpen(true)} />
             </div>
           )}
         </div>

--- a/dashboard/src/routes/monitoring.tsx
+++ b/dashboard/src/routes/monitoring.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {createFileRoute, Link, Outlet, redirect, useRouterState} from '@tanstack/react-router'
-import {useEffect, useRef, useState, type ComponentType, type MutableRefObject, type RefObject} from 'react'
+import {useEffect, useRef, useState, type ComponentType} from 'react'
 import {api} from '@/lib/api'
 import {useEnterpriseFeatures, hasEnterpriseModule} from '@/hooks/useEnterpriseFeatures'
 import {
@@ -50,14 +50,6 @@ type MonitoringTab = Readonly<{
 type MonitoringTabNavProps = Readonly<{
   tabs: readonly MonitoringTab[]
   currentPath: string
-}>
-
-type UseVisibleTabsResult = Readonly<{
-  navRef: RefObject<HTMLElement | null>
-  itemRefs: MutableRefObject<Array<HTMLSpanElement | null>>
-  moreRef: MutableRefObject<HTMLSpanElement | null>
-  visibleTabs: readonly MonitoringTab[]
-  overflowTabs: readonly MonitoringTab[]
 }>
 
 type VisibleTabCountOptions = Readonly<{
@@ -103,7 +95,7 @@ function createResizeObserver(onResize: () => void): ResizeObserver | null {
   return new globalThis.ResizeObserver(onResize)
 }
 
-function useVisibleMonitoringTabs(tabs: readonly MonitoringTab[]): UseVisibleTabsResult {
+function useVisibleMonitoringTabs(tabs: readonly MonitoringTab[]) {
   const navRef = useRef<HTMLElement>(null)
   const itemRefs = useRef<Array<HTMLSpanElement | null>>([])
   const moreRef = useRef<HTMLSpanElement | null>(null)

--- a/dashboard/src/routes/monitoring.tsx
+++ b/dashboard/src/routes/monitoring.tsx
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {createFileRoute, Link, Outlet, redirect, useRouterState} from '@tanstack/react-router'
+import {useEffect, useRef, useState, type ComponentType, type MutableRefObject, type RefObject} from 'react'
 import {api} from '@/lib/api'
 import {useEnterpriseFeatures, hasEnterpriseModule} from '@/hooks/useEnterpriseFeatures'
 import {
@@ -25,6 +26,7 @@ import {
     Database,
     HardDrive,
     HelpCircle,
+    MoreHorizontal,
     Network,
     Package,
     Router,
@@ -34,9 +36,216 @@ import {
 } from 'lucide-react'
 import {cn} from '@/lib/utils'
 import {Button} from '@/components/ui/button'
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu'
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip'
-import {HostsHeaderActions} from './monitoring.index'
-import {DebuggerHeaderActions} from './monitoring.debugger'
+
+type MonitoringTab = Readonly<{
+  id: string
+  label: string
+  href: string
+  icon: ComponentType<{className?: string}>
+  requiresDatadog?: boolean
+}>
+
+type MonitoringTabNavProps = Readonly<{
+  tabs: readonly MonitoringTab[]
+  currentPath: string
+}>
+
+type UseVisibleTabsResult = Readonly<{
+  navRef: RefObject<HTMLElement | null>
+  itemRefs: MutableRefObject<Array<HTMLSpanElement | null>>
+  moreRef: MutableRefObject<HTMLSpanElement | null>
+  visibleTabs: readonly MonitoringTab[]
+  overflowTabs: readonly MonitoringTab[]
+}>
+
+type VisibleTabCountOptions = Readonly<{
+  availableWidth: number
+  tabCount: number
+  itemRefs: readonly (HTMLSpanElement | null)[]
+  moreWidth?: number
+}>
+
+const TAB_BASE_CLASS = 'flex h-8 items-center gap-1.5 whitespace-nowrap px-2.5 text-xs font-medium'
+const OVERFLOW_FALLBACK_WIDTH = 80
+
+function isTabActive(tab: MonitoringTab, currentPath: string): boolean {
+  if (tab.href === '/monitoring') {
+    return currentPath === '/monitoring' || currentPath === '/monitoring/'
+  }
+  return currentPath.startsWith(tab.href)
+}
+
+function computeVisibleTabCount({
+  availableWidth,
+  tabCount,
+  itemRefs,
+  moreWidth = OVERFLOW_FALLBACK_WIDTH,
+}: VisibleTabCountOptions): number {
+  if (availableWidth === 0) return tabCount
+
+  let usedWidth = 0
+  for (let index = 0; index < tabCount; index += 1) {
+    const width = itemRefs[index]?.offsetWidth ?? 0
+    const reserveForMore = index < tabCount - 1 ? moreWidth : 0
+    if (usedWidth + width + reserveForMore > availableWidth) {
+      return Math.min(tabCount, Math.max(1, index))
+    }
+    usedWidth += width
+  }
+
+  return tabCount
+}
+
+function createResizeObserver(onResize: () => void): ResizeObserver | null {
+  if (globalThis.ResizeObserver === undefined) return null
+  return new globalThis.ResizeObserver(onResize)
+}
+
+function useVisibleMonitoringTabs(tabs: readonly MonitoringTab[]): UseVisibleTabsResult {
+  const navRef = useRef<HTMLElement>(null)
+  const itemRefs = useRef<Array<HTMLSpanElement | null>>([])
+  const moreRef = useRef<HTMLSpanElement | null>(null)
+  const [visibleCount, setVisibleCount] = useState(tabs.length)
+
+  useEffect(() => {
+    const nav = navRef.current
+    if (nav === null) return undefined
+
+    const recompute = () => {
+      setVisibleCount(
+        computeVisibleTabCount({
+          availableWidth: nav.clientWidth,
+          tabCount: tabs.length,
+          itemRefs: itemRefs.current,
+          moreWidth: moreRef.current?.offsetWidth,
+        }),
+      )
+    }
+
+    recompute()
+    const observer = createResizeObserver(recompute)
+    observer?.observe(nav)
+    return () => observer?.disconnect()
+  }, [tabs])
+
+  return {
+    navRef,
+    itemRefs,
+    moreRef,
+    visibleTabs: tabs.slice(0, visibleCount),
+    overflowTabs: tabs.slice(visibleCount),
+  }
+}
+
+function MonitoringTabNav({tabs, currentPath}: MonitoringTabNavProps) {
+  const {navRef, itemRefs, moreRef, visibleTabs, overflowTabs} = useVisibleMonitoringTabs(tabs)
+  const overflowHasActive = overflowTabs.some((tab) => isTabActive(tab, currentPath))
+
+  return (
+    <div className="relative min-w-0 flex-1 overflow-hidden">
+      <div aria-hidden className="pointer-events-none invisible absolute left-0 top-0 flex gap-0.5">
+        {tabs.map((tab, index) => {
+          const Icon = tab.icon
+          return (
+            <span
+              key={tab.id}
+              ref={(element) => {
+                itemRefs.current[index] = element
+              }}
+              className={TAB_BASE_CLASS}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              {tab.label}
+            </span>
+          )
+        })}
+        <span ref={moreRef} className={TAB_BASE_CLASS}>
+          <MoreHorizontal className="h-3.5 w-3.5 shrink-0" />
+          More
+        </span>
+      </div>
+
+      <nav ref={navRef} className="flex w-full items-stretch gap-0.5 overflow-hidden" aria-label="Monitoring tabs">
+        {visibleTabs.map((tab) => (
+          <MonitoringTabLink key={tab.id} tab={tab} currentPath={currentPath} />
+        ))}
+        {overflowTabs.length > 0 && (
+          <MonitoringOverflowMenu tabs={overflowTabs} currentPath={currentPath} hasActiveTab={overflowHasActive} />
+        )}
+      </nav>
+    </div>
+  )
+}
+
+type MonitoringTabLinkProps = Readonly<{
+  tab: MonitoringTab
+  currentPath: string
+}>
+
+function MonitoringTabLink({tab, currentPath}: MonitoringTabLinkProps) {
+  const Icon = tab.icon
+  const active = isTabActive(tab, currentPath)
+
+  return (
+    <Link
+      to={tab.href}
+      className={cn(
+        TAB_BASE_CLASS,
+        'border-b-2 transition-colors',
+        active ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground',
+      )}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      {tab.label}
+    </Link>
+  )
+}
+
+type MonitoringOverflowMenuProps = Readonly<{
+  tabs: readonly MonitoringTab[]
+  currentPath: string
+  hasActiveTab: boolean
+}>
+
+function MonitoringOverflowMenu({tabs, currentPath, hasActiveTab}: MonitoringOverflowMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            TAB_BASE_CLASS,
+            'border-b-2 transition-colors',
+            hasActiveTab
+              ? 'border-primary text-primary'
+              : 'border-transparent text-muted-foreground hover:text-foreground',
+          )}
+        >
+          <MoreHorizontal className="h-3.5 w-3.5 shrink-0" />
+          More
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-44">
+        {tabs.map((tab) => {
+          const Icon = tab.icon
+          return (
+            <DropdownMenuItem key={tab.id} asChild>
+              <Link
+                to={tab.href}
+                className={cn('flex items-center gap-2 text-xs', isTabActive(tab, currentPath) && 'text-primary')}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                {tab.label}
+              </Link>
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
 
 export const Route = createFileRoute('/monitoring')({
   beforeLoad: async () => {
@@ -63,7 +272,7 @@ const TAB_DOCS_URLS: Record<string, string> = {
   sbom: '/docs/datadog-agent/sbom',
 }
 
-const allTabs = [
+const allTabs: MonitoringTab[] = [
   {id: 'hosts', label: 'Hosts', href: '/monitoring', icon: HardDrive},
   {id: 'map', label: 'Map', href: '/monitoring/map', icon: MapIcon},
   {id: 'containers', label: 'Containers', href: '/monitoring/containers', icon: Box},
@@ -117,7 +326,6 @@ function MonitoringLayout() {
     )
   }
 
-  const isHostsPage = currentPath === '/monitoring' || currentPath === '/monitoring/'
   const activeTabId = tabs.find((t) =>
     t.href === '/monitoring'
       ? currentPath === '/monitoring' || currentPath === '/monitoring/'
@@ -128,45 +336,20 @@ function MonitoringLayout() {
   return (
     <div>
       <div className="border-b bg-card/50">
-        <div className="container mx-auto px-4 py-2.5">
-          <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-2">
-            <nav className="flex gap-0.5 min-w-0 overflow-x-auto pb-1 sm:flex-1 sm:pb-0" aria-label="Monitoring tabs">
-              {tabs.map((tab) => {
-              const isActive =
-                tab.href === '/monitoring'
-                  ? currentPath === '/monitoring' || currentPath === '/monitoring/'
-                  : currentPath.startsWith(tab.href)
-              const Icon = tab.icon
-
-              return (
-                <Link
-                  key={tab.id}
-                  to={tab.href}
-                  className={cn(
-                    'flex items-center gap-1.5 px-2.5 py-2 border-b-2 transition-all font-medium text-xs rounded-t-md whitespace-nowrap',
-                    isActive
-                      ? 'border-primary text-primary bg-primary/5'
-                      : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50'
-                  )}
-                >
-                  <Icon className="h-3.5 w-3.5 shrink-0" />
-                  {tab.label}
-                </Link>
-              )
-            })}
-            </nav>
-            <div className="flex items-center gap-2 shrink-0">
-            {isHostsPage ? (
-              <HostsHeaderActions />
-            ) : currentPath.startsWith('/monitoring/debugger') ? (
-              <DebuggerHeaderActions />
-            ) : docsUrl ? (
+        <div className="flex h-10 items-end gap-2 px-4">
+          <MonitoringTabNav tabs={tabs} currentPath={currentPath} />
+          <div className="flex shrink-0 items-center gap-2 self-center">
+            {docsUrl ? (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <a href={docsUrl} target="_blank" rel="noreferrer"
+                    <a
+                      href={docsUrl}
+                      target="_blank"
+                      rel="noreferrer"
                       className="inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                      aria-label="View docs">
+                      aria-label="View docs"
+                    >
                       <HelpCircle className="h-4 w-4" />
                     </a>
                   </TooltipTrigger>
@@ -176,7 +359,6 @@ function MonitoringLayout() {
                 </Tooltip>
               </TooltipProvider>
             ) : null}
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add overflow-safe monitoring tabs with a More menu
- Keep monitoring docs in the shared route header
- Move hosts and debugger actions into their page content

## Validation
- npm run lint
- npm run build
- git diff --check
- Browser smoke: /monitoring, /monitoring/map, /monitoring/debugger at narrow width with no horizontal overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Monitoring UI Improvements

* **New Features**
  * Responsive tab navigation that keeps visible tabs inline and moves overflow into a "More" dropdown.

* **UI Changes**
  * Streamlined monitoring headers by removing redundant documentation links and right-aligning header actions.
  * Simplified Hosts header flow and Add Host interaction to use parent-provided host data.

* **Tests**
  * Added tests covering route rendering and responsive tab overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->