### PR TITLE
feat: polish map canvas primitives

### DIFF
--- a/dashboard/src/components/maps/MapCanvas.tsx
+++ b/dashboard/src/components/maps/MapCanvas.tsx
@@ -6,13 +6,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {ReactFlow, Controls, Background, BackgroundVariant, type Edge, type Node} from '@xyflow/react'
+import {ReactFlow, Controls, Background, BackgroundVariant, useReactFlow, type Edge, type Node} from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import {Loader2} from 'lucide-react'
-import type {ComponentProps, ComponentType, ReactNode} from 'react'
+import {useEffect, type ComponentProps, type ComponentType, type ReactNode} from 'react'
 import {cn} from '@/lib/utils'
 
 type ReactFlowProps = ComponentProps<typeof ReactFlow>
+const DEFAULT_FIT_VIEW_OPTIONS: ReactFlowProps['fitViewOptions'] = {padding: 0.25}
 
 type MapCanvasProps = Readonly<{
   nodes: Node[]
@@ -40,6 +41,25 @@ type MapCanvasFrameProps = Readonly<{
   className?: string
 }>
 
+function FitOnChange({
+  signature,
+  fitViewOptions,
+}: Readonly<{
+  signature?: string
+  fitViewOptions: ReactFlowProps['fitViewOptions']
+}>) {
+  const {fitView} = useReactFlow()
+
+  useEffect(() => {
+    const frame = globalThis.requestAnimationFrame(() => {
+      void fitView(fitViewOptions)
+    })
+    return () => globalThis.cancelAnimationFrame(frame)
+  }, [signature, fitView, fitViewOptions])
+
+  return null
+}
+
 export function MapCanvas({
   nodes,
   edges = [],
@@ -56,7 +76,7 @@ export function MapCanvas({
   children,
   className,
   fitSignature,
-  fitViewOptions = {padding: 0.25},
+  fitViewOptions = DEFAULT_FIT_VIEW_OPTIONS,
   minZoom = 0.2,
   maxZoom = 2,
 }: MapCanvasProps) {
@@ -102,7 +122,6 @@ export function MapCanvas({
   return (
     <MapCanvasFrame className={className}>
       <ReactFlow
-        key={fitSignature}
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
@@ -117,11 +136,12 @@ export function MapCanvas({
         maxZoom={maxZoom}
         proOptions={{hideAttribution: true}}
       >
+        <FitOnChange signature={fitSignature} fitViewOptions={fitViewOptions} />
         <Background
           variant={BackgroundVariant.Dots}
           gap={24}
           size={1}
-          className="!bg-background"
+          color="hsl(var(--viz-grid) / 0.1)"
         />
         <Controls showInteractive={false} />
       </ReactFlow>
@@ -132,7 +152,7 @@ export function MapCanvas({
 
 function MapCanvasFrame({children, className}: MapCanvasFrameProps) {
   return (
-    <div className={cn('map-canvas relative rounded-lg border bg-card/50 overflow-hidden', className)}>
+    <div className={cn('map-canvas relative rounded-lg border bg-[hsl(var(--viz-surface))] overflow-hidden', className)}>
       {children}
     </div>
   )

--- a/dashboard/src/components/maps/MapNodeCard.tsx
+++ b/dashboard/src/components/maps/MapNodeCard.tsx
@@ -47,9 +47,9 @@ export function MapNodeCard({
   return (
     <div
       className={cn(
-        'rounded-lg border-2 bg-card text-card-foreground',
-        'transition-all duration-200 cursor-pointer',
-        selected && 'ring-2 ring-primary scale-[1.02]',
+        'rounded-lg border bg-card text-card-foreground',
+        'transition-colors duration-200 cursor-pointer',
+        selected && 'ring-1 ring-primary',
         dimmed && 'opacity-25',
         dashed && 'border-dashed',
         borderClassName,

--- a/dashboard/src/components/maps/__tests__/MapPrimitives.test.tsx
+++ b/dashboard/src/components/maps/__tests__/MapPrimitives.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import type {Node} from '@xyflow/react'
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const {mockFlow} = vi.hoisted(() => ({
+  mockFlow: {
+    fitView: vi.fn(),
+    mountCount: 0,
+    unmountCount: 0,
+  },
+}))
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlow: ({children}: {children: React.ReactNode}) => {
+    React.useEffect(() => {
+      mockFlow.mountCount += 1
+      return () => {
+        mockFlow.unmountCount += 1
+      }
+    }, [])
+    return <div data-testid="react-flow">{children}</div>
+  },
+  Controls: ({showInteractive}: {showInteractive?: boolean}) => (
+    <div data-testid="flow-controls" data-show-interactive={String(showInteractive)} />
+  ),
+  Background: ({color, gap, size, variant}: {color?: string; gap?: number; size?: number; variant?: string}) => (
+    <div
+      data-testid="flow-background"
+      data-color={color}
+      data-gap={String(gap)}
+      data-size={String(size)}
+      data-variant={variant}
+    />
+  ),
+  BackgroundVariant: {
+    Dots: 'dots',
+  },
+  useReactFlow: () => ({fitView: mockFlow.fitView}),
+}))
+
+import {MapCanvas} from '../MapCanvas'
+import {MapNodeCard} from '../MapNodeCard'
+
+const nodes: Node[] = [
+  {
+    id: 'api',
+    position: {x: 0, y: 0},
+    data: {},
+  },
+]
+
+describe('map primitives', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFlow.mountCount = 0
+    mockFlow.unmountCount = 0
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  it('refits the map when the signature changes without remounting the flow', () => {
+    const {rerender, container} = render(<MapCanvas nodes={nodes} fitSignature="services:2" />)
+
+    expect(screen.getByTestId('flow-background')).toHaveAttribute('data-color', 'hsl(var(--viz-grid) / 0.1)')
+    expect(container.firstElementChild).toHaveClass('bg-[hsl(var(--viz-surface))]')
+    expect(mockFlow.mountCount).toBe(1)
+    expect(mockFlow.unmountCount).toBe(0)
+    expect(mockFlow.fitView).toHaveBeenLastCalledWith({padding: 0.25})
+
+    rerender(<MapCanvas nodes={nodes} fitSignature="services:3" fitViewOptions={{padding: 0.4}} />)
+
+    expect(mockFlow.mountCount).toBe(1)
+    expect(mockFlow.unmountCount).toBe(0)
+    expect(mockFlow.fitView).toHaveBeenLastCalledWith({padding: 0.4})
+  })
+
+  it('uses stable node-card chrome for selected and dimmed nodes', () => {
+    const {container} = render(
+      <MapNodeCard
+        title="api"
+        subtitle="checkout"
+        selected
+        dimmed
+        dashed
+        borderColor="rgb(1, 2, 3)"
+        minWidth={180}
+      />
+    )
+    const card = container.firstElementChild as HTMLElement
+
+    expect(card).toHaveClass('border', 'ring-1', 'ring-primary', 'opacity-25', 'border-dashed')
+    expect(card).not.toHaveClass('border-2', 'ring-2', 'scale-[1.02]', 'transition-all')
+    expect(card).toHaveStyle({borderColor: 'rgb(1, 2, 3)', minWidth: '180px'})
+  })
+})

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -61,6 +61,9 @@
     --chart-8: 358 75% 59%;
     --chart-9: 189 95% 43%;
     --chart-10: 201 96% 32%;
+    /* Dense viz canvas: dark in both themes so topology maps read as a field. */
+    --viz-surface: 222 30% 9%;
+    --viz-grid: 220 14% 100%;
     --radius: 0.5rem;
   }
   .dark {
@@ -111,6 +114,8 @@
     --chart-8: 358 75% 59%;
     --chart-9: 189 95% 43%;
     --chart-10: 201 96% 32%;
+    --viz-surface: 222 33% 7%;
+    --viz-grid: 220 14% 100%;
   }
 
   .theme-midnight {


### PR DESCRIPTION
## Summary
- keep map canvas fit updates within the existing React Flow instance
- add semantic canvas tokens and calmer node-card selection chrome
- cover map primitives with focused tests

## Validation
- npm test -- --run src/components/maps/__tests__/MapPrimitives.test.tsx src/components/apm/__tests__/ServiceMap.test.tsx src/components/monitoring/__tests__/MonitoringMap.test.tsx
- npm run lint
- npm run build
- npm run test:coverage -- --run src/components/maps/__tests__/MapPrimitives.test.tsx
- browser smoke: /monitoring/map?scope=services and /monitoring/map?scope=hosts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test coverage for map visualization components and behavior.

* **Style**
  * Updated map node card styling for improved visual hierarchy and consistency.
  * Enhanced map canvas background styling with improved theme support.
  * Refined map view fitting behavior for better user experience.

* **Tests**
  * New test suite for map primitives validates component rendering and interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->