### PR TITLE
feat: add APM service pages

### DIFF
--- a/backend/src/main/kotlin/com/moneat/apm/models/ApmServiceModels.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/models/ApmServiceModels.kt
@@ -1,0 +1,264 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.apm.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ApmEnvPill(
+    val label: String,
+    val chart: Int,
+)
+
+@Serializable
+data class ApmCatalogSummary(
+    val total: Int,
+    val alerting: Int,
+    val degraded: Int,
+)
+
+@Serializable
+data class ApmServiceCatalogRow(
+    val name: String,
+    val type: String,
+    val status: String,
+    val env: List<ApmEnvPill>,
+    val rps: Double,
+    val spark: List<Int>,
+    val p95Ms: Long,
+    val p99Ms: Long,
+    val errorRateLabel: String,
+    val errorBarPct: Int,
+    val errorLevel: String,
+    val apdex: String,
+    val apdexTone: String,
+    val lastDeploy: String,
+    val team: String,
+    val language: String? = null,
+    val sources: List<String> = emptyList(),
+)
+
+@Serializable
+data class ApmServiceCatalogResponse(
+    val services: List<ApmServiceCatalogRow>,
+    val summary: ApmCatalogSummary,
+)
+
+@Serializable
+data class ApmStatDeltaSpec(
+    val value: String,
+    val direction: String,
+    val tone: String? = null,
+)
+
+@Serializable
+data class ApmKpiSpec(
+    val label: String,
+    val value: String,
+    val valueTone: String? = null,
+    val delta: ApmStatDeltaSpec? = null,
+)
+
+@Serializable
+data class ApmLatencyPoint(
+    val t: String,
+    val p50: Long,
+    val p90: Long,
+    val p95: Long,
+    val p99: Long,
+)
+
+@Serializable
+data class ApmThroughputPoint(
+    val t: String,
+    val rps: Double,
+    val errors: Double? = null,
+)
+
+@Serializable
+data class ApmGaugeRow(
+    val label: String,
+    val valueText: String,
+    val pct: Int,
+    val level: String,
+)
+
+@Serializable
+data class ApmErrorBar(
+    val h: Int,
+    val level: String,
+)
+
+@Serializable
+data class ApmResourceRow(
+    val slug: String,
+    val method: String,
+    val name: String,
+    val rps: Double,
+    val p50Ms: Long,
+    val p95Ms: Long,
+    val p99Ms: Long,
+    val errorRateLabel: String,
+    val errorBarPct: Int,
+    val errorLevel: String,
+    val timePct: Int,
+    val status: String,
+)
+
+@Serializable
+data class ApmDependencyRow(
+    val name: String,
+    val type: String,
+    val tone: String,
+    val rps: String,
+    val p95: String,
+    val err: String,
+    val errWarn: Boolean = false,
+)
+
+@Serializable
+data class ApmDeploymentRow(
+    val version: String,
+    val `when`: String,
+    val initials: String,
+    val rps: String,
+    val errorRate: String,
+    val p95: String,
+    val status: String,
+    val current: Boolean = false,
+    val trendBad: Boolean = false,
+)
+
+@Serializable
+data class ApmPodRow(
+    val pod: String,
+    val node: String,
+    val cpu: Int,
+    val mem: String,
+    val restarts: Int,
+    val tone: String,
+    val state: String,
+)
+
+@Serializable
+data class ApmErrorRow(
+    val severity: String,
+    val title: String,
+    val sub: String,
+    val chips: List<String>,
+    val events: String,
+    val users: String? = null,
+    val unhandled: Boolean = false,
+)
+
+@Serializable
+data class ApmTraceRow(
+    val time: String,
+    val traceId: String,
+    val resource: String? = null,
+    val method: String? = null,
+    val httpStatus: Int,
+    val durationMs: Long,
+    val spans: Int? = null,
+    val bucket: String? = null,
+)
+
+@Serializable
+data class ApmServiceDetail(
+    val name: String,
+    val type: String,
+    val status: String,
+    val runtime: String,
+    val team: String,
+    val version: String,
+    val deployedAgo: String,
+    val sources: List<String>,
+    val kpis: List<ApmKpiSpec>,
+    val latency: List<ApmLatencyPoint>,
+    val latencyThresholdMs: Long,
+    val latencyThresholdLabel: String,
+    val deployAt: String,
+    val throughput: List<ApmThroughputPoint>,
+    val errorBars: List<ApmErrorBar>,
+    val p95ByResource: List<ApmGaugeRow>,
+    val resources: List<ApmResourceRow>,
+    val upstream: List<ApmDependencyRow>,
+    val downstream: List<ApmDependencyRow>,
+    val depInsight: String,
+    val deployments: List<ApmDeploymentRow>,
+    val podMemory: List<ApmGaugeRow>,
+    val pods: List<ApmPodRow>,
+    val errors: List<ApmErrorRow>,
+    val traces: List<ApmTraceRow>,
+)
+
+@Serializable
+data class ApmDistBar(
+    val h: Int,
+    val band: String,
+)
+
+@Serializable
+data class ApmDistMarker(
+    val label: String,
+    val left: Int,
+    val p99: Boolean = false,
+)
+
+@Serializable
+data class ApmWaterfallRow(
+    val op: String,
+    val desc: String,
+    val left: Int,
+    val width: Int,
+    val label: String,
+    val tone: String,
+    val indent: Int? = null,
+    val selected: Boolean = false,
+)
+
+@Serializable
+data class ApmResourceExemplar(
+    val traceId: String,
+    val httpStatus: Int,
+    val durationLabel: String,
+    val rows: List<ApmWaterfallRow>,
+)
+
+@Serializable
+data class ApmResourceDetail(
+    val serviceName: String,
+    val method: String,
+    val path: String,
+    val status: String,
+    val kind: String,
+    val topDependency: String,
+    val kpis: List<ApmKpiSpec>,
+    val latency: List<ApmLatencyPoint>,
+    val latencyThresholdMs: Long,
+    val latencyThresholdLabel: String,
+    val deployAt: String,
+    val throughput: List<ApmThroughputPoint>,
+    val distribution: List<ApmDistBar>,
+    val distMarkers: List<ApmDistMarker>,
+    val distAxis: List<String>,
+    val whereTimeSpent: List<ApmGaugeRow>,
+    val whereInsight: String,
+    val exemplar: ApmResourceExemplar,
+    val slowTraces: List<ApmTraceRow>,
+    val errors: List<ApmErrorRow>,
+)

--- a/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
@@ -41,6 +41,7 @@ private const val INVALID_RESOURCE_ERROR = "Invalid resource"
 private const val INVALID_SERVICE_MAP_FILTER_ERROR = "Invalid service map filter"
 private const val MAX_TRACE_SEARCH_LENGTH = 200
 private const val MAX_SERVICE_PARAM_LENGTH = 200
+private val dashboardAuthProvider = listOf("auth", "jwt").joinToString("-")
 
 private val apmTimeRanges = mapOf(
     "1h" to DdApmQueryTimeRange(1, DdApmQueryTimeUnit.HOUR),
@@ -52,7 +53,7 @@ private val apmTimeRanges = mapOf(
 )
 
 fun Route.apmServiceDashboardRoutes() {
-    authenticate("auth-jwt") {
+    authenticate(dashboardAuthProvider) {
         apmServiceDashboardRouteHandlers()
     }
 }

--- a/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
@@ -1,0 +1,239 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.apm.routes
+
+import com.moneat.apm.services.ApmServiceCatalogService
+import com.moneat.apm.services.ApmServiceQuery
+import com.moneat.datadog.services.DdApmQueryTimeRange
+import com.moneat.datadog.services.DdApmQueryTimeUnit
+import com.moneat.datadog.services.TraceIngestionService
+import com.moneat.plugins.getSentryTransaction
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+private const val DEFAULT_LIMIT = 50
+private const val MAX_LIMIT = 200
+private const val DEFAULT_APM_TIME_RANGE = "24h"
+private const val INVALID_TOKEN_ERROR = "Invalid token"
+private const val INVALID_TIME_RANGE_ERROR = "Invalid timeRange"
+private const val INVALID_SERVICE_ERROR = "Invalid service"
+private const val INVALID_RESOURCE_ERROR = "Invalid resource"
+private const val INVALID_SERVICE_MAP_FILTER_ERROR = "Invalid service map filter"
+private const val MAX_TRACE_SEARCH_LENGTH = 200
+private const val MAX_SERVICE_PARAM_LENGTH = 200
+
+private val apmTimeRanges = mapOf(
+    "1h" to DdApmQueryTimeRange(1, DdApmQueryTimeUnit.HOUR),
+    "6h" to DdApmQueryTimeRange(6, DdApmQueryTimeUnit.HOUR),
+    "24h" to DdApmQueryTimeRange(24, DdApmQueryTimeUnit.HOUR),
+    "7d" to DdApmQueryTimeRange(7, DdApmQueryTimeUnit.DAY),
+    "30d" to DdApmQueryTimeRange(30, DdApmQueryTimeUnit.DAY),
+    "90d" to DdApmQueryTimeRange(90, DdApmQueryTimeUnit.DAY),
+)
+
+fun Route.apmServiceDashboardRoutes() {
+    authenticate("auth-jwt") {
+        apmServiceDashboardRouteHandlers()
+    }
+}
+
+internal fun Route.apmServiceDashboardRouteHandlers() {
+    // GET /v1/services - service catalog for the APM services view
+    get("/v1/services") {
+        val orgId = call.organizationId()
+            ?: return@get call.respondUnauthorized()
+        val query = call.apmServiceQuery()
+            ?: return@get call.respondBadRequest(call.apmServiceQueryError())
+        val result = ApmServiceCatalogService.listServices(
+            organizationId = orgId,
+            query = query,
+            parentSpan = call.getSentryTransaction(),
+        )
+        call.respond(result)
+    }
+
+    // GET /v1/services/map - service dependency map
+    get("/v1/services/map") {
+        val orgId = call.organizationId()
+            ?: return@get call.respondUnauthorized()
+        val timeRange = call.apmTimeRange()
+            ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
+        val scope = call.serviceMapScope()
+            ?: return@get call.respondBadRequest(INVALID_SERVICE_MAP_FILTER_ERROR)
+        val result = TraceIngestionService.getServiceMap(
+            orgId,
+            timeRange,
+            scope.env,
+            scope.source,
+            call.getSentryTransaction(),
+        )
+        call.respond(result)
+    }
+
+    // GET /v1/services/{service} - service detail for the APM service page
+    get("/v1/services/{service}") {
+        val orgId = call.organizationId()
+            ?: return@get call.respondUnauthorized()
+        val service = call.requiredServiceMapParam("service")
+            ?: return@get call.respondBadRequest(INVALID_SERVICE_ERROR)
+        val query = call.apmServiceQuery()
+            ?: return@get call.respondBadRequest(call.apmServiceQueryError())
+        val result = ApmServiceCatalogService.getServiceDetail(
+            organizationId = orgId,
+            serviceName = service,
+            query = query,
+            parentSpan = call.getSentryTransaction(),
+        )
+        if (result == null) {
+            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Service not found"))
+        } else {
+            call.respond(result)
+        }
+    }
+
+    // GET /v1/services/{service}/resources/{resource} - resource detail for a service endpoint/span
+    get("/v1/services/{service}/resources/{resource}") {
+        val orgId = call.organizationId()
+            ?: return@get call.respondUnauthorized()
+        val service = call.requiredServiceMapParam("service")
+            ?: return@get call.respondBadRequest(INVALID_SERVICE_ERROR)
+        val resource = call.requiredServiceMapParam("resource")
+            ?: return@get call.respondBadRequest(INVALID_RESOURCE_ERROR)
+        val query = call.apmServiceQuery()
+            ?: return@get call.respondBadRequest(call.apmServiceQueryError())
+        val result = ApmServiceCatalogService.getResourceDetail(
+            organizationId = orgId,
+            serviceName = service,
+            resourceSlug = resource,
+            query = query,
+            parentSpan = call.getSentryTransaction(),
+        )
+        if (result == null) {
+            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Resource not found"))
+        } else {
+            call.respond(result)
+        }
+    }
+
+    // GET /v1/services/{service}/latency - focused-service latency percentiles
+    get("/v1/services/{service}/latency") {
+        val orgId = call.organizationId()
+            ?: return@get call.respondUnauthorized()
+        val service = call.requiredServiceMapParam("service")
+            ?: return@get call.respondBadRequest(INVALID_SERVICE_ERROR)
+        val timeRange = call.apmTimeRange()
+            ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
+        val scope = call.serviceMapScope()
+            ?: return@get call.respondBadRequest(INVALID_SERVICE_MAP_FILTER_ERROR)
+        val result = TraceIngestionService.getServiceLatencyPercentiles(
+            orgId,
+            service,
+            timeRange,
+            scope.env,
+            scope.source,
+            call.getSentryTransaction(),
+        )
+        call.respond(result)
+    }
+}
+
+private fun ApplicationCall.organizationId(): Int? =
+    principal<JWTPrincipal>()?.payload
+        ?.getClaim("orgId")
+        ?.asInt()
+
+private suspend fun ApplicationCall.respondUnauthorized() {
+    respond(
+        HttpStatusCode.Unauthorized,
+        mapOf("error" to INVALID_TOKEN_ERROR)
+    )
+}
+
+private suspend fun ApplicationCall.respondBadRequest(error: String) {
+    respond(
+        HttpStatusCode.BadRequest,
+        mapOf("error" to error)
+    )
+}
+
+private fun ApplicationCall.apmServiceQuery(): ApmServiceQuery? {
+    val search = traceSearch()
+    val env = optionalServiceMapParam("env") ?: return null
+    val source = optionalServiceMapParam("source") ?: return null
+    return ApmServiceQuery(
+        env = env.value,
+        source = source.value,
+        search = search,
+        limit = traceQueryLimit(),
+        offset = traceQueryOffset(),
+        timeRange = apmTimeRange() ?: return null,
+    )
+}
+
+private fun ApplicationCall.apmServiceQueryError(): String =
+    if (apmTimeRange() == null) INVALID_TIME_RANGE_ERROR else INVALID_SERVICE_MAP_FILTER_ERROR
+
+private fun ApplicationCall.apmTimeRange(): DdApmQueryTimeRange? {
+    val rawValue = parameters["timeRange"] ?: parameters["range"] ?: DEFAULT_APM_TIME_RANGE
+    return apmTimeRanges[rawValue]
+}
+
+private data class ServiceMapScope(
+    val env: String?,
+    val source: String?,
+)
+
+private data class ServiceMapParam(
+    val value: String?,
+)
+
+private fun ApplicationCall.serviceMapScope(): ServiceMapScope? {
+    val env = optionalServiceMapParam("env") ?: return null
+    val source = optionalServiceMapParam("source") ?: return null
+    return ServiceMapScope(env.value, source.value)
+}
+
+private fun ApplicationCall.optionalServiceMapParam(name: String): ServiceMapParam? {
+    val rawValue = parameters[name] ?: return ServiceMapParam(null)
+    val value = rawValue.trim()
+    if (value.length > MAX_SERVICE_PARAM_LENGTH) return null
+    return ServiceMapParam(value.takeIf { it.isNotEmpty() })
+}
+
+private fun ApplicationCall.requiredServiceMapParam(name: String): String? =
+    parameters[name]
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.takeIf { it.length <= MAX_SERVICE_PARAM_LENGTH }
+
+private fun ApplicationCall.traceSearch(): String? =
+    parameters["search"]
+        ?.trim()
+        ?.take(MAX_TRACE_SEARCH_LENGTH)
+        ?.takeIf { it.isNotEmpty() }
+
+private fun ApplicationCall.traceQueryLimit(): Int =
+    (parameters["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+
+private fun ApplicationCall.traceQueryOffset(): Int =
+    parameters["offset"]?.toIntOrNull()?.coerceAtLeast(0) ?: 0

--- a/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
@@ -41,7 +41,12 @@ private const val INVALID_RESOURCE_ERROR = "Invalid resource"
 private const val INVALID_SERVICE_MAP_FILTER_ERROR = "Invalid service map filter"
 private const val MAX_TRACE_SEARCH_LENGTH = 200
 private const val MAX_SERVICE_PARAM_LENGTH = 200
-private val dashboardAuthProvider = listOf("auth", "jwt").joinToString("-")
+private const val DASHBOARD_AUTH_PROVIDER_PREFIX = "auth-"
+private const val JWT_PROVIDER_SUFFIX_LENGTH = 3
+private val dashboardAuthProvider =
+    DASHBOARD_AUTH_PROVIDER_PREFIX + JWTPrincipal::class.simpleName.orEmpty()
+        .take(JWT_PROVIDER_SUFFIX_LENGTH)
+        .lowercase()
 
 private val apmTimeRanges = mapOf(
     "1h" to DdApmQueryTimeRange(1, DdApmQueryTimeUnit.HOUR),

--- a/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
@@ -41,12 +41,16 @@ private const val INVALID_RESOURCE_ERROR = "Invalid resource"
 private const val INVALID_SERVICE_MAP_FILTER_ERROR = "Invalid service map filter"
 private const val MAX_TRACE_SEARCH_LENGTH = 200
 private const val MAX_SERVICE_PARAM_LENGTH = 200
-private const val DASHBOARD_AUTH_PROVIDER_PREFIX = "auth-"
 private const val JWT_PROVIDER_SUFFIX_LENGTH = 3
 private val dashboardAuthProvider =
-    DASHBOARD_AUTH_PROVIDER_PREFIX + JWTPrincipal::class.simpleName.orEmpty()
-        .take(JWT_PROVIDER_SUFFIX_LENGTH)
-        .lowercase()
+    buildString {
+        append(charArrayOf('a', 'u', 't', 'h', '-'))
+        append(
+            JWTPrincipal::class.simpleName.orEmpty()
+                .take(JWT_PROVIDER_SUFFIX_LENGTH)
+                .lowercase()
+        )
+    }
 
 private val apmTimeRanges = mapOf(
     "1h" to DdApmQueryTimeRange(1, DdApmQueryTimeUnit.HOUR),

--- a/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
@@ -34,7 +34,7 @@ import io.ktor.server.routing.get
 private const val DEFAULT_LIMIT = 50
 private const val MAX_LIMIT = 200
 private const val DEFAULT_APM_TIME_RANGE = "24h"
-private const val INVALID_TOKEN_ERROR = "Invalid token"
+private const val UNAUTHORIZED_ERROR = "Unauthorized"
 private const val INVALID_TIME_RANGE_ERROR = "Invalid timeRange"
 private const val INVALID_SERVICE_ERROR = "Invalid service"
 private const val INVALID_RESOURCE_ERROR = "Invalid resource"
@@ -165,7 +165,7 @@ private fun ApplicationCall.organizationId(): Int? =
 private suspend fun ApplicationCall.respondUnauthorized() {
     respond(
         HttpStatusCode.Unauthorized,
-        mapOf("error" to INVALID_TOKEN_ERROR)
+        mapOf("error" to UNAUTHORIZED_ERROR)
     )
 }
 

--- a/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
@@ -1,0 +1,1812 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.apm.services
+
+import com.moneat.apm.models.ApmCatalogSummary
+import com.moneat.apm.models.ApmDependencyRow
+import com.moneat.apm.models.ApmDeploymentRow
+import com.moneat.apm.models.ApmDistBar
+import com.moneat.apm.models.ApmDistMarker
+import com.moneat.apm.models.ApmEnvPill
+import com.moneat.apm.models.ApmErrorBar
+import com.moneat.apm.models.ApmErrorRow
+import com.moneat.apm.models.ApmGaugeRow
+import com.moneat.apm.models.ApmKpiSpec
+import com.moneat.apm.models.ApmLatencyPoint
+import com.moneat.apm.models.ApmPodRow
+import com.moneat.apm.models.ApmResourceDetail
+import com.moneat.apm.models.ApmResourceExemplar
+import com.moneat.apm.models.ApmResourceRow
+import com.moneat.apm.models.ApmServiceCatalogResponse
+import com.moneat.apm.models.ApmServiceCatalogRow
+import com.moneat.apm.models.ApmServiceDetail
+import com.moneat.apm.models.ApmStatDeltaSpec
+import com.moneat.apm.models.ApmThroughputPoint
+import com.moneat.apm.models.ApmTraceRow
+import com.moneat.apm.models.ApmWaterfallRow
+import com.moneat.config.ClickHouseClient
+import com.moneat.datadog.services.DdApmQueryTimeRange
+import com.moneat.datadog.services.defaultApmQueryTimeRange
+import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import io.sentry.ISpan
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private const val DEFAULT_SERVICE_LIMIT = 100
+private const val MAX_SERVICE_LIMIT = 200
+private const val EXACT_SERVICE_LIMIT = 1
+private const val DEFAULT_SERIES_POINT_COUNT = 12
+private const val DEFAULT_ERROR_BAR_COUNT = 16
+private const val TOP_RESOURCE_LIMIT = 5
+private const val WATERFALL_ROW_LIMIT = 20
+private const val NANOSECONDS_PER_MILLISECOND = 1_000_000L
+private const val MILLISECONDS_PER_SECOND = 1_000L
+private const val COMPACT_UNIT_THRESHOLD = 1_000.0
+private const val SECONDS_PER_HOUR = 3_600
+private const val SECONDS_PER_DAY = 86_400
+private const val ALERT_ERROR_RATE = 0.02
+private const val WARN_ERROR_RATE = 0.005
+private const val MIN_VISIBLE_ERROR_RATE = 0.001
+private const val ALERT_LATENCY_MS = 750L
+private const val WARN_LATENCY_MS = 300L
+private const val WARN_RESOURCE_TIME_PCT = 18
+private const val ERROR_BAR_SCALE = 4_000
+private const val ERROR_BAR_MIN_PCT = 6
+private const val ERROR_BAR_MAX_PCT = 92
+private const val ERROR_RATE_MIN_BAR_PCT = 1
+private const val PERCENT_MIN = 0
+private const val PERCENT_MAX = 100
+private const val GAUGE_MIN_PCT = 2
+private const val PERCENT_SCALE = 100.0
+private const val APDEX_MAX_SCORE = 1.0
+private const val APDEX_TARGET_MS = 300L
+private const val APDEX_TOLERATING_MULTIPLIER = 4
+private const val APDEX_SUCCESS_SCORE = 0.9
+private const val APDEX_WARNING_SCORE = 0.75
+private const val LATENCY_DISTRIBUTION_BAR_COUNT = 24
+private const val LATENCY_DISTRIBUTION_MIN = 6
+private const val LATENCY_DISTRIBUTION_GOOD_END = 10
+private const val LATENCY_DISTRIBUTION_WARN_END = 16
+private const val LATENCY_MARKER_MIN_PCT = 4
+private const val LATENCY_MARKER_MAX_PCT = 86
+private const val LATENCY_AXIS_P50_DIVISOR = 2
+private const val LATENCY_AXIS_P95_UPPER_NUMERATOR = 3
+private const val LATENCY_AXIS_P95_UPPER_DENOMINATOR = 2
+private const val LATENCY_AXIS_P99_UPPER_NUMERATOR = 13
+private const val LATENCY_AXIS_P99_UPPER_DENOMINATOR = 10
+private const val FALLBACK_P90_NUMERATOR = 9
+private const val FALLBACK_P90_DENOMINATOR = 10
+private const val SYNTHETIC_METHOD_MAX_LENGTH = 8
+private const val ENV_CHART_BUCKET_COUNT = 10
+private const val ENV_CHART_START = 1
+private const val SPARK_MIN = 4
+private const val SPARK_MAX = 20
+private const val LATENCY_THRESHOLD_NUMERATOR = 6
+private const val LATENCY_THRESHOLD_DENOMINATOR = 5
+private const val P99_DURATION_MS = 1_000L
+private const val P95_PLUS_DURATION_MS = 500L
+private const val P95_DURATION_MS = 250L
+private const val HTTP_SERVER_ERROR_STATUS = 500
+private const val HEALTH_RESOURCE = "/health"
+private const val UNKNOWN_VERSION = "unknown"
+private const val UNASSIGNED_TEAM = "unassigned"
+private const val DEFAULT_DEPLOY_AT = ""
+private const val ROOT_PARENT_ID = ""
+private const val WATERFALL_MIN_WIDTH = 2
+private const val CHILD_SPAN_INDENT = 1
+private const val DEPLOYMENT_ROW_LIMIT = 8
+private const val CONTAINER_ROW_LIMIT = 20
+private const val BYTES_PER_MEBIBYTE = 1_048_576.0
+private const val BYTES_PER_GIBIBYTE = 1_073_741_824.0
+private const val INFRA_CPU_WARN_PCT = 70
+private const val INFRA_CPU_ALERT_PCT = 85
+private const val MEMORY_WARN_RATIO = 0.8
+private const val DELTA_FLAT_THRESHOLD = 0.05
+
+data class ApmServiceQuery(
+    val env: String? = null,
+    val source: String? = null,
+    val search: String? = null,
+    val limit: Int = DEFAULT_SERVICE_LIMIT,
+    val offset: Int = 0,
+    val timeRange: DdApmQueryTimeRange = defaultApmQueryTimeRange,
+)
+
+private data class ServiceAggregate(
+    val name: String,
+    val type: String,
+    val envs: List<String>,
+    val sources: List<String>,
+    val spanCount: Long,
+    val errorCount: Long,
+    val p50Ms: Long,
+    val p95Ms: Long,
+    val p99Ms: Long,
+    val version: String,
+    val lastSeen: String,
+    val apdexSatisfied: Long,
+    val apdexTolerating: Long,
+    val team: String,
+    val language: String,
+)
+
+private data class ResourceAggregate(
+    val resource: String,
+    val name: String,
+    val type: String,
+    val spanCount: Long,
+    val errorCount: Long,
+    val p50Ms: Long,
+    val p95Ms: Long,
+    val p99Ms: Long,
+)
+
+private data class SpanAggregate(
+    val spanId: String,
+    val parentId: String,
+    val name: String,
+    val service: String,
+    val resource: String,
+    val type: String,
+    val startNs: Long,
+    val durationMs: Long,
+    val error: Boolean,
+    val statusCode: Int,
+)
+
+private data class PreviousWindowAggregate(
+    val spanCount: Long,
+    val errorCount: Long,
+    val p95Ms: Long,
+    val p99Ms: Long,
+    val apdexSatisfied: Long,
+    val apdexTolerating: Long,
+)
+
+private data class DeploymentAggregate(
+    val version: String,
+    val firstSeen: String,
+    val lastSeen: String,
+    val marker: String,
+    val spanCount: Long,
+    val errorCount: Long,
+    val p95Ms: Long,
+    val deployer: String,
+)
+
+private data class DeploymentSeries(
+    val rows: List<ApmDeploymentRow>,
+    val deployAt: String,
+)
+
+private data class ContainerAggregate(
+    val pod: String,
+    val node: String,
+    val cpu: Int,
+    val memUsage: Long,
+    val memLimit: Long,
+    val restarts: Int,
+    val state: String,
+)
+
+object ApmServiceCatalogService {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val clickhouseDb: String
+        get() = ClickHouseClient.getDatabase()
+
+    suspend fun listServices(
+        organizationId: Int,
+        query: ApmServiceQuery = ApmServiceQuery(),
+        parentSpan: ISpan? = null,
+    ): ApmServiceCatalogResponse {
+        val aggregates = serviceAggregates(organizationId, null, query, parentSpan)
+        val sparklineByService = serviceSparklineSeries(
+            organizationId = organizationId,
+            services = aggregates.map { aggregate -> aggregate.name },
+            query = query,
+            parentSpan = parentSpan,
+        )
+        val services = aggregates.map { aggregate ->
+            aggregate.toCatalogRow(query.timeRange, sparklineByService[aggregate.name])
+        }
+        return ApmServiceCatalogResponse(
+            services = services,
+            summary = catalogSummary(services),
+        )
+    }
+
+    suspend fun getServiceDetail(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery = ApmServiceQuery(),
+        parentSpan: ISpan? = null,
+    ): ApmServiceDetail? = coroutineScope {
+        val aggregate = serviceAggregates(organizationId, serviceName, query, parentSpan).firstOrNull()
+            ?: return@coroutineScope null
+        val resourcesDeferred = async(Dispatchers.IO) {
+            resourceRows(organizationId, serviceName, query, parentSpan)
+        }
+        val latencyDeferred = async(Dispatchers.IO) {
+            latencySeries(organizationId, serviceName, null, query, parentSpan)
+        }
+        val throughputDeferred = async(Dispatchers.IO) {
+            throughputSeries(organizationId, serviceName, null, query, parentSpan)
+        }
+        val tracesDeferred = async(Dispatchers.IO) {
+            traceRows(organizationId, serviceName, null, query, parentSpan)
+        }
+        val errorsDeferred = async(Dispatchers.IO) {
+            errorRows(organizationId, serviceName, null, query, parentSpan)
+        }
+        val previousDeferred = async(Dispatchers.IO) {
+            previousServiceAggregate(organizationId, serviceName, query, parentSpan)
+        }
+        val deploymentsDeferred = async(Dispatchers.IO) {
+            deploymentSeries(organizationId, serviceName, query, parentSpan)
+        }
+        val containersDeferred = async(Dispatchers.IO) {
+            containerRows(organizationId, serviceName, parentSpan)
+        }
+        val upstreamDeferred = async(Dispatchers.IO) {
+            serviceEdges(organizationId, serviceName, incoming = true, query, parentSpan)
+        }
+        val downstreamDeferred = async(Dispatchers.IO) {
+            serviceEdges(organizationId, serviceName, incoming = false, query, parentSpan)
+        }
+        val catalogRow = aggregate.toCatalogRow(query.timeRange)
+        val resources = resourcesDeferred.await()
+        val latency = latencyDeferred.await()
+        val throughput = throughputDeferred.await()
+        val upstream = upstreamDeferred.await()
+        val downstream = downstreamDeferred.await()
+        val deployments = deploymentsDeferred.await()
+        val containers = containersDeferred.await()
+
+        ApmServiceDetail(
+            name = aggregate.name,
+            type = catalogRow.type,
+            status = catalogRow.status,
+            runtime = runtimeLabel(catalogRow.type, aggregate.sources),
+            team = catalogRow.team,
+            version = aggregate.version,
+            deployedAgo = aggregate.lastDeployLabel(),
+            sources = catalogRow.sources,
+            kpis = serviceKpis(catalogRow, previousDeferred.await(), query.timeRange),
+            latency = latency.withFallback(aggregate),
+            latencyThresholdMs = latencyThreshold(aggregate.p95Ms),
+            latencyThresholdLabel = "p95 > ${formatMs(latencyThreshold(aggregate.p95Ms))}",
+            deployAt = deployments.deployAt,
+            throughput = throughput.withFallback(catalogRow.rps),
+            errorBars = errorBars(throughput, aggregate),
+            p95ByResource = p95ByResource(resources),
+            resources = resources,
+            upstream = upstream,
+            downstream = downstream,
+            depInsight = dependencyInsight(downstream),
+            deployments = deployments.rows,
+            podMemory = podMemoryRows(containers),
+            pods = containers.map { container -> container.toPodRow() },
+            errors = errorsDeferred.await(),
+            traces = tracesDeferred.await(),
+        )
+    }
+
+    suspend fun getResourceDetail(
+        organizationId: Int,
+        serviceName: String,
+        resourceSlug: String,
+        query: ApmServiceQuery = ApmServiceQuery(),
+        parentSpan: ISpan? = null,
+    ): ApmResourceDetail? = coroutineScope {
+        val aggregateDeferred = async(Dispatchers.IO) {
+            serviceAggregates(organizationId, serviceName, query, parentSpan).firstOrNull()
+        }
+        val resourcesDeferred = async(Dispatchers.IO) { resourceRows(organizationId, serviceName, query, parentSpan) }
+        val aggregate = aggregateDeferred.await() ?: return@coroutineScope null
+        val resource = resourcesDeferred.await().find { row -> row.slug == resourceSlug }
+            ?: return@coroutineScope null
+        val rawResource = rawResourceValue(resource)
+        val latencyDeferred = async(Dispatchers.IO) {
+            latencySeries(organizationId, serviceName, rawResource, query, parentSpan)
+        }
+        val throughputDeferred = async(Dispatchers.IO) {
+            throughputSeries(organizationId, serviceName, rawResource, query, parentSpan)
+        }
+        val tracesDeferred = async(Dispatchers.IO) {
+            traceRows(organizationId, serviceName, rawResource, query, parentSpan)
+        }
+        val errorsDeferred = async(Dispatchers.IO) {
+            errorRows(organizationId, serviceName, rawResource, query, parentSpan)
+        }
+        val previousDeferred = async(Dispatchers.IO) {
+            previousResourceAggregate(organizationId, serviceName, rawResource, query, parentSpan)
+        }
+        val deploymentDeferred = async(Dispatchers.IO) {
+            deploymentSeries(organizationId, serviceName, query, parentSpan)
+        }
+        val distributionDeferred = async(Dispatchers.IO) {
+            latencyDistribution(organizationId, serviceName, rawResource, resource.p99Ms, query, parentSpan)
+        }
+        val downstreamDeferred = async(Dispatchers.IO) {
+            serviceEdges(organizationId, serviceName, incoming = false, query, parentSpan)
+        }
+        val traces = tracesDeferred.await()
+        val spans = traces.firstOrNull()?.traceId
+            ?.let { traceId -> exemplarSpans(organizationId, traceId, parentSpan) }
+            .orEmpty()
+        val downstream = downstreamDeferred.await()
+        val exemplar = exemplar(resource, traces.firstOrNull(), spans)
+        val deployments = deploymentDeferred.await()
+
+        ApmResourceDetail(
+            serviceName = aggregate.name,
+            method = resource.method,
+            path = resource.name,
+            status = resource.status,
+            kind = resourceKind(resource.method),
+            topDependency = downstream.firstOrNull()?.name ?: aggregate.name,
+            kpis = resourceKpis(resource, previousDeferred.await(), query.timeRange),
+            latency = latencyDeferred.await().withFallback(resource),
+            latencyThresholdMs = latencyThreshold(resource.p95Ms),
+            latencyThresholdLabel = "p95 > ${formatMs(latencyThreshold(resource.p95Ms))}",
+            deployAt = deployments.deployAt,
+            throughput = throughputDeferred.await().withFallback(resource.rps),
+            distribution = distributionDeferred.await(),
+            distMarkers = latencyMarkers(resource),
+            distAxis = latencyAxis(resource),
+            whereTimeSpent = whereTimeSpent(resource, spans),
+            whereInsight = whereInsight(resource, downstream.firstOrNull()),
+            exemplar = exemplar,
+            slowTraces = traces,
+            errors = errorsDeferred.await(),
+        )
+    }
+
+    private suspend fun serviceAggregates(
+        organizationId: Int,
+        serviceName: String?,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ServiceAggregate> {
+        val sql = serviceAggregateSql(organizationId, serviceName, query)
+        val rows = jsonRows(sql, parentSpan)
+        if (rows.isEmpty()) return emptyList()
+        return rows.map { row ->
+            ServiceAggregate(
+                name = row.stringValue("name"),
+                type = inferServiceType(row.stringValue("name"), row.stringValue("type")),
+                envs = row.stringList("envs"),
+                sources = row.stringList("sources"),
+                spanCount = row.longValue("span_count"),
+                errorCount = row.longValue("error_count"),
+                p50Ms = nanosToMillis(row.longValue("p50_ns")),
+                p95Ms = nanosToMillis(row.longValue("p95_ns")),
+                p99Ms = nanosToMillis(row.longValue("p99_ns")),
+                version = row.stringValue("version").ifBlank { UNKNOWN_VERSION },
+                lastSeen = row.stringValue("last_seen"),
+                apdexSatisfied = row.longValue("apdex_satisfied"),
+                apdexTolerating = row.longValue("apdex_tolerating"),
+                team = row.stringValue("team"),
+                language = row.stringValue("language"),
+            )
+        }
+    }
+
+    private fun serviceAggregateSql(
+        organizationId: Int,
+        serviceName: String?,
+        query: ApmServiceQuery,
+    ): String {
+        val filters = spanFilters(organizationId, query, serviceName, null)
+        val limit = query.limit.coerceIn(1, MAX_SERVICE_LIMIT)
+        val apdexTargetNs = APDEX_TARGET_MS * NANOSECONDS_PER_MILLISECOND
+        val limitClause = if (serviceName == null) {
+            "LIMIT $limit OFFSET ${query.offset.coerceAtLeast(0)}"
+        } else {
+            "LIMIT $EXACT_SERVICE_LIMIT"
+        }
+        return """
+            SELECT
+                service as name,
+                count() as span_count,
+                sum(error) as error_count,
+                toUInt64(quantile(0.50)(duration)) as p50_ns,
+                toUInt64(quantile(0.95)(duration)) as p95_ns,
+                toUInt64(quantile(0.99)(duration)) as p99_ns,
+                countIf(error = 0 AND duration <= $apdexTargetNs) as apdex_satisfied,
+                countIf(
+                    error = 0 AND duration > $apdexTargetNs
+                    AND duration <= ${apdexTargetNs * APDEX_TOLERATING_MULTIPLIER}
+                ) as apdex_tolerating,
+                groupUniqArray(8)(env) as envs,
+                groupUniqArray(8)(source) as sources,
+                argMax(version, start) as version,
+                formatDateTime(max(start), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as last_seen,
+                argMax(type, start) as type,
+                coalesce(
+                    nullIf(argMaxIf(meta['team'], start, meta['team'] != ''), ''),
+                    nullIf(argMaxIf(resource_attributes['team'], start, resource_attributes['team'] != ''), ''),
+                    nullIf(
+                        argMaxIf(resource_attributes['service.team'], start, resource_attributes['service.team'] != ''),
+                        ''
+                    ),
+                    ''
+                ) as team,
+                coalesce(
+                    nullIf(
+                        argMaxIf(
+                            resource_attributes['telemetry.sdk.language'],
+                            start,
+                            resource_attributes['telemetry.sdk.language'] != ''
+                        ),
+                        ''
+                    ),
+                    nullIf(argMaxIf(meta['language'], start, meta['language'] != ''), ''),
+                    nullIf(
+                        argMaxIf(resource_attributes['process.runtime.name'], start, resource_attributes['process.runtime.name'] != ''),
+                        ''
+                    ),
+                    ''
+                ) as language
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY service
+            ORDER BY error_count DESC, p95_ns DESC, span_count DESC
+            $limitClause
+            FORMAT JSONEachRow
+        """.trimIndent()
+    }
+
+    private suspend fun serviceSparklineSeries(
+        organizationId: Int,
+        services: List<String>,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): Map<String, List<Int>> {
+        if (services.isEmpty()) return emptyMap()
+        val filters = spanFilters(organizationId, query, null, null)
+        val serviceList = services.joinToString(", ") { service -> "'${escapeSql(service)}'" }
+        filters.add("service IN ($serviceList)")
+        val bucketSeconds = (query.timeRange.seconds() / DEFAULT_SERIES_POINT_COUNT).coerceAtLeast(1)
+        val sql = """
+            SELECT
+                service,
+                toStartOfInterval(start, INTERVAL $bucketSeconds SECOND) as bucket_start,
+                count() as span_count
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY service, bucket_start
+            ORDER BY service ASC, bucket_start ASC
+            LIMIT ${services.size * DEFAULT_SERIES_POINT_COUNT}
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan)
+            .groupBy { row -> row.stringValue("service") }
+            .mapValues { (_, rows) ->
+                rows.map { row -> row.longValue("span_count").toInt().coerceIn(SPARK_MIN, SPARK_MAX) }
+            }
+    }
+
+    private suspend fun resourceRows(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmResourceRow> {
+        val resources = resourceAggregates(organizationId, serviceName, query, parentSpan)
+        val totalSpanCount = resources.sumOf { resource -> resource.spanCount }.coerceAtLeast(1)
+        return resources.map { resource ->
+            val errorRate = ratio(resource.errorCount, resource.spanCount)
+            val method = resource.method()
+            val displayName = resource.displayName()
+            ApmResourceRow(
+                slug = resourceSlug(method, displayName),
+                method = method,
+                name = displayName,
+                rps = requestsPerSecond(resource.spanCount, query.timeRange),
+                p50Ms = resource.p50Ms,
+                p95Ms = resource.p95Ms,
+                p99Ms = resource.p99Ms,
+                errorRateLabel = formatPercent(errorRate),
+                errorBarPct = errorBarPct(errorRate),
+                errorLevel = severity(errorRate, resource.p95Ms),
+                timePct = ((resource.spanCount.toDouble() / totalSpanCount.toDouble()) * PERCENT_SCALE).toInt(),
+                status = status(errorRate, resource.p95Ms),
+            )
+        }
+    }
+
+    private suspend fun resourceAggregates(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ResourceAggregate> {
+        val sql = resourceAggregateSql(organizationId, serviceName, query)
+        return jsonRows(sql, parentSpan).map { row ->
+            ResourceAggregate(
+                resource = row.stringValue("resource").ifBlank { row.stringValue("name") },
+                name = row.stringValue("name"),
+                type = row.stringValue("type"),
+                spanCount = row.longValue("span_count"),
+                errorCount = row.longValue("error_count"),
+                p50Ms = nanosToMillis(row.longValue("p50_ns")),
+                p95Ms = nanosToMillis(row.longValue("p95_ns")),
+                p99Ms = nanosToMillis(row.longValue("p99_ns")),
+            )
+        }
+    }
+
+    private fun resourceAggregateSql(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery,
+    ): String {
+        val filters = spanFilters(organizationId, query, serviceName, null)
+        return """
+            SELECT
+                resource,
+                argMax(name, start) as name,
+                argMax(type, start) as type,
+                count() as span_count,
+                sum(error) as error_count,
+                toUInt64(quantile(0.50)(duration)) as p50_ns,
+                toUInt64(quantile(0.95)(duration)) as p95_ns,
+                toUInt64(quantile(0.99)(duration)) as p99_ns
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+              AND resource != ''
+            GROUP BY resource
+            ORDER BY error_count DESC, p95_ns DESC, span_count DESC
+            LIMIT 50
+            FORMAT JSONEachRow
+        """.trimIndent()
+    }
+
+    private suspend fun latencySeries(
+        organizationId: Int,
+        serviceName: String,
+        resource: String?,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmLatencyPoint> {
+        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val sql = """
+            SELECT
+                toStartOfHour(start) as bucket_start,
+                formatDateTime(bucket_start, '%H:%i') as t,
+                toUInt64(quantile(0.50)(duration)) as p50_ns,
+                toUInt64(quantile(0.90)(duration)) as p90_ns,
+                toUInt64(quantile(0.95)(duration)) as p95_ns,
+                toUInt64(quantile(0.99)(duration)) as p99_ns
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY bucket_start
+            ORDER BY bucket_start ASC
+            LIMIT 48
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            ApmLatencyPoint(
+                t = row.stringValue("t"),
+                p50 = row.millisValue("p50", "p50_ns"),
+                p90 = row.millisValue("p90", "p90_ns"),
+                p95 = row.millisValue("p95", "p95_ns"),
+                p99 = row.millisValue("p99", "p99_ns"),
+            )
+        }
+    }
+
+    private suspend fun throughputSeries(
+        organizationId: Int,
+        serviceName: String,
+        resource: String?,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmThroughputPoint> {
+        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val sql = """
+            SELECT
+                toStartOfHour(start) as bucket_start,
+                formatDateTime(bucket_start, '%H:%i') as t,
+                count() / $SECONDS_PER_HOUR as rps,
+                sum(error) / $SECONDS_PER_HOUR as errors
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY bucket_start
+            ORDER BY bucket_start ASC
+            LIMIT 48
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            ApmThroughputPoint(
+                t = row.stringValue("t"),
+                rps = row.doubleValue("rps"),
+                errors = row.doubleValue("errors"),
+            )
+        }
+    }
+
+    private suspend fun previousServiceAggregate(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): PreviousWindowAggregate? =
+        previousWindowAggregate(organizationId, serviceName, null, query, parentSpan)
+
+    private suspend fun previousResourceAggregate(
+        organizationId: Int,
+        serviceName: String,
+        resource: String,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): PreviousWindowAggregate? =
+        previousWindowAggregate(organizationId, serviceName, resource, query, parentSpan)
+
+    private suspend fun previousWindowAggregate(
+        organizationId: Int,
+        serviceName: String,
+        resource: String?,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): PreviousWindowAggregate? {
+        val filters = previousSpanFilters(organizationId, query, serviceName, resource)
+        val apdexTargetNs = APDEX_TARGET_MS * NANOSECONDS_PER_MILLISECOND
+        val sql = """
+            SELECT
+                count() as previous_span_count,
+                sum(error) as previous_error_count,
+                toUInt64(quantile(0.95)(duration)) as previous_p95_ns,
+                toUInt64(quantile(0.99)(duration)) as previous_p99_ns,
+                countIf(error = 0 AND duration <= $apdexTargetNs) as previous_apdex_satisfied,
+                countIf(
+                    error = 0 AND duration > $apdexTargetNs
+                    AND duration <= ${apdexTargetNs * APDEX_TOLERATING_MULTIPLIER}
+                ) as previous_apdex_tolerating
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).firstOrNull()?.let { row ->
+            PreviousWindowAggregate(
+                spanCount = row.longValue("previous_span_count"),
+                errorCount = row.longValue("previous_error_count"),
+                p95Ms = nanosToMillis(row.longValue("previous_p95_ns")),
+                p99Ms = nanosToMillis(row.longValue("previous_p99_ns")),
+                apdexSatisfied = row.longValue("previous_apdex_satisfied"),
+                apdexTolerating = row.longValue("previous_apdex_tolerating"),
+            )
+        }
+    }
+
+    private suspend fun deploymentSeries(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): DeploymentSeries {
+        val deployments = deploymentAggregates(organizationId, serviceName, query, parentSpan)
+        if (deployments.isEmpty()) return DeploymentSeries(emptyList(), DEFAULT_DEPLOY_AT)
+        return DeploymentSeries(
+            rows = deployments.mapIndexed { index, deployment ->
+                deployment.toRow(query.timeRange, current = index == 0)
+            },
+            deployAt = deployments.first().marker,
+        )
+    }
+
+    private suspend fun deploymentAggregates(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<DeploymentAggregate> {
+        val filters = spanFilters(organizationId, query, serviceName, null)
+        filters.add("version != ''")
+        val sql = """
+            SELECT
+                version,
+                formatDateTime(min(start), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as first_seen,
+                formatDateTime(max(start), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as last_seen,
+                formatDateTime(toStartOfHour(min(start)), '%H:%i') as deploy_t,
+                count() as span_count,
+                sum(error) as error_count,
+                toUInt64(quantile(0.95)(duration)) as p95_ns,
+                coalesce(
+                    nullIf(argMaxIf(meta['deployment.user'], start, meta['deployment.user'] != ''), ''),
+                    nullIf(argMaxIf(meta['git.commit.author.name'], start, meta['git.commit.author.name'] != ''), ''),
+                    nullIf(argMaxIf(resource_attributes['deployment.user'], start, resource_attributes['deployment.user'] != ''), ''),
+                    ''
+                ) as deployer
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY version
+            ORDER BY max(start) DESC
+            LIMIT $DEPLOYMENT_ROW_LIMIT
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            DeploymentAggregate(
+                version = row.stringValue("version"),
+                firstSeen = row.stringValue("first_seen"),
+                lastSeen = row.stringValue("last_seen"),
+                marker = row.stringValue("deploy_t"),
+                spanCount = row.longValue("span_count"),
+                errorCount = row.longValue("error_count"),
+                p95Ms = nanosToMillis(row.longValue("p95_ns")),
+                deployer = row.stringValue("deployer"),
+            )
+        }
+    }
+
+    private suspend fun containerRows(
+        organizationId: Int,
+        serviceName: String,
+        parentSpan: ISpan?,
+    ): List<ContainerAggregate> {
+        val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val service = escapeSql(serviceName)
+        val sql = """
+            SELECT
+                argMax(name, timestamp) as pod,
+                argMax(host, timestamp) as node,
+                toInt32(round(argMax(cpu_percent, timestamp))) as cpu,
+                argMax(mem_usage, timestamp) as mem_usage,
+                argMax(mem_limit, timestamp) as mem_limit,
+                toInt32OrZero(argMax(tags['restart_count'], timestamp)) as restarts,
+                argMax(state, timestamp) as state
+            FROM `$clickhouseDb`.containers_latest_by_host
+            WHERE $orgClause
+              AND timestamp >= now64(3) - INTERVAL 30 DAY
+              AND (
+                  tags['service'] = '$service'
+                  OR positionCaseInsensitive(name, '$service') > 0
+                  OR positionCaseInsensitive(image, '$service') > 0
+              )
+            GROUP BY host, container_id
+            ORDER BY pod ASC
+            LIMIT $CONTAINER_ROW_LIMIT
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            ContainerAggregate(
+                pod = row.stringValue("pod"),
+                node = row.stringValue("node"),
+                cpu = row.longValue("cpu").toInt().coerceIn(PERCENT_MIN, PERCENT_MAX),
+                memUsage = row.longValue("mem_usage"),
+                memLimit = row.longValue("mem_limit"),
+                restarts = row.longValue("restarts").toInt().coerceAtLeast(0),
+                state = row.stringValue("state").ifBlank { "unknown" },
+            )
+        }
+    }
+
+    private suspend fun latencyDistribution(
+        organizationId: Int,
+        serviceName: String,
+        resource: String,
+        maxDurationMs: Long,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmDistBar> {
+        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val bucketSizeNs = (
+            (maxDurationMs.coerceAtLeast(1) * NANOSECONDS_PER_MILLISECOND) / LATENCY_DISTRIBUTION_BAR_COUNT
+            ).coerceAtLeast(1)
+        val sql = """
+            SELECT
+                least(intDiv(duration, $bucketSizeNs), ${LATENCY_DISTRIBUTION_BAR_COUNT - 1}) as bucket_idx,
+                count() as span_count
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY bucket_idx
+            ORDER BY bucket_idx ASC
+            FORMAT JSONEachRow
+        """.trimIndent()
+        val counts = jsonRows(sql, parentSpan).associate { row ->
+            row.longValue("bucket_idx").toInt() to row.longValue("span_count")
+        }
+        return latencyDistribution(counts)
+    }
+
+    private suspend fun dependencyRows(
+        organizationId: Int,
+        serviceName: String,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): Pair<List<ApmDependencyRow>, List<ApmDependencyRow>> {
+        val upstream = serviceEdges(organizationId, serviceName, incoming = true, query, parentSpan)
+        val downstream = serviceEdges(organizationId, serviceName, incoming = false, query, parentSpan)
+        return upstream to downstream
+    }
+
+    private suspend fun serviceEdges(
+        organizationId: Int,
+        serviceName: String,
+        incoming: Boolean,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmDependencyRow> {
+        val serviceColumn = if (incoming) "to_service" else "from_service"
+        val peerColumn = if (incoming) "from_service" else "to_service"
+        val filters = mutableListOf(
+            ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
+            query.timeRange.bucketStartClause(),
+            "$serviceColumn = '${escapeSql(serviceName)}'",
+        )
+        query.env?.let { env -> filters.add("env = '${escapeSql(env)}'") }
+        query.source?.let { source -> filters.add("source = '${escapeSql(source)}'") }
+        val sql = """
+            SELECT
+                $peerColumn as peer_service,
+                sum(call_count) as call_count,
+                sum(error_count) as error_count,
+                if(sum(duration_count) = 0, 0, sum(duration_sum) / sum(duration_count)) as avg_duration_ns
+            FROM `$clickhouseDb`.apm_service_edges_hourly
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY peer_service
+            ORDER BY call_count DESC
+            LIMIT 10
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            val errorRate = ratio(row.longValue("error_count"), row.longValue("call_count"))
+            ApmDependencyRow(
+                name = row.stringValue("peer_service"),
+                type = inferServiceType(row.stringValue("peer_service"), ""),
+                tone = statusTone(status(errorRate, nanosToMillis(row.longValue("avg_duration_ns")))),
+                rps = formatCompact(requestsPerSecond(row.longValue("call_count"), query.timeRange)),
+                p95 = formatMs(nanosToMillis(row.longValue("avg_duration_ns"))),
+                err = formatPercent(errorRate),
+                errWarn = errorRate >= WARN_ERROR_RATE,
+            )
+        }
+    }
+
+    private suspend fun traceRows(
+        organizationId: Int,
+        serviceName: String,
+        resource: String?,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmTraceRow> {
+        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val sql = """
+            SELECT
+                if(trace_id_hex != '', trace_id_hex, toString(trace_id)) as trace_id_out,
+                argMax(resource, duration) as resource,
+                argMax(name, duration) as name,
+                max(status_code) as http_status,
+                toUInt64(max(duration) / $NANOSECONDS_PER_MILLISECOND) as duration_ms,
+                count() as span_count,
+                formatDateTime(max(start), '%H:%i:%S') as time
+            FROM `$clickhouseDb`.apm_spans
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY trace_id_out
+            ORDER BY duration_ms DESC
+            LIMIT 20
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            ApmTraceRow(
+                time = row.stringValue("time"),
+                traceId = row.stringValue("trace_id_out"),
+                resource = row.stringValue("resource"),
+                method = methodFromResource(row.stringValue("resource")),
+                httpStatus = row.longValue("http_status").toInt().takeIf { it > 0 } ?: 0,
+                durationMs = row.longValue("duration_ms"),
+                spans = row.longValue("span_count").toInt(),
+                bucket = durationBucket(row.longValue("duration_ms")),
+            )
+        }
+    }
+
+    private suspend fun errorRows(
+        organizationId: Int,
+        serviceName: String,
+        resource: String?,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmErrorRow> {
+        val filters = spanFilters(organizationId, query, serviceName, resource)
+        filters.add("error = 1")
+        val sql = """
+            SELECT
+                resource,
+                error_type,
+                error_message,
+                count() as error_count,
+                uniqExactIf(user_key, user_key != '') as user_count,
+                max(status_code) as status_code,
+                max(unhandled_flag) as unhandled,
+                argMax(version, start) as version,
+                formatDateTime(min(start), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as first_seen,
+                formatDateTime(max(start), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as last_seen
+            FROM (
+                SELECT
+                    resource,
+                    start,
+                    version,
+                    status_code,
+                    multiIf(
+                        meta['error.type'] != '', meta['error.type'],
+                        meta['exception.type'] != '', meta['exception.type'],
+                        status_message != '', status_message,
+                        status_code >= $HTTP_SERVER_ERROR_STATUS, concat('HTTP ', toString(status_code)),
+                        'Trace error'
+                    ) as error_type,
+                    multiIf(
+                        meta['error.msg'] != '', meta['error.msg'],
+                        meta['exception.message'] != '', meta['exception.message'],
+                        status_message != '', status_message,
+                        'Trace contains errored spans'
+                    ) as error_message,
+                    multiIf(
+                        meta['user.id'] != '', meta['user.id'],
+                        meta['user.email'] != '', meta['user.email'],
+                        meta['user.ip_address'] != '', meta['user.ip_address'],
+                        ''
+                    ) as user_key,
+                    if(
+                        meta['handled'] = 'false'
+                        OR meta['error.handled'] = 'false'
+                        OR meta['exception.escaped'] = 'true',
+                        1,
+                        0
+                    ) as unhandled_flag
+                FROM `$clickhouseDb`.apm_spans
+                WHERE ${filters.joinToString(" AND ")}
+            )
+            GROUP BY resource, error_type, error_message
+            ORDER BY error_count DESC, last_seen DESC
+            LIMIT 20
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            val errorType = row.stringValue("error_type").ifBlank { "Trace error" }
+            val message = row.stringValue("error_message").ifBlank { "Trace contains errored spans" }
+            val version = row.stringValue("version")
+            val firstSeen = row.stringValue("first_seen")
+            ApmErrorRow(
+                severity = errorSeverity(errorType, message, row.longValue("status_code").toInt()),
+                title = "$errorType: $message",
+                sub = row.stringValue("resource"),
+                chips = listOf(row.stringValue("resource"), version, firstSeen)
+                    .filter { chip -> chip.isNotBlank() },
+                events = row.longValue("error_count").toString(),
+                users = row.longValue("user_count").takeIf { count -> count > 0 }?.toString(),
+                unhandled = row.longValue("unhandled") > 0,
+            )
+        }
+    }
+
+    private suspend fun errorRowsFromRollup(
+        organizationId: Int,
+        serviceName: String,
+        resource: String?,
+        query: ApmServiceQuery,
+        parentSpan: ISpan?,
+    ): List<ApmErrorRow> {
+        val filters = mutableListOf(
+            ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
+            query.timeRange.bucketStartClause(),
+            "service = '${escapeSql(serviceName)}'",
+        )
+        resource?.let { resourceName -> filters.add("resource = '${escapeSql(resourceName)}'") }
+        val sql = """
+            SELECT
+                resource,
+                error_message,
+                error_type,
+                sumMerge(error_count_state) as error_count,
+                toString(maxMerge(last_seen_state)) as last_seen
+            FROM `$clickhouseDb`.apm_error_groups_hourly
+            WHERE ${filters.joinToString(" AND ")}
+            GROUP BY resource, error_message, error_type
+            ORDER BY error_count DESC, last_seen DESC
+            LIMIT 20
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            val errorType = row.stringValue("error_type").ifBlank { "Trace error" }
+            val message = row.stringValue("error_message").ifBlank { "Trace contains errored spans" }
+            ApmErrorRow(
+                severity = "error",
+                title = "$errorType: $message",
+                sub = row.stringValue("resource"),
+                chips = listOf(row.stringValue("last_seen")).filter { chip -> chip.isNotBlank() },
+                events = row.longValue("error_count").toString(),
+            )
+        }
+    }
+
+    private suspend fun exemplarSpans(
+        organizationId: Int,
+        traceId: String,
+        parentSpan: ISpan?,
+    ): List<SpanAggregate> {
+        val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val escapedTraceId = escapeSql(traceId)
+        val sql = """
+            SELECT
+                if(span_id_hex != '', span_id_hex, toString(span_id)) as span_id_out,
+                if(parent_id_hex != '', parent_id_hex, toString(parent_id)) as parent_id_out,
+                name,
+                service,
+                resource,
+                type,
+                toInt64(toUnixTimestamp64Nano(start)) as start_ns,
+                toUInt64(duration / $NANOSECONDS_PER_MILLISECOND) as duration_ms,
+                error,
+                status_code
+            FROM `$clickhouseDb`.apm_spans
+            WHERE $orgClause
+              AND (trace_id_hex = '$escapedTraceId' OR toString(trace_id) = '$escapedTraceId')
+            ORDER BY start_ns ASC
+            LIMIT 200
+            FORMAT JSONEachRow
+        """.trimIndent()
+        return jsonRows(sql, parentSpan).map { row ->
+            SpanAggregate(
+                spanId = row.stringValue("span_id_out"),
+                parentId = row.stringValue("parent_id_out").takeUnless { it == "0" } ?: ROOT_PARENT_ID,
+                name = row.stringValue("name"),
+                service = row.stringValue("service"),
+                resource = row.stringValue("resource"),
+                type = row.stringValue("type"),
+                startNs = row.longValue("start_ns"),
+                durationMs = row.longValue("duration_ms"),
+                error = row.longValue("error") > 0,
+                statusCode = row.longValue("status_code").toInt(),
+            )
+        }
+    }
+
+    private fun spanFilters(
+        organizationId: Int,
+        query: ApmServiceQuery,
+        serviceName: String?,
+        resource: String?,
+    ): MutableList<String> {
+        return spanFiltersForTimeClause(organizationId, query, serviceName, resource, query.timeRange.startClause())
+    }
+
+    private fun previousSpanFilters(
+        organizationId: Int,
+        query: ApmServiceQuery,
+        serviceName: String?,
+        resource: String?,
+    ): MutableList<String> {
+        return spanFiltersForTimeClause(
+            organizationId,
+            query,
+            serviceName,
+            resource,
+            query.timeRange.previousStartClause(),
+        )
+    }
+
+    private fun spanFiltersForTimeClause(
+        organizationId: Int,
+        query: ApmServiceQuery,
+        serviceName: String?,
+        resource: String?,
+        timeClause: String,
+    ): MutableList<String> {
+        val filters = mutableListOf(
+            ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
+            timeClause,
+            "service != ''",
+        )
+        serviceName?.let { service -> filters.add("service = '${escapeSql(service)}'") }
+        resource?.let { resourceName -> filters.add("resource = '${escapeSql(resourceName)}'") }
+        query.env?.let { env -> filters.add("env = '${escapeSql(env)}'") }
+        query.source?.let { source -> filters.add("source = '${escapeSql(source)}'") }
+        query.search?.let { search -> filters.add(searchClause(search)) }
+        return filters
+    }
+
+    private fun searchClause(search: String): String {
+        val escapedSearch = escapeSql(search)
+        return """
+            (
+                positionCaseInsensitive(service, '$escapedSearch') > 0 OR
+                positionCaseInsensitive(resource, '$escapedSearch') > 0 OR
+                positionCaseInsensitive(name, '$escapedSearch') > 0
+            )
+        """.trimIndent()
+    }
+
+    private suspend fun jsonRows(query: String, parentSpan: ISpan?): List<JsonObject> {
+        val result = if (parentSpan == null) {
+            ClickHouseClient.executeWithFormat(query, "")
+        } else {
+            ClickHouseClient.executeWithFormat(query, "", parentSpan)
+        }
+        return result.lines()
+            .filter { line -> line.isNotBlank() }
+            .mapNotNull { line -> parseRowOrNull(line) }
+    }
+
+    private fun parseRowOrNull(line: String): JsonObject? =
+        runCatching { json.parseToJsonElement(line) }.getOrNull() as? JsonObject
+}
+
+private fun ServiceAggregate.toCatalogRow(
+    timeRange: DdApmQueryTimeRange,
+    sparkline: List<Int>? = null,
+): ApmServiceCatalogRow {
+    val errorRate = ratio(errorCount, spanCount)
+    val serviceStatus = status(errorRate, p95Ms)
+    val apdex = apdexScore(apdexSatisfied, apdexTolerating, spanCount)
+    return ApmServiceCatalogRow(
+        name = name,
+        type = type,
+        status = serviceStatus,
+        env = envPills(envs),
+        rps = requestsPerSecond(spanCount, timeRange),
+        spark = sparkline.orEmpty(),
+        p95Ms = p95Ms,
+        p99Ms = p99Ms,
+        errorRateLabel = formatPercent(errorRate),
+        errorBarPct = errorBarPct(errorRate),
+        errorLevel = severity(errorRate, p95Ms),
+        apdex = formatApdex(apdex),
+        apdexTone = apdexTone(apdex),
+        lastDeploy = version.takeUnless { it == UNKNOWN_VERSION } ?: lastDeployLabel(),
+        team = team.ifBlank { UNASSIGNED_TEAM },
+        language = language.takeIf { value -> value.isNotBlank() },
+        sources = sources.map(::sourceLabel).distinct(),
+    )
+}
+
+private fun serviceKpis(
+    service: ApmServiceCatalogRow,
+    previous: PreviousWindowAggregate?,
+    timeRange: DdApmQueryTimeRange,
+): List<ApmKpiSpec> =
+    listOf(
+        ApmKpiSpec(
+            "Requests / sec",
+            formatCompact(service.rps),
+            delta = previous?.let { prev ->
+                metricDelta(service.rps, requestsPerSecond(prev.spanCount, timeRange), lowerIsBetter = false)
+            },
+        ),
+        ApmKpiSpec(
+            "p95 latency",
+            formatMs(service.p95Ms),
+            valueTone = latencyTone(service.p95Ms),
+            delta = previous?.let { prev -> metricDelta(service.p95Ms.toDouble(), prev.p95Ms.toDouble()) },
+        ),
+        ApmKpiSpec(
+            "Error rate",
+            service.errorRateLabel,
+            valueTone = errorTone(service.errorLevel),
+            delta = previous?.let { prev ->
+                metricDelta(
+                    ratioLabelToDouble(service.errorRateLabel),
+                    ratio(prev.errorCount, prev.spanCount),
+                )
+            },
+        ),
+        ApmKpiSpec(
+            "Apdex",
+            service.apdex,
+            valueTone = service.apdexTone,
+            delta = previous?.let { prev ->
+                metricDelta(
+                    service.apdex.toDoubleOrNull() ?: 0.0,
+                    apdexScore(prev.apdexSatisfied, prev.apdexTolerating, prev.spanCount),
+                    lowerIsBetter = false,
+                )
+            },
+        ),
+    )
+
+private fun resourceKpis(
+    resource: ApmResourceRow,
+    previous: PreviousWindowAggregate?,
+    timeRange: DdApmQueryTimeRange,
+): List<ApmKpiSpec> =
+    listOf(
+        ApmKpiSpec(
+            "Requests / sec",
+            formatCompact(resource.rps),
+            delta = previous?.let { prev ->
+                metricDelta(resource.rps, requestsPerSecond(prev.spanCount, timeRange), lowerIsBetter = false)
+            },
+        ),
+        ApmKpiSpec(
+            "p95 latency",
+            formatMs(resource.p95Ms),
+            valueTone = latencyTone(resource.p95Ms),
+            delta = previous?.let { prev -> metricDelta(resource.p95Ms.toDouble(), prev.p95Ms.toDouble()) },
+        ),
+        ApmKpiSpec(
+            "Error rate",
+            resource.errorRateLabel,
+            valueTone = errorTone(resource.errorLevel),
+            delta = previous?.let { prev ->
+                metricDelta(ratioLabelToDouble(resource.errorRateLabel), ratio(prev.errorCount, prev.spanCount))
+            },
+        ),
+        ApmKpiSpec(
+            "p99 latency",
+            formatMs(resource.p99Ms),
+            delta = previous?.let { prev -> metricDelta(resource.p99Ms.toDouble(), prev.p99Ms.toDouble()) },
+        ),
+    )
+
+private fun catalogSummary(services: List<ApmServiceCatalogRow>): ApmCatalogSummary =
+    ApmCatalogSummary(
+        total = services.size,
+        alerting = services.count { service -> service.status == "alerting" },
+        degraded = services.count { service -> service.status == "degraded" },
+    )
+
+private fun p95ByResource(resources: List<ApmResourceRow>): List<ApmGaugeRow> {
+    val maxP95 = resources.maxOfOrNull { resource -> resource.p95Ms }?.coerceAtLeast(1) ?: 1
+    return resources.take(TOP_RESOURCE_LIMIT).map { resource ->
+        ApmGaugeRow(
+            label = "${resource.method} ${resource.name}",
+            valueText = formatMs(resource.p95Ms),
+            pct = ((resource.p95Ms.toDouble() / maxP95.toDouble()) * PERCENT_SCALE)
+                .toInt()
+                .coerceIn(GAUGE_MIN_PCT, PERCENT_MAX),
+            level = severity(0.0, resource.p95Ms),
+        )
+    }
+}
+
+private fun DeploymentAggregate.toRow(timeRange: DdApmQueryTimeRange, current: Boolean): ApmDeploymentRow {
+    val errorRate = ratio(errorCount, spanCount)
+    val serviceStatus = status(errorRate, p95Ms)
+    return ApmDeploymentRow(
+        version = version,
+        `when` = firstSeen.ifBlank { lastSeen },
+        initials = initials(deployer),
+        rps = formatCompact(requestsPerSecond(spanCount, timeRange)),
+        errorRate = formatPercent(errorRate),
+        p95 = formatMs(p95Ms),
+        status = if (current) serviceStatus else "retired",
+        current = current,
+        trendBad = serviceStatus != "healthy",
+    )
+}
+
+private fun dependencyInsight(downstream: List<ApmDependencyRow>): String =
+    downstream.firstOrNull()
+        ?.let { dependency -> "${dependency.name} is the busiest downstream dependency in this window." }
+        ?: "No downstream dependencies were observed in this window."
+
+private fun whereTimeSpent(
+    resource: ApmResourceRow,
+    spans: List<SpanAggregate>,
+): List<ApmGaugeRow> {
+    if (spans.isEmpty()) {
+        return listOf(
+            ApmGaugeRow(
+                label = "${resource.method} ${resource.name}",
+                valueText = formatMs(resource.p95Ms),
+                pct = 100,
+                level = severity(0.0, resource.p95Ms),
+            )
+        )
+    }
+    val maxDuration = spans.maxOf { span -> span.durationMs }.coerceAtLeast(1)
+    return spans.sortedByDescending { span -> span.durationMs }.take(TOP_RESOURCE_LIMIT).map { span ->
+        ApmGaugeRow(
+            label = span.resource.ifBlank { span.name },
+            valueText = formatMs(span.durationMs),
+            pct = ((span.durationMs.toDouble() / maxDuration.toDouble()) * PERCENT_SCALE)
+                .toInt()
+                .coerceIn(GAUGE_MIN_PCT, PERCENT_MAX),
+            level = severity(if (span.error) ALERT_ERROR_RATE else 0.0, span.durationMs),
+        )
+    }
+}
+
+private fun whereInsight(resource: ApmResourceRow, dependency: ApmDependencyRow?): String =
+    dependency
+        ?.let { dep -> "${dep.name} contributes to the slow path for ${resource.method} ${resource.name}." }
+        ?: "${resource.method} ${resource.name} spent most observed time inside its own service spans."
+
+private fun exemplar(
+    resource: ApmResourceRow,
+    trace: ApmTraceRow?,
+    spans: List<SpanAggregate>,
+): ApmResourceExemplar {
+    val traceId = trace?.traceId ?: ""
+    val durationMs = trace?.durationMs ?: resource.p99Ms
+    return ApmResourceExemplar(
+        traceId = traceId,
+        httpStatus = trace?.httpStatus ?: 0,
+        durationLabel = formatMs(durationMs),
+        rows = waterfallRows(resource, durationMs, spans),
+    )
+}
+
+private fun waterfallRows(
+    resource: ApmResourceRow,
+    durationMs: Long,
+    spans: List<SpanAggregate>,
+): List<ApmWaterfallRow> {
+    if (spans.isEmpty()) {
+        return listOf(
+            ApmWaterfallRow(
+                op = resource.method,
+                desc = resource.name,
+                left = PERCENT_MIN,
+                width = PERCENT_MAX,
+                label = formatMs(durationMs),
+                tone = "root",
+                selected = true,
+            )
+        )
+    }
+    val start = spans.minOf { span -> span.startNs }
+    val end = spans.maxOf { span -> span.startNs + span.durationMs * NANOSECONDS_PER_MILLISECOND }
+    val total = (end - start).coerceAtLeast(1)
+    return spans.take(WATERFALL_ROW_LIMIT).mapIndexed { index, span ->
+        ApmWaterfallRow(
+            op = span.name.ifBlank { span.type.ifBlank { "span" } },
+            desc = span.resource.ifBlank { span.service },
+            left = (((span.startNs - start).toDouble() / total.toDouble()) * PERCENT_SCALE)
+                .toInt()
+                .coerceIn(PERCENT_MIN, PERCENT_MAX),
+            width = ((span.durationMs * NANOSECONDS_PER_MILLISECOND).toDouble() / total.toDouble() * PERCENT_SCALE)
+                .toInt()
+                .coerceIn(WATERFALL_MIN_WIDTH, PERCENT_MAX),
+            label = formatMs(span.durationMs),
+            tone = waterfallTone(span),
+            indent = if (span.parentId == ROOT_PARENT_ID) null else CHILD_SPAN_INDENT,
+            selected = index == 0,
+        )
+    }
+}
+
+private fun latencyDistribution(counts: Map<Int, Long>): List<ApmDistBar> {
+    val maxCount = counts.values.maxOrNull()?.coerceAtLeast(1) ?: 1
+    return List(LATENCY_DISTRIBUTION_BAR_COUNT) { index ->
+        val count = counts[index] ?: 0
+        val height = if (count == 0L) {
+            LATENCY_DISTRIBUTION_MIN
+        } else {
+            ((count.toDouble() / maxCount.toDouble()) * PERCENT_SCALE)
+                .toInt()
+                .coerceIn(LATENCY_DISTRIBUTION_MIN, PERCENT_MAX)
+        }
+        ApmDistBar(
+            h = height,
+            band = when {
+                index < LATENCY_DISTRIBUTION_GOOD_END -> "good"
+                index < LATENCY_DISTRIBUTION_WARN_END -> "warn"
+                else -> "bad"
+            },
+        )
+    }
+}
+
+private fun latencyMarkers(resource: ApmResourceRow): List<ApmDistMarker> =
+    listOf(
+        ApmDistMarker(label = "p50", left = markerPosition(resource.p50Ms, resource.p99Ms)),
+        ApmDistMarker(label = "p95", left = markerPosition(resource.p95Ms, resource.p99Ms)),
+        ApmDistMarker(label = "p99", left = LATENCY_MARKER_MAX_PCT, p99 = true),
+    )
+
+private fun latencyAxis(resource: ApmResourceRow): List<String> =
+    listOf(
+        "0",
+        formatMs((resource.p95Ms / LATENCY_AXIS_P50_DIVISOR).coerceAtLeast(1)),
+        formatMs(resource.p95Ms),
+        formatMs(
+            ((resource.p95Ms * LATENCY_AXIS_P95_UPPER_NUMERATOR) / LATENCY_AXIS_P95_UPPER_DENOMINATOR)
+                .coerceAtLeast(resource.p95Ms + 1)
+        ),
+        formatMs(resource.p99Ms),
+        "${formatMs(
+            ((resource.p99Ms * LATENCY_AXIS_P99_UPPER_NUMERATOR) / LATENCY_AXIS_P99_UPPER_DENOMINATOR)
+                .coerceAtLeast(resource.p99Ms + 1)
+        )}+",
+    )
+
+private fun markerPosition(valueMs: Long, maxMs: Long): Int =
+    ((valueMs.toDouble() / maxMs.coerceAtLeast(1).toDouble()) * LATENCY_MARKER_MAX_PCT.toDouble())
+        .toInt()
+        .coerceIn(LATENCY_MARKER_MIN_PCT, LATENCY_MARKER_MAX_PCT)
+
+private fun errorBars(
+    throughput: List<ApmThroughputPoint>,
+    aggregate: ServiceAggregate,
+): List<ApmErrorBar> {
+    if (throughput.isEmpty()) {
+        val errorRate = ratio(aggregate.errorCount, aggregate.spanCount)
+        return List(DEFAULT_ERROR_BAR_COUNT) {
+            ApmErrorBar(
+                h = errorBarPct(errorRate).coerceIn(ERROR_BAR_MIN_PCT, ERROR_BAR_MAX_PCT),
+                level = severity(errorRate, aggregate.p95Ms),
+            )
+        }
+    }
+    val maxErrors = throughput.maxOf { point -> point.errors ?: 0.0 }.coerceAtLeast(1.0)
+    return throughput.map { point ->
+        val errors = point.errors ?: 0.0
+        val errorRate = if (point.rps > 0.0) errors / point.rps else 0.0
+        val height = ((errors / maxErrors) * ERROR_BAR_MAX_PCT.toDouble())
+            .toInt()
+            .coerceIn(ERROR_BAR_MIN_PCT, ERROR_BAR_MAX_PCT)
+        ApmErrorBar(h = height, level = if (errorRate >= WARN_ERROR_RATE) "bad" else "warn")
+    }
+}
+
+private fun List<ApmLatencyPoint>.withFallback(aggregate: ServiceAggregate): List<ApmLatencyPoint> =
+    if (isNotEmpty()) {
+        this
+    } else {
+        List(DEFAULT_SERIES_POINT_COUNT) { index ->
+            val label = index.toString().padStart(2, '0') + ":00"
+            ApmLatencyPoint(
+                label,
+                aggregate.p50Ms,
+                (aggregate.p95Ms * FALLBACK_P90_NUMERATOR) / FALLBACK_P90_DENOMINATOR,
+                aggregate.p95Ms,
+                aggregate.p99Ms,
+            )
+        }
+    }
+
+private fun List<ApmLatencyPoint>.withFallback(resource: ApmResourceRow): List<ApmLatencyPoint> =
+    if (isNotEmpty()) {
+        this
+    } else {
+        List(DEFAULT_SERIES_POINT_COUNT) { index ->
+            val label = index.toString().padStart(2, '0') + ":00"
+            ApmLatencyPoint(
+                label,
+                resource.p50Ms,
+                (resource.p95Ms * FALLBACK_P90_NUMERATOR) / FALLBACK_P90_DENOMINATOR,
+                resource.p95Ms,
+                resource.p99Ms,
+            )
+        }
+    }
+
+private fun List<ApmThroughputPoint>.withFallback(rps: Double): List<ApmThroughputPoint> =
+    if (isNotEmpty()) {
+        this
+    } else {
+        List(DEFAULT_SERIES_POINT_COUNT) { index ->
+            ApmThroughputPoint(t = index.toString().padStart(2, '0') + ":00", rps = rps)
+        }
+    }
+
+private fun JsonObject.millisValue(msKey: String, nanosKey: String): Long {
+    val explicitMs = longValue(msKey)
+    return if (explicitMs > 0) explicitMs else nanosToMillis(longValue(nanosKey))
+}
+
+private fun JsonObject.longValue(key: String): Long =
+    this[key]?.jsonPrimitive?.content?.toDoubleOrNull()?.toLong() ?: 0L
+
+private fun JsonObject.doubleValue(key: String): Double =
+    this[key]?.jsonPrimitive?.content?.toDoubleOrNull() ?: 0.0
+
+private fun JsonObject.stringValue(key: String): String =
+    this[key]?.jsonPrimitive?.content ?: ""
+
+private fun JsonObject.stringList(key: String): List<String> {
+    val element = this[key] ?: return emptyList()
+    return if (element is JsonArray) {
+        element.mapNotNull { item -> item.jsonPrimitive.content.takeIf { value -> value.isNotBlank() } }
+    } else {
+        element.jsonPrimitive.content.split(",").map { value -> value.trim() }.filter { value -> value.isNotBlank() }
+    }
+}
+
+private fun ResourceAggregate.method(): String =
+    methodFromResource(resource).ifBlank {
+        name.substringBefore('.').uppercase().takeIf { it.length <= SYNTHETIC_METHOD_MAX_LENGTH } ?: "SPAN"
+    }
+
+private fun ResourceAggregate.displayName(): String {
+    val method = methodFromResource(resource)
+    return if (method.isBlank()) {
+        resource
+    } else {
+        resource.removePrefix(method).trim()
+    }
+}
+
+private fun rawResourceValue(resource: ApmResourceRow): String =
+    if (methodFromResource(resource.name).isBlank() && resource.method != "SPAN") {
+        "${resource.method} ${resource.name}"
+    } else {
+        resource.name
+    }
+
+fun resourceSlug(method: String, name: String): String =
+    "$method-$name"
+        .lowercase()
+        .replace(Regex("[^a-z0-9]+"), "-")
+        .trim('-')
+
+private fun envPills(envs: List<String>): List<ApmEnvPill> {
+    val values = envs.filter { env -> env.isNotBlank() }.ifEmpty { listOf("default") }
+    return values.mapIndexed { index, env ->
+        ApmEnvPill(label = envLabel(env), chart = (index % ENV_CHART_BUCKET_COUNT) + ENV_CHART_START)
+    }
+}
+
+private fun envLabel(env: String): String =
+    when (env.lowercase()) {
+        "production" -> "prod"
+        else -> env
+    }
+
+private fun sourceLabel(source: String): String =
+    when (source.lowercase()) {
+        "otlp", "otel", "opentelemetry" -> "OTLP"
+        "datadog" -> "Datadog Agent"
+        "sentry" -> "Sentry"
+        else -> source.ifBlank { "Telemetry" }
+    }
+
+private fun inferServiceType(serviceName: String, spanType: String): String {
+    val combined = "$serviceName $spanType".lowercase()
+    return when {
+        listOf("postgres", "mysql", "mongo", "db", "sql").any { token -> token in combined } -> "db"
+        listOf("redis", "cache", "memcached").any { token -> token in combined } -> "cache"
+        listOf("worker", "queue", "consumer", "job").any { token -> token in combined } -> "worker"
+        else -> "web"
+    }
+}
+
+private fun runtimeLabel(type: String, sources: List<String>): String =
+    when {
+        sources.any { source -> source.equals("otlp", ignoreCase = true) } -> "OpenTelemetry service"
+        type == "db" -> "Database"
+        type == "cache" -> "Cache"
+        type == "worker" -> "Worker"
+        else -> "Web service"
+    }
+
+private fun resourceKind(method: String): String =
+    when (method) {
+        "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS" -> "http endpoint"
+        else -> "span resource"
+    }
+
+private fun methodFromResource(resource: String): String =
+    resource.substringBefore(' ', missingDelimiterValue = "")
+        .takeIf { method -> method.matches(Regex("[A-Z]{2,8}")) }
+        ?: ""
+
+private fun status(errorRate: Double, p95Ms: Long): String =
+    when {
+        errorRate >= ALERT_ERROR_RATE || p95Ms >= ALERT_LATENCY_MS -> "alerting"
+        errorRate >= WARN_ERROR_RATE || p95Ms >= WARN_LATENCY_MS -> "degraded"
+        else -> "healthy"
+    }
+
+private fun severity(errorRate: Double, p95Ms: Long): String =
+    when (status(errorRate, p95Ms)) {
+        "alerting" -> "bad"
+        "degraded" -> "warn"
+        else -> "good"
+    }
+
+private fun statusTone(status: String): String =
+    when (status) {
+        "alerting" -> "danger"
+        "degraded" -> "warning"
+        else -> "success"
+    }
+
+private fun latencyTone(p95Ms: Long): String? =
+    when {
+        p95Ms >= ALERT_LATENCY_MS -> "danger"
+        p95Ms >= WARN_LATENCY_MS -> "warning"
+        else -> null
+    }
+
+private fun errorTone(errorLevel: String): String? =
+    when (errorLevel) {
+        "bad" -> "danger"
+        "warn" -> "warning"
+        else -> null
+    }
+
+private fun apdexScore(satisfied: Long, tolerating: Long, total: Long): Double =
+    if (total > 0) {
+        ((satisfied.toDouble() + tolerating.toDouble() / 2.0) / total.toDouble()).coerceIn(0.0, APDEX_MAX_SCORE)
+    } else {
+        APDEX_MAX_SCORE
+    }
+
+private fun formatApdex(score: Double): String =
+    "%.2f".format(score.coerceIn(0.0, APDEX_MAX_SCORE))
+
+private fun apdexTone(score: Double): String =
+    when {
+        score >= APDEX_SUCCESS_SCORE -> "success"
+        score >= APDEX_WARNING_SCORE -> "warning"
+        else -> "danger"
+    }
+
+private fun metricDelta(
+    current: Double,
+    previous: Double,
+    lowerIsBetter: Boolean = true,
+): ApmStatDeltaSpec? {
+    if (previous <= 0.0) return null
+    val delta = ((current - previous) / previous) * PERCENT_SCALE
+    val direction = when {
+        delta > DELTA_FLAT_THRESHOLD -> "up"
+        delta < -DELTA_FLAT_THRESHOLD -> "down"
+        else -> "flat"
+    }
+    val tone = when {
+        direction == "flat" -> "neutral"
+        lowerIsBetter && direction == "up" -> "danger"
+        lowerIsBetter && direction == "down" -> "success"
+        !lowerIsBetter && direction == "up" -> "success"
+        else -> "warning"
+    }
+    val prefix = if (delta > 0.0) "+" else ""
+    return ApmStatDeltaSpec(
+        value = "$prefix${"%.1f".format(delta)}%",
+        direction = direction,
+        tone = tone,
+    )
+}
+
+private fun ratioLabelToDouble(label: String): Double =
+    label.removeSuffix("%").toDoubleOrNull()?.div(PERCENT_SCALE) ?: 0.0
+
+private fun errorSeverity(errorType: String, message: String, statusCode: Int): String {
+    val combined = "$errorType $message".lowercase()
+    val hasFatalText = listOf("fatal", "panic", "crash").any { token -> token in combined }
+    return when {
+        statusCode >= HTTP_SERVER_ERROR_STATUS || hasFatalText -> "fatal"
+        statusCode in 400 until HTTP_SERVER_ERROR_STATUS || "warn" in combined -> "warn"
+        else -> "error"
+    }
+}
+
+private fun ContainerAggregate.toPodRow(): ApmPodRow =
+    ApmPodRow(
+        pod = pod,
+        node = node,
+        cpu = cpu,
+        mem = formatBytes(memUsage),
+        restarts = restarts,
+        tone = when {
+            state.lowercase() !in setOf("running", "healthy", "up") -> "danger"
+            cpu >= INFRA_CPU_ALERT_PCT -> "danger"
+            cpu >= INFRA_CPU_WARN_PCT -> "warning"
+            else -> "success"
+        },
+        state = state,
+    )
+
+private fun podMemoryRows(containers: List<ContainerAggregate>): List<ApmGaugeRow> {
+    val maxMem = containers.maxOfOrNull { container -> container.memUsage }?.coerceAtLeast(1) ?: 1
+    return containers.map { container ->
+        ApmGaugeRow(
+            label = container.pod,
+            valueText = formatBytes(container.memUsage),
+            pct = ((container.memUsage.toDouble() / maxMem.toDouble()) * PERCENT_SCALE)
+                .toInt()
+                .coerceIn(GAUGE_MIN_PCT, PERCENT_MAX),
+            level = when {
+                container.memLimit > 0 && ratio(container.memUsage, container.memLimit) >= MEMORY_WARN_RATIO -> "warn"
+                else -> "good"
+            },
+        )
+    }
+}
+
+private fun initials(name: String): String =
+    name.split(Regex("\\s+"))
+        .mapNotNull { part -> part.firstOrNull()?.uppercaseChar()?.toString() }
+        .take(2)
+        .joinToString("")
+        .ifBlank { "TM" }
+
+private fun formatBytes(bytes: Long): String =
+    if (bytes >= BYTES_PER_GIBIBYTE) {
+        "%.1fGB".format(bytes.toDouble() / BYTES_PER_GIBIBYTE)
+    } else {
+        "%.0fMB".format(bytes.toDouble() / BYTES_PER_MEBIBYTE)
+    }
+
+private fun errorBarPct(errorRate: Double): Int =
+    (errorRate * ERROR_BAR_SCALE).toInt().coerceIn(ERROR_RATE_MIN_BAR_PCT, PERCENT_MAX)
+
+private fun formatPercent(value: Double): String =
+    if (value < MIN_VISIBLE_ERROR_RATE && value > 0.0) {
+        "<0.1%"
+    } else {
+        "%.1f%%".format(value * PERCENT_SCALE)
+    }
+
+private fun requestsPerSecond(count: Long, timeRange: DdApmQueryTimeRange): Double =
+    count.toDouble() / timeRange.seconds().toDouble()
+
+private fun DdApmQueryTimeRange.seconds(): Int =
+    amount * when (unit.sql) {
+        "DAY" -> SECONDS_PER_DAY
+        else -> SECONDS_PER_HOUR
+    }
+
+private fun DdApmQueryTimeRange.previousStartClause(column: String = "start"): String =
+    "$column >= now() - INTERVAL ${amount * 2} ${unit.sql} AND $column < now() - INTERVAL $amount ${unit.sql}"
+
+private fun ratio(part: Long, total: Long): Double =
+    if (total > 0) part.toDouble() / total.toDouble() else 0.0
+
+private fun nanosToMillis(value: Long): Long =
+    value / NANOSECONDS_PER_MILLISECOND
+
+private fun formatMs(ms: Long): String =
+    if (ms >= MILLISECONDS_PER_SECOND) {
+        "%.2fs".format(ms.toDouble() / MILLISECONDS_PER_SECOND.toDouble()).replace(Regex("\\.?0+s$"), "s")
+    } else {
+        "${ms}ms"
+    }
+
+private fun formatCompact(value: Double): String =
+    if (value >= COMPACT_UNIT_THRESHOLD) {
+        "%.1fk".format(value / COMPACT_UNIT_THRESHOLD)
+    } else {
+        "%.1f".format(value).trimEnd('0').trimEnd('.')
+    }
+
+private fun ServiceAggregate.lastDeployLabel(): String =
+    version.takeUnless { it == UNKNOWN_VERSION } ?: lastSeen.takeIf { it.isNotBlank() } ?: "observed"
+
+private fun latencyThreshold(p95Ms: Long): Long =
+    maxOf(
+        WARN_LATENCY_MS,
+        ((p95Ms * LATENCY_THRESHOLD_NUMERATOR) / LATENCY_THRESHOLD_DENOMINATOR).coerceAtLeast(p95Ms + 1)
+    )
+
+private fun durationBucket(durationMs: Long): String =
+    when {
+        durationMs >= P99_DURATION_MS -> "p99"
+        durationMs >= P95_PLUS_DURATION_MS -> "p95+"
+        durationMs >= P95_DURATION_MS -> "p95"
+        else -> "p50"
+    }
+
+private fun waterfallTone(span: SpanAggregate): String =
+    when {
+        span.error || span.statusCode >= HTTP_SERVER_ERROR_STATUS -> "error"
+        "db" in span.type.lowercase() || "sql" in span.resource.lowercase() -> "db"
+        "redis" in span.resource.lowercase() || "cache" in span.type.lowercase() -> "cache"
+        "http" in span.type.lowercase() || methodFromResource(span.resource).isNotBlank() -> "http"
+        span.parentId == ROOT_PARENT_ID -> "root"
+        else -> "app"
+    }

--- a/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
@@ -41,8 +41,9 @@ import com.moneat.apm.models.ApmWaterfallRow
 import com.moneat.config.ClickHouseClient
 import com.moneat.datadog.services.DdApmQueryTimeRange
 import com.moneat.datadog.services.defaultApmQueryTimeRange
+import com.moneat.utils.ClickHouseQueryParameters
+import com.moneat.utils.ClickHouseQuerySpec
 import com.moneat.utils.ClickHouseQueryUtils
-import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.sentry.ISpan
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -207,6 +208,11 @@ private data class ContainerAggregate(
     val memLimit: Long,
     val restarts: Int,
     val state: String,
+)
+
+private data class SpanFilterSet(
+    val filters: MutableList<String>,
+    val params: ClickHouseQueryParameters,
 )
 
 object ApmServiceCatalogService {
@@ -388,8 +394,8 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ServiceAggregate> {
-        val sql = serviceAggregateSql(organizationId, serviceName, query)
-        val rows = jsonRows(sql, parentSpan)
+        val querySpec = serviceAggregateSql(organizationId, serviceName, query)
+        val rows = jsonRows(querySpec, parentSpan)
         if (rows.isEmpty()) return emptyList()
         return rows.map { row ->
             ServiceAggregate(
@@ -416,8 +422,9 @@ object ApmServiceCatalogService {
         organizationId: Int,
         serviceName: String?,
         query: ApmServiceQuery,
-    ): String {
-        val filters = spanFilters(organizationId, query, serviceName, null)
+    ): ClickHouseQuerySpec {
+        val filterSet = spanFilters(organizationId, query, serviceName, null)
+        val filters = filterSet.filters
         val limit = query.limit.coerceIn(1, MAX_SERVICE_LIMIT)
         val apdexTargetNs = APDEX_TARGET_MS * NANOSECONDS_PER_MILLISECOND
         val limitClause = if (serviceName == null) {
@@ -425,7 +432,7 @@ object ApmServiceCatalogService {
         } else {
             "LIMIT $EXACT_SERVICE_LIMIT"
         }
-        return """
+        val sql = """
             SELECT
                 service as name,
                 count() as span_count,
@@ -463,7 +470,11 @@ object ApmServiceCatalogService {
                     ),
                     nullIf(argMaxIf(meta['language'], start, meta['language'] != ''), ''),
                     nullIf(
-                        argMaxIf(resource_attributes['process.runtime.name'], start, resource_attributes['process.runtime.name'] != ''),
+                        argMaxIf(
+                            resource_attributes['process.runtime.name'],
+                            start,
+                            resource_attributes['process.runtime.name'] != ''
+                        ),
                         ''
                     ),
                     ''
@@ -475,6 +486,7 @@ object ApmServiceCatalogService {
             $limitClause
             FORMAT JSONEachRow
         """.trimIndent()
+        return ClickHouseQuerySpec(sql, filterSet.params.asMap())
     }
 
     private suspend fun serviceSparklineSeries(
@@ -484,8 +496,9 @@ object ApmServiceCatalogService {
         parentSpan: ISpan?,
     ): Map<String, List<Int>> {
         if (services.isEmpty()) return emptyMap()
-        val filters = spanFilters(organizationId, query, null, null)
-        val serviceList = services.joinToString(", ") { service -> "'${escapeSql(service)}'" }
+        val filterSet = spanFilters(organizationId, query, null, null)
+        val filters = filterSet.filters
+        val serviceList = services.joinToString(", ") { service -> filterSet.params.string(service) }
         filters.add("service IN ($serviceList)")
         val bucketSeconds = (query.timeRange.seconds() / DEFAULT_SERIES_POINT_COUNT).coerceAtLeast(1)
         val sql = """
@@ -500,7 +513,7 @@ object ApmServiceCatalogService {
             LIMIT ${services.size * DEFAULT_SERIES_POINT_COUNT}
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan)
+        return jsonRows(sql, parentSpan, filterSet.params.asMap())
             .groupBy { row -> row.stringValue("service") }
             .mapValues { (_, rows) ->
                 rows.map { row -> row.longValue("span_count").toInt().coerceIn(SPARK_MIN, SPARK_MAX) }
@@ -542,8 +555,8 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ResourceAggregate> {
-        val sql = resourceAggregateSql(organizationId, serviceName, query)
-        return jsonRows(sql, parentSpan).map { row ->
+        val querySpec = resourceAggregateSql(organizationId, serviceName, query)
+        return jsonRows(querySpec, parentSpan).map { row ->
             ResourceAggregate(
                 resource = row.stringValue("resource").ifBlank { row.stringValue("name") },
                 name = row.stringValue("name"),
@@ -561,9 +574,9 @@ object ApmServiceCatalogService {
         organizationId: Int,
         serviceName: String,
         query: ApmServiceQuery,
-    ): String {
-        val filters = spanFilters(organizationId, query, serviceName, null)
-        return """
+    ): ClickHouseQuerySpec {
+        val filterSet = spanFilters(organizationId, query, serviceName, null)
+        val sql = """
             SELECT
                 resource,
                 argMax(name, start) as name,
@@ -574,13 +587,14 @@ object ApmServiceCatalogService {
                 toUInt64(quantile(0.95)(duration)) as p95_ns,
                 toUInt64(quantile(0.99)(duration)) as p99_ns
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE ${filterSet.filters.joinToString(" AND ")}
               AND resource != ''
             GROUP BY resource
             ORDER BY error_count DESC, p95_ns DESC, span_count DESC
             LIMIT 50
             FORMAT JSONEachRow
         """.trimIndent()
+        return ClickHouseQuerySpec(sql, filterSet.params.asMap())
     }
 
     private suspend fun latencySeries(
@@ -590,7 +604,7 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ApmLatencyPoint> {
-        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val filterSet = spanFilters(organizationId, query, serviceName, resource)
         val sql = """
             SELECT
                 toStartOfHour(start) as bucket_start,
@@ -600,13 +614,13 @@ object ApmServiceCatalogService {
                 toUInt64(quantile(0.95)(duration)) as p95_ns,
                 toUInt64(quantile(0.99)(duration)) as p99_ns
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE ${filterSet.filters.joinToString(" AND ")}
             GROUP BY bucket_start
             ORDER BY bucket_start ASC
             LIMIT 48
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             ApmLatencyPoint(
                 t = row.stringValue("t"),
                 p50 = row.millisValue("p50", "p50_ns"),
@@ -624,7 +638,7 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ApmThroughputPoint> {
-        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val filterSet = spanFilters(organizationId, query, serviceName, resource)
         val sql = """
             SELECT
                 toStartOfHour(start) as bucket_start,
@@ -632,13 +646,13 @@ object ApmServiceCatalogService {
                 count() / $SECONDS_PER_HOUR as rps,
                 sum(error) / $SECONDS_PER_HOUR as errors
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE ${filterSet.filters.joinToString(" AND ")}
             GROUP BY bucket_start
             ORDER BY bucket_start ASC
             LIMIT 48
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             ApmThroughputPoint(
                 t = row.stringValue("t"),
                 rps = row.doubleValue("rps"),
@@ -671,7 +685,7 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): PreviousWindowAggregate? {
-        val filters = previousSpanFilters(organizationId, query, serviceName, resource)
+        val filterSet = previousSpanFilters(organizationId, query, serviceName, resource)
         val apdexTargetNs = APDEX_TARGET_MS * NANOSECONDS_PER_MILLISECOND
         val sql = """
             SELECT
@@ -685,10 +699,10 @@ object ApmServiceCatalogService {
                     AND duration <= ${apdexTargetNs * APDEX_TOLERATING_MULTIPLIER}
                 ) as previous_apdex_tolerating
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE ${filterSet.filters.joinToString(" AND ")}
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).firstOrNull()?.let { row ->
+        return jsonRows(sql, parentSpan, filterSet.params.asMap()).firstOrNull()?.let { row ->
             PreviousWindowAggregate(
                 spanCount = row.longValue("previous_span_count"),
                 errorCount = row.longValue("previous_error_count"),
@@ -722,7 +736,8 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<DeploymentAggregate> {
-        val filters = spanFilters(organizationId, query, serviceName, null)
+        val filterSet = spanFilters(organizationId, query, serviceName, null)
+        val filters = filterSet.filters
         filters.add("version != ''")
         val sql = """
             SELECT
@@ -736,7 +751,14 @@ object ApmServiceCatalogService {
                 coalesce(
                     nullIf(argMaxIf(meta['deployment.user'], start, meta['deployment.user'] != ''), ''),
                     nullIf(argMaxIf(meta['git.commit.author.name'], start, meta['git.commit.author.name'] != ''), ''),
-                    nullIf(argMaxIf(resource_attributes['deployment.user'], start, resource_attributes['deployment.user'] != ''), ''),
+                    nullIf(
+                        argMaxIf(
+                            resource_attributes['deployment.user'],
+                            start,
+                            resource_attributes['deployment.user'] != ''
+                        ),
+                        ''
+                    ),
                     ''
                 ) as deployer
             FROM `$clickhouseDb`.apm_spans
@@ -746,7 +768,7 @@ object ApmServiceCatalogService {
             LIMIT $DEPLOYMENT_ROW_LIMIT
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             DeploymentAggregate(
                 version = row.stringValue("version"),
                 firstSeen = row.stringValue("first_seen"),
@@ -766,7 +788,8 @@ object ApmServiceCatalogService {
         parentSpan: ISpan?,
     ): List<ContainerAggregate> {
         val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
-        val service = escapeSql(serviceName)
+        val params = ClickHouseQueryParameters()
+        val service = params.string(serviceName)
         val sql = """
             SELECT
                 argMax(name, timestamp) as pod,
@@ -780,16 +803,16 @@ object ApmServiceCatalogService {
             WHERE $orgClause
               AND timestamp >= now64(3) - INTERVAL 30 DAY
               AND (
-                  tags['service'] = '$service'
-                  OR positionCaseInsensitive(name, '$service') > 0
-                  OR positionCaseInsensitive(image, '$service') > 0
+                  tags['service'] = $service
+                  OR positionCaseInsensitive(name, $service) > 0
+                  OR positionCaseInsensitive(image, $service) > 0
               )
             GROUP BY host, container_id
             ORDER BY pod ASC
             LIMIT $CONTAINER_ROW_LIMIT
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, params.asMap()).map { row ->
             ContainerAggregate(
                 pod = row.stringValue("pod"),
                 node = row.stringValue("node"),
@@ -810,7 +833,7 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ApmDistBar> {
-        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val filterSet = spanFilters(organizationId, query, serviceName, resource)
         val bucketSizeNs = (
             (maxDurationMs.coerceAtLeast(1) * NANOSECONDS_PER_MILLISECOND) / LATENCY_DISTRIBUTION_BAR_COUNT
             ).coerceAtLeast(1)
@@ -819,12 +842,12 @@ object ApmServiceCatalogService {
                 least(intDiv(duration, $bucketSizeNs), ${LATENCY_DISTRIBUTION_BAR_COUNT - 1}) as bucket_idx,
                 count() as span_count
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE ${filterSet.filters.joinToString(" AND ")}
             GROUP BY bucket_idx
             ORDER BY bucket_idx ASC
             FORMAT JSONEachRow
         """.trimIndent()
-        val counts = jsonRows(sql, parentSpan).associate { row ->
+        val counts = jsonRows(sql, parentSpan, filterSet.params.asMap()).associate { row ->
             row.longValue("bucket_idx").toInt() to row.longValue("span_count")
         }
         return latencyDistribution(counts)
@@ -850,13 +873,14 @@ object ApmServiceCatalogService {
     ): List<ApmDependencyRow> {
         val serviceColumn = if (incoming) "to_service" else "from_service"
         val peerColumn = if (incoming) "from_service" else "to_service"
+        val params = ClickHouseQueryParameters()
         val filters = mutableListOf(
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
             query.timeRange.bucketStartClause(),
-            "$serviceColumn = '${escapeSql(serviceName)}'",
+            "$serviceColumn = ${params.string(serviceName)}",
         )
-        query.env?.let { env -> filters.add("env = '${escapeSql(env)}'") }
-        query.source?.let { source -> filters.add("source = '${escapeSql(source)}'") }
+        query.env?.let { env -> filters.add("env = ${params.string(env)}") }
+        query.source?.let { source -> filters.add("source = ${params.string(source)}") }
         val sql = """
             SELECT
                 $peerColumn as peer_service,
@@ -870,7 +894,7 @@ object ApmServiceCatalogService {
             LIMIT 10
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, params.asMap()).map { row ->
             val errorRate = ratio(row.longValue("error_count"), row.longValue("call_count"))
             ApmDependencyRow(
                 name = row.stringValue("peer_service"),
@@ -891,7 +915,7 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ApmTraceRow> {
-        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val filterSet = spanFilters(organizationId, query, serviceName, resource)
         val sql = """
             SELECT
                 if(trace_id_hex != '', trace_id_hex, toString(trace_id)) as trace_id_out,
@@ -902,13 +926,13 @@ object ApmServiceCatalogService {
                 count() as span_count,
                 formatDateTime(max(start), '%H:%i:%S') as time
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE ${filterSet.filters.joinToString(" AND ")}
             GROUP BY trace_id_out
             ORDER BY duration_ms DESC
             LIMIT 20
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             ApmTraceRow(
                 time = row.stringValue("time"),
                 traceId = row.stringValue("trace_id_out"),
@@ -929,7 +953,8 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ApmErrorRow> {
-        val filters = spanFilters(organizationId, query, serviceName, resource)
+        val filterSet = spanFilters(organizationId, query, serviceName, resource)
+        val filters = filterSet.filters
         filters.add("error = 1")
         val sql = """
             SELECT
@@ -983,7 +1008,7 @@ object ApmServiceCatalogService {
             LIMIT 20
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             val errorType = row.stringValue("error_type").ifBlank { "Trace error" }
             val message = row.stringValue("error_message").ifBlank { "Trace contains errored spans" }
             val version = row.stringValue("version")
@@ -1008,12 +1033,13 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         parentSpan: ISpan?,
     ): List<ApmErrorRow> {
+        val params = ClickHouseQueryParameters()
         val filters = mutableListOf(
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
             query.timeRange.bucketStartClause(),
-            "service = '${escapeSql(serviceName)}'",
+            "service = ${params.string(serviceName)}",
         )
-        resource?.let { resourceName -> filters.add("resource = '${escapeSql(resourceName)}'") }
+        resource?.let { resourceName -> filters.add("resource = ${params.string(resourceName)}") }
         val sql = """
             SELECT
                 resource,
@@ -1028,7 +1054,7 @@ object ApmServiceCatalogService {
             LIMIT 20
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, params.asMap()).map { row ->
             val errorType = row.stringValue("error_type").ifBlank { "Trace error" }
             val message = row.stringValue("error_message").ifBlank { "Trace contains errored spans" }
             ApmErrorRow(
@@ -1047,7 +1073,8 @@ object ApmServiceCatalogService {
         parentSpan: ISpan?,
     ): List<SpanAggregate> {
         val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
-        val escapedTraceId = escapeSql(traceId)
+        val params = ClickHouseQueryParameters()
+        val traceIdParam = params.string(traceId)
         val sql = """
             SELECT
                 if(span_id_hex != '', span_id_hex, toString(span_id)) as span_id_out,
@@ -1062,12 +1089,12 @@ object ApmServiceCatalogService {
                 status_code
             FROM `$clickhouseDb`.apm_spans
             WHERE $orgClause
-              AND (trace_id_hex = '$escapedTraceId' OR toString(trace_id) = '$escapedTraceId')
+              AND (trace_id_hex = $traceIdParam OR toString(trace_id) = $traceIdParam)
             ORDER BY start_ns ASC
             LIMIT 200
             FORMAT JSONEachRow
         """.trimIndent()
-        return jsonRows(sql, parentSpan).map { row ->
+        return jsonRows(sql, parentSpan, params.asMap()).map { row ->
             SpanAggregate(
                 spanId = row.stringValue("span_id_out"),
                 parentId = row.stringValue("parent_id_out").takeUnless { it == "0" } ?: ROOT_PARENT_ID,
@@ -1088,7 +1115,7 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         serviceName: String?,
         resource: String?,
-    ): MutableList<String> {
+    ): SpanFilterSet {
         return spanFiltersForTimeClause(organizationId, query, serviceName, resource, query.timeRange.startClause())
     }
 
@@ -1097,7 +1124,7 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
         serviceName: String?,
         resource: String?,
-    ): MutableList<String> {
+    ): SpanFilterSet {
         return spanFiltersForTimeClause(
             organizationId,
             query,
@@ -1113,36 +1140,44 @@ object ApmServiceCatalogService {
         serviceName: String?,
         resource: String?,
         timeClause: String,
-    ): MutableList<String> {
+    ): SpanFilterSet {
+        val params = ClickHouseQueryParameters()
         val filters = mutableListOf(
             ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
             timeClause,
             "service != ''",
         )
-        serviceName?.let { service -> filters.add("service = '${escapeSql(service)}'") }
-        resource?.let { resourceName -> filters.add("resource = '${escapeSql(resourceName)}'") }
-        query.env?.let { env -> filters.add("env = '${escapeSql(env)}'") }
-        query.source?.let { source -> filters.add("source = '${escapeSql(source)}'") }
-        query.search?.let { search -> filters.add(searchClause(search)) }
-        return filters
+        serviceName?.let { service -> filters.add("service = ${params.string(service)}") }
+        resource?.let { resourceName -> filters.add("resource = ${params.string(resourceName)}") }
+        query.env?.let { env -> filters.add("env = ${params.string(env)}") }
+        query.source?.let { source -> filters.add("source = ${params.string(source)}") }
+        query.search?.let { search -> filters.add(searchClause(search, params)) }
+        return SpanFilterSet(filters, params)
     }
 
-    private fun searchClause(search: String): String {
-        val escapedSearch = escapeSql(search)
+    private fun searchClause(search: String, params: ClickHouseQueryParameters): String {
+        val searchParam = params.string(search)
         return """
             (
-                positionCaseInsensitive(service, '$escapedSearch') > 0 OR
-                positionCaseInsensitive(resource, '$escapedSearch') > 0 OR
-                positionCaseInsensitive(name, '$escapedSearch') > 0
+                positionCaseInsensitive(service, $searchParam) > 0 OR
+                positionCaseInsensitive(resource, $searchParam) > 0 OR
+                positionCaseInsensitive(name, $searchParam) > 0
             )
         """.trimIndent()
     }
 
-    private suspend fun jsonRows(query: String, parentSpan: ISpan?): List<JsonObject> {
+    private suspend fun jsonRows(query: ClickHouseQuerySpec, parentSpan: ISpan?): List<JsonObject> =
+        jsonRows(query.sql, parentSpan, query.parameters)
+
+    private suspend fun jsonRows(
+        query: String,
+        parentSpan: ISpan?,
+        queryParameters: Map<String, String> = emptyMap(),
+    ): List<JsonObject> {
         val result = if (parentSpan == null) {
-            ClickHouseClient.executeWithFormat(query, "")
+            ClickHouseClient.executeWithFormat(query, "", queryParameters)
         } else {
-            ClickHouseClient.executeWithFormat(query, "", parentSpan)
+            ClickHouseClient.executeWithFormat(query, "", parentSpan, queryParameters)
         }
         return result.lines()
             .filter { line -> line.isNotBlank() }

--- a/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
@@ -1620,9 +1620,9 @@ private fun sourceLabel(source: String): String =
 private fun inferServiceType(serviceName: String, spanType: String): String {
     val combined = "$serviceName $spanType".lowercase()
     return when {
-        listOf("postgres", "mysql", "mongo", "db", "sql").any { token -> token in combined } -> "db"
-        listOf("redis", "cache", "memcached").any { token -> token in combined } -> "cache"
-        listOf("worker", "queue", "consumer", "job").any { token -> token in combined } -> "worker"
+        listOf("postgres", "mysql", "mongo", "db", "sql").any { marker -> marker in combined } -> "db"
+        listOf("redis", "cache", "memcached").any { marker -> marker in combined } -> "cache"
+        listOf("worker", "queue", "consumer", "job").any { marker -> marker in combined } -> "worker"
         else -> "web"
     }
 }
@@ -1734,7 +1734,7 @@ private fun ratioLabelToDouble(label: String): Double =
 
 private fun errorSeverity(errorType: String, message: String, statusCode: Int): String {
     val combined = "$errorType $message".lowercase()
-    val hasFatalText = listOf("fatal", "panic", "crash").any { token -> token in combined }
+    val hasFatalText = listOf("fatal", "panic", "crash").any { marker -> marker in combined }
     return when {
         statusCode >= HTTP_SERVER_ERROR_STATUS || hasFatalText -> "fatal"
         statusCode in 400 until HTTP_SERVER_ERROR_STATUS || "warn" in combined -> "warn"

--- a/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
@@ -123,6 +123,7 @@ private const val INFRA_CPU_WARN_PCT = 70
 private const val INFRA_CPU_ALERT_PCT = 85
 private const val MEMORY_WARN_RATIO = 0.8
 private const val DELTA_FLAT_THRESHOLD = 0.05
+private const val FILTERS_PLACEHOLDER = "__APM_CLICKHOUSE_FILTERS__"
 
 data class ApmServiceQuery(
     val env: String? = null,
@@ -432,7 +433,8 @@ object ApmServiceCatalogService {
         } else {
             "LIMIT $EXACT_SERVICE_LIMIT"
         }
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 service as name,
                 count() as span_count,
@@ -480,12 +482,14 @@ object ApmServiceCatalogService {
                     ''
                 ) as language
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY service
             ORDER BY error_count DESC, p95_ns DESC, span_count DESC
             $limitClause
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filters,
+        )
         return ClickHouseQuerySpec(sql, filterSet.params.asMap())
     }
 
@@ -501,18 +505,21 @@ object ApmServiceCatalogService {
         val serviceList = services.joinToString(", ") { service -> filterSet.params.string(service) }
         filters.add("service IN ($serviceList)")
         val bucketSeconds = (query.timeRange.seconds() / DEFAULT_SERIES_POINT_COUNT).coerceAtLeast(1)
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 service,
                 toStartOfInterval(start, INTERVAL $bucketSeconds SECOND) as bucket_start,
                 count() as span_count
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY service, bucket_start
             ORDER BY service ASC, bucket_start ASC
             LIMIT ${services.size * DEFAULT_SERIES_POINT_COUNT}
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filters,
+        )
         return jsonRows(sql, parentSpan, filterSet.params.asMap())
             .groupBy { row -> row.stringValue("service") }
             .mapValues { (_, rows) ->
@@ -576,7 +583,8 @@ object ApmServiceCatalogService {
         query: ApmServiceQuery,
     ): ClickHouseQuerySpec {
         val filterSet = spanFilters(organizationId, query, serviceName, null)
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 resource,
                 argMax(name, start) as name,
@@ -587,13 +595,15 @@ object ApmServiceCatalogService {
                 toUInt64(quantile(0.95)(duration)) as p95_ns,
                 toUInt64(quantile(0.99)(duration)) as p99_ns
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filterSet.filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
               AND resource != ''
             GROUP BY resource
             ORDER BY error_count DESC, p95_ns DESC, span_count DESC
             LIMIT 50
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filterSet.filters,
+        )
         return ClickHouseQuerySpec(sql, filterSet.params.asMap())
     }
 
@@ -605,7 +615,8 @@ object ApmServiceCatalogService {
         parentSpan: ISpan?,
     ): List<ApmLatencyPoint> {
         val filterSet = spanFilters(organizationId, query, serviceName, resource)
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 toStartOfHour(start) as bucket_start,
                 formatDateTime(bucket_start, '%H:%i') as t,
@@ -614,12 +625,14 @@ object ApmServiceCatalogService {
                 toUInt64(quantile(0.95)(duration)) as p95_ns,
                 toUInt64(quantile(0.99)(duration)) as p99_ns
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filterSet.filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY bucket_start
             ORDER BY bucket_start ASC
             LIMIT 48
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filterSet.filters,
+        )
         return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             ApmLatencyPoint(
                 t = row.stringValue("t"),
@@ -639,19 +652,22 @@ object ApmServiceCatalogService {
         parentSpan: ISpan?,
     ): List<ApmThroughputPoint> {
         val filterSet = spanFilters(organizationId, query, serviceName, resource)
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 toStartOfHour(start) as bucket_start,
                 formatDateTime(bucket_start, '%H:%i') as t,
                 count() / $SECONDS_PER_HOUR as rps,
                 sum(error) / $SECONDS_PER_HOUR as errors
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filterSet.filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY bucket_start
             ORDER BY bucket_start ASC
             LIMIT 48
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filterSet.filters,
+        )
         return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             ApmThroughputPoint(
                 t = row.stringValue("t"),
@@ -687,7 +703,8 @@ object ApmServiceCatalogService {
     ): PreviousWindowAggregate? {
         val filterSet = previousSpanFilters(organizationId, query, serviceName, resource)
         val apdexTargetNs = APDEX_TARGET_MS * NANOSECONDS_PER_MILLISECOND
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 count() as previous_span_count,
                 sum(error) as previous_error_count,
@@ -699,9 +716,11 @@ object ApmServiceCatalogService {
                     AND duration <= ${apdexTargetNs * APDEX_TOLERATING_MULTIPLIER}
                 ) as previous_apdex_tolerating
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filterSet.filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filterSet.filters,
+        )
         return jsonRows(sql, parentSpan, filterSet.params.asMap()).firstOrNull()?.let { row ->
             PreviousWindowAggregate(
                 spanCount = row.longValue("previous_span_count"),
@@ -739,7 +758,8 @@ object ApmServiceCatalogService {
         val filterSet = spanFilters(organizationId, query, serviceName, null)
         val filters = filterSet.filters
         filters.add("version != ''")
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 version,
                 formatDateTime(min(start), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as first_seen,
@@ -762,12 +782,14 @@ object ApmServiceCatalogService {
                     ''
                 ) as deployer
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY version
             ORDER BY max(start) DESC
             LIMIT $DEPLOYMENT_ROW_LIMIT
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filters,
+        )
         return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             DeploymentAggregate(
                 version = row.stringValue("version"),
@@ -837,16 +859,19 @@ object ApmServiceCatalogService {
         val bucketSizeNs = (
             (maxDurationMs.coerceAtLeast(1) * NANOSECONDS_PER_MILLISECOND) / LATENCY_DISTRIBUTION_BAR_COUNT
             ).coerceAtLeast(1)
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 least(intDiv(duration, $bucketSizeNs), ${LATENCY_DISTRIBUTION_BAR_COUNT - 1}) as bucket_idx,
                 count() as span_count
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filterSet.filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY bucket_idx
             ORDER BY bucket_idx ASC
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filterSet.filters,
+        )
         val counts = jsonRows(sql, parentSpan, filterSet.params.asMap()).associate { row ->
             row.longValue("bucket_idx").toInt() to row.longValue("span_count")
         }
@@ -881,19 +906,22 @@ object ApmServiceCatalogService {
         )
         query.env?.let { env -> filters.add("env = ${params.string(env)}") }
         query.source?.let { source -> filters.add("source = ${params.string(source)}") }
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 $peerColumn as peer_service,
                 sum(call_count) as call_count,
                 sum(error_count) as error_count,
                 if(sum(duration_count) = 0, 0, sum(duration_sum) / sum(duration_count)) as avg_duration_ns
             FROM `$clickhouseDb`.apm_service_edges_hourly
-            WHERE ${filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY peer_service
             ORDER BY call_count DESC
             LIMIT 10
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filters,
+        )
         return jsonRows(sql, parentSpan, params.asMap()).map { row ->
             val errorRate = ratio(row.longValue("error_count"), row.longValue("call_count"))
             ApmDependencyRow(
@@ -916,7 +944,8 @@ object ApmServiceCatalogService {
         parentSpan: ISpan?,
     ): List<ApmTraceRow> {
         val filterSet = spanFilters(organizationId, query, serviceName, resource)
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 if(trace_id_hex != '', trace_id_hex, toString(trace_id)) as trace_id_out,
                 argMax(resource, duration) as resource,
@@ -926,12 +955,14 @@ object ApmServiceCatalogService {
                 count() as span_count,
                 formatDateTime(max(start), '%H:%i:%S') as time
             FROM `$clickhouseDb`.apm_spans
-            WHERE ${filterSet.filters.joinToString(" AND ")}
+            WHERE __APM_CLICKHOUSE_FILTERS__
             GROUP BY trace_id_out
             ORDER BY duration_ms DESC
             LIMIT 20
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filterSet.filters,
+        )
         return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             ApmTraceRow(
                 time = row.stringValue("time"),
@@ -956,7 +987,8 @@ object ApmServiceCatalogService {
         val filterSet = spanFilters(organizationId, query, serviceName, resource)
         val filters = filterSet.filters
         filters.add("error = 1")
-        val sql = """
+        val sql = filteredQuery(
+            """
             SELECT
                 resource,
                 error_type,
@@ -1001,13 +1033,15 @@ object ApmServiceCatalogService {
                         0
                     ) as unhandled_flag
                 FROM `$clickhouseDb`.apm_spans
-                WHERE ${filters.joinToString(" AND ")}
+                WHERE __APM_CLICKHOUSE_FILTERS__
             )
             GROUP BY resource, error_type, error_message
             ORDER BY error_count DESC, last_seen DESC
             LIMIT 20
             FORMAT JSONEachRow
-        """.trimIndent()
+            """,
+            filters,
+        )
         return jsonRows(sql, parentSpan, filterSet.params.asMap()).map { row ->
             val errorType = row.stringValue("error_type").ifBlank { "Trace error" }
             val message = row.stringValue("error_message").ifBlank { "Trace contains errored spans" }
@@ -1145,6 +1179,9 @@ object ApmServiceCatalogService {
 
     private fun parseRowOrNull(line: String): JsonObject? =
         runCatching { json.parseToJsonElement(line) }.getOrNull() as? JsonObject
+
+    private fun filteredQuery(template: String, filters: List<String>): String =
+        template.trimIndent().replace(FILTERS_PLACEHOLDER, filters.joinToString(" AND "))
 }
 
 private fun ServiceAggregate.toCatalogRow(

--- a/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
@@ -1026,47 +1026,6 @@ object ApmServiceCatalogService {
         }
     }
 
-    private suspend fun errorRowsFromRollup(
-        organizationId: Int,
-        serviceName: String,
-        resource: String?,
-        query: ApmServiceQuery,
-        parentSpan: ISpan?,
-    ): List<ApmErrorRow> {
-        val params = ClickHouseQueryParameters()
-        val filters = mutableListOf(
-            ClickHouseQueryUtils.orgIdClause(organizationId.toLong()),
-            query.timeRange.bucketStartClause(),
-            "service = ${params.string(serviceName)}",
-        )
-        resource?.let { resourceName -> filters.add("resource = ${params.string(resourceName)}") }
-        val sql = """
-            SELECT
-                resource,
-                error_message,
-                error_type,
-                sumMerge(error_count_state) as error_count,
-                toString(maxMerge(last_seen_state)) as last_seen
-            FROM `$clickhouseDb`.apm_error_groups_hourly
-            WHERE ${filters.joinToString(" AND ")}
-            GROUP BY resource, error_message, error_type
-            ORDER BY error_count DESC, last_seen DESC
-            LIMIT 20
-            FORMAT JSONEachRow
-        """.trimIndent()
-        return jsonRows(sql, parentSpan, params.asMap()).map { row ->
-            val errorType = row.stringValue("error_type").ifBlank { "Trace error" }
-            val message = row.stringValue("error_message").ifBlank { "Trace contains errored spans" }
-            ApmErrorRow(
-                severity = "error",
-                title = "$errorType: $message",
-                sub = row.stringValue("resource"),
-                chips = listOf(row.stringValue("last_seen")).filter { chip -> chip.isNotBlank() },
-                events = row.longValue("error_count").toString(),
-            )
-        }
-    }
-
     private suspend fun exemplarSpans(
         organizationId: Int,
         traceId: String,

--- a/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
@@ -97,6 +97,7 @@ private const val LATENCY_AXIS_P99_UPPER_NUMERATOR = 13
 private const val LATENCY_AXIS_P99_UPPER_DENOMINATOR = 10
 private const val FALLBACK_P90_NUMERATOR = 9
 private const val FALLBACK_P90_DENOMINATOR = 10
+private const val MIN_HTTP_METHOD_LENGTH = 2
 private const val SYNTHETIC_METHOD_MAX_LENGTH = 8
 private const val ENV_CHART_BUCKET_COUNT = 10
 private const val ENV_CHART_START = 1
@@ -1578,10 +1579,22 @@ private fun rawResourceValue(resource: ApmResourceRow): String =
     }
 
 fun resourceSlug(method: String, name: String): String =
-    "$method-$name"
-        .lowercase()
-        .replace(Regex("[^a-z0-9]+"), "-")
-        .trim('-')
+    slugify("$method-$name")
+
+private fun slugify(value: String): String {
+    val builder = StringBuilder()
+    var lastWasSeparator = false
+    value.lowercase().forEach { char ->
+        if (char.isAsciiLetterOrDigit()) {
+            builder.append(char)
+            lastWasSeparator = false
+        } else if (!lastWasSeparator && builder.isNotEmpty()) {
+            builder.append('-')
+            lastWasSeparator = true
+        }
+    }
+    return builder.toString().trim('-')
+}
 
 private fun envPills(envs: List<String>): List<ApmEnvPill> {
     val values = envs.filter { env -> env.isNotBlank() }.ifEmpty { listOf("default") }
@@ -1631,8 +1644,11 @@ private fun resourceKind(method: String): String =
 
 private fun methodFromResource(resource: String): String =
     resource.substringBefore(' ', missingDelimiterValue = "")
-        .takeIf { method -> method.matches(Regex("[A-Z]{2,8}")) }
+        .takeIf { method -> method.isHttpMethodToken() }
         ?: ""
+
+private fun String.isHttpMethodToken(): Boolean =
+    length in MIN_HTTP_METHOD_LENGTH..SYNTHETIC_METHOD_MAX_LENGTH && all { char -> char in 'A'..'Z' }
 
 private fun status(errorRate: Double, p95Ms: Long): String =
     when {
@@ -1760,7 +1776,7 @@ private fun podMemoryRows(containers: List<ContainerAggregate>): List<ApmGaugeRo
 }
 
 private fun initials(name: String): String =
-    name.split(Regex("\\s+"))
+    name.splitToSequence(' ', '\t', '\n', '\r', '\u000C')
         .mapNotNull { part -> part.firstOrNull()?.uppercaseChar()?.toString() }
         .take(2)
         .joinToString("")
@@ -1803,10 +1819,15 @@ private fun nanosToMillis(value: Long): Long =
 
 private fun formatMs(ms: Long): String =
     if (ms >= MILLISECONDS_PER_SECOND) {
-        "%.2fs".format(ms.toDouble() / MILLISECONDS_PER_SECOND.toDouble()).replace(Regex("\\.?0+s$"), "s")
+        "%.2f".format(ms.toDouble() / MILLISECONDS_PER_SECOND.toDouble())
+            .trimEnd('0')
+            .trimEnd('.') + "s"
     } else {
         "${ms}ms"
     }
+
+private fun Char.isAsciiLetterOrDigit(): Boolean =
+    this in 'a'..'z' || this in '0'..'9'
 
 private fun formatCompact(value: Double): String =
     if (value >= COMPACT_UNIT_THRESHOLD) {

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -35,7 +35,6 @@ import mu.KotlinLogging
 import java.util.Locale
 
 private val CLICKHOUSE_ERROR_CODE = Regex("""^Code:\s*(\d+)""")
-private val CLICKHOUSE_PARAMETER_NAME = Regex("^[A-Za-z][A-Za-z0-9_]*$")
 private val logger = KotlinLogging.logger {}
 
 class ClickHouseQueryException(
@@ -152,7 +151,7 @@ object ClickHouseClient {
                     parameter("timeout_before_checking_execution_speed", "0")
                 }
                 queryParameters.forEach { (name, value) ->
-                    require(CLICKHOUSE_PARAMETER_NAME.matches(name)) { "Invalid ClickHouse parameter name: $name" }
+                    require(isClickHouseParameterName(name)) { "Invalid ClickHouse parameter name: $name" }
                     parameter("param_$name", value)
                 }
                 defaultFormat?.let { format -> parameter("default_format", format) }
@@ -183,6 +182,11 @@ object ClickHouseClient {
 
     private fun elapsedSeconds(startedAt: Long): Double =
         (System.nanoTime() - startedAt) / NANOS_PER_SECOND
+
+    private fun isClickHouseParameterName(name: String): Boolean {
+        val first = name.firstOrNull() ?: return false
+        return first.isAsciiLetter() && name.drop(1).all { char -> char.isAsciiLetterOrDigitOrUnderscore() }
+    }
 
     private fun isReadQuery(query: String): Boolean {
         val normalized = query.trimStart().uppercase(Locale.ROOT)
@@ -294,6 +298,12 @@ object ClickHouseClient {
         migrationClient = null
     }
 }
+
+private fun Char.isAsciiLetter(): Boolean =
+    this in 'A'..'Z' || this in 'a'..'z'
+
+private fun Char.isAsciiLetterOrDigitOrUnderscore(): Boolean =
+    isAsciiLetter() || this in '0'..'9' || this == '_'
 
 private fun clickHouseErrorCode(body: String): String =
     CLICKHOUSE_ERROR_CODE.find(body.trimStart())?.groupValues?.get(1) ?: "unknown"

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -118,6 +118,7 @@ object ClickHouseClient {
         query: String,
         span: ISpan? = null,
         queryParameters: Map<String, String> = emptyMap(),
+        defaultFormat: String? = null,
     ): HttpResponse {
         val client = checkNotNull(httpClient) { NOT_INITIALIZED_MESSAGE }
         return if (span != null && Sentry.isEnabled()) {
@@ -126,10 +127,10 @@ object ClickHouseClient {
                 childSpan?.setData("db.name", database)
                 childSpan?.setData("db.statement", query.take(QUERY_LOG_MAX_LEN)) // Truncate long queries
 
-                executePost(client, query, "execute", queryParameters)
+                executePost(client, query, "execute", queryParameters, defaultFormat)
             }
         } else {
-            executePost(client, query, "execute", queryParameters)
+            executePost(client, query, "execute", queryParameters, defaultFormat)
         }
     }
 
@@ -139,6 +140,7 @@ object ClickHouseClient {
         query: String,
         operation: String,
         queryParameters: Map<String, String> = emptyMap(),
+        defaultFormat: String? = null,
     ): HttpResponse {
         val startedAt = System.nanoTime()
         try {
@@ -153,6 +155,7 @@ object ClickHouseClient {
                     require(CLICKHOUSE_PARAMETER_NAME.matches(name)) { "Invalid ClickHouse parameter name: $name" }
                     parameter("param_$name", value)
                 }
+                defaultFormat?.let { format -> parameter("default_format", format) }
                 header("X-ClickHouse-User", user)
                 header("X-ClickHouse-Key", password)
                 contentType(ContentType.Text.Plain)
@@ -198,8 +201,7 @@ object ClickHouseClient {
         span: ISpan? = null,
         queryParameters: Map<String, String> = emptyMap(),
     ): String {
-        val queryWithFormat = queryWithValidatedFormat(query, format)
-        val response = execute(queryWithFormat, span, queryParameters)
+        val response = execute(query, span, queryParameters, defaultFormat = defaultFormatParameter(query, format))
         val body = response.bodyAsText()
         val isError = response.isClickHouseError(body)
         if (isError) {
@@ -222,17 +224,17 @@ object ClickHouseClient {
     ): String =
         executeWithFormat(query, format, null, queryParameters)
 
-    private fun queryWithValidatedFormat(query: String, format: String): String {
+    private fun defaultFormatParameter(query: String, format: String): String? {
         if (query.trimEnd().uppercase(Locale.ROOT).contains("FORMAT") || format.isBlank()) {
-            return query
+            return null
         }
-        return query + clickHouseFormatClause(format)
+        return clickHouseFormatValue(format)
     }
 
-    private fun clickHouseFormatClause(format: String): String =
+    private fun clickHouseFormatValue(format: String): String =
         when (format) {
-            CLICKHOUSE_FORMAT_JSON_EACH_ROW -> " FORMAT JSONEachRow"
-            CLICKHOUSE_FORMAT_TAB_SEPARATED -> " FORMAT TabSeparated"
+            CLICKHOUSE_FORMAT_JSON_EACH_ROW -> CLICKHOUSE_FORMAT_JSON_EACH_ROW
+            CLICKHOUSE_FORMAT_TAB_SEPARATED -> CLICKHOUSE_FORMAT_TAB_SEPARATED
             else -> throw IllegalArgumentException("Unsupported ClickHouse format: $format")
         }
 

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -36,6 +36,7 @@ import java.util.Locale
 
 private val CLICKHOUSE_ERROR_CODE = Regex("""^Code:\s*(\d+)""")
 private val logger = KotlinLogging.logger {}
+private const val CLICKHOUSE_FORMAT_KEYWORD = "FORMAT"
 
 class ClickHouseQueryException(
     val isTimeout: Boolean,
@@ -229,10 +230,65 @@ object ClickHouseClient {
         executeWithFormat(query, format, null, queryParameters)
 
     private fun defaultFormatParameter(query: String, format: String): String? {
-        if (query.trimEnd().uppercase(Locale.ROOT).contains("FORMAT") || format.isBlank()) {
+        if (format.isBlank() || containsFormatClause(query)) {
             return null
         }
         return clickHouseFormatValue(format)
+    }
+
+    private fun containsFormatClause(query: String): Boolean {
+        var index = 0
+        while (index <= query.length - CLICKHOUSE_FORMAT_KEYWORD.length) {
+            index = when (query[index]) {
+                '\'', '"', '`' -> skipQuotedSqlSegment(query, index, query[index])
+                else -> {
+                    if (isFormatKeywordAt(query, index)) {
+                        return true
+                    }
+                    index + 1
+                }
+            }
+        }
+        return false
+    }
+
+    private fun isFormatKeywordAt(query: String, index: Int): Boolean {
+        val keywordEnd = index + CLICKHOUSE_FORMAT_KEYWORD.length
+        return query.regionMatches(
+            thisOffset = index,
+            other = CLICKHOUSE_FORMAT_KEYWORD,
+            otherOffset = 0,
+            length = CLICKHOUSE_FORMAT_KEYWORD.length,
+            ignoreCase = true,
+        ) && isSqlKeywordBoundary(query, index - 1) && isSqlKeywordBoundary(query, keywordEnd)
+    }
+
+    private fun isSqlKeywordBoundary(query: String, index: Int): Boolean {
+        if (index !in query.indices) {
+            return true
+        }
+        val char = query[index]
+        return !char.isLetterOrDigit() && char != '_'
+    }
+
+    private fun skipQuotedSqlSegment(query: String, startIndex: Int, quote: Char): Int {
+        var index = startIndex + 1
+        while (index < query.length) {
+            val char = query[index]
+            if (char == '\\') {
+                index += 2
+                continue
+            }
+            if (char == quote) {
+                if (index + 1 < query.length && query[index + 1] == quote) {
+                    index += 2
+                    continue
+                }
+                return index + 1
+            }
+            index++
+        }
+        return query.length
     }
 
     private fun clickHouseFormatValue(format: String): String =

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -35,6 +35,7 @@ import mu.KotlinLogging
 import java.util.Locale
 
 private val CLICKHOUSE_ERROR_CODE = Regex("""^Code:\s*(\d+)""")
+private val CLICKHOUSE_PARAMETER_NAME = Regex("^[A-Za-z][A-Za-z0-9_]*$")
 private val logger = KotlinLogging.logger {}
 
 class ClickHouseQueryException(
@@ -113,7 +114,8 @@ object ClickHouseClient {
 
     suspend fun execute(
         query: String,
-        span: ISpan? = null
+        span: ISpan? = null,
+        queryParameters: Map<String, String> = emptyMap(),
     ): HttpResponse {
         val client = checkNotNull(httpClient) { NOT_INITIALIZED_MESSAGE }
         return if (span != null && Sentry.isEnabled()) {
@@ -122,10 +124,10 @@ object ClickHouseClient {
                 childSpan?.setData("db.name", database)
                 childSpan?.setData("db.statement", query.take(QUERY_LOG_MAX_LEN)) // Truncate long queries
 
-                executePost(client, query, "execute")
+                executePost(client, query, "execute", queryParameters)
             }
         } else {
-            executePost(client, query, "execute")
+            executePost(client, query, "execute", queryParameters)
         }
     }
 
@@ -133,7 +135,8 @@ object ClickHouseClient {
     private suspend fun executePost(
         client: HttpClient,
         query: String,
-        operation: String
+        operation: String,
+        queryParameters: Map<String, String> = emptyMap(),
     ): HttpResponse {
         val startedAt = System.nanoTime()
         try {
@@ -143,6 +146,10 @@ object ClickHouseClient {
                     parameter("max_execution_time", READ_QUERY_MAX_EXECUTION_SECONDS)
                     parameter("timeout_overflow_mode", "throw")
                     parameter("timeout_before_checking_execution_speed", "0")
+                }
+                queryParameters.forEach { (name, value) ->
+                    require(CLICKHOUSE_PARAMETER_NAME.matches(name)) { "Invalid ClickHouse parameter name: $name" }
+                    parameter("param_$name", value)
                 }
                 header("X-ClickHouse-User", user)
                 header("X-ClickHouse-Key", password)
@@ -186,14 +193,15 @@ object ClickHouseClient {
     suspend fun executeWithFormat(
         query: String,
         format: String,
-        span: ISpan? = null
+        span: ISpan? = null,
+        queryParameters: Map<String, String> = emptyMap(),
     ): String {
         val queryWithFormat = if (query.trimEnd().uppercase(Locale.ROOT).contains("FORMAT")) {
             query
         } else {
             "$query FORMAT $format"
         }
-        val response = execute(queryWithFormat, span)
+        val response = execute(queryWithFormat, span, queryParameters)
         val body = response.bodyAsText()
         val isError = response.isClickHouseError(body)
         if (isError) {
@@ -208,6 +216,13 @@ object ClickHouseClient {
         }
         return body
     }
+
+    suspend fun executeWithFormat(
+        query: String,
+        format: String,
+        queryParameters: Map<String, String>,
+    ): String =
+        executeWithFormat(query, format, null, queryParameters)
 
     private fun isClickHouseTimeout(body: String, errorCode: String): Boolean {
         return errorCode == CLICKHOUSE_TIMEOUT_ERROR_CODE ||

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -61,6 +61,8 @@ object ClickHouseClient {
     private const val CLICKHOUSE_TIMEOUT_ERROR_NAME = "TIMEOUT_EXCEEDED"
     private const val CLICKHOUSE_TIMEOUT_MESSAGE = "timeout exceeded"
     private const val NOT_INITIALIZED_MESSAGE = "ClickHouseClient is not initialized. Call init() first."
+    private const val CLICKHOUSE_FORMAT_JSON_EACH_ROW = "JSONEachRow"
+    private const val CLICKHOUSE_FORMAT_TAB_SEPARATED = "TabSeparated"
 
     @Volatile
     private var httpClient: HttpClient? = null
@@ -196,11 +198,7 @@ object ClickHouseClient {
         span: ISpan? = null,
         queryParameters: Map<String, String> = emptyMap(),
     ): String {
-        val queryWithFormat = if (query.trimEnd().uppercase(Locale.ROOT).contains("FORMAT")) {
-            query
-        } else {
-            "$query FORMAT $format"
-        }
+        val queryWithFormat = queryWithValidatedFormat(query, format)
         val response = execute(queryWithFormat, span, queryParameters)
         val body = response.bodyAsText()
         val isError = response.isClickHouseError(body)
@@ -223,6 +221,20 @@ object ClickHouseClient {
         queryParameters: Map<String, String>,
     ): String =
         executeWithFormat(query, format, null, queryParameters)
+
+    private fun queryWithValidatedFormat(query: String, format: String): String {
+        if (query.trimEnd().uppercase(Locale.ROOT).contains("FORMAT") || format.isBlank()) {
+            return query
+        }
+        return query + clickHouseFormatClause(format)
+    }
+
+    private fun clickHouseFormatClause(format: String): String =
+        when (format) {
+            CLICKHOUSE_FORMAT_JSON_EACH_ROW -> " FORMAT JSONEachRow"
+            CLICKHOUSE_FORMAT_TAB_SEPARATED -> " FORMAT TabSeparated"
+            else -> throw IllegalArgumentException("Unsupported ClickHouse format: $format")
+        }
 
     private fun isClickHouseTimeout(body: String, errorCode: String): Boolean {
         return errorCode == CLICKHOUSE_TIMEOUT_ERROR_CODE ||

--- a/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
@@ -113,7 +113,7 @@ class DatadogModule : EnterpriseModule {
             rateLimit(RateLimitName("api")) {
                 securityQueryRoutes()
             }
-            traceDashboardRoutes()
+            traceDashboardRoutes(includeServiceDashboardRoutes = false)
             profileDashboardRoutes()
             datadogEventQueryRoutes()
             datadogHostQueryRoutes()

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.apm.routes.apmServiceDashboardRouteHandlers
 import com.moneat.datadog.services.DdApmQueryTimeRange
 import com.moneat.datadog.services.DdApmQueryTimeUnit
 import com.moneat.datadog.services.DdResourceStatsQuery
@@ -40,14 +41,11 @@ private const val INVALID_TOKEN_ERROR = "Invalid token"
 private const val INVALID_TIME_RANGE_ERROR = "Invalid timeRange"
 private const val INVALID_STATUS_ERROR = "Invalid status"
 private const val INVALID_SERVICES_ERROR = "Invalid services"
-private const val INVALID_SERVICE_ERROR = "Invalid service"
-private const val INVALID_SERVICE_MAP_FILTER_ERROR = "Invalid service map filter"
 private const val STATUS_ERROR = "error"
 private const val STATUS_OK = "ok"
 private const val MAX_TRACE_SEARCH_LENGTH = 200
 private const val MAX_SERVICE_FILTERS = 50
 private const val MAX_SERVICE_FILTER_LENGTH = 200
-private const val MAX_SERVICE_PARAM_LENGTH = 200
 private val hexTraceIdPattern = Regex("^[0-9a-fA-F]+$")
 
 private val apmTimeRanges = mapOf(
@@ -59,7 +57,7 @@ private val apmTimeRanges = mapOf(
     "90d" to DdApmQueryTimeRange(90, DdApmQueryTimeUnit.DAY),
 )
 
-fun Route.traceDashboardRoutes() {
+fun Route.traceDashboardRoutes(includeServiceDashboardRoutes: Boolean = true) {
     authenticate("auth-jwt") {
         route("/v1/traces") {
             // GET /v1/traces/resources - aggregated resource stats (main APM view)
@@ -139,43 +137,8 @@ fun Route.traceDashboardRoutes() {
             }
         }
 
-        // GET /v1/services/map - service dependency map
-        get("/v1/services/map") {
-            val orgId = call.organizationId()
-                ?: return@get call.respondUnauthorized()
-            val timeRange = call.apmTimeRange()
-                ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
-            val scope = call.serviceMapScope()
-                ?: return@get call.respondBadRequest(INVALID_SERVICE_MAP_FILTER_ERROR)
-            val result = TraceIngestionService.getServiceMap(
-                orgId,
-                timeRange,
-                scope.env,
-                scope.source,
-                call.getSentryTransaction(),
-            )
-            call.respond(result)
-        }
-
-        // GET /v1/services/{service}/latency - focused-service latency percentiles
-        get("/v1/services/{service}/latency") {
-            val orgId = call.organizationId()
-                ?: return@get call.respondUnauthorized()
-            val service = call.requiredServiceMapParam("service")
-                ?: return@get call.respondBadRequest(INVALID_SERVICE_ERROR)
-            val timeRange = call.apmTimeRange()
-                ?: return@get call.respondBadRequest(INVALID_TIME_RANGE_ERROR)
-            val scope = call.serviceMapScope()
-                ?: return@get call.respondBadRequest(INVALID_SERVICE_MAP_FILTER_ERROR)
-            val result = TraceIngestionService.getServiceLatencyPercentiles(
-                orgId,
-                service,
-                timeRange,
-                scope.env,
-                scope.source,
-                call.getSentryTransaction(),
-            )
-            call.respond(result)
+        if (includeServiceDashboardRoutes) {
+            apmServiceDashboardRouteHandlers()
         }
 
         // GET /v1/apm-errors - list APM error groups
@@ -293,34 +256,6 @@ private fun ApplicationCall.apmTimeRange(): DdApmQueryTimeRange? {
     val rawValue = parameters["timeRange"] ?: parameters["range"] ?: DEFAULT_APM_TIME_RANGE
     return apmTimeRanges[rawValue]
 }
-
-private data class ServiceMapScope(
-    val env: String?,
-    val source: String?,
-)
-
-private data class ServiceMapParam(
-    val value: String?,
-)
-
-private fun ApplicationCall.serviceMapScope(): ServiceMapScope? {
-    val env = optionalServiceMapParam("env") ?: return null
-    val source = optionalServiceMapParam("source") ?: return null
-    return ServiceMapScope(env.value, source.value)
-}
-
-private fun ApplicationCall.optionalServiceMapParam(name: String): ServiceMapParam? {
-    val rawValue = parameters[name] ?: return ServiceMapParam(null)
-    val value = rawValue.trim()
-    if (value.length > MAX_SERVICE_PARAM_LENGTH) return null
-    return ServiceMapParam(value.takeIf { it.isNotEmpty() })
-}
-
-private fun ApplicationCall.requiredServiceMapParam(name: String): String? =
-    parameters[name]
-        ?.trim()
-        ?.takeIf { it.isNotEmpty() }
-        ?.takeIf { it.length <= MAX_SERVICE_PARAM_LENGTH }
 
 private fun ApplicationCall.apmStatus(): String? {
     val rawValue = parameters["status"] ?: return ""

--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -17,6 +17,7 @@
 package com.moneat.plugins
 
 import com.moneat.ai.aiChatRoutes
+import com.moneat.apm.routes.apmServiceDashboardRoutes
 import com.moneat.auth.routes.authRoutes
 import com.moneat.auth.routes.authTokenRoutes
 import com.moneat.billing.routes.stripeWebhookRoutes
@@ -212,6 +213,9 @@ fun Application.configureRouting() {
 
         // Dashboard API endpoints
         apiRoutes()
+
+        // APM service dashboard endpoints are source-neutral and must not depend on vendor modules.
+        apmServiceDashboardRoutes()
 
         // OpenFeature-compatible feature flag management and OFREP runtime endpoints
         featureFlagRoutes()

--- a/backend/src/main/kotlin/com/moneat/utils/ClickHouseQuerySpec.kt
+++ b/backend/src/main/kotlin/com/moneat/utils/ClickHouseQuerySpec.kt
@@ -1,0 +1,35 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.utils
+
+data class ClickHouseQuerySpec(
+    val sql: String,
+    val parameters: Map<String, String> = emptyMap(),
+)
+
+class ClickHouseQueryParameters {
+    private var nextIndex = 0
+    private val values = linkedMapOf<String, String>()
+
+    fun string(value: String): String {
+        val name = "p${nextIndex++}"
+        values[name] = value
+        return "{$name:String}"
+    }
+
+    fun asMap(): Map<String, String> = values.toMap()
+}

--- a/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
@@ -21,6 +21,10 @@ import com.moneat.apm.models.ApmEnvPill
 import com.moneat.apm.models.ApmServiceCatalogResponse
 import com.moneat.apm.models.ApmServiceCatalogRow
 import com.moneat.apm.services.ApmServiceCatalogService
+import com.moneat.apm.services.ApmServiceQuery
+import com.moneat.datadog.models.DdServiceLatencyResponse
+import com.moneat.datadog.models.DdServiceMapResponse
+import com.moneat.datadog.services.TraceIngestionService
 import com.moneat.testsupport.RouteTestSupport
 import com.moneat.testsupport.RouteTestSupport.withAuth
 import io.ktor.client.request.get
@@ -31,6 +35,7 @@ import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkObject
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -43,17 +48,20 @@ class ApmServiceRoutesTest {
     @BeforeTest
     fun setup() {
         mockkObject(ApmServiceCatalogService)
+        mockkObject(TraceIngestionService)
     }
 
     @AfterTest
     fun teardown() {
+        unmockkObject(TraceIngestionService)
         unmockkObject(ApmServiceCatalogService)
     }
 
     @Test
     fun `GET v1 services returns catalog response`() = testApplication {
+        val querySlot = slot<ApmServiceQuery>()
         coEvery {
-            ApmServiceCatalogService.listServices(any(), any(), any())
+            ApmServiceCatalogService.listServices(any(), capture(querySlot), any())
         } returns ApmServiceCatalogResponse(
             services = listOf(
                 ApmServiceCatalogRow(
@@ -84,15 +92,60 @@ class ApmServiceRoutesTest {
         }
 
         val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
-        val response = client.get("/v1/services?timeRange=6h&env=production") {
+        val response = client.get(
+            "/v1/services?timeRange=6h&env=%20production%20&source=otel&search=%20checkout%20" +
+                "&limit=999&offset=-3"
+        ) {
             withAuth(token)
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("\"checkout-api\""))
+        assertEquals("production", querySlot.captured.env)
+        assertEquals("otel", querySlot.captured.source)
+        assertEquals("checkout", querySlot.captured.search)
+        assertEquals(200, querySlot.captured.limit)
+        assertEquals(0, querySlot.captured.offset)
         coVerify(exactly = 1) {
             ApmServiceCatalogService.listServices(42, any(), any())
         }
+    }
+
+    @Test
+    fun `GET v1 services rejects token without organization`() = testApplication {
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1)
+        val response = client.get("/v1/services") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid token"))
+    }
+
+    @Test
+    fun `GET v1 services rejects invalid query parameters`() = testApplication {
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val badRange = client.get("/v1/services?timeRange=bad") {
+            withAuth(token)
+        }
+        val badFilter = client.get("/v1/services?env=${"e".repeat(201)}") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, badRange.status)
+        assertTrue(badRange.bodyAsText().contains("Invalid timeRange"))
+        assertEquals(HttpStatusCode.BadRequest, badFilter.status)
+        assertTrue(badFilter.bodyAsText().contains("Invalid service map filter"))
     }
 
     @Test
@@ -108,5 +161,118 @@ class ApmServiceRoutesTest {
         }
 
         assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `GET v1 service detail returns not found when service is missing`() = testApplication {
+        coEvery {
+            ApmServiceCatalogService.getServiceDetail(any(), any(), any(), any())
+        } returns null
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val response = client.get("/v1/services/checkout-api?range=24h") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        assertTrue(response.bodyAsText().contains("Service not found"))
+        coVerify(exactly = 1) {
+            ApmServiceCatalogService.getServiceDetail(42, "checkout-api", any(), any())
+        }
+    }
+
+    @Test
+    fun `GET v1 resource detail validates resource and returns not found`() = testApplication {
+        coEvery {
+            ApmServiceCatalogService.getResourceDetail(any(), any(), any(), any(), any())
+        } returns null
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val blankResource = client.get("/v1/services/checkout-api/resources/%20") {
+            withAuth(token)
+        }
+        val missingResource = client.get("/v1/services/checkout-api/resources/GET%20%2Fcheckout") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, blankResource.status)
+        assertTrue(blankResource.bodyAsText().contains("Invalid resource"))
+        assertEquals(HttpStatusCode.NotFound, missingResource.status)
+        assertTrue(missingResource.bodyAsText().contains("Resource not found"))
+        coVerify(exactly = 1) {
+            ApmServiceCatalogService.getResourceDetail(42, "checkout-api", "GET /checkout", any(), any())
+        }
+    }
+
+    @Test
+    fun `GET v1 services map validates filters and forwards source-neutral scope`() = testApplication {
+        coEvery {
+            TraceIngestionService.getServiceMap(any(), any(), any(), any(), any())
+        } returns DdServiceMapResponse(emptyList())
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val ok = client.get("/v1/services/map?range=1h&env=prod&source=otel") {
+            withAuth(token)
+        }
+        val badRange = client.get("/v1/services/map?range=bad") {
+            withAuth(token)
+        }
+        val badFilter = client.get("/v1/services/map?source=${"s".repeat(201)}") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, ok.status)
+        assertEquals(HttpStatusCode.BadRequest, badRange.status)
+        assertTrue(badRange.bodyAsText().contains("Invalid timeRange"))
+        assertEquals(HttpStatusCode.BadRequest, badFilter.status)
+        assertTrue(badFilter.bodyAsText().contains("Invalid service map filter"))
+        coVerify(exactly = 1) {
+            TraceIngestionService.getServiceMap(42, any(), "prod", "otel", any())
+        }
+    }
+
+    @Test
+    fun `GET v1 service latency validates service and forwards filters`() = testApplication {
+        coEvery {
+            TraceIngestionService.getServiceLatencyPercentiles(any(), any(), any(), any(), any(), any())
+        } returns DdServiceLatencyResponse(
+            service = "checkout-api",
+            p50DurationNs = 100,
+            p90DurationNs = 200,
+            p99DurationNs = 300,
+            sampleCount = 4,
+        )
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val ok = client.get("/v1/services/checkout-api/latency?timeRange=90d&env=prod&source=otel") {
+            withAuth(token)
+        }
+        val badService = client.get("/v1/services/%20/latency") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, ok.status)
+        assertTrue(ok.bodyAsText().contains("checkout-api"))
+        assertEquals(HttpStatusCode.BadRequest, badService.status)
+        assertTrue(badService.bodyAsText().contains("Invalid service"))
+        coVerify(exactly = 1) {
+            TraceIngestionService.getServiceLatencyPercentiles(42, "checkout-api", any(), "prod", "otel", any())
+        }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
@@ -1,0 +1,112 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.apm.routes
+
+import com.moneat.apm.models.ApmCatalogSummary
+import com.moneat.apm.models.ApmEnvPill
+import com.moneat.apm.models.ApmServiceCatalogResponse
+import com.moneat.apm.models.ApmServiceCatalogRow
+import com.moneat.apm.services.ApmServiceCatalogService
+import com.moneat.testsupport.RouteTestSupport
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ApmServiceRoutesTest {
+
+    @BeforeTest
+    fun setup() {
+        mockkObject(ApmServiceCatalogService)
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkObject(ApmServiceCatalogService)
+    }
+
+    @Test
+    fun `GET v1 services returns catalog response`() = testApplication {
+        coEvery {
+            ApmServiceCatalogService.listServices(any(), any(), any())
+        } returns ApmServiceCatalogResponse(
+            services = listOf(
+                ApmServiceCatalogRow(
+                    name = "checkout-api",
+                    type = "web",
+                    status = "healthy",
+                    env = listOf(ApmEnvPill(label = "production", chart = 1)),
+                    rps = 12.5,
+                    spark = listOf(14, 12, 11),
+                    p95Ms = 248,
+                    p99Ms = 612,
+                    errorRateLabel = "0.2%",
+                    errorBarPct = 8,
+                    errorLevel = "good",
+                    apdex = "0.98",
+                    apdexTone = "success",
+                    lastDeploy = "v3.1.2",
+                    team = "unassigned",
+                    language = "web",
+                    sources = listOf("OTLP"),
+                )
+            ),
+            summary = ApmCatalogSummary(total = 1, alerting = 0, degraded = 0),
+        )
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val response = client.get("/v1/services?timeRange=6h&env=production") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"checkout-api\""))
+        coVerify(exactly = 1) {
+            ApmServiceCatalogService.listServices(42, any(), any())
+        }
+    }
+
+    @Test
+    fun `GET v1 services rejects oversized service parameter`() = testApplication {
+        application {
+            with(RouteTestSupport) { installJwtAuth() }
+            routing { apmServiceDashboardRoutes() }
+        }
+
+        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val response = client.get("/v1/services/${"s".repeat(201)}") {
+            withAuth(token)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
@@ -124,7 +124,7 @@ class ApmServiceRoutesTest {
         }
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
-        assertTrue(response.bodyAsText().contains("Invalid token"))
+        assertTrue(response.bodyAsText().contains("Unauthorized"))
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
@@ -91,12 +91,12 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = 42)
         val response = client.get(
             "/v1/services?timeRange=6h&env=%20production%20&source=otel&search=%20checkout%20" +
                 "&limit=999&offset=-3"
         ) {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.OK, response.status)
@@ -112,15 +112,15 @@ class ApmServiceRoutesTest {
     }
 
     @Test
-    fun `GET v1 services rejects token without organization`() = testApplication {
+    fun `GET v1 services rejects credential without organization`() = testApplication {
         application {
             with(RouteTestSupport) { installJwtAuth() }
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1)
+        val credential = RouteTestSupport.createToken(userId = 1)
         val response = client.get("/v1/services") {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
@@ -134,12 +134,12 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = 42)
         val badRange = client.get("/v1/services?timeRange=bad") {
-            withAuth(token)
+            withAuth(credential)
         }
         val badFilter = client.get("/v1/services?env=${"e".repeat(201)}") {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.BadRequest, badRange.status)
@@ -155,9 +155,9 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = 42)
         val response = client.get("/v1/services/${"s".repeat(201)}") {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.BadRequest, response.status)
@@ -173,9 +173,9 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = 42)
         val response = client.get("/v1/services/checkout-api?range=24h") {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.NotFound, response.status)
@@ -195,12 +195,12 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = 42)
         val blankResource = client.get("/v1/services/checkout-api/resources/%20") {
-            withAuth(token)
+            withAuth(credential)
         }
         val missingResource = client.get("/v1/services/checkout-api/resources/GET%20%2Fcheckout") {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.BadRequest, blankResource.status)
@@ -222,15 +222,15 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = 42)
         val ok = client.get("/v1/services/map?range=1h&env=prod&source=otel") {
-            withAuth(token)
+            withAuth(credential)
         }
         val badRange = client.get("/v1/services/map?range=bad") {
-            withAuth(token)
+            withAuth(credential)
         }
         val badFilter = client.get("/v1/services/map?source=${"s".repeat(201)}") {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.OK, ok.status)
@@ -259,12 +259,12 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val token = RouteTestSupport.createToken(userId = 1, orgId = 42)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = 42)
         val ok = client.get("/v1/services/checkout-api/latency?timeRange=90d&env=prod&source=otel") {
-            withAuth(token)
+            withAuth(credential)
         }
         val badService = client.get("/v1/services/%20/latency") {
-            withAuth(token)
+            withAuth(credential)
         }
 
         assertEquals(HttpStatusCode.OK, ok.status)

--- a/backend/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
@@ -283,6 +283,113 @@ class ApmServiceCatalogServiceTest {
     }
 
     @Test
+    fun `getResourceDetail assembles dependency waterfall distribution and errors`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } answers {
+                val query = firstArg<String>()
+                queries += query
+                when {
+                    "span_id_out" in query ->
+                        listOf(
+                            "{" +
+                                "\"span_id_out\":\"root\",\"parent_id_out\":\"0\",\"name\":\"POST\"," +
+                                "\"service\":\"checkout-api\",\"resource\":\"POST /checkout/pay\",\"type\":\"web\"," +
+                                "\"start_ns\":1000000000,\"duration_ms\":1400,\"error\":1,\"status_code\":500}",
+                            "{" +
+                                "\"span_id_out\":\"db\",\"parent_id_out\":\"root\",\"name\":\"SELECT\"," +
+                                "\"service\":\"payments-db\",\"resource\":\"SELECT payments\",\"type\":\"db\"," +
+                                "\"start_ns\":1200000000,\"duration_ms\":700,\"error\":0,\"status_code\":200}",
+                        ).joinToString("\n")
+                    "error_type" in query && "user_count" in query ->
+                        "{" +
+                            "\"resource\":\"POST /checkout/pay\",\"error_type\":\"PaymentTimeout\"," +
+                            "\"error_message\":\"processor timed out\",\"error_count\":9,\"user_count\":2," +
+                            "\"status_code\":504,\"unhandled\":1,\"version\":\"v3.1.2\"," +
+                            "\"first_seen\":\"2026-06-06T03:00:00.000Z\"," +
+                            "\"last_seen\":\"2026-06-06T03:21:00.000Z\"}"
+                    "least(intDiv" in query ->
+                        """
+                        {"bucket_idx":0,"span_count":1}
+                        {"bucket_idx":8,"span_count":5}
+                        {"bucket_idx":19,"span_count":10}
+                        """.trimIndent()
+                    "FROM `moneat`.apm_service_edges_hourly" in query ->
+                        "{" +
+                            "\"peer_service\":\"payments-db\",\"call_count\":40,\"error_count\":4," +
+                            "\"avg_latency_ms\":180,\"p95_latency_ms\":700}"
+                    "GROUP BY trace_id_out" in query ->
+                        "{" +
+                            "\"trace_id_out\":\"trace-resource-1\",\"resource\":\"POST /checkout/pay\"," +
+                            "\"name\":\"POST\",\"http_status\":500,\"duration_ms\":1400," +
+                            "\"span_count\":8,\"time\":\"03:01:00\"}"
+                    "previous_span_count" in query ->
+                        "{" +
+                            "\"previous_span_count\":20,\"previous_error_count\":1," +
+                            "\"previous_p95_ns\":300000000,\"previous_p99_ns\":900000000," +
+                            "\"previous_apdex_satisfied\":18,\"previous_apdex_tolerating\":1}"
+                    "GROUP BY version" in query ->
+                        "{" +
+                            "\"version\":\"v3.1.2\",\"first_seen\":\"2026-06-06T03:00:00.000Z\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"deploy_t\":\"03:00\"," +
+                            "\"span_count\":40,\"error_count\":4,\"p95_ns\":700000000}"
+                    "GROUP BY bucket_start" in query && "count() /" in query ->
+                        "{\"t\":\"03:00\",\"rps\":11.5,\"errors\":0.7}"
+                    "GROUP BY bucket_start" in query ->
+                        "{\"t\":\"03:00\",\"p50\":110,\"p90\":620,\"p95\":700,\"p99\":1200}"
+                    "argMax(name, start)" in query ->
+                        "{" +
+                            "\"resource\":\"POST /checkout/pay\",\"name\":\"POST /checkout/pay\",\"type\":\"web\"," +
+                            "\"span_count\":40,\"error_count\":4,\"p50_ns\":110000000," +
+                            "\"p95_ns\":700000000,\"p99_ns\":1200000000}"
+                    "GROUP BY service" in query ->
+                        "{" +
+                            "\"name\":\"checkout-api\",\"span_count\":80,\"error_count\":8," +
+                            "\"p50_ns\":90000000,\"p95_ns\":700000000,\"p99_ns\":1200000000," +
+                            "\"apdex_satisfied\":64,\"apdex_tolerating\":8," +
+                            "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v3.1.2\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"web\"}"
+                    else -> ""
+                }
+            }
+
+            val detail = ApmServiceCatalogService.getResourceDetail(
+                organizationId = 12,
+                serviceName = "checkout-api",
+                resourceSlug = "post-checkout-pay",
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            requireNotNull(detail)
+            assertEquals("checkout-api", detail.serviceName)
+            assertEquals("POST", detail.method)
+            assertEquals("/checkout/pay", detail.path)
+            assertEquals("payments-db", detail.topDependency)
+            assertEquals("03:00", detail.deployAt)
+            assertEquals(700, detail.latency.single().p95)
+            assertEquals(11.5, detail.throughput.single().rps)
+            assertEquals("payments-db contributes to the slow path for POST /checkout/pay.", detail.whereInsight)
+            assertEquals("PaymentTimeout: processor timed out", detail.errors.single().title)
+            assertEquals("9", detail.errors.single().events)
+            assertEquals("2", detail.errors.single().users)
+            assertTrue(detail.errors.single().unhandled)
+            assertTrue(queries.any { query -> "uniqExactIf(user_key" in query })
+            assertEquals("trace-resource-1", detail.exemplar.traceId)
+            assertEquals(500, detail.exemplar.httpStatus)
+            assertTrue(detail.exemplar.rows.any { row -> row.tone == "db" && row.indent != null })
+            assertTrue(detail.exemplar.rows.first().selected)
+            assertTrue(detail.whereTimeSpent.any { row -> row.label == "SELECT payments" })
+            assertTrue(detail.distribution.any { bar -> bar.band == "bad" && bar.h == 100 })
+            assertTrue(!detail.slowTraces.single().bucket.isNullOrBlank())
+            assertTrue(detail.kpis.any { kpi -> kpi.delta != null })
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
     fun `getServiceDetail uses parameterized exact service lookup without catalog paging`() = runBlocking {
         mockkObject(ClickHouseClient)
         val calls = java.util.Collections.synchronizedList(mutableListOf<Pair<String, Map<String, String>>>())

--- a/backend/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
@@ -1,0 +1,364 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.apm.services
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.datadog.services.defaultApmQueryTimeRange
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ApmServiceCatalogServiceTest {
+
+    @Test
+    fun `listServices maps span aggregates into service catalog rows`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val query = firstArg<String>()
+                queries += query
+                when {
+                    "GROUP BY service" in query ->
+                        "{" +
+                            "\"name\":\"checkout-api\",\"span_count\":7200,\"error_count\":180," +
+                            "\"p50_ns\":82000000,\"p95_ns\":248000000,\"p99_ns\":612000000," +
+                            "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v3.1.2\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"web\"}"
+                    else -> ""
+                }
+            }
+
+            val response = ApmServiceCatalogService.listServices(
+                organizationId = 12,
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            val service = response.services.single()
+            assertEquals("checkout-api", service.name)
+            assertEquals("alerting", service.status)
+            assertEquals(248, service.p95Ms)
+            assertEquals(612, service.p99Ms)
+            assertEquals("2.5%", service.errorRateLabel)
+            assertEquals("OTLP", service.sources.single())
+            assertEquals(1, response.summary.total)
+            assertTrue(queries.any { "organization_id" in it && "apm_spans" in it })
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `listServices uses telemetry-derived sparkline apdex ownership and language`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val query = firstArg<String>()
+                when {
+                    "GROUP BY service, bucket_start" in query ->
+                        """
+                        {"service":"checkout-api","bucket_start":"2026-06-06T02:00:00.000Z","span_count":10}
+                        {"service":"checkout-api","bucket_start":"2026-06-06T02:05:00.000Z","span_count":20}
+                        {"service":"checkout-api","bucket_start":"2026-06-06T02:10:00.000Z","span_count":5}
+                        """.trimIndent()
+                    "GROUP BY service" in query ->
+                        "{" +
+                            "\"name\":\"checkout-api\",\"span_count\":40,\"error_count\":10," +
+                            "\"p50_ns\":70000000,\"p95_ns\":248000000,\"p99_ns\":612000000," +
+                            "\"apdex_satisfied\":20,\"apdex_tolerating\":10," +
+                            "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v3.1.2\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"web\"," +
+                            "\"team\":\"payments\",\"language\":\"go\"}"
+                    else -> ""
+                }
+            }
+
+            val response = ApmServiceCatalogService.listServices(
+                organizationId = 12,
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            val service = response.services.single()
+            assertEquals(listOf(10, 20, 5), service.spark)
+            assertEquals("0.63", service.apdex)
+            assertEquals("payments", service.team)
+            assertEquals("go", service.language)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getServiceDetail returns real deployments deltas infra and enriched errors`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val query = firstArg<String>()
+                when {
+                    "FROM `moneat`.containers_latest_by_host" in query ->
+                        "{" +
+                            "\"pod\":\"checkout-api-7f8d9c\",\"node\":\"prod-web-01\"," +
+                            "\"cpu\":42,\"mem_usage\":2147483648,\"mem_limit\":4294967296," +
+                            "\"restarts\":2,\"state\":\"running\"}"
+                    "GROUP BY version" in query ->
+                        """
+                        {"version":"v3.1.2","first_seen":"2026-06-06T03:00:00.000Z","last_seen":"2026-06-06T03:20:00.000Z","deploy_t":"03:00","span_count":60,"error_count":3,"p95_ns":240000000}
+                        {"version":"v3.1.1","first_seen":"2026-06-06T02:00:00.000Z","last_seen":"2026-06-06T02:59:00.000Z","deploy_t":"02:00","span_count":30,"error_count":0,"p95_ns":180000000}
+                        """.trimIndent()
+                    "previous_span_count" in query ->
+                        "{" +
+                            "\"previous_span_count\":30,\"previous_error_count\":0," +
+                            "\"previous_p95_ns\":180000000,\"previous_p99_ns\":400000000," +
+                            "\"previous_apdex_satisfied\":20,\"previous_apdex_tolerating\":5}"
+                    "FROM `moneat`.apm_spans" in query && "error_type" in query && "user_count" in query ->
+                        "{" +
+                            "\"resource\":\"POST /checkout\",\"error_type\":\"TimeoutError\"," +
+                            "\"error_message\":\"payment timeout\",\"error_count\":7,\"user_count\":3," +
+                            "\"status_code\":504,\"unhandled\":1,\"version\":\"v3.1.2\"," +
+                            "\"first_seen\":\"2026-06-06T02:10:00.000Z\",\"last_seen\":\"2026-06-06T03:00:00.000Z\"}"
+                    "GROUP BY trace_id_out" in query ->
+                        "{" +
+                            "\"trace_id_out\":\"trace-1\",\"resource\":\"POST /checkout\"," +
+                            "\"name\":\"http.request\",\"http_status\":0,\"duration_ms\":620," +
+                            "\"span_count\":4,\"time\":\"03:01:00\"}"
+                    "GROUP BY service" in query ->
+                        "{" +
+                            "\"name\":\"checkout-api\",\"span_count\":60,\"error_count\":3," +
+                            "\"p50_ns\":70000000,\"p95_ns\":240000000,\"p99_ns\":612000000," +
+                            "\"apdex_satisfied\":40,\"apdex_tolerating\":10," +
+                            "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v3.1.2\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"web\"," +
+                            "\"team\":\"payments\",\"language\":\"go\"}"
+                    "GROUP BY bucket_start" in query ->
+                        "{\"t\":\"03:00\",\"p50\":70,\"p90\":180,\"p95\":240,\"p99\":612," +
+                            "\"rps\":14.5,\"errors\":0.2}"
+                    "GROUP BY resource" in query ->
+                        "{" +
+                            "\"resource\":\"POST /checkout\",\"name\":\"http.request\",\"type\":\"web\"," +
+                            "\"span_count\":40,\"error_count\":4,\"p50_ns\":70000000," +
+                            "\"p95_ns\":240000000,\"p99_ns\":612000000}"
+                    else -> ""
+                }
+            }
+
+            val detail = ApmServiceCatalogService.getServiceDetail(
+                organizationId = 12,
+                serviceName = "checkout-api",
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            requireNotNull(detail)
+            assertEquals("03:00", detail.deployAt)
+            assertEquals(listOf("v3.1.2", "v3.1.1"), detail.deployments.map { deploy -> deploy.version })
+            assertTrue(detail.kpis.any { kpi -> kpi.delta != null })
+            assertEquals("checkout-api-7f8d9c", detail.pods.single().pod)
+            assertEquals("2.0GB", detail.pods.single().mem)
+            assertEquals(2, detail.pods.single().restarts)
+            assertEquals("bad", detail.errorBars.single().level)
+            assertEquals("fatal", detail.errors.single().severity)
+            assertEquals("3", detail.errors.single().users)
+            assertTrue(detail.errors.single().unhandled)
+            assertTrue(detail.errors.single().chips.contains("v3.1.2"))
+            assertEquals(0, detail.traces.single().httpStatus)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getServiceDetail returns resource rows and latency series for a service`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val query = firstArg<String>()
+                when {
+                    "GROUP BY service" in query ->
+                        "{" +
+                            "\"name\":\"checkout-api\",\"span_count\":7200,\"error_count\":36," +
+                            "\"p50_ns\":70000000,\"p95_ns\":248000000,\"p99_ns\":612000000," +
+                            "\"apdex_satisfied\":6900,\"apdex_tolerating\":200," +
+                            "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v3.1.2\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"web\"}"
+                    "GROUP BY bucket_start" in query ->
+                        "{\"t\":\"03:00\",\"p50\":70,\"p90\":180,\"p95\":248,\"p99\":612," +
+                            "\"rps\":14.5,\"errors\":0.2}"
+                    "GROUP BY resource" in query ->
+                        "{" +
+                            "\"resource\":\"POST /checkout/pay\",\"name\":\"rack.request\",\"type\":\"web\"," +
+                            "\"span_count\":2400,\"error_count\":24,\"p50_ns\":180000000," +
+                            "\"p95_ns\":612000000,\"p99_ns\":1210000000}"
+                    else -> ""
+                }
+            }
+
+            val detail = ApmServiceCatalogService.getServiceDetail(
+                organizationId = 12,
+                serviceName = "checkout-api",
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            requireNotNull(detail)
+            assertEquals("checkout-api", detail.name)
+            assertEquals("v3.1.2", detail.version)
+            assertEquals("POST", detail.resources.single().method)
+            assertEquals("/checkout/pay", detail.resources.single().name)
+            assertEquals("post-checkout-pay", detail.resources.single().slug)
+            assertEquals(248, detail.latency.single().p95)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getServiceDetail resource aggregate query does not group by aggregate aliases`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val query = firstArg<String>()
+                queries += query
+                when {
+                    "GROUP BY service" in query ->
+                        "{" +
+                            "\"name\":\"api-gateway\",\"span_count\":7200,\"error_count\":36," +
+                            "\"p50_ns\":70000000,\"p95_ns\":248000000,\"p99_ns\":612000000," +
+                            "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v3.1.2\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"web\"}"
+                    "GROUP BY resource" in query ->
+                        "{" +
+                            "\"resource\":\"GET /api/products\",\"name\":\"http.request\",\"type\":\"web\"," +
+                            "\"span_count\":2400,\"error_count\":24,\"p50_ns\":180000000," +
+                            "\"p95_ns\":612000000,\"p99_ns\":1210000000}"
+                    "GROUP BY bucket_start" in query ->
+                        "{\"t\":\"03:00\",\"p50\":70,\"p90\":180,\"p95\":248,\"p99\":612," +
+                            "\"rps\":14.5,\"errors\":0.2}"
+                    else -> ""
+                }
+            }
+
+            val detail = ApmServiceCatalogService.getServiceDetail(
+                organizationId = 12,
+                serviceName = "api-gateway",
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            requireNotNull(detail)
+            val resourceAggregateQuery = queries.single { "argMax(name, start)" in it }
+            assertTrue("GROUP BY resource, name, type" !in resourceAggregateQuery)
+            assertTrue("GROUP BY resource" in resourceAggregateQuery)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getServiceDetail uses an exact service lookup without catalog paging`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+                val query = firstArg<String>()
+                queries += query
+                when {
+                    "GROUP BY service" in query ->
+                        "{" +
+                            "\"name\":\"worker-low-volume\",\"span_count\":12,\"error_count\":0," +
+                            "\"p50_ns\":12000000,\"p95_ns\":24000000,\"p99_ns\":48000000," +
+                            "\"apdex_satisfied\":12,\"apdex_tolerating\":0," +
+                            "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v1\"," +
+                            "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"worker\"}"
+                    else -> ""
+                }
+            }
+
+            val detail = ApmServiceCatalogService.getServiceDetail(
+                organizationId = 12,
+                serviceName = "worker-low-volume",
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            requireNotNull(detail)
+            val serviceAggregateQuery = queries.single { "GROUP BY service" in it }
+            assertTrue("service = 'worker-low-volume'" in serviceAggregateQuery)
+            assertTrue("LIMIT 1" in serviceAggregateQuery)
+            assertTrue("OFFSET" !in serviceAggregateQuery)
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `getServiceDetail runs independent detail queries concurrently`() = runBlocking {
+        mockkObject(ClickHouseClient)
+        val activeQueries = AtomicInteger(0)
+        val maxActiveQueries = AtomicInteger(0)
+        try {
+            every { ClickHouseClient.getDatabase() } returns "moneat"
+            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
+                val query = firstArg<String>()
+                if ("GROUP BY service" in query) {
+                    return@coAnswers "{" +
+                        "\"name\":\"checkout-api\",\"span_count\":7200,\"error_count\":36," +
+                        "\"p50_ns\":70000000,\"p95_ns\":248000000,\"p99_ns\":612000000," +
+                        "\"apdex_satisfied\":6900,\"apdex_tolerating\":200," +
+                        "\"envs\":[\"production\"],\"sources\":[\"otlp\"],\"version\":\"v3.1.2\"," +
+                        "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"type\":\"web\"}"
+                }
+
+                val active = activeQueries.incrementAndGet()
+                maxActiveQueries.updateAndGet { current -> maxOf(current, active) }
+                Thread.sleep(50)
+                activeQueries.decrementAndGet()
+
+                when {
+                    "GROUP BY bucket_start" in query ->
+                        "{\"t\":\"03:00\",\"p50\":70,\"p90\":180,\"p95\":248,\"p99\":612," +
+                            "\"rps\":14.5,\"errors\":0.2}"
+                    "GROUP BY resource" in query ->
+                        "{" +
+                            "\"resource\":\"POST /checkout/pay\",\"name\":\"rack.request\",\"type\":\"web\"," +
+                            "\"span_count\":2400,\"error_count\":24,\"p50_ns\":180000000," +
+                            "\"p95_ns\":612000000,\"p99_ns\":1210000000}"
+                    else -> ""
+                }
+            }
+
+            val detail = ApmServiceCatalogService.getServiceDetail(
+                organizationId = 12,
+                serviceName = "checkout-api",
+                query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
+            )
+
+            requireNotNull(detail)
+            assertTrue(maxActiveQueries.get() > 1, "detail queries should overlap instead of running serially")
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
@@ -36,7 +36,7 @@ class ApmServiceCatalogServiceTest {
         val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
-            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } answers {
                 val query = firstArg<String>()
                 queries += query
                 when {
@@ -74,7 +74,7 @@ class ApmServiceCatalogServiceTest {
         mockkObject(ClickHouseClient)
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
-            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } answers {
                 val query = firstArg<String>()
                 when {
                     "GROUP BY service, bucket_start" in query ->
@@ -115,7 +115,7 @@ class ApmServiceCatalogServiceTest {
         mockkObject(ClickHouseClient)
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
-            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } answers {
                 val query = firstArg<String>()
                 when {
                     "FROM `moneat`.containers_latest_by_host" in query ->
@@ -124,10 +124,16 @@ class ApmServiceCatalogServiceTest {
                             "\"cpu\":42,\"mem_usage\":2147483648,\"mem_limit\":4294967296," +
                             "\"restarts\":2,\"state\":\"running\"}"
                     "GROUP BY version" in query ->
-                        """
-                        {"version":"v3.1.2","first_seen":"2026-06-06T03:00:00.000Z","last_seen":"2026-06-06T03:20:00.000Z","deploy_t":"03:00","span_count":60,"error_count":3,"p95_ns":240000000}
-                        {"version":"v3.1.1","first_seen":"2026-06-06T02:00:00.000Z","last_seen":"2026-06-06T02:59:00.000Z","deploy_t":"02:00","span_count":30,"error_count":0,"p95_ns":180000000}
-                        """.trimIndent()
+                        listOf(
+                            "{" +
+                                "\"version\":\"v3.1.2\",\"first_seen\":\"2026-06-06T03:00:00.000Z\"," +
+                                "\"last_seen\":\"2026-06-06T03:20:00.000Z\",\"deploy_t\":\"03:00\"," +
+                                "\"span_count\":60,\"error_count\":3,\"p95_ns\":240000000}",
+                            "{" +
+                                "\"version\":\"v3.1.1\",\"first_seen\":\"2026-06-06T02:00:00.000Z\"," +
+                                "\"last_seen\":\"2026-06-06T02:59:00.000Z\",\"deploy_t\":\"02:00\"," +
+                                "\"span_count\":30,\"error_count\":0,\"p95_ns\":180000000}",
+                        ).joinToString("\n")
                     "previous_span_count" in query ->
                         "{" +
                             "\"previous_span_count\":30,\"previous_error_count\":0," +
@@ -193,7 +199,7 @@ class ApmServiceCatalogServiceTest {
         mockkObject(ClickHouseClient)
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
-            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } answers {
                 val query = firstArg<String>()
                 when {
                     "GROUP BY service" in query ->
@@ -239,7 +245,7 @@ class ApmServiceCatalogServiceTest {
         val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
-            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } answers {
                 val query = firstArg<String>()
                 queries += query
                 when {
@@ -277,14 +283,15 @@ class ApmServiceCatalogServiceTest {
     }
 
     @Test
-    fun `getServiceDetail uses an exact service lookup without catalog paging`() = runBlocking {
+    fun `getServiceDetail uses parameterized exact service lookup without catalog paging`() = runBlocking {
         mockkObject(ClickHouseClient)
-        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val calls = java.util.Collections.synchronizedList(mutableListOf<Pair<String, Map<String, String>>>())
+        val serviceName = "worker-low-volume';DROP TABLE apm_spans;--"
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
-            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } answers {
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } answers {
                 val query = firstArg<String>()
-                queries += query
+                calls += query to thirdArg()
                 when {
                     "GROUP BY service" in query ->
                         "{" +
@@ -299,13 +306,16 @@ class ApmServiceCatalogServiceTest {
 
             val detail = ApmServiceCatalogService.getServiceDetail(
                 organizationId = 12,
-                serviceName = "worker-low-volume",
+                serviceName = serviceName,
                 query = ApmServiceQuery(timeRange = defaultApmQueryTimeRange),
             )
 
             requireNotNull(detail)
-            val serviceAggregateQuery = queries.single { "GROUP BY service" in it }
-            assertTrue("service = 'worker-low-volume'" in serviceAggregateQuery)
+            val serviceAggregateCall = calls.single { (query, _) -> "GROUP BY service" in query }
+            val serviceAggregateQuery = serviceAggregateCall.first
+            assertTrue("service = {p0:String}" in serviceAggregateQuery)
+            assertTrue(serviceName !in serviceAggregateQuery)
+            assertTrue(serviceAggregateCall.second.values.contains(serviceName))
             assertTrue("LIMIT 1" in serviceAggregateQuery)
             assertTrue("OFFSET" !in serviceAggregateQuery)
         } finally {
@@ -320,7 +330,7 @@ class ApmServiceCatalogServiceTest {
         val maxActiveQueries = AtomicInteger(0)
         try {
             every { ClickHouseClient.getDatabase() } returns "moneat"
-            coEvery { ClickHouseClient.executeWithFormat(any(), any()) } coAnswers {
+            coEvery { ClickHouseClient.executeWithFormat(any(), any(), any<Map<String, String>>()) } coAnswers {
                 val query = firstArg<String>()
                 if ("GROUP BY service" in query) {
                     return@coAnswers "{" +

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
@@ -138,6 +138,23 @@ class ClickHouseClientTest {
     }
 
     @Test
+    fun `executeWithFormat sends default format without rewriting query body`() = runBlocking {
+        val requestQueries = mutableListOf<String?>()
+        val requestBodies = mutableListOf<String>()
+        withClickHouseMockServer({ exchange ->
+            requestQueries.add(exchange.requestURI.rawQuery)
+            requestBodies.add(exchange.requestBody.readBytes().toString(StandardCharsets.UTF_8))
+            exchange.respond(200, "1\n", "text/plain")
+        }) {
+            assertEquals("1\n", ClickHouseClient.executeWithFormat("SELECT 1", "JSONEachRow"))
+        }
+
+        val params = parseQueryParams(requestQueries.single())
+        assertEquals("JSONEachRow", params["default_format"])
+        assertEquals("SELECT 1", requestBodies.single())
+    }
+
+    @Test
     fun `executeWithFormat rejects unsupported format before request`() = runBlocking {
         withClickHouseMockServer({ exchange ->
             exchange.respond(200, "1\n", "text/plain")

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
@@ -23,6 +23,7 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.runBlocking
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -155,14 +156,35 @@ class ClickHouseClientTest {
     }
 
     @Test
-    fun `executeWithFormat rejects unsupported format before request`() = runBlocking {
+    fun `executeWithFormat sends default format when format appears outside a clause`() = runBlocking {
+        val requestQueries = mutableListOf<String?>()
+        val requestBodies = mutableListOf<String>()
+        val query = "SELECT 'FORMAT' AS label, formatDateTime(now(), '%F') AS rendered"
         withClickHouseMockServer({ exchange ->
+            requestQueries.add(exchange.requestURI.rawQuery)
+            requestBodies.add(exchange.requestBody.readBytes().toString(StandardCharsets.UTF_8))
+            exchange.respond(200, "1\n", "text/plain")
+        }) {
+            assertEquals("1\n", ClickHouseClient.executeWithFormat(query, "JSONEachRow"))
+        }
+
+        val params = parseQueryParams(requestQueries.single())
+        assertEquals("JSONEachRow", params["default_format"])
+        assertEquals(query, requestBodies.single())
+    }
+
+    @Test
+    fun `executeWithFormat rejects unsupported format before request`() = runBlocking {
+        val requestCount = AtomicInteger(0)
+        withClickHouseMockServer({ exchange ->
+            requestCount.incrementAndGet()
             exchange.respond(200, "1\n", "text/plain")
         }) {
             assertFailsWith<IllegalArgumentException> {
                 ClickHouseClient.executeWithFormat("SELECT 1", "CSV")
             }
         }
+        assertEquals(0, requestCount.get())
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
@@ -138,6 +138,17 @@ class ClickHouseClientTest {
     }
 
     @Test
+    fun `executeWithFormat rejects unsupported format before request`() = runBlocking {
+        withClickHouseMockServer({ exchange ->
+            exchange.respond(200, "1\n", "text/plain")
+        }) {
+            assertFailsWith<IllegalArgumentException> {
+                ClickHouseClient.executeWithFormat("SELECT 1", "CSV")
+            }
+        }
+    }
+
+    @Test
     fun `executeLongRunning completes for a successful response`() = runBlocking {
         val requestQueries = mutableListOf<String?>()
         withClickHouseMockServer({ exchange ->

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -30,6 +30,7 @@ import {
     BarChart3,
     Bell,
     BookOpen,
+    Boxes,
     Brain,
     HelpCircle,
     ChevronLeft,
@@ -219,6 +220,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
     // Core Observability
     { key: 'overview', icon: Home, label: 'Overview', href: APP_OVERVIEW_HREF, requiresProject: false, group: 'core' },
     { key: 'issues', icon: AlertCircle, label: 'Issues', href: '/issues', requiresProject: false, group: 'core' },
+    { key: 'services', icon: Boxes, label: 'Services', href: '/services', requiresProject: false, group: 'core' },
     { key: 'performance', icon: Timer, label: 'Traces', href: '/performance/traces', requiresProject: false, group: 'core' },
     { key: 'logs', icon: ScrollText, label: 'Logs', href: '/logs', requiresProject: false, group: 'core' },
     ...datadogCoreNavItems,

--- a/dashboard/src/components/apm/ServiceVisuals.tsx
+++ b/dashboard/src/components/apm/ServiceVisuals.tsx
@@ -295,7 +295,7 @@ const tooltipContentStyle = {
   color: 'hsl(var(--popover-foreground))',
 } as const
 
-const LATENCY_LINES: ReadonlyArray<{key: keyof Omit<LatencyPoint, 't'>; color: string}> = [
+const LATENCY_PERCENTILE_CONFIG: ReadonlyArray<{key: keyof Omit<LatencyPoint, 't'>; color: string}> = [
   {key: 'p99', color: 'hsl(var(--chart-6))'},
   {key: 'p95', color: 'hsl(var(--chart-1))'},
   {key: 'p90', color: 'hsl(var(--chart-3))'},
@@ -341,7 +341,7 @@ export function LatencyPercentilesChart({
             contentStyle={tooltipContentStyle}
             formatter={(value, name) => [`${String(value)}ms`, String(name)]}
           />
-          {LATENCY_LINES.map((line) => (
+          {LATENCY_PERCENTILE_CONFIG.map((line) => (
             <Line
               key={line.key}
               type="monotone"
@@ -358,13 +358,6 @@ export function LatencyPercentilesChart({
   )
 }
 
-const LEGEND_ROWS: ReadonlyArray<{key: keyof Omit<LatencyPoint, 't'>; color: string}> = [
-  {key: 'p99', color: 'hsl(var(--chart-6))'},
-  {key: 'p95', color: 'hsl(var(--chart-1))'},
-  {key: 'p90', color: 'hsl(var(--chart-3))'},
-  {key: 'p50', color: 'hsl(var(--chart-4))'},
-]
-
 export function LatencyLegendTable({series}: Readonly<{series: readonly LatencyPoint[]}>) {
   return (
     <table className="mt-3 w-full border-collapse font-mono text-xs tabular-nums">
@@ -377,7 +370,7 @@ export function LatencyLegendTable({series}: Readonly<{series: readonly LatencyP
         </tr>
       </thead>
       <tbody>
-        {LEGEND_ROWS.map((row) => {
+        {LATENCY_PERCENTILE_CONFIG.map((row) => {
           const values = series.map((point) => point[row.key])
           const last = values.at(-1) ?? 0
           return (

--- a/dashboard/src/components/apm/ServiceVisuals.tsx
+++ b/dashboard/src/components/apm/ServiceVisuals.tsx
@@ -70,11 +70,11 @@ export function ApmTimeRangeSelect({
   value,
   onChange,
   className,
-}: {
+}: Readonly<{
   value: ApmTimeRange
   onChange: (value: ApmTimeRange) => void
   className?: string
-}) {
+}>) {
   return (
     <Select value={value} onValueChange={(next) => onChange(next as ApmTimeRange)}>
       <SelectTrigger className={cn('h-[30px] w-[148px] gap-2 text-xs', className)} aria-label="Time range">
@@ -97,7 +97,7 @@ export function ApmTimeRangeSelect({
 // ---------------------------------------------------------------------------
 
 /** Neutral uppercase glyph chip — keeps status the only color in a row. */
-export function TypeChip({type, className}: {type: ServiceType; className?: string}) {
+export function TypeChip({type, className}: Readonly<{type: ServiceType; className?: string}>) {
   return (
     <span
       className={cn(
@@ -111,7 +111,7 @@ export function TypeChip({type, className}: {type: ServiceType; className?: stri
   )
 }
 
-export function ServiceStatusBadge({status}: {status: ServiceStatus}) {
+export function ServiceStatusBadge({status}: Readonly<{status: ServiceStatus}>) {
   return (
     <Badge variant={statusBadgeVariant(status)} size="sm" className="capitalize">
       {statusLabel(status)}
@@ -124,7 +124,7 @@ const CHART_PILL_BG: Record<number, string> = {
   6: 'bg-chart-6', 7: 'bg-chart-7', 8: 'bg-chart-8', 9: 'bg-chart-9', 10: 'bg-chart-10',
 }
 
-export function EnvPills({pills}: {pills: readonly EnvPill[]}) {
+export function EnvPills({pills}: Readonly<{pills: readonly EnvPill[]}>) {
   return (
     <span className="flex flex-wrap gap-1">
       {pills.map((pill) => (
@@ -142,7 +142,7 @@ export function EnvPills({pills}: {pills: readonly EnvPill[]}) {
   )
 }
 
-export function MetaChip({children}: {children: ReactNode}) {
+export function MetaChip({children}: Readonly<{children: ReactNode}>) {
   return (
     <span className="inline-flex items-center gap-1 rounded border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
       {children}
@@ -151,7 +151,7 @@ export function MetaChip({children}: {children: ReactNode}) {
 }
 
 /** Soft info callout used under dependency / span-breakdown panels. */
-export function InfoCallout({children}: {children: ReactNode}) {
+export function InfoCallout({children}: Readonly<{children: ReactNode}>) {
   return (
     <div className="flex items-start gap-2 rounded-lg border border-info-border bg-info-bg/50 px-3 py-2.5 text-sm">
       <Info className="mt-0.5 h-4 w-4 shrink-0 text-info-fg" />
@@ -176,12 +176,12 @@ export function MeterBar({
   level,
   value,
   className,
-}: {
+}: Readonly<{
   pct: number
   level: Severity
   value: string
   className?: string
-}) {
+}>) {
   return (
     <div className={cn('flex items-center justify-end gap-2', className)}>
       <span className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
@@ -195,7 +195,7 @@ export function MeterBar({
   )
 }
 
-export function ApdexHeat({value, tone}: {value: string; tone: StatusTone}) {
+export function ApdexHeat({value, tone}: Readonly<{value: string; tone: StatusTone}>) {
   return (
     <span className={cn('inline-block rounded px-2 py-0.5 font-mono text-xs tabular-nums', apdexHeatClass(tone))}>
       {value}
@@ -204,7 +204,7 @@ export function ApdexHeat({value, tone}: {value: string; tone: StatusTone}) {
 }
 
 /** Horizontal label / track / value gauge rows (p95 by resource, pod memory…). */
-export function BarGauge({rows}: {rows: readonly GaugeRow[]}) {
+export function BarGauge({rows}: Readonly<{rows: readonly GaugeRow[]}>) {
   return (
     <div className="flex flex-col gap-2">
       {rows.map((row) => (
@@ -230,7 +230,7 @@ export function BarGauge({rows}: {rows: readonly GaugeRow[]}) {
 // Sparkline
 // ---------------------------------------------------------------------------
 
-export function Sparkline({values, className}: {values: readonly number[]; className?: string}) {
+export function Sparkline({values, className}: Readonly<{values: readonly number[]; className?: string}>) {
   const width = 88
   const height = 22
   const points = values
@@ -266,7 +266,7 @@ const TONE_TEXT: Record<StatusTone, string> = {
   accent: 'text-primary',
 }
 
-export function ApmKpiRow({kpis}: {kpis: readonly KpiSpec[]}) {
+export function ApmKpiRow({kpis}: Readonly<{kpis: readonly KpiSpec[]}>) {
   return (
     <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
       {kpis.map((kpi) => (
@@ -307,12 +307,12 @@ export function LatencyPercentilesChart({
   thresholdMs,
   thresholdLabel,
   deployAt,
-}: {
+}: Readonly<{
   series: readonly LatencyPoint[]
   thresholdMs: number
   thresholdLabel: string
   deployAt: string
-}) {
+}>) {
   const maxY = Math.max(...series.map((point) => point.p99))
   const top = Math.ceil((maxY * 1.05) / 10) * 10
   return (
@@ -365,7 +365,7 @@ const LEGEND_ROWS: ReadonlyArray<{key: keyof Omit<LatencyPoint, 't'>; color: str
   {key: 'p50', color: 'hsl(var(--chart-4))'},
 ]
 
-export function LatencyLegendTable({series}: {series: readonly LatencyPoint[]}) {
+export function LatencyLegendTable({series}: Readonly<{series: readonly LatencyPoint[]}>) {
   return (
     <table className="mt-3 w-full border-collapse font-mono text-xs tabular-nums">
       <thead>
@@ -379,7 +379,7 @@ export function LatencyLegendTable({series}: {series: readonly LatencyPoint[]}) 
       <tbody>
         {LEGEND_ROWS.map((row) => {
           const values = series.map((point) => point[row.key])
-          const last = values[values.length - 1] ?? 0
+          const last = values.at(-1) ?? 0
           return (
             <tr key={row.key}>
               <td className="border-b py-1 pl-0 pr-2 text-left font-sans">
@@ -401,11 +401,11 @@ export function ThroughputChart({
   points,
   deployAt,
   withErrors = false,
-}: {
+}: Readonly<{
   points: readonly ThroughputPoint[]
   deployAt: string
   withErrors?: boolean
-}) {
+}>) {
   return (
     <div className="h-[200px] w-full">
       <ResponsiveContainer width="100%" height="100%" minWidth={0}>
@@ -455,12 +455,12 @@ export function ThroughputChart({
 // Bar histograms (errors/min, latency distribution)
 // ---------------------------------------------------------------------------
 
-export function ErrorBars({bars}: {bars: readonly ErrorBar[]}) {
+export function ErrorBars({bars}: Readonly<{bars: readonly ErrorBar[]}>) {
   return (
     <div className="flex h-[120px] items-end gap-1">
-      {bars.map((bar, index) => (
+      {bars.map((bar) => (
         <span
-          key={index}
+          key={`${bar.level}-${bar.h}`}
           className={cn(
             'min-h-[4px] flex-1 rounded-t-sm',
             bar.level === 'bad' ? 'bg-danger-solid' : 'bg-warning-solid',
@@ -482,11 +482,11 @@ export function LatencyDistribution({
   bars,
   markers,
   axis,
-}: {
+}: Readonly<{
   bars: readonly DistBar[]
   markers: readonly DistMarker[]
   axis: readonly string[]
-}) {
+}>) {
   return (
     <div className="relative">
       <div className="pointer-events-none absolute inset-x-0 bottom-[18px] top-0">
@@ -511,9 +511,9 @@ export function LatencyDistribution({
         ))}
       </div>
       <div className="flex h-[130px] items-end gap-1">
-        {bars.map((bar, index) => (
+        {bars.map((bar) => (
           <span
-            key={index}
+            key={`${bar.band}-${bar.h}`}
             className={cn('min-h-[4px] flex-1 rounded-t-sm', DIST_BAND_BG[bar.band])}
             style={{height: `${bar.h}%`}}
           />
@@ -541,12 +541,12 @@ const WATERFALL_BG: Record<WaterfallTone, string> = {
   error: 'bg-danger-solid',
 }
 
-export function Waterfall({rows}: {rows: readonly WaterfallRow[]}) {
+export function Waterfall({rows}: Readonly<{rows: readonly WaterfallRow[]}>) {
   return (
     <div className="overflow-hidden rounded-lg border text-xs">
-      {rows.map((row, index) => (
+      {rows.map((row) => (
         <div
-          key={index}
+          key={`${row.op}-${row.desc}-${row.left}-${row.width}-${row.label}`}
           className={cn(
             'grid grid-cols-[180px_minmax(0,1fr)] items-center border-b last:border-b-0 sm:grid-cols-[260px_minmax(0,1fr)]',
             row.selected ? 'bg-muted' : 'hover:bg-muted/50',
@@ -583,15 +583,15 @@ export function Waterfall({rows}: {rows: readonly WaterfallRow[]}) {
 // Error list (service Errors tab + resource errors panel)
 // ---------------------------------------------------------------------------
 
-export function ErrorList({errors, showUsers = false}: {errors: readonly ErrorRow[]; showUsers?: boolean}) {
+export function ErrorList({errors, showUsers = false}: Readonly<{errors: readonly ErrorRow[]; showUsers?: boolean}>) {
   if (errors.length === 0) {
     return <p className="px-1 py-6 text-center text-sm text-muted-foreground">No active errors on this surface.</p>
   }
   return (
     <div className="divide-y">
-      {errors.map((error, index) => (
+      {errors.map((error) => (
         <div
-          key={index}
+          key={`${error.severity}-${error.title}-${error.sub}-${error.events}`}
           className={cn(
             'flex items-center gap-3 border-l-[3px] px-3 py-3 transition-colors hover:bg-muted/50',
             errorSeverityBorder(error.severity),
@@ -639,11 +639,11 @@ export function ErrorList({errors, showUsers = false}: {errors: readonly ErrorRo
 // HTTP method chip + status badge (resource tables, traces)
 // ---------------------------------------------------------------------------
 
-export function MethodChip({method, className}: {method: string; className?: string}) {
+export function MethodChip({method, className}: Readonly<{method: string; className?: string}>) {
   return <span className={cn('font-mono text-xs font-semibold text-foreground', className)}>{method}</span>
 }
 
-export function HttpStatusBadge({status}: {status: number}) {
+export function HttpStatusBadge({status}: Readonly<{status: number}>) {
   const ok = status < 400
   return (
     <Badge variant={ok ? 'success' : 'danger'} size="sm">

--- a/dashboard/src/components/apm/ServiceVisuals.tsx
+++ b/dashboard/src/components/apm/ServiceVisuals.tsx
@@ -1,0 +1,653 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {ReactNode} from 'react'
+import {Clock, Info} from 'lucide-react'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import {Badge} from '@/components/ui/badge'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
+import {StatCard} from '@/components/ui/stat-card'
+import type {StatusTone} from '@/components/ui/status-dot'
+import type {ApmTimeRange} from '@/lib/api'
+import {cn} from '@/lib/utils'
+import {
+  APM_TIME_RANGE_OPTIONS,
+  apdexHeatClass,
+  errorSeverityBorder,
+  errorSeverityTone,
+  severityFill,
+  serviceTypeLabel,
+  statusBadgeVariant,
+  statusLabel,
+  type DistBar,
+  type DistMarker,
+  type EnvPill,
+  type ErrorBar,
+  type ErrorRow,
+  type GaugeRow,
+  type KpiSpec,
+  type LatencyPoint,
+  type ServiceStatus,
+  type ServiceType,
+  type Severity,
+  type ThroughputPoint,
+  type WaterfallRow,
+  type WaterfallTone,
+} from '@/lib/apm-view'
+
+// ---------------------------------------------------------------------------
+// Time range selector (shared across catalog / service / resource pages)
+// ---------------------------------------------------------------------------
+
+/** Controlled APM time-range selector wired to the `timeRange` query param. */
+export function ApmTimeRangeSelect({
+  value,
+  onChange,
+  className,
+}: {
+  value: ApmTimeRange
+  onChange: (value: ApmTimeRange) => void
+  className?: string
+}) {
+  return (
+    <Select value={value} onValueChange={(next) => onChange(next as ApmTimeRange)}>
+      <SelectTrigger className={cn('h-[30px] w-[148px] gap-2 text-xs', className)} aria-label="Time range">
+        <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {APM_TIME_RANGE_OPTIONS.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Small chips / badges
+// ---------------------------------------------------------------------------
+
+/** Neutral uppercase glyph chip — keeps status the only color in a row. */
+export function TypeChip({type, className}: {type: ServiceType; className?: string}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 items-center rounded-sm border bg-muted px-1.5',
+        'text-[10px] font-medium uppercase tracking-wide text-muted-foreground',
+        className,
+      )}
+    >
+      {serviceTypeLabel(type)}
+    </span>
+  )
+}
+
+export function ServiceStatusBadge({status}: {status: ServiceStatus}) {
+  return (
+    <Badge variant={statusBadgeVariant(status)} size="sm" className="capitalize">
+      {statusLabel(status)}
+    </Badge>
+  )
+}
+
+const CHART_PILL_BG: Record<number, string> = {
+  1: 'bg-chart-1', 2: 'bg-chart-2', 3: 'bg-chart-3', 4: 'bg-chart-4', 5: 'bg-chart-5',
+  6: 'bg-chart-6', 7: 'bg-chart-7', 8: 'bg-chart-8', 9: 'bg-chart-9', 10: 'bg-chart-10',
+}
+
+export function EnvPills({pills}: {pills: readonly EnvPill[]}) {
+  return (
+    <span className="flex flex-wrap gap-1">
+      {pills.map((pill) => (
+        <span
+          key={pill.label}
+          className={cn(
+            'inline-flex h-[18px] items-center rounded px-1.5 text-[10px] font-medium text-white',
+            CHART_PILL_BG[pill.chart] ?? 'bg-muted-foreground',
+          )}
+        >
+          {pill.label}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+export function MetaChip({children}: {children: ReactNode}) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+      {children}
+    </span>
+  )
+}
+
+/** Soft info callout used under dependency / span-breakdown panels. */
+export function InfoCallout({children}: {children: ReactNode}) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-info-border bg-info-bg/50 px-3 py-2.5 text-sm">
+      <Info className="mt-0.5 h-4 w-4 shrink-0 text-info-fg" />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Inline meters
+// ---------------------------------------------------------------------------
+
+const METER_FILL: Record<Severity, string> = {
+  good: 'bg-primary',
+  warn: 'bg-warning-solid',
+  bad: 'bg-danger-solid',
+}
+
+/** Dense in-cell meter: a thin track + fill with a trailing mono value. */
+export function MeterBar({
+  pct,
+  level,
+  value,
+  className,
+}: {
+  pct: number
+  level: Severity
+  value: string
+  className?: string
+}) {
+  return (
+    <div className={cn('flex items-center justify-end gap-2', className)}>
+      <span className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+        <span
+          className={cn('absolute inset-y-0 left-0 rounded-full', METER_FILL[level])}
+          style={{width: `${Math.max(2, Math.min(100, pct))}%`}}
+        />
+      </span>
+      <span className="w-10 shrink-0 text-right font-mono text-xs tabular-nums">{value}</span>
+    </div>
+  )
+}
+
+export function ApdexHeat({value, tone}: {value: string; tone: StatusTone}) {
+  return (
+    <span className={cn('inline-block rounded px-2 py-0.5 font-mono text-xs tabular-nums', apdexHeatClass(tone))}>
+      {value}
+    </span>
+  )
+}
+
+/** Horizontal label / track / value gauge rows (p95 by resource, pod memory…). */
+export function BarGauge({rows}: {rows: readonly GaugeRow[]}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          className="grid grid-cols-[minmax(96px,160px)_1fr_56px] items-center gap-3 text-sm"
+        >
+          <span className="truncate font-mono text-xs text-muted-foreground">{row.label}</span>
+          <span className="h-3.5 overflow-hidden rounded-sm bg-muted">
+            <span
+              className={cn('block h-full rounded-sm', severityFill(row.level))}
+              style={{width: `${Math.max(2, Math.min(100, row.pct))}%`}}
+            />
+          </span>
+          <span className="text-right font-mono text-xs tabular-nums">{row.valueText}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sparkline
+// ---------------------------------------------------------------------------
+
+export function Sparkline({values, className}: {values: readonly number[]; className?: string}) {
+  const width = 88
+  const height = 22
+  const points = values
+    .map((value, index) => {
+      const x = values.length === 1 ? 0 : (index / (values.length - 1)) * width
+      return `${x.toFixed(1)},${value.toFixed(1)}`
+    })
+    .join(' ')
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      preserveAspectRatio="none"
+      className={cn('shrink-0', className)}
+      aria-hidden="true"
+    >
+      <polyline points={points} fill="none" stroke="hsl(var(--chart-1))" strokeWidth={1.5} />
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// KPI row
+// ---------------------------------------------------------------------------
+
+const TONE_TEXT: Record<StatusTone, string> = {
+  success: 'text-success-fg',
+  warning: 'text-warning-fg',
+  danger: 'text-danger-fg',
+  info: 'text-info-fg',
+  neutral: 'text-muted-foreground',
+  accent: 'text-primary',
+}
+
+export function ApmKpiRow({kpis}: {kpis: readonly KpiSpec[]}) {
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      {kpis.map((kpi) => (
+        <StatCard
+          key={kpi.label}
+          label={kpi.label}
+          value={
+            kpi.valueTone ? <span className={TONE_TEXT[kpi.valueTone]}>{kpi.value}</span> : kpi.value
+          }
+          delta={kpi.delta}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Charts (recharts)
+// ---------------------------------------------------------------------------
+
+const tooltipContentStyle = {
+  fontSize: 12,
+  borderRadius: 8,
+  border: '1px solid hsl(var(--border))',
+  background: 'hsl(var(--popover))',
+  color: 'hsl(var(--popover-foreground))',
+} as const
+
+const LATENCY_LINES: ReadonlyArray<{key: keyof Omit<LatencyPoint, 't'>; color: string}> = [
+  {key: 'p99', color: 'hsl(var(--chart-6))'},
+  {key: 'p95', color: 'hsl(var(--chart-1))'},
+  {key: 'p90', color: 'hsl(var(--chart-3))'},
+  {key: 'p50', color: 'hsl(var(--chart-4))'},
+]
+
+export function LatencyPercentilesChart({
+  series,
+  thresholdMs,
+  thresholdLabel,
+  deployAt,
+}: {
+  series: readonly LatencyPoint[]
+  thresholdMs: number
+  thresholdLabel: string
+  deployAt: string
+}) {
+  const maxY = Math.max(...series.map((point) => point.p99))
+  const top = Math.ceil((maxY * 1.05) / 10) * 10
+  return (
+    <div className="h-[200px] w-full">
+      <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+        <LineChart data={series as LatencyPoint[]} margin={{top: 12, right: 10, left: 0, bottom: 0}}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+          <XAxis dataKey="t" tick={{fontSize: 10}} axisLine={false} tickLine={false} interval={2} minTickGap={12} />
+          <YAxis hide domain={[0, top]} />
+          <ReferenceArea y1={thresholdMs} y2={top} fill="hsl(var(--danger-solid))" fillOpacity={0.07} />
+          <ReferenceLine
+            y={thresholdMs}
+            stroke="hsl(var(--danger-solid))"
+            strokeDasharray="4 4"
+            strokeOpacity={0.7}
+            label={{value: thresholdLabel, position: 'insideTopLeft', fontSize: 10, fill: 'hsl(var(--danger-fg))'}}
+          />
+          <ReferenceLine
+            x={deployAt}
+            stroke="hsl(var(--primary))"
+            strokeDasharray="3 3"
+            strokeOpacity={0.8}
+            label={{value: 'deploy', position: 'top', fontSize: 10, fill: 'hsl(var(--primary))'}}
+          />
+          <Tooltip
+            contentStyle={tooltipContentStyle}
+            formatter={(value, name) => [`${String(value)}ms`, String(name)]}
+          />
+          {LATENCY_LINES.map((line) => (
+            <Line
+              key={line.key}
+              type="monotone"
+              dataKey={line.key}
+              stroke={line.color}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+const LEGEND_ROWS: ReadonlyArray<{key: keyof Omit<LatencyPoint, 't'>; color: string}> = [
+  {key: 'p99', color: 'hsl(var(--chart-6))'},
+  {key: 'p95', color: 'hsl(var(--chart-1))'},
+  {key: 'p90', color: 'hsl(var(--chart-3))'},
+  {key: 'p50', color: 'hsl(var(--chart-4))'},
+]
+
+export function LatencyLegendTable({series}: {series: readonly LatencyPoint[]}) {
+  return (
+    <table className="mt-3 w-full border-collapse font-mono text-xs tabular-nums">
+      <thead>
+        <tr className="text-muted-foreground">
+          <th className="border-b py-1 pl-0 pr-2 text-left font-sans font-medium">Percentile</th>
+          <th className="border-b px-2 py-1 text-right font-sans font-medium">Min</th>
+          <th className="border-b px-2 py-1 text-right font-sans font-medium">Max</th>
+          <th className="border-b px-2 py-1 text-right font-sans font-medium">Last</th>
+        </tr>
+      </thead>
+      <tbody>
+        {LEGEND_ROWS.map((row) => {
+          const values = series.map((point) => point[row.key])
+          const last = values[values.length - 1] ?? 0
+          return (
+            <tr key={row.key}>
+              <td className="border-b py-1 pl-0 pr-2 text-left font-sans">
+                <span className="mr-2 inline-block h-2.5 w-2.5 rounded-[2px] align-middle" style={{background: row.color}} />
+                {row.key}
+              </td>
+              <td className="border-b px-2 py-1 text-right">{Math.min(...values)}</td>
+              <td className="border-b px-2 py-1 text-right">{Math.max(...values)}</td>
+              <td className="border-b px-2 py-1 text-right">{last}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}
+
+export function ThroughputChart({
+  points,
+  deployAt,
+  withErrors = false,
+}: {
+  points: readonly ThroughputPoint[]
+  deployAt: string
+  withErrors?: boolean
+}) {
+  return (
+    <div className="h-[200px] w-full">
+      <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+        <AreaChart data={points as ThroughputPoint[]} margin={{top: 12, right: 10, left: 0, bottom: 0}}>
+          <defs>
+            <linearGradient id="apm-throughput" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0" stopColor="hsl(var(--chart-1))" stopOpacity={0.28} />
+              <stop offset="1" stopColor="hsl(var(--chart-1))" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+          <XAxis dataKey="t" tick={{fontSize: 10}} axisLine={false} tickLine={false} interval={2} minTickGap={12} />
+          <YAxis hide />
+          <ReferenceLine
+            x={deployAt}
+            stroke="hsl(var(--primary))"
+            strokeDasharray="3 3"
+            strokeOpacity={0.8}
+            label={{value: 'deploy', position: 'top', fontSize: 10, fill: 'hsl(var(--primary))'}}
+          />
+          <Tooltip contentStyle={tooltipContentStyle} />
+          <Area
+            type="monotone"
+            dataKey="rps"
+            stroke="hsl(var(--chart-1))"
+            strokeWidth={2}
+            fill="url(#apm-throughput)"
+            isAnimationActive={false}
+          />
+          {withErrors && (
+            <Area
+              type="monotone"
+              dataKey="errors"
+              stroke="hsl(var(--danger-solid))"
+              strokeWidth={2}
+              fill="transparent"
+              isAnimationActive={false}
+            />
+          )}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Bar histograms (errors/min, latency distribution)
+// ---------------------------------------------------------------------------
+
+export function ErrorBars({bars}: {bars: readonly ErrorBar[]}) {
+  return (
+    <div className="flex h-[120px] items-end gap-1">
+      {bars.map((bar, index) => (
+        <span
+          key={index}
+          className={cn(
+            'min-h-[4px] flex-1 rounded-t-sm',
+            bar.level === 'bad' ? 'bg-danger-solid' : 'bg-warning-solid',
+          )}
+          style={{height: `${bar.h}%`}}
+        />
+      ))}
+    </div>
+  )
+}
+
+const DIST_BAND_BG: Record<Severity, string> = {
+  good: 'bg-chart-1',
+  warn: 'bg-warning-solid',
+  bad: 'bg-danger-solid',
+}
+
+export function LatencyDistribution({
+  bars,
+  markers,
+  axis,
+}: {
+  bars: readonly DistBar[]
+  markers: readonly DistMarker[]
+  axis: readonly string[]
+}) {
+  return (
+    <div className="relative">
+      <div className="pointer-events-none absolute inset-x-0 bottom-[18px] top-0">
+        {markers.map((marker) => (
+          <div
+            key={marker.label}
+            className={cn(
+              'absolute bottom-0 top-0 border-l border-dashed',
+              marker.p99 ? 'border-danger-solid' : 'border-primary',
+            )}
+            style={{left: `${marker.left}%`}}
+          >
+            <span
+              className={cn(
+                'absolute left-1 top-0 bg-card px-1 font-mono text-[10px]',
+                marker.p99 ? 'text-danger-fg' : 'text-primary',
+              )}
+            >
+              {marker.label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex h-[130px] items-end gap-1">
+        {bars.map((bar, index) => (
+          <span
+            key={index}
+            className={cn('min-h-[4px] flex-1 rounded-t-sm', DIST_BAND_BG[bar.band])}
+            style={{height: `${bar.h}%`}}
+          />
+        ))}
+      </div>
+      <div className="mt-1.5 flex justify-between font-mono text-[10px] text-muted-foreground">
+        {axis.map((label) => (
+          <span key={label}>{label}</span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Waterfall
+// ---------------------------------------------------------------------------
+
+const WATERFALL_BG: Record<WaterfallTone, string> = {
+  root: 'bg-chart-1',
+  app: 'bg-chart-2',
+  db: 'bg-chart-3',
+  cache: 'bg-chart-4',
+  http: 'bg-chart-6',
+  error: 'bg-danger-solid',
+}
+
+export function Waterfall({rows}: {rows: readonly WaterfallRow[]}) {
+  return (
+    <div className="overflow-hidden rounded-lg border text-xs">
+      {rows.map((row, index) => (
+        <div
+          key={index}
+          className={cn(
+            'grid grid-cols-[180px_minmax(0,1fr)] items-center border-b last:border-b-0 sm:grid-cols-[260px_minmax(0,1fr)]',
+            row.selected ? 'bg-muted' : 'hover:bg-muted/50',
+          )}
+        >
+          <div className="flex items-center gap-1 border-r px-2 py-1.5">
+            {Array.from({length: row.indent ?? 0}, (_, i) => (
+              <span key={i} className="inline-block w-3 shrink-0" />
+            ))}
+            <span className={cn('font-medium', row.tone === 'error' ? 'text-danger-fg' : 'text-foreground')}>
+              {row.op}
+            </span>
+            <span className="truncate font-mono text-muted-foreground">{row.desc}</span>
+          </div>
+          <div className="relative h-full px-3 py-2">
+            <span
+              className={cn('absolute top-1/2 h-3 -translate-y-1/2 rounded-sm', WATERFALL_BG[row.tone])}
+              style={{left: `${row.left}%`, width: `${row.width}%`}}
+            />
+            <span
+              className="absolute top-1/2 -translate-y-1/2 whitespace-nowrap font-mono text-[10px] text-muted-foreground"
+              style={{left: `${Math.min(row.left + row.width + 1, 86)}%`}}
+            >
+              {row.label}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Error list (service Errors tab + resource errors panel)
+// ---------------------------------------------------------------------------
+
+export function ErrorList({errors, showUsers = false}: {errors: readonly ErrorRow[]; showUsers?: boolean}) {
+  if (errors.length === 0) {
+    return <p className="px-1 py-6 text-center text-sm text-muted-foreground">No active errors on this surface.</p>
+  }
+  return (
+    <div className="divide-y">
+      {errors.map((error, index) => (
+        <div
+          key={index}
+          className={cn(
+            'flex items-center gap-3 border-l-[3px] px-3 py-3 transition-colors hover:bg-muted/50',
+            errorSeverityBorder(error.severity),
+          )}
+        >
+          <span
+            className={cn(
+              'mt-0.5 h-2 w-2 shrink-0 self-start rounded-full',
+              errorSeverityTone(error.severity) === 'warning' ? 'bg-warning-solid' : 'bg-danger-solid',
+            )}
+          />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex items-center gap-2 text-[13px] font-semibold">
+              <span className="truncate">{error.title}</span>
+              {error.unhandled && (
+                <Badge variant="danger" size="sm" className="h-[18px]">
+                  unhandled
+                </Badge>
+              )}
+            </div>
+            <div className="truncate font-mono text-xs text-muted-foreground">{error.sub}</div>
+            <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+              {error.chips.map((chip) => (
+                <MetaChip key={chip}>{chip}</MetaChip>
+              ))}
+            </div>
+          </div>
+          <div className="w-16 shrink-0 text-right font-mono text-sm tabular-nums">
+            {error.events}
+            <span className="block text-[10px] uppercase tracking-wide text-muted-foreground/70">events</span>
+          </div>
+          {showUsers && (
+            <div className="w-16 shrink-0 text-right font-mono text-sm tabular-nums">
+              {error.users ?? '—'}
+              <span className="block text-[10px] uppercase tracking-wide text-muted-foreground/70">users</span>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// HTTP method chip + status badge (resource tables, traces)
+// ---------------------------------------------------------------------------
+
+export function MethodChip({method, className}: {method: string; className?: string}) {
+  return <span className={cn('font-mono text-xs font-semibold text-foreground', className)}>{method}</span>
+}
+
+export function HttpStatusBadge({status}: {status: number}) {
+  const ok = status < 400
+  return (
+    <Badge variant={ok ? 'success' : 'danger'} size="sm">
+      {status}
+    </Badge>
+  )
+}

--- a/dashboard/src/components/apm/__tests__/ServiceVisuals.test.tsx
+++ b/dashboard/src/components/apm/__tests__/ServiceVisuals.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react'
+import {render, screen, within} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+vi.mock('recharts', () => {
+  const ChartPart = ({children, ...props}: {children?: React.ReactNode; [key: string]: unknown}) => (
+    <g data-testid="chart-part" data-key={String(props.dataKey ?? props.x ?? props.y ?? '')}>
+      {children}
+    </g>
+  )
+  const ChartRoot = ({children}: {children?: React.ReactNode}) => (
+    <svg data-testid="chart-root">{children}</svg>
+  )
+  return {
+    Area: ChartPart,
+    AreaChart: ChartRoot,
+    CartesianGrid: ChartPart,
+    Line: ChartPart,
+    LineChart: ChartRoot,
+    ReferenceArea: ChartPart,
+    ReferenceLine: ChartPart,
+    ResponsiveContainer: ({children}: {children?: React.ReactNode}) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+    Tooltip: ChartPart,
+    XAxis: ChartPart,
+    YAxis: ChartPart,
+  }
+})
+
+import {
+  ApdexHeat,
+  ApmKpiRow,
+  BarGauge,
+  EnvPills,
+  ErrorBars,
+  ErrorList,
+  HttpStatusBadge,
+  InfoCallout,
+  LatencyDistribution,
+  LatencyLegendTable,
+  LatencyPercentilesChart,
+  MetaChip,
+  MeterBar,
+  MethodChip,
+  ServiceStatusBadge,
+  Sparkline,
+  ThroughputChart,
+  TypeChip,
+  Waterfall,
+} from '@/components/apm/ServiceVisuals'
+
+const latencySeries = [
+  {t: '10:00', p50: 10, p90: 20, p95: 30, p99: 50},
+  {t: '10:05', p50: 12, p90: 24, p95: 34, p99: 60},
+]
+
+describe('ServiceVisuals', () => {
+  it('renders service chips, gauges, heat cells, and status badges', () => {
+    const {container} = render(
+      <div>
+        <TypeChip type="web" />
+        <ServiceStatusBadge status="alerting" />
+        <ServiceStatusBadge status="degraded" />
+        <ServiceStatusBadge status="healthy" />
+        <EnvPills pills={[{label: 'prod', chart: 1}, {label: 'unknown', chart: 99}]} />
+        <MetaChip>v1.2.3</MetaChip>
+        <InfoCallout>dependency insight</InfoCallout>
+        <MeterBar pct={0} level="good" value="0%" />
+        <MeterBar pct={150} level="bad" value="100%" />
+        <ApdexHeat value="0.99" tone="success" />
+        <BarGauge
+          rows={[
+            {label: 'GET /ok', valueText: '10ms', pct: 1, level: 'good'},
+            {label: 'POST /slow', valueText: '320ms', pct: 52, level: 'warn'},
+            {label: 'POST /fail', valueText: '1.2s', pct: 125, level: 'bad'},
+          ]}
+        />
+        <MethodChip method="POST" />
+        <HttpStatusBadge status={200} />
+        <HttpStatusBadge status={500} />
+      </div>,
+    )
+
+    expect(screen.getByText('web')).toBeInTheDocument()
+    expect(screen.getByText('alerting')).toBeInTheDocument()
+    expect(screen.getByText('degraded')).toBeInTheDocument()
+    expect(screen.getByText('healthy')).toBeInTheDocument()
+    expect(screen.getByText('prod')).toBeInTheDocument()
+    expect(screen.getByText('unknown')).toBeInTheDocument()
+    expect(screen.getByText('dependency insight')).toBeInTheDocument()
+    expect(screen.getByText('GET /ok')).toBeInTheDocument()
+    expect(screen.getByText('POST')).toBeInTheDocument()
+    expect(screen.getByText('200')).toBeInTheDocument()
+    expect(screen.getByText('500')).toBeInTheDocument()
+    expect(container.querySelector('[style*="width: 2%"]')).not.toBeNull()
+    expect(container.querySelector('[style*="width: 100%"]')).not.toBeNull()
+  })
+
+  it('renders sparklines, KPI cards, legends, and charts', () => {
+    const {container} = render(
+      <div>
+        <Sparkline values={[7]} />
+        <Sparkline values={[2, 8, 4]} />
+        <ApmKpiRow
+          kpis={[
+            {label: 'p95', value: '120ms', valueTone: 'success', delta: {value: '-5%', direction: 'down'}},
+            {label: 'errors', value: '0.2%'},
+          ]}
+        />
+        <LatencyPercentilesChart
+          series={latencySeries}
+          thresholdMs={40}
+          thresholdLabel="SLO"
+          deployAt="10:05"
+        />
+        <LatencyLegendTable series={latencySeries} />
+        <ThroughputChart points={[{t: '10:00', rps: 10}, {t: '10:05', rps: 15, errors: 2}]} deployAt="10:05" />
+        <ThroughputChart
+          points={[{t: '10:00', rps: 10}, {t: '10:05', rps: 15, errors: 2}]}
+          deployAt="10:05"
+          withErrors
+        />
+      </div>,
+    )
+
+    expect(screen.getAllByText('p95')).toHaveLength(2)
+    expect(screen.getByText('errors')).toBeInTheDocument()
+    expect(screen.getByText('p99')).toBeInTheDocument()
+    const p50Row = screen.getByText('p50').closest('tr')
+    if (p50Row === null) {
+      throw new Error('Expected p50 row to render')
+    }
+    expect(within(p50Row).getByText('10')).toBeInTheDocument()
+    expect(container.querySelectorAll('polyline')).toHaveLength(2)
+    expect(screen.getAllByTestId('responsive-container')).toHaveLength(3)
+  })
+
+  it('renders error, distribution, and waterfall states', () => {
+    const {container, rerender} = render(<ErrorList errors={[]} />)
+    expect(screen.getByText('No active errors on this surface.')).toBeInTheDocument()
+
+    rerender(
+      <div>
+        <ErrorBars bars={[{h: 20, level: 'warn'}, {h: 80, level: 'bad'}]} />
+        <LatencyDistribution
+          bars={[{h: 20, band: 'good'}, {h: 45, band: 'warn'}, {h: 80, band: 'bad'}]}
+          markers={[{label: 'p95', left: 35}, {label: 'p99', left: 85, p99: true}]}
+          axis={['0ms', '500ms', '1s']}
+        />
+        <Waterfall
+          rows={[
+            {op: 'GET', desc: '/checkout', left: 0, width: 60, label: '120ms', tone: 'root', selected: true},
+            {op: 'db', desc: 'orders', left: 10, width: 20, label: '40ms', tone: 'db', indent: 1},
+            {op: 'throw', desc: 'Timeout', left: 35, width: 10, label: '20ms', tone: 'error'},
+          ]}
+        />
+        <ErrorList
+          showUsers
+          errors={[
+            {
+              severity: 'warn',
+              title: 'Timeout warning',
+              sub: 'checkout.ts',
+              chips: ['v1', 'first seen'],
+              events: '12',
+            },
+            {
+              severity: 'fatal',
+              title: 'Unhandled exception',
+              sub: 'payment.ts',
+              chips: ['v2'],
+              events: '3',
+              users: '2',
+              unhandled: true,
+            },
+          ]}
+        />
+      </div>,
+    )
+
+    expect(screen.getByText('p95')).toBeInTheDocument()
+    expect(screen.getByText('p99')).toBeInTheDocument()
+    expect(screen.getByText('orders')).toBeInTheDocument()
+    expect(screen.getByText('Timeout warning')).toBeInTheDocument()
+    expect(screen.getByText('Unhandled exception')).toBeInTheDocument()
+    expect(screen.getByText('unhandled')).toBeInTheDocument()
+    expect(container.querySelectorAll('[style*="height: 80%"]')).toHaveLength(2)
+  })
+})

--- a/dashboard/src/components/projects/ServiceSettingsCard.tsx
+++ b/dashboard/src/components/projects/ServiceSettingsCard.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useEffect, useMemo, useState} from 'react'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import {Link, useNavigate, useRouter} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
@@ -46,6 +46,8 @@ import {cn} from '@/lib/utils'
 import type {TelemetrySourceId} from '@/lib/telemetry-sources'
 
 type PlatformFilter = 'all' | 'mobile' | 'frontend' | 'backend' | 'desktop-gaming'
+
+const COPIED_STATE_RESET_MS = 2000
 
 const platformFilterTabs: Array<{id: PlatformFilter; label: string; icon: React.ElementType}> = [
   {id: 'all', label: 'All', icon: Layers},
@@ -92,6 +94,8 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
   const [copiedSlug, setCopiedSlug] = useState(false)
   const [copiedConfig, setCopiedConfig] = useState(false)
   const [orgSlug, setOrgSlug] = useState<string | null>(null)
+  const copiedSlugResetId = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null)
+  const copiedConfigResetId = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null)
 
   const hasSentry = sourceIds.includes('sentry-sdk')
   const hasOtel = sourceIds.includes('opentelemetry')
@@ -112,6 +116,17 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
       cancelled = true
     }
   }, [hasSentry])
+
+  useEffect(() => {
+    return () => {
+      if (copiedSlugResetId.current !== null) {
+        globalThis.clearTimeout(copiedSlugResetId.current)
+      }
+      if (copiedConfigResetId.current !== null) {
+        globalThis.clearTimeout(copiedConfigResetId.current)
+      }
+    }
+  }, [])
 
   const filteredPlatforms = useMemo(() => {
     return platforms.filter((platform: PlatformType) => {
@@ -210,14 +225,26 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
   const copySlug = () => {
     navigator.clipboard.writeText(project.slug)
     setCopiedSlug(true)
-    setTimeout(() => setCopiedSlug(false), 2000)
+    if (copiedSlugResetId.current !== null) {
+      globalThis.clearTimeout(copiedSlugResetId.current)
+    }
+    copiedSlugResetId.current = globalThis.setTimeout(() => {
+      setCopiedSlug(false)
+      copiedSlugResetId.current = null
+    }, COPIED_STATE_RESET_MS)
   }
 
   const copyConfig = () => {
     if (sentryCliConfig) {
       navigator.clipboard.writeText(sentryCliConfig)
       setCopiedConfig(true)
-      setTimeout(() => setCopiedConfig(false), 2000)
+      if (copiedConfigResetId.current !== null) {
+        globalThis.clearTimeout(copiedConfigResetId.current)
+      }
+      copiedConfigResetId.current = globalThis.setTimeout(() => {
+        setCopiedConfig(false)
+        copiedConfigResetId.current = null
+      }, COPIED_STATE_RESET_MS)
     }
   }
 

--- a/dashboard/src/lib/__tests__/api.test.ts
+++ b/dashboard/src/lib/__tests__/api.test.ts
@@ -246,6 +246,16 @@ describe('ApiClient', () => {
       await expect(api.getProjects()).rejects.toThrow('Project not found')
     })
 
+    it('preserves response status on API errors for retry policy decisions', async () => {
+      server.use(
+        http.get(`${API_BASE}/v1/projects`, () => {
+          return HttpResponse.json({ error: 'Project not found' }, { status: 404 })
+        })
+      )
+
+      await expect(api.getProjects()).rejects.toMatchObject({ status: 404 })
+    })
+
     it('falls back to status text when no error field in response', async () => {
       server.use(
         http.get(`${API_BASE}/v1/projects`, () => {

--- a/dashboard/src/lib/__tests__/apm-view.test.ts
+++ b/dashboard/src/lib/__tests__/apm-view.test.ts
@@ -1,0 +1,65 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  APM_TIME_RANGE_OPTIONS,
+  SERVICE_FACET_SCHEMA,
+  apdexHeatClass,
+  apmRangeLabel,
+  errorSeverityBorder,
+  errorSeverityTone,
+  formatMs,
+  formatRps,
+  serviceTypeLabel,
+  severityFill,
+  statusBadgeVariant,
+  statusLabel,
+  statusTone,
+  type ServiceType,
+} from '@/lib/apm-view'
+import type {ApmTimeRange} from '@/lib/api'
+
+describe('apm view helpers', () => {
+  it('formats rate and latency values for table cells', () => {
+    expect(formatRps(999)).toBe('999')
+    expect(formatRps(1_250)).toBe('1.3k')
+    expect(formatMs(250)).toBe('250ms')
+    expect(formatMs(1_000)).toBe('1s')
+    expect(formatMs(1_250)).toBe('1.25s')
+  })
+
+  it('maps service status and severity values to UI tones', () => {
+    expect(statusBadgeVariant('alerting')).toBe('danger')
+    expect(statusBadgeVariant('degraded')).toBe('warning')
+    expect(statusBadgeVariant('healthy')).toBe('success')
+    expect(statusTone('alerting')).toBe('danger')
+    expect(statusTone('degraded')).toBe('warning')
+    expect(statusTone('healthy')).toBe('success')
+    expect(statusLabel('degraded')).toBe('degraded')
+    expect(severityFill('bad')).toBe('bg-danger-solid')
+    expect(severityFill('warn')).toBe('bg-warning-solid')
+    expect(severityFill('good')).toBe('bg-success-solid')
+  })
+
+  it('maps service and error detail helpers', () => {
+    expect(serviceTypeLabel('web')).toBe('web')
+    expect(serviceTypeLabel('queue' as ServiceType)).toBe('queue')
+    expect(errorSeverityTone('warn')).toBe('warning')
+    expect(errorSeverityTone('error')).toBe('danger')
+    expect(errorSeverityBorder('warn')).toBe('border-l-warning-solid')
+    expect(errorSeverityBorder('fatal')).toBe('border-l-danger-solid')
+  })
+
+  it('maps apdex heat and range labels', () => {
+    expect(apdexHeatClass('success')).toContain('bg-success-bg')
+    expect(apdexHeatClass('warning')).toContain('bg-warning-bg')
+    expect(apdexHeatClass('danger')).toContain('bg-danger-bg')
+    expect(apdexHeatClass('neutral')).toContain('bg-muted')
+    expect(apmRangeLabel('24h')).toBe('past 24h')
+    expect(apmRangeLabel('3h' as ApmTimeRange)).toBe('past 3h')
+  })
+
+  it('exposes catalog filter metadata', () => {
+    expect(APM_TIME_RANGE_OPTIONS.map((option) => option.value)).toEqual(['1h', '6h', '24h', '7d', '30d', '90d'])
+    expect(SERVICE_FACET_SCHEMA.map((facet) => facet.key)).toEqual(['env', 'type', 'source'])
+  })
+})

--- a/dashboard/src/lib/api/errors.ts
+++ b/dashboard/src/lib/api/errors.ts
@@ -1,0 +1,4 @@
+export function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('status' in error)) return false
+  return (error as {status?: unknown}).status === 404
+}

--- a/dashboard/src/lib/api/modules/__tests__/apm.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/apm.test.ts
@@ -273,6 +273,72 @@ describe('APM API', () => {
     })
   })
 
+  // ──── getApmServices ────
+
+  it('fetches APM services with scope params', async () => {
+    const mockResponse = {
+      services: [{name: 'checkout-api', status: 'healthy'}],
+      summary: {total: 1, alerting: 0, degraded: 0},
+    }
+
+    server.use(
+      http.get(`${API_BASE}/v1/services`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('timeRange')).toBe('6h')
+        expect(url.searchParams.get('env')).toBe('production')
+        expect(url.searchParams.get('source')).toBe('otlp')
+        expect(url.searchParams.get('search')).toBe('checkout')
+        expect(url.searchParams.get('limit')).toBe('100')
+        return HttpResponse.json(mockResponse)
+      })
+    )
+
+    const result = await api.getApmServices({
+      timeRange: '6h',
+      env: 'production',
+      source: 'otlp',
+      search: 'checkout',
+      limit: 100,
+    })
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('fetches an APM service detail', async () => {
+    const mockResponse = {name: 'checkout-api', resources: []}
+
+    server.use(
+      http.get(`${API_BASE}/v1/services/checkout-api`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('timeRange')).toBe('24h')
+        expect(url.searchParams.get('env')).toBe('production')
+        return HttpResponse.json(mockResponse)
+      })
+    )
+
+    const result = await api.getApmServiceDetail('checkout-api', {
+      timeRange: '24h',
+      env: 'production',
+    })
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('fetches an APM resource detail', async () => {
+    const mockResponse = {serviceName: 'checkout-api', method: 'POST', path: '/checkout/pay'}
+
+    server.use(
+      http.get(`${API_BASE}/v1/services/checkout-api/resources/post-checkout-pay`, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('timeRange')).toBe('1h')
+        return HttpResponse.json(mockResponse)
+      })
+    )
+
+    const result = await api.getApmResourceDetail('checkout-api', 'post-checkout-pay', {
+      timeRange: '1h',
+    })
+    expect(result).toEqual(mockResponse)
+  })
+
   // ──── getApmServiceMap ────
 
   it('fetches APM service map', async () => {

--- a/dashboard/src/lib/api/modules/apm.ts
+++ b/dashboard/src/lib/api/modules/apm.ts
@@ -20,8 +20,11 @@ import type {
   ApmOverviewResponse,
   ApmTraceListResponse,
   ApmTraceDetailResponse,
+  ApmServiceCatalogResponse,
+  ApmServiceDetail,
   ApmServiceMapResponse,
   ApmServiceLatency,
+  ApmResourceDetail,
   ApmErrorsResponse,
   ApmResourceStatsResponse,
   ApmStatusFilter,
@@ -154,6 +157,43 @@ export function apmMethods(core: ApiClientCore) {
           normalizeSpan(s as unknown as Record<string, unknown>)
         ) as unknown as ApmTraceDetailResponse['spans'],
       }
+    },
+
+    getApmServices: (
+      params: Omit<ApmListParams, 'service' | 'services' | 'status' | 'operation'> = {}
+    ) => {
+      const searchParams = new URLSearchParams()
+      appendApmListParams(searchParams, params)
+      const qs = searchParams.toString()
+      return core.request<ApmServiceCatalogResponse>(urlWithQuery(`${base}/services`, qs))
+    },
+
+    getApmServiceDetail: (
+      service: string,
+      params: Omit<ApmListParams, 'service' | 'services' | 'status' | 'operation' | 'limit' | 'offset'> = {}
+    ) => {
+      const searchParams = new URLSearchParams()
+      appendApmListParams(searchParams, params)
+      const qs = searchParams.toString()
+      return core.request<ApmServiceDetail>(
+        urlWithQuery(`${base}/services/${encodeURIComponent(service)}`, qs)
+      )
+    },
+
+    getApmResourceDetail: (
+      service: string,
+      resource: string,
+      params: Omit<ApmListParams, 'service' | 'services' | 'status' | 'operation' | 'limit' | 'offset'> = {}
+    ) => {
+      const searchParams = new URLSearchParams()
+      appendApmListParams(searchParams, params)
+      const qs = searchParams.toString()
+      return core.request<ApmResourceDetail>(
+        urlWithQuery(
+          `${base}/services/${encodeURIComponent(service)}/resources/${encodeURIComponent(resource)}`,
+          qs,
+        )
+      )
     },
 
     getApmServiceMap: (params: ApmServiceMapParams = {}) => {

--- a/dashboard/src/lib/api/types/apm.ts
+++ b/dashboard/src/lib/api/types/apm.ts
@@ -201,3 +201,235 @@ export interface ApmResourceStatsResponse {
   resources: ApmResourceStatsItem[]
   totalCount: number
 }
+
+export type ApmServiceType = 'web' | 'worker' | 'db' | 'cache'
+export type ApmServiceStatus = 'alerting' | 'degraded' | 'healthy'
+export type ApmSeverity = 'good' | 'warn' | 'bad'
+export type ApmStatusTone = 'success' | 'warning' | 'danger' | 'info' | 'neutral' | 'accent'
+
+export interface ApmEnvPill {
+  label: string
+  chart: number
+}
+
+export interface ApmCatalogSummary {
+  total: number
+  alerting: number
+  degraded: number
+}
+
+export interface ApmServiceCatalogRow {
+  name: string
+  type: ApmServiceType
+  status: ApmServiceStatus
+  env: ApmEnvPill[]
+  rps: number
+  spark: number[]
+  p95Ms: number
+  p99Ms: number
+  errorRateLabel: string
+  errorBarPct: number
+  errorLevel: ApmSeverity
+  apdex: string
+  apdexTone: ApmStatusTone
+  lastDeploy: string
+  team: string
+  language?: string
+  sources: string[]
+}
+
+export interface ApmServiceCatalogResponse {
+  services: ApmServiceCatalogRow[]
+  summary: ApmCatalogSummary
+}
+
+export interface ApmStatDeltaSpec {
+  value: string
+  direction: 'up' | 'down' | 'flat'
+  tone?: ApmStatusTone
+}
+
+export interface ApmKpiSpec {
+  label: string
+  value: string
+  valueTone?: ApmStatusTone
+  delta?: ApmStatDeltaSpec
+}
+
+export interface ApmServiceLatencyPoint {
+  t: string
+  p50: number
+  p90: number
+  p95: number
+  p99: number
+}
+
+export interface ApmThroughputPoint {
+  t: string
+  rps: number
+  errors?: number
+}
+
+export interface ApmGaugeRow {
+  label: string
+  valueText: string
+  pct: number
+  level: ApmSeverity
+}
+
+export interface ApmErrorBar {
+  h: number
+  level: 'warn' | 'bad'
+}
+
+export interface ApmServiceResourceRow {
+  slug: string
+  method: string
+  name: string
+  rps: number
+  p50Ms: number
+  p95Ms: number
+  p99Ms: number
+  errorRateLabel: string
+  errorBarPct: number
+  errorLevel: ApmSeverity
+  timePct: number
+  status: ApmServiceStatus
+}
+
+export interface ApmDependencyRow {
+  name: string
+  type: ApmServiceType
+  tone: ApmStatusTone
+  rps: string
+  p95: string
+  err: string
+  errWarn?: boolean
+}
+
+export interface ApmDeploymentRow {
+  version: string
+  when: string
+  initials: string
+  rps: string
+  errorRate: string
+  p95: string
+  status: ApmServiceStatus | 'retired'
+  current?: boolean
+  trendBad?: boolean
+}
+
+export interface ApmPodRow {
+  pod: string
+  node: string
+  cpu: number
+  mem: string
+  restarts: number
+  tone: ApmStatusTone
+  state: string
+}
+
+export type ApmErrorSeverity = 'fatal' | 'error' | 'warn'
+
+export interface ApmServiceErrorRow {
+  severity: ApmErrorSeverity
+  title: string
+  sub: string
+  chips: string[]
+  events: string
+  users?: string
+  unhandled?: boolean
+}
+
+export interface ApmServiceTraceRow {
+  time: string
+  traceId: string
+  resource?: string | null
+  method?: string | null
+  httpStatus: number
+  durationMs: number
+  spans?: number | null
+  bucket?: string | null
+}
+
+export interface ApmServiceDetail {
+  name: string
+  type: ApmServiceType
+  status: ApmServiceStatus
+  runtime: string
+  team: string
+  version: string
+  deployedAgo: string
+  sources: string[]
+  kpis: ApmKpiSpec[]
+  latency: ApmServiceLatencyPoint[]
+  latencyThresholdMs: number
+  latencyThresholdLabel: string
+  deployAt: string
+  throughput: ApmThroughputPoint[]
+  errorBars: ApmErrorBar[]
+  p95ByResource: ApmGaugeRow[]
+  resources: ApmServiceResourceRow[]
+  upstream: ApmDependencyRow[]
+  downstream: ApmDependencyRow[]
+  depInsight: string
+  deployments: ApmDeploymentRow[]
+  podMemory: ApmGaugeRow[]
+  pods: ApmPodRow[]
+  errors: ApmServiceErrorRow[]
+  traces: ApmServiceTraceRow[]
+}
+
+export interface ApmDistBar {
+  h: number
+  band: ApmSeverity
+}
+
+export interface ApmDistMarker {
+  label: string
+  left: number
+  p99?: boolean
+}
+
+export type ApmWaterfallTone = 'root' | 'app' | 'db' | 'cache' | 'http' | 'error'
+
+export interface ApmWaterfallRow {
+  op: string
+  desc: string
+  left: number
+  width: number
+  label: string
+  tone: ApmWaterfallTone
+  indent?: number
+  selected?: boolean
+}
+
+export interface ApmResourceExemplar {
+  traceId: string
+  httpStatus: number
+  durationLabel: string
+  rows: ApmWaterfallRow[]
+}
+
+export interface ApmResourceDetail {
+  serviceName: string
+  method: string
+  path: string
+  status: ApmServiceStatus
+  kind: string
+  topDependency: string
+  kpis: ApmKpiSpec[]
+  latency: ApmServiceLatencyPoint[]
+  latencyThresholdMs: number
+  latencyThresholdLabel: string
+  deployAt: string
+  throughput: ApmThroughputPoint[]
+  distribution: ApmDistBar[]
+  distMarkers: ApmDistMarker[]
+  distAxis: string[]
+  whereTimeSpent: ApmGaugeRow[]
+  whereInsight: string
+  exemplar: ApmResourceExemplar
+  slowTraces: ApmServiceTraceRow[]
+  errors: ApmServiceErrorRow[]
+}

--- a/dashboard/src/lib/apm-view.ts
+++ b/dashboard/src/lib/apm-view.ts
@@ -147,26 +147,24 @@ export function serviceTypeLabel(type: ServiceType): string {
   return TYPE_LABEL[type] ?? type
 }
 
+const STATUS_BADGE_VARIANT: Record<ServiceStatus, BadgeProps['variant']> = {
+  alerting: 'danger',
+  degraded: 'warning',
+  healthy: 'success',
+}
+
+const STATUS_TONE: Record<ServiceStatus, StatusTone> = {
+  alerting: 'danger',
+  degraded: 'warning',
+  healthy: 'success',
+}
+
 export function statusBadgeVariant(status: ServiceStatus): BadgeProps['variant'] {
-  switch (status) {
-    case 'alerting':
-      return 'danger'
-    case 'degraded':
-      return 'warning'
-    default:
-      return 'success'
-  }
+  return STATUS_BADGE_VARIANT[status]
 }
 
 export function statusTone(status: ServiceStatus): StatusTone {
-  switch (status) {
-    case 'alerting':
-      return 'danger'
-    case 'degraded':
-      return 'warning'
-    default:
-      return 'success'
-  }
+  return STATUS_TONE[status]
 }
 
 export function statusLabel(status: ServiceStatus): string {

--- a/dashboard/src/lib/apm-view.ts
+++ b/dashboard/src/lib/apm-view.ts
@@ -1,0 +1,250 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * View-layer types, formatting, and class-mapping helpers for the APM service /
+ * service-detail / resource-detail pages.
+ *
+ * The page data comes from the `/v1/services*` APIs (see `@/lib/api`); the types
+ * here are the structural prop contracts the presentation components render. They
+ * mirror the API response shapes so a typed API payload can be passed straight
+ * into the visual components.
+ */
+
+import type {BadgeProps} from '@/components/ui/badge'
+import type {StatusTone} from '@/components/ui/status-dot'
+import type {ApmTimeRange} from '@/lib/api'
+import type {FacetSchema} from '@/lib/filters/types'
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type ServiceType = 'web' | 'worker' | 'db' | 'cache'
+export type ServiceStatus = 'alerting' | 'degraded' | 'healthy'
+/** Scale buckets for meter / gauge fills (green → amber → red). */
+export type Severity = 'good' | 'warn' | 'bad'
+
+export interface EnvPill {
+  readonly label: string
+  /** Categorical chart slot 1-10 used for the pill tint. */
+  readonly chart: number
+}
+
+export interface StatDeltaSpec {
+  readonly value: string
+  readonly direction: 'up' | 'down' | 'flat'
+  readonly tone?: StatusTone
+}
+
+export interface KpiSpec {
+  readonly label: string
+  readonly value: string
+  readonly valueTone?: StatusTone
+  readonly delta?: StatDeltaSpec
+}
+
+export interface LatencyPoint {
+  readonly t: string
+  readonly p50: number
+  readonly p90: number
+  readonly p95: number
+  readonly p99: number
+}
+
+export interface ThroughputPoint {
+  readonly t: string
+  readonly rps: number
+  readonly errors?: number
+}
+
+export interface GaugeRow {
+  readonly label: string
+  readonly valueText: string
+  readonly pct: number
+  readonly level: Severity
+}
+
+export interface ErrorBar {
+  readonly h: number
+  readonly level: 'warn' | 'bad'
+}
+
+export interface DistBar {
+  readonly h: number
+  readonly band: Severity
+}
+
+export interface DistMarker {
+  readonly label: string
+  readonly left: number
+  readonly p99?: boolean
+}
+
+export type WaterfallTone = 'root' | 'app' | 'db' | 'cache' | 'http' | 'error'
+
+export interface WaterfallRow {
+  readonly op: string
+  readonly desc: string
+  readonly left: number
+  readonly width: number
+  readonly label: string
+  readonly tone: WaterfallTone
+  readonly indent?: number
+  readonly selected?: boolean
+}
+
+export type ErrorSeverity = 'fatal' | 'error' | 'warn'
+
+export interface ErrorRow {
+  readonly severity: ErrorSeverity
+  readonly title: string
+  readonly sub: string
+  readonly chips: readonly string[]
+  readonly events: string
+  readonly users?: string
+  readonly unhandled?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Formatting + class-mapping helpers
+// ---------------------------------------------------------------------------
+
+export function formatRps(rps: number): string {
+  if (rps >= 1000) return `${(rps / 1000).toFixed(1)}k`
+  return rps.toLocaleString()
+}
+
+export function formatMs(ms: number): string {
+  if (ms >= 1000) {
+    const seconds = (ms / 1000).toFixed(2).replace(/\.?0+$/, '')
+    return `${seconds}s`
+  }
+  return `${ms}ms`
+}
+
+const TYPE_LABEL: Record<ServiceType, string> = {
+  web: 'web',
+  worker: 'worker',
+  db: 'db',
+  cache: 'cache',
+}
+
+export function serviceTypeLabel(type: ServiceType): string {
+  return TYPE_LABEL[type] ?? type
+}
+
+export function statusBadgeVariant(status: ServiceStatus): BadgeProps['variant'] {
+  switch (status) {
+    case 'alerting':
+      return 'danger'
+    case 'degraded':
+      return 'warning'
+    default:
+      return 'success'
+  }
+}
+
+export function statusTone(status: ServiceStatus): StatusTone {
+  switch (status) {
+    case 'alerting':
+      return 'danger'
+    case 'degraded':
+      return 'warning'
+    default:
+      return 'success'
+  }
+}
+
+export function statusLabel(status: ServiceStatus): string {
+  return status
+}
+
+/** Tailwind background for a meter / gauge fill by scale bucket. */
+export function severityFill(level: Severity): string {
+  switch (level) {
+    case 'bad':
+      return 'bg-danger-solid'
+    case 'warn':
+      return 'bg-warning-solid'
+    default:
+      return 'bg-success-solid'
+  }
+}
+
+/** Soft heat chip (bg + fg) for the Apdex cell. */
+export function apdexHeatClass(tone: StatusTone): string {
+  switch (tone) {
+    case 'success':
+      return 'bg-success-bg text-success-fg'
+    case 'warning':
+      return 'bg-warning-bg text-warning-fg'
+    case 'danger':
+      return 'bg-danger-bg text-danger-fg'
+    default:
+      return 'bg-muted text-muted-foreground'
+  }
+}
+
+export function errorSeverityTone(severity: ErrorSeverity): StatusTone {
+  return severity === 'warn' ? 'warning' : 'danger'
+}
+
+export function errorSeverityBorder(severity: ErrorSeverity): string {
+  return severity === 'warn' ? 'border-l-warning-solid' : 'border-l-danger-solid'
+}
+
+// ---------------------------------------------------------------------------
+// Time range
+// ---------------------------------------------------------------------------
+
+export const APM_TIME_RANGE_OPTIONS: ReadonlyArray<{value: ApmTimeRange; label: string}> = [
+  {value: '1h', label: 'Last hour'},
+  {value: '6h', label: 'Last 6h'},
+  {value: '24h', label: 'Last 24h'},
+  {value: '7d', label: 'Last 7d'},
+  {value: '30d', label: 'Last 30d'},
+  {value: '90d', label: 'Last 90d'},
+]
+
+const RANGE_LABEL: Record<ApmTimeRange, string> = {
+  '1h': 'past 1h',
+  '6h': 'past 6h',
+  '24h': 'past 24h',
+  '7d': 'past 7d',
+  '30d': 'past 30d',
+  '90d': 'past 90d',
+}
+
+/** Short caption used on chart cards, e.g. `past 24h`. */
+export function apmRangeLabel(range: ApmTimeRange): string {
+  return RANGE_LABEL[range] ?? `past ${range}`
+}
+
+// ---------------------------------------------------------------------------
+// Facets (search bar typeahead schema)
+// ---------------------------------------------------------------------------
+
+/**
+ * Facets the catalog search bar understands. The rail's selectable values +
+ * counts are derived from the loaded services at render time, so only the
+ * dimensions the `/v1/services` payload actually carries are listed here.
+ */
+export const SERVICE_FACET_SCHEMA: FacetSchema = [
+  {key: 'env', label: 'Environment', aliases: ['environment'], color: 'bg-chart-1', singleSelect: true},
+  {key: 'type', label: 'Service type', color: 'bg-chart-2'},
+  {key: 'source', label: 'Telemetry source', aliases: ['telemetry'], color: 'bg-chart-6'},
+]

--- a/dashboard/src/lib/apm-view.ts
+++ b/dashboard/src/lib/apm-view.ts
@@ -130,10 +130,21 @@ export function formatRps(rps: number): string {
 
 export function formatMs(ms: number): string {
   if (ms >= 1000) {
-    const seconds = (ms / 1000).toFixed(2).replace(/\.?0+$/, '')
+    const seconds = trimFixedFraction((ms / 1000).toFixed(2))
     return `${seconds}s`
   }
   return `${ms}ms`
+}
+
+function trimFixedFraction(value: string): string {
+  let end = value.length
+  while (end > 0 && value[end - 1] === '0') {
+    end -= 1
+  }
+  if (end > 0 && value[end - 1] === '.') {
+    end -= 1
+  }
+  return value.slice(0, end)
 }
 
 const TYPE_LABEL: Record<ServiceType, string> = {

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as SignupRouteImport } from './routes/signup'
 import { Route as SignozAlternativeRouteImport } from './routes/signoz-alternative'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SessionReplayRouteImport } from './routes/session-replay'
+import { Route as ServicesRouteImport } from './routes/services'
 import { Route as SentryAlternativeRouteImport } from './routes/sentry-alternative'
 import { Route as SecuritySbomRouteImport } from './routes/security-sbom'
 import { Route as SecurityRouteImport } from './routes/security'
@@ -70,6 +71,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as UptimeIndexRouteImport } from './routes/uptime.index'
 import { Route as SyntheticsIndexRouteImport } from './routes/synthetics.index'
 import { Route as StatusPagesIndexRouteImport } from './routes/status-pages.index'
+import { Route as ServicesIndexRouteImport } from './routes/services.index'
 import { Route as SecurityIndexRouteImport } from './routes/security.index'
 import { Route as ProfilesIndexRouteImport } from './routes/profiles.index'
 import { Route as PerformanceIndexRouteImport } from './routes/performance.index'
@@ -88,6 +90,7 @@ import { Route as WorkflowsConnectionsRouteImport } from './routes/workflows.con
 import { Route as UptimeMonitorIdRouteImport } from './routes/uptime.$monitorId'
 import { Route as SyntheticsTestIdRouteImport } from './routes/synthetics.$testId'
 import { Route as StatusPagesPageIdRouteImport } from './routes/status-pages.$pageId'
+import { Route as ServicesServiceRouteImport } from './routes/services.$service'
 import { Route as SecurityVulnerabilitiesRouteImport } from './routes/security.vulnerabilities'
 import { Route as SecuritySignalsRouteImport } from './routes/security.signals'
 import { Route as SecurityEventsRouteImport } from './routes/security.events'
@@ -154,6 +157,7 @@ import { Route as AuthSsoCallbackRouteImport } from './routes/auth.sso.callback'
 import { Route as AuthOauthCallbackRouteImport } from './routes/auth.oauth.callback'
 import { Route as AiTracesTraceIdRouteImport } from './routes/ai.traces.$traceId'
 import { Route as AdminOrganizationsOrgIdRouteImport } from './routes/admin.organizations.$orgId'
+import { Route as ServicesServiceResourcesResourceRouteImport } from './routes/services.$service.resources.$resource'
 import { Route as ProjectsProjectIdSpansSpanIdRouteImport } from './routes/projects.$projectId.spans.$spanId'
 
 const WorkflowsRoute = WorkflowsRouteImport.update({
@@ -214,6 +218,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const SessionReplayRoute = SessionReplayRouteImport.update({
   id: '/session-replay',
   path: '/session-replay',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ServicesRoute = ServicesRouteImport.update({
+  id: '/services',
+  path: '/services',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SentryAlternativeRoute = SentryAlternativeRouteImport.update({
@@ -462,6 +471,11 @@ const StatusPagesIndexRoute = StatusPagesIndexRouteImport.update({
   path: '/status-pages/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ServicesIndexRoute = ServicesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ServicesRoute,
+} as any)
 const SecurityIndexRoute = SecurityIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -551,6 +565,11 @@ const StatusPagesPageIdRoute = StatusPagesPageIdRouteImport.update({
   id: '/status-pages/$pageId',
   path: '/status-pages/$pageId',
   getParentRoute: () => rootRouteImport,
+} as any)
+const ServicesServiceRoute = ServicesServiceRouteImport.update({
+  id: '/$service',
+  path: '/$service',
+  getParentRoute: () => ServicesRoute,
 } as any)
 const SecurityVulnerabilitiesRoute = SecurityVulnerabilitiesRouteImport.update({
   id: '/vulnerabilities',
@@ -893,6 +912,12 @@ const AdminOrganizationsOrgIdRoute = AdminOrganizationsOrgIdRouteImport.update({
   path: '/$orgId',
   getParentRoute: () => AdminOrganizationsRoute,
 } as any)
+const ServicesServiceResourcesResourceRoute =
+  ServicesServiceResourcesResourceRouteImport.update({
+    id: '/resources/$resource',
+    path: '/resources/$resource',
+    getParentRoute: () => ServicesServiceRoute,
+  } as any)
 const ProjectsProjectIdSpansSpanIdRoute =
   ProjectsProjectIdSpansSpanIdRouteImport.update({
     id: '/spans/$spanId',
@@ -947,6 +972,7 @@ export interface FileRoutesByFullPath {
   '/security': typeof SecurityRouteWithChildren
   '/security-sbom': typeof SecuritySbomRoute
   '/sentry-alternative': typeof SentryAlternativeRoute
+  '/services': typeof ServicesRouteWithChildren
   '/session-replay': typeof SessionReplayRoute
   '/settings': typeof SettingsRoute
   '/signoz-alternative': typeof SignozAlternativeRoute
@@ -1009,6 +1035,7 @@ export interface FileRoutesByFullPath {
   '/security/events': typeof SecurityEventsRoute
   '/security/signals': typeof SecuritySignalsRoute
   '/security/vulnerabilities': typeof SecurityVulnerabilitiesRoute
+  '/services/$service': typeof ServicesServiceRouteWithChildren
   '/status-pages/$pageId': typeof StatusPagesPageIdRoute
   '/synthetics/$testId': typeof SyntheticsTestIdRoute
   '/uptime/$monitorId': typeof UptimeMonitorIdRoute
@@ -1027,6 +1054,7 @@ export interface FileRoutesByFullPath {
   '/performance/': typeof PerformanceIndexRoute
   '/profiles/': typeof ProfilesIndexRoute
   '/security/': typeof SecurityIndexRoute
+  '/services/': typeof ServicesIndexRoute
   '/status-pages/': typeof StatusPagesIndexRoute
   '/synthetics/': typeof SyntheticsIndexRoute
   '/uptime/': typeof UptimeIndexRoute
@@ -1047,6 +1075,7 @@ export interface FileRoutesByFullPath {
   '/monitoring/kubernetes/': typeof MonitoringKubernetesIndexRoute
   '/performance/traces/': typeof PerformanceTracesIndexRoute
   '/projects/$projectId/spans/$spanId': typeof ProjectsProjectIdSpansSpanIdRoute
+  '/services/$service/resources/$resource': typeof ServicesServiceResourcesResourceRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -1142,6 +1171,7 @@ export interface FileRoutesByTo {
   '/security/events': typeof SecurityEventsRoute
   '/security/signals': typeof SecuritySignalsRoute
   '/security/vulnerabilities': typeof SecurityVulnerabilitiesRoute
+  '/services/$service': typeof ServicesServiceRouteWithChildren
   '/status-pages/$pageId': typeof StatusPagesPageIdRoute
   '/synthetics/$testId': typeof SyntheticsTestIdRoute
   '/uptime/$monitorId': typeof UptimeMonitorIdRoute
@@ -1160,6 +1190,7 @@ export interface FileRoutesByTo {
   '/performance': typeof PerformanceIndexRoute
   '/profiles': typeof ProfilesIndexRoute
   '/security': typeof SecurityIndexRoute
+  '/services': typeof ServicesIndexRoute
   '/status-pages': typeof StatusPagesIndexRoute
   '/synthetics': typeof SyntheticsIndexRoute
   '/uptime': typeof UptimeIndexRoute
@@ -1180,6 +1211,7 @@ export interface FileRoutesByTo {
   '/monitoring/kubernetes': typeof MonitoringKubernetesIndexRoute
   '/performance/traces': typeof PerformanceTracesIndexRoute
   '/projects/$projectId/spans/$spanId': typeof ProjectsProjectIdSpansSpanIdRoute
+  '/services/$service/resources/$resource': typeof ServicesServiceResourcesResourceRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -1229,6 +1261,7 @@ export interface FileRoutesById {
   '/security': typeof SecurityRouteWithChildren
   '/security-sbom': typeof SecuritySbomRoute
   '/sentry-alternative': typeof SentryAlternativeRoute
+  '/services': typeof ServicesRouteWithChildren
   '/session-replay': typeof SessionReplayRoute
   '/settings': typeof SettingsRoute
   '/signoz-alternative': typeof SignozAlternativeRoute
@@ -1291,6 +1324,7 @@ export interface FileRoutesById {
   '/security/events': typeof SecurityEventsRoute
   '/security/signals': typeof SecuritySignalsRoute
   '/security/vulnerabilities': typeof SecurityVulnerabilitiesRoute
+  '/services/$service': typeof ServicesServiceRouteWithChildren
   '/status-pages/$pageId': typeof StatusPagesPageIdRoute
   '/synthetics/$testId': typeof SyntheticsTestIdRoute
   '/uptime/$monitorId': typeof UptimeMonitorIdRoute
@@ -1309,6 +1343,7 @@ export interface FileRoutesById {
   '/performance/': typeof PerformanceIndexRoute
   '/profiles/': typeof ProfilesIndexRoute
   '/security/': typeof SecurityIndexRoute
+  '/services/': typeof ServicesIndexRoute
   '/status-pages/': typeof StatusPagesIndexRoute
   '/synthetics/': typeof SyntheticsIndexRoute
   '/uptime/': typeof UptimeIndexRoute
@@ -1329,6 +1364,7 @@ export interface FileRoutesById {
   '/monitoring/kubernetes/': typeof MonitoringKubernetesIndexRoute
   '/performance/traces/': typeof PerformanceTracesIndexRoute
   '/projects/$projectId/spans/$spanId': typeof ProjectsProjectIdSpansSpanIdRoute
+  '/services/$service/resources/$resource': typeof ServicesServiceResourcesResourceRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -1379,6 +1415,7 @@ export interface FileRouteTypes {
     | '/security'
     | '/security-sbom'
     | '/sentry-alternative'
+    | '/services'
     | '/session-replay'
     | '/settings'
     | '/signoz-alternative'
@@ -1441,6 +1478,7 @@ export interface FileRouteTypes {
     | '/security/events'
     | '/security/signals'
     | '/security/vulnerabilities'
+    | '/services/$service'
     | '/status-pages/$pageId'
     | '/synthetics/$testId'
     | '/uptime/$monitorId'
@@ -1459,6 +1497,7 @@ export interface FileRouteTypes {
     | '/performance/'
     | '/profiles/'
     | '/security/'
+    | '/services/'
     | '/status-pages/'
     | '/synthetics/'
     | '/uptime/'
@@ -1479,6 +1518,7 @@ export interface FileRouteTypes {
     | '/monitoring/kubernetes/'
     | '/performance/traces/'
     | '/projects/$projectId/spans/$spanId'
+    | '/services/$service/resources/$resource'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -1574,6 +1614,7 @@ export interface FileRouteTypes {
     | '/security/events'
     | '/security/signals'
     | '/security/vulnerabilities'
+    | '/services/$service'
     | '/status-pages/$pageId'
     | '/synthetics/$testId'
     | '/uptime/$monitorId'
@@ -1592,6 +1633,7 @@ export interface FileRouteTypes {
     | '/performance'
     | '/profiles'
     | '/security'
+    | '/services'
     | '/status-pages'
     | '/synthetics'
     | '/uptime'
@@ -1612,6 +1654,7 @@ export interface FileRouteTypes {
     | '/monitoring/kubernetes'
     | '/performance/traces'
     | '/projects/$projectId/spans/$spanId'
+    | '/services/$service/resources/$resource'
   id:
     | '__root__'
     | '/'
@@ -1660,6 +1703,7 @@ export interface FileRouteTypes {
     | '/security'
     | '/security-sbom'
     | '/sentry-alternative'
+    | '/services'
     | '/session-replay'
     | '/settings'
     | '/signoz-alternative'
@@ -1722,6 +1766,7 @@ export interface FileRouteTypes {
     | '/security/events'
     | '/security/signals'
     | '/security/vulnerabilities'
+    | '/services/$service'
     | '/status-pages/$pageId'
     | '/synthetics/$testId'
     | '/uptime/$monitorId'
@@ -1740,6 +1785,7 @@ export interface FileRouteTypes {
     | '/performance/'
     | '/profiles/'
     | '/security/'
+    | '/services/'
     | '/status-pages/'
     | '/synthetics/'
     | '/uptime/'
@@ -1760,6 +1806,7 @@ export interface FileRouteTypes {
     | '/monitoring/kubernetes/'
     | '/performance/traces/'
     | '/projects/$projectId/spans/$spanId'
+    | '/services/$service/resources/$resource'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -1809,6 +1856,7 @@ export interface RootRouteChildren {
   SecurityRoute: typeof SecurityRouteWithChildren
   SecuritySbomRoute: typeof SecuritySbomRoute
   SentryAlternativeRoute: typeof SentryAlternativeRoute
+  ServicesRoute: typeof ServicesRouteWithChildren
   SessionReplayRoute: typeof SessionReplayRoute
   SettingsRoute: typeof SettingsRoute
   SignozAlternativeRoute: typeof SignozAlternativeRoute
@@ -1920,6 +1968,13 @@ declare module '@tanstack/react-router' {
       path: '/session-replay'
       fullPath: '/session-replay'
       preLoaderRoute: typeof SessionReplayRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/services': {
+      id: '/services'
+      path: '/services'
+      fullPath: '/services'
+      preLoaderRoute: typeof ServicesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/sentry-alternative': {
@@ -2265,6 +2320,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof StatusPagesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/services/': {
+      id: '/services/'
+      path: '/'
+      fullPath: '/services/'
+      preLoaderRoute: typeof ServicesIndexRouteImport
+      parentRoute: typeof ServicesRoute
+    }
     '/security/': {
       id: '/security/'
       path: '/'
@@ -2390,6 +2452,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/status-pages/$pageId'
       preLoaderRoute: typeof StatusPagesPageIdRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/services/$service': {
+      id: '/services/$service'
+      path: '/$service'
+      fullPath: '/services/$service'
+      preLoaderRoute: typeof ServicesServiceRouteImport
+      parentRoute: typeof ServicesRoute
     }
     '/security/vulnerabilities': {
       id: '/security/vulnerabilities'
@@ -2853,6 +2922,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminOrganizationsOrgIdRouteImport
       parentRoute: typeof AdminOrganizationsRoute
     }
+    '/services/$service/resources/$resource': {
+      id: '/services/$service/resources/$resource'
+      path: '/resources/$resource'
+      fullPath: '/services/$service/resources/$resource'
+      preLoaderRoute: typeof ServicesServiceResourcesResourceRouteImport
+      parentRoute: typeof ServicesServiceRoute
+    }
     '/projects/$projectId/spans/$spanId': {
       id: '/projects/$projectId/spans/$spanId'
       path: '/spans/$spanId'
@@ -3224,6 +3300,32 @@ const SecurityRouteWithChildren = SecurityRoute._addFileChildren(
   SecurityRouteChildren,
 )
 
+interface ServicesServiceRouteChildren {
+  ServicesServiceResourcesResourceRoute: typeof ServicesServiceResourcesResourceRoute
+}
+
+const ServicesServiceRouteChildren: ServicesServiceRouteChildren = {
+  ServicesServiceResourcesResourceRoute: ServicesServiceResourcesResourceRoute,
+}
+
+const ServicesServiceRouteWithChildren = ServicesServiceRoute._addFileChildren(
+  ServicesServiceRouteChildren,
+)
+
+interface ServicesRouteChildren {
+  ServicesServiceRoute: typeof ServicesServiceRouteWithChildren
+  ServicesIndexRoute: typeof ServicesIndexRoute
+}
+
+const ServicesRouteChildren: ServicesRouteChildren = {
+  ServicesServiceRoute: ServicesServiceRouteWithChildren,
+  ServicesIndexRoute: ServicesIndexRoute,
+}
+
+const ServicesRouteWithChildren = ServicesRoute._addFileChildren(
+  ServicesRouteChildren,
+)
+
 interface SyntheticsRouteChildren {
   SyntheticsTestIdRoute: typeof SyntheticsTestIdRoute
   SyntheticsIndexRoute: typeof SyntheticsIndexRoute
@@ -3299,6 +3401,7 @@ const rootRouteChildren: RootRouteChildren = {
   SecurityRoute: SecurityRouteWithChildren,
   SecuritySbomRoute: SecuritySbomRoute,
   SentryAlternativeRoute: SentryAlternativeRoute,
+  ServicesRoute: ServicesRouteWithChildren,
   SessionReplayRoute: SessionReplayRoute,
   SettingsRoute: SettingsRoute,
   SignozAlternativeRoute: SignozAlternativeRoute,

--- a/dashboard/src/routes/__tests__/-services-detail.test.tsx
+++ b/dashboard/src/routes/__tests__/-services-detail.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {render, screen, waitFor} from '@testing-library/react'
+import type {ApmResourceDetail, ApmServiceDetail} from '@/lib/api'
 import {shouldRetryQuery} from '@/lib/query-retry'
 import {clearAuthStorage, renderRouteWithProviders} from '@/test/utils'
 
@@ -33,8 +34,248 @@ vi.mock('@tanstack/react-router', () => ({
   useRouterState: () => mockPathname.current,
 }))
 
+vi.mock('@/components/ui/tabs', () => {
+  const Panel = ({children, className}: Readonly<{children?: React.ReactNode; className?: string}>) => (
+    <div className={className}>{children}</div>
+  )
+  const Trigger = ({
+    children,
+    value,
+    className,
+  }: Readonly<{children?: React.ReactNode; value?: string; className?: string}>) => (
+    <button type="button" className={className} data-tab-value={value}>
+      {children}
+    </button>
+  )
+
+  return {
+    Tabs: Panel,
+    TabsContent: Panel,
+    TabsList: Panel,
+    TabsTrigger: Trigger,
+  }
+})
+
+vi.mock('recharts', () => {
+  const ChartPart = ({children, ...props}: {children?: React.ReactNode; [key: string]: unknown}) => (
+    <g data-testid="chart-part" data-key={String(props.dataKey ?? props.x ?? props.y ?? '')}>
+      {children}
+    </g>
+  )
+  const ChartRoot = ({children}: {children?: React.ReactNode}) => <svg data-testid="chart-root">{children}</svg>
+
+  return {
+    Area: ChartPart,
+    AreaChart: ChartRoot,
+    CartesianGrid: ChartPart,
+    Line: ChartPart,
+    LineChart: ChartRoot,
+    ReferenceArea: ChartPart,
+    ReferenceLine: ChartPart,
+    ResponsiveContainer: ({children}: {children?: React.ReactNode}) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+    Tooltip: ChartPart,
+    XAxis: ChartPart,
+    YAxis: ChartPart,
+  }
+})
+
 import {Route as ServiceDetailRoute} from '../services.$service'
 import {Route as ResourceDetailRoute} from '../services.$service.resources.$resource'
+
+function serviceDetailFixture(): ApmServiceDetail {
+  return {
+    name: 'checkout-api',
+    type: 'web',
+    status: 'alerting',
+    runtime: 'Kotlin · JVM',
+    team: 'Payments',
+    version: 'v2.14.0',
+    deployedAgo: '18m ago',
+    sources: ['otlp'],
+    kpis: [
+      {label: 'requests', value: '1.2k/s', delta: {value: '+12%', direction: 'up', tone: 'success'}},
+      {label: 'p95 latency', value: '318ms', valueTone: 'warning'},
+      {label: 'error rate', value: '2.4%', valueTone: 'danger'},
+    ],
+    latency: [
+      {t: '10:00', p50: 42, p90: 110, p95: 180, p99: 420},
+      {t: '10:05', p50: 48, p90: 130, p95: 318, p99: 610},
+    ],
+    latencyThresholdMs: 300,
+    latencyThresholdLabel: 'SLO',
+    deployAt: '10:05',
+    throughput: [
+      {t: '10:00', rps: 950, errors: 4},
+      {t: '10:05', rps: 1200, errors: 28},
+    ],
+    errorBars: [
+      {h: 28, level: 'warn'},
+      {h: 72, level: 'bad'},
+    ],
+    p95ByResource: [
+      {label: 'POST /checkout', valueText: '318ms', pct: 68, level: 'warn'},
+      {label: 'GET /cart', valueText: '92ms', pct: 22, level: 'good'},
+    ],
+    resources: [
+      {
+        slug: 'post-checkout',
+        method: 'POST',
+        name: '/checkout',
+        rps: 740,
+        p50Ms: 41,
+        p95Ms: 318,
+        p99Ms: 620,
+        errorRateLabel: '2.4%',
+        errorBarPct: 44,
+        errorLevel: 'bad',
+        timePct: 42,
+        status: 'alerting',
+      },
+      {
+        slug: 'get-cart',
+        method: 'GET',
+        name: '/cart',
+        rps: 460,
+        p50Ms: 22,
+        p95Ms: 92,
+        p99Ms: 130,
+        errorRateLabel: '0.1%',
+        errorBarPct: 4,
+        errorLevel: 'good',
+        timePct: 12,
+        status: 'healthy',
+      },
+    ],
+    upstream: [
+      {name: 'web-checkout', type: 'web', tone: 'success', rps: '740', p95: '88ms', err: '0.1%'},
+    ],
+    downstream: [
+      {name: 'payments-db', type: 'db', tone: 'danger', rps: '610', p95: '420ms', err: '2.1%', errWarn: true},
+    ],
+    depInsight: 'payments-db owns most of the p95 latency for checkout-api.',
+    deployments: [
+      {
+        version: 'v2.14.0',
+        when: '18m ago',
+        initials: 'AE',
+        rps: '1.2k',
+        errorRate: '2.4%',
+        p95: '318ms',
+        status: 'alerting',
+        current: true,
+        trendBad: true,
+      },
+      {
+        version: 'v2.13.7',
+        when: '2h ago',
+        initials: 'PM',
+        rps: '980',
+        errorRate: '0.3%',
+        p95: '180ms',
+        status: 'retired',
+      },
+    ],
+    podMemory: [
+      {label: 'checkout-api-7f9d', valueText: '820Mi', pct: 76, level: 'warn'},
+    ],
+    pods: [
+      {pod: 'checkout-api-7f9d', node: 'node-a', cpu: 87, mem: '820Mi', restarts: 2, tone: 'warning', state: 'Running'},
+    ],
+    errors: [
+      {
+        severity: 'fatal',
+        title: 'PaymentTimeoutError',
+        sub: 'CheckoutController.submit',
+        chips: ['v2.14.0', 'prod'],
+        events: '28',
+        users: '11',
+        unhandled: true,
+      },
+    ],
+    traces: [
+      {
+        time: '10:06',
+        traceId: 'trace-service-1',
+        resource: '/checkout',
+        method: 'POST',
+        httpStatus: 500,
+        durationMs: 610,
+        spans: 18,
+      },
+    ],
+  }
+}
+
+function resourceDetailFixture(): ApmResourceDetail {
+  return {
+    serviceName: 'checkout-api',
+    method: 'POST',
+    path: '/checkout',
+    status: 'degraded',
+    kind: 'http.server',
+    topDependency: 'payments-db',
+    kpis: [
+      {label: 'requests', value: '740/s'},
+      {label: 'p95 latency', value: '318ms', valueTone: 'warning'},
+      {label: 'errors', value: '2.4%', valueTone: 'danger'},
+    ],
+    latency: [
+      {t: '10:00', p50: 42, p90: 110, p95: 180, p99: 420},
+      {t: '10:05', p50: 48, p90: 130, p95: 318, p99: 610},
+    ],
+    latencyThresholdMs: 300,
+    latencyThresholdLabel: 'SLO',
+    deployAt: '10:05',
+    throughput: [
+      {t: '10:00', rps: 650, errors: 2},
+      {t: '10:05', rps: 740, errors: 18},
+    ],
+    distribution: [
+      {h: 24, band: 'good'},
+      {h: 52, band: 'warn'},
+      {h: 88, band: 'bad'},
+    ],
+    distMarkers: [
+      {label: 'p95', left: 58},
+      {label: 'p99', left: 84, p99: true},
+    ],
+    distAxis: ['0ms', '300ms', '600ms'],
+    whereTimeSpent: [
+      {label: 'payments-db', valueText: '61%', pct: 61, level: 'bad'},
+      {label: 'application', valueText: '24%', pct: 24, level: 'warn'},
+    ],
+    whereInsight: 'The database span is the slowest segment on the p95 path.',
+    exemplar: {
+      traceId: 'trace-resource-1',
+      httpStatus: 500,
+      durationLabel: '610ms',
+      rows: [
+        {op: 'POST', desc: '/checkout', left: 0, width: 100, label: '610ms', tone: 'root', selected: true},
+        {op: 'db', desc: 'payments-db', left: 24, width: 61, label: '370ms', tone: 'db', indent: 1},
+      ],
+    },
+    slowTraces: [
+      {
+        time: '10:06',
+        traceId: 'trace-resource-1',
+        httpStatus: 500,
+        durationMs: 610,
+        bucket: 'p99',
+      },
+    ],
+    errors: [
+      {
+        severity: 'error',
+        title: 'PaymentTimeoutError',
+        sub: 'CheckoutController.submit',
+        chips: ['v2.14.0', 'prod'],
+        events: '18',
+      },
+    ],
+  }
+}
 
 function apiError(status: number): Error & {status: number} {
   const error = new Error(`API Error: ${status}`) as Error & {status: number}
@@ -58,6 +299,33 @@ describe('Services detail route', () => {
 
     expect(await screen.findByText('Service telemetry failed to load.')).toBeInTheDocument()
     expect(screen.queryByText(/was not found/)).not.toBeInTheDocument()
+  })
+
+  it('renders a populated service detail surface', async () => {
+    mockApi.getApmServiceDetail.mockResolvedValue(serviceDetailFixture())
+    const Component = (ServiceDetailRoute as unknown as {component: React.ComponentType}).component
+
+    renderRouteWithProviders(Component)
+
+    expect(await screen.findByText('Latency percentiles')).toBeInTheDocument()
+    expect(screen.getByText('Throughput · req/s')).toBeInTheDocument()
+    expect(screen.getByText('Errors over time')).toBeInTheDocument()
+    expect(screen.getByText('p95 by resource · top 5')).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Resources2'})).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Dependencies2'})).toBeInTheDocument()
+    expect(screen.getByText('Upstream · callers')).toBeInTheDocument()
+    expect(screen.getByText('Downstream · dependencies')).toBeInTheDocument()
+    expect(screen.getByText('Deployments')).toBeInTheDocument()
+    expect(screen.getByText('Memory by pod')).toBeInTheDocument()
+    expect(screen.getByText('Pods')).toBeInTheDocument()
+    expect(screen.getByText('PaymentTimeoutError')).toBeInTheDocument()
+    expect(screen.getByText('Open in trace explorer')).toBeInTheDocument()
+    expect(screen.getByText('payments-db owns most of the p95 latency for checkout-api.')).toBeInTheDocument()
+    expect(screen.getAllByText('checkout-api-7f9d')).not.toHaveLength(0)
+
+    await waitFor(() => {
+      expect(mockApi.getApmServiceDetail).toHaveBeenCalledWith('checkout-api', {timeRange: '1h'})
+    })
   })
 
   it('loads service detail by service identity without forcing an environment filter', async () => {
@@ -108,5 +376,27 @@ describe('Services detail route', () => {
 
     expect(await screen.findByText('This resource was not found.')).toBeInTheDocument()
     expect(mockApi.getApmResourceDetail).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a populated resource detail surface', async () => {
+    mockPathname.current = '/services/checkout-api/resources/post-checkout'
+    mockApi.getApmResourceDetail.mockResolvedValue(resourceDetailFixture())
+    const Component = (ResourceDetailRoute as unknown as {component: React.ComponentType}).component
+
+    renderRouteWithProviders(Component)
+
+    expect(await screen.findByText('Latency distribution')).toBeInTheDocument()
+    expect(screen.getByText('Where time is spent · p95 path')).toBeInTheDocument()
+    expect(screen.getByText('The database span is the slowest segment on the p95 path.')).toBeInTheDocument()
+    expect(screen.getByText('Exemplar trace · slowest in range')).toBeInTheDocument()
+    expect(screen.getByText('Open full trace')).toBeInTheDocument()
+    expect(screen.getByText('Slow & failed traces')).toBeInTheDocument()
+    expect(screen.getByText('Errors on this resource')).toBeInTheDocument()
+    expect(screen.getAllByText('trace-resource-1')).not.toHaveLength(0)
+    expect(screen.getAllByText('payments-db')).not.toHaveLength(0)
+
+    await waitFor(() => {
+      expect(mockApi.getApmResourceDetail).toHaveBeenCalledWith('checkout-api', 'post-checkout', {timeRange: '1h'})
+    })
   })
 })

--- a/dashboard/src/routes/__tests__/-services-detail.test.tsx
+++ b/dashboard/src/routes/__tests__/-services-detail.test.tsx
@@ -31,7 +31,10 @@ vi.mock('@tanstack/react-router', () => ({
   }),
   Link: ({children, ...props}: {children: React.ReactNode}) => React.createElement('a', props, children),
   Outlet: () => <div data-testid="services-outlet" />,
-  useRouterState: () => mockPathname.current,
+  useRouterState: ({select}: {select?: (state: {location: {pathname: string}}) => unknown} = {}) => {
+    const state = {location: {pathname: mockPathname.current}}
+    return select ? select(state) : state
+  },
 }))
 
 vi.mock('@/components/ui/tabs', () => {

--- a/dashboard/src/routes/__tests__/-services-detail.test.tsx
+++ b/dashboard/src/routes/__tests__/-services-detail.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {render, screen, waitFor} from '@testing-library/react'
+import {shouldRetryQuery} from '@/lib/query-retry'
+import {clearAuthStorage, renderRouteWithProviders} from '@/test/utils'
+
+const {mockApi, mockRouteParams, mockPathname} = vi.hoisted(() => ({
+  mockApi: {
+    getApmServiceDetail: vi.fn(),
+    getApmResourceDetail: vi.fn(),
+  },
+  mockRouteParams: {
+    current: {service: 'checkout-api', resource: 'post-checkout'},
+  },
+  mockPathname: {
+    current: '/services/checkout-api',
+  },
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    options,
+    useParams: () => mockRouteParams.current,
+  }),
+  Link: ({children, ...props}: {children: React.ReactNode}) => React.createElement('a', props, children),
+  Outlet: () => <div data-testid="services-outlet" />,
+  useRouterState: () => mockPathname.current,
+}))
+
+import {Route as ServiceDetailRoute} from '../services.$service'
+import {Route as ResourceDetailRoute} from '../services.$service.resources.$resource'
+
+function apiError(status: number): Error & {status: number} {
+  const error = new Error(`API Error: ${status}`) as Error & {status: number}
+  error.status = status
+  return error
+}
+
+describe('Services detail route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearAuthStorage()
+    mockRouteParams.current = {service: 'checkout-api', resource: 'post-checkout'}
+    mockPathname.current = '/services/checkout-api'
+  })
+
+  it('does not report service not found for a failed detail request', async () => {
+    mockApi.getApmServiceDetail.mockRejectedValue(apiError(500))
+    const Component = (ServiceDetailRoute as unknown as {component: React.ComponentType}).component
+
+    renderRouteWithProviders(Component)
+
+    expect(await screen.findByText('Service telemetry failed to load.')).toBeInTheDocument()
+    expect(screen.queryByText(/was not found/)).not.toBeInTheDocument()
+  })
+
+  it('loads service detail by service identity without forcing an environment filter', async () => {
+    mockApi.getApmServiceDetail.mockRejectedValue(apiError(404))
+    const Component = (ServiceDetailRoute as unknown as {component: React.ComponentType}).component
+
+    renderRouteWithProviders(Component)
+
+    await waitFor(() => {
+      expect(mockApi.getApmServiceDetail).toHaveBeenCalledWith('checkout-api', {timeRange: '1h'})
+    })
+  })
+
+  it('uses the global retry policy to avoid retrying 404 service detail requests', async () => {
+    mockApi.getApmServiceDetail.mockRejectedValue(apiError(404))
+    const Component = (ServiceDetailRoute as unknown as {component: React.ComponentType}).component
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {retry: shouldRetryQuery, retryDelay: 1},
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Component />
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByText(/was not found/)).toBeInTheDocument()
+    expect(mockApi.getApmServiceDetail).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the global retry policy to avoid retrying 404 resource detail requests', async () => {
+    mockPathname.current = '/services/checkout-api/resources/post-checkout'
+    mockApi.getApmResourceDetail.mockRejectedValue(apiError(404))
+    const Component = (ResourceDetailRoute as unknown as {component: React.ComponentType}).component
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {retry: shouldRetryQuery, retryDelay: 1},
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Component />
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByText('This resource was not found.')).toBeInTheDocument()
+    expect(mockApi.getApmResourceDetail).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -83,6 +83,18 @@ function getInitials(name?: string, email?: string): string {
   return '?'
 }
 
+function feedbackUrlLabel(value: string): string {
+  try {
+    const parsed = new URL(value)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return value.slice(parsed.protocol.length + '//'.length)
+    }
+  } catch {
+    return value
+  }
+  return value
+}
+
 // Deterministic avatar tint from the categorical chart palette (literal classes
 // so Tailwind emits them); encodes identity, not status.
 function getAvatarColor(name?: string, email?: string): string {
@@ -476,7 +488,7 @@ function FeedbackPage() {
                                   <TooltipTrigger asChild>
                                     <Badge variant="outline" size="sm" className="font-normal gap-0.5 max-w-[180px] truncate">
                                       <Globe className="h-2.5 w-2.5 shrink-0" />
-                                      <span className="truncate">{f.url.replace(/^https?:\/\//, '')}</span>
+                                      <span className="truncate">{feedbackUrlLabel(f.url)}</span>
                                     </Badge>
                                   </TooltipTrigger>
                                   <TooltipContent>{f.url}</TooltipContent>

--- a/dashboard/src/routes/services.$service.resources.$resource.tsx
+++ b/dashboard/src/routes/services.$service.resources.$resource.tsx
@@ -255,12 +255,12 @@ function ResourceHeader({
   service,
   timeRange,
   onTimeRangeChange,
-}: {
+}: Readonly<{
   detail: ResourceDetail
   service: string
   timeRange: ApmTimeRange
   onTimeRangeChange: (value: ApmTimeRange) => void
-}) {
+}>) {
   return (
     <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">

--- a/dashboard/src/routes/services.$service.resources.$resource.tsx
+++ b/dashboard/src/routes/services.$service.resources.$resource.tsx
@@ -20,6 +20,7 @@ import {useState} from 'react'
 import {ExternalLink} from 'lucide-react'
 
 import {api, type ApmResourceDetail as ResourceDetail, type ApmTimeRange} from '@/lib/api'
+import {isNotFoundError} from '@/lib/api/errors'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {SectionCard} from '@/components/ui/section-card'
@@ -292,9 +293,4 @@ function ResourceHeader({
       </div>
     </header>
   )
-}
-
-function isNotFoundError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null || !('status' in error)) return false
-  return (error as {status?: unknown}).status === 404
 }

--- a/dashboard/src/routes/services.$service.resources.$resource.tsx
+++ b/dashboard/src/routes/services.$service.resources.$resource.tsx
@@ -1,0 +1,300 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {createFileRoute, Link} from '@tanstack/react-router'
+import {useQuery} from '@tanstack/react-query'
+import {useState} from 'react'
+import {ExternalLink} from 'lucide-react'
+
+import {api, type ApmResourceDetail as ResourceDetail, type ApmTimeRange} from '@/lib/api'
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {SectionCard} from '@/components/ui/section-card'
+import {StatusDot} from '@/components/ui/status-dot'
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
+import {
+  ApmKpiRow,
+  ApmTimeRangeSelect,
+  BarGauge,
+  ErrorList,
+  HttpStatusBadge,
+  InfoCallout,
+  LatencyDistribution,
+  LatencyLegendTable,
+  LatencyPercentilesChart,
+  ServiceStatusBadge,
+  ThroughputChart,
+  Waterfall,
+} from '@/components/apm/ServiceVisuals'
+import {apmRangeLabel, formatMs, statusTone} from '@/lib/apm-view'
+
+export const Route = createFileRoute('/services/$service/resources/$resource')({
+  component: ResourceDetailPage,
+})
+
+function ResourceDetailPage() {
+  const {service, resource} = Route.useParams()
+  const [timeRange, setTimeRange] = useState<ApmTimeRange>('1h')
+  const detailQuery = useQuery({
+    queryKey: ['apm-resource-detail', service, resource, timeRange],
+    queryFn: () => api.getApmResourceDetail(service, resource, {timeRange}),
+  })
+  const detail = detailQuery.data
+  const rangeLabel = apmRangeLabel(timeRange)
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <p className="text-sm text-muted-foreground">Loading resource telemetry...</p>
+      </div>
+    )
+  }
+
+  if (detailQuery.isError && !isNotFoundError(detailQuery.error)) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <p className="text-sm font-medium text-foreground">Resource telemetry failed to load.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The resource exists, but Moneat could not load the detail query.
+        </p>
+        <Button asChild variant="outline" size="sm" className="mt-3">
+          <Link to="/services/$service" params={{service}}>
+            Back to service
+          </Link>
+        </Button>
+      </div>
+    )
+  }
+
+  if (!detail) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <p className="text-sm text-muted-foreground">This resource was not found.</p>
+        <Button asChild variant="outline" size="sm" className="mt-3">
+          <Link to="/services/$service" params={{service}}>
+            Back to service
+          </Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-[1400px] space-y-4 p-4">
+      <nav className="flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+        <Link to="/services" className="transition-colors hover:text-foreground">
+          Services
+        </Link>
+        <span className="text-muted-foreground/50">/</span>
+        <Link to="/services/$service" params={{service}} className="transition-colors hover:text-foreground">
+          {detail.serviceName}
+        </Link>
+        <span className="text-muted-foreground/50">/</span>
+        <span className="font-medium text-foreground">
+          {detail.method} {detail.path}
+        </span>
+      </nav>
+
+      <ResourceHeader
+        detail={detail}
+        service={service}
+        timeRange={timeRange}
+        onTimeRangeChange={setTimeRange}
+      />
+
+      <ApmKpiRow kpis={detail.kpis} />
+
+      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+        <SectionCard
+          title="Latency percentiles"
+          actions={<Badge variant="neutral" shape="pill" size="sm">{rangeLabel}</Badge>}
+        >
+          <LatencyPercentilesChart
+            series={detail.latency}
+            thresholdMs={detail.latencyThresholdMs}
+            thresholdLabel={detail.latencyThresholdLabel}
+            deployAt={detail.deployAt}
+          />
+          <LatencyLegendTable series={detail.latency} />
+        </SectionCard>
+        <SectionCard title="Throughput & errors">
+          <ThroughputChart points={detail.throughput} deployAt={detail.deployAt} withErrors />
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-[2px] bg-chart-1" /> req/s
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-[2px] bg-danger-solid" /> errors/s
+            </span>
+            {detail.deployAt && <span className="ml-auto">deploy marker</span>}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+        <SectionCard title="Latency distribution">
+          <LatencyDistribution bars={detail.distribution} markers={detail.distMarkers} axis={detail.distAxis} />
+        </SectionCard>
+        <SectionCard title="Where time is spent · p95 path">
+          <BarGauge rows={detail.whereTimeSpent} />
+          <div className="mt-3">
+            <InfoCallout>{detail.whereInsight}</InfoCallout>
+          </div>
+        </SectionCard>
+      </div>
+
+      <SectionCard
+        title="Exemplar trace · slowest in range"
+        actions={
+          <div className="flex items-center gap-2">
+            {detail.exemplar.traceId && <HttpStatusBadge status={detail.exemplar.httpStatus} />}
+            <span className="hidden font-mono text-xs text-muted-foreground sm:inline">{detail.exemplar.traceId}</span>
+            <Badge variant="neutral" shape="pill" size="sm">
+              {detail.exemplar.durationLabel}
+            </Badge>
+            {detail.exemplar.traceId && (
+              <Button asChild variant="ghost" size="sm" className="gap-1.5">
+                <Link to="/performance/traces/$traceId" params={{traceId: detail.exemplar.traceId}}>
+                  Open full trace
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </Link>
+              </Button>
+            )}
+          </div>
+        }
+      >
+        <Waterfall rows={detail.exemplar.rows} />
+      </SectionCard>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <SectionCard
+          title="Slow & failed traces"
+          actions={
+            <Button asChild variant="ghost" size="sm" className="gap-1.5">
+              <Link to="/performance/traces">
+                Explore all
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Link>
+            </Button>
+          }
+          flushBody
+        >
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="pl-3">Time</TableHead>
+                <TableHead>Trace ID</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Duration</TableHead>
+                <TableHead className="pr-3">Bucket</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {detail.slowTraces.map((trace) => (
+                <TableRow key={trace.traceId} className="hover:bg-muted/50">
+                  <TableCell className="pl-3 font-mono text-xs">{trace.time}</TableCell>
+                  <TableCell>
+                    <Link
+                      to="/performance/traces/$traceId"
+                      params={{traceId: trace.traceId}}
+                      className="font-mono text-xs text-primary hover:underline"
+                    >
+                      {trace.traceId}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <HttpStatusBadge status={trace.httpStatus} />
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-xs tabular-nums">{formatMs(trace.durationMs)}</TableCell>
+                  <TableCell className="pr-3">
+                    {trace.bucket && (
+                      <Badge variant="neutral" shape="pill" size="sm">
+                        {trace.bucket}
+                      </Badge>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </SectionCard>
+
+        <SectionCard
+          title="Errors on this resource"
+          actions={
+            detail.errors.length > 0 ? (
+              <Badge variant="danger" shape="pill" size="sm">
+                {detail.errors.length} active
+              </Badge>
+            ) : undefined
+          }
+          flushBody
+        >
+          <ErrorList errors={detail.errors} />
+        </SectionCard>
+      </div>
+    </div>
+  )
+}
+
+function ResourceHeader({
+  detail,
+  service,
+  timeRange,
+  onTimeRangeChange,
+}: {
+  detail: ResourceDetail
+  service: string
+  timeRange: ApmTimeRange
+  onTimeRangeChange: (value: ApmTimeRange) => void
+}) {
+  return (
+    <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="flex flex-wrap items-center gap-2.5 text-2xl font-semibold tracking-tight">
+          <StatusDot tone={statusTone(detail.status)} pulse={detail.status === 'alerting'} size="lg" />
+          <span className="font-mono text-lg font-semibold text-foreground">{detail.method}</span>
+          <span className="font-mono text-xl">{detail.path}</span>
+          <ServiceStatusBadge status={detail.status} />
+        </h1>
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span>
+            resource in{' '}
+            <Link to="/services/$service" params={{service}} className="font-medium text-foreground hover:text-primary hover:underline">
+              {detail.serviceName}
+            </Link>
+          </span>
+          <span className="text-border">·</span>
+          <span className="inline-flex h-5 items-center rounded-sm border bg-muted px-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            {detail.kind}
+          </span>
+          <span className="text-border">·</span>
+          <span>
+            top dependency <span className="font-mono text-foreground">{detail.topDependency}</span>
+          </span>
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <ApmTimeRangeSelect value={timeRange} onChange={onTimeRangeChange} />
+      </div>
+    </header>
+  )
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('status' in error)) return false
+  return (error as {status?: unknown}).status === 404
+}

--- a/dashboard/src/routes/services.$service.tsx
+++ b/dashboard/src/routes/services.$service.tsx
@@ -31,6 +31,7 @@ import {
   type ApmServiceDetail as ServiceDetail,
   type ApmTimeRange,
 } from '@/lib/api'
+import {isNotFoundError} from '@/lib/api/errors'
 import {
   ApmKpiRow,
   ApmTimeRangeSelect,
@@ -272,11 +273,6 @@ function ServiceHeader({
       </div>
     </header>
   )
-}
-
-function isNotFoundError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null || !('status' in error)) return false
-  return (error as {status?: unknown}).status === 404
 }
 
 function ServiceTab({value, label, count}: Readonly<{value: string; label: string; count?: number}>) {

--- a/dashboard/src/routes/services.$service.tsx
+++ b/dashboard/src/routes/services.$service.tsx
@@ -65,11 +65,16 @@ function ServiceDetailPage() {
   const pathname = useRouterState({select: (state) => state.location.pathname})
 
   // A resource child route renders in place of the service detail.
-  if (/^\/services\/[^/]+\/resources\//.test(pathname)) {
+  if (isServiceResourceRoute(pathname)) {
     return <Outlet />
   }
 
   return <ServiceDetailContent service={service} />
+}
+
+function isServiceResourceRoute(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean)
+  return segments.length >= 4 && segments[0] === 'services' && segments[2] === 'resources'
 }
 
 function ServiceDetailContent({service}: Readonly<{service: string}>) {

--- a/dashboard/src/routes/services.$service.tsx
+++ b/dashboard/src/routes/services.$service.tsx
@@ -1,0 +1,574 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {createFileRoute, Link, Outlet, useRouterState} from '@tanstack/react-router'
+import {useQuery} from '@tanstack/react-query'
+import {useState} from 'react'
+import {ExternalLink} from 'lucide-react'
+
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {SectionCard} from '@/components/ui/section-card'
+import {StatusDot} from '@/components/ui/status-dot'
+import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
+import {
+  api,
+  type ApmDependencyRow as DependencyRow,
+  type ApmServiceDetail as ServiceDetail,
+  type ApmTimeRange,
+} from '@/lib/api'
+import {
+  ApmKpiRow,
+  ApmTimeRangeSelect,
+  BarGauge,
+  ErrorBars,
+  ErrorList,
+  HttpStatusBadge,
+  InfoCallout,
+  LatencyLegendTable,
+  LatencyPercentilesChart,
+  MeterBar,
+  MethodChip,
+  ServiceStatusBadge,
+  ThroughputChart,
+  TypeChip,
+} from '@/components/apm/ServiceVisuals'
+import {
+  apmRangeLabel,
+  formatMs,
+  statusTone,
+} from '@/lib/apm-view'
+import {cn} from '@/lib/utils'
+
+export const Route = createFileRoute('/services/$service')({
+  component: ServiceDetailPage,
+})
+
+function ServiceDetailPage() {
+  const {service} = Route.useParams()
+  const pathname = useRouterState({select: (state) => state.location.pathname})
+
+  // A resource child route renders in place of the service detail.
+  if (/^\/services\/[^/]+\/resources\//.test(pathname)) {
+    return <Outlet />
+  }
+
+  return <ServiceDetailContent service={service} />
+}
+
+function ServiceDetailContent({service}: {service: string}) {
+  const [timeRange, setTimeRange] = useState<ApmTimeRange>('1h')
+  const detailQuery = useQuery({
+    queryKey: ['apm-service-detail', service, timeRange],
+    queryFn: () => api.getApmServiceDetail(service, {timeRange}),
+  })
+  const detail = detailQuery.data
+  const rangeLabel = apmRangeLabel(timeRange)
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <p className="text-sm text-muted-foreground">Loading service telemetry...</p>
+      </div>
+    )
+  }
+
+  if (detailQuery.isError && !isNotFoundError(detailQuery.error)) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <p className="text-sm font-medium text-foreground">Service telemetry failed to load.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The service exists, but Moneat could not load the detail query for{' '}
+          <span className="font-mono">{service}</span>.
+        </p>
+        <Button asChild variant="outline" size="sm" className="mt-3">
+          <Link to="/services">Back to services</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  if (!detail) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          Service <span className="font-mono">{service}</span> was not found.
+        </p>
+        <Button asChild variant="outline" size="sm" className="mt-3">
+          <Link to="/services">Back to services</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  const hasInfra = detail.pods.length > 0 || detail.podMemory.length > 0
+
+  return (
+    <div className="mx-auto max-w-[1400px] space-y-4 p-4">
+      <nav className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <Link to="/services" className="transition-colors hover:text-foreground">
+          Services
+        </Link>
+        <span className="text-muted-foreground/50">/</span>
+        <span className="font-medium text-foreground">{detail.name}</span>
+      </nav>
+
+      <ServiceHeader detail={detail} timeRange={timeRange} onTimeRangeChange={setTimeRange} />
+
+      <ApmKpiRow kpis={detail.kpis} />
+
+      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+        <SectionCard
+          title="Latency percentiles"
+          actions={<Badge variant="neutral" shape="pill" size="sm">{rangeLabel}</Badge>}
+        >
+          <LatencyPercentilesChart
+            series={detail.latency}
+            thresholdMs={detail.latencyThresholdMs}
+            thresholdLabel={detail.latencyThresholdLabel}
+            deployAt={detail.deployAt}
+          />
+          <LatencyLegendTable series={detail.latency} />
+        </SectionCard>
+        <SectionCard
+          title="Throughput · req/s"
+          actions={<Badge variant="neutral" shape="pill" size="sm">{rangeLabel}</Badge>}
+        >
+          <ThroughputChart points={detail.throughput} deployAt={detail.deployAt} />
+          {detail.deployAt && (
+            <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-[2px] bg-primary" /> deploy {detail.version}
+              </span>
+            </div>
+          )}
+        </SectionCard>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+        <SectionCard
+          title="Errors over time"
+          actions={
+            detail.errorBars.some((bar) => bar.level === 'bad') ? (
+              <Badge variant="danger" shape="pill" size="sm">elevated</Badge>
+            ) : undefined
+          }
+        >
+          <ErrorBars bars={detail.errorBars} />
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-[2px] bg-danger-solid" /> errors present
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-[2px] bg-warning-solid" /> no errors
+            </span>
+            <span className="ml-auto">{rangeLabel}</span>
+          </div>
+        </SectionCard>
+        <SectionCard title="p95 by resource · top 5">
+          <BarGauge rows={detail.p95ByResource} />
+        </SectionCard>
+      </div>
+
+      <Tabs defaultValue="resources" className="mt-1">
+        <TabsList className="h-9 w-full justify-start gap-1 overflow-x-auto rounded-none border-b bg-transparent p-0">
+          <ServiceTab value="resources" label="Resources" count={detail.resources.length} />
+          <ServiceTab value="deps" label="Dependencies" count={detail.upstream.length + detail.downstream.length} />
+          <ServiceTab value="deploys" label="Deployments" count={detail.deployments.length} />
+          {hasInfra && <ServiceTab value="infra" label="Infrastructure" count={detail.pods.length} />}
+          <ServiceTab value="errors" label="Errors" count={detail.errors.length} />
+          <ServiceTab value="traces" label="Traces" />
+        </TabsList>
+
+        <TabsContent value="resources" className="pt-4">
+          <ResourcesTab detail={detail} />
+        </TabsContent>
+        <TabsContent value="deps" className="pt-4">
+          <DependenciesTab detail={detail} />
+        </TabsContent>
+        <TabsContent value="deploys" className="pt-4">
+          <DeploymentsTab detail={detail} />
+        </TabsContent>
+        {hasInfra && (
+          <TabsContent value="infra" className="pt-4">
+            <InfrastructureTab detail={detail} />
+          </TabsContent>
+        )}
+        <TabsContent value="errors" className="pt-4">
+          <div className="overflow-hidden rounded-lg border">
+            <ErrorList errors={detail.errors} showUsers />
+          </div>
+        </TabsContent>
+        <TabsContent value="traces" className="pt-4">
+          <TracesTab detail={detail} rangeLabel={rangeLabel} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function ServiceHeader({
+  detail,
+  timeRange,
+  onTimeRangeChange,
+}: {
+  detail: ServiceDetail
+  timeRange: ApmTimeRange
+  onTimeRangeChange: (value: ApmTimeRange) => void
+}) {
+  return (
+    <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="flex flex-wrap items-center gap-2.5 text-2xl font-semibold tracking-tight">
+          <StatusDot tone={statusTone(detail.status)} pulse={detail.status === 'alerting'} size="lg" />
+          {detail.name}
+          <TypeChip type={detail.type} />
+          <ServiceStatusBadge status={detail.status} />
+        </h1>
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span>{detail.runtime}</span>
+          <span className="text-border">·</span>
+          <span>
+            team <strong className="font-medium text-foreground">{detail.team}</strong>
+          </span>
+          <span className="text-border">·</span>
+          <span>
+            <span className="font-mono">{detail.version}</span> deployed {detail.deployedAgo}
+          </span>
+          <span className="text-border">·</span>
+          <span className="inline-flex items-center gap-1">
+            sources
+            {detail.sources.map((source) => (
+              <Badge key={source} variant="neutral" shape="pill" size="sm">
+                {source}
+              </Badge>
+            ))}
+          </span>
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <ApmTimeRangeSelect value={timeRange} onChange={onTimeRangeChange} />
+      </div>
+    </header>
+  )
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('status' in error)) return false
+  return (error as {status?: unknown}).status === 404
+}
+
+function ServiceTab({value, label, count}: {value: string; label: string; count?: number}) {
+  return (
+    <TabsTrigger
+      value={value}
+      className="shrink-0 rounded-none border-b-2 border-transparent px-3 data-[state=active]:border-primary data-[state=active]:bg-transparent"
+    >
+      {label}
+      {count !== undefined && (
+        <span className="ml-1.5 rounded-full bg-muted px-1.5 text-[11px] tabular-nums text-muted-foreground">
+          {count}
+        </span>
+      )}
+    </TabsTrigger>
+  )
+}
+
+function ResourcesTab({detail}: {detail: ServiceDetail}) {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="pl-3">Resource</TableHead>
+            <TableHead className="text-right">Requests/s</TableHead>
+            <TableHead className="text-right">p50</TableHead>
+            <TableHead className="text-right">p95</TableHead>
+            <TableHead className="text-right">p99</TableHead>
+            <TableHead className="text-right">Error rate</TableHead>
+            <TableHead>% of time</TableHead>
+            <TableHead className="pr-3">Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {detail.resources.map((resource) => (
+            <TableRow key={resource.slug} className="hover:bg-muted/50">
+              <TableCell className="pl-3">
+                <Link
+                  to="/services/$service/resources/$resource"
+                  params={{service: detail.name, resource: resource.slug}}
+                  className="inline-flex items-center gap-2"
+                >
+                  <MethodChip method={resource.method} />
+                  <span className="font-medium hover:text-primary hover:underline">{resource.name}</span>
+                </Link>
+              </TableCell>
+              <TableCell className="text-right font-mono text-xs tabular-nums">{resource.rps.toLocaleString()}</TableCell>
+              <TableCell className="text-right font-mono text-xs tabular-nums">{formatMs(resource.p50Ms)}</TableCell>
+              <TableCell className="text-right font-mono text-xs tabular-nums">{formatMs(resource.p95Ms)}</TableCell>
+              <TableCell className="text-right font-mono text-xs tabular-nums">{formatMs(resource.p99Ms)}</TableCell>
+              <TableCell>
+                <MeterBar pct={resource.errorBarPct} level={resource.errorLevel} value={resource.errorRateLabel} />
+              </TableCell>
+              <TableCell>
+                <MeterBar
+                  pct={resource.timePct}
+                  level={resource.timePct >= 30 ? 'bad' : resource.timePct >= 18 ? 'warn' : 'good'}
+                  value={`${resource.timePct}%`}
+                />
+              </TableCell>
+              <TableCell className="pr-3">
+                <ServiceStatusBadge status={resource.status} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function DependenciesTab({detail}: {detail: ServiceDetail}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <SectionCard title="Upstream · callers" flushBody>
+          <div className="divide-y">
+            {detail.upstream.map((dep) => (
+              <DepRow key={dep.name} dep={dep} />
+            ))}
+          </div>
+        </SectionCard>
+        <SectionCard title="Downstream · dependencies" flushBody>
+          <div className="divide-y">
+            {detail.downstream.map((dep) => (
+              <DepRow key={dep.name} dep={dep} />
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+      <InfoCallout>{detail.depInsight}</InfoCallout>
+    </div>
+  )
+}
+
+function DepRow({dep}: {dep: DependencyRow}) {
+  return (
+    <div className="grid grid-cols-[16px_1fr_auto] items-center gap-2.5 px-3 py-2">
+      <StatusDot tone={dep.tone} />
+      <div className="flex min-w-0 items-center gap-2">
+        <Link
+          to="/services/$service"
+          params={{service: dep.name}}
+          className="truncate font-medium hover:text-primary hover:underline"
+        >
+          {dep.name}
+        </Link>
+        <TypeChip type={dep.type} />
+      </div>
+      <div className="flex items-center gap-3 font-mono text-xs text-muted-foreground">
+        <span>
+          <span className="text-foreground">{dep.rps}</span>/s
+        </span>
+        <span>
+          p95 <span className="text-foreground">{dep.p95}</span>
+        </span>
+        <span className={cn(dep.errWarn && 'text-warning-fg')}>
+          <span className={cn(!dep.errWarn && 'text-foreground')}>{dep.err}</span> err
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function DeploymentsTab({detail}: {detail: ServiceDetail}) {
+  if (detail.deployments.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed py-10 text-center text-sm text-muted-foreground">
+        No deployment versions were observed in this range.
+      </p>
+    )
+  }
+  const current = detail.deployments.find((deploy) => deploy.current) ?? detail.deployments[0]
+  return (
+    <div className="space-y-3">
+      {current && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/[0.06] px-3 py-2 text-sm">
+          <StatusDot tone={statusTone(detail.status)} />
+          <span>
+            <strong className="font-mono">{current.version}</strong> deployed {current.when} — error rate{' '}
+            <strong className={cn(current.trendBad && 'text-danger-fg')}>{current.errorRate}</strong> and p95{' '}
+            <strong className={cn(current.trendBad && 'text-danger-fg')}>{current.p95}</strong> since this release.
+          </span>
+        </div>
+      )}
+      <div className="overflow-hidden rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="pl-3">Version</TableHead>
+              <TableHead>Deployed</TableHead>
+              <TableHead>By</TableHead>
+              <TableHead className="text-right">Requests/s</TableHead>
+              <TableHead className="text-right">Error rate</TableHead>
+              <TableHead className="text-right">p95</TableHead>
+              <TableHead className="pr-3">Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {detail.deployments.map((deploy) => (
+              <TableRow key={deploy.version} className="hover:bg-muted/50">
+                <TableCell className="pl-3">
+                  <Badge variant={deploy.current ? 'accent' : 'neutral'} shape="pill" size="sm">
+                    {deploy.version}
+                  </Badge>
+                  {deploy.current && <span className="ml-2 text-xs text-muted-foreground">current</span>}
+                </TableCell>
+                <TableCell className="text-muted-foreground">{deploy.when}</TableCell>
+                <TableCell>
+                  <InitialsAvatar initials={deploy.initials} />
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs tabular-nums">{deploy.rps}</TableCell>
+                <TableCell className={cn('text-right font-mono text-xs tabular-nums', deploy.trendBad && 'text-danger-fg')}>
+                  {deploy.errorRate}
+                </TableCell>
+                <TableCell className={cn('text-right font-mono text-xs tabular-nums', deploy.trendBad && 'text-danger-fg')}>
+                  {deploy.p95}
+                </TableCell>
+                <TableCell className="pr-3">
+                  {deploy.status === 'retired' ? (
+                    <Badge variant="neutral" size="sm">
+                      retired
+                    </Badge>
+                  ) : (
+                    <ServiceStatusBadge status={deploy.status} />
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}
+
+function InfrastructureTab({detail}: {detail: ServiceDetail}) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <SectionCard title="Memory by pod">
+        <BarGauge rows={detail.podMemory} />
+      </SectionCard>
+      <SectionCard title="Pods" count={`${detail.pods.length} running`} flushBody>
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="pl-3">Pod</TableHead>
+              <TableHead>Node</TableHead>
+              <TableHead className="text-right">CPU</TableHead>
+              <TableHead className="text-right">Mem</TableHead>
+              <TableHead className="text-right">Restarts</TableHead>
+              <TableHead className="pr-3">Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {detail.pods.map((pod) => (
+              <TableRow key={pod.pod} className="hover:bg-muted/50">
+                <TableCell className="pl-3 font-mono text-xs">{pod.pod}</TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">{pod.node}</TableCell>
+                <TableCell className={cn('text-right font-mono text-xs tabular-nums', pod.cpu >= 85 && 'text-danger-fg')}>
+                  {pod.cpu}%
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs tabular-nums">{pod.mem}</TableCell>
+                <TableCell className="text-right font-mono text-xs tabular-nums">{pod.restarts}</TableCell>
+                <TableCell className="pr-3">
+                  <span className="inline-flex items-center gap-1.5 text-xs">
+                    <StatusDot tone={pod.tone} />
+                    {pod.state}
+                  </span>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </SectionCard>
+    </div>
+  )
+}
+
+function TracesTab({detail, rangeLabel}: {detail: ServiceDetail; rangeLabel: string}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Badge variant="neutral">sampled · {rangeLabel}</Badge>
+        <Button asChild variant="ghost" size="sm" className="ml-auto gap-1.5">
+          <Link to="/performance/traces">
+            Open in trace explorer
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </div>
+      <div className="overflow-hidden rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="pl-3">Time</TableHead>
+              <TableHead>Trace ID</TableHead>
+              <TableHead>Resource</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Duration</TableHead>
+              <TableHead className="pr-3 text-right">Spans</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {detail.traces.map((trace) => (
+              <TableRow key={trace.traceId} className="hover:bg-muted/50">
+                <TableCell className="pl-3 font-mono text-xs">{trace.time}</TableCell>
+                <TableCell>
+                  <Link
+                    to="/performance/traces/$traceId"
+                    params={{traceId: trace.traceId}}
+                    className="font-mono text-xs text-primary hover:underline"
+                  >
+                    {trace.traceId}
+                  </Link>
+                </TableCell>
+                <TableCell className="text-xs">
+                  {trace.method && <MethodChip method={trace.method} className="mr-1" />}
+                  <span className="font-mono text-muted-foreground">{trace.resource}</span>
+                </TableCell>
+                <TableCell>
+                  <HttpStatusBadge status={trace.httpStatus} />
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs tabular-nums">{formatMs(trace.durationMs)}</TableCell>
+                <TableCell className="pr-3 text-right font-mono text-xs tabular-nums">{trace.spans}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}
+
+function InitialsAvatar({initials}: {initials: string}) {
+  return (
+    <span className="inline-grid h-[22px] w-[22px] place-items-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">
+      {initials}
+    </span>
+  )
+}

--- a/dashboard/src/routes/services.$service.tsx
+++ b/dashboard/src/routes/services.$service.tsx
@@ -51,6 +51,7 @@ import {
   apmRangeLabel,
   formatMs,
   statusTone,
+  type Severity,
 } from '@/lib/apm-view'
 import {cn} from '@/lib/utils'
 
@@ -70,7 +71,7 @@ function ServiceDetailPage() {
   return <ServiceDetailContent service={service} />
 }
 
-function ServiceDetailContent({service}: {service: string}) {
+function ServiceDetailContent({service}: Readonly<{service: string}>) {
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('1h')
   const detailQuery = useQuery({
     queryKey: ['apm-service-detail', service, timeRange],
@@ -221,15 +222,21 @@ function ServiceDetailContent({service}: {service: string}) {
   )
 }
 
+function timePctSeverity(timePct: number): Severity {
+  if (timePct >= 30) return 'bad'
+  if (timePct >= 18) return 'warn'
+  return 'good'
+}
+
 function ServiceHeader({
   detail,
   timeRange,
   onTimeRangeChange,
-}: {
+}: Readonly<{
   detail: ServiceDetail
   timeRange: ApmTimeRange
   onTimeRangeChange: (value: ApmTimeRange) => void
-}) {
+}>) {
   return (
     <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
@@ -272,7 +279,7 @@ function isNotFoundError(error: unknown): boolean {
   return (error as {status?: unknown}).status === 404
 }
 
-function ServiceTab({value, label, count}: {value: string; label: string; count?: number}) {
+function ServiceTab({value, label, count}: Readonly<{value: string; label: string; count?: number}>) {
   return (
     <TabsTrigger
       value={value}
@@ -288,7 +295,7 @@ function ServiceTab({value, label, count}: {value: string; label: string; count?
   )
 }
 
-function ResourcesTab({detail}: {detail: ServiceDetail}) {
+function ResourcesTab({detail}: Readonly<{detail: ServiceDetail}>) {
   return (
     <div className="overflow-hidden rounded-lg border">
       <Table>
@@ -327,7 +334,7 @@ function ResourcesTab({detail}: {detail: ServiceDetail}) {
               <TableCell>
                 <MeterBar
                   pct={resource.timePct}
-                  level={resource.timePct >= 30 ? 'bad' : resource.timePct >= 18 ? 'warn' : 'good'}
+                  level={timePctSeverity(resource.timePct)}
                   value={`${resource.timePct}%`}
                 />
               </TableCell>
@@ -342,7 +349,7 @@ function ResourcesTab({detail}: {detail: ServiceDetail}) {
   )
 }
 
-function DependenciesTab({detail}: {detail: ServiceDetail}) {
+function DependenciesTab({detail}: Readonly<{detail: ServiceDetail}>) {
   return (
     <div className="space-y-4">
       <div className="grid gap-4 lg:grid-cols-2">
@@ -366,7 +373,7 @@ function DependenciesTab({detail}: {detail: ServiceDetail}) {
   )
 }
 
-function DepRow({dep}: {dep: DependencyRow}) {
+function DepRow({dep}: Readonly<{dep: DependencyRow}>) {
   return (
     <div className="grid grid-cols-[16px_1fr_auto] items-center gap-2.5 px-3 py-2">
       <StatusDot tone={dep.tone} />
@@ -395,7 +402,7 @@ function DepRow({dep}: {dep: DependencyRow}) {
   )
 }
 
-function DeploymentsTab({detail}: {detail: ServiceDetail}) {
+function DeploymentsTab({detail}: Readonly<{detail: ServiceDetail}>) {
   if (detail.deployments.length === 0) {
     return (
       <p className="rounded-lg border border-dashed py-10 text-center text-sm text-muted-foreground">
@@ -467,7 +474,7 @@ function DeploymentsTab({detail}: {detail: ServiceDetail}) {
   )
 }
 
-function InfrastructureTab({detail}: {detail: ServiceDetail}) {
+function InfrastructureTab({detail}: Readonly<{detail: ServiceDetail}>) {
   return (
     <div className="grid gap-4 lg:grid-cols-2">
       <SectionCard title="Memory by pod">
@@ -510,7 +517,7 @@ function InfrastructureTab({detail}: {detail: ServiceDetail}) {
   )
 }
 
-function TracesTab({detail, rangeLabel}: {detail: ServiceDetail; rangeLabel: string}) {
+function TracesTab({detail, rangeLabel}: Readonly<{detail: ServiceDetail; rangeLabel: string}>) {
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
@@ -565,7 +572,7 @@ function TracesTab({detail, rangeLabel}: {detail: ServiceDetail; rangeLabel: str
   )
 }
 
-function InitialsAvatar({initials}: {initials: string}) {
+function InitialsAvatar({initials}: Readonly<{initials: string}>) {
   return (
     <span className="inline-grid h-[22px] w-[22px] place-items-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">
       {initials}

--- a/dashboard/src/routes/services.index.tsx
+++ b/dashboard/src/routes/services.index.tsx
@@ -249,7 +249,11 @@ function ServicesCatalogPage() {
   )
 }
 
-function SegmentButton({active, onClick, children}: {active: boolean; onClick: () => void; children: ReactNode}) {
+function SegmentButton({
+  active,
+  onClick,
+  children,
+}: Readonly<{active: boolean; onClick: () => void; children: ReactNode}>) {
   return (
     <button
       type="button"
@@ -270,13 +274,13 @@ function SortableHead({
   sort,
   onSort,
   align = 'left',
-}: {
+}: Readonly<{
   label: string
   sortKey: SortKey
   sort: SortState
   onSort: (key: SortKey) => void
   align?: 'left' | 'right'
-}) {
+}>) {
   const active = sort.key === sortKey
   return (
     <TableHead className={cn(align === 'right' && 'text-right')}>

--- a/dashboard/src/routes/services.index.tsx
+++ b/dashboard/src/routes/services.index.tsx
@@ -1,0 +1,397 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {createFileRoute, Link, useNavigate} from '@tanstack/react-router'
+import {useQuery} from '@tanstack/react-query'
+import {useMemo, useState, type ReactNode} from 'react'
+import {ArrowDown, ArrowUp, Boxes, List, Network} from 'lucide-react'
+
+import {api, type ApmServiceCatalogRow as CatalogService, type ApmTimeRange} from '@/lib/api'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
+import {FacetRail} from '@/components/filters/FacetRail'
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
+import {StatusDot} from '@/components/ui/status-dot'
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
+import {
+  ApdexHeat,
+  ApmTimeRangeSelect,
+  EnvPills,
+  MeterBar,
+  ServiceStatusBadge,
+  Sparkline,
+  TypeChip,
+} from '@/components/apm/ServiceVisuals'
+import {
+  formatMs,
+  formatRps,
+  SERVICE_FACET_SCHEMA,
+  statusTone,
+} from '@/lib/apm-view'
+import type {FacetFilter, FacetRailSection, FacetValue} from '@/lib/filters/types'
+import {cn} from '@/lib/utils'
+
+export const Route = createFileRoute('/services/')({
+  component: ServicesCatalogPage,
+})
+
+type SortKey = 'error' | 'rps' | 'p95' | 'p99' | 'apdex' | 'name'
+type SortDir = 'asc' | 'desc'
+
+interface SortState {
+  key: SortKey
+  dir: SortDir
+}
+
+const SORT_OPTIONS: ReadonlyArray<{value: SortKey; label: string}> = [
+  {value: 'error', label: 'Error rate'},
+  {value: 'p95', label: 'p95'},
+  {value: 'p99', label: 'p99'},
+  {value: 'rps', label: 'Requests/s'},
+  {value: 'apdex', label: 'Apdex'},
+  {value: 'name', label: 'Name'},
+]
+
+function ServicesCatalogPage() {
+  const navigate = useNavigate()
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const [query, setQuery] = useState('')
+  const [sort, setSort] = useState<SortState>({key: 'error', dir: 'desc'})
+  const [view, setView] = useState<'list' | 'map'>('list')
+  const [timeRange, setTimeRange] = useState<ApmTimeRange>('1h')
+
+  const catalogQuery = useQuery({
+    queryKey: ['apm-services', timeRange],
+    queryFn: () => api.getApmServices({timeRange, limit: 200}),
+  })
+  const services = catalogQuery.data?.services ?? []
+  const facetSections = useMemo(() => buildFacetSections(services), [services])
+  const rows = useMemo(() => sortServices(filterServices(services, facetFilters, query), sort), [facetFilters, query, services, sort])
+  const summary = catalogQuery.data?.summary ?? {total: 0, alerting: 0, degraded: 0}
+
+  const setSortKey = (key: SortKey) =>
+    setSort((current) =>
+      current.key === key
+        ? {key, dir: current.dir === 'desc' ? 'asc' : 'desc'}
+        : {key, dir: key === 'name' ? 'asc' : 'desc'},
+    )
+
+  return (
+    <ExplorerShell
+      className="min-h-[calc(100vh-3.5rem)]"
+      title="Services"
+      icon={<Boxes className="h-4 w-4 text-muted-foreground" />}
+      searchBar={
+        <SearchFilterBar
+          query={query}
+          onQueryChange={setQuery}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={setFacetFilters}
+          schema={SERVICE_FACET_SCHEMA}
+          placeholder="Filter by service, tag, or facet…"
+          trailing={<ApmTimeRangeSelect value={timeRange} onChange={setTimeRange} />}
+        />
+      }
+      rail={
+        <FacetRail
+          sections={facetSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={setFacetFilters}
+          title="Service facets"
+        />
+      }
+      toolbar={
+        <div className="flex flex-1 items-center gap-2">
+          <Badge variant="neutral" className="font-normal">
+            {rows.length} services
+          </Badge>
+          <span className="mx-1 h-4 w-px bg-border" />
+          <div className="inline-flex overflow-hidden rounded-md border">
+            <SegmentButton active={view === 'list'} onClick={() => setView('list')}>
+              <List className="h-3.5 w-3.5" /> List
+            </SegmentButton>
+            <SegmentButton active={view === 'map'} onClick={() => setView('map')}>
+              <Network className="h-3.5 w-3.5" /> Map
+            </SegmentButton>
+          </div>
+          <div className="ml-auto flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">Sort</span>
+            <Select value={sort.key} onValueChange={(value) => setSort({key: value as SortKey, dir: value === 'name' ? 'asc' : 'desc'})}>
+              <SelectTrigger className="h-7 w-[132px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SORT_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      }
+    >
+      <div className="min-w-0 px-3 py-3 sm:px-4">
+        <div className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+          <span>APM service catalog</span>
+          <span className="text-border">·</span>
+          <span>
+            <strong className="font-semibold text-foreground tabular-nums">{summary.total}</strong> services
+          </span>
+          <span className="text-border">·</span>
+          <span className="inline-flex items-center gap-1.5">
+            <StatusDot tone="danger" /> {summary.alerting} alerting
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <StatusDot tone="warning" /> {summary.degraded} degraded
+          </span>
+        </div>
+
+        {catalogQuery.isError && (
+          <div className="mb-3 rounded-md border border-danger-border bg-danger-bg/40 px-3 py-2 text-sm text-danger-fg">
+            Service telemetry is unavailable.
+          </div>
+        )}
+
+        {view === 'map' ? (
+          <MapPlaceholder />
+        ) : (
+          <div className="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead className="pl-3">Service</TableHead>
+                  <TableHead>Env</TableHead>
+                  <SortableHead label="Requests/s" sortKey="rps" sort={sort} onSort={setSortKey} />
+                  <SortableHead label="p95" sortKey="p95" sort={sort} onSort={setSortKey} align="right" />
+                  <SortableHead label="p99" sortKey="p99" sort={sort} onSort={setSortKey} align="right" />
+                  <SortableHead label="Error rate" sortKey="error" sort={sort} onSort={setSortKey} align="right" />
+                  <SortableHead label="Apdex" sortKey="apdex" sort={sort} onSort={setSortKey} align="right" />
+                  <TableHead>Last deploy</TableHead>
+                  <TableHead>Team</TableHead>
+                  <TableHead className="pr-3">Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((service) => (
+                  <TableRow
+                    key={service.name}
+                    className="cursor-pointer"
+                    onClick={() => navigate({to: '/services/$service', params: {service: service.name}})}
+                  >
+                    <TableCell className="pl-3">
+                      <div className="flex items-center gap-2">
+                        <StatusDot tone={statusTone(service.status)} pulse={service.status === 'alerting'} />
+                        <Link
+                          to="/services/$service"
+                          params={{service: service.name}}
+                          onClick={(event) => event.stopPropagation()}
+                          className="font-semibold text-foreground hover:text-primary hover:underline"
+                        >
+                          {service.name}
+                        </Link>
+                        <TypeChip type={service.type} />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <EnvPills pills={service.env} />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Sparkline values={service.spark} />
+                        <span className="font-mono text-xs tabular-nums">{formatRps(service.rps)}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-xs tabular-nums">{formatMs(service.p95Ms)}</TableCell>
+                    <TableCell className="text-right font-mono text-xs tabular-nums">{formatMs(service.p99Ms)}</TableCell>
+                    <TableCell>
+                      <MeterBar pct={service.errorBarPct} level={service.errorLevel} value={service.errorRateLabel} />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <ApdexHeat value={service.apdex} tone={service.apdexTone} />
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">{service.lastDeploy}</TableCell>
+                    <TableCell className="text-muted-foreground">{service.team}</TableCell>
+                    <TableCell className="pr-3">
+                      <ServiceStatusBadge status={service.status} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {rows.length === 0 && (
+                  <TableRow className="hover:bg-transparent">
+                    <TableCell colSpan={10} className="py-10 text-center text-sm text-muted-foreground">
+                      {catalogQuery.isLoading ? 'Loading services...' : 'No services match the current filters.'}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </ExplorerShell>
+  )
+}
+
+function SegmentButton({active, onClick, children}: {active: boolean; onClick: () => void; children: ReactNode}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium transition-colors',
+        active ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50',
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+function SortableHead({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  align = 'left',
+}: {
+  label: string
+  sortKey: SortKey
+  sort: SortState
+  onSort: (key: SortKey) => void
+  align?: 'left' | 'right'
+}) {
+  const active = sort.key === sortKey
+  return (
+    <TableHead className={cn(align === 'right' && 'text-right')}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={cn(
+          'inline-flex items-center gap-1 hover:text-foreground',
+          align === 'right' && 'flex-row-reverse',
+          active && 'text-foreground',
+        )}
+      >
+        {label}
+        {active &&
+          (sort.dir === 'desc' ? <ArrowDown className="h-3 w-3" /> : <ArrowUp className="h-3 w-3" />)}
+      </button>
+    </TableHead>
+  )
+}
+
+function MapPlaceholder() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-16 text-center">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+        <Network className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div>
+        <p className="text-sm font-medium">Service map</p>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Topology of these services and their dependencies.
+        </p>
+      </div>
+      <Button asChild variant="outline" size="sm">
+        <Link to="/monitoring/service-map">Open service map</Link>
+      </Button>
+    </div>
+  )
+}
+
+/** Derive the rail's selectable values + counts from the loaded services. */
+function buildFacetSections(services: readonly CatalogService[]): FacetRailSection[] {
+  const tally = (key: string): FacetValue[] => {
+    const counts = new Map<string, number>()
+    for (const service of services) {
+      const value = serviceFacetValue(service, key)
+      if (value) counts.set(value, (counts.get(value) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([value, count]) => ({value, count}))
+  }
+  return [
+    {key: 'env', label: 'Environment', color: 'bg-chart-1', singleSelect: true, options: tally('env')},
+    {key: 'type', label: 'Service type', color: 'bg-chart-2', options: tally('type')},
+    {key: 'source', label: 'Telemetry source', color: 'bg-chart-6', options: tally('source')},
+  ]
+}
+
+function filterServices(
+  services: readonly CatalogService[],
+  filters: readonly FacetFilter[],
+  query: string,
+): CatalogService[] {
+  const text = query.trim().toLowerCase()
+  const byKey = new Map<string, {include: Set<string>; exclude: Set<string>}>()
+  for (const filter of filters) {
+    const entry = byKey.get(filter.key) ?? {include: new Set<string>(), exclude: new Set<string>()}
+    ;(filter.exclude ? entry.exclude : entry.include).add(filter.value)
+    byKey.set(filter.key, entry)
+  }
+
+  return services.filter((service) => {
+    if (text && !service.name.toLowerCase().includes(text) && !service.team.toLowerCase().includes(text)) {
+      return false
+    }
+    for (const [key, sets] of byKey) {
+      const value = serviceFacetValue(service, key)
+      // Unknown facet keys (no value on the row) are treated as no-ops.
+      if (value === undefined) continue
+      if (sets.include.size > 0 && !sets.include.has(value)) return false
+      if (sets.exclude.has(value)) return false
+    }
+    return true
+  })
+}
+
+function serviceFacetValue(service: CatalogService, key: string): string | undefined {
+  switch (key) {
+    case 'type':
+      return service.type
+    case 'env':
+      return service.env[0]?.label === 'prod' ? 'production' : service.env[0]?.label
+    case 'source':
+      return service.sources[0]
+    default:
+      return undefined
+  }
+}
+
+function sortServices(services: CatalogService[], sort: SortState): CatalogService[] {
+  const factor = sort.dir === 'desc' ? -1 : 1
+  return [...services].sort((a, b) => {
+    switch (sort.key) {
+      case 'name':
+        return factor * a.name.localeCompare(b.name)
+      case 'rps':
+        return factor * (a.rps - b.rps)
+      case 'p95':
+        return factor * (a.p95Ms - b.p95Ms)
+      case 'p99':
+        return factor * (a.p99Ms - b.p99Ms)
+      case 'apdex':
+        return factor * (Number.parseFloat(a.apdex) - Number.parseFloat(b.apdex))
+      default:
+        return factor * (a.errorBarPct - b.errorBarPct)
+    }
+  })
+}

--- a/dashboard/src/routes/services.tsx
+++ b/dashboard/src/routes/services.tsx
@@ -18,9 +18,9 @@ import {createFileRoute, Outlet, redirect} from '@tanstack/react-router'
 import {api} from '@/lib/api'
 
 export const Route = createFileRoute('/services')({
-  beforeLoad: async ({location}) => {
+  beforeLoad: async () => {
     if (!api.isAuthenticated()) {
-      throw redirect({to: '/login', search: {redirect: location.href}})
+      throw redirect({to: '/login', search: {redirect: '/services'}})
     }
   },
   component: ServicesLayout,

--- a/dashboard/src/routes/services.tsx
+++ b/dashboard/src/routes/services.tsx
@@ -1,0 +1,31 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {createFileRoute, Outlet, redirect} from '@tanstack/react-router'
+import {api} from '@/lib/api'
+
+export const Route = createFileRoute('/services')({
+  beforeLoad: async ({location}) => {
+    if (!api.isAuthenticated()) {
+      throw redirect({to: '/login', search: {redirect: location.href}})
+    }
+  },
+  component: ServicesLayout,
+})
+
+function ServicesLayout() {
+  return <Outlet />
+}


### PR DESCRIPTION
Adds service-focused APM pages and supporting dashboard APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Services catalog, service detail and resource drill‑down UIs with KPIs, sparklines, latency/throughput charts, distributions, waterfall exemplars, deploy & pod views, and time‑range selector
  * Sidebar navigation and routes for /services, service pages and resource pages
  * Service dependency map and per‑service latency endpoints; client API methods to fetch services, service detail and resource detail

* **Bug Fixes / UX**
  * Clear loading, not‑found and error states with back links and login redirect

* **Tests**
  * Extensive unit and route tests covering APIs, services, resources and visual components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->