### PR TITLE
feat: support source-neutral feedback telemetry

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
@@ -541,7 +541,13 @@ data class FeedbackListItem(
     val platform: String,
     val user: UserInfo?,
     val associatedEventId: String?,
-    val replayId: String?
+    val replayId: String?,
+    val sourceType: String = "sentry",
+    val sourceName: String = "Sentry-compatible SDK",
+    val sourceEventName: String = "feedback",
+    val traceId: String = "",
+    val spanId: String = "",
+    val resourceAttributes: Map<String, String> = emptyMap()
 )
 
 @Serializable
@@ -561,7 +567,13 @@ data class FeedbackDetailResponse(
     val replayId: String?,
     val tags: Map<String, String>,
     val sdkName: String,
-    val sdkVersion: String
+    val sdkVersion: String,
+    val sourceType: String = "sentry",
+    val sourceName: String = "Sentry-compatible SDK",
+    val sourceEventName: String = "feedback",
+    val traceId: String = "",
+    val spanId: String = "",
+    val resourceAttributes: Map<String, String> = emptyMap()
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
@@ -264,12 +264,14 @@ class EventRepositoryImpl(
 
     override suspend fun insertFeedback(data: FeedbackInsertData): Boolean {
         val tagsMap = tagsToMap(data.tags)
+        val resourceAttributesMap = tagsToMap(data.resourceAttributes)
         val sql = """
             INSERT INTO `$db`.user_feedback (
                 feedback_id, service_id, project_id, organization_id, timestamp, message, contact_email, name, url,
                 associated_event_id, replay_id, environment, release, platform,
                 user_id, user_email, user_username, user_ip_address,
-                sdk_name, sdk_version, tags, status
+                sdk_name, sdk_version, tags, status,
+                source_type, source_name, source_event_name, trace_id, span_id, resource_attributes
             ) VALUES (
                 toUUID('${escapeSql(data.feedbackId)}'),
                 ${data.projectId},
@@ -292,7 +294,13 @@ class EventRepositoryImpl(
                 '${escapeSql(data.sdkName)}',
                 '${escapeSql(data.sdkVersion)}',
                 $tagsMap,
-                'unresolved'
+                'unresolved',
+                '${escapeSql(data.sourceType)}',
+                '${escapeSql(data.sourceName)}',
+                '${escapeSql(data.sourceEventName)}',
+                '${escapeSql(data.traceId)}',
+                '${escapeSql(data.spanId)}',
+                $resourceAttributesMap
             )
         """.trimIndent()
         return executeInsert(sql)

--- a/backend/src/main/kotlin/com/moneat/events/repositories/models/EventInsertData.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/models/EventInsertData.kt
@@ -123,7 +123,13 @@ data class FeedbackInsertData(
     val sdkName: String,
     val sdkVersion: String,
     val tags: Map<String, String>?,
-    val organizationId: Int
+    val organizationId: Int,
+    val sourceType: String = "sentry",
+    val sourceName: String = "Sentry-compatible SDK",
+    val sourceEventName: String = "feedback",
+    val traceId: String = "",
+    val spanId: String = "",
+    val resourceAttributes: Map<String, String>? = null
 )
 
 data class ReplayEventInsertData(

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -690,7 +690,10 @@ class EventService(
             userIpAddress = userIpAddress,
             sdkName = feedback.sdk?.name ?: "",
             sdkVersion = feedback.sdk?.version ?: "",
-            tags = feedback.tags
+            tags = feedback.tags,
+            sourceType = "sentry",
+            sourceName = "Sentry-compatible SDK",
+            sourceEventName = if (itemType == "event") "feedback" else itemType
         )
 
         suspendRunCatching {

--- a/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
@@ -123,7 +123,13 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
                 user_email,
                 user_username,
                 associated_event_id,
-                replay_id
+                replay_id,
+                source_type,
+                source_name,
+                source_event_name,
+                trace_id,
+                span_id,
+                resource_attributes
             FROM `$clickhouseDb`.user_feedback FINAL
             WHERE $projectIdClause
                 AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
@@ -149,7 +155,13 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
                 user = queryHelper.extractUserInfo(obj),
                 associatedEventId =
                 obj["associated_event_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
-                replayId = obj["replay_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                replayId = obj["replay_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
+                sourceType = obj["source_type"]?.jsonPrimitive?.content ?: "sentry",
+                sourceName = obj["source_name"]?.jsonPrimitive?.content ?: "Sentry-compatible SDK",
+                sourceEventName = obj["source_event_name"]?.jsonPrimitive?.content ?: "feedback",
+                traceId = obj["trace_id"]?.jsonPrimitive?.content ?: "",
+                spanId = obj["span_id"]?.jsonPrimitive?.content ?: "",
+                resourceAttributes = parseTagsMap(obj["resource_attributes"])
             )
         }
     }
@@ -181,7 +193,13 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
                 replay_id,
                 tags,
                 sdk_name,
-                sdk_version
+                sdk_version,
+                source_type,
+                source_name,
+                source_event_name,
+                trace_id,
+                span_id,
+                resource_attributes
             FROM `$clickhouseDb`.user_feedback FINAL
             WHERE toString(feedback_id) = '$normalizedFeedbackId'
                 AND $projectIdClause
@@ -208,7 +226,13 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
             replayId = obj["replay_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             tags = tagsMap,
             sdkName = obj["sdk_name"]?.jsonPrimitive?.content ?: "",
-            sdkVersion = obj["sdk_version"]?.jsonPrimitive?.content ?: ""
+            sdkVersion = obj["sdk_version"]?.jsonPrimitive?.content ?: "",
+            sourceType = obj["source_type"]?.jsonPrimitive?.content ?: "sentry",
+            sourceName = obj["source_name"]?.jsonPrimitive?.content ?: "Sentry-compatible SDK",
+            sourceEventName = obj["source_event_name"]?.jsonPrimitive?.content ?: "feedback",
+            traceId = obj["trace_id"]?.jsonPrimitive?.content ?: "",
+            spanId = obj["span_id"]?.jsonPrimitive?.content ?: "",
+            resourceAttributes = parseTagsMap(obj["resource_attributes"])
         )
     }
 

--- a/backend/src/main/kotlin/com/moneat/otlp/models/OtlpServiceRoutingModels.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/models/OtlpServiceRoutingModels.kt
@@ -50,6 +50,7 @@ data class OtlpObservedServiceResponse(
     @SerialName("seen_logs") val seenLogs: Boolean,
     @SerialName("seen_traces") val seenTraces: Boolean,
     @SerialName("seen_metrics") val seenMetrics: Boolean,
+    @SerialName("seen_feedback") val seenFeedback: Boolean = false,
     @SerialName("last_environment") val lastEnvironment: String? = null,
     @SerialName("first_seen_at") val firstSeenAt: String,
     @SerialName("last_seen_at") val lastSeenAt: String,

--- a/backend/src/main/kotlin/com/moneat/otlp/routes/OtlpFeedbackRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/routes/OtlpFeedbackRoutes.kt
@@ -1,0 +1,156 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.otlp.routes
+
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.billing.services.QuotaExceededResponse
+import com.moneat.datadog.decompression.DecompressionService
+import com.moneat.otlp.OtlpAuth
+import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.otlp.services.OtlpFeedbackIngestResult
+import com.moneat.otlp.services.OtlpFeedbackInsert
+import com.moneat.otlp.services.OtlpFeedbackService
+import com.moneat.otlp.services.OtlpServiceDescriptor
+import com.moneat.otlp.services.OtlpServiceRoutingService
+import com.moneat.otlp.services.OtlpSignalType
+import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.header
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import org.koin.core.context.GlobalContext
+
+fun Route.otlpFeedbackRoutes(
+    feedbackService: OtlpFeedbackService = OtlpFeedbackService(),
+    quotaService: BillingQuotaService = GlobalContext.get().get(),
+    otlpApiKeyService: OtlpApiKeyService = GlobalContext.get().get(),
+    otlpServiceRoutingService: OtlpServiceRoutingService = GlobalContext.get().get(),
+) {
+    route("/v1") {
+        post("/feedback/otlp") {
+            handleOtlpFeedbackIngest(
+                call,
+                feedbackService,
+                quotaService,
+                otlpApiKeyService,
+                otlpServiceRoutingService
+            )
+        }
+    }
+}
+
+private suspend fun handleOtlpFeedbackIngest(
+    call: ApplicationCall,
+    feedbackService: OtlpFeedbackService,
+    quotaService: BillingQuotaService,
+    otlpApiKeyService: OtlpApiKeyService,
+    otlpServiceRoutingService: OtlpServiceRoutingService,
+) {
+    val contentType = call.request.header(HttpHeaders.ContentType) ?: ""
+    val isJson = contentType.contains("application/json", ignoreCase = true)
+    val isProtobuf = contentType.contains("application/x-protobuf", ignoreCase = true)
+    if (!isJson && !isProtobuf) {
+        call.respond(
+            HttpStatusCode.UnsupportedMediaType,
+            ErrorResponse(
+                "OTLP feedback endpoint requires Content-Type: application/json or application/x-protobuf."
+            )
+        )
+        return
+    }
+
+    val organizationId = OtlpAuth.extractOrgId(call, otlpApiKeyService)
+    if (organizationId == null) {
+        call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Missing or invalid OTLP API key"))
+        return
+    }
+
+    val bodyBytes = call.receive<ByteArray>()
+    val encoding = call.request.header(HttpHeaders.ContentEncoding)
+    val payloadBytes = suspendRunCatching {
+        DecompressionService.decompress(bodyBytes, encoding)
+    }.getOrElse { _ ->
+        call.respond(HttpStatusCode.BadRequest, ErrorResponse("Failed to decompress request body"))
+        return
+    }
+
+    val parsedFeedback = if (isProtobuf) {
+        feedbackService.parseOtlpFeedbackProtobuf(payloadBytes)
+    } else {
+        feedbackService.parseOtlpFeedbackJson(payloadBytes.decodeToString())
+    }
+    if (parsedFeedback == null) {
+        call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid OTLP feedback payload"))
+        return
+    }
+    if (parsedFeedback.isEmpty()) {
+        call.respond(HttpStatusCode.Accepted, OtlpFeedbackIngestResult(accepted = 0, unmapped = 0))
+        return
+    }
+
+    val routedFeedback = routeFeedback(organizationId, parsedFeedback, otlpServiceRoutingService)
+    val mappedFeedback = routedFeedback.filter { it.projectId != null }
+    val unmapped = routedFeedback.size - mappedFeedback.size
+    if (mappedFeedback.isEmpty()) {
+        call.respond(HttpStatusCode.Accepted, OtlpFeedbackIngestResult(accepted = 0, unmapped = unmapped))
+        return
+    }
+
+    if (quotaService.isEnforcementEnabled()) {
+        val reservation = quotaService.reserveUnits(
+            organizationId = organizationId,
+            requestedUnits = mappedFeedback.size,
+            eventType = "feedback",
+            requestedBytes = payloadBytes.size.toLong()
+        )
+        if (!reservation.allowed) {
+            call.respond(
+                HttpStatusCode.TooManyRequests,
+                QuotaExceededResponse(reason = reservation.reason, usage = reservation.usage)
+            )
+            return
+        }
+    }
+
+    val result = feedbackService.insertFeedback(organizationId, mappedFeedback)
+    call.respond(HttpStatusCode.Accepted, result.copy(unmapped = result.unmapped + unmapped))
+}
+
+private fun routeFeedback(
+    organizationId: Int,
+    rows: List<OtlpFeedbackInsert>,
+    routingService: OtlpServiceRoutingService,
+): List<OtlpFeedbackInsert> {
+    val descriptors = rows.map { row ->
+        OtlpServiceDescriptor(
+            serviceNamespace = row.serviceNamespace,
+            serviceName = row.service,
+            environment = row.environment,
+        )
+    }
+    val projectIds = routingService.resolveProjectIds(organizationId, descriptors, OtlpSignalType.FEEDBACK)
+    return rows.map { row ->
+        val identity = routingService.normalizeIdentity(row.serviceNamespace, row.service)
+        row.copy(projectId = identity?.let { projectIds[it] })
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpFeedbackService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpFeedbackService.kt
@@ -1,0 +1,298 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.otlp.services
+
+import com.google.protobuf.InvalidProtocolBufferException
+import com.moneat.events.repositories.EventRepository
+import com.moneat.events.repositories.EventRepositoryImpl
+import com.moneat.events.repositories.models.FeedbackInsertData
+import com.moneat.otlp.OtlpParsingUtils
+import com.moneat.otlp.OtlpProtobufParser
+import com.moneat.otlp.ResourceContext
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import io.opentelemetry.proto.logs.v1.LogRecord
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import mu.KotlinLogging
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+private val json = Json { ignoreUnknownKeys = true }
+private const val FEEDBACK_EVENT_NAME = "moneat.user_feedback"
+private const val OTLP_SOURCE_TYPE = "otlp"
+private const val OTLP_SOURCE_NAME = "OpenTelemetry"
+
+private val canonicalRecordAttributes = setOf(
+    "event.name",
+    "moneat.feedback.id",
+    "moneat.feedback.message",
+    "moneat.feedback.contact_email",
+    "moneat.feedback.name",
+    "moneat.feedback.url",
+    "moneat.feedback.associated_event_id",
+    "moneat.feedback.replay_id",
+    "user.id",
+    "user.email",
+    "user.name",
+    "user.username",
+    "url.full",
+)
+
+data class OtlpFeedbackInsert(
+    val feedbackId: String,
+    val projectId: Long? = null,
+    val timestampMs: Long,
+    val message: String,
+    val contactEmail: String,
+    val name: String,
+    val url: String,
+    val associatedEventId: String,
+    val replayId: String,
+    val environment: String,
+    val release: String,
+    val platform: String,
+    val userId: String,
+    val userEmail: String,
+    val userUsername: String,
+    val traceId: String,
+    val spanId: String,
+    val sourceType: String,
+    val sourceName: String,
+    val sourceEventName: String,
+    val serviceNamespace: String,
+    val service: String,
+    val tags: Map<String, String>,
+    val resourceAttributes: Map<String, String>,
+)
+
+@Serializable
+data class OtlpFeedbackIngestResult(
+    val accepted: Int,
+    val unmapped: Int,
+)
+
+class OtlpFeedbackService(
+    private val eventRepository: EventRepository = EventRepositoryImpl(),
+) {
+    fun parseOtlpFeedbackJson(payload: String): List<OtlpFeedbackInsert>? {
+        val parsed =
+            runCatching {
+                json.parseToJsonElement(payload).jsonObject
+            }.getOrElse { e ->
+                logger.warn(e) { "Invalid OTLP JSON feedback payload" }
+                return null
+            }
+
+        val rows = mutableListOf<OtlpFeedbackInsert>()
+        val resourceLogs = parsed["resourceLogs"]?.jsonArray ?: return emptyList()
+        resourceLogs.forEach { resourceLogElement ->
+            appendJsonResourceLog(resourceLogElement.jsonObject, rows)
+        }
+        return rows
+    }
+
+    fun parseOtlpFeedbackProtobuf(bytes: ByteArray): List<OtlpFeedbackInsert> {
+        val request =
+            try {
+                ExportLogsServiceRequest.parseFrom(bytes)
+            } catch (e: InvalidProtocolBufferException) {
+                logger.warn { "Invalid OTLP protobuf feedback payload: ${e.message}" }
+                return emptyList()
+            }
+
+        val rows = mutableListOf<OtlpFeedbackInsert>()
+        request.resourceLogsList.forEach { resourceLogs ->
+            val resourceCtx = OtlpProtobufParser.extractResourceContext(resourceLogs.resource)
+            resourceLogs.scopeLogsList.forEach { scopeLogs ->
+                scopeLogs.logRecordsList.mapNotNullTo(rows) { record ->
+                    feedbackFromProtobufRecord(record, resourceCtx)
+                }
+            }
+        }
+        return rows
+    }
+
+    suspend fun insertFeedback(
+        organizationId: Int,
+        rows: List<OtlpFeedbackInsert>,
+    ): OtlpFeedbackIngestResult {
+        var accepted = 0
+        for (row in rows) {
+            val projectId = row.projectId ?: continue
+            val inserted = eventRepository.insertFeedback(row.toInsertData(organizationId, projectId))
+            if (inserted) accepted++
+        }
+        return OtlpFeedbackIngestResult(accepted = accepted, unmapped = 0)
+    }
+
+    private fun appendJsonResourceLog(
+        resourceLog: JsonObject,
+        rows: MutableList<OtlpFeedbackInsert>,
+    ) {
+        val resourceCtx = OtlpParsingUtils.extractResourceContext(resourceLog["resource"]?.jsonObject)
+        val scopeLogs =
+            resourceLog["scopeLogs"]?.jsonArray
+                ?: resourceLog["instrumentationLibraryLogs"]?.jsonArray
+                ?: JsonArray(emptyList())
+        scopeLogs.forEach { scopeElement ->
+            val scopeLog = scopeElement.jsonObject
+            OtlpParsingUtils.safeJsonArray(scopeLog["logRecords"]).forEach { recordElement ->
+                feedbackFromJsonRecord(recordElement.jsonObject, resourceCtx)?.let(rows::add)
+            }
+        }
+    }
+
+    private fun feedbackFromJsonRecord(
+        record: JsonObject,
+        resourceCtx: ResourceContext,
+    ): OtlpFeedbackInsert? {
+        val attributes = OtlpParsingUtils.attributesToMap(record["attributes"])
+        val eventName = record["eventName"]?.jsonPrimitive?.contentOrNull
+            ?: attributes["event.name"]
+            ?: return null
+        if (eventName != FEEDBACK_EVENT_NAME) return null
+
+        val timestampNs = OtlpParsingUtils.extractTimestampNanos(
+            record,
+            "timeUnixNano",
+            "observedTimeUnixNano"
+        )
+        val timestampMs = OtlpParsingUtils.nanoToEpochMs(timestampNs) ?: System.currentTimeMillis()
+        val bodyText = OtlpParsingUtils.extractAnyValue(record["body"]) ?: ""
+        return buildFeedbackRow(
+            attributes = attributes,
+            resourceCtx = resourceCtx,
+            eventName = eventName,
+            timestampMs = timestampMs,
+            message = bodyText.ifBlank { attributes["moneat.feedback.message"].orEmpty() },
+            traceId = record["traceId"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+            spanId = record["spanId"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+        )
+    }
+
+    private fun feedbackFromProtobufRecord(
+        record: LogRecord,
+        resourceCtx: ResourceContext,
+    ): OtlpFeedbackInsert? {
+        val attributes = OtlpProtobufParser.attributesToMap(record.attributesList)
+        val eventName = record.eventName.ifBlank { attributes["event.name"].orEmpty() }
+        if (eventName != FEEDBACK_EVENT_NAME) return null
+
+        val timestampMs =
+            OtlpProtobufParser.nanoToEpochMs(
+                record.timeUnixNano.takeIf { it != 0L } ?: record.observedTimeUnixNano
+            ) ?: System.currentTimeMillis()
+        val bodyText =
+            if (record.hasBody()) {
+                OtlpProtobufParser.extractAnyValue(record.body).orEmpty()
+            } else {
+                ""
+            }
+        return buildFeedbackRow(
+            attributes = attributes,
+            resourceCtx = resourceCtx,
+            eventName = eventName,
+            timestampMs = timestampMs,
+            message = bodyText.ifBlank { attributes["moneat.feedback.message"].orEmpty() },
+            traceId = OtlpProtobufParser.bytesToHex(record.traceId),
+            spanId = OtlpProtobufParser.bytesToHex(record.spanId),
+        )
+    }
+
+    private fun buildFeedbackRow(
+        attributes: Map<String, String>,
+        resourceCtx: ResourceContext,
+        eventName: String,
+        timestampMs: Long,
+        message: String,
+        traceId: String,
+        spanId: String,
+    ): OtlpFeedbackInsert =
+        OtlpFeedbackInsert(
+            feedbackId = normalizeFeedbackId(attributes["moneat.feedback.id"]),
+            timestampMs = timestampMs,
+            message = message,
+            contactEmail = attributes["moneat.feedback.contact_email"] ?: attributes["user.email"].orEmpty(),
+            name = attributes["moneat.feedback.name"] ?: attributes["user.name"].orEmpty(),
+            url = attributes["url.full"] ?: attributes["moneat.feedback.url"].orEmpty(),
+            associatedEventId = attributes["moneat.feedback.associated_event_id"].orEmpty(),
+            replayId = attributes["moneat.feedback.replay_id"].orEmpty(),
+            environment = resourceCtx.environment,
+            release = resourceCtx.serviceVersion,
+            platform = resourceCtx.attributes["telemetry.sdk.language"] ?: resourceCtx.attributes["os.type"].orEmpty(),
+            userId = attributes["user.id"].orEmpty(),
+            userEmail = attributes["user.email"] ?: attributes["moneat.feedback.contact_email"].orEmpty(),
+            userUsername = attributes["user.username"].orEmpty(),
+            traceId = traceId,
+            spanId = spanId,
+            sourceType = OTLP_SOURCE_TYPE,
+            sourceName = OTLP_SOURCE_NAME,
+            sourceEventName = eventName,
+            serviceNamespace = resourceCtx.serviceNamespace,
+            service = resourceCtx.serviceName,
+            tags = attributes.filterKeys { it !in canonicalRecordAttributes },
+            resourceAttributes = resourceCtx.attributes,
+        )
+
+    private fun normalizeFeedbackId(rawId: String?): String =
+        rawId
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { id ->
+                runCatching { UUID.fromString(id).toString() }.getOrNull()
+            }
+            ?: UUID.randomUUID().toString()
+
+    private fun OtlpFeedbackInsert.toInsertData(
+        organizationId: Int,
+        projectId: Long,
+    ): FeedbackInsertData =
+        FeedbackInsertData(
+            feedbackId = feedbackId,
+            projectId = projectId,
+            organizationId = organizationId,
+            timestampMs = timestampMs,
+            message = message,
+            contactEmail = contactEmail,
+            name = name,
+            url = url,
+            associatedEventId = associatedEventId,
+            replayId = replayId,
+            environment = environment,
+            release = release,
+            platform = platform,
+            userId = userId,
+            userEmail = userEmail,
+            userUsername = userUsername,
+            userIpAddress = "",
+            sdkName = sourceName,
+            sdkVersion = "",
+            tags = tags,
+            sourceType = sourceType,
+            sourceName = sourceName,
+            sourceEventName = sourceEventName,
+            traceId = traceId,
+            spanId = spanId,
+            resourceAttributes = resourceAttributes
+        )
+}

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpFeedbackService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpFeedbackService.kt
@@ -150,12 +150,17 @@ class OtlpFeedbackService(
         rows: List<OtlpFeedbackInsert>,
     ): OtlpFeedbackIngestResult {
         var accepted = 0
+        var unmapped = 0
         for (row in rows) {
-            val projectId = row.projectId ?: continue
+            val projectId = row.projectId
+            if (projectId == null) {
+                unmapped++
+                continue
+            }
             val inserted = eventRepository.insertFeedback(row.toInsertData(organizationId, projectId))
             if (inserted) accepted++
         }
-        return OtlpFeedbackIngestResult(accepted = accepted, unmapped = 0)
+        return OtlpFeedbackIngestResult(accepted = accepted, unmapped = unmapped)
     }
 
     private fun appendJsonResourceLog(

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpFeedbackService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpFeedbackService.kt
@@ -41,21 +41,34 @@ private val json = Json { ignoreUnknownKeys = true }
 private const val FEEDBACK_EVENT_NAME = "moneat.user_feedback"
 private const val OTLP_SOURCE_TYPE = "otlp"
 private const val OTLP_SOURCE_NAME = "OpenTelemetry"
+private const val EVENT_NAME_ATTRIBUTE = "event.name"
+private const val FEEDBACK_ID_ATTRIBUTE = "moneat.feedback.id"
+private const val FEEDBACK_MESSAGE_ATTRIBUTE = "moneat.feedback.message"
+private const val FEEDBACK_CONTACT_EMAIL_ATTRIBUTE = "moneat.feedback.contact_email"
+private const val FEEDBACK_NAME_ATTRIBUTE = "moneat.feedback.name"
+private const val FEEDBACK_URL_ATTRIBUTE = "moneat.feedback.url"
+private const val FEEDBACK_ASSOCIATED_EVENT_ID_ATTRIBUTE = "moneat.feedback.associated_event_id"
+private const val FEEDBACK_REPLAY_ID_ATTRIBUTE = "moneat.feedback.replay_id"
+private const val USER_ID_ATTRIBUTE = "user.id"
+private const val USER_EMAIL_ATTRIBUTE = "user.email"
+private const val USER_NAME_ATTRIBUTE = "user.name"
+private const val USER_USERNAME_ATTRIBUTE = "user.username"
+private const val URL_FULL_ATTRIBUTE = "url.full"
 
 private val canonicalRecordAttributes = setOf(
-    "event.name",
-    "moneat.feedback.id",
-    "moneat.feedback.message",
-    "moneat.feedback.contact_email",
-    "moneat.feedback.name",
-    "moneat.feedback.url",
-    "moneat.feedback.associated_event_id",
-    "moneat.feedback.replay_id",
-    "user.id",
-    "user.email",
-    "user.name",
-    "user.username",
-    "url.full",
+    EVENT_NAME_ATTRIBUTE,
+    FEEDBACK_ID_ATTRIBUTE,
+    FEEDBACK_MESSAGE_ATTRIBUTE,
+    FEEDBACK_CONTACT_EMAIL_ATTRIBUTE,
+    FEEDBACK_NAME_ATTRIBUTE,
+    FEEDBACK_URL_ATTRIBUTE,
+    FEEDBACK_ASSOCIATED_EVENT_ID_ATTRIBUTE,
+    FEEDBACK_REPLAY_ID_ATTRIBUTE,
+    USER_ID_ATTRIBUTE,
+    USER_EMAIL_ATTRIBUTE,
+    USER_NAME_ATTRIBUTE,
+    USER_USERNAME_ATTRIBUTE,
+    URL_FULL_ATTRIBUTE,
 )
 
 data class OtlpFeedbackInsert(
@@ -168,7 +181,7 @@ class OtlpFeedbackService(
     ): OtlpFeedbackInsert? {
         val attributes = OtlpParsingUtils.attributesToMap(record["attributes"])
         val eventName = record["eventName"]?.jsonPrimitive?.contentOrNull
-            ?: attributes["event.name"]
+            ?: attributes[EVENT_NAME_ATTRIBUTE]
             ?: return null
         if (eventName != FEEDBACK_EVENT_NAME) return null
 
@@ -184,7 +197,7 @@ class OtlpFeedbackService(
             resourceCtx = resourceCtx,
             eventName = eventName,
             timestampMs = timestampMs,
-            message = bodyText.ifBlank { attributes["moneat.feedback.message"].orEmpty() },
+            message = bodyText.ifBlank { attributes[FEEDBACK_MESSAGE_ATTRIBUTE].orEmpty() },
             traceId = record["traceId"]?.jsonPrimitive?.contentOrNull.orEmpty(),
             spanId = record["spanId"]?.jsonPrimitive?.contentOrNull.orEmpty(),
         )
@@ -195,7 +208,7 @@ class OtlpFeedbackService(
         resourceCtx: ResourceContext,
     ): OtlpFeedbackInsert? {
         val attributes = OtlpProtobufParser.attributesToMap(record.attributesList)
-        val eventName = record.eventName.ifBlank { attributes["event.name"].orEmpty() }
+        val eventName = record.eventName.ifBlank { attributes[EVENT_NAME_ATTRIBUTE].orEmpty() }
         if (eventName != FEEDBACK_EVENT_NAME) return null
 
         val timestampMs =
@@ -213,7 +226,7 @@ class OtlpFeedbackService(
             resourceCtx = resourceCtx,
             eventName = eventName,
             timestampMs = timestampMs,
-            message = bodyText.ifBlank { attributes["moneat.feedback.message"].orEmpty() },
+            message = bodyText.ifBlank { attributes[FEEDBACK_MESSAGE_ATTRIBUTE].orEmpty() },
             traceId = OtlpProtobufParser.bytesToHex(record.traceId),
             spanId = OtlpProtobufParser.bytesToHex(record.spanId),
         )
@@ -229,20 +242,20 @@ class OtlpFeedbackService(
         spanId: String,
     ): OtlpFeedbackInsert =
         OtlpFeedbackInsert(
-            feedbackId = normalizeFeedbackId(attributes["moneat.feedback.id"]),
+            feedbackId = normalizeFeedbackId(attributes[FEEDBACK_ID_ATTRIBUTE]),
             timestampMs = timestampMs,
             message = message,
-            contactEmail = attributes["moneat.feedback.contact_email"] ?: attributes["user.email"].orEmpty(),
-            name = attributes["moneat.feedback.name"] ?: attributes["user.name"].orEmpty(),
-            url = attributes["url.full"] ?: attributes["moneat.feedback.url"].orEmpty(),
-            associatedEventId = attributes["moneat.feedback.associated_event_id"].orEmpty(),
-            replayId = attributes["moneat.feedback.replay_id"].orEmpty(),
+            contactEmail = attributes[FEEDBACK_CONTACT_EMAIL_ATTRIBUTE] ?: attributes[USER_EMAIL_ATTRIBUTE].orEmpty(),
+            name = attributes[FEEDBACK_NAME_ATTRIBUTE] ?: attributes[USER_NAME_ATTRIBUTE].orEmpty(),
+            url = attributes[URL_FULL_ATTRIBUTE] ?: attributes[FEEDBACK_URL_ATTRIBUTE].orEmpty(),
+            associatedEventId = attributes[FEEDBACK_ASSOCIATED_EVENT_ID_ATTRIBUTE].orEmpty(),
+            replayId = attributes[FEEDBACK_REPLAY_ID_ATTRIBUTE].orEmpty(),
             environment = resourceCtx.environment,
             release = resourceCtx.serviceVersion,
             platform = resourceCtx.attributes["telemetry.sdk.language"] ?: resourceCtx.attributes["os.type"].orEmpty(),
-            userId = attributes["user.id"].orEmpty(),
-            userEmail = attributes["user.email"] ?: attributes["moneat.feedback.contact_email"].orEmpty(),
-            userUsername = attributes["user.username"].orEmpty(),
+            userId = attributes[USER_ID_ATTRIBUTE].orEmpty(),
+            userEmail = attributes[USER_EMAIL_ATTRIBUTE] ?: attributes[FEEDBACK_CONTACT_EMAIL_ATTRIBUTE].orEmpty(),
+            userUsername = attributes[USER_USERNAME_ATTRIBUTE].orEmpty(),
             traceId = traceId,
             spanId = spanId,
             sourceType = OTLP_SOURCE_TYPE,

--- a/backend/src/main/kotlin/com/moneat/otlp/services/OtlpServiceRoutingService.kt
+++ b/backend/src/main/kotlin/com/moneat/otlp/services/OtlpServiceRoutingService.kt
@@ -51,6 +51,7 @@ enum class OtlpSignalType {
     LOGS,
     TRACES,
     METRICS,
+    FEEDBACK,
 }
 
 class OtlpServiceRoutingService {
@@ -107,6 +108,7 @@ class OtlpServiceRoutingService {
                         seenLogs = row[OtelObservedServices.seen_logs],
                         seenTraces = row[OtelObservedServices.seen_traces],
                         seenMetrics = row[OtelObservedServices.seen_metrics],
+                        seenFeedback = row[OtelObservedServices.seen_feedback],
                         lastEnvironment = row[OtelObservedServices.last_environment],
                         firstSeenAt = row[OtelObservedServices.first_seen_at].toString(),
                         lastSeenAt = row[OtelObservedServices.last_seen_at].toString(),
@@ -211,6 +213,7 @@ class OtlpServiceRoutingService {
             it[OtelObservedServices.seen_logs] = signalType == OtlpSignalType.LOGS
             it[OtelObservedServices.seen_traces] = signalType == OtlpSignalType.TRACES
             it[OtelObservedServices.seen_metrics] = signalType == OtlpSignalType.METRICS
+            it[OtelObservedServices.seen_feedback] = signalType == OtlpSignalType.FEEDBACK
             it[OtelObservedServices.last_environment] = environment
         }
         OtelObservedServices.update({
@@ -224,6 +227,7 @@ class OtlpServiceRoutingService {
                 OtlpSignalType.LOGS -> it[OtelObservedServices.seen_logs] = true
                 OtlpSignalType.TRACES -> it[OtelObservedServices.seen_traces] = true
                 OtlpSignalType.METRICS -> it[OtelObservedServices.seen_metrics] = true
+                OtlpSignalType.FEEDBACK -> it[OtelObservedServices.seen_feedback] = true
             }
         }
     }

--- a/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/Routing.kt
@@ -42,6 +42,7 @@ import com.moneat.monitoring.OperationalMetrics
 import com.moneat.org.routes.adminRoutes
 import com.moneat.org.routes.orgManagementRoutes
 import com.moneat.otlp.routes.otlpMetricsRoutes
+import com.moneat.otlp.routes.otlpFeedbackRoutes
 import com.moneat.otlp.routes.otlpTraceRoutes
 import com.moneat.security.detection.detectionRuleRoutes
 import com.moneat.security.signals.signalRoutes
@@ -247,6 +248,7 @@ fun Application.configureRouting() {
         rateLimit(RateLimitName("otlp-ingestion")) {
             otlpTraceRoutes()
             otlpMetricsRoutes()
+            otlpFeedbackRoutes()
         }
 
         // Uptime monitoring endpoints

--- a/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
+++ b/backend/src/main/kotlin/com/moneat/shared/models/DatabaseModels.kt
@@ -267,6 +267,7 @@ object OtelObservedServices : Table("otel_observed_services") {
     val seen_logs = bool("seen_logs").default(false)
     val seen_traces = bool("seen_traces").default(false)
     val seen_metrics = bool("seen_metrics").default(false)
+    val seen_feedback = bool("seen_feedback").default(false)
     val last_environment = varchar("last_environment", OTEL_SERVICE_FIELD_MAX_LENGTH).nullable()
     init {
         uniqueIndex(organization_id, service_namespace, service_name)

--- a/backend/src/main/resources/db/clickhouse_migration/V53__feedback_source_metadata.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V53__feedback_source_metadata.sql
@@ -1,0 +1,17 @@
+ALTER TABLE user_feedback
+    ADD COLUMN IF NOT EXISTS source_type LowCardinality(String) DEFAULT 'sentry' AFTER status;
+
+ALTER TABLE user_feedback
+    ADD COLUMN IF NOT EXISTS source_name String DEFAULT 'Sentry-compatible SDK' AFTER source_type;
+
+ALTER TABLE user_feedback
+    ADD COLUMN IF NOT EXISTS source_event_name String DEFAULT 'feedback' AFTER source_name;
+
+ALTER TABLE user_feedback
+    ADD COLUMN IF NOT EXISTS trace_id String DEFAULT '' AFTER source_event_name;
+
+ALTER TABLE user_feedback
+    ADD COLUMN IF NOT EXISTS span_id String DEFAULT '' AFTER trace_id;
+
+ALTER TABLE user_feedback
+    ADD COLUMN IF NOT EXISTS resource_attributes Map(String, String) DEFAULT map() AFTER span_id;

--- a/backend/src/main/resources/db/migration/V130__add_otlp_feedback_observed_services.sql
+++ b/backend/src/main/resources/db/migration/V130__add_otlp_feedback_observed_services.sql
@@ -1,0 +1,2 @@
+ALTER TABLE otel_observed_services
+    ADD COLUMN IF NOT EXISTS seen_feedback BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
@@ -132,4 +132,43 @@ class FeedbackServiceTest {
         assertEquals(true, querySlot.captured.contains("project_id = 3"))
         assertEquals(true, querySlot.captured.contains("status = 'archived'"))
     }
+
+    @Test
+    fun `getFeedback maps list source metadata with Sentry defaults`() = runBlocking {
+        val row = buildJsonObject {
+            put("feedback_id", FEEDBACK_UUID)
+            put("message", "Checkout keeps spinning")
+            put("contact_email", "user0@example.com")
+            put("name", "Jordan Lee")
+            put("url", "https://shop.acme.com/checkout")
+            put("status", "unresolved")
+            put("created_at", "2026-05-29T17:39:22.000Z")
+            put("environment", "production")
+            put("release", "1.3.0")
+            put("platform", "android")
+            put("associated_event_id", "event-1")
+            put("replay_id", "replay-1")
+            put("trace_id", "00000000000000000000000000000001")
+            put("span_id", "0000000000000001")
+            put(
+                "resource_attributes",
+                buildJsonObject {
+                    put("service.name", "checkout-api")
+                }
+            )
+        }
+        coEvery { queryHelper.executeJsonEachRowQuery(any(), "Feedback list") } returns listOf(row)
+
+        val result = service.getFeedback(projectId = 3L)
+
+        assertEquals(1, result.size)
+        assertEquals("event-1", result.single().associatedEventId)
+        assertEquals("replay-1", result.single().replayId)
+        assertEquals("sentry", result.single().sourceType)
+        assertEquals("Sentry-compatible SDK", result.single().sourceName)
+        assertEquals("feedback", result.single().sourceEventName)
+        assertEquals("00000000000000000000000000000001", result.single().traceId)
+        assertEquals("0000000000000001", result.single().spanId)
+        assertEquals(mapOf("service.name" to "checkout-api"), result.single().resourceAttributes)
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
@@ -78,6 +78,17 @@ class FeedbackServiceTest {
             put("platform", "android")
             put("sdk_name", "sentry.java.android")
             put("sdk_version", "7.14.0")
+            put("source_type", "sentry")
+            put("source_name", "Sentry-compatible SDK")
+            put("source_event_name", "feedback")
+            put("trace_id", "")
+            put("span_id", "")
+            put(
+                "resource_attributes",
+                buildJsonObject {
+                    put("service.name", "checkout-api")
+                }
+            )
         }
         coEvery { queryHelper.executeJsonEachRowQuery(any(), any()) } returns listOf(row)
 
@@ -85,6 +96,12 @@ class FeedbackServiceTest {
         assertEquals(FEEDBACK_UUID, detail?.feedbackId)
         assertEquals("2026-05-29T17:39:22.000Z", detail?.timestamp)
         assertEquals("unresolved", detail?.status)
+        assertEquals("sentry", detail?.sourceType)
+        assertEquals("Sentry-compatible SDK", detail?.sourceName)
+        assertEquals("feedback", detail?.sourceEventName)
+        assertEquals("", detail?.traceId)
+        assertEquals("", detail?.spanId)
+        assertEquals(mapOf("service.name" to "checkout-api"), detail?.resourceAttributes)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/otlp/OtlpIngestRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/OtlpIngestRoutesTest.kt
@@ -17,9 +17,15 @@
 package com.moneat.otlp
 
 import com.moneat.billing.services.BillingQuotaService
+import com.moneat.billing.models.BillingUsageResponse
+import com.moneat.billing.services.QuotaReservationResult
 import com.moneat.otlp.routes.otlpMetricsRoutes
+import com.moneat.otlp.routes.otlpFeedbackRoutes
 import com.moneat.otlp.routes.otlpTraceRoutes
 import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.otlp.services.OtlpFeedbackIngestResult
+import com.moneat.otlp.services.OtlpFeedbackInsert
+import com.moneat.otlp.services.OtlpFeedbackService
 import com.moneat.otlp.services.OtlpMetricInsert
 import com.moneat.otlp.services.OtlpMetricsService
 import com.moneat.otlp.services.OtlpServiceDescriptor
@@ -43,6 +49,7 @@ import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -63,6 +70,7 @@ class OtlpIngestRoutesTest {
     private val otlpApiKeyService = mockk<OtlpApiKeyService>()
     private val traceService = mockk<OtlpTraceService>(relaxed = true)
     private val metricsService = mockk<OtlpMetricsService>(relaxed = true)
+    private val feedbackService = mockk<OtlpFeedbackService>(relaxed = true)
     private val quotaService = mockk<BillingQuotaService>(relaxed = true)
     private val routingService = mockk<OtlpServiceRoutingService>(relaxed = true)
 
@@ -83,6 +91,7 @@ class OtlpIngestRoutesTest {
             routing {
                 otlpTraceRoutes(traceService, quotaService, otlpApiKeyService, routingService)
                 otlpMetricsRoutes(metricsService, quotaService, otlpApiKeyService, routingService)
+                otlpFeedbackRoutes(feedbackService, quotaService, otlpApiKeyService, routingService)
             }
         }
     }
@@ -402,6 +411,134 @@ class OtlpIngestRoutesTest {
         assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
+    // ──── Feedback Routes ────
+
+    @Test
+    fun `POST feedback otlp returns 401 without bearer token`() = testApplication {
+        installRoutes()()
+        val response = client.post("/v1/feedback/otlp") {
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
+    fun `POST feedback otlp returns 415 for unsupported content type`() = testApplication {
+        every { otlpApiKeyService.validateKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val response = client.post("/v1/feedback/otlp") {
+            header(HttpHeaders.Authorization, "Bearer $VALID_KEY")
+            header(HttpHeaders.ContentType, "text/plain")
+            setBody("feedback")
+        }
+        assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+    }
+
+    @Test
+    fun `POST feedback otlp routes feedback by service mapping before insert`() = testApplication {
+        val checkoutIdentity = OtlpServiceIdentity("checkout", "api")
+        val storedFeedback = slot<List<OtlpFeedbackInsert>>()
+        every { otlpApiKeyService.validateKey(VALID_KEY) } returns ORG_ID
+        every { feedbackService.parseOtlpFeedbackJson(any()) } returns listOf(
+            feedback(serviceNamespace = "checkout", service = "api", environment = "production"),
+            feedback(serviceNamespace = "", service = "", environment = "")
+        )
+        every {
+            routingService.resolveProjectIds(
+                ORG_ID,
+                any<List<OtlpServiceDescriptor>>(),
+                OtlpSignalType.FEEDBACK
+            )
+        } returns mapOf(checkoutIdentity to 44L)
+        every { routingService.normalizeIdentity("checkout", "api") } returns checkoutIdentity
+        every { routingService.normalizeIdentity("", "") } returns null
+        coEvery { feedbackService.insertFeedback(ORG_ID, capture(storedFeedback)) } returns
+            OtlpFeedbackIngestResult(accepted = 1, unmapped = 0)
+        installRoutes()()
+
+        val response = client.post("/v1/feedback/otlp") {
+            header(HttpHeaders.Authorization, "Bearer $VALID_KEY")
+            contentType(ContentType.Application.Json)
+            setBody("""{"resourceLogs":[{}]}""")
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        assertTrue(response.bodyAsText().contains(""""accepted":1"""))
+        assertTrue(response.bodyAsText().contains(""""unmapped":1"""))
+        assertEquals(44L, storedFeedback.captured.single().projectId)
+        verify {
+            routingService.resolveProjectIds(
+                ORG_ID,
+                match<List<OtlpServiceDescriptor>> {
+                    it.first().serviceNamespace == "checkout" &&
+                        it.first().serviceName == "api" &&
+                        it.first().environment == "production"
+                },
+                OtlpSignalType.FEEDBACK
+            )
+        }
+    }
+
+    @Test
+    fun `POST feedback otlp reserves feedback quota for mapped records`() = testApplication {
+        every { otlpApiKeyService.validateKey(VALID_KEY) } returns ORG_ID
+        every { feedbackService.parseOtlpFeedbackJson(any()) } returns listOf(
+            feedback(serviceNamespace = "checkout", service = "api", environment = "production")
+        )
+        every {
+            routingService.resolveProjectIds(
+                ORG_ID,
+                any<List<OtlpServiceDescriptor>>(),
+                OtlpSignalType.FEEDBACK
+            )
+        } returns mapOf(OtlpServiceIdentity("checkout", "api") to 44L)
+        every { routingService.normalizeIdentity("checkout", "api") } returns OtlpServiceIdentity("checkout", "api")
+        every { quotaService.isEnforcementEnabled() } returns true
+        every { quotaService.reserveUnits(ORG_ID, 1, "feedback", any()) } returns
+            QuotaReservationResult(allowed = true, usage = billingUsage())
+        coEvery { feedbackService.insertFeedback(ORG_ID, any()) } returns
+            OtlpFeedbackIngestResult(accepted = 1, unmapped = 0)
+        installRoutes()()
+
+        val response = client.post("/v1/feedback/otlp") {
+            header(HttpHeaders.Authorization, "Bearer $VALID_KEY")
+            contentType(ContentType.Application.Json)
+            setBody("""{"resourceLogs":[{}]}""")
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        verify { quotaService.reserveUnits(ORG_ID, 1, "feedback", any()) }
+    }
+
+    @Test
+    fun `POST feedback otlp returns 429 when feedback quota is exceeded`() = testApplication {
+        every { otlpApiKeyService.validateKey(VALID_KEY) } returns ORG_ID
+        every { feedbackService.parseOtlpFeedbackJson(any()) } returns listOf(
+            feedback(serviceNamespace = "checkout", service = "api", environment = "production")
+        )
+        every {
+            routingService.resolveProjectIds(
+                ORG_ID,
+                any<List<OtlpServiceDescriptor>>(),
+                OtlpSignalType.FEEDBACK
+            )
+        } returns mapOf(OtlpServiceIdentity("checkout", "api") to 44L)
+        every { routingService.normalizeIdentity("checkout", "api") } returns OtlpServiceIdentity("checkout", "api")
+        every { quotaService.isEnforcementEnabled() } returns true
+        every { quotaService.reserveUnits(ORG_ID, 1, "feedback", any()) } returns
+            QuotaReservationResult(allowed = false, reason = "feedback limit reached", usage = billingUsage())
+        installRoutes()()
+
+        val response = client.post("/v1/feedback/otlp") {
+            header(HttpHeaders.Authorization, "Bearer $VALID_KEY")
+            contentType(ContentType.Application.Json)
+            setBody("""{"resourceLogs":[{}]}""")
+        }
+
+        assertEquals(HttpStatusCode.TooManyRequests, response.status)
+    }
+
     private fun traceSpan(
         serviceNamespace: String,
         service: String,
@@ -460,5 +597,69 @@ class OtlpIngestRoutesTest {
             service = service,
             env = env,
             host = "api-host"
+        )
+
+    private fun feedback(
+        serviceNamespace: String,
+        service: String,
+        environment: String,
+    ): OtlpFeedbackInsert =
+        OtlpFeedbackInsert(
+            feedbackId = "4f01ede1-5802-4ff1-81b7-f2fe9add31e5",
+            projectId = null,
+            timestampMs = 1_700_000_000_000L,
+            message = "Checkout is confusing",
+            contactEmail = "user@example.com",
+            name = "User Example",
+            url = "https://app.example.com/checkout",
+            associatedEventId = "",
+            replayId = "",
+            environment = environment,
+            release = "1.0.0",
+            platform = "javascript",
+            userId = "user-1",
+            userEmail = "user@example.com",
+            userUsername = "user",
+            traceId = "00000000000000000000000000000001",
+            spanId = "0000000000000001",
+            sourceType = "otlp",
+            sourceName = "OpenTelemetry",
+            sourceEventName = "moneat.user_feedback",
+            serviceNamespace = serviceNamespace,
+            service = service,
+            tags = emptyMap(),
+            resourceAttributes = emptyMap()
+        )
+
+    private fun billingUsage(): BillingUsageResponse =
+        BillingUsageResponse(
+            organizationId = ORG_ID,
+            periodStart = "2026-06-01T00:00:00Z",
+            periodEnd = "2026-07-01T00:00:00Z",
+            retentionDays = 30,
+            logRetentionDays = 30,
+            replayRetentionDays = 30,
+            llmRetentionDays = 30,
+            apmTraceRetentionDays = 30,
+            usedUnits = 1,
+            usedErrors = 0,
+            errorLimit = 1_000,
+            usedTransactions = 0,
+            transactionLimit = 1_000,
+            usedReplays = 0,
+            replayLimit = 1_000,
+            usedFeedback = 1,
+            feedbackLimit = 1_000,
+            usedBytes = 100,
+            bytesLimit = 1_000_000,
+            baseLimitUnits = 1_000,
+            paygLimitUnits = 0,
+            totalLimitUnits = 1_000,
+            paygBudgetCents = 0,
+            paygUsedUnits = 0,
+            paygUsedCentsEstimate = 0,
+            plan = "free",
+            status = "active",
+            withinQuota = true
         )
 }

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpFeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpFeedbackServiceTest.kt
@@ -230,7 +230,7 @@ class OtlpFeedbackServiceTest {
 
         val result = service.insertFeedback(organizationId = 7, rows = listOf(mapped, unmapped))
 
-        assertEquals(OtlpFeedbackIngestResult(accepted = 1, unmapped = 0), result)
+        assertEquals(OtlpFeedbackIngestResult(accepted = 1, unmapped = 1), result)
         assertEquals(42L, capturedFeedback.captured.projectId)
         assertEquals(7, capturedFeedback.captured.organizationId)
         assertEquals("otlp", capturedFeedback.captured.sourceType)

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpFeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpFeedbackServiceTest.kt
@@ -17,6 +17,8 @@
 package com.moneat.otlp.services
 
 import com.google.protobuf.ByteString
+import com.moneat.events.repositories.EventRepository
+import com.moneat.events.repositories.models.FeedbackInsertData
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
 import io.opentelemetry.proto.common.v1.AnyValue
 import io.opentelemetry.proto.common.v1.KeyValue
@@ -24,8 +26,13 @@ import io.opentelemetry.proto.logs.v1.LogRecord
 import io.opentelemetry.proto.logs.v1.ResourceLogs
 import io.opentelemetry.proto.logs.v1.ScopeLogs
 import io.opentelemetry.proto.resource.v1.Resource
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class OtlpFeedbackServiceTest {
     private val service = OtlpFeedbackService()
@@ -94,6 +101,53 @@ class OtlpFeedbackServiceTest {
     }
 
     @Test
+    fun `parseOtlpFeedbackJson supports eventName and fallback attributes`() {
+        val feedbackId = "4f01ede1-5802-4ff1-81b7-f2fe9add31e5"
+        val payload =
+            """
+            {
+              "resourceLogs": [{
+                "resource": {"attributes": [
+                  {"key": "service.name", "value": {"stringValue": "checkout-web"}},
+                  {"key": "os.type", "value": {"stringValue": "linux"}}
+                ]},
+                "instrumentationLibraryLogs": [{
+                  "logRecords": [{
+                    "eventName": "moneat.user_feedback",
+                    "observedTimeUnixNano": "1700000001000000000",
+                    "body": {"stringValue": ""},
+                    "attributes": [
+                      {"key": "moneat.feedback.id", "value": {"stringValue": "$feedbackId"}},
+                      {"key": "moneat.feedback.message", "value": {"stringValue": "Need a clearer CTA"}},
+                      {"key": "user.email", "value": {"stringValue": "fallback@example.com"}},
+                      {"key": "user.name", "value": {"stringValue": "Fallback User"}},
+                      {"key": "moneat.feedback.url", "value": {"stringValue": "https://app.example.com/pricing"}}
+                    ]
+                  }]
+                }]
+              }]
+            }
+            """.trimIndent()
+
+        val row = service.parseOtlpFeedbackJson(payload)?.single()
+
+        assertEquals(feedbackId, row?.feedbackId)
+        assertEquals("Need a clearer CTA", row?.message)
+        assertEquals("fallback@example.com", row?.contactEmail)
+        assertEquals("Fallback User", row?.name)
+        assertEquals("https://app.example.com/pricing", row?.url)
+        assertEquals("linux", row?.platform)
+        assertEquals("checkout-web", row?.service)
+        assertEquals(1_700_000_001_000L, row?.timestampMs)
+    }
+
+    @Test
+    fun `parseOtlpFeedbackJson rejects invalid json and accepts missing resource logs`() {
+        assertNull(service.parseOtlpFeedbackJson("{"))
+        assertEquals(emptyList(), service.parseOtlpFeedbackJson("{}"))
+    }
+
+    @Test
     fun `parseOtlpFeedbackProtobuf extracts eventName feedback records`() {
         val record = LogRecord.newBuilder()
             .setEventName("moneat.user_feedback")
@@ -131,6 +185,90 @@ class OtlpFeedbackServiceTest {
         assertEquals("0000000000000002", row.spanId)
         assertEquals(mapOf("priority" to "high"), row.tags)
     }
+
+    @Test
+    fun `parseOtlpFeedbackProtobuf supports event name attributes and message fallback`() {
+        val record = LogRecord.newBuilder()
+            .setObservedTimeUnixNano(1_700_000_001_000_000_000L)
+            .addAttributes(attribute("event.name", "moneat.user_feedback"))
+            .addAttributes(attribute("moneat.feedback.message", "Message from attributes"))
+            .addAttributes(attribute("user.email", "fallback@example.com"))
+            .build()
+        val request = ExportLogsServiceRequest.newBuilder()
+            .addResourceLogs(
+                ResourceLogs.newBuilder()
+                    .setResource(
+                        Resource.newBuilder()
+                            .addAttributes(attribute("service.name", "worker"))
+                            .addAttributes(attribute("os.type", "linux"))
+                    )
+                    .addScopeLogs(ScopeLogs.newBuilder().addLogRecords(record))
+            )
+            .build()
+
+        val row = service.parseOtlpFeedbackProtobuf(request.toByteArray()).single()
+
+        assertEquals("Message from attributes", row.message)
+        assertEquals("fallback@example.com", row.contactEmail)
+        assertEquals("linux", row.platform)
+        assertEquals(1_700_000_001_000L, row.timestampMs)
+    }
+
+    @Test
+    fun `parseOtlpFeedbackProtobuf returns empty for invalid protobuf`() {
+        assertEquals(emptyList(), service.parseOtlpFeedbackProtobuf(byteArrayOf(1, 2, 3)))
+    }
+
+    @Test
+    fun `insertFeedback inserts mapped rows and preserves source metadata`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        val capturedFeedback = slot<FeedbackInsertData>()
+        coEvery { repository.insertFeedback(capture(capturedFeedback)) } returns true
+        val service = OtlpFeedbackService(repository)
+        val mapped = feedbackInsert(projectId = 42L)
+        val unmapped = feedbackInsert(projectId = null)
+
+        val result = service.insertFeedback(organizationId = 7, rows = listOf(mapped, unmapped))
+
+        assertEquals(OtlpFeedbackIngestResult(accepted = 1, unmapped = 0), result)
+        assertEquals(42L, capturedFeedback.captured.projectId)
+        assertEquals(7, capturedFeedback.captured.organizationId)
+        assertEquals("otlp", capturedFeedback.captured.sourceType)
+        assertEquals("OpenTelemetry", capturedFeedback.captured.sourceName)
+        assertEquals("moneat.user_feedback", capturedFeedback.captured.sourceEventName)
+        assertEquals("00000000000000000000000000000001", capturedFeedback.captured.traceId)
+        assertEquals("0000000000000001", capturedFeedback.captured.spanId)
+        assertEquals(mapOf("feature" to "checkout"), capturedFeedback.captured.tags)
+        assertEquals(mapOf("service.name" to "api"), capturedFeedback.captured.resourceAttributes)
+    }
+
+    private fun feedbackInsert(projectId: Long?): OtlpFeedbackInsert =
+        OtlpFeedbackInsert(
+            feedbackId = "4f01ede1-5802-4ff1-81b7-f2fe9add31e5",
+            projectId = projectId,
+            timestampMs = 1_700_000_000_000L,
+            message = "Checkout is confusing",
+            contactEmail = "user@example.com",
+            name = "User Example",
+            url = "https://app.example.com/checkout",
+            associatedEventId = "event-1",
+            replayId = "replay-1",
+            environment = "production",
+            release = "1.2.3",
+            platform = "javascript",
+            userId = "user-1",
+            userEmail = "user@example.com",
+            userUsername = "user",
+            traceId = "00000000000000000000000000000001",
+            spanId = "0000000000000001",
+            sourceType = "otlp",
+            sourceName = "OpenTelemetry",
+            sourceEventName = "moneat.user_feedback",
+            serviceNamespace = "checkout",
+            service = "api",
+            tags = mapOf("feature" to "checkout"),
+            resourceAttributes = mapOf("service.name" to "api"),
+        )
 
     private fun attribute(key: String, value: String): KeyValue =
         KeyValue.newBuilder()

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpFeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpFeedbackServiceTest.kt
@@ -1,0 +1,146 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.otlp.services
+
+import com.google.protobuf.ByteString
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import io.opentelemetry.proto.common.v1.AnyValue
+import io.opentelemetry.proto.common.v1.KeyValue
+import io.opentelemetry.proto.logs.v1.LogRecord
+import io.opentelemetry.proto.logs.v1.ResourceLogs
+import io.opentelemetry.proto.logs.v1.ScopeLogs
+import io.opentelemetry.proto.resource.v1.Resource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OtlpFeedbackServiceTest {
+    private val service = OtlpFeedbackService()
+
+    @Test
+    fun `parseOtlpFeedbackJson extracts moneat feedback events from log records`() {
+        val payload =
+            """
+            {
+              "resourceLogs": [{
+                "resource": {"attributes": [
+                  {"key": "service.namespace", "value": {"stringValue": "checkout"}},
+                  {"key": "service.name", "value": {"stringValue": "api"}},
+                  {"key": "deployment.environment.name", "value": {"stringValue": "production"}},
+                  {"key": "service.version", "value": {"stringValue": "1.2.3"}},
+                  {"key": "telemetry.sdk.language", "value": {"stringValue": "javascript"}}
+                ]},
+                "scopeLogs": [{
+                  "scope": {"name": "feedback-widget", "version": "1.0.0"},
+                  "logRecords": [{
+                    "timeUnixNano": "1700000000000000000",
+                    "traceId": "00000000000000000000000000000001",
+                    "spanId": "0000000000000001",
+                    "body": {"stringValue": "Checkout is confusing"},
+                    "attributes": [
+                      {"key": "event.name", "value": {"stringValue": "moneat.user_feedback"}},
+                      {"key": "moneat.feedback.contact_email", "value": {"stringValue": "user@example.com"}},
+                      {"key": "moneat.feedback.name", "value": {"stringValue": "User Example"}},
+                      {"key": "url.full", "value": {"stringValue": "https://app.example.com/checkout"}},
+                      {"key": "moneat.feedback.associated_event_id", "value": {"stringValue": "evt-1"}},
+                      {"key": "moneat.feedback.replay_id", "value": {"stringValue": "replay-1"}},
+                      {"key": "user.id", "value": {"stringValue": "user-1"}},
+                      {"key": "feature", "value": {"stringValue": "checkout"}}
+                    ]
+                  }, {
+                    "body": {"stringValue": "ordinary log"},
+                    "attributes": [
+                      {"key": "event.name", "value": {"stringValue": "ordinary.event"}}
+                    ]
+                  }]
+                }]
+              }]
+            }
+            """.trimIndent()
+
+        val feedback = service.parseOtlpFeedbackJson(payload)
+
+        assertEquals(1, feedback?.size)
+        val row = feedback?.single()
+        assertEquals("Checkout is confusing", row?.message)
+        assertEquals("user@example.com", row?.contactEmail)
+        assertEquals("User Example", row?.name)
+        assertEquals("https://app.example.com/checkout", row?.url)
+        assertEquals("evt-1", row?.associatedEventId)
+        assertEquals("replay-1", row?.replayId)
+        assertEquals("production", row?.environment)
+        assertEquals("1.2.3", row?.release)
+        assertEquals("javascript", row?.platform)
+        assertEquals("checkout", row?.serviceNamespace)
+        assertEquals("api", row?.service)
+        assertEquals("otlp", row?.sourceType)
+        assertEquals("OpenTelemetry", row?.sourceName)
+        assertEquals("moneat.user_feedback", row?.sourceEventName)
+        assertEquals(mapOf("feature" to "checkout"), row?.tags)
+        assertEquals("api", row?.resourceAttributes?.get("service.name"))
+    }
+
+    @Test
+    fun `parseOtlpFeedbackProtobuf extracts eventName feedback records`() {
+        val record = LogRecord.newBuilder()
+            .setEventName("moneat.user_feedback")
+            .setTimeUnixNano(1_700_000_000_000_000_000L)
+            .setTraceId(ByteString.copyFrom(hexBytes("00000000000000000000000000000002")))
+            .setSpanId(ByteString.copyFrom(hexBytes("0000000000000002")))
+            .setBody(stringValue("Checkout button does nothing"))
+            .addAttributes(attribute("moneat.feedback.contact_email", "user@example.com"))
+            .addAttributes(attribute("user.name", "User Example"))
+            .addAttributes(attribute("url.full", "https://app.example.com/checkout"))
+            .addAttributes(attribute("priority", "high"))
+            .build()
+        val request = ExportLogsServiceRequest.newBuilder()
+            .addResourceLogs(
+                ResourceLogs.newBuilder()
+                    .setResource(
+                        Resource.newBuilder()
+                            .addAttributes(attribute("service.namespace", "checkout"))
+                            .addAttributes(attribute("service.name", "api"))
+                            .addAttributes(attribute("deployment.environment.name", "production"))
+                            .addAttributes(attribute("service.version", "1.2.3"))
+                            .addAttributes(attribute("telemetry.sdk.language", "javascript"))
+                    )
+                    .addScopeLogs(ScopeLogs.newBuilder().addLogRecords(record))
+            )
+            .build()
+
+        val feedback = service.parseOtlpFeedbackProtobuf(request.toByteArray())
+
+        assertEquals(1, feedback.size)
+        val row = feedback.single()
+        assertEquals("Checkout button does nothing", row.message)
+        assertEquals("User Example", row.name)
+        assertEquals("00000000000000000000000000000002", row.traceId)
+        assertEquals("0000000000000002", row.spanId)
+        assertEquals(mapOf("priority" to "high"), row.tags)
+    }
+
+    private fun attribute(key: String, value: String): KeyValue =
+        KeyValue.newBuilder()
+            .setKey(key)
+            .setValue(stringValue(value))
+            .build()
+
+    private fun stringValue(value: String): AnyValue =
+        AnyValue.newBuilder().setStringValue(value).build()
+
+    private fun hexBytes(value: String): ByteArray =
+        value.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+}

--- a/backend/src/test/kotlin/com/moneat/otlp/services/OtlpServiceRoutingServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/otlp/services/OtlpServiceRoutingServiceTest.kt
@@ -165,6 +165,30 @@ class OtlpServiceRoutingServiceTest {
     }
 
     @Test
+    fun `resolveProjectIds marks feedback on an existing observed service`() {
+        val serviceDescriptor = OtlpServiceDescriptor(
+            serviceNamespace = "checkout",
+            serviceName = "checkout-api",
+            environment = "production"
+        )
+
+        service.resolveProjectIds(
+            organizationId = orgOne.id,
+            services = listOf(serviceDescriptor),
+            signalType = OtlpSignalType.TRACES
+        )
+        service.resolveProjectIds(
+            organizationId = orgOne.id,
+            services = listOf(serviceDescriptor),
+            signalType = OtlpSignalType.FEEDBACK
+        )
+
+        val observed = service.listObservedServices(orgOne.id).single()
+        assertTrue(observed.seenTraces)
+        assertTrue(observed.seenFeedback)
+    }
+
+    @Test
     fun `upsertMapping only accepts a valid service and project in the organization`() {
         val unknownServiceMapping = service.upsertMapping(
             organizationId = orgOne.id,

--- a/dashboard/src/components/settings/OtlpApiKeysTab.tsx
+++ b/dashboard/src/components/settings/OtlpApiKeysTab.tsx
@@ -37,6 +37,7 @@ function signalBadges(service: OtlpObservedService) {
     service.seenLogs ? 'logs' : null,
     service.seenTraces ? 'traces' : null,
     service.seenMetrics ? 'metrics' : null,
+    service.seenFeedback ? 'feedback' : null,
   ].filter((signal): signal is string => signal != null)
 }
 

--- a/dashboard/src/components/settings/__tests__/OtlpApiKeysTab.test.tsx
+++ b/dashboard/src/components/settings/__tests__/OtlpApiKeysTab.test.tsx
@@ -86,6 +86,7 @@ function mockBaseResponses() {
             seen_logs: true,
             seen_traces: true,
             seen_metrics: false,
+            seen_feedback: true,
             last_environment: 'production',
             first_seen_at: '2026-01-01T00:00:00Z',
             last_seen_at: '2026-01-01T01:00:00Z',
@@ -100,6 +101,7 @@ function mockBaseResponses() {
             seen_logs: false,
             seen_traces: false,
             seen_metrics: true,
+            seen_feedback: false,
             last_environment: null,
             first_seen_at: '2026-01-01T00:00:00Z',
             last_seen_at: '2026-01-01T01:00:00Z',
@@ -139,6 +141,7 @@ describe('OtlpApiKeysTab', () => {
     expect(screen.getByText('logs')).toBeInTheDocument()
     expect(screen.getByText('traces')).toBeInTheDocument()
     expect(screen.getByText('metrics')).toBeInTheDocument()
+    expect(screen.getByText('feedback')).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Remove mapping for checkout/api'})).toBeEnabled()
     expect(screen.getByRole('button', {name: 'Remove mapping for worker'})).toBeDisabled()
   })

--- a/dashboard/src/docs/pages/user-feedback.mdx
+++ b/dashboard/src/docs/pages/user-feedback.mdx
@@ -1,15 +1,18 @@
 ---
 title: User Feedback
-description: Collect and manage user feedback submitted through Sentry SDKs.
+description: Collect and manage user feedback submitted through Sentry-compatible SDKs or OTLP events.
 ---
 
 # User Feedback
 
-User feedback lets your users report problems directly from your application. Feedback is ingested via the Sentry envelope endpoint and stored alongside your error and replay data.
+User feedback lets your users report problems directly from your application. Moneat stores feedback from
+Sentry-compatible SDKs and OTLP events in the same feedback inbox, alongside related error and replay data.
 
 ## Submitting Feedback
 
-Use the Sentry SDK's feedback API to capture feedback from users:
+### Sentry-compatible SDKs
+
+Use the Sentry SDK feedback API to capture feedback from users:
 
 ```javascript
 Sentry.captureFeedback({
@@ -19,7 +22,63 @@ Sentry.captureFeedback({
 });
 ```
 
-Feedback can optionally be linked to an error event or a session replay by including the associated event ID or replay ID.
+Feedback can optionally be linked to an error event or a session replay by including the associated event ID
+or replay ID.
+
+### OTLP Events
+
+Send OpenTelemetry Events as LogRecords to the feedback OTLP endpoint:
+
+```bash
+curl https://api.moneat.io/v1/feedback/otlp \
+  -H "Authorization: Bearer $MONEAT_OTLP_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data @feedback-otlp.json
+```
+
+`feedback-otlp.json`:
+
+```json
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {"key": "service.name", "value": {"stringValue": "checkout-api"}},
+          {"key": "service.version", "value": {"stringValue": "2026.06.06"}},
+          {"key": "deployment.environment.name", "value": {"stringValue": "production"}},
+          {"key": "telemetry.sdk.language", "value": {"stringValue": "javascript"}}
+        ]
+      },
+      "scopeLogs": [
+        {
+          "logRecords": [
+            {
+              "timeUnixNano": "1780776000000000000",
+              "eventName": "moneat.user_feedback",
+              "body": {"stringValue": "The checkout button does not work"},
+              "attributes": [
+                {"key": "moneat.feedback.contact_email", "value": {"stringValue": "user@example.com"}},
+                {"key": "moneat.feedback.name", "value": {"stringValue": "Jane"}},
+                {"key": "url.full", "value": {"stringValue": "https://app.example.com/checkout"}},
+                {"key": "moneat.feedback.associated_event_id", "value": {"stringValue": "event-id"}},
+                {"key": "moneat.feedback.replay_id", "value": {"stringValue": "replay-id"}},
+                {"key": "feature", "value": {"stringValue": "checkout"}}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+The endpoint also accepts OTLP protobuf with `Content-Type: application/x-protobuf`. Moneat stores records
+whose `eventName` or `event.name` is `moneat.user_feedback`.
+
+Datadog-specific feedback parsing is not part of this release. Datadog browser custom actions can be mapped
+to feedback in a later integration.
 
 ## Viewing Feedback
 
@@ -29,7 +88,8 @@ Navigate to **Feedback** in the sidebar. The list view shows:
 - Search and status filtering
 - Bulk actions (resolve, archive)
 
-Click a feedback entry to see the full message, submitter details (name, email, URL), environment and SDK metadata, tags, and links to any associated error or replay.
+Click a feedback entry to see the full message, submitter details (name, email, URL), source metadata,
+environment and SDK metadata, tags, and links to any associated error or replay.
 
 ## Status Management
 

--- a/dashboard/src/docs/pages/user-feedback.mdx
+++ b/dashboard/src/docs/pages/user-feedback.mdx
@@ -75,10 +75,11 @@ curl https://api.moneat.io/v1/feedback/otlp \
 ```
 
 The endpoint also accepts OTLP protobuf with `Content-Type: application/x-protobuf`. Moneat stores records
-whose `eventName` or `event.name` is `moneat.user_feedback`.
+whose `eventName` is `moneat.user_feedback`; when `eventName` is absent, it falls back to the `event.name`
+attribute.
 
-Datadog-specific feedback parsing is not part of this release. Datadog browser custom actions can be mapped
-to feedback in a later integration.
+This release does not include a Datadog feedback parser. A later integration can map Datadog browser custom
+actions to the same feedback model.
 
 ## Viewing Feedback
 

--- a/dashboard/src/lib/__tests__/telemetry-sources.test.ts
+++ b/dashboard/src/lib/__tests__/telemetry-sources.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest'
 import {
   ALL_TELEMETRY_SOURCE_IDS,
+  feedbackSourceLabel,
   getTelemetrySourceStatus,
   loadTelemetrySourceIdsForService,
   parseTelemetrySourceIds,
@@ -61,5 +62,13 @@ describe('telemetry-sources', () => {
       'sentry-sdk',
       'datadog-agent',
     ])
+  })
+
+  it('labels feedback telemetry sources from source metadata', () => {
+    expect(feedbackSourceLabel('otlp', '')).toBe('OpenTelemetry')
+    expect(feedbackSourceLabel('datadog', null)).toBe('Datadog')
+    expect(feedbackSourceLabel('sentry', undefined)).toBe('Sentry-compatible SDK')
+    expect(feedbackSourceLabel('custom', '  Embedded widget  ')).toBe('Embedded widget')
+    expect(feedbackSourceLabel('custom', '')).toBe('Telemetry source')
   })
 })

--- a/dashboard/src/lib/api/modules/__tests__/otlp-api-keys.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/otlp-api-keys.test.ts
@@ -129,6 +129,7 @@ describe('OTLP API Keys', () => {
                 seen_logs: true,
                 seen_traces: true,
                 seen_metrics: false,
+                seen_feedback: true,
                 last_environment: 'production',
                 first_seen_at: '2026-01-01T00:00:00Z',
                 last_seen_at: '2026-01-01T01:00:00Z',
@@ -151,6 +152,7 @@ describe('OTLP API Keys', () => {
           seenLogs: true,
           seenTraces: true,
           seenMetrics: false,
+          seenFeedback: true,
           lastEnvironment: 'production',
           firstSeenAt: '2026-01-01T00:00:00Z',
           lastSeenAt: '2026-01-01T01:00:00Z',
@@ -183,6 +185,7 @@ describe('OTLP API Keys', () => {
         seenLogs: false,
         seenTraces: false,
         seenMetrics: false,
+        seenFeedback: false,
         firstSeenAt: '2026-01-02T00:00:00Z',
         lastSeenAt: '2026-01-02T01:00:00Z',
       })

--- a/dashboard/src/lib/api/modules/logs.ts
+++ b/dashboard/src/lib/api/modules/logs.ts
@@ -76,6 +76,7 @@ function mapOtlpObservedService(service: Record<string, unknown>): OtlpObservedS
     seenLogs: (service.seenLogs ?? service.seen_logs ?? false) as boolean,
     seenTraces: (service.seenTraces ?? service.seen_traces ?? false) as boolean,
     seenMetrics: (service.seenMetrics ?? service.seen_metrics ?? false) as boolean,
+    seenFeedback: (service.seenFeedback ?? service.seen_feedback ?? false) as boolean,
     lastEnvironment: (service.lastEnvironment ?? service.last_environment) as string | null | undefined,
     firstSeenAt: (service.firstSeenAt ?? service.first_seen_at) as string,
     lastSeenAt: (service.lastSeenAt ?? service.last_seen_at) as string,

--- a/dashboard/src/lib/api/types/logs.ts
+++ b/dashboard/src/lib/api/types/logs.ts
@@ -112,6 +112,7 @@ export interface OtlpObservedService {
   seenLogs: boolean
   seenTraces: boolean
   seenMetrics: boolean
+  seenFeedback: boolean
   lastEnvironment?: string | null
   firstSeenAt: string
   lastSeenAt: string

--- a/dashboard/src/lib/api/types/replays.ts
+++ b/dashboard/src/lib/api/types/replays.ts
@@ -50,8 +50,6 @@ export interface EventIssueLink {
   projectResourceId: string
 }
 
-export type FeedbackSourceType = string
-
 export interface Feedback {
   feedbackId: string
   message: string
@@ -66,7 +64,7 @@ export interface Feedback {
   user?: { id?: string; email?: string; username?: string }
   associatedEventId?: string | null
   replayId?: string | null
-  sourceType: FeedbackSourceType
+  sourceType: string
   sourceName: string
   sourceEventName: string
   traceId: string

--- a/dashboard/src/lib/api/types/replays.ts
+++ b/dashboard/src/lib/api/types/replays.ts
@@ -50,7 +50,7 @@ export interface EventIssueLink {
   projectResourceId: string
 }
 
-export type FeedbackSourceType = 'sentry' | 'otlp' | 'datadog' | 'custom' | (string & {})
+export type FeedbackSourceType = string
 
 export interface Feedback {
   feedbackId: string

--- a/dashboard/src/lib/api/types/replays.ts
+++ b/dashboard/src/lib/api/types/replays.ts
@@ -50,6 +50,8 @@ export interface EventIssueLink {
   projectResourceId: string
 }
 
+export type FeedbackSourceType = 'sentry' | 'otlp' | 'datadog' | 'custom' | (string & {})
+
 export interface Feedback {
   feedbackId: string
   message: string
@@ -64,6 +66,12 @@ export interface Feedback {
   user?: { id?: string; email?: string; username?: string }
   associatedEventId?: string | null
   replayId?: string | null
+  sourceType: FeedbackSourceType
+  sourceName: string
+  sourceEventName: string
+  traceId: string
+  spanId: string
+  resourceAttributes: Record<string, string>
 }
 
 export interface FeedbackDetail extends Feedback {

--- a/dashboard/src/lib/telemetry-sources.ts
+++ b/dashboard/src/lib/telemetry-sources.ts
@@ -162,6 +162,16 @@ export function storeTelemetrySourceIdsForService(
   globalThis.localStorage?.setItem(telemetrySourcesStorageKey(serviceId), serializeTelemetrySourceIds(sourceIds))
 }
 
+export function feedbackSourceLabel(sourceType?: string | null, sourceName?: string | null): string {
+  const trimmedSourceName = sourceName?.trim()
+  if (trimmedSourceName) return trimmedSourceName
+
+  if (sourceType === 'otlp') return 'OpenTelemetry'
+  if (sourceType === 'datadog') return 'Datadog'
+  if (sourceType === 'sentry') return 'Sentry-compatible SDK'
+  return 'Telemetry source'
+}
+
 export function getTelemetrySourceStatus(
   sourceId: TelemetrySourceId,
   input: TelemetrySourceStatusInput

--- a/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
+++ b/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
@@ -3,24 +3,33 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {fireEvent, screen, waitFor} from '@testing-library/react'
 import {clearAuthStorage, renderRoute} from '@/test/utils'
 
-const {mockApi, mockRouteParams} = vi.hoisted(() => ({
-  mockApi: {
-    isAuthenticated: vi.fn(),
-    checkAuth: vi.fn(),
-    getCurrentUser: vi.fn(),
-    updateUserTimezone: vi.fn(),
-    getProjects: vi.fn(),
-    getOrganizationReleases: vi.fn(),
-    getOrganizationReleaseStats: vi.fn(),
-    getOrganizationReplays: vi.fn(),
-    getBillingUsage: vi.fn(),
-    getOrganizationFeedback: vi.fn(),
-    updateFeedback: vi.fn(),
-  },
-  mockRouteParams: {
-    current: {version: '1.0.0'},
-  },
-}))
+const {mockApi, mockRouteParams} = vi.hoisted(() => {
+  type MockRouteParams = {
+    feedbackId?: string
+    version?: string
+  }
+
+  return {
+    mockApi: {
+      isAuthenticated: vi.fn(),
+      checkAuth: vi.fn(),
+      getCurrentUser: vi.fn(),
+      updateUserTimezone: vi.fn(),
+      getProjects: vi.fn(),
+      getOrganizationReleases: vi.fn(),
+      getOrganizationReleaseStats: vi.fn(),
+      getOrganizationReplays: vi.fn(),
+      getBillingUsage: vi.fn(),
+      getOrganizationFeedback: vi.fn(),
+      getFeedbackDetail: vi.fn(),
+      getIssueLinkForEvent: vi.fn(),
+      updateFeedback: vi.fn(),
+    },
+    mockRouteParams: {
+      current: {version: '1.0.0'} as MockRouteParams,
+    },
+  }
+})
 
 vi.mock('@/lib/api', () => ({
   api: mockApi,
@@ -58,6 +67,7 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 import {Route as FeedbackRoute} from '../feedback'
+import {Route as FeedbackDetailRoute} from '../feedback.$feedbackId'
 import {Route as ReleaseDetailRoute} from '../releases.$version'
 import {Route as ReleasesRoute} from '../releases'
 import {Route as ReplaysRoute} from '../replays'
@@ -186,6 +196,12 @@ const feedback = {
   platform: 'javascript',
   associatedEventId: null,
   replayId: 'replay-1',
+  sourceType: 'otlp',
+  sourceName: 'OpenTelemetry',
+  sourceEventName: 'moneat.user_feedback',
+  traceId: '00000000000000000000000000000001',
+  spanId: '0000000000000001',
+  resourceAttributes: {'service.name': 'api'},
 }
 
 const resolvedFeedback = {
@@ -217,6 +233,8 @@ describe('release, replay, and feedback service facets', () => {
     mockApi.getOrganizationReplays.mockResolvedValue([replay])
     mockApi.getBillingUsage.mockResolvedValue({retentionDays: 30})
     mockApi.getOrganizationFeedback.mockResolvedValue([feedback])
+    mockApi.getFeedbackDetail.mockResolvedValue({...feedback, sdkName: 'otel-js', sdkVersion: '1.0.0', tags: {}})
+    mockApi.getIssueLinkForEvent.mockResolvedValue(null)
     mockApi.updateFeedback.mockResolvedValue(feedback)
   })
 
@@ -373,6 +391,7 @@ describe('release, replay, and feedback service facets', () => {
     renderRoute(FeedbackRoute)
 
     expect(await screen.findByText('Checkout is confusing')).toBeInTheDocument()
+    expect((await screen.findAllByText('OpenTelemetry')).length).toBeGreaterThan(0)
     expect(mockApi.getOrganizationFeedback).toHaveBeenCalledWith({page: 1, limit: 500})
     expect(mockApi.getOrganizationFeedback).toHaveBeenCalledWith({
       page: 1,
@@ -456,6 +475,18 @@ describe('release, replay, and feedback service facets', () => {
     fireEvent.click(screen.getAllByTitle('Exclude this value')[0])
 
     expect(await screen.findByText('No services match filters')).toBeInTheDocument()
+  })
+
+  it('renders feedback detail source metadata', async () => {
+    mockRouteParams.current = {feedbackId: 'feedback-1'}
+
+    renderRoute(FeedbackDetailRoute)
+
+    expect(await screen.findByText('Telemetry Source')).toBeInTheDocument()
+    expect(screen.getByText('OpenTelemetry')).toBeInTheDocument()
+    expect(screen.getByText('moneat.user_feedback')).toBeInTheDocument()
+    expect(screen.getByText('00000000000000000000000000000001')).toBeInTheDocument()
+    expect(screen.getByText('0000000000000001')).toBeInTheDocument()
   })
 
   it('does not query scoped release data when there are no services', async () => {

--- a/dashboard/src/routes/feedback.$feedbackId.tsx
+++ b/dashboard/src/routes/feedback.$feedbackId.tsx
@@ -28,6 +28,7 @@ import {StatusDot, type StatusTone} from '@/components/ui/status-dot'
 import {Avatar, AvatarFallback} from '@/components/ui/avatar'
 import {Separator} from '@/components/ui/separator'
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from '@/components/ui/tooltip'
+import {feedbackSourceLabel} from '@/lib/telemetry-sources'
 import {
   AlertCircle,
   Archive,
@@ -194,9 +195,20 @@ function FeedbackDetailPage() {
   const initials = getInitials(feedback.name, feedback.contactEmail)
   const avatarColor = getAvatarColor(feedback.name, feedback.contactEmail)
   const hasSubmitter = feedback.name || feedback.contactEmail || feedback.url
-  const hasMetadata = feedback.environment || feedback.release || feedback.platform || feedback.sdkName || feedback.sdkVersion
+  const hasSourceMetadata =
+    feedback.sourceType || feedback.sourceName || feedback.sourceEventName || feedback.traceId || feedback.spanId
+  const hasMetadata =
+    feedback.environment ||
+    feedback.release ||
+    feedback.platform ||
+    feedback.sdkName ||
+    feedback.sdkVersion ||
+    hasSourceMetadata
   const hasTags = Object.keys(feedback.tags ?? {}).length > 0
+  const resourceAttributes = feedback.resourceAttributes ?? {}
+  const hasResourceAttributes = Object.keys(resourceAttributes).length > 0
   const hasRelated = feedback.associatedEventId || feedback.replayId
+  const sourceLabel = feedbackSourceLabel(feedback.sourceType, feedback.sourceName)
 
   return (
     <TooltipProvider>
@@ -398,11 +410,11 @@ function FeedbackDetailPage() {
                         </div>
                         <div>
                           <p className="text-xs text-muted-foreground">Environment</p>
-                          <p className="text-sm font-medium">
+                          <div className="mt-0.5">
                             <Badge variant={environmentBadgeVariant(feedback.environment)} className="font-medium">
                               {feedback.environment}
                             </Badge>
-                          </p>
+                          </div>
                         </div>
                       </div>
                     )}
@@ -444,6 +456,68 @@ function FeedbackDetailPage() {
                         </div>
                       </div>
                     )}
+                    {(feedback.sourceType || feedback.sourceName) && (
+                      <div className="flex items-center gap-3">
+                        <div className="rounded-md bg-muted p-2">
+                          <Code className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground">Telemetry Source</p>
+                          <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+                            <Badge variant="outline" className="font-medium">
+                              {sourceLabel}
+                            </Badge>
+                            {feedback.sourceType && (
+                              <span className="font-mono text-xs text-muted-foreground">
+                                {feedback.sourceType}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                    {feedback.sourceEventName && (
+                      <div className="flex items-center gap-3 group">
+                        <div className="rounded-md bg-muted p-2">
+                          <Code className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs text-muted-foreground">Source Event</p>
+                          <p className="text-sm font-medium font-mono truncate">{feedback.sourceEventName}</p>
+                        </div>
+                        <div className="opacity-0 group-hover:opacity-100 transition shrink-0">
+                          <CopyButton text={feedback.sourceEventName} />
+                        </div>
+                      </div>
+                    )}
+                    {feedback.traceId && (
+                      <div className="flex items-center gap-3 group">
+                        <div className="rounded-md bg-muted p-2">
+                          <Code className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs text-muted-foreground">Trace ID</p>
+                          <p className="text-sm font-medium font-mono truncate">{feedback.traceId}</p>
+                        </div>
+                        <div className="opacity-0 group-hover:opacity-100 transition shrink-0">
+                          <CopyButton text={feedback.traceId} />
+                        </div>
+                      </div>
+                    )}
+                    {feedback.spanId && (
+                      <div className="flex items-center gap-3 group">
+                        <div className="rounded-md bg-muted p-2">
+                          <Code className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs text-muted-foreground">Span ID</p>
+                          <p className="text-sm font-medium font-mono truncate">{feedback.spanId}</p>
+                        </div>
+                        <div className="opacity-0 group-hover:opacity-100 transition shrink-0">
+                          <CopyButton text={feedback.spanId} />
+                        </div>
+                      </div>
+                    )}
                   </div>
                 ) : (
                   <div className="text-center py-4 text-muted-foreground">
@@ -462,6 +536,30 @@ function FeedbackDetailPage() {
                     <div
                       key={k}
                       className="inline-flex items-center rounded-lg border border-border/60 bg-muted/50 px-3 py-1.5 text-sm"
+                    >
+                      <span className="text-muted-foreground font-medium">{k}</span>
+                      <span className="mx-1.5 text-muted-foreground/40">=</span>
+                      <span className="font-mono text-xs">{v}</span>
+                    </div>
+                  ))}
+                </div>
+            </SectionCard>
+          )}
+
+          {hasResourceAttributes && (
+            <SectionCard
+              title="Resource Attributes"
+              icon={Server}
+              count={Object.keys(resourceAttributes).length}
+              className="mt-6"
+            >
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(resourceAttributes).map(([k, v]) => (
+                    <div
+                      key={k}
+                      className={
+                        'inline-flex items-center rounded-lg border border-border/60 bg-muted/50 px-3 py-1.5 text-sm'
+                      }
                     >
                       <span className="text-muted-foreground font-medium">{k}</span>
                       <span className="mx-1.5 text-muted-foreground/40">=</span>

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -53,6 +53,7 @@ import {
 } from '@/lib/service-facet-scope'
 import {feedbackSourceLabel} from '@/lib/telemetry-sources'
 import type {FacetFilter} from '@/lib/filters/types'
+import type {Feedback} from '@/lib/api/types/replays'
 
 export const Route = createFileRoute('/feedback')({
   beforeLoad: async ({ location }) => {
@@ -129,6 +130,13 @@ const statusConfig = {
   },
 } as const
 
+type FeedbackStats = {
+  readonly total: number
+  readonly unresolved: number
+  readonly resolved: number
+  readonly archived: number
+}
+
 function FeedbackStatCard({
   label,
   value,
@@ -157,6 +165,398 @@ function FeedbackStatCard({
         )}
       />
     </button>
+  )
+}
+
+function getFeedbackScopeEmptyState(projectCount: number, hasFeedbackScope: boolean): ReactNode {
+  if (projectCount === 0) {
+    return (
+      <EmptyState
+        icon={MessageSquare}
+        title="No services yet"
+        description="Create a service and integrate the feedback widget to see user feedback here."
+      />
+    )
+  }
+
+  if (hasFeedbackScope) {
+    return null
+  }
+
+  return (
+    <EmptyState
+      icon={MessageSquare}
+      title="No services match filters"
+      description="Adjust the selected services to view feedback."
+    />
+  )
+}
+
+function FeedbackStatsGrid({
+  stats,
+  feedbackCount,
+  statusFilter,
+  onStatusFilterChange,
+}: {
+  readonly stats: FeedbackStats
+  readonly feedbackCount: number
+  readonly statusFilter: string
+  readonly onStatusFilterChange: (status: string) => void
+}) {
+  if (feedbackCount === 0) {
+    return null
+  }
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <FeedbackStatCard
+        label="Total"
+        value={stats.total}
+        icon={Inbox}
+        tone="accent"
+        active={statusFilter === 'all'}
+        onClick={() => onStatusFilterChange('all')}
+      />
+      <FeedbackStatCard
+        label="Unresolved"
+        value={stats.unresolved}
+        icon={CircleDot}
+        tone="warning"
+        active={statusFilter === 'unresolved'}
+        onClick={() => onStatusFilterChange('unresolved')}
+      />
+      <FeedbackStatCard
+        label="Resolved"
+        value={stats.resolved}
+        icon={CheckCircle2}
+        tone="success"
+        active={statusFilter === 'resolved'}
+        onClick={() => onStatusFilterChange('resolved')}
+      />
+      <FeedbackStatCard
+        label="Archived"
+        value={stats.archived}
+        icon={Archive}
+        tone="neutral"
+        active={statusFilter === 'archived'}
+        onClick={() => onStatusFilterChange('archived')}
+      />
+    </div>
+  )
+}
+
+function FeedbackToolbar({
+  feedbackCount,
+  selectedCount,
+  isResolvingSelected,
+  searchQuery,
+  onSearchQueryChange,
+  onToggleAll,
+  onResolveSelected,
+}: {
+  readonly feedbackCount: number
+  readonly selectedCount: number
+  readonly isResolvingSelected: boolean
+  readonly searchQuery: string
+  readonly onSearchQueryChange: (query: string) => void
+  readonly onToggleAll: () => void
+  readonly onResolveSelected: () => void
+}) {
+  return (
+    <div className="mb-3 flex gap-2 items-center flex-wrap">
+      {feedbackCount > 0 && (
+        <div className="flex items-center gap-2">
+          <Checkbox
+            checked={selectedCount === feedbackCount}
+            onCheckedChange={onToggleAll}
+            aria-label="Select all feedback"
+          />
+          <span className="text-xs text-muted-foreground whitespace-nowrap">Select all</span>
+        </div>
+      )}
+      {selectedCount > 0 && (
+        <div className="flex items-center gap-1.5 bg-success-bg border border-success-border rounded-lg px-2.5 py-1">
+          <CheckCircle2 className="h-3 w-3 text-success-fg" />
+          <span className="text-xs font-medium whitespace-nowrap">
+            {selectedCount} selected
+          </span>
+          <Button
+            onClick={onResolveSelected}
+            disabled={isResolvingSelected}
+            size="sm"
+            className="h-6 text-xs ml-1.5"
+          >
+            {isResolvingSelected ? 'Resolving...' : 'Resolve'}
+          </Button>
+        </div>
+      )}
+      <div className="relative flex-1 min-w-[180px]">
+        <Search className="absolute left-2.5 top-1/2 transform -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+        <Input
+          placeholder="Search by message, name, or email..."
+          value={searchQuery}
+          onChange={(e) => onSearchQueryChange(e.target.value)}
+          className="pl-8 h-8 text-xs"
+        />
+      </div>
+    </div>
+  )
+}
+
+function FeedbackResultEmptyState({searchQuery}: {readonly searchQuery: string}) {
+  if (searchQuery) {
+    return (
+      <EmptyState
+        icon={Search}
+        title="No feedback match your search"
+        description="Try adjusting your search or changing the status filter."
+      />
+    )
+  }
+
+  return (
+    <EmptyState
+      icon={MessageSquare}
+      title="No feedback yet"
+      description="Use the feedback widget in your app to collect user feedback. It will appear here."
+    />
+  )
+}
+
+function FeedbackListItem({
+  feedback,
+  isSelected,
+  onToggleFeedback,
+  onOpenFeedback,
+  onOpenReplay,
+}: {
+  readonly feedback: Feedback
+  readonly isSelected: boolean
+  readonly onToggleFeedback: (feedbackId: string) => void
+  readonly onOpenFeedback: (feedbackId: string) => void
+  readonly onOpenReplay: (replayId: string) => void
+}) {
+  const config = statusConfig[feedback.status as keyof typeof statusConfig] ?? statusConfig.unresolved
+  const displayName = feedback.name || feedback.contactEmail || 'Anonymous'
+  const initials = getInitials(feedback.name, feedback.contactEmail)
+  const avatarColor = getAvatarColor(feedback.name, feedback.contactEmail)
+  const sourceLabel = feedbackSourceLabel(feedback.sourceType, feedback.sourceName)
+  const replayId = feedback.replayId
+
+  return (
+    <div
+      key={feedback.feedbackId}
+      onClick={() => onOpenFeedback(feedback.feedbackId)}
+      className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
+    >
+      <div className="flex items-start gap-2 p-2">
+        <div className="flex items-center pt-0.5">
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={() => onToggleFeedback(feedback.feedbackId)}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Select feedback"
+          />
+        </div>
+
+        <Avatar className="h-6 w-6 shrink-0 mt-0.5">
+          <AvatarFallback className={`text-[10px] font-semibold ${avatarColor}`}>
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 mb-0.5">
+            <span className="font-semibold text-xs truncate">{displayName}</span>
+            {feedback.contactEmail && feedback.name && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Mail className="h-3 w-3 text-muted-foreground/60 shrink-0" />
+                </TooltipTrigger>
+                <TooltipContent>{feedback.contactEmail}</TooltipContent>
+              </Tooltip>
+            )}
+            <span className="text-[11px] text-muted-foreground ml-auto shrink-0 flex items-center gap-0.5">
+              <Clock className="h-2.5 w-2.5" />
+              {formatRelativeTime(feedback.timestamp)}
+            </span>
+          </div>
+
+          <p className="text-xs text-foreground/80 line-clamp-2 mb-1.5">
+            {feedback.message || '(No message)'}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant={config.badge} size="sm" className="font-medium">
+              <StatusDot tone={config.tone} size="sm" className="mr-0.5" />
+              {config.label}
+            </Badge>
+            {feedback.environment && (
+              <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
+                {feedback.environment}
+              </Badge>
+            )}
+            <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
+              {sourceLabel}
+            </Badge>
+            {feedback.platform && (
+              <Badge variant="outline" size="sm" className="font-normal gap-0.5">
+                <Monitor className="h-2.5 w-2.5" />
+                {feedback.platform}
+              </Badge>
+            )}
+            {feedback.url && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge variant="outline" size="sm" className="font-normal gap-0.5 max-w-[180px] truncate">
+                    <Globe className="h-2.5 w-2.5 shrink-0" />
+                    <span className="truncate">{feedback.url.replace(/^https?:\/\//, '')}</span>
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>{feedback.url}</TooltipContent>
+              </Tooltip>
+            )}
+            {feedback.associatedEventId && (
+              <Badge variant="warning" size="sm" className="font-normal gap-0.5">
+                <AlertCircle className="h-2.5 w-2.5" />
+                Event linked
+              </Badge>
+            )}
+            {replayId && (
+              <span
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onOpenReplay(replayId)
+                }}
+                className="inline-flex items-center gap-0.5 text-[11px] font-medium text-primary hover:underline cursor-pointer bg-[hsl(var(--primary)/0.12)] border border-[hsl(var(--primary)/0.3)] rounded-full px-2 py-0.5"
+              >
+                <Video className="h-2.5 w-2.5" />
+                Replay
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FeedbackList({
+  feedbackList,
+  selectedFeedback,
+  searchQuery,
+  onToggleFeedback,
+  onOpenFeedback,
+  onOpenReplay,
+}: {
+  readonly feedbackList: readonly Feedback[]
+  readonly selectedFeedback: ReadonlySet<string>
+  readonly searchQuery: string
+  readonly onToggleFeedback: (feedbackId: string) => void
+  readonly onOpenFeedback: (feedbackId: string) => void
+  readonly onOpenReplay: (replayId: string) => void
+}) {
+  if (feedbackList.length === 0) {
+    return <FeedbackResultEmptyState searchQuery={searchQuery} />
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="space-y-1.5">
+        {feedbackList.map((feedback) => (
+          <FeedbackListItem
+            key={feedback.feedbackId}
+            feedback={feedback}
+            isSelected={selectedFeedback.has(feedback.feedbackId)}
+            onToggleFeedback={onToggleFeedback}
+            onOpenFeedback={onOpenFeedback}
+            onOpenReplay={onOpenReplay}
+          />
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function FeedbackFooter({
+  feedbackCount,
+  searchQuery,
+}: {
+  readonly feedbackCount: number
+  readonly searchQuery: string
+}) {
+  if (feedbackCount === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-3 text-center">
+      <p className="text-xs text-muted-foreground">
+        Showing {feedbackCount} feedback item{feedbackCount === 1 ? '' : 's'}
+        {searchQuery && ' matching your search'}
+      </p>
+    </div>
+  )
+}
+
+function FeedbackMainContent({
+  stats,
+  allFeedbackCount,
+  statusFilter,
+  filteredFeedback,
+  selectedFeedback,
+  resolvingSelected,
+  searchQuery,
+  onStatusFilterChange,
+  onToggleAll,
+  onToggleFeedback,
+  onResolveSelected,
+  onSearchQueryChange,
+  onOpenFeedback,
+  onOpenReplay,
+}: {
+  readonly stats: FeedbackStats
+  readonly allFeedbackCount: number
+  readonly statusFilter: string
+  readonly filteredFeedback: readonly Feedback[]
+  readonly selectedFeedback: ReadonlySet<string>
+  readonly resolvingSelected: boolean
+  readonly searchQuery: string
+  readonly onStatusFilterChange: (status: string) => void
+  readonly onToggleAll: () => void
+  readonly onToggleFeedback: (feedbackId: string) => void
+  readonly onResolveSelected: () => void
+  readonly onSearchQueryChange: (query: string) => void
+  readonly onOpenFeedback: (feedbackId: string) => void
+  readonly onOpenReplay: (replayId: string) => void
+}) {
+  return (
+    <>
+      <FeedbackStatsGrid
+        stats={stats}
+        feedbackCount={allFeedbackCount}
+        statusFilter={statusFilter}
+        onStatusFilterChange={onStatusFilterChange}
+      />
+      <FeedbackToolbar
+        feedbackCount={filteredFeedback.length}
+        selectedCount={selectedFeedback.size}
+        isResolvingSelected={resolvingSelected}
+        searchQuery={searchQuery}
+        onSearchQueryChange={onSearchQueryChange}
+        onToggleAll={onToggleAll}
+        onResolveSelected={onResolveSelected}
+      />
+      <FeedbackList
+        feedbackList={filteredFeedback}
+        selectedFeedback={selectedFeedback}
+        searchQuery={searchQuery}
+        onToggleFeedback={onToggleFeedback}
+        onOpenFeedback={onOpenFeedback}
+        onOpenReplay={onOpenReplay}
+      />
+      <FeedbackFooter feedbackCount={filteredFeedback.length} searchQuery={searchQuery} />
+    </>
   )
 }
 
@@ -278,242 +678,25 @@ function FeedbackPage() {
     return matchesSearch
   })
 
-  let feedbackContent: ReactNode
-  if (projectList.length === 0) {
-    feedbackContent = (
-      <EmptyState
-        icon={MessageSquare}
-        title="No services yet"
-        description="Create a service and integrate the feedback widget to see user feedback here."
-      />
-    )
-  } else if (!hasFeedbackScope) {
-    feedbackContent = (
-      <EmptyState
-        icon={MessageSquare}
-        title="No services match filters"
-        description="Adjust the selected services to view feedback."
-      />
-    )
-  } else {
-    feedbackContent = (
-      <>
-        {/* Stats Cards (also act as status filters) */}
-        {allFeedback.length > 0 && (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <FeedbackStatCard
-              label="Total"
-              value={stats.total}
-              icon={Inbox}
-              tone="accent"
-              active={statusFilter === 'all'}
-              onClick={() => setStatusFilter('all')}
-            />
-            <FeedbackStatCard
-              label="Unresolved"
-              value={stats.unresolved}
-              icon={CircleDot}
-              tone="warning"
-              active={statusFilter === 'unresolved'}
-              onClick={() => setStatusFilter('unresolved')}
-            />
-            <FeedbackStatCard
-              label="Resolved"
-              value={stats.resolved}
-              icon={CheckCircle2}
-              tone="success"
-              active={statusFilter === 'resolved'}
-              onClick={() => setStatusFilter('resolved')}
-            />
-            <FeedbackStatCard
-              label="Archived"
-              value={stats.archived}
-              icon={Archive}
-              tone="neutral"
-              active={statusFilter === 'archived'}
-              onClick={() => setStatusFilter('archived')}
-            />
-          </div>
-        )}
-
-        {/* Toolbar */}
-        <div className="mb-3 flex gap-2 items-center flex-wrap">
-          {filteredFeedback.length > 0 && (
-            <div className="flex items-center gap-2">
-              <Checkbox
-                checked={selectedFeedback.size === filteredFeedback.length && filteredFeedback.length > 0}
-                onCheckedChange={handleToggleAll}
-                aria-label="Select all feedback"
-              />
-              <span className="text-xs text-muted-foreground whitespace-nowrap">Select all</span>
-            </div>
-          )}
-          {selectedFeedback.size > 0 && (
-            <div className="flex items-center gap-1.5 bg-success-bg border border-success-border rounded-lg px-2.5 py-1">
-              <CheckCircle2 className="h-3 w-3 text-success-fg" />
-              <span className="text-xs font-medium whitespace-nowrap">
-                {selectedFeedback.size} selected
-              </span>
-              <Button
-                onClick={handleResolveSelected}
-                disabled={resolveMutation.isPending}
-                size="sm"
-                className="h-6 text-xs ml-1.5"
-              >
-                {resolveMutation.isPending ? 'Resolving...' : 'Resolve'}
-              </Button>
-            </div>
-          )}
-          <div className="relative flex-1 min-w-[180px]">
-            <Search className="absolute left-2.5 top-1/2 transform -translate-y-1/2 h-3 w-3 text-muted-foreground" />
-            <Input
-              placeholder="Search by message, name, or email..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-8 h-8 text-xs"
-            />
-          </div>
-        </div>
-
-        {filteredFeedback.length === 0 ? (
-          <EmptyState
-            icon={searchQuery ? Search : MessageSquare}
-            title={searchQuery ? 'No feedback match your search' : 'No feedback yet'}
-            description={
-              searchQuery
-                ? 'Try adjusting your search or changing the status filter.'
-                : 'Use the feedback widget in your app to collect user feedback. It will appear here.'
-            }
-          />
-        ) : (
-          <TooltipProvider>
-            <div className="space-y-1.5">
-              {filteredFeedback.map((f) => {
-                const config = statusConfig[f.status as keyof typeof statusConfig] || statusConfig.unresolved
-                const displayName = f.name || f.contactEmail || 'Anonymous'
-                const initials = getInitials(f.name, f.contactEmail)
-                const avatarColor = getAvatarColor(f.name, f.contactEmail)
-                const sourceLabel = feedbackSourceLabel(f.sourceType, f.sourceName)
-
-                return (
-                  <div
-                    key={f.feedbackId}
-                    onClick={() => navigate({ to: '/feedback/$feedbackId', params: { feedbackId: f.feedbackId } })}
-                    className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
-                  >
-                    <div className="flex items-start gap-2 p-2">
-                      {/* Checkbox */}
-                      <div className="flex items-center pt-0.5">
-                        <Checkbox
-                          checked={selectedFeedback.has(f.feedbackId)}
-                          onCheckedChange={() => handleToggleFeedback(f.feedbackId)}
-                          onClick={(e) => e.stopPropagation()}
-                          aria-label="Select feedback"
-                        />
-                      </div>
-
-                      {/* Avatar */}
-                      <Avatar className="h-6 w-6 shrink-0 mt-0.5">
-                        <AvatarFallback className={`text-[10px] font-semibold ${avatarColor}`}>
-                          {initials}
-                        </AvatarFallback>
-                      </Avatar>
-
-                      {/* Content */}
-                      <div className="flex-1 min-w-0">
-                        {/* Top row: name + time */}
-                        <div className="flex items-center gap-1.5 mb-0.5">
-                          <span className="font-semibold text-xs truncate">{displayName}</span>
-                          {f.contactEmail && f.name && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Mail className="h-3 w-3 text-muted-foreground/60 shrink-0" />
-                              </TooltipTrigger>
-                              <TooltipContent>{f.contactEmail}</TooltipContent>
-                            </Tooltip>
-                          )}
-                          <span className="text-[11px] text-muted-foreground ml-auto shrink-0 flex items-center gap-0.5">
-                            <Clock className="h-2.5 w-2.5" />
-                            {formatRelativeTime(f.timestamp)}
-                          </span>
-                        </div>
-
-                        {/* Message */}
-                        <p className="text-xs text-foreground/80 line-clamp-2 mb-1.5">
-                          {f.message || '(No message)'}
-                        </p>
-
-                        {/* Bottom row: badges */}
-                        <div className="flex flex-wrap items-center gap-1.5">
-                          <Badge variant={config.badge} size="sm" className="font-medium">
-                            <StatusDot tone={config.tone} size="sm" className="mr-0.5" />
-                            {config.label}
-                          </Badge>
-                          {f.environment && (
-                            <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
-                              {f.environment}
-                            </Badge>
-                          )}
-                          <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
-                            {sourceLabel}
-                          </Badge>
-                          {f.platform && (
-                            <Badge variant="outline" size="sm" className="font-normal gap-0.5">
-                              <Monitor className="h-2.5 w-2.5" />
-                              {f.platform}
-                            </Badge>
-                          )}
-                          {f.url && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Badge variant="outline" size="sm" className="font-normal gap-0.5 max-w-[180px] truncate">
-                                  <Globe className="h-2.5 w-2.5 shrink-0" />
-                                  <span className="truncate">{f.url.replace(/^https?:\/\//, '')}</span>
-                                </Badge>
-                              </TooltipTrigger>
-                              <TooltipContent>{f.url}</TooltipContent>
-                            </Tooltip>
-                          )}
-                          {f.associatedEventId && (
-                            <Badge variant="warning" size="sm" className="font-normal gap-0.5">
-                              <AlertCircle className="h-2.5 w-2.5" />
-                              Event linked
-                            </Badge>
-                          )}
-                          {f.replayId && (
-                            <span
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                navigate({ to: '/replays/$replayId', params: { replayId: f.replayId! } })
-                              }}
-                              className="inline-flex items-center gap-0.5 text-[11px] font-medium text-primary hover:underline cursor-pointer bg-[hsl(var(--primary)/0.12)] border border-[hsl(var(--primary)/0.3)] rounded-full px-2 py-0.5"
-                            >
-                              <Video className="h-2.5 w-2.5" />
-                              Replay
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </TooltipProvider>
-        )}
-
-        {/* Footer count */}
-        {filteredFeedback.length > 0 && (
-          <div className="mt-3 text-center">
-            <p className="text-xs text-muted-foreground">
-              Showing {filteredFeedback.length} feedback item{filteredFeedback.length === 1 ? '' : 's'}
-              {searchQuery && ' matching your search'}
-            </p>
-          </div>
-        )}
-      </>
-    )
-  }
+  const feedbackScopeEmptyState = getFeedbackScopeEmptyState(projectList.length, hasFeedbackScope)
+  const feedbackContent = feedbackScopeEmptyState ?? (
+    <FeedbackMainContent
+      stats={stats}
+      allFeedbackCount={allFeedback.length}
+      statusFilter={statusFilter}
+      filteredFeedback={filteredFeedback}
+      selectedFeedback={selectedFeedback}
+      resolvingSelected={resolveMutation.isPending}
+      searchQuery={searchQuery}
+      onStatusFilterChange={setStatusFilter}
+      onToggleAll={handleToggleAll}
+      onToggleFeedback={handleToggleFeedback}
+      onResolveSelected={handleResolveSelected}
+      onSearchQueryChange={setSearchQuery}
+      onOpenFeedback={(feedbackId) => navigate({ to: '/feedback/$feedbackId', params: { feedbackId } })}
+      onOpenReplay={(replayId) => navigate({ to: '/replays/$replayId', params: { replayId } })}
+    />
+  )
 
   return (
     <div className="min-h-screen">

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -51,6 +51,7 @@ import {
   serviceRailSections,
   serviceScopeKey,
 } from '@/lib/service-facet-scope'
+import {feedbackSourceLabel} from '@/lib/telemetry-sources'
 import type {FacetFilter} from '@/lib/filters/types'
 
 export const Route = createFileRoute('/feedback')({
@@ -405,6 +406,7 @@ function FeedbackPage() {
                     const displayName = f.name || f.contactEmail || 'Anonymous'
                     const initials = getInitials(f.name, f.contactEmail)
                     const avatarColor = getAvatarColor(f.name, f.contactEmail)
+                    const sourceLabel = feedbackSourceLabel(f.sourceType, f.sourceName)
 
                     return (
                       <div
@@ -465,6 +467,9 @@ function FeedbackPage() {
                                   {f.environment}
                                 </Badge>
                               )}
+                              <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
+                                {sourceLabel}
+                              </Badge>
                               {f.platform && (
                                 <Badge variant="outline" size="sm" className="font-normal gap-0.5">
                                   <Monitor className="h-2.5 w-2.5" />

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -342,11 +342,27 @@ function FeedbackListItem({
   const avatarColor = getAvatarColor(feedback.name, feedback.contactEmail)
   const sourceLabel = feedbackSourceLabel(feedback.sourceType, feedback.sourceName)
   const replayId = feedback.replayId
+  const handleOpenFeedbackKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) {
+      return
+    }
+
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return
+    }
+
+    event.preventDefault()
+    onOpenFeedback(feedback.feedbackId)
+  }
 
   return (
     <div
       key={feedback.feedbackId}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open feedback from ${displayName}`}
       onClick={() => onOpenFeedback(feedback.feedbackId)}
+      onKeyDown={handleOpenFeedbackKeyDown}
       className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
     >
       <div className="flex items-start gap-2 p-2">
@@ -423,7 +439,8 @@ function FeedbackListItem({
               </Badge>
             )}
             {replayId && (
-              <span
+              <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation()
                   onOpenReplay(replayId)
@@ -432,7 +449,7 @@ function FeedbackListItem({
               >
                 <Video className="h-2.5 w-2.5" />
                 Replay
-              </span>
+              </button>
             )}
           </div>
         </div>

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -506,22 +506,7 @@ function FeedbackFooter({
   )
 }
 
-function FeedbackMainContent({
-  stats,
-  allFeedbackCount,
-  statusFilter,
-  filteredFeedback,
-  selectedFeedback,
-  resolvingSelected,
-  searchQuery,
-  onStatusFilterChange,
-  onToggleAll,
-  onToggleFeedback,
-  onResolveSelected,
-  onSearchQueryChange,
-  onOpenFeedback,
-  onOpenReplay,
-}: {
+interface FeedbackMainContentProps {
   readonly stats: FeedbackStats
   readonly allFeedbackCount: number
   readonly statusFilter: string
@@ -536,7 +521,26 @@ function FeedbackMainContent({
   readonly onSearchQueryChange: (query: string) => void
   readonly onOpenFeedback: (feedbackId: string) => void
   readonly onOpenReplay: (replayId: string) => void
-}) {
+}
+
+function FeedbackMainContent(props: FeedbackMainContentProps) {
+  const {
+    stats,
+    allFeedbackCount,
+    statusFilter,
+    filteredFeedback,
+    selectedFeedback,
+    resolvingSelected,
+    searchQuery,
+    onStatusFilterChange,
+    onToggleAll,
+    onToggleFeedback,
+    onResolveSelected,
+    onSearchQueryChange,
+    onOpenFeedback,
+    onOpenReplay,
+  } = props
+
   return (
     <>
       <FeedbackStatsGrid

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -43,7 +43,7 @@ import {
   Search,
   Video,
 } from 'lucide-react'
-import {useMemo, useState} from 'react'
+import {useMemo, useState, type ReactNode} from 'react'
 import {useToast} from '@/hooks/useToast'
 import {
   facetValues,
@@ -278,6 +278,243 @@ function FeedbackPage() {
     return matchesSearch
   })
 
+  let feedbackContent: ReactNode
+  if (projectList.length === 0) {
+    feedbackContent = (
+      <EmptyState
+        icon={MessageSquare}
+        title="No services yet"
+        description="Create a service and integrate the feedback widget to see user feedback here."
+      />
+    )
+  } else if (!hasFeedbackScope) {
+    feedbackContent = (
+      <EmptyState
+        icon={MessageSquare}
+        title="No services match filters"
+        description="Adjust the selected services to view feedback."
+      />
+    )
+  } else {
+    feedbackContent = (
+      <>
+        {/* Stats Cards (also act as status filters) */}
+        {allFeedback.length > 0 && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <FeedbackStatCard
+              label="Total"
+              value={stats.total}
+              icon={Inbox}
+              tone="accent"
+              active={statusFilter === 'all'}
+              onClick={() => setStatusFilter('all')}
+            />
+            <FeedbackStatCard
+              label="Unresolved"
+              value={stats.unresolved}
+              icon={CircleDot}
+              tone="warning"
+              active={statusFilter === 'unresolved'}
+              onClick={() => setStatusFilter('unresolved')}
+            />
+            <FeedbackStatCard
+              label="Resolved"
+              value={stats.resolved}
+              icon={CheckCircle2}
+              tone="success"
+              active={statusFilter === 'resolved'}
+              onClick={() => setStatusFilter('resolved')}
+            />
+            <FeedbackStatCard
+              label="Archived"
+              value={stats.archived}
+              icon={Archive}
+              tone="neutral"
+              active={statusFilter === 'archived'}
+              onClick={() => setStatusFilter('archived')}
+            />
+          </div>
+        )}
+
+        {/* Toolbar */}
+        <div className="mb-3 flex gap-2 items-center flex-wrap">
+          {filteredFeedback.length > 0 && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                checked={selectedFeedback.size === filteredFeedback.length && filteredFeedback.length > 0}
+                onCheckedChange={handleToggleAll}
+                aria-label="Select all feedback"
+              />
+              <span className="text-xs text-muted-foreground whitespace-nowrap">Select all</span>
+            </div>
+          )}
+          {selectedFeedback.size > 0 && (
+            <div className="flex items-center gap-1.5 bg-success-bg border border-success-border rounded-lg px-2.5 py-1">
+              <CheckCircle2 className="h-3 w-3 text-success-fg" />
+              <span className="text-xs font-medium whitespace-nowrap">
+                {selectedFeedback.size} selected
+              </span>
+              <Button
+                onClick={handleResolveSelected}
+                disabled={resolveMutation.isPending}
+                size="sm"
+                className="h-6 text-xs ml-1.5"
+              >
+                {resolveMutation.isPending ? 'Resolving...' : 'Resolve'}
+              </Button>
+            </div>
+          )}
+          <div className="relative flex-1 min-w-[180px]">
+            <Search className="absolute left-2.5 top-1/2 transform -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+            <Input
+              placeholder="Search by message, name, or email..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-8 h-8 text-xs"
+            />
+          </div>
+        </div>
+
+        {filteredFeedback.length === 0 ? (
+          <EmptyState
+            icon={searchQuery ? Search : MessageSquare}
+            title={searchQuery ? 'No feedback match your search' : 'No feedback yet'}
+            description={
+              searchQuery
+                ? 'Try adjusting your search or changing the status filter.'
+                : 'Use the feedback widget in your app to collect user feedback. It will appear here.'
+            }
+          />
+        ) : (
+          <TooltipProvider>
+            <div className="space-y-1.5">
+              {filteredFeedback.map((f) => {
+                const config = statusConfig[f.status as keyof typeof statusConfig] || statusConfig.unresolved
+                const displayName = f.name || f.contactEmail || 'Anonymous'
+                const initials = getInitials(f.name, f.contactEmail)
+                const avatarColor = getAvatarColor(f.name, f.contactEmail)
+                const sourceLabel = feedbackSourceLabel(f.sourceType, f.sourceName)
+
+                return (
+                  <div
+                    key={f.feedbackId}
+                    onClick={() => navigate({ to: '/feedback/$feedbackId', params: { feedbackId: f.feedbackId } })}
+                    className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
+                  >
+                    <div className="flex items-start gap-2 p-2">
+                      {/* Checkbox */}
+                      <div className="flex items-center pt-0.5">
+                        <Checkbox
+                          checked={selectedFeedback.has(f.feedbackId)}
+                          onCheckedChange={() => handleToggleFeedback(f.feedbackId)}
+                          onClick={(e) => e.stopPropagation()}
+                          aria-label="Select feedback"
+                        />
+                      </div>
+
+                      {/* Avatar */}
+                      <Avatar className="h-6 w-6 shrink-0 mt-0.5">
+                        <AvatarFallback className={`text-[10px] font-semibold ${avatarColor}`}>
+                          {initials}
+                        </AvatarFallback>
+                      </Avatar>
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        {/* Top row: name + time */}
+                        <div className="flex items-center gap-1.5 mb-0.5">
+                          <span className="font-semibold text-xs truncate">{displayName}</span>
+                          {f.contactEmail && f.name && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Mail className="h-3 w-3 text-muted-foreground/60 shrink-0" />
+                              </TooltipTrigger>
+                              <TooltipContent>{f.contactEmail}</TooltipContent>
+                            </Tooltip>
+                          )}
+                          <span className="text-[11px] text-muted-foreground ml-auto shrink-0 flex items-center gap-0.5">
+                            <Clock className="h-2.5 w-2.5" />
+                            {formatRelativeTime(f.timestamp)}
+                          </span>
+                        </div>
+
+                        {/* Message */}
+                        <p className="text-xs text-foreground/80 line-clamp-2 mb-1.5">
+                          {f.message || '(No message)'}
+                        </p>
+
+                        {/* Bottom row: badges */}
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <Badge variant={config.badge} size="sm" className="font-medium">
+                            <StatusDot tone={config.tone} size="sm" className="mr-0.5" />
+                            {config.label}
+                          </Badge>
+                          {f.environment && (
+                            <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
+                              {f.environment}
+                            </Badge>
+                          )}
+                          <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
+                            {sourceLabel}
+                          </Badge>
+                          {f.platform && (
+                            <Badge variant="outline" size="sm" className="font-normal gap-0.5">
+                              <Monitor className="h-2.5 w-2.5" />
+                              {f.platform}
+                            </Badge>
+                          )}
+                          {f.url && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge variant="outline" size="sm" className="font-normal gap-0.5 max-w-[180px] truncate">
+                                  <Globe className="h-2.5 w-2.5 shrink-0" />
+                                  <span className="truncate">{f.url.replace(/^https?:\/\//, '')}</span>
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent>{f.url}</TooltipContent>
+                            </Tooltip>
+                          )}
+                          {f.associatedEventId && (
+                            <Badge variant="warning" size="sm" className="font-normal gap-0.5">
+                              <AlertCircle className="h-2.5 w-2.5" />
+                              Event linked
+                            </Badge>
+                          )}
+                          {f.replayId && (
+                            <span
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                navigate({ to: '/replays/$replayId', params: { replayId: f.replayId! } })
+                              }}
+                              className="inline-flex items-center gap-0.5 text-[11px] font-medium text-primary hover:underline cursor-pointer bg-[hsl(var(--primary)/0.12)] border border-[hsl(var(--primary)/0.3)] rounded-full px-2 py-0.5"
+                            >
+                              <Video className="h-2.5 w-2.5" />
+                              Replay
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </TooltipProvider>
+        )}
+
+        {/* Footer count */}
+        {filteredFeedback.length > 0 && (
+          <div className="mt-3 text-center">
+            <p className="text-xs text-muted-foreground">
+              Showing {filteredFeedback.length} feedback item{filteredFeedback.length === 1 ? '' : 's'}
+              {searchQuery && ' matching your search'}
+            </p>
+          </div>
+        )}
+      </>
+    )
+  }
+
   return (
     <div className="min-h-screen">
       <div className="container mx-auto px-4 py-4 space-y-3">
@@ -297,235 +534,7 @@ function FeedbackPage() {
           />
 
           <div className="min-w-0">
-            {projectList.length === 0 ? (
-              <EmptyState
-                icon={MessageSquare}
-                title="No services yet"
-                description="Create a service and integrate the feedback widget to see user feedback here."
-              />
-            ) : !hasFeedbackScope ? (
-              <EmptyState
-                icon={MessageSquare}
-                title="No services match filters"
-                description="Adjust the selected services to view feedback."
-              />
-            ) : (
-              <>
-                {/* Stats Cards (also act as status filters) */}
-                {allFeedback.length > 0 && (
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                    <FeedbackStatCard
-                      label="Total"
-                      value={stats.total}
-                      icon={Inbox}
-                      tone="accent"
-                      active={statusFilter === 'all'}
-                      onClick={() => setStatusFilter('all')}
-                    />
-                    <FeedbackStatCard
-                      label="Unresolved"
-                      value={stats.unresolved}
-                      icon={CircleDot}
-                      tone="warning"
-                      active={statusFilter === 'unresolved'}
-                      onClick={() => setStatusFilter('unresolved')}
-                    />
-                    <FeedbackStatCard
-                      label="Resolved"
-                      value={stats.resolved}
-                      icon={CheckCircle2}
-                      tone="success"
-                      active={statusFilter === 'resolved'}
-                      onClick={() => setStatusFilter('resolved')}
-                    />
-                    <FeedbackStatCard
-                      label="Archived"
-                      value={stats.archived}
-                      icon={Archive}
-                      tone="neutral"
-                      active={statusFilter === 'archived'}
-                      onClick={() => setStatusFilter('archived')}
-                    />
-                  </div>
-                )}
-
-                {/* Toolbar */}
-                <div className="mb-3 flex gap-2 items-center flex-wrap">
-              {filteredFeedback.length > 0 && (
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    checked={selectedFeedback.size === filteredFeedback.length && filteredFeedback.length > 0}
-                    onCheckedChange={handleToggleAll}
-                    aria-label="Select all feedback"
-                  />
-                  <span className="text-xs text-muted-foreground whitespace-nowrap">Select all</span>
-                </div>
-              )}
-              {selectedFeedback.size > 0 && (
-                <div className="flex items-center gap-1.5 bg-success-bg border border-success-border rounded-lg px-2.5 py-1">
-                  <CheckCircle2 className="h-3 w-3 text-success-fg" />
-                  <span className="text-xs font-medium whitespace-nowrap">
-                    {selectedFeedback.size} selected
-                  </span>
-                  <Button
-                    onClick={handleResolveSelected}
-                    disabled={resolveMutation.isPending}
-                    size="sm"
-                    className="h-6 text-xs ml-1.5"
-                  >
-                    {resolveMutation.isPending ? 'Resolving...' : 'Resolve'}
-                  </Button>
-                </div>
-              )}
-              <div className="relative flex-1 min-w-[180px]">
-                <Search className="absolute left-2.5 top-1/2 transform -translate-y-1/2 h-3 w-3 text-muted-foreground" />
-                <Input
-                  placeholder="Search by message, name, or email..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-8 h-8 text-xs"
-                />
-              </div>
-                </div>
-
-                {filteredFeedback.length === 0 ? (
-              <EmptyState
-                icon={searchQuery ? Search : MessageSquare}
-                title={searchQuery ? 'No feedback match your search' : 'No feedback yet'}
-                description={
-                  searchQuery
-                    ? 'Try adjusting your search or changing the status filter.'
-                    : 'Use the feedback widget in your app to collect user feedback. It will appear here.'
-                }
-              />
-                ) : (
-              <TooltipProvider>
-                <div className="space-y-1.5">
-                  {filteredFeedback.map((f) => {
-                    const config = statusConfig[f.status as keyof typeof statusConfig] || statusConfig.unresolved
-                    const displayName = f.name || f.contactEmail || 'Anonymous'
-                    const initials = getInitials(f.name, f.contactEmail)
-                    const avatarColor = getAvatarColor(f.name, f.contactEmail)
-                    const sourceLabel = feedbackSourceLabel(f.sourceType, f.sourceName)
-
-                    return (
-                      <div
-                        key={f.feedbackId}
-                        onClick={() => navigate({ to: '/feedback/$feedbackId', params: { feedbackId: f.feedbackId } })}
-                        className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
-                      >
-                        <div className="flex items-start gap-2 p-2">
-                          {/* Checkbox */}
-                          <div className="flex items-center pt-0.5">
-                            <Checkbox
-                              checked={selectedFeedback.has(f.feedbackId)}
-                              onCheckedChange={() => handleToggleFeedback(f.feedbackId)}
-                              onClick={(e) => e.stopPropagation()}
-                              aria-label="Select feedback"
-                            />
-                          </div>
-
-                          {/* Avatar */}
-                          <Avatar className="h-6 w-6 shrink-0 mt-0.5">
-                            <AvatarFallback className={`text-[10px] font-semibold ${avatarColor}`}>
-                              {initials}
-                            </AvatarFallback>
-                          </Avatar>
-
-                          {/* Content */}
-                          <div className="flex-1 min-w-0">
-                            {/* Top row: name + time */}
-                            <div className="flex items-center gap-1.5 mb-0.5">
-                              <span className="font-semibold text-xs truncate">{displayName}</span>
-                              {f.contactEmail && f.name && (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Mail className="h-3 w-3 text-muted-foreground/60 shrink-0" />
-                                  </TooltipTrigger>
-                                  <TooltipContent>{f.contactEmail}</TooltipContent>
-                                </Tooltip>
-                              )}
-                              <span className="text-[11px] text-muted-foreground ml-auto shrink-0 flex items-center gap-0.5">
-                                <Clock className="h-2.5 w-2.5" />
-                                {formatRelativeTime(f.timestamp)}
-                              </span>
-                            </div>
-
-                            {/* Message */}
-                            <p className="text-xs text-foreground/80 line-clamp-2 mb-1.5">
-                              {f.message || '(No message)'}
-                            </p>
-
-                            {/* Bottom row: badges */}
-                            <div className="flex flex-wrap items-center gap-1.5">
-                              <Badge variant={config.badge} size="sm" className="font-medium">
-                                <StatusDot tone={config.tone} size="sm" className="mr-0.5" />
-                                {config.label}
-                              </Badge>
-                              {f.environment && (
-                                <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
-                                  {f.environment}
-                                </Badge>
-                              )}
-                              <Badge variant="outline" size="sm" className="font-normal text-muted-foreground">
-                                {sourceLabel}
-                              </Badge>
-                              {f.platform && (
-                                <Badge variant="outline" size="sm" className="font-normal gap-0.5">
-                                  <Monitor className="h-2.5 w-2.5" />
-                                  {f.platform}
-                                </Badge>
-                              )}
-                              {f.url && (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Badge variant="outline" size="sm" className="font-normal gap-0.5 max-w-[180px] truncate">
-                                      <Globe className="h-2.5 w-2.5 shrink-0" />
-                                      <span className="truncate">{f.url.replace(/^https?:\/\//, '')}</span>
-                                    </Badge>
-                                  </TooltipTrigger>
-                                  <TooltipContent>{f.url}</TooltipContent>
-                                </Tooltip>
-                              )}
-                              {f.associatedEventId && (
-                                <Badge variant="warning" size="sm" className="font-normal gap-0.5">
-                                  <AlertCircle className="h-2.5 w-2.5" />
-                                  Event linked
-                                </Badge>
-                              )}
-                              {f.replayId && (
-                                <span
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    navigate({ to: '/replays/$replayId', params: { replayId: f.replayId! } })
-                                  }}
-                                  className="inline-flex items-center gap-0.5 text-[11px] font-medium text-primary hover:underline cursor-pointer bg-[hsl(var(--primary)/0.12)] border border-[hsl(var(--primary)/0.3)] rounded-full px-2 py-0.5"
-                                >
-                                  <Video className="h-2.5 w-2.5" />
-                                  Replay
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              </TooltipProvider>
-                )}
-
-                {/* Footer count */}
-                {filteredFeedback.length > 0 && (
-              <div className="mt-3 text-center">
-                <p className="text-xs text-muted-foreground">
-                  Showing {filteredFeedback.length} feedback item{filteredFeedback.length === 1 ? '' : 's'}
-                  {searchQuery && ' matching your search'}
-                </p>
-              </div>
-                )}
-              </>
-            )}
+            {feedbackContent}
           </div>
         </div>
       </div>

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -342,28 +342,11 @@ function FeedbackListItem({
   const avatarColor = getAvatarColor(feedback.name, feedback.contactEmail)
   const sourceLabel = feedbackSourceLabel(feedback.sourceType, feedback.sourceName)
   const replayId = feedback.replayId
-  const handleOpenFeedbackKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget) {
-      return
-    }
-
-    if (event.key !== 'Enter' && event.key !== ' ') {
-      return
-    }
-
-    event.preventDefault()
-    onOpenFeedback(feedback.feedbackId)
-  }
 
   return (
     <div
       key={feedback.feedbackId}
-      role="button"
-      tabIndex={0}
-      aria-label={`Open feedback from ${displayName}`}
-      onClick={() => onOpenFeedback(feedback.feedbackId)}
-      onKeyDown={handleOpenFeedbackKeyDown}
-      className={`cursor-pointer rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
+      className={`rounded-lg border border-border/60 bg-card hover:bg-accent/50 hover:border-primary/20 transition-all border-l-[3px] ${config.border}`}
     >
       <div className="flex items-start gap-2 p-2">
         <div className="flex items-center pt-0.5">
@@ -382,25 +365,32 @@ function FeedbackListItem({
         </Avatar>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 mb-0.5">
-            <span className="font-semibold text-xs truncate">{displayName}</span>
-            {feedback.contactEmail && feedback.name && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Mail className="h-3 w-3 text-muted-foreground/60 shrink-0" />
-                </TooltipTrigger>
-                <TooltipContent>{feedback.contactEmail}</TooltipContent>
-              </Tooltip>
-            )}
-            <span className="text-[11px] text-muted-foreground ml-auto shrink-0 flex items-center gap-0.5">
-              <Clock className="h-2.5 w-2.5" />
-              {formatRelativeTime(feedback.timestamp)}
-            </span>
-          </div>
+          <button
+            type="button"
+            aria-label={`Open feedback from ${displayName}`}
+            onClick={() => onOpenFeedback(feedback.feedbackId)}
+            className="block w-full cursor-pointer text-left"
+          >
+            <div className="flex items-center gap-1.5 mb-0.5">
+              <span className="font-semibold text-xs truncate">{displayName}</span>
+              {feedback.contactEmail && feedback.name && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Mail className="h-3 w-3 text-muted-foreground/60 shrink-0" />
+                  </TooltipTrigger>
+                  <TooltipContent>{feedback.contactEmail}</TooltipContent>
+                </Tooltip>
+              )}
+              <span className="text-[11px] text-muted-foreground ml-auto shrink-0 flex items-center gap-0.5">
+                <Clock className="h-2.5 w-2.5" />
+                {formatRelativeTime(feedback.timestamp)}
+              </span>
+            </div>
 
-          <p className="text-xs text-foreground/80 line-clamp-2 mb-1.5">
-            {feedback.message || '(No message)'}
-          </p>
+            <p className="text-xs text-foreground/80 line-clamp-2 mb-1.5">
+              {feedback.message || '(No message)'}
+            </p>
+          </button>
 
           <div className="flex flex-wrap items-center gap-1.5">
             <Badge variant={config.badge} size="sm" className="font-medium">


### PR DESCRIPTION
## Summary
- add source metadata to user feedback storage and API responses
- ingest OpenTelemetry feedback events through OTLP JSON and protobuf
- show feedback source details in the dashboard and docs

## Validation
- cd backend && ./gradlew test detekt
- cd dashboard && npm run lint
- cd dashboard && npm run typecheck
- cd dashboard && npm test -- --run src/routes/__tests__/release-replay-feedback-service-facets.test.tsx src/lib/api/modules/__tests__/otlp-api-keys.test.ts src/components/settings/__tests__/OtlpApiKeysTab.test.tsx
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OTLP feedback ingestion endpoint (JSON + protobuf) with routing, quota handling, and persistence.
  * Feedback payloads now include telemetry source metadata, trace/span IDs, and resource attributes.

* **Improvements**
  * Feedback list/detail pages show telemetry source, source event, trace/span, and resource attributes; UI badges updated.
  * Observed services now record whether feedback was seen.

* **Documentation**
  * Docs updated with OTLP feedback submission examples.

* **Tests**
  * Added/extended tests covering OTLP feedback parsing, routing, quota, and UI mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->