### PR TITLE
fix: parse process last-seen timestamps

### DIFF
--- a/dashboard/src/components/StatusPagePreview.tsx
+++ b/dashboard/src/components/StatusPagePreview.tsx
@@ -113,7 +113,7 @@ function UptimeHistoryBar({
               />
             </TooltipTrigger>
             <TooltipContent side="top" className="text-xs">
-              <p className="font-medium">{formatMonthDay(new Date(point.date), timezone)}</p>
+              <p className="font-medium">{formatMonthDay(point.date, timezone)}</p>
               <p className={`tabular-nums ${getTooltipUptimeColor(point.uptime)}`}>
                 {point.uptime.toFixed(2)}% uptime
               </p>

--- a/dashboard/src/components/logs/EmbeddedLogs.tsx
+++ b/dashboard/src/components/logs/EmbeddedLogs.tsx
@@ -188,7 +188,7 @@ export function EmbeddedLogs({
               {centerTimestamp ? (
                 <>
                   Logs ±{contextMinutes}min around{' '}
-                  {formatDateTime(new Date(centerTimestamp), timezone)}
+                  {formatDateTime(centerTimestamp, timezone)}
                 </>
               ) : (
                 'Logs'

--- a/dashboard/src/components/logs/LogExplorer.tsx
+++ b/dashboard/src/components/logs/LogExplorer.tsx
@@ -63,6 +63,7 @@ import {type FacetFilter, type FacetRailSection, type FacetSchema} from '@/lib/f
 import {TIME_PRESETS} from '@/lib/filters/time'
 import {logLevelBadgeClass} from '@/lib/severity'
 import {cn} from '@/lib/utils'
+import {parseDate} from '@/lib/date-format'
 import {
   Activity,
   Bell,
@@ -1420,7 +1421,7 @@ export function LogExplorer({
   
   // View in context: clear filters and show ±5 minute window around selected log
   const handleViewInContext = useCallback((log: LogEntry) => {
-    const logTime = new Date(log.timestamp)
+    const logTime = parseDate(log.timestamp)
     if (Number.isNaN(logTime.getTime())) return
     
     // Calculate ±5 minutes

--- a/dashboard/src/components/logs/LogHistogram.tsx
+++ b/dashboard/src/components/logs/LogHistogram.tsx
@@ -18,7 +18,7 @@ import {useMemo} from 'react'
 import {Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts'
 import type {LogAggregateBucket} from '@/lib/api'
 import {useTimezone} from '@/hooks/useTimezone'
-import {formatDateTime, formatMonthDay, formatTimeHM} from '@/lib/date-format'
+import {formatDateTime, formatMonthDay, formatTimeHM, parseDate} from '@/lib/date-format'
 import {logIntervalToMs} from '@/components/logs/logInterval'
 
 interface LogHistogramProps {
@@ -74,7 +74,7 @@ function colorForGroup(key: string): string {
 
 function toTimestampMs(value: string | undefined): number | undefined {
   if (!value) return undefined
-  const timestamp = new Date(value).getTime()
+  const timestamp = parseDate(value).getTime()
   return Number.isNaN(timestamp) ? undefined : timestamp
 }
 
@@ -102,14 +102,14 @@ export function LogHistogram({
     }
     return formatMonthDay(date, timezone)
   }
-  const formatTooltipTime = (ts: number): string => formatDateTime(new Date(ts), timezone)
+  const formatTooltipTime = (ts: number): string => formatDateTime(ts, timezone)
   const {chartData, groupKeys, totalRangeMs, domainMin, domainMax, estimatedBucketCount} = useMemo(() => {
     const keys = new Set<string>()
     const data: HistogramPoint[] = buckets
       .map((b) => {
         const point: HistogramPoint = {
           timestamp: b.timestamp,
-          timestampMs: new Date(b.timestamp).getTime(),
+          timestampMs: parseDate(b.timestamp).getTime(),
           total: b.count,
         }
         if (grouped && Object.keys(b.groups).length > 0) {

--- a/dashboard/src/components/logs/LogTable.tsx
+++ b/dashboard/src/components/logs/LogTable.tsx
@@ -23,7 +23,7 @@ import {stripAnsi} from '@/lib/ansi'
 import {groupExceptionLogs, type LogGroup} from '@/components/logs/groupExceptionLogs'
 import {getNow} from '@/lib/demo'
 import {useTimezone} from '@/hooks/useTimezone'
-import {formatDateTimeWithMs, formatTimeWithMs} from '@/lib/date-format'
+import {formatDateTimeWithMs, formatTimeWithMs, parseDate} from '@/lib/date-format'
 
 interface LogTableProps {
   logs: LogEntry[]
@@ -40,20 +40,20 @@ interface LogTableProps {
 const STACK_TRACE_TAG_KEYS = ['exception.stacktrace', 'exception.stack_trace']
 
 function formatTimestamp(value: string, timezone: string): string {
-  const date = new Date(value)
+  const date = parseDate(value)
   if (Number.isNaN(date.getTime())) return value
   return formatDateTimeWithMs(date, timezone)
 }
 
 function formatMobileTimestamp(value: string, timezone: string): string {
-  const date = new Date(value)
+  const date = parseDate(value)
   if (Number.isNaN(date.getTime())) return value
   return formatTimeWithMs(date, timezone)
 }
 
 function formatRelativeTime(value: string): string {
   const now = getNow()
-  const date = new Date(value)
+  const date = parseDate(value)
   if (Number.isNaN(date.getTime())) return value
   const diffMs = now - date.getTime()
   if (diffMs < 0) return 'just now'

--- a/dashboard/src/components/logs/groupExceptionLogs.ts
+++ b/dashboard/src/components/logs/groupExceptionLogs.ts
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import type {LogEntry} from '@/lib/api'
+import {parseDate} from '@/lib/date-format'
 import {stripAnsi} from '@/lib/ansi'
 
 /**
@@ -74,8 +75,8 @@ function isExceptionContinuation(logs: LogEntry[], index: number): boolean {
 function sameContext(a: LogEntry, b: LogEntry): boolean {
   if ((a.service || '') !== (b.service || '')) return false
   if ((a.host || '') !== (b.host || '')) return false
-  const ta = new Date(a.timestamp).getTime()
-  const tb = new Date(b.timestamp).getTime()
+  const ta = parseDate(a.timestamp).getTime()
+  const tb = parseDate(b.timestamp).getTime()
   return Math.abs(ta - tb) <= MAX_GROUP_MS
 }
 

--- a/dashboard/src/components/logs/tabs/LogContextTab.tsx
+++ b/dashboard/src/components/logs/tabs/LogContextTab.tsx
@@ -19,6 +19,7 @@ import {api} from '@/lib/api'
 import type {LogEntry} from '@/lib/api'
 import {LogTable} from '@/components/logs/LogTable'
 import {Loader2} from 'lucide-react'
+import {parseDate} from '@/lib/date-format'
 
 const CONTEXT_WINDOW_MINUTES = 5
 
@@ -28,7 +29,7 @@ interface LogContextTabProps {
 }
 
 export function LogContextTab({log, active}: LogContextTabProps) {
-  const logTime = new Date(log.timestamp).getTime()
+  const logTime = parseDate(log.timestamp).getTime()
   const from = new Date(logTime - CONTEXT_WINDOW_MINUTES * 60_000).toISOString()
   const to = new Date(logTime + CONTEXT_WINDOW_MINUTES * 60_000).toISOString()
 

--- a/dashboard/src/components/logs/tabs/LogContextTab.tsx
+++ b/dashboard/src/components/logs/tabs/LogContextTab.tsx
@@ -30,8 +30,13 @@ interface LogContextTabProps {
 
 export function LogContextTab({log, active}: LogContextTabProps) {
   const logTime = parseDate(log.timestamp).getTime()
-  const from = new Date(logTime - CONTEXT_WINDOW_MINUTES * 60_000).toISOString()
-  const to = new Date(logTime + CONTEXT_WINDOW_MINUTES * 60_000).toISOString()
+  const hasValidLogTime = Number.isFinite(logTime)
+  const from = hasValidLogTime
+    ? new Date(logTime - CONTEXT_WINDOW_MINUTES * 60_000).toISOString()
+    : undefined
+  const to = hasValidLogTime
+    ? new Date(logTime + CONTEXT_WINDOW_MINUTES * 60_000).toISOString()
+    : undefined
 
   const {data, error, isError, isLoading} = useQuery({
     queryKey: ['logDetailContext', log.logId, log.service, log.timestamp],
@@ -41,10 +46,19 @@ export function LogContextTab({log, active}: LogContextTabProps) {
       service: log.service || undefined,
       limit: 100,
     }),
-    enabled: active,
+    enabled: active && hasValidLogTime,
     staleTime: 30 * 1000,
     retry: false,
   })
+
+  if (!hasValidLogTime) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-12 text-muted-foreground">
+        <p className="text-sm">Could not load surrounding logs</p>
+        <p className="max-w-md text-center text-xs">Invalid timestamp on selected log</p>
+      </div>
+    )
+  }
 
   if (isLoading) {
     return (

--- a/dashboard/src/components/monitoring/ContainerList.tsx
+++ b/dashboard/src/components/monitoring/ContainerList.tsx
@@ -45,12 +45,12 @@ import {
   Boxes,
 } from 'lucide-react'
 import {useState, useMemo} from 'react'
-import {cn} from '@/lib/utils'
-import {formatRelativeTime} from '@/lib/utils'
+import {cn, formatRelativeTime} from '@/lib/utils'
+import {parseDate} from '@/lib/date-format'
 
 function parseTimestamp(ts: string | undefined): number {
   if (!ts) return 0
-  const parsed = Date.parse(ts)
+  const parsed = parseDate(ts).getTime()
   return isNaN(parsed) ? 0 : parsed
 }
 

--- a/dashboard/src/components/monitoring/HostList.tsx
+++ b/dashboard/src/components/monitoring/HostList.tsx
@@ -28,6 +28,7 @@ import {
 } from 'lucide-react'
 import {useState, useMemo} from 'react'
 import {cn, formatRelativeTime} from '@/lib/utils'
+import {parseDate} from '@/lib/date-format'
 
 function formatBytes(kb: number): string {
   if (kb < 1024) return `${kb} KB`
@@ -87,7 +88,7 @@ export function HostList() {
         case 'memory':
           return ((a.memoryTotalKb || 0) - (b.memoryTotalKb || 0)) * dir
         case 'lastSeen':
-          return (new Date(a.lastSeenAt).getTime() - new Date(b.lastSeenAt).getTime()) * dir
+          return (parseDate(a.lastSeenAt).getTime() - parseDate(b.lastSeenAt).getTime()) * dir
         default:
           return 0
       }

--- a/dashboard/src/components/uptime/MonitorListItem.tsx
+++ b/dashboard/src/components/uptime/MonitorListItem.tsx
@@ -126,7 +126,7 @@ export default function MonitorListItem({monitor}: MonitorListItemProps) {
                   {monitor.url || monitor.hostname}
                 </a>
                 <span className="text-xs">•</span>
-                <span className="text-xs" title={formatDateTime(new Date(monitor.lastCheckAt || 0), timezone)}>
+                <span className="text-xs" title={formatDateTime(monitor.lastCheckAt || 0, timezone)}>
                   Checked {monitor.lastCheckAt ? formatRelativeTime(monitor.lastCheckAt) : 'never'}
                 </span>
               </div>
@@ -163,7 +163,7 @@ export default function MonitorListItem({monitor}: MonitorListItemProps) {
           <div className="flex items-center justify-between pt-1.5 border-t mt-1.5">
             <div className="text-xs text-muted-foreground">
               {heartbeats.length > 0 ? (
-                <span>Last heartbeat: {formatTime(new Date(heartbeats[heartbeats.length - 1].timestamp), timezone)}</span>
+                <span>Last heartbeat: {formatTime(heartbeats[heartbeats.length - 1].timestamp, timezone)}</span>
               ) : (
                 <span>No heartbeat data</span>
               )}

--- a/dashboard/src/components/uptime/MonitorListItem.tsx
+++ b/dashboard/src/components/uptime/MonitorListItem.tsx
@@ -63,6 +63,8 @@ export default function MonitorListItem({monitor}: MonitorListItemProps) {
     enabled: true,
   })
   const lastHeartbeat = heartbeats.at(-1)
+  const lastCheckAt = monitor.lastCheckAt
+  const hasLastCheckAt = lastCheckAt !== undefined && lastCheckAt !== null
 
   const deleteMutation = useMutation({
     mutationFn: (monitorId: string) => api.deleteUptimeMonitor(monitorId),
@@ -127,8 +129,11 @@ export default function MonitorListItem({monitor}: MonitorListItemProps) {
                   {monitor.url || monitor.hostname}
                 </a>
                 <span className="text-xs">•</span>
-                <span className="text-xs" title={formatDateTime(monitor.lastCheckAt || 0, timezone)}>
-                  Checked {monitor.lastCheckAt ? formatRelativeTime(monitor.lastCheckAt) : 'never'}
+                <span
+                  className="text-xs"
+                  title={hasLastCheckAt ? formatDateTime(lastCheckAt, timezone) : undefined}
+                >
+                  Checked {hasLastCheckAt ? formatRelativeTime(lastCheckAt) : 'never'}
                 </span>
               </div>
             </div>

--- a/dashboard/src/components/uptime/MonitorListItem.tsx
+++ b/dashboard/src/components/uptime/MonitorListItem.tsx
@@ -62,6 +62,7 @@ export default function MonitorListItem({monitor}: MonitorListItemProps) {
     // Only fetch if monitor is active/up/down (not paused ideally, but user might want to see history)
     enabled: true,
   })
+  const lastHeartbeat = heartbeats.at(-1)
 
   const deleteMutation = useMutation({
     mutationFn: (monitorId: string) => api.deleteUptimeMonitor(monitorId),
@@ -162,8 +163,8 @@ export default function MonitorListItem({monitor}: MonitorListItemProps) {
           {/* Actions Row */}
           <div className="flex items-center justify-between pt-1.5 border-t mt-1.5">
             <div className="text-xs text-muted-foreground">
-              {heartbeats.length > 0 ? (
-                <span>Last heartbeat: {formatTime(heartbeats[heartbeats.length - 1].timestamp, timezone)}</span>
+              {lastHeartbeat ? (
+                <span>Last heartbeat: {formatTime(lastHeartbeat.timestamp, timezone)}</span>
               ) : (
                 <span>No heartbeat data</span>
               )}

--- a/dashboard/src/lib/__tests__/date-format.test.ts
+++ b/dashboard/src/lib/__tests__/date-format.test.ts
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
+  parseDate,
   formatDateTime,
   formatDate,
   formatMonthDay,
@@ -32,6 +33,36 @@ const ISO = '2025-01-15T14:34:56.789Z'
 const DATE_OBJ = new Date(ISO)
 const EPOCH_MS = DATE_OBJ.getTime()
 const TZ = 'UTC'
+
+// ──── parseDate ────
+
+describe('parseDate', () => {
+  let originalDate: typeof Date
+
+  beforeEach(() => {
+    originalDate = global.Date
+  })
+
+  afterEach(() => {
+    global.Date = originalDate
+  })
+
+  it('handles ClickHouse DateTime64 format in strict mobile date parsers', () => {
+    global.Date = class extends originalDate {
+      constructor(value?: string | number | Date) {
+        if (value === undefined) {
+          super()
+        } else if (typeof value === 'string' && value.includes(' ')) {
+          super(Number.NaN)
+        } else {
+          super(value)
+        }
+      }
+    } as unknown as DateConstructor
+
+    expect(parseDate('2025-01-15 14:34:56.789').toISOString()).toBe(ISO)
+  })
+})
 
 // ──── formatDateTime ────
 

--- a/dashboard/src/lib/__tests__/utils.test.ts
+++ b/dashboard/src/lib/__tests__/utils.test.ts
@@ -102,6 +102,29 @@ describe('utils', () => {
       expect(formatRelativeTime(clickhouseFormat)).toBe('5m ago')
     })
 
+    it('handles ClickHouse DateTime64 format in strict mobile date parsers', () => {
+      global.Date = class extends originalDate {
+        constructor(value?: string | number | Date) {
+          if (value === undefined) {
+            super('2024-02-11T12:00:00Z')
+          } else if (typeof value === 'string' && value.includes(' UTC')) {
+            super(Number.NaN)
+          } else {
+            super(value)
+          }
+        }
+        static now() {
+          return new originalDate('2024-02-11T12:00:00Z').getTime()
+        }
+      } as unknown as DateConstructor
+
+      expect(formatRelativeTime('2024-02-11 11:55:00.000')).toBe('5m ago')
+    })
+
+    it('returns "unknown" for invalid date strings', () => {
+      expect(formatRelativeTime('not a date')).toBe('unknown')
+    })
+
     it('handles Unix timestamp (number)', () => {
       const timestamp = new Date('2024-02-11T11:55:00Z').getTime()
       expect(formatRelativeTime(timestamp)).toBe('5m ago')

--- a/dashboard/src/lib/__tests__/utils.test.ts
+++ b/dashboard/src/lib/__tests__/utils.test.ts
@@ -66,6 +66,10 @@ describe('utils', () => {
       expect(formatRelativeTime(undefined)).toBe('unknown')
     })
 
+    it('handles epoch zero as a valid timestamp', () => {
+      expect(formatRelativeTime(0, 'UTC')).toMatch(/Jan 1, 1970/)
+    })
+
     it('returns "just now" for < 60 seconds', () => {
       const thirtySecondsAgo = new Date('2024-02-11T11:59:30Z').getTime()
       expect(formatRelativeTime(thirtySecondsAgo)).toBe('just now')

--- a/dashboard/src/lib/date-format.ts
+++ b/dashboard/src/lib/date-format.ts
@@ -20,14 +20,15 @@
  * Use useTimezone() to obtain the current user's timezone preference.
  */
 
-function toDate(date: Date | string | number): Date {
+export function parseDate(date: Date | string | number): Date {
   if (date instanceof Date) return date
+  if (typeof date === 'string') return new Date(normalizeDateString(date))
   return new Date(date)
 }
 
 /** Full date + time: "Jan 15, 2:34:56 PM" */
 export function formatDateTime(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -41,7 +42,7 @@ export function formatDateTime(date: Date | string | number, timezone: string): 
 
 /** Date only: "Jan 15, 2025" */
 export function formatDate(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -53,7 +54,7 @@ export function formatDate(date: Date | string | number, timezone: string): stri
 
 /** Month + day only: "Jan 15" */
 export function formatMonthDay(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -64,7 +65,7 @@ export function formatMonthDay(date: Date | string | number, timezone: string): 
 
 /** Time only: "02:34:56" (24h) */
 export function formatTime(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -77,7 +78,7 @@ export function formatTime(date: Date | string | number, timezone: string): stri
 
 /** Hour + minute only: "02:34" (24h) */
 export function formatTimeHM(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -89,7 +90,7 @@ export function formatTimeHM(date: Date | string | number, timezone: string): st
 
 /** Hour + minute, 12h format: "2:34 PM" */
 export function formatTimeHM12(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -101,7 +102,7 @@ export function formatTimeHM12(date: Date | string | number, timezone: string): 
 
 /** Full date + time with milliseconds: "Jan 15, 02:34:56.789" */
 export function formatDateTimeWithMs(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   const base = new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -117,7 +118,7 @@ export function formatDateTimeWithMs(date: Date | string | number, timezone: str
 
 /** Time with milliseconds: "02:34:56.789" (24h) */
 export function formatTimeWithMs(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   const base = new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -132,7 +133,7 @@ export function formatTimeWithMs(date: Date | string | number, timezone: string)
 
 /** Full datetime with weekday and timezone name: "Mon, Jan 15, 2025, 02:34:56 EST" */
 export function formatDateTimeFull(date: Date | string | number, timezone: string): string {
-  const d = toDate(date)
+  const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
     timeZone: timezone,
@@ -150,4 +151,62 @@ export function formatDateTimeFull(date: Date | string | number, timezone: strin
 /** Returns the browser's current timezone identifier */
 export function browserTimezone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+function normalizeDateString(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.includes('T')) return trimmed
+
+  const separatorIndex = trimmed.indexOf(' ')
+  if (separatorIndex > 0) {
+    const datePart = trimmed.slice(0, separatorIndex)
+    const timePart = trimmed.slice(separatorIndex + 1)
+    if (isIsoDatePart(datePart) && isClockTimePart(timePart)) {
+      return `${datePart}T${timePart}Z`
+    }
+  }
+
+  return trimmed
+}
+
+function isIsoDatePart(value: string): boolean {
+  return value.length === 10 &&
+    isDigit(value[0]) &&
+    isDigit(value[1]) &&
+    isDigit(value[2]) &&
+    isDigit(value[3]) &&
+    value[4] === '-' &&
+    isDigit(value[5]) &&
+    isDigit(value[6]) &&
+    value[7] === '-' &&
+    isDigit(value[8]) &&
+    isDigit(value[9])
+}
+
+function isClockTimePart(value: string): boolean {
+  const timeAndFraction = value.split('.')
+  if (timeAndFraction.length > 2) return false
+
+  const timePart = timeAndFraction[0]
+  const fractionPart = timeAndFraction[1]
+  const hasValidTime = timePart.length === 8 &&
+    isDigit(timePart[0]) &&
+    isDigit(timePart[1]) &&
+    timePart[2] === ':' &&
+    isDigit(timePart[3]) &&
+    isDigit(timePart[4]) &&
+    timePart[5] === ':' &&
+    isDigit(timePart[6]) &&
+    isDigit(timePart[7])
+
+  if (!hasValidTime) return false
+  return fractionPart === undefined || isDigitString(fractionPart)
+}
+
+function isDigitString(value: string): boolean {
+  return value.length > 0 && Array.from(value).every(isDigit)
+}
+
+function isDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= '0' && value <= '9'
 }

--- a/dashboard/src/lib/date-format.ts
+++ b/dashboard/src/lib/date-format.ts
@@ -20,14 +20,16 @@
  * Use useTimezone() to obtain the current user's timezone preference.
  */
 
-export function parseDate(date: Date | string | number): Date {
+export type DateInput = Date | string | number
+
+export function parseDate(date: DateInput): Date {
   if (date instanceof Date) return date
   if (typeof date === 'string') return new Date(normalizeDateString(date))
   return new Date(date)
 }
 
 /** Full date + time: "Jan 15, 2:34:56 PM" */
-export function formatDateTime(date: Date | string | number, timezone: string): string {
+export function formatDateTime(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
@@ -41,7 +43,7 @@ export function formatDateTime(date: Date | string | number, timezone: string): 
 }
 
 /** Date only: "Jan 15, 2025" */
-export function formatDate(date: Date | string | number, timezone: string): string {
+export function formatDate(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
@@ -53,7 +55,7 @@ export function formatDate(date: Date | string | number, timezone: string): stri
 }
 
 /** Month + day only: "Jan 15" */
-export function formatMonthDay(date: Date | string | number, timezone: string): string {
+export function formatMonthDay(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
@@ -64,7 +66,7 @@ export function formatMonthDay(date: Date | string | number, timezone: string): 
 }
 
 /** Time only: "02:34:56" (24h) */
-export function formatTime(date: Date | string | number, timezone: string): string {
+export function formatTime(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
@@ -77,7 +79,7 @@ export function formatTime(date: Date | string | number, timezone: string): stri
 }
 
 /** Hour + minute only: "02:34" (24h) */
-export function formatTimeHM(date: Date | string | number, timezone: string): string {
+export function formatTimeHM(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
@@ -89,7 +91,7 @@ export function formatTimeHM(date: Date | string | number, timezone: string): st
 }
 
 /** Hour + minute, 12h format: "2:34 PM" */
-export function formatTimeHM12(date: Date | string | number, timezone: string): string {
+export function formatTimeHM12(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {
@@ -101,7 +103,7 @@ export function formatTimeHM12(date: Date | string | number, timezone: string): 
 }
 
 /** Full date + time with milliseconds: "Jan 15, 02:34:56.789" */
-export function formatDateTimeWithMs(date: Date | string | number, timezone: string): string {
+export function formatDateTimeWithMs(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   const base = new Intl.DateTimeFormat(undefined, {
@@ -117,7 +119,7 @@ export function formatDateTimeWithMs(date: Date | string | number, timezone: str
 }
 
 /** Time with milliseconds: "02:34:56.789" (24h) */
-export function formatTimeWithMs(date: Date | string | number, timezone: string): string {
+export function formatTimeWithMs(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   const base = new Intl.DateTimeFormat(undefined, {
@@ -132,7 +134,7 @@ export function formatTimeWithMs(date: Date | string | number, timezone: string)
 }
 
 /** Full datetime with weekday and timezone name: "Mon, Jan 15, 2025, 02:34:56 EST" */
-export function formatDateTimeFull(date: Date | string | number, timezone: string): string {
+export function formatDateTimeFull(date: DateInput, timezone: string): string {
   const d = parseDate(date)
   if (isNaN(d.getTime())) return String(date)
   return new Intl.DateTimeFormat(undefined, {

--- a/dashboard/src/lib/host-metrics-chart.ts
+++ b/dashboard/src/lib/host-metrics-chart.ts
@@ -56,7 +56,7 @@ export function formatHostMetricTooltipLabel(value: string | number | undefined,
 
   const timestamp = Number(value)
   if (Number.isNaN(timestamp)) return String(value)
-  return formatDateTime(new Date(timestamp), timezone)
+  return formatDateTime(timestamp, timezone)
 }
 
 export function compactHostMetricChartData<T extends HostMetricChartDatum>(

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -25,17 +25,10 @@ export function cn(...inputs: ClassValue[]) {
 
 export function formatRelativeTime(dateValue: string | number | undefined, timezone?: string): string {
   if (!dateValue) return 'unknown'
-  
-  // Handle ClickHouse DateTime format (YYYY-MM-DD HH:MM:SS) as UTC
-  let date: Date
-  if (typeof dateValue === 'number') {
-    date = new Date(dateValue)
-  } else if (dateValue.includes('T')) {
-    date = new Date(dateValue)
-  } else {
-    date = new Date(dateValue + ' UTC')
-  }
-  
+
+  const date = parseRelativeDate(dateValue)
+  if (!Number.isFinite(date.getTime())) return 'unknown'
+
   const now = getNowDate()
   const seconds = Math.floor((now.getTime() - date.getTime()) / 1000)
 
@@ -44,4 +37,67 @@ export function formatRelativeTime(dateValue: string | number | undefined, timez
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
   if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`
   return formatDate(date, timezone ?? browserTimezone())
+}
+
+function parseRelativeDate(dateValue: string | number): Date {
+  if (typeof dateValue === 'number') return new Date(dateValue)
+  return new Date(normalizeRelativeDateString(dateValue))
+}
+
+function normalizeRelativeDateString(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.includes('T')) return trimmed
+
+  const separatorIndex = trimmed.indexOf(' ')
+  if (separatorIndex > 0) {
+    const datePart = trimmed.slice(0, separatorIndex)
+    const timePart = trimmed.slice(separatorIndex + 1)
+    if (isIsoDatePart(datePart) && isClockTimePart(timePart)) {
+      return `${datePart}T${timePart}Z`
+    }
+  }
+
+  return `${trimmed} UTC`
+}
+
+function isIsoDatePart(value: string): boolean {
+  return value.length === 10 &&
+    isDigit(value[0]) &&
+    isDigit(value[1]) &&
+    isDigit(value[2]) &&
+    isDigit(value[3]) &&
+    value[4] === '-' &&
+    isDigit(value[5]) &&
+    isDigit(value[6]) &&
+    value[7] === '-' &&
+    isDigit(value[8]) &&
+    isDigit(value[9])
+}
+
+function isClockTimePart(value: string): boolean {
+  const timeAndFraction = value.split('.')
+  if (timeAndFraction.length > 2) return false
+
+  const timePart = timeAndFraction[0]
+  const fractionPart = timeAndFraction[1]
+  const hasValidTime = timePart.length === 8 &&
+    isDigit(timePart[0]) &&
+    isDigit(timePart[1]) &&
+    timePart[2] === ':' &&
+    isDigit(timePart[3]) &&
+    isDigit(timePart[4]) &&
+    timePart[5] === ':' &&
+    isDigit(timePart[6]) &&
+    isDigit(timePart[7])
+
+  if (!hasValidTime) return false
+  return fractionPart === undefined || isDigitString(fractionPart)
+}
+
+function isDigitString(value: string): boolean {
+  return value.length > 0 && Array.from(value).every(isDigit)
+}
+
+function isDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= '0' && value <= '9'
 }

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -17,7 +17,7 @@
 import {type ClassValue, clsx} from "clsx"
 import {twMerge} from "tailwind-merge"
 import {getNowDate} from './demo'
-import {browserTimezone, formatDate} from './date-format'
+import {browserTimezone, formatDate, parseDate} from './date-format'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -26,7 +26,7 @@ export function cn(...inputs: ClassValue[]) {
 export function formatRelativeTime(dateValue: string | number | undefined, timezone?: string): string {
   if (!dateValue) return 'unknown'
 
-  const date = parseRelativeDate(dateValue)
+  const date = parseDate(dateValue)
   if (!Number.isFinite(date.getTime())) return 'unknown'
 
   const now = getNowDate()
@@ -37,67 +37,4 @@ export function formatRelativeTime(dateValue: string | number | undefined, timez
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
   if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`
   return formatDate(date, timezone ?? browserTimezone())
-}
-
-function parseRelativeDate(dateValue: string | number): Date {
-  if (typeof dateValue === 'number') return new Date(dateValue)
-  return new Date(normalizeRelativeDateString(dateValue))
-}
-
-function normalizeRelativeDateString(value: string): string {
-  const trimmed = value.trim()
-  if (trimmed.includes('T')) return trimmed
-
-  const separatorIndex = trimmed.indexOf(' ')
-  if (separatorIndex > 0) {
-    const datePart = trimmed.slice(0, separatorIndex)
-    const timePart = trimmed.slice(separatorIndex + 1)
-    if (isIsoDatePart(datePart) && isClockTimePart(timePart)) {
-      return `${datePart}T${timePart}Z`
-    }
-  }
-
-  return `${trimmed} UTC`
-}
-
-function isIsoDatePart(value: string): boolean {
-  return value.length === 10 &&
-    isDigit(value[0]) &&
-    isDigit(value[1]) &&
-    isDigit(value[2]) &&
-    isDigit(value[3]) &&
-    value[4] === '-' &&
-    isDigit(value[5]) &&
-    isDigit(value[6]) &&
-    value[7] === '-' &&
-    isDigit(value[8]) &&
-    isDigit(value[9])
-}
-
-function isClockTimePart(value: string): boolean {
-  const timeAndFraction = value.split('.')
-  if (timeAndFraction.length > 2) return false
-
-  const timePart = timeAndFraction[0]
-  const fractionPart = timeAndFraction[1]
-  const hasValidTime = timePart.length === 8 &&
-    isDigit(timePart[0]) &&
-    isDigit(timePart[1]) &&
-    timePart[2] === ':' &&
-    isDigit(timePart[3]) &&
-    isDigit(timePart[4]) &&
-    timePart[5] === ':' &&
-    isDigit(timePart[6]) &&
-    isDigit(timePart[7])
-
-  if (!hasValidTime) return false
-  return fractionPart === undefined || isDigitString(fractionPart)
-}
-
-function isDigitString(value: string): boolean {
-  return value.length > 0 && Array.from(value).every(isDigit)
-}
-
-function isDigit(value: string | undefined): boolean {
-  return value !== undefined && value >= '0' && value <= '9'
 }

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -24,7 +24,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatRelativeTime(dateValue: string | number | undefined, timezone?: string): string {
-  if (!dateValue) return 'unknown'
+  if (dateValue === undefined || dateValue === '') return 'unknown'
 
   const date = parseDate(dateValue)
   if (!Number.isFinite(date.getTime())) return 'unknown'

--- a/dashboard/src/routes/admin.billing.tsx
+++ b/dashboard/src/routes/admin.billing.tsx
@@ -2077,8 +2077,8 @@ function AdminBillingPage() {
                       <TableCell className="text-xs text-muted-foreground">
                         {sub.currentPeriodStart && sub.currentPeriodEnd ? (
                           <>
-                            {formatDate(new Date(sub.currentPeriodStart), timezone)} &ndash;{' '}
-                            {formatDate(new Date(sub.currentPeriodEnd), timezone)}
+                            {formatDate(sub.currentPeriodStart, timezone)} &ndash;{' '}
+                            {formatDate(sub.currentPeriodEnd, timezone)}
                           </>
                         ) : (
                           '—'

--- a/dashboard/src/routes/admin.telemetry.tsx
+++ b/dashboard/src/routes/admin.telemetry.tsx
@@ -86,7 +86,7 @@ function AdminTelemetryPage() {
               </div>
               <div>
                 <p className="text-sm font-medium">
-                  {lastSeenAt ? formatDateTime(new Date(lastSeenAt), timezone) : '—'}
+                  {lastSeenAt ? formatDateTime(lastSeenAt, timezone) : '—'}
                 </p>
                 <p className="text-sm text-muted-foreground">Last pulse received</p>
               </div>
@@ -185,7 +185,7 @@ function AdminTelemetryPage() {
                       {formatNumber(d.issueCount)}
                     </TableCell>
                     <TableCell className="text-xs text-right text-muted-foreground whitespace-nowrap">
-                      {formatDateTime(new Date(d.receivedAt), timezone)}
+                      {formatDateTime(d.receivedAt, timezone)}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/dashboard/src/routes/ai.generations.tsx
+++ b/dashboard/src/routes/ai.generations.tsx
@@ -245,7 +245,7 @@ function GenerationsPage() {
                         onClick={() => setSelectedGenId(gen.generationId)}
                       >
                         <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
-                          {formatDateTime(new Date(gen.timestamp), timezone)}
+                          {formatDateTime(gen.timestamp, timezone)}
                         </TableCell>
                         <TableCell className="font-medium text-sm max-w-48 truncate">
                           {gen.name || '-'}

--- a/dashboard/src/routes/ai.traces.$traceId.tsx
+++ b/dashboard/src/routes/ai.traces.$traceId.tsx
@@ -25,6 +25,7 @@ import { SectionCard } from '@/components/ui/section-card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Brain, Clock, Coins, Hash, AlertTriangle } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import {parseDate} from '@/lib/date-format'
 
 export const Route = createFileRoute('/ai/traces/$traceId')({
   component: TraceDetailPage,
@@ -58,6 +59,10 @@ function typeColor(type: string): string {
 
 type GenerationNode = LlmGenerationDetail & { children: GenerationNode[] }
 
+function generationTimestampMs(generation: LlmGenerationDetail): number {
+  return parseDate(generation.timestamp).getTime()
+}
+
 function buildTree(generations: LlmGenerationDetail[]): GenerationNode[] {
   const nodes = generations.map((gen) => ({ ...gen, children: [] as GenerationNode[] }))
   const spanIndex = new Map<string, GenerationNode[]>()
@@ -74,7 +79,7 @@ function buildTree(generations: LlmGenerationDetail[]): GenerationNode[] {
   }
 
   for (const bucket of spanIndex.values()) {
-    bucket.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+    bucket.sort((a, b) => generationTimestampMs(a) - generationTimestampMs(b))
   }
 
   for (const node of nodes) {
@@ -87,7 +92,7 @@ function buildTree(generations: LlmGenerationDetail[]): GenerationNode[] {
   }
 
   const sortNodes = (items: GenerationNode[]) => {
-    items.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+    items.sort((a, b) => generationTimestampMs(a) - generationTimestampMs(b))
     for (const item of items) sortNodes(item.children)
   }
   sortNodes(roots)
@@ -97,13 +102,13 @@ function buildTree(generations: LlmGenerationDetail[]): GenerationNode[] {
 function findParentBySpanId(candidates: GenerationNode[] | undefined, child: GenerationNode): GenerationNode | undefined {
   if (!candidates || candidates.length === 0) return undefined
 
-  const childTs = new Date(child.timestamp).getTime()
+  const childTs = generationTimestampMs(child)
   let fallback: GenerationNode | undefined
 
   for (const candidate of candidates) {
     if (candidate.generationId === child.generationId) continue
     fallback = candidate
-    if (new Date(candidate.timestamp).getTime() > childTs) {
+    if (generationTimestampMs(candidate) > childTs) {
       break
     }
   }
@@ -135,8 +140,8 @@ function TraceDetailPage() {
   const tree = buildTree(trace.generations)
 
   // Calculate waterfall timings
-  const minTs = Math.min(...trace.generations.map(g => new Date(g.timestamp).getTime() - g.durationMs))
-  const maxTs = Math.max(...trace.generations.map(g => new Date(g.timestamp).getTime()))
+  const minTs = Math.min(...trace.generations.map(g => generationTimestampMs(g) - g.durationMs))
+  const maxTs = Math.max(...trace.generations.map(g => generationTimestampMs(g)))
   const totalSpan = maxTs - minTs || 1
 
   return (
@@ -217,7 +222,7 @@ function renderNodes(
   setSelectedGen: (gen: LlmGenerationDetail) => void
 ): React.ReactNode[] {
   return nodes.flatMap(node => {
-    const startMs = new Date(node.timestamp).getTime() - node.durationMs
+    const startMs = generationTimestampMs(node) - node.durationMs
     const leftPct = ((startMs - minTs) / totalSpan) * 100
     const widthPct = Math.max((node.durationMs / totalSpan) * 100, 0.5)
     const isSelected = selectedGen?.generationId === node.generationId

--- a/dashboard/src/routes/issues.$issueId.tsx
+++ b/dashboard/src/routes/issues.$issueId.tsx
@@ -372,14 +372,14 @@ function IssueDetailPage() {
             value={formatRelativeTime(issue.firstSeen)}
             icon={Clock3}
             tone="neutral"
-            subtitle={formatDateTime(new Date(issue.firstSeen), timezone)}
+            subtitle={formatDateTime(issue.firstSeen, timezone)}
           />
           <StatCard
             label="Last seen"
             value={formatRelativeTime(issue.lastSeen)}
             icon={Clock3}
             tone="neutral"
-            subtitle={formatDateTime(new Date(issue.lastSeen), timezone)}
+            subtitle={formatDateTime(issue.lastSeen, timezone)}
           />
         </div>
 
@@ -460,7 +460,7 @@ function IssueDetailPage() {
                     </div>
                     <div className="flex justify-between gap-2">
                       <span className="text-muted-foreground flex-shrink-0">Timestamp</span>
-                      <span className="text-xs">{formatDateTime(new Date(latestEvent.timestamp), timezone)}</span>
+                      <span className="text-xs">{formatDateTime(latestEvent.timestamp, timezone)}</span>
                     </div>
                     {latestEvent.environment && (
                       <div className="flex justify-between gap-2">
@@ -1150,7 +1150,7 @@ function BreadcrumbsViewer({ breadcrumbs }: { breadcrumbs: string }) {
                   {getBreadcrumbIcon(category, crumb.data)}
                 </div>
                 <span className="text-muted-foreground font-mono text-xs">
-                  {timestamp ? formatTime(new Date(timestamp), timezone) : '--:--:--'}
+                  {timestamp ? formatTime(timestamp, timezone) : '--:--:--'}
                 </span>
                 <Badge className={`text-[10px] leading-tight px-1.5 py-0 border-0 ${colors.badge}`}>
                   {category}

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -51,12 +51,13 @@ import {
 import {useEffect, useMemo, useState} from 'react'
 import {useToast} from '@/hooks/useToast'
 import {getNow} from '@/lib/demo'
+import {parseDate} from '@/lib/date-format'
 // Level → Badge variant and left-border indicator come from the shared severity
 // helper (@/lib/severity) so every surface uses the same status language.
 
 // Get freshness color based on how recently the last event occurred
 function getLastSeenColor(lastSeen: string): string {
-  const diff = getNow() - new Date(lastSeen).getTime()
+  const diff = getNow() - parseDate(lastSeen).getTime()
   const hours = diff / (1000 * 60 * 60)
   if (hours < 1) return 'text-danger-fg'
   if (hours < 24) return 'text-warning-fg'
@@ -65,7 +66,7 @@ function getLastSeenColor(lastSeen: string): string {
 
 // Check if an issue is new (first seen within last 24 hours)
 function isNewIssue(firstSeen: string): boolean {
-  const diff = getNow() - new Date(firstSeen).getTime()
+  const diff = getNow() - parseDate(firstSeen).getTime()
   return diff < 24 * 60 * 60 * 1000
 }
 

--- a/dashboard/src/routes/monitoring.index.tsx
+++ b/dashboard/src/routes/monitoring.index.tsx
@@ -18,6 +18,7 @@ import {createFileRoute, Link, redirect, useNavigate} from '@tanstack/react-rout
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api, type DdHostResponse} from '@/lib/api'
 import {cn, formatRelativeTime} from '@/lib/utils'
+import {parseDate} from '@/lib/date-format'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
@@ -977,7 +978,7 @@ function MonitoringHostsPage() {
         case 'memory':
           return ((a.memoryTotalKb || 0) - (b.memoryTotalKb || 0)) * dir
         case 'lastSeen':
-          return (new Date(a.lastSeenAt).getTime() - new Date(b.lastSeenAt).getTime()) * dir
+          return (parseDate(a.lastSeenAt).getTime() - parseDate(b.lastSeenAt).getTime()) * dir
         default:
           return 0
       }

--- a/dashboard/src/routes/releases.tsx
+++ b/dashboard/src/routes/releases.tsx
@@ -35,6 +35,7 @@ import {
   serviceScopeKey,
 } from '@/lib/service-facet-scope'
 import type {FacetFilter} from '@/lib/filters/types'
+import {parseDate} from '@/lib/date-format'
 
 export const Route = createFileRoute('/releases')({
   beforeLoad: async ({ location }) => {
@@ -140,7 +141,7 @@ function ReleasesPage() {
 
     const mostActive = [...releaseList].sort((a, b) => b.eventCount - a.eventCount)[0]
     const latest = [...releaseList].sort(
-      (a, b) => new Date(b.lastSeen).getTime() - new Date(a.lastSeen).getTime()
+      (a, b) => parseDate(b.lastSeen).getTime() - parseDate(a.lastSeen).getTime()
     )[0]
 
     return {
@@ -166,13 +167,13 @@ function ReleasesPage() {
         return bRate - aRate
       }
 
-      return new Date(b.lastSeen).getTime() - new Date(a.lastSeen).getTime()
+      return parseDate(b.lastSeen).getTime() - parseDate(a.lastSeen).getTime()
     })
   }, [releaseList, searchQuery, sortBy])
 
   const formatDate = (isoString: string) => {
     if (!isoString) return 'N/A'
-    const date = new Date(isoString)
+    const date = parseDate(isoString)
     if (isNaN(date.getTime())) return 'Invalid Date'
     return date.toLocaleDateString('en-US', {
       month: 'short',

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -20,7 +20,7 @@ import {useCallback, useMemo, useRef, useState} from 'react'
 import {api} from '@/lib/api'
 import {formatRelativeTime} from '@/lib/utils'
 import {useTimezone} from '@/hooks/useTimezone'
-import {formatDateTime as formatDateTimeUtil} from '@/lib/date-format'
+import {formatDateTime as formatDateTimeUtil, parseDate} from '@/lib/date-format'
 import {ReplayPlayer, type ReplayPlayerHandle} from '@/components/ReplayPlayer'
 import {MobileReplayViewer, type MobileReplayViewerHandle, type ReplayStatusBarContext} from '@/components/MobileReplayViewer'
 import {ReplayTimelinePanel} from '@/components/ReplayTimelinePanel'
@@ -62,7 +62,7 @@ function formatDuration(ms: number) {
 
 function formatDate(isoString: string, timezone: string) {
   if (!isoString) return 'N/A'
-  const date = new Date(isoString)
+  const date = parseDate(isoString)
   if (isNaN(date.getTime())) return 'Invalid Date'
   return formatDateTimeUtil(date, timezone)
 }
@@ -498,7 +498,7 @@ function ReplayDetailPage() {
 
       let normalizedOffset = Math.max(0, rawOffset)
       if (mobileCompressedTimeMapper) {
-        const absoluteMs = Date.parse(item.timestamp)
+        const absoluteMs = parseDate(item.timestamp).getTime()
         if (Number.isFinite(absoluteMs)) {
           normalizedOffset = mobileCompressedTimeMapper(absoluteMs)
         }

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -19,7 +19,7 @@ import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {formatRelativeTime} from '@/lib/utils'
 import {useTimezone} from '@/hooks/useTimezone'
-import {formatDate as formatDateUtil} from '@/lib/date-format'
+import {formatDate as formatDateUtil, parseDate} from '@/lib/date-format'
 import {useMemo, useState} from 'react'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {Badge} from '@/components/ui/badge'
@@ -85,7 +85,7 @@ function formatDuration(ms: number) {
 
 function formatDate(isoString: string, timezone: string) {
   if (!isoString) return 'N/A'
-  const date = new Date(isoString)
+  const date = parseDate(isoString)
   if (isNaN(date.getTime())) return 'Invalid Date'
   return formatDateUtil(date, timezone)
 }

--- a/dashboard/src/routes/s.$slug.tsx
+++ b/dashboard/src/routes/s.$slug.tsx
@@ -27,7 +27,13 @@ import {
     Loader2,
 } from 'lucide-react'
 import {Helmet} from 'react-helmet-async'
-import {browserTimezone, formatDateTime as formatDateTimeFn, formatMonthDay, formatTimeHM12} from '@/lib/date-format'
+import {
+  browserTimezone,
+  formatDateTime as formatDateTimeFn,
+  formatMonthDay,
+  formatTimeHM12,
+  parseDate,
+} from '@/lib/date-format'
 import {StatusBanner, StatusPageMonitorRow} from '@/components/StatusPagePreview'
 
 export const Route = createFileRoute('/s/$slug')({
@@ -219,7 +225,7 @@ function IncidentCard({
   isDarkMode: boolean
 }) {
   const sortedUpdates = [...incident.updates].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    (a, b) => parseDate(b.createdAt).getTime() - parseDate(a.createdAt).getTime()
   )
 
   return (
@@ -238,7 +244,7 @@ function IncidentCard({
             </div>
           </div>
           <span className={`text-[11px] flex-shrink-0 ${isDarkMode ? 'text-slate-500' : 'text-slate-400'}`}>
-            {formatMonthDay(new Date(incident.createdAt), browserTimezone())}
+            {formatMonthDay(incident.createdAt, browserTimezone())}
           </span>
         </div>
       </div>
@@ -255,7 +261,7 @@ function IncidentCard({
                 )}
                 <p className={`text-sm leading-relaxed ${isDarkMode ? 'text-slate-300' : 'text-slate-700'}`}>{update.message}</p>
                 <p className={`text-[11px] mt-1 ${isDarkMode ? 'text-slate-600' : 'text-slate-400'}`}>
-                  {formatDateTimeFn(new Date(update.createdAt), browserTimezone())}
+                  {formatDateTimeFn(update.createdAt, browserTimezone())}
                 </p>
               </div>
             ))}

--- a/dashboard/src/routes/status-pages.$pageId.tsx
+++ b/dashboard/src/routes/status-pages.$pageId.tsx
@@ -1167,7 +1167,7 @@ function IncidentCard({incident}: {incident: StatusPageIncident}) {
                 </Badge>
                 <span className="text-xs text-muted-foreground flex items-center gap-1">
                   <Clock className="h-3 w-3" />
-                  {formatDateTime(new Date(incident.createdAt), timezone)}
+                  {formatDateTime(incident.createdAt, timezone)}
                 </span>
               </div>
             </div>
@@ -1183,7 +1183,7 @@ function IncidentCard({incident}: {incident: StatusPageIncident}) {
                 <p className="text-sm text-foreground/90">{update.message}</p>
                 <p className="text-xs text-muted-foreground mt-1 flex items-center gap-1">
                   <Clock className="h-2.5 w-2.5" />
-                  {formatDateTime(new Date(update.createdAt), timezone)}
+                  {formatDateTime(update.createdAt, timezone)}
                 </p>
               </div>
             ))}

--- a/dashboard/src/routes/status-pages.index.tsx
+++ b/dashboard/src/routes/status-pages.index.tsx
@@ -259,7 +259,7 @@ function StatusPagesListPage() {
 
                   {/* Meta info */}
                   <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                    <span>Created {formatDate(new Date(page.createdAt), timezone)}</span>
+                    <span>Created {formatDate(page.createdAt, timezone)}</span>
                   </div>
                 </CardContent>
 

--- a/dashboard/src/routes/uptime.$monitorId.tsx
+++ b/dashboard/src/routes/uptime.$monitorId.tsx
@@ -123,7 +123,7 @@ function UptimeDetailPage() {
   const chartData = heartbeats
     .filter((h) => h.responseTimeMs >= 0)
     .map((h) => ({
-      timestamp: formatTimeHM(new Date(h.timestamp), timezone),
+      timestamp: formatTimeHM(h.timestamp, timezone),
       responseTime: h.responseTimeMs,
     }))
     .reverse()


### PR DESCRIPTION
Fixes process Last Seen rendering for ClickHouse timestamp strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized and improved date parsing across the dashboard for consistent timestamp interpretation; many components now accept raw timestamp inputs directly.
  * Epoch zero (0) is treated as a valid timestamp and invalid/missing dates render as "unknown".
  * Components gracefully handle invalid timestamps (e.g., avoid queries or show empty/invalid state).

* **Tests**
  * Added tests covering millisecond timestamps, ClickHouse-style date strings, epoch 0, and invalid-date edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->