### PR TITLE
fix: avoid private method test access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,15 @@ To avoid Sonar/ESLint code smells in `dashboard/`:
 
 ## Key Conventions
 
+### Testing Guidelines
+
+- ❌ **Do not call production private methods from new or touched tests** — avoid reflection helpers like
+  `getDeclaredMethod`, `declaredFunctions`, `isAccessible = true`, or equivalent access hacks for behavior coverage.
+- ✅ **Test observable behavior through public APIs, routes, or service methods** whenever practical.
+- ✅ **Extract complex private logic into a small collaborator** with an explicit `internal` or public API when direct
+  unit coverage is warranted.
+- ✅ **Test-local private helper methods are fine** — the rule is about reaching into production internals.
+
 ### Warnings and lint fixes (suppress rarely)
 
 **CRITICAL:** When asked to fix a compiler warning, linter finding, or static analysis issue (Detekt, ESLint, Sonar, Kotlin compiler, etc.):

--- a/backend/src/main/kotlin/com/moneat/uptime/services/SslCertificateEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/SslCertificateEvaluator.kt
@@ -20,6 +20,7 @@ import com.moneat.uptime.models.CheckResult
 import java.security.cert.X509Certificate
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSocket
 
 internal class SslCertificateEvaluator {
@@ -28,7 +29,11 @@ internal class SslCertificateEvaluator {
         responseTime: Int,
         warnDays: Long,
     ): CheckResult {
-        val cert = socket.session.peerCertificates.firstOrNull() as? X509Certificate
+        val cert = try {
+            socket.session.peerCertificates.firstOrNull() as? X509Certificate
+        } catch (_: SSLPeerUnverifiedException) {
+            null
+        }
             ?: return CheckResult(0, responseTime, 0, "No SSL certificate found")
         return evaluateCertificate(cert, responseTime, warnDays)
     }
@@ -40,12 +45,14 @@ internal class SslCertificateEvaluator {
     ): CheckResult {
         val expiryDate = cert.notAfter.toInstant()
         val now = Instant.now()
+        if (!expiryDate.isAfter(now)) {
+            val daysExpired = ChronoUnit.DAYS.between(expiryDate, now).coerceAtLeast(1)
+            return CheckResult(0, responseTime, 0, "SSL certificate expired $daysExpired days ago")
+        }
+
         val daysUntilExpiry = ChronoUnit.DAYS.between(now, expiryDate)
 
         return when {
-            daysUntilExpiry < 0 ->
-                CheckResult(0, responseTime, 0, "SSL certificate expired ${-daysUntilExpiry} days ago")
-
             daysUntilExpiry < warnDays ->
                 CheckResult(
                     0,

--- a/backend/src/main/kotlin/com/moneat/uptime/services/SslCertificateEvaluator.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/SslCertificateEvaluator.kt
@@ -1,0 +1,61 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.uptime.services
+
+import com.moneat.uptime.models.CheckResult
+import java.security.cert.X509Certificate
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import javax.net.ssl.SSLSocket
+
+internal class SslCertificateEvaluator {
+    fun evaluateSocket(
+        socket: SSLSocket,
+        responseTime: Int,
+        warnDays: Long,
+    ): CheckResult {
+        val cert = socket.session.peerCertificates.firstOrNull() as? X509Certificate
+            ?: return CheckResult(0, responseTime, 0, "No SSL certificate found")
+        return evaluateCertificate(cert, responseTime, warnDays)
+    }
+
+    fun evaluateCertificate(
+        cert: X509Certificate,
+        responseTime: Int,
+        warnDays: Long,
+    ): CheckResult {
+        val expiryDate = cert.notAfter.toInstant()
+        val now = Instant.now()
+        val daysUntilExpiry = ChronoUnit.DAYS.between(now, expiryDate)
+
+        return when {
+            daysUntilExpiry < 0 ->
+                CheckResult(0, responseTime, 0, "SSL certificate expired ${-daysUntilExpiry} days ago")
+
+            daysUntilExpiry < warnDays ->
+                CheckResult(
+                    0,
+                    responseTime,
+                    0,
+                    "SSL certificate expires in $daysUntilExpiry days (warning threshold: $warnDays)"
+                )
+
+            else ->
+                CheckResult(1, responseTime, 0, "SSL certificate valid (expires in $daysUntilExpiry days)")
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeCheckExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeCheckExecutor.kt
@@ -40,10 +40,7 @@ import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
-import java.security.cert.X509Certificate
 import java.sql.DriverManager
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 import javax.naming.NamingException
 import javax.naming.directory.InitialDirContext
 import javax.net.ssl.SSLSocket
@@ -84,6 +81,8 @@ class UptimeCheckExecutor {
                 requestTimeout = 60_000
             }
         }
+
+    private val sslCertificateEvaluator = SslCertificateEvaluator()
 
     /**
      * Execute a check for the given monitor.
@@ -560,7 +559,7 @@ class UptimeCheckExecutor {
                 socket.soTimeout = timeoutMillis
                 socket.startHandshake()
                 val responseTime = (System.currentTimeMillis() - startTime).toInt()
-                sslCertificateResult(socket, responseTime, monitor.sslExpiryWarnDays.toLong())
+                sslCertificateEvaluator.evaluateSocket(socket, responseTime, monitor.sslExpiryWarnDays.toLong())
             }
         } catch (e: IOException) {
             val responseTime = (System.currentTimeMillis() - startTime).toInt()
@@ -586,42 +585,6 @@ class UptimeCheckExecutor {
         } catch (e: RuntimeException) {
             rawSocket.close()
             throw e
-        }
-    }
-
-    private fun sslCertificateResult(
-        socket: SSLSocket,
-        responseTime: Int,
-        warnDays: Long,
-    ): CheckResult {
-        val cert = socket.session.peerCertificates.firstOrNull() as? X509Certificate
-            ?: return CheckResult(0, responseTime, 0, "No SSL certificate found")
-        return sslExpiryResult(cert, responseTime, warnDays)
-    }
-
-    private fun sslExpiryResult(
-        cert: X509Certificate,
-        responseTime: Int,
-        warnDays: Long,
-    ): CheckResult {
-        val expiryDate = cert.notAfter.toInstant()
-        val now = Instant.now()
-        val daysUntilExpiry = ChronoUnit.DAYS.between(now, expiryDate)
-
-        return when {
-            daysUntilExpiry < 0 ->
-                CheckResult(0, responseTime, 0, "SSL certificate expired ${-daysUntilExpiry} days ago")
-
-            daysUntilExpiry < warnDays ->
-                CheckResult(
-                    0,
-                    responseTime,
-                    0,
-                    "SSL certificate expires in $daysUntilExpiry days (warning threshold: $warnDays)"
-                )
-
-            else ->
-                CheckResult(1, responseTime, 0, "SSL certificate valid (expires in $daysUntilExpiry days)")
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/UptimeCheckExecutorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/UptimeCheckExecutorTest.kt
@@ -16,30 +16,26 @@
 
 package com.moneat.services
 
-import com.moneat.uptime.models.CheckResult
 import com.moneat.uptime.models.UptimeMonitorData
+import com.moneat.uptime.services.SslCertificateEvaluator
 import com.moneat.uptime.services.UptimeCheckExecutor
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import java.lang.reflect.InvocationTargetException
-import java.net.InetAddress
-import java.net.ServerSocket
 import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.Date
 import java.util.UUID
 import javax.net.ssl.SSLSession
 import javax.net.ssl.SSLSocket
-import kotlin.concurrent.thread
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 
 class UptimeCheckExecutorTest {
     private val executor = UptimeCheckExecutor()
+    private val sslCertificateEvaluator = SslCertificateEvaluator()
 
     private fun monitor(
         type: String,
@@ -186,16 +182,28 @@ class UptimeCheckExecutorTest {
         }
 
     @Test
-    fun `ssl expiry result reports valid warning and expired certificates`() {
-        val valid = invokeSslExpiryResult(certificateExpiringInDays(90), warnDays = 30)
+    fun `ssl certificate evaluator reports valid warning and expired certificates`() {
+        val valid = sslCertificateEvaluator.evaluateCertificate(
+            certificateExpiringInDays(90),
+            responseTime = 25,
+            warnDays = 30,
+        )
         assertEquals(1, valid.status)
         assertTrue(valid.message.contains("valid"), valid.message)
 
-        val warning = invokeSslExpiryResult(certificateExpiringInDays(3), warnDays = 30)
+        val warning = sslCertificateEvaluator.evaluateCertificate(
+            certificateExpiringInDays(3),
+            responseTime = 25,
+            warnDays = 30,
+        )
         assertEquals(0, warning.status)
         assertTrue(warning.message.contains("warning threshold"), warning.message)
 
-        val expired = invokeSslExpiryResult(certificateExpiringInDays(-2), warnDays = 30)
+        val expired = sslCertificateEvaluator.evaluateCertificate(
+            certificateExpiringInDays(-2),
+            responseTime = 25,
+            warnDays = 30,
+        )
         assertEquals(0, expired.status)
         assertTrue(expired.message.contains("expired"), expired.message)
     }
@@ -207,7 +215,7 @@ class UptimeCheckExecutorTest {
         every { socket.session } returns session
         every { session.peerCertificates } returns emptyArray()
 
-        val result = invokeSslCertificateResult(socket, warnDays = 30)
+        val result = sslCertificateEvaluator.evaluateSocket(socket, responseTime = 25, warnDays = 30)
 
         assertEquals(0, result.status)
         assertTrue(result.message.contains("No SSL certificate"), result.message)
@@ -220,103 +228,26 @@ class UptimeCheckExecutorTest {
         every { socket.session } returns session
         every { session.peerCertificates } returns arrayOf(certificateExpiringInDays(90))
 
-        val result = invokeSslCertificateResult(socket, warnDays = 30)
+        val result = sslCertificateEvaluator.evaluateSocket(socket, responseTime = 25, warnDays = 30)
 
         assertEquals(1, result.status)
         assertTrue(result.message.contains("valid"), result.message)
     }
 
     @Test
-    fun `connectSslSocket pins the vetted address`() {
-        ServerSocket(0).use { server ->
-            val accepted = thread(start = true) {
-                server.accept().use { socket ->
-                    socket.getInputStream().read()
-                }
+    fun `executeCheck reports SSL connection failure when host is allowed`() =
+        runBlocking {
+            withSelfHosted("true") {
+                val result = executor.executeCheck(monitor(type = "ssl", hostname = "127.0.0.1", port = 1))
+                assertEquals(0, result.status)
+                assertTrue(result.message.contains("SSL check failed"), result.message)
             }
-
-            val socket = invokeConnectSslSocket(
-                hostname = "localhost",
-                port = server.localPort,
-                address = InetAddress.getByName("127.0.0.1"),
-            )
-            socket.close()
-            accepted.join(1000)
         }
-    }
-
-    @Test
-    fun `connectSslSocket closes raw socket when connect fails`() {
-        assertFailsWith<java.net.ConnectException> {
-            invokeConnectSslSocket(
-                hostname = "localhost",
-                port = 1,
-                address = InetAddress.getByName("127.0.0.1"),
-            )
-        }
-    }
 
     private fun certificateExpiringInDays(days: Long): X509Certificate {
         val cert = mockk<X509Certificate>()
         every { cert.notAfter } returns Date.from(java.time.Instant.now().plus(Duration.ofDays(days)))
         return cert
-    }
-
-    private fun invokeSslExpiryResult(
-        cert: X509Certificate,
-        warnDays: Long,
-    ): CheckResult =
-        invokePrivate(
-            "sslExpiryResult",
-            arrayOf(X509Certificate::class.java, Int::class.javaPrimitiveType!!, Long::class.javaPrimitiveType!!),
-            cert,
-            25,
-            warnDays,
-        ) as CheckResult
-
-    private fun invokeSslCertificateResult(
-        socket: SSLSocket,
-        warnDays: Long,
-    ): CheckResult =
-        invokePrivate(
-            "sslCertificateResult",
-            arrayOf(SSLSocket::class.java, Int::class.javaPrimitiveType!!, Long::class.javaPrimitiveType!!),
-            socket,
-            25,
-            warnDays,
-        ) as CheckResult
-
-    private fun invokeConnectSslSocket(
-        hostname: String,
-        port: Int,
-        address: InetAddress,
-    ): SSLSocket =
-        invokePrivate(
-            "connectSslSocket",
-            arrayOf(
-                String::class.java,
-                Int::class.javaPrimitiveType!!,
-                InetAddress::class.java,
-                Int::class.javaPrimitiveType!!,
-            ),
-            hostname,
-            port,
-            address,
-            1000,
-        ) as SSLSocket
-
-    private fun invokePrivate(
-        name: String,
-        parameterTypes: Array<Class<*>>,
-        vararg args: Any,
-    ): Any {
-        val method = UptimeCheckExecutor::class.java.getDeclaredMethod(name, *parameterTypes)
-        method.isAccessible = true
-        return try {
-            method.invoke(executor, *args)
-        } catch (e: InvocationTargetException) {
-            throw e.targetException
-        }
     }
 
     private suspend fun <T> withSelfHosted(value: String, block: suspend () -> T): T {

--- a/backend/src/test/kotlin/com/moneat/services/UptimeCheckExecutorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/UptimeCheckExecutorTest.kt
@@ -26,6 +26,7 @@ import java.security.cert.X509Certificate
 import java.time.Duration
 import java.util.Date
 import java.util.UUID
+import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
 import javax.net.ssl.SSLSocket
 import kotlin.test.Test
@@ -222,6 +223,19 @@ class UptimeCheckExecutorTest {
     }
 
     @Test
+    fun `ssl certificate result handles unverified peer certificate`() {
+        val socket = mockk<SSLSocket>()
+        val session = mockk<SSLSession>()
+        every { socket.session } returns session
+        every { session.peerCertificates } throws SSLPeerUnverifiedException("unverified")
+
+        val result = sslCertificateEvaluator.evaluateSocket(socket, responseTime = 25, warnDays = 30)
+
+        assertEquals(0, result.status)
+        assertTrue(result.message.contains("No SSL certificate"), result.message)
+    }
+
+    @Test
     fun `ssl certificate result evaluates peer certificate`() {
         val socket = mockk<SSLSocket>()
         val session = mockk<SSLSession>()
@@ -235,6 +249,18 @@ class UptimeCheckExecutorTest {
     }
 
     @Test
+    fun `ssl certificate evaluator reports recently expired certificate as expired`() {
+        val result = sslCertificateEvaluator.evaluateCertificate(
+            certificateExpiringIn(Duration.ofHours(-1)),
+            responseTime = 25,
+            warnDays = 30,
+        )
+
+        assertEquals(0, result.status)
+        assertTrue(result.message.contains("expired"), result.message)
+    }
+
+    @Test
     fun `executeCheck reports SSL connection failure when host is allowed`() =
         runBlocking {
             withSelfHosted("true") {
@@ -245,8 +271,12 @@ class UptimeCheckExecutorTest {
         }
 
     private fun certificateExpiringInDays(days: Long): X509Certificate {
+        return certificateExpiringIn(Duration.ofDays(days))
+    }
+
+    private fun certificateExpiringIn(duration: Duration): X509Certificate {
         val cert = mockk<X509Certificate>()
-        every { cert.notAfter } returns Date.from(java.time.Instant.now().plus(Duration.ofDays(days)))
+        every { cert.notAfter } returns Date.from(java.time.Instant.now().plus(duration))
         return cert
     }
 


### PR DESCRIPTION
## Summary
- moves SSL certificate evaluation behind an explicit helper
- updates test guidance

## Validation
- backend detekt
- UptimeCheckExecutorTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSL certificate monitoring now evaluates certificate validity and expiry status with configurable warning thresholds during uptime checks.

* **Chores**
  * Refactored internal certificate evaluation logic and improved test coverage with enhanced testing guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->