### PR TITLE
feat: align dashboard explorer shell chrome

### DIFF
--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -302,7 +302,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
   const renderSidebarContent = () => (
     <>
       {/* Logo at top */}
-      <div className={cn('shrink-0 border-b flex items-center justify-center h-[42px]', isExpanded ? 'px-2.5' : 'px-1.5')}>
+      <div className={cn('shrink-0 border-b flex items-center justify-center h-[var(--app-header-h)]', isExpanded ? 'px-2.5' : 'px-1.5')}>
         <Link
           to="/"
           search={APP_OVERVIEW_SEARCH}
@@ -312,7 +312,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
         </Link>
       </div>
       {/* Search bar */}
-      <div className="shrink-0 border-b flex items-center h-9 px-1.5">
+      <div className="shrink-0 border-b flex items-center h-[var(--app-subheader-h)] px-1.5">
         {isExpanded ? (
           <button
             type="button"

--- a/dashboard/src/components/filters/ExplorerShell.tsx
+++ b/dashboard/src/components/filters/ExplorerShell.tsx
@@ -26,6 +26,8 @@ export interface ExplorerShellProps {
   /** Optional left-of-search label (icon badge + title), the log-viewer style. */
   title?: string
   icon?: ReactNode
+  /** Section tabs / mode switch (a <SegmentedTabs/>), rendered left of the search. */
+  tabs?: ReactNode
   /** Header right side — page actions (e.g. New Project). */
   actions?: ReactNode
   /** The collapsible facet rail (typically a <FacetRail/>). Omit for no rail. */
@@ -47,6 +49,7 @@ export function ExplorerShell({
   searchBar,
   title,
   icon,
+  tabs,
   actions,
   rail,
   toolbar,
@@ -59,13 +62,14 @@ export function ExplorerShell({
   return (
     <div className={cn('flex h-full flex-col', className)}>
       {/* Header bar */}
-      <div className="@container/header flex min-h-[42px] items-center gap-2 border-b px-2 py-1 sm:px-3">
+      <div className="@container/header flex min-h-[var(--app-header-h)] items-center gap-2 border-b px-2 py-1 sm:px-3">
         {(icon || title) && (
           <div className="flex shrink-0 items-center gap-2">
             {icon}
             {title && <h2 className="hidden text-xs font-semibold leading-tight sm:block">{title}</h2>}
           </div>
         )}
+        {tabs && <div className="flex shrink-0 items-center">{tabs}</div>}
         <div className="min-w-0 flex-1">{searchBar}</div>
         {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
       </div>
@@ -75,7 +79,7 @@ export function ExplorerShell({
         {rail && (
           <div
             className={cn(
-              'shrink-0 border-r transition-all duration-200',
+              'shrink-0 self-stretch overflow-y-auto border-r transition-all duration-200',
               railOpen ? 'w-[220px]' : 'w-0 overflow-hidden border-r-0'
             )}
           >
@@ -85,7 +89,7 @@ export function ExplorerShell({
 
         <div className="flex min-w-0 flex-1 flex-col">
           {(rail || toolbar) && (
-            <div className="flex h-9 shrink-0 items-center gap-1.5 border-b bg-card/30 px-2">
+            <div className="flex h-[var(--app-subheader-h)] shrink-0 items-center gap-1.5 border-b bg-card/30 px-2">
               {rail && (
                 <button
                   type="button"

--- a/dashboard/src/components/filters/ExplorerShell.tsx
+++ b/dashboard/src/components/filters/ExplorerShell.tsx
@@ -56,7 +56,7 @@ export function ExplorerShell({
   defaultRailOpen = true,
   children,
   className,
-}: ExplorerShellProps) {
+}: Readonly<ExplorerShellProps>) {
   const [railOpen, setRailOpen] = useState(defaultRailOpen)
 
   return (

--- a/dashboard/src/components/filters/SegmentedTabs.tsx
+++ b/dashboard/src/components/filters/SegmentedTabs.tsx
@@ -1,0 +1,72 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {ComponentType} from 'react'
+
+import {cn} from '@/lib/utils'
+
+export type SegmentedOption<TValue extends string> = Readonly<{
+  value: TValue
+  label: string
+  icon: ComponentType<{className?: string}>
+}>
+
+export type SegmentedTabsProps<TValue extends string> = Readonly<{
+  value: TValue
+  options: ReadonlyArray<SegmentedOption<TValue>>
+  onChange: (value: TValue) => void
+  ariaLabel: string
+}>
+
+/**
+ * Segmented control / pill group for the explorer header — the canonical way to
+ * carry section tabs or a mode switch immediately left of the search box. The
+ * selected segment is raised on a card-colored chip; the rest read as muted
+ * text. Shared by the monitoring map (as a mode switch) and faceted result
+ * pages such as Issues (as section tabs), so the header reads as one tight row.
+ */
+export function SegmentedTabs<TValue extends string>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: SegmentedTabsProps<TValue>) {
+  return (
+    <fieldset className="flex h-7 shrink-0 rounded-md border bg-muted/40 p-0.5">
+      <legend className="sr-only">{ariaLabel}</legend>
+      {options.map((option) => {
+        const Icon = option.icon
+        const active = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            title={option.label}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-sm px-2.5 text-xs font-medium transition-colors',
+              active ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">{option.label}</span>
+          </button>
+        )
+      })}
+    </fieldset>
+  )
+}

--- a/dashboard/src/components/filters/__tests__/ExplorerShell.test.tsx
+++ b/dashboard/src/components/filters/__tests__/ExplorerShell.test.tsx
@@ -82,4 +82,17 @@ describe('ExplorerShell', () => {
     expect(screen.getByLabelText('Plain search')).toBeTruthy()
     expect(screen.getByText('Plain rows')).toBeTruthy()
   })
+
+  it('renders section tabs in the header', () => {
+    render(
+      <ExplorerShell
+        tabs={<button type="button">APM Errors</button>}
+        searchBar={<input aria-label="Search" />}
+      >
+        <div>Rows</div>
+      </ExplorerShell>
+    )
+
+    expect(screen.getByRole('button', {name: 'APM Errors'})).toBeTruthy()
+  })
 })

--- a/dashboard/src/components/filters/__tests__/SegmentedTabs.test.tsx
+++ b/dashboard/src/components/filters/__tests__/SegmentedTabs.test.tsx
@@ -1,0 +1,45 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {render, screen, fireEvent} from '@testing-library/react'
+import {describe, it, expect, vi} from 'vitest'
+import {AlertCircle, Cpu} from 'lucide-react'
+
+import {SegmentedTabs, type SegmentedOption} from '@/components/filters/SegmentedTabs'
+
+type View = 'issues' | 'apm-errors'
+
+const OPTIONS = [
+  {value: 'issues', label: 'Issues', icon: AlertCircle},
+  {value: 'apm-errors', label: 'APM Errors', icon: Cpu},
+] as const satisfies ReadonlyArray<SegmentedOption<View>>
+
+describe('SegmentedTabs', () => {
+  it('renders every option and marks the active one pressed', () => {
+    render(<SegmentedTabs ariaLabel="View" value="issues" options={OPTIONS} onChange={() => {}} />)
+
+    expect(screen.getByRole('button', {name: 'Issues'}).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', {name: 'APM Errors'}).getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('calls onChange with the option value when a segment is clicked', () => {
+    const onChange = vi.fn()
+    render(<SegmentedTabs ariaLabel="View" value="issues" options={OPTIONS} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'APM Errors'}))
+    expect(onChange).toHaveBeenCalledWith('apm-errors')
+  })
+})

--- a/dashboard/src/components/monitoring/map/MapControls.tsx
+++ b/dashboard/src/components/monitoring/map/MapControls.tsx
@@ -14,62 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import type {ComponentType} from 'react'
 import {Search} from 'lucide-react'
 
-import {cn} from '@/lib/utils'
 import {Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
 
-export type SegmentedOption<TValue extends string> = Readonly<{
-  value: TValue
-  label: string
-  icon: ComponentType<{className?: string}>
-}>
-
-export type MapModeSwitchProps<TValue extends string> = Readonly<{
-  value: TValue
-  options: ReadonlyArray<SegmentedOption<TValue>>
-  onChange: (value: TValue) => void
-  ariaLabel: string
-}>
-
-/**
- * The mockup's `.seg` segmented control: a pill group that sits immediately
- * left of the search box. The selected segment is raised on a card-colored
- * chip; the rest read as muted text.
- */
-export function MapModeSwitch<TValue extends string>({
-  value,
-  options,
-  onChange,
-  ariaLabel,
-}: MapModeSwitchProps<TValue>) {
-  return (
-    <fieldset className="flex h-7 shrink-0 rounded-md border bg-muted/40 p-0.5">
-      <legend className="sr-only">{ariaLabel}</legend>
-      {options.map((option) => {
-        const Icon = option.icon
-        const active = option.value === value
-        return (
-          <button
-            key={option.value}
-            type="button"
-            aria-pressed={active}
-            title={option.label}
-            onClick={() => onChange(option.value)}
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-sm px-2.5 text-xs font-medium transition-colors',
-              active ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            <Icon className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">{option.label}</span>
-          </button>
-        )
-      })}
-    </fieldset>
-  )
-}
+// The map's mode switch is the shared SegmentedTabs control, re-exported under
+// its original name so existing map imports keep working.
+export {SegmentedTabs as MapModeSwitch} from '@/components/filters/SegmentedTabs'
+export type {SegmentedOption} from '@/components/filters/SegmentedTabs'
 
 export type MapControlOption<TValue extends string> = Readonly<{
   value: TValue

--- a/dashboard/src/components/monitoring/map/MapExplorerShell.tsx
+++ b/dashboard/src/components/monitoring/map/MapExplorerShell.tsx
@@ -56,7 +56,7 @@ export function MapExplorerShell({
 }: MapExplorerShellProps) {
   return (
     <div className={cn('flex h-full flex-col', className)}>
-      <div className="flex flex-wrap items-center gap-2 border-b px-3 py-1.5">
+      <div className="flex min-h-[var(--app-header-h)] flex-wrap items-center gap-2 border-b px-3 py-1.5">
         <div className="flex shrink-0 items-center gap-2">
           {icon}
           <h2 className="whitespace-nowrap text-sm font-semibold leading-tight">{title}</h2>

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -12,6 +12,12 @@
 @layer base {
   /* Default (light) theme — Internal Tools style guide: cyan accent over cool neutrals. */
   :root {
+    /* App chrome geometry — single source of truth so the content header stays
+       locked to the sidebar. Consumed by Sidebar (logo + search rows),
+       ExplorerShell (header + toolbar), and MapExplorerShell. Edit here; never
+       hard-code these pixel heights in components. */
+    --app-header-h: 42px;     /* top band: sidebar logo row · explorer header */
+    --app-subheader-h: 36px;  /* second band: sidebar search row · explorer toolbar */
     --background: 220 23% 98%;
     --foreground: 225 21% 11%;
     --border: 218 16% 87%;

--- a/dashboard/src/routes/__tests__/analytics-index-service-facets.test.tsx
+++ b/dashboard/src/routes/__tests__/analytics-index-service-facets.test.tsx
@@ -90,9 +90,7 @@ const overview = {
 }
 
 function selectProductTab() {
-  const productTab = screen.getByRole('tab', {name: 'Product'})
-  fireEvent.pointerDown(productTab, {button: 0, ctrlKey: false})
-  fireEvent.mouseDown(productTab, {button: 0, ctrlKey: false})
+  const productTab = screen.getByRole('button', {name: 'Product'})
   fireEvent.click(productTab)
 }
 

--- a/dashboard/src/routes/ai.generations.tsx
+++ b/dashboard/src/routes/ai.generations.tsx
@@ -18,6 +18,7 @@ import {createFileRoute, Link} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {useCallback, useMemo, useState} from 'react'
 import {api, type LlmGenerationsParams, type LlmScopeParams} from '@/lib/api'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
@@ -25,7 +26,6 @@ import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Dialog, DialogContent, DialogHeader, DialogTitle} from '@/components/ui/dialog'
 import {Input} from '@/components/ui/input'
-import {PageHeader} from '@/components/ui/page-header'
 import {SectionCard} from '@/components/ui/section-card'
 import {EmptyState} from '@/components/ui/empty-state'
 import {Brain, ChevronLeft, ChevronRight} from 'lucide-react'
@@ -145,16 +145,72 @@ function GenerationsPage() {
   const totalPages = data ? Math.ceil(data.total / data.pageSize) : 0
 
   return (
-    <div className="grid gap-2 p-3 lg:grid-cols-[220px_minmax(0,1fr)]">
-      <FacetRail
-        sections={railSections}
-        facetFilters={facetFilters}
-        onFacetFiltersChange={handleFacetFiltersChange}
-        title="AI"
-        className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
-      />
-
-      <div className="min-w-0 space-y-3">
+    <ExplorerShell
+      title="Generations"
+      icon={<Brain className="h-4 w-4 text-muted-foreground" />}
+      searchBar={<div />}
+      actions={
+        <div className="flex flex-wrap gap-1.5">
+          <Input
+            placeholder="Filter by model..."
+            value={modelFilter}
+            onChange={(e) => { setModelFilter(e.target.value); setPage(1) }}
+            className="w-36 h-7 text-xs"
+          />
+          <Select
+            value={typeFilter}
+            onValueChange={(v) => { setTypeFilter(v === 'all' ? '' : v); setPage(1) }}
+          >
+            <SelectTrigger className="w-24 h-7 text-xs">
+              <SelectValue placeholder="Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              <SelectItem value="chat">Chat</SelectItem>
+              <SelectItem value="completion">Completion</SelectItem>
+              <SelectItem value="embedding">Embedding</SelectItem>
+              <SelectItem value="tool_call">Tool Call</SelectItem>
+              <SelectItem value="agent">Agent</SelectItem>
+              <SelectItem value="chain">Chain</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select
+            value={statusFilter}
+            onValueChange={(v) => { setStatusFilter(v === 'all' ? '' : v); setPage(1) }}
+          >
+            <SelectTrigger className="w-24 h-7 text-xs">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="success">Success</SelectItem>
+              <SelectItem value="error">Error</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={range} onValueChange={(v) => { setRange(v); setPage(1) }}>
+            <SelectTrigger className="w-24 h-7 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="1h">Last 1h</SelectItem>
+              <SelectItem value="6h">Last 6h</SelectItem>
+              <SelectItem value="24h">Last 24h</SelectItem>
+              <SelectItem value="7d">Last 7d</SelectItem>
+              <SelectItem value="30d">Last 30d</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      }
+      rail={
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          title="AI"
+        />
+      }
+    >
+      <div className="space-y-3 p-3">
         {!hasLlmScope ? (
           <div className="py-10">
             <EmptyState
@@ -165,63 +221,6 @@ function GenerationsPage() {
           </div>
         ) : (
           <>
-            <PageHeader
-              icon={Brain}
-              title="Generations"
-              actions={
-              <div className="flex flex-wrap gap-1.5">
-                <Input
-                  placeholder="Filter by model..."
-                  value={modelFilter}
-                  onChange={(e) => { setModelFilter(e.target.value); setPage(1) }}
-                  className="w-36 h-8 text-xs"
-                />
-                <Select
-                  value={typeFilter}
-                  onValueChange={(v) => { setTypeFilter(v === 'all' ? '' : v); setPage(1) }}
-                >
-                  <SelectTrigger className="w-24 h-8 text-xs">
-                    <SelectValue placeholder="Type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Types</SelectItem>
-                    <SelectItem value="chat">Chat</SelectItem>
-                    <SelectItem value="completion">Completion</SelectItem>
-                    <SelectItem value="embedding">Embedding</SelectItem>
-                    <SelectItem value="tool_call">Tool Call</SelectItem>
-                    <SelectItem value="agent">Agent</SelectItem>
-                    <SelectItem value="chain">Chain</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select
-                  value={statusFilter}
-                  onValueChange={(v) => { setStatusFilter(v === 'all' ? '' : v); setPage(1) }}
-                >
-                  <SelectTrigger className="w-24 h-8 text-xs">
-                    <SelectValue placeholder="Status" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="success">Success</SelectItem>
-                    <SelectItem value="error">Error</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select value={range} onValueChange={(v) => { setRange(v); setPage(1) }}>
-                  <SelectTrigger className="w-24 h-8 text-xs">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="1h">Last 1h</SelectItem>
-                    <SelectItem value="6h">Last 6h</SelectItem>
-                    <SelectItem value="24h">Last 24h</SelectItem>
-                    <SelectItem value="7d">Last 7d</SelectItem>
-                    <SelectItem value="30d">Last 30d</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              }
-            />
-
             <SectionCard title="Generations" icon={Brain} count={data?.total} flushBody bodyClassName="overflow-x-auto">
                 <Table className="[&_th]:h-8 [&_th]:px-1.5 [&_th]:text-xs [&_td]:py-1.5 [&_td]:px-1.5">
                   <TableHeader>
@@ -318,48 +317,48 @@ function GenerationsPage() {
             </div>
           </div>
         )}
-
-        {/* Detail Dialog */}
-        <Dialog open={!!selectedGenId} onOpenChange={(open) => { if (!open) setSelectedGenId(null) }}>
-          <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle>Generation Detail</DialogTitle>
-            </DialogHeader>
-            {detail && (
-              <div className="space-y-2">
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
-                  <div><span className="text-muted-foreground">Model:</span> <span className="font-medium">{detail.model}</span></div>
-                  <div><span className="text-muted-foreground">Provider:</span> <span className="font-medium">{detail.provider}</span></div>
-                  <div><span className="text-muted-foreground">Type:</span> <Badge variant="outline">{detail.type}</Badge></div>
-                  <div><span className="text-muted-foreground">Status:</span> <Badge variant={detail.status === 'error' ? 'destructive' : 'secondary'}>{detail.status}</Badge></div>
-                  <div><span className="text-muted-foreground">Duration:</span> <span className="font-medium">{formatDuration(detail.durationMs)}</span></div>
-                  <div><span className="text-muted-foreground">Tokens:</span> <span className="font-medium">{detail.inputTokens} / {detail.outputTokens}</span></div>
-                  <div><span className="text-muted-foreground">Cost:</span> <span className="font-medium">{formatCost(detail.costUsd)}</span></div>
-                  <div><span className="text-muted-foreground">Temperature:</span> <span className="font-medium">{detail.temperature}</span></div>
-                </div>
-                {detail.errorMessage && (
-                  <div className="rounded-md bg-destructive/10 p-2 text-xs text-destructive">
-                    <strong>Error:</strong> {detail.errorMessage}
-                  </div>
-                )}
-                <div>
-                  <h4 className="text-xs font-semibold mb-1">Input</h4>
-                  <pre className="bg-muted rounded-md p-2 text-xs overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
-                    {tryFormatJson(detail.input)}
-                  </pre>
-                </div>
-                <div>
-                  <h4 className="text-xs font-semibold mb-1">Output</h4>
-                  <pre className="bg-muted rounded-md p-2 text-xs overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
-                    {tryFormatJson(detail.output)}
-                  </pre>
-                </div>
-              </div>
-            )}
-          </DialogContent>
-        </Dialog>
       </div>
-    </div>
+
+      {/* Detail Dialog */}
+      <Dialog open={!!selectedGenId} onOpenChange={(open) => { if (!open) setSelectedGenId(null) }}>
+        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Generation Detail</DialogTitle>
+          </DialogHeader>
+          {detail && (
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
+                <div><span className="text-muted-foreground">Model:</span> <span className="font-medium">{detail.model}</span></div>
+                <div><span className="text-muted-foreground">Provider:</span> <span className="font-medium">{detail.provider}</span></div>
+                <div><span className="text-muted-foreground">Type:</span> <Badge variant="outline">{detail.type}</Badge></div>
+                <div><span className="text-muted-foreground">Status:</span> <Badge variant={detail.status === 'error' ? 'destructive' : 'secondary'}>{detail.status}</Badge></div>
+                <div><span className="text-muted-foreground">Duration:</span> <span className="font-medium">{formatDuration(detail.durationMs)}</span></div>
+                <div><span className="text-muted-foreground">Tokens:</span> <span className="font-medium">{detail.inputTokens} / {detail.outputTokens}</span></div>
+                <div><span className="text-muted-foreground">Cost:</span> <span className="font-medium">{formatCost(detail.costUsd)}</span></div>
+                <div><span className="text-muted-foreground">Temperature:</span> <span className="font-medium">{detail.temperature}</span></div>
+              </div>
+              {detail.errorMessage && (
+                <div className="rounded-md bg-destructive/10 p-2 text-xs text-destructive">
+                  <strong>Error:</strong> {detail.errorMessage}
+                </div>
+              )}
+              <div>
+                <h4 className="text-xs font-semibold mb-1">Input</h4>
+                <pre className="bg-muted rounded-md p-2 text-xs overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
+                  {tryFormatJson(detail.input)}
+                </pre>
+              </div>
+              <div>
+                <h4 className="text-xs font-semibold mb-1">Output</h4>
+                <pre className="bg-muted rounded-md p-2 text-xs overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
+                  {tryFormatJson(detail.output)}
+                </pre>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </ExplorerShell>
   )
 }
 

--- a/dashboard/src/routes/ai.generations.tsx
+++ b/dashboard/src/routes/ai.generations.tsx
@@ -211,7 +211,85 @@ function GenerationsPage() {
       }
     >
       <div className="space-y-3 p-3">
-        {!hasLlmScope ? (
+        {hasLlmScope ? (
+          <SectionCard title="Generations" icon={Brain} count={data?.total} flushBody bodyClassName="overflow-x-auto">
+              <Table className="[&_th]:h-8 [&_th]:px-1.5 [&_th]:text-xs [&_td]:py-1.5 [&_td]:px-1.5">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Timestamp</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Model</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead className="text-right">Tokens</TableHead>
+                    <TableHead className="text-right">Cost</TableHead>
+                    <TableHead className="text-right">Duration</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Trace</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data?.generations.map((gen) => (
+                    <TableRow
+                      key={gen.generationId}
+                      className="cursor-pointer hover:bg-accent/50"
+                      onClick={() => setSelectedGenId(gen.generationId)}
+                    >
+                      <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                        {formatDateTime(gen.timestamp, timezone)}
+                      </TableCell>
+                      <TableCell className="font-medium text-sm max-w-48 truncate">
+                        {gen.name || '-'}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <ProviderLogo provider={gen.provider} showName={false} className="shrink-0" />
+                          <div>
+                            <div className="text-sm">{gen.model || '-'}</div>
+                            <div className="text-xs text-muted-foreground">{gen.provider}</div>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="text-xs">{gen.type}</Badge>
+                      </TableCell>
+                      <TableCell className="text-right text-sm">
+                        {gen.totalTokens > 0 ? gen.totalTokens.toLocaleString() : '-'}
+                      </TableCell>
+                      <TableCell className="text-right text-sm">{formatCost(gen.costUsd)}</TableCell>
+                      <TableCell className="text-right text-sm">{formatDuration(gen.durationMs)}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={gen.status === 'error' ? 'destructive' : 'secondary'}
+                          className="text-xs"
+                        >
+                          {gen.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {gen.traceId && (
+                          <Link
+                            to="/ai/traces/$traceId"
+                            params={{ traceId: gen.traceId }}
+                            className="text-xs text-primary hover:underline"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            {gen.traceId.slice(0, 8)}...
+                          </Link>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {(!data?.generations || data.generations.length === 0) && !isLoading && (
+                    <TableRow>
+                      <TableCell colSpan={9} className="text-center text-muted-foreground py-6">
+                        No generations found for the selected filters.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+          </SectionCard>
+        ) : (
           <div className="py-10">
             <EmptyState
               icon={Brain}
@@ -219,86 +297,6 @@ function GenerationsPage() {
               description="Adjust the selected services to view generations."
             />
           </div>
-        ) : (
-          <>
-            <SectionCard title="Generations" icon={Brain} count={data?.total} flushBody bodyClassName="overflow-x-auto">
-                <Table className="[&_th]:h-8 [&_th]:px-1.5 [&_th]:text-xs [&_td]:py-1.5 [&_td]:px-1.5">
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Timestamp</TableHead>
-                      <TableHead>Name</TableHead>
-                      <TableHead>Model</TableHead>
-                      <TableHead>Type</TableHead>
-                      <TableHead className="text-right">Tokens</TableHead>
-                      <TableHead className="text-right">Cost</TableHead>
-                      <TableHead className="text-right">Duration</TableHead>
-                      <TableHead>Status</TableHead>
-                      <TableHead className="text-right">Trace</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {data?.generations.map((gen) => (
-                      <TableRow
-                        key={gen.generationId}
-                        className="cursor-pointer hover:bg-accent/50"
-                        onClick={() => setSelectedGenId(gen.generationId)}
-                      >
-                        <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
-                          {formatDateTime(gen.timestamp, timezone)}
-                        </TableCell>
-                        <TableCell className="font-medium text-sm max-w-48 truncate">
-                          {gen.name || '-'}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-2">
-                            <ProviderLogo provider={gen.provider} showName={false} className="shrink-0" />
-                            <div>
-                              <div className="text-sm">{gen.model || '-'}</div>
-                              <div className="text-xs text-muted-foreground">{gen.provider}</div>
-                            </div>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="outline" className="text-xs">{gen.type}</Badge>
-                        </TableCell>
-                        <TableCell className="text-right text-sm">
-                          {gen.totalTokens > 0 ? gen.totalTokens.toLocaleString() : '-'}
-                        </TableCell>
-                        <TableCell className="text-right text-sm">{formatCost(gen.costUsd)}</TableCell>
-                        <TableCell className="text-right text-sm">{formatDuration(gen.durationMs)}</TableCell>
-                        <TableCell>
-                          <Badge
-                            variant={gen.status === 'error' ? 'destructive' : 'secondary'}
-                            className="text-xs"
-                          >
-                            {gen.status}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          {gen.traceId && (
-                            <Link
-                              to="/ai/traces/$traceId"
-                              params={{ traceId: gen.traceId }}
-                              className="text-xs text-primary hover:underline"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              {gen.traceId.slice(0, 8)}...
-                            </Link>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                    {(!data?.generations || data.generations.length === 0) && !isLoading && (
-                      <TableRow>
-                        <TableCell colSpan={9} className="text-center text-muted-foreground py-6">
-                          No generations found for the selected filters.
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
-            </SectionCard>
-          </>
         )}
 
         {/* Pagination */}

--- a/dashboard/src/routes/ai.index.tsx
+++ b/dashboard/src/routes/ai.index.tsx
@@ -21,12 +21,12 @@ import { api, type LlmRangeParams } from '@/lib/api'
 import { StatsCard } from '@/components/charts/StatsCard'
 import { EventsChart } from '@/components/charts/EventsChart'
 import { BarChart } from '@/components/charts/BarChart'
+import { ExplorerShell } from '@/components/filters/ExplorerShell'
 import { FacetRail } from '@/components/filters/FacetRail'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { PageHeader } from '@/components/ui/page-header'
 import { SectionCard } from '@/components/ui/section-card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Brain, Coins, Clock, AlertTriangle, Hash, Zap, BookOpen, ArrowRight, TrendingUp } from 'lucide-react'
@@ -136,16 +136,47 @@ function AiOverviewPage() {
   })
 
   return (
-    <div className="grid gap-2 p-3 lg:grid-cols-[220px_minmax(0,1fr)]">
-      <FacetRail
-        sections={railSections}
-        facetFilters={facetFilters}
-        onFacetFiltersChange={setFacetFilters}
-        title="AI"
-        className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
-      />
-
-      <div className="min-w-0 space-y-3">
+    <ExplorerShell
+      title="AI Observability"
+      icon={<Brain className="h-4 w-4 text-muted-foreground" />}
+      searchBar={<div />}
+      actions={
+        <>
+          <Link to="/ai/generations" className="text-xs text-primary hover:underline">
+            View all generations
+          </Link>
+          <Button asChild size="sm">
+            <a href="/docs/ai-observability">
+              <BookOpen className="h-3.5 w-3.5" />
+              Get started
+              <ArrowRight className="h-3.5 w-3.5" />
+            </a>
+          </Button>
+          <Select value={range} onValueChange={setRange}>
+            <SelectTrigger className="w-full sm:w-28 h-7 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="1h">Last 1h</SelectItem>
+              <SelectItem value="6h">Last 6h</SelectItem>
+              <SelectItem value="24h">Last 24h</SelectItem>
+              <SelectItem value="7d">Last 7d</SelectItem>
+              <SelectItem value="14d">Last 14d</SelectItem>
+              <SelectItem value="30d">Last 30d</SelectItem>
+            </SelectContent>
+          </Select>
+        </>
+      }
+      rail={
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={setFacetFilters}
+          title="AI"
+        />
+      }
+    >
+      <div className="space-y-3 p-3">
         {!hasLlmScope ? (
           <div className="py-10">
             <EmptyState
@@ -156,39 +187,6 @@ function AiOverviewPage() {
           </div>
         ) : (
           <>
-            <PageHeader
-              icon={Brain}
-              title="AI Observability"
-              description="Monitor your LLM applications, trace agent executions, and track costs."
-              actions={
-                <>
-                  <Link to="/ai/generations" className="text-xs text-primary hover:underline">
-                    View all generations
-                  </Link>
-                  <Button asChild size="sm">
-                    <a href="/docs/ai-observability">
-                      <BookOpen className="h-3.5 w-3.5" />
-                      Get started
-                      <ArrowRight className="h-3.5 w-3.5" />
-                    </a>
-                  </Button>
-                  <Select value={range} onValueChange={setRange}>
-                    <SelectTrigger className="w-full sm:w-28 h-9 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="1h">Last 1h</SelectItem>
-                      <SelectItem value="6h">Last 6h</SelectItem>
-                      <SelectItem value="24h">Last 24h</SelectItem>
-                      <SelectItem value="7d">Last 7d</SelectItem>
-                      <SelectItem value="14d">Last 14d</SelectItem>
-                      <SelectItem value="30d">Last 30d</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </>
-              }
-            />
-
             {/* Stats Row */}
             <div className="grid grid-cols-2 md:grid-cols-5 gap-1.5">
               <StatsCard
@@ -298,6 +296,6 @@ function AiOverviewPage() {
           </>
         )}
       </div>
-    </div>
+    </ExplorerShell>
   )
 }

--- a/dashboard/src/routes/ai.index.tsx
+++ b/dashboard/src/routes/ai.index.tsx
@@ -59,6 +59,21 @@ function formatTokens(tokens: number): string {
   return String(tokens)
 }
 
+type LlmOverview = Awaited<ReturnType<typeof api.getLlmOverview>>
+
+function llmBreakdowns(overview: LlmOverview | undefined) {
+  const modelBreakdown: Record<string, number> = {}
+  const tokenBreakdown: Record<string, number> = {}
+  const costBreakdown: Record<string, number> = {}
+  overview?.topModels.forEach(m => {
+    const label = m.model || 'unknown'
+    modelBreakdown[label] = Number(m.callCount)
+    tokenBreakdown[label] = Number(m.totalTokens)
+    costBreakdown[label] = m.totalCost
+  })
+  return {modelBreakdown, tokenBreakdown, costBreakdown}
+}
+
 function AiOverviewPage() {
   const [range, setRange] = useState('24h')
   const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
@@ -125,15 +140,7 @@ function AiOverviewPage() {
     count: Number(p.count),
   })) ?? []
 
-  const modelBreakdown: Record<string, number> = {}
-  const tokenBreakdown: Record<string, number> = {}
-  const costBreakdown: Record<string, number> = {}
-  overview?.topModels.forEach(m => {
-    const label = m.model || 'unknown'
-    modelBreakdown[label] = Number(m.callCount)
-    tokenBreakdown[label] = Number(m.totalTokens)
-    costBreakdown[label] = m.totalCost
-  })
+  const {modelBreakdown, tokenBreakdown, costBreakdown} = llmBreakdowns(overview)
 
   return (
     <ExplorerShell
@@ -177,7 +184,16 @@ function AiOverviewPage() {
       }
     >
       <div className="space-y-3 p-3">
-        {!hasLlmScope ? (
+        {hasLlmScope ? (
+          <AiOverviewResults
+            overview={overview}
+            isLoading={isLoading}
+            timelineData={timelineData}
+            modelBreakdown={modelBreakdown}
+            tokenBreakdown={tokenBreakdown}
+            costBreakdown={costBreakdown}
+          />
+        ) : (
           <div className="py-10">
             <EmptyState
               icon={Brain}
@@ -185,117 +201,133 @@ function AiOverviewPage() {
               description="Adjust the selected services to view AI observability data."
             />
           </div>
-        ) : (
-          <>
-            {/* Stats Row */}
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-1.5">
-              <StatsCard
-                compact
-                title="Total Generations"
-                value={isLoading ? '...' : formatTokens(overview?.totalGenerations ?? 0)}
-                icon={Zap}
-                accent="blue"
-              />
-              <StatsCard
-                compact
-                title="Total Tokens"
-                value={isLoading ? '...' : formatTokens(overview?.totalTokens ?? 0)}
-                icon={Hash}
-                accent="violet"
-              />
-              <StatsCard
-                compact
-                title="Total Cost"
-                value={isLoading ? '...' : formatCost(overview?.totalCost ?? 0)}
-                icon={Coins}
-                accent="emerald"
-              />
-              <StatsCard
-                compact
-                title="Avg Latency"
-                value={isLoading ? '...' : formatDuration(overview?.avgDurationMs ?? 0)}
-                icon={Clock}
-                accent="amber"
-              />
-              <StatsCard
-                compact
-                title="Error Rate"
-                value={isLoading ? '...' : `${(overview?.errorRate ?? 0).toFixed(1)}%`}
-                icon={AlertTriangle}
-                accent="rose"
-              />
-            </div>
-
-            {/* Charts Row */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
-              <EventsChart data={timelineData} title="LLM Calls Over Time" height={160} />
-              <BarChart data={modelBreakdown} title="Calls by Model" height={160} />
-            </div>
-
-            {/* Token Breakdown & Cost */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
-              <BarChart data={tokenBreakdown} title="Tokens by Model" height={160} />
-              <BarChart data={costBreakdown} title="Cost by Model" height={160} />
-            </div>
-
-            {/* Top Models Table */}
-            <SectionCard title="Top Models" icon={TrendingUp} flushBody bodyClassName="overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Model</TableHead>
-                      <TableHead className="text-right">Calls</TableHead>
-                      <TableHead className="text-right">Tokens</TableHead>
-                      <TableHead className="text-right">Cost</TableHead>
-                      <TableHead className="text-right">Avg Latency</TableHead>
-                      <TableHead className="text-right">Errors</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {overview?.topModels.map((m) => (
-                      <TableRow key={`${m.provider}-${m.model}`}>
-                        <TableCell>
-                          <div className="flex items-center gap-2.5">
-                            <ProviderLogo provider={m.provider} showName={false} className="shrink-0" />
-                            <div className="min-w-0">
-                              <div className="font-medium text-sm">{m.model || 'unknown'}</div>
-                              <div className="text-xs text-muted-foreground">{m.provider}</div>
-                            </div>
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">{m.callCount}</TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          {formatTokens(Number(m.totalTokens))}
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">{formatCost(m.totalCost)}</TableCell>
-                        <TableCell className="text-right tabular-nums">{formatDuration(m.avgDurationMs)}</TableCell>
-                        <TableCell className="text-right">
-                          <Badge
-                            variant={m.errorRate > 5 ? 'destructive' : 'secondary'}
-                            className="text-xs tabular-nums"
-                          >
-                            {m.errorRate.toFixed(1)}%
-                          </Badge>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                    {(!overview?.topModels || overview.topModels.length === 0) && (
-                      <TableRow>
-                        <TableCell colSpan={6} className="text-center text-muted-foreground py-6">
-                          No LLM data yet.{' '}
-                          <a href="/docs/ai-observability" className="text-primary hover:underline">
-                            Read the docs
-                          </a>{' '}
-                          to get started.
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
-            </SectionCard>
-          </>
         )}
       </div>
     </ExplorerShell>
+  )
+}
+
+type AiOverviewResultsProps = Readonly<{
+  overview: LlmOverview | undefined
+  isLoading: boolean
+  timelineData: {timestamp: string; count: number}[]
+  modelBreakdown: Record<string, number>
+  tokenBreakdown: Record<string, number>
+  costBreakdown: Record<string, number>
+}>
+
+function AiOverviewResults({
+  overview,
+  isLoading,
+  timelineData,
+  modelBreakdown,
+  tokenBreakdown,
+  costBreakdown,
+}: AiOverviewResultsProps) {
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-1.5">
+        <StatsCard
+          compact
+          title="Total Generations"
+          value={isLoading ? '...' : formatTokens(overview?.totalGenerations ?? 0)}
+          icon={Zap}
+          accent="blue"
+        />
+        <StatsCard
+          compact
+          title="Total Tokens"
+          value={isLoading ? '...' : formatTokens(overview?.totalTokens ?? 0)}
+          icon={Hash}
+          accent="violet"
+        />
+        <StatsCard
+          compact
+          title="Total Cost"
+          value={isLoading ? '...' : formatCost(overview?.totalCost ?? 0)}
+          icon={Coins}
+          accent="emerald"
+        />
+        <StatsCard
+          compact
+          title="Avg Latency"
+          value={isLoading ? '...' : formatDuration(overview?.avgDurationMs ?? 0)}
+          icon={Clock}
+          accent="amber"
+        />
+        <StatsCard
+          compact
+          title="Error Rate"
+          value={isLoading ? '...' : `${(overview?.errorRate ?? 0).toFixed(1)}%`}
+          icon={AlertTriangle}
+          accent="rose"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
+        <EventsChart data={timelineData} title="LLM Calls Over Time" height={160} />
+        <BarChart data={modelBreakdown} title="Calls by Model" height={160} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
+        <BarChart data={tokenBreakdown} title="Tokens by Model" height={160} />
+        <BarChart data={costBreakdown} title="Cost by Model" height={160} />
+      </div>
+
+      <SectionCard title="Top Models" icon={TrendingUp} flushBody bodyClassName="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Model</TableHead>
+              <TableHead className="text-right">Calls</TableHead>
+              <TableHead className="text-right">Tokens</TableHead>
+              <TableHead className="text-right">Cost</TableHead>
+              <TableHead className="text-right">Avg Latency</TableHead>
+              <TableHead className="text-right">Errors</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {overview?.topModels.map((m) => (
+              <TableRow key={`${m.provider}-${m.model}`}>
+                <TableCell>
+                  <div className="flex items-center gap-2.5">
+                    <ProviderLogo provider={m.provider} showName={false} className="shrink-0" />
+                    <div className="min-w-0">
+                      <div className="font-medium text-sm">{m.model || 'unknown'}</div>
+                      <div className="text-xs text-muted-foreground">{m.provider}</div>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{m.callCount}</TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {formatTokens(Number(m.totalTokens))}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{formatCost(m.totalCost)}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatDuration(m.avgDurationMs)}</TableCell>
+                <TableCell className="text-right">
+                  <Badge
+                    variant={m.errorRate > 5 ? 'destructive' : 'secondary'}
+                    className="text-xs tabular-nums"
+                  >
+                    {m.errorRate.toFixed(1)}%
+                  </Badge>
+                </TableCell>
+              </TableRow>
+            ))}
+            {(!overview?.topModels || overview.topModels.length === 0) && (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground py-6">
+                  No LLM data yet.{' '}
+                  <a href="/docs/ai-observability" className="text-primary hover:underline">
+                    Read the docs
+                  </a>{' '}
+                  to get started.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </SectionCard>
+    </>
   )
 }

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -9,7 +9,9 @@ import {AnalyticsKpiCards, AnalyticsKpiCardsSkeleton} from '@/components/analyti
 import {AnalyticsChart} from '@/components/analytics/AnalyticsChart'
 import {AnalyticsBreakdownTable} from '@/components/analytics/AnalyticsBreakdownTable'
 import {AnalyticsRetentionTable} from '@/components/analytics/AnalyticsRetentionTable'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
+import {SegmentedTabs, type SegmentedOption} from '@/components/filters/SegmentedTabs'
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
 import {Card, CardContent} from '@/components/ui/card'
 import {CopyBlock} from '@/components/ui/copy-block'
@@ -33,6 +35,12 @@ import type {FacetFilter, FacetRailSection} from '@/lib/filters/types'
 export const Route = createFileRoute('/analytics/')({
   component: AnalyticsOverview,
 })
+
+type AnalyticsView = 'web' | 'product'
+const ANALYTICS_VIEW_TABS = [
+  {value: 'web', label: 'Web', icon: Globe},
+  {value: 'product', label: 'Product', icon: Target},
+] as const satisfies ReadonlyArray<SegmentedOption<AnalyticsView>>
 
 const PRODUCT_PRESENCE_PARAMS: AnalyticsParams = {period: '12mo'}
 const DEFAULT_PRODUCT_FUNNEL_STEPS = ['signup.completed', 'recording.started', 'export.completed']
@@ -243,16 +251,28 @@ function AnalyticsOverview() {
   }
 
   return (
-    <div className="grid gap-2 lg:grid-cols-[220px_minmax(0,1fr)]">
-      <FacetRail
-        sections={analyticsRailSections}
-        facetFilters={facetFilters}
-        onFacetFiltersChange={setFacetFilters}
-        title="Analytics"
-        className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
-      />
-
-      <div className="min-w-0 space-y-2">
+    <ExplorerShell
+      title="Analytics"
+      icon={<BarChart3 className="h-4 w-4 text-muted-foreground" />}
+      tabs={
+        <SegmentedTabs
+          ariaLabel="Analytics view"
+          value={activeAnalyticsTab as AnalyticsView}
+          onChange={setAnalyticsTab}
+          options={ANALYTICS_VIEW_TABS}
+        />
+      }
+      searchBar={<div />}
+      rail={
+        <FacetRail
+          sections={analyticsRailSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={setFacetFilters}
+          title="Analytics"
+        />
+      }
+    >
+      <div className="space-y-2 p-3">
         {!hasAnalyticsScope ? (
           <div className="py-10">
             <EmptyState
@@ -261,18 +281,8 @@ function AnalyticsOverview() {
               description="Adjust the selected services to view analytics."
             />
           </div>
-        ) : (
-          <Tabs value={activeAnalyticsTab} onValueChange={setAnalyticsTab}>
-            <TabsList className="h-7">
-              <TabsTrigger value="web" className="gap-1.5 text-xs">
-                <Globe className="h-3.5 w-3.5" /> Web
-              </TabsTrigger>
-              <TabsTrigger value="product" className="gap-1.5 text-xs">
-                <Target className="h-3.5 w-3.5" /> Product
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="web" className="mt-2 space-y-2">
+        ) : activeAnalyticsTab === 'web' ? (
+          <div className="space-y-2">
               {!overviewLoading && !hasWebAnalytics ? (
                 <WebAnalyticsEmptyState service={setupService} />
               ) : (
@@ -424,24 +434,23 @@ function AnalyticsOverview() {
                   </Tabs>
                 </>
               )}
-            </TabsContent>
-
-            <TabsContent value="product" className="mt-2">
-              {productPresenceLoading ? (
-                <div className="h-[220px] w-full animate-pulse rounded bg-muted" />
-              ) : hasProductEvents ? (
-                <ProductAnalyticsTab scopeId={ORGANIZATION_ANALYTICS_SCOPE} params={productParams} />
-              ) : (
-                <ProductAnalyticsEmptyState
-                  service={setupService}
-                  serviceId={setupService?.resourceId ?? 'your-service-id'}
-                />
-              )}
-            </TabsContent>
-          </Tabs>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {productPresenceLoading ? (
+              <div className="h-[220px] w-full animate-pulse rounded bg-muted" />
+            ) : hasProductEvents ? (
+              <ProductAnalyticsTab scopeId={ORGANIZATION_ANALYTICS_SCOPE} params={productParams} />
+            ) : (
+              <ProductAnalyticsEmptyState
+                service={setupService}
+                serviceId={setupService?.resourceId ?? 'your-service-id'}
+              />
+            )}
+          </div>
         )}
       </div>
-    </div>
+    </ExplorerShell>
   )
 }
 

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -70,71 +70,21 @@ function findSetupService(services: readonly Project[], serviceNames: readonly s
   return services.find((service) => service.name === serviceNames[0]) ?? services[0]
 }
 
-function AnalyticsOverview() {
-  const {period, customFrom, customTo} = useAnalyticsParams()
-  const [filters, setFilters] = useState<AnalyticsFilter[]>([])
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
-  const [breakdownTab, setBreakdownTab] = useState('pages')
-  const [analyticsTab, setAnalyticsTab] = useState('web')
+type UseAnalyticsQueriesArgs = Readonly<{
+  hasAnalyticsScope: boolean
+  scopeKey: string
+  params: AnalyticsParams
+  productPresenceParams: AnalyticsParams
+  breakdownTab: string
+}>
 
-  const {data: services, isLoading: servicesLoading, error: servicesError} = useQuery({
-    queryKey: ['projects'],
-    queryFn: () => api.getProjects(),
-  })
-
-  const serviceList = services ?? []
-  const includedServices = useMemo(
-    () => facetValues(facetFilters, 'service', false),
-    [facetFilters]
-  )
-  const excludedServices = useMemo(
-    () => facetValues(facetFilters, 'service', true),
-    [facetFilters]
-  )
-  const hasServiceFilters = includedServices.length > 0 || excludedServices.length > 0
-  const serviceNames = useMemo(
-    () => serviceNamesForQuery(serviceList, includedServices, excludedServices),
-    [serviceList, includedServices, excludedServices]
-  )
-  const scopeKey = analyticsScopeKey(serviceNames, hasServiceFilters)
-  const hasAnalyticsScope = serviceList.length > 0 && (!hasServiceFilters || serviceNames.length > 0)
-  const serviceParams = useMemo(() => analyticsServiceParams(serviceNames), [serviceNames])
-  const setupService = findSetupService(serviceList, serviceNames)
-
-  const dateParams = useMemo((): AnalyticsParams => ({
-    period,
-    ...(period === 'custom' && customFrom && customTo ? {from: customFrom, to: customTo} : {}),
-  }), [period, customFrom, customTo])
-
-  const params = useMemo((): AnalyticsParams => ({
-    ...dateParams,
-    ...serviceParams,
-    filters: filters.length > 0 ? filters : undefined,
-    comparison: 'previous_period',
-  }), [dateParams, filters, serviceParams])
-
-  const productParams = useMemo((): AnalyticsParams => ({
-    ...dateParams,
-    ...serviceParams,
-  }), [dateParams, serviceParams])
-
-  const productPresenceParams = useMemo((): AnalyticsParams => ({
-    ...PRODUCT_PRESENCE_PARAMS,
-    ...serviceParams,
-  }), [serviceParams])
-
-  const analyticsRailSections: FacetRailSection[] = useMemo(
-    () => [
-      {
-        key: 'service',
-        label: 'Service',
-        color: 'bg-primary',
-        options: serviceList.map((service) => ({value: service.name})),
-      },
-    ],
-    [serviceList]
-  )
-
+function useAnalyticsQueries({
+  hasAnalyticsScope,
+  scopeKey,
+  params,
+  productPresenceParams,
+  breakdownTab,
+}: UseAnalyticsQueriesArgs) {
   const {data: overview, isLoading: overviewLoading} = useQuery({
     queryKey: ['analytics-overview', 'organization', scopeKey, params],
     queryFn: () => api.getAnalyticsOverview(ORGANIZATION_ANALYTICS_SCOPE, params),
@@ -217,13 +167,120 @@ function AnalyticsOverview() {
     enabled: hasAnalyticsScope,
   })
 
-  const hasProductEvents = (productEventsPreview?.length ?? 0) > 0
-  const hasWebAnalytics = (overview?.uniqueVisitors ?? 0) > 0 || (overview?.totalPageviews ?? 0) > 0
+  return {
+    overview,
+    overviewLoading,
+    timeseries,
+    timeseriesLoading,
+    pages,
+    pagesLoading,
+    entryPages,
+    entryPagesLoading,
+    exitPages,
+    exitPagesLoading,
+    sources,
+    sourcesLoading,
+    locations,
+    locationsLoading,
+    browsers,
+    browsersLoading,
+    operatingSystems,
+    osLoading,
+    deviceTypes,
+    deviceTypesLoading,
+    utmSources,
+    utmSourcesLoading,
+    customEvents,
+    customEventsLoading,
+    productEventsPreview,
+    productPresenceLoading,
+  }
+}
+
+function AnalyticsOverview() {
+  const {period, customFrom, customTo} = useAnalyticsParams()
+  const [filters, setFilters] = useState<AnalyticsFilter[]>([])
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const [breakdownTab, setBreakdownTab] = useState('pages')
+  const [analyticsTab, setAnalyticsTab] = useState<AnalyticsView>('web')
+
+  const {data: services, isLoading: servicesLoading, error: servicesError} = useQuery({
+    queryKey: ['projects'],
+    queryFn: () => api.getProjects(),
+  })
+
+  const serviceList = services ?? []
+  const includedServices = useMemo(
+    () => facetValues(facetFilters, 'service', false),
+    [facetFilters]
+  )
+  const excludedServices = useMemo(
+    () => facetValues(facetFilters, 'service', true),
+    [facetFilters]
+  )
+  const hasServiceFilters = includedServices.length > 0 || excludedServices.length > 0
+  const serviceNames = useMemo(
+    () => serviceNamesForQuery(serviceList, includedServices, excludedServices),
+    [serviceList, includedServices, excludedServices]
+  )
+  const scopeKey = analyticsScopeKey(serviceNames, hasServiceFilters)
+  const hasAnalyticsScope = serviceList.length > 0 && (!hasServiceFilters || serviceNames.length > 0)
+  const serviceParams = useMemo(() => analyticsServiceParams(serviceNames), [serviceNames])
+  const setupService = findSetupService(serviceList, serviceNames)
+
+  const dateParams = useMemo((): AnalyticsParams => ({
+    period,
+    ...(period === 'custom' && customFrom && customTo ? {from: customFrom, to: customTo} : {}),
+  }), [period, customFrom, customTo])
+
+  const params = useMemo((): AnalyticsParams => ({
+    ...dateParams,
+    ...serviceParams,
+    filters: filters.length > 0 ? filters : undefined,
+    comparison: 'previous_period',
+  }), [dateParams, filters, serviceParams])
+
+  const productParams = useMemo((): AnalyticsParams => ({
+    ...dateParams,
+    ...serviceParams,
+  }), [dateParams, serviceParams])
+
+  const productPresenceParams = useMemo((): AnalyticsParams => ({
+    ...PRODUCT_PRESENCE_PARAMS,
+    ...serviceParams,
+  }), [serviceParams])
+
+  const analyticsRailSections: FacetRailSection[] = useMemo(
+    () => [
+      {
+        key: 'service',
+        label: 'Service',
+        color: 'bg-primary',
+        options: serviceList.map((service) => ({value: service.name})),
+      },
+    ],
+    [serviceList]
+  )
+
+  const analyticsData = useAnalyticsQueries({
+    hasAnalyticsScope,
+    scopeKey,
+    params,
+    productPresenceParams,
+    breakdownTab,
+  })
+
+  const hasProductEvents = (analyticsData.productEventsPreview?.length ?? 0) > 0
+  const hasWebAnalytics =
+    (analyticsData.overview?.uniqueVisitors ?? 0) > 0 || (analyticsData.overview?.totalPageviews ?? 0) > 0
   const activeAnalyticsTab = analyticsTab
 
   const addFilterFromRow = (property: string) => (item: AnalyticsBreakdownItem) => {
-    if (filters.some(f => f.property === property && f.value === item.name)) return
-    setFilters([...filters, {property, operator: 'is', value: item.name}])
+    setFilters(current =>
+      current.some(f => f.property === property && f.value === item.name)
+        ? current
+        : [...current, {property, operator: 'is', value: item.name}]
+    )
   }
 
   if (servicesLoading) {
@@ -273,184 +330,326 @@ function AnalyticsOverview() {
       }
     >
       <div className="space-y-2 p-3">
-        {!hasAnalyticsScope ? (
-          <div className="py-10">
-            <EmptyState
-              icon={BarChart3}
-              title="No services match filters"
-              description="Adjust the selected services to view analytics."
-            />
-          </div>
-        ) : activeAnalyticsTab === 'web' ? (
-          <div className="space-y-2">
-              {!overviewLoading && !hasWebAnalytics ? (
-                <WebAnalyticsEmptyState service={setupService} />
-              ) : (
-                <>
-                  <AnalyticsFilterBar filters={filters} onFiltersChange={setFilters} />
-
-                  {overviewLoading ? (
-                    <AnalyticsKpiCardsSkeleton />
-                  ) : (
-                    <AnalyticsKpiCards data={overview} isLoading={overviewLoading} />
-                  )}
-
-                  <AnalyticsChart data={timeseries} isLoading={timeseriesLoading} />
-
-                  <Tabs value={breakdownTab} onValueChange={setBreakdownTab}>
-                    <TabsList className="h-7">
-                      <TabsTrigger value="pages" className="gap-1.5 text-xs">
-                        <FileText className="h-3.5 w-3.5" /> Pages
-                      </TabsTrigger>
-                      <TabsTrigger value="entry-pages" className="gap-1.5 text-xs">
-                        <LogIn className="h-3.5 w-3.5" /> Entry Pages
-                      </TabsTrigger>
-                      <TabsTrigger value="exit-pages" className="gap-1.5 text-xs">
-                        <LogOut className="h-3.5 w-3.5" /> Exit Pages
-                      </TabsTrigger>
-                      <TabsTrigger value="sources" className="gap-1.5 text-xs">
-                        <Share2 className="h-3.5 w-3.5" /> Sources
-                      </TabsTrigger>
-                      <TabsTrigger value="locations" className="gap-1.5 text-xs">
-                        <MapPin className="h-3.5 w-3.5" /> Locations
-                      </TabsTrigger>
-                      <TabsTrigger value="devices" className="gap-1.5 text-xs">
-                        <Laptop className="h-3.5 w-3.5" /> Devices
-                      </TabsTrigger>
-                      <TabsTrigger value="utm" className="gap-1.5 text-xs">
-                        <Megaphone className="h-3.5 w-3.5" /> UTM
-                      </TabsTrigger>
-                      <TabsTrigger value="events" className="gap-1.5 text-xs">
-                        <MousePointerClick className="h-3.5 w-3.5" /> Events
-                      </TabsTrigger>
-                    </TabsList>
-
-                    <TabsContent value="pages" className="mt-2">
-                      <AnalyticsBreakdownTable
-                        title="Top Pages"
-                        icon={FileText}
-                        iconColor="text-chart-1"
-                        data={pages}
-                        isLoading={pagesLoading}
-                        showBounceRate
-                        showDuration
-                        onRowClick={addFilterFromRow('pathname')}
-                      />
-                    </TabsContent>
-
-                    <TabsContent value="entry-pages" className="mt-2">
-                      <AnalyticsBreakdownTable
-                        title="Entry Pages"
-                        icon={LogIn}
-                        iconColor="text-chart-2"
-                        data={entryPages}
-                        isLoading={entryPagesLoading}
-                        showBounceRate
-                        onRowClick={addFilterFromRow('entry_page')}
-                      />
-                    </TabsContent>
-
-                    <TabsContent value="exit-pages" className="mt-2">
-                      <AnalyticsBreakdownTable
-                        title="Exit Pages"
-                        icon={LogOut}
-                        iconColor="text-chart-3"
-                        data={exitPages}
-                        isLoading={exitPagesLoading}
-                        onRowClick={addFilterFromRow('exit_page')}
-                      />
-                    </TabsContent>
-
-                    <TabsContent value="sources" className="mt-2">
-                      <AnalyticsBreakdownTable
-                        title="Top Sources"
-                        icon={Share2}
-                        iconColor="text-chart-4"
-                        data={sources}
-                        isLoading={sourcesLoading}
-                        onRowClick={addFilterFromRow('referrer_source')}
-                      />
-                    </TabsContent>
-
-                    <TabsContent value="locations" className="mt-2">
-                      <AnalyticsBreakdownTable
-                        title="Countries"
-                        icon={MapPin}
-                        iconColor="text-chart-5"
-                        data={locations}
-                        isLoading={locationsLoading}
-                        onRowClick={addFilterFromRow('country_code')}
-                      />
-                    </TabsContent>
-
-                    <TabsContent value="devices" className="mt-2">
-                      <div className="grid gap-2 lg:grid-cols-3">
-                        <AnalyticsBreakdownTable
-                          title="Browsers"
-                          icon={Globe}
-                          iconColor="text-chart-1"
-                          data={browsers}
-                          isLoading={browsersLoading}
-                          onRowClick={addFilterFromRow('browser')}
-                        />
-                        <AnalyticsBreakdownTable
-                          title="Operating Systems"
-                          icon={Laptop}
-                          iconColor="text-chart-2"
-                          data={operatingSystems}
-                          isLoading={osLoading}
-                          onRowClick={addFilterFromRow('os')}
-                        />
-                        <AnalyticsBreakdownTable
-                          title="Device Types"
-                          icon={Laptop}
-                          iconColor="text-chart-4"
-                          data={deviceTypes}
-                          isLoading={deviceTypesLoading}
-                          onRowClick={addFilterFromRow('device_type')}
-                        />
-                      </div>
-                    </TabsContent>
-
-                    <TabsContent value="utm" className="mt-2">
-                      <AnalyticsBreakdownTable
-                        title="UTM Sources"
-                        icon={Megaphone}
-                        iconColor="text-chart-6"
-                        data={utmSources}
-                        isLoading={utmSourcesLoading}
-                      />
-                    </TabsContent>
-
-                    <TabsContent value="events" className="mt-2">
-                      <AnalyticsBreakdownTable
-                        title="Custom Events"
-                        icon={MousePointerClick}
-                        iconColor="text-chart-7"
-                        data={customEvents}
-                        isLoading={customEventsLoading}
-                      />
-                    </TabsContent>
-                  </Tabs>
-                </>
-              )}
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {productPresenceLoading ? (
-              <div className="h-[220px] w-full animate-pulse rounded bg-muted" />
-            ) : hasProductEvents ? (
-              <ProductAnalyticsTab scopeId={ORGANIZATION_ANALYTICS_SCOPE} params={productParams} />
-            ) : (
-              <ProductAnalyticsEmptyState
-                service={setupService}
-                serviceId={setupService?.resourceId ?? 'your-service-id'}
-              />
-            )}
-          </div>
-        )}
+        <AnalyticsContent
+          hasAnalyticsScope={hasAnalyticsScope}
+          activeAnalyticsTab={activeAnalyticsTab}
+          hasWebAnalytics={hasWebAnalytics}
+          hasProductEvents={hasProductEvents}
+          setupService={setupService}
+          filters={filters}
+          setFilters={setFilters}
+          breakdownTab={breakdownTab}
+          setBreakdownTab={setBreakdownTab}
+          addFilterFromRow={addFilterFromRow}
+          productParams={productParams}
+          {...analyticsData}
+        />
       </div>
     </ExplorerShell>
+  )
+}
+
+type AddAnalyticsFilter = (property: string) => (item: AnalyticsBreakdownItem) => void
+
+type AnalyticsContentProps = Readonly<ReturnType<typeof useAnalyticsQueries> & {
+  hasAnalyticsScope: boolean
+  activeAnalyticsTab: AnalyticsView
+  hasWebAnalytics: boolean
+  hasProductEvents: boolean
+  setupService: Project | undefined
+  filters: AnalyticsFilter[]
+  setFilters: (filters: AnalyticsFilter[]) => void
+  breakdownTab: string
+  setBreakdownTab: (tab: string) => void
+  addFilterFromRow: AddAnalyticsFilter
+  productParams: AnalyticsParams
+}>
+
+function AnalyticsContent({
+  hasAnalyticsScope,
+  activeAnalyticsTab,
+  hasWebAnalytics,
+  hasProductEvents,
+  setupService,
+  filters,
+  setFilters,
+  breakdownTab,
+  setBreakdownTab,
+  addFilterFromRow,
+  productParams,
+  ...data
+}: AnalyticsContentProps) {
+  if (!hasAnalyticsScope) {
+    return (
+      <div className="py-10">
+        <EmptyState
+          icon={BarChart3}
+          title="No services match filters"
+          description="Adjust the selected services to view analytics."
+        />
+      </div>
+    )
+  }
+
+  if (activeAnalyticsTab === 'web') {
+    return (
+      <WebAnalyticsContent
+        hasWebAnalytics={hasWebAnalytics}
+        setupService={setupService}
+        filters={filters}
+        setFilters={setFilters}
+        breakdownTab={breakdownTab}
+        setBreakdownTab={setBreakdownTab}
+        addFilterFromRow={addFilterFromRow}
+        {...data}
+      />
+    )
+  }
+
+  return (
+    <ProductAnalyticsContent
+      productPresenceLoading={data.productPresenceLoading}
+      hasProductEvents={hasProductEvents}
+      setupService={setupService}
+      productParams={productParams}
+    />
+  )
+}
+
+type WebAnalyticsContentProps = Readonly<ReturnType<typeof useAnalyticsQueries> & {
+  hasWebAnalytics: boolean
+  setupService: Project | undefined
+  filters: AnalyticsFilter[]
+  setFilters: (filters: AnalyticsFilter[]) => void
+  breakdownTab: string
+  setBreakdownTab: (tab: string) => void
+  addFilterFromRow: AddAnalyticsFilter
+}>
+
+function WebAnalyticsContent({
+  hasWebAnalytics,
+  setupService,
+  filters,
+  setFilters,
+  breakdownTab,
+  setBreakdownTab,
+  addFilterFromRow,
+  overview,
+  overviewLoading,
+  timeseries,
+  timeseriesLoading,
+  pages,
+  pagesLoading,
+  entryPages,
+  entryPagesLoading,
+  exitPages,
+  exitPagesLoading,
+  sources,
+  sourcesLoading,
+  locations,
+  locationsLoading,
+  browsers,
+  browsersLoading,
+  operatingSystems,
+  osLoading,
+  deviceTypes,
+  deviceTypesLoading,
+  utmSources,
+  utmSourcesLoading,
+  customEvents,
+  customEventsLoading,
+}: WebAnalyticsContentProps) {
+  if (!overviewLoading && !hasWebAnalytics) {
+    return <WebAnalyticsEmptyState service={setupService} />
+  }
+
+  return (
+    <div className="space-y-2">
+      <AnalyticsFilterBar filters={filters} onFiltersChange={setFilters} />
+
+      {overviewLoading ? (
+        <AnalyticsKpiCardsSkeleton />
+      ) : (
+        <AnalyticsKpiCards data={overview} isLoading={overviewLoading} />
+      )}
+
+      <AnalyticsChart data={timeseries} isLoading={timeseriesLoading} />
+
+      <Tabs value={breakdownTab} onValueChange={setBreakdownTab}>
+        <TabsList className="h-7">
+          <TabsTrigger value="pages" className="gap-1.5 text-xs">
+            <FileText className="h-3.5 w-3.5" /> Pages
+          </TabsTrigger>
+          <TabsTrigger value="entry-pages" className="gap-1.5 text-xs">
+            <LogIn className="h-3.5 w-3.5" /> Entry Pages
+          </TabsTrigger>
+          <TabsTrigger value="exit-pages" className="gap-1.5 text-xs">
+            <LogOut className="h-3.5 w-3.5" /> Exit Pages
+          </TabsTrigger>
+          <TabsTrigger value="sources" className="gap-1.5 text-xs">
+            <Share2 className="h-3.5 w-3.5" /> Sources
+          </TabsTrigger>
+          <TabsTrigger value="locations" className="gap-1.5 text-xs">
+            <MapPin className="h-3.5 w-3.5" /> Locations
+          </TabsTrigger>
+          <TabsTrigger value="devices" className="gap-1.5 text-xs">
+            <Laptop className="h-3.5 w-3.5" /> Devices
+          </TabsTrigger>
+          <TabsTrigger value="utm" className="gap-1.5 text-xs">
+            <Megaphone className="h-3.5 w-3.5" /> UTM
+          </TabsTrigger>
+          <TabsTrigger value="events" className="gap-1.5 text-xs">
+            <MousePointerClick className="h-3.5 w-3.5" /> Events
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="pages" className="mt-2">
+          <AnalyticsBreakdownTable
+            title="Top Pages"
+            icon={FileText}
+            iconColor="text-chart-1"
+            data={pages}
+            isLoading={pagesLoading}
+            showBounceRate
+            showDuration
+            onRowClick={addFilterFromRow('pathname')}
+          />
+        </TabsContent>
+
+        <TabsContent value="entry-pages" className="mt-2">
+          <AnalyticsBreakdownTable
+            title="Entry Pages"
+            icon={LogIn}
+            iconColor="text-chart-2"
+            data={entryPages}
+            isLoading={entryPagesLoading}
+            showBounceRate
+            onRowClick={addFilterFromRow('entry_page')}
+          />
+        </TabsContent>
+
+        <TabsContent value="exit-pages" className="mt-2">
+          <AnalyticsBreakdownTable
+            title="Exit Pages"
+            icon={LogOut}
+            iconColor="text-chart-3"
+            data={exitPages}
+            isLoading={exitPagesLoading}
+            onRowClick={addFilterFromRow('exit_page')}
+          />
+        </TabsContent>
+
+        <TabsContent value="sources" className="mt-2">
+          <AnalyticsBreakdownTable
+            title="Top Sources"
+            icon={Share2}
+            iconColor="text-chart-4"
+            data={sources}
+            isLoading={sourcesLoading}
+            onRowClick={addFilterFromRow('referrer_source')}
+          />
+        </TabsContent>
+
+        <TabsContent value="locations" className="mt-2">
+          <AnalyticsBreakdownTable
+            title="Countries"
+            icon={MapPin}
+            iconColor="text-chart-5"
+            data={locations}
+            isLoading={locationsLoading}
+            onRowClick={addFilterFromRow('country_code')}
+          />
+        </TabsContent>
+
+        <TabsContent value="devices" className="mt-2">
+          <div className="grid gap-2 lg:grid-cols-3">
+            <AnalyticsBreakdownTable
+              title="Browsers"
+              icon={Globe}
+              iconColor="text-chart-1"
+              data={browsers}
+              isLoading={browsersLoading}
+              onRowClick={addFilterFromRow('browser')}
+            />
+            <AnalyticsBreakdownTable
+              title="Operating Systems"
+              icon={Laptop}
+              iconColor="text-chart-2"
+              data={operatingSystems}
+              isLoading={osLoading}
+              onRowClick={addFilterFromRow('os')}
+            />
+            <AnalyticsBreakdownTable
+              title="Device Types"
+              icon={Laptop}
+              iconColor="text-chart-4"
+              data={deviceTypes}
+              isLoading={deviceTypesLoading}
+              onRowClick={addFilterFromRow('device_type')}
+            />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="utm" className="mt-2">
+          <AnalyticsBreakdownTable
+            title="UTM Sources"
+            icon={Megaphone}
+            iconColor="text-chart-6"
+            data={utmSources}
+            isLoading={utmSourcesLoading}
+          />
+        </TabsContent>
+
+        <TabsContent value="events" className="mt-2">
+          <AnalyticsBreakdownTable
+            title="Custom Events"
+            icon={MousePointerClick}
+            iconColor="text-chart-7"
+            data={customEvents}
+            isLoading={customEventsLoading}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+type ProductAnalyticsContentProps = Readonly<{
+  productPresenceLoading: boolean
+  hasProductEvents: boolean
+  setupService: Project | undefined
+  productParams: AnalyticsParams
+}>
+
+function ProductAnalyticsContent({
+  productPresenceLoading,
+  hasProductEvents,
+  setupService,
+  productParams,
+}: ProductAnalyticsContentProps) {
+  if (productPresenceLoading) {
+    return (
+      <div className="space-y-2">
+        <div className="h-[220px] w-full animate-pulse rounded bg-muted" />
+      </div>
+    )
+  }
+
+  if (hasProductEvents) {
+    return (
+      <div className="space-y-2">
+        <ProductAnalyticsTab scopeId={ORGANIZATION_ANALYTICS_SCOPE} params={productParams} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <ProductAnalyticsEmptyState
+        service={setupService}
+        serviceId={setupService?.resourceId ?? 'your-service-id'}
+      />
+    </div>
   )
 }
 

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -65,6 +65,16 @@ function analyticsServiceParams(serviceNames: readonly string[]): Pick<Analytics
   return serviceNames.length > 0 ? {services: [...serviceNames]} : {}
 }
 
+function analyticsFiltersWithRow(
+  current: AnalyticsFilter[],
+  property: string,
+  item: AnalyticsBreakdownItem
+): AnalyticsFilter[] {
+  const hasFilter = current.some((filter) => filter.property === property && filter.value === item.name)
+  if (hasFilter) return current
+  return [...current, {property, operator: 'is', value: item.name}]
+}
+
 function findSetupService(services: readonly Project[], serviceNames: readonly string[]): Project | undefined {
   if (serviceNames.length === 0) return services[0]
   return services.find((service) => service.name === serviceNames[0]) ?? services[0]
@@ -276,11 +286,7 @@ function AnalyticsOverview() {
   const activeAnalyticsTab = analyticsTab
 
   const addFilterFromRow = (property: string) => (item: AnalyticsBreakdownItem) => {
-    setFilters(current =>
-      current.some(f => f.property === property && f.value === item.name)
-        ? current
-        : [...current, {property, operator: 'is', value: item.name}]
-    )
+    setFilters((current) => analyticsFiltersWithRow(current, property, item))
   }
 
   if (servicesLoading) {
@@ -314,7 +320,7 @@ function AnalyticsOverview() {
       tabs={
         <SegmentedTabs
           ariaLabel="Analytics view"
-          value={activeAnalyticsTab as AnalyticsView}
+          value={activeAnalyticsTab}
           onChange={setAnalyticsTab}
           options={ANALYTICS_VIEW_TABS}
         />

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -18,11 +18,11 @@ import {createFileRoute, Outlet, redirect, useMatches, useNavigate} from '@tanst
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {formatRelativeTime, cn} from '@/lib/utils'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
-import {PageHeader} from '@/components/ui/page-header'
 import {StatCard} from '@/components/ui/stat-card'
 import {EmptyState} from '@/components/ui/empty-state'
 import {StatusDot, type StatusTone} from '@/components/ui/status-dot'
@@ -722,28 +722,22 @@ function FeedbackPage() {
   )
 
   return (
-    <div className="min-h-screen">
-      <div className="container mx-auto px-4 py-4 space-y-3">
-        <PageHeader
-          icon={MessageSquare}
-          title="User Feedback"
-          description="Review and manage feedback from your users"
+    <ExplorerShell
+      title="User Feedback"
+      icon={<MessageSquare className="h-4 w-4 text-muted-foreground" />}
+      searchBar={<div />}
+      rail={
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          title="Feedback"
         />
-
-        <div className="grid gap-2 lg:grid-cols-[220px_minmax(0,1fr)]">
-          <FacetRail
-            sections={railSections}
-            facetFilters={facetFilters}
-            onFacetFiltersChange={handleFacetFiltersChange}
-            title="Feedback"
-            className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
-          />
-
-          <div className="min-w-0">
-            {feedbackContent}
-          </div>
-        </div>
+      }
+    >
+      <div className="space-y-3 p-3">
+        {feedbackContent}
       </div>
-    </div>
+    </ExplorerShell>
   )
 }

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -433,7 +433,7 @@ function IndexPage() {
   )
 
   return (
-    <div className="h-[calc(100vh-var(--header-height,0px))] overflow-hidden">
+    <div className="h-[calc(100vh-var(--app-header-h,0px))] overflow-hidden">
       {activeTab === 'issues' ? (
         <DashboardPage tabs={viewTabs} />
       ) : (
@@ -525,11 +525,11 @@ function DashboardPage({tabs}: DashboardPageProps) {
 
   const handleToggleIssue = (issue: SafeIssue) => {
     const key = issueSelectionKey(issue)
-    setSelectedIssueKeys(toggledSelection(selectedIssueKeys, key))
+    setSelectedIssueKeys((prev) => toggledSelection(prev, key))
   }
 
   const handleToggleAll = () => {
-    setSelectedIssueKeys(toggledPageSelection(selectedIssueKeys, pagedIssues))
+    setSelectedIssueKeys((prev) => toggledPageSelection(prev, pagedIssues))
   }
 
   const handleResolveSelected = () => {

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -116,8 +116,172 @@ type IssueUpdateTarget = {
   projectResourceId: string
 }
 
+type IssueActionStatus = 'resolved' | 'ignored' | 'resolvedInNextRelease'
+type ToastFn = ReturnType<typeof useToast>['toast']
+type QueryClient = ReturnType<typeof useQueryClient>
+
 function issueSelectionKey(issue: Pick<SafeIssue, 'id' | 'projectResourceId'>): string {
   return `${issue.projectResourceId}:${issue.id}`
+}
+
+function toggledSelection(current: ReadonlySet<string>, key: string): Set<string> {
+  const next = new Set(current)
+  if (next.has(key)) {
+    next.delete(key)
+  } else {
+    next.add(key)
+  }
+  return next
+}
+
+function toggledPageSelection(
+  current: ReadonlySet<string>,
+  issues: readonly SafeIssue[]
+): Set<string> {
+  const pageKeys = issues.map(issueSelectionKey)
+  const next = new Set(current)
+  const allPageIssuesSelected = pageKeys.every((key) => current.has(key))
+  if (allPageIssuesSelected) {
+    pageKeys.forEach((key) => next.delete(key))
+  } else {
+    pageKeys.forEach((key) => next.add(key))
+  }
+  return next
+}
+
+function issueTargetsFromSelection(
+  keys: ReadonlySet<string>,
+  byKey: ReadonlyMap<string, IssueUpdateTarget>
+): IssueUpdateTarget[] {
+  const targets: IssueUpdateTarget[] = []
+  keys.forEach((key) => {
+    const target = byKey.get(key)
+    if (target) targets.push(target)
+  })
+  return targets
+}
+
+function matchesIssueFilters(
+  issue: SafeIssue,
+  normalizedSearchQuery: string,
+  statusIncludes: readonly string[],
+  statusExcludes: readonly string[],
+  levelIncludes: readonly string[],
+  levelExcludes: readonly string[]
+): boolean {
+  const matchesSearch =
+    normalizedSearchQuery === '' ||
+    issue.title.toLowerCase().includes(normalizedSearchQuery) ||
+    issue.culprit.toLowerCase().includes(normalizedSearchQuery)
+  const matchesStatus =
+    (statusIncludes.length === 0 || statusIncludes.includes(issue.status)) &&
+    !statusExcludes.includes(issue.status)
+  const matchesLevel =
+    (levelIncludes.length === 0 || levelIncludes.includes(issue.level)) &&
+    !levelExcludes.includes(issue.level)
+  return matchesSearch && matchesStatus && matchesLevel
+}
+
+function issueActionToast({
+  submitted,
+  successCount,
+  successLabel,
+}: Readonly<{
+  submitted: number
+  successCount: number
+  successLabel: string
+}>) {
+  if (successCount === submitted) {
+    return {
+      title: 'Success',
+      description: `${submitted} issue${submitted === 1 ? '' : 's'} ${successLabel}`,
+    }
+  }
+
+  return {
+    title: 'Partial Success',
+    description: `${successCount}/${submitted} issues ${successLabel}`,
+    variant: 'destructive' as const,
+  }
+}
+
+function useIssueBulkMutation({
+  status,
+  eventName,
+  successLabel,
+  errorDescription,
+  queryClient,
+  toast,
+  clearSelection,
+}: Readonly<{
+  status: IssueActionStatus
+  eventName: string
+  successLabel: string
+  errorDescription: string
+  queryClient: QueryClient
+  toast: ToastFn
+  clearSelection: () => void
+}>) {
+  return useMutation({
+    mutationFn: async (issues: IssueUpdateTarget[]) => {
+      const results = await Promise.allSettled(
+        issues.map((issue) => api.updateIssue(issue.id, { status }, issue.projectResourceId))
+      )
+      const successCount = results.filter(r => r.status === 'fulfilled').length
+      if (successCount === 0) throw new Error('All requests failed')
+      return { submitted: issues.length, successCount }
+    },
+    onSuccess: ({ submitted, successCount }) => {
+      trackEvent(eventName, { count: String(successCount) })
+      queryClient.invalidateQueries({ queryKey: ['issues'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
+      toast(issueActionToast({submitted, successCount, successLabel}))
+      clearSelection()
+    },
+    onError: () => {
+      toast({ title: 'Error', description: errorDescription, variant: 'destructive' })
+    },
+  })
+}
+
+function useIssueBulkMutations({
+  queryClient,
+  toast,
+  clearSelection,
+}: Readonly<{
+  queryClient: QueryClient
+  toast: ToastFn
+  clearSelection: () => void
+}>) {
+  const resolveMutation = useIssueBulkMutation({
+    status: 'resolved',
+    eventName: 'Issue Resolve',
+    successLabel: 'resolved',
+    errorDescription: 'Failed to resolve issues',
+    queryClient,
+    toast,
+    clearSelection,
+  })
+  const ignoreMutation = useIssueBulkMutation({
+    status: 'ignored',
+    eventName: 'Issue Ignore',
+    successLabel: 'ignored',
+    errorDescription: 'Failed to ignore issues',
+    queryClient,
+    toast,
+    clearSelection,
+  })
+  const resolveNextReleaseMutation = useIssueBulkMutation({
+    status: 'resolvedInNextRelease',
+    eventName: 'Issue ResolveInNextRelease',
+    successLabel: 'marked to resolve in next release',
+    errorDescription: 'Failed to update issues',
+    queryClient,
+    toast,
+    clearSelection,
+  })
+
+  return {resolveMutation, ignoreMutation, resolveNextReleaseMutation}
 }
 
 function clampText(value: string, maxChars: number): string {
@@ -279,7 +443,11 @@ function IndexPage() {
   )
 }
 
-function DashboardPage({tabs}: {tabs?: ReactNode}) {
+type DashboardPageProps = Readonly<{
+  tabs?: ReactNode
+}>
+
+function DashboardPage({tabs}: DashboardPageProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
   const [selectedIssueKeys, setSelectedIssueKeys] = useState<Set<string>>(new Set())
@@ -343,131 +511,25 @@ function DashboardPage({tabs}: {tabs?: ReactNode}) {
     enabled: issuesQueryEnabled,
   })
 
-  const resolveMutation = useMutation({
-    mutationFn: async (issues: IssueUpdateTarget[]) => {
-      const results = await Promise.allSettled(
-        issues.map((issue) => api.updateIssue(issue.id, { status: 'resolved' }, issue.projectResourceId))
-      )
-      const successCount = results.filter(r => r.status === 'fulfilled').length
-      if (successCount === 0) throw new Error('All requests failed')
-      return { submitted: issues.length, successCount }
-    },
-    onSuccess: ({ submitted, successCount }) => {
-      trackEvent('Issue Resolve', { count: String(successCount) })
-      queryClient.invalidateQueries({ queryKey: ['issues'] })
-      queryClient.invalidateQueries({ queryKey: ['stats'] })
-      if (successCount === submitted) {
-        toast({
-          title: 'Success',
-          description: `${submitted} issue${submitted === 1 ? '' : 's'} resolved`,
-        })
-      } else {
-        toast({
-          title: 'Partial Success',
-          description: `${successCount}/${submitted} issues resolved`,
-          variant: 'destructive',
-        })
-      }
-      setSelectedIssueKeys(new Set())
-    },
-    onError: () => {
-      toast({
-        title: 'Error',
-        description: 'Failed to resolve issues',
-        variant: 'destructive',
-      })
-    },
-  })
-
-  const ignoreMutation = useMutation({
-    mutationFn: async (issues: IssueUpdateTarget[]) => {
-      const results = await Promise.allSettled(
-        issues.map((issue) => api.updateIssue(issue.id, { status: 'ignored' }, issue.projectResourceId))
-      )
-      const successCount = results.filter(r => r.status === 'fulfilled').length
-      if (successCount === 0) throw new Error('All requests failed')
-      return { submitted: issues.length, successCount }
-    },
-    onSuccess: ({ submitted, successCount }) => {
-      trackEvent('Issue Ignore', { count: String(successCount) })
-      queryClient.invalidateQueries({ queryKey: ['issues'] })
-      queryClient.invalidateQueries({ queryKey: ['stats'] })
-      if (successCount === submitted) {
-        toast({
-          title: 'Success',
-          description: `${submitted} issue${submitted === 1 ? '' : 's'} ignored`,
-        })
-      } else {
-        toast({
-          title: 'Partial Success',
-          description: `${successCount}/${submitted} issues ignored`,
-          variant: 'destructive',
-        })
-      }
-      setSelectedIssueKeys(new Set())
-    },
-    onError: () => {
-      toast({ title: 'Error', description: 'Failed to ignore issues', variant: 'destructive' })
-    },
-  })
-
-  const resolveNextReleaseMutation = useMutation({
-    mutationFn: async (issues: IssueUpdateTarget[]) => {
-      const results = await Promise.allSettled(
-        issues.map((issue) =>
-          api.updateIssue(issue.id, { status: 'resolvedInNextRelease' }, issue.projectResourceId)
-        )
-      )
-      const successCount = results.filter(r => r.status === 'fulfilled').length
-      if (successCount === 0) throw new Error('All requests failed')
-      return { submitted: issues.length, successCount }
-    },
-    onSuccess: ({ submitted, successCount }) => {
-      trackEvent('Issue ResolveInNextRelease', { count: String(successCount) })
-      queryClient.invalidateQueries({ queryKey: ['issues'] })
-      queryClient.invalidateQueries({ queryKey: ['stats'] })
-      if (successCount === submitted) {
-        toast({
-          title: 'Success',
-          description: `${submitted} issue${submitted === 1 ? '' : 's'} marked to resolve in next release`,
-        })
-      } else {
-        toast({
-          title: 'Partial Success',
-          description: `${successCount}/${submitted} issues marked to resolve in next release`,
-          variant: 'destructive',
-        })
-      }
-      setSelectedIssueKeys(new Set())
-    },
-    onError: () => {
-      toast({ title: 'Error', description: 'Failed to update issues', variant: 'destructive' })
-    },
+  const {
+    resolveMutation,
+    ignoreMutation,
+    resolveNextReleaseMutation,
+  } = useIssueBulkMutations({
+    queryClient,
+    toast,
+    clearSelection: () => setSelectedIssueKeys(new Set()),
   })
 
   const bulkPending = resolveMutation.isPending || ignoreMutation.isPending || resolveNextReleaseMutation.isPending
 
   const handleToggleIssue = (issue: SafeIssue) => {
     const key = issueSelectionKey(issue)
-    const newSelected = new Set(selectedIssueKeys)
-    if (newSelected.has(key)) {
-      newSelected.delete(key)
-    } else {
-      newSelected.add(key)
-    }
-    setSelectedIssueKeys(newSelected)
+    setSelectedIssueKeys(toggledSelection(selectedIssueKeys, key))
   }
 
   const handleToggleAll = () => {
-    const pageKeys = pagedIssues.map(issueSelectionKey)
-    const allPageIssuesSelected = pageKeys.every((key) => selectedIssueKeys.has(key))
-    const nextSelected = new Set(selectedIssueKeys)
-    if (allPageIssuesSelected) {
-      pageKeys.forEach((key) => nextSelected.delete(key))
-    } else {
-      pageKeys.forEach((key) => nextSelected.add(key))
-    }
-    setSelectedIssueKeys(nextSelected)
+    setSelectedIssueKeys(toggledPageSelection(selectedIssueKeys, pagedIssues))
   }
 
   const handleResolveSelected = () => {
@@ -503,30 +565,21 @@ function DashboardPage({tabs}: {tabs?: ReactNode}) {
     })
     return byKey
   }, [safeIssues])
-  const selectedIssueTargets: IssueUpdateTarget[] = []
-  selectedIssueKeys.forEach((key) => {
-    const target = safeIssuesByKey.get(key)
-    if (target) selectedIssueTargets.push(target)
-  })
+  const selectedIssueTargets = issueTargetsFromSelection(selectedIssueKeys, safeIssuesByKey)
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase()
 
   // Service filters are resolved by the org-wide API. Status, level, and search
   // narrow the loaded issue set client-side so include/exclude semantics remain.
   const filteredIssues = safeIssues
-    .filter((issue) => {
-      const matchesSearch =
-        normalizedSearchQuery === '' ||
-        issue.title.toLowerCase().includes(normalizedSearchQuery) ||
-        issue.culprit.toLowerCase().includes(normalizedSearchQuery)
-      const matchesStatus =
-        (statusIncludes.length === 0 || statusIncludes.includes(issue.status)) &&
-        !statusExcludes.includes(issue.status)
-      const matchesLevel =
-        (levelIncludes.length === 0 || levelIncludes.includes(issue.level)) &&
-        !levelExcludes.includes(issue.level)
-      return matchesSearch && matchesStatus && matchesLevel
-    })
+    .filter((issue) => matchesIssueFilters(
+      issue,
+      normalizedSearchQuery,
+      statusIncludes,
+      statusExcludes,
+      levelIncludes,
+      levelExcludes
+    ))
     .sort((a, b) => (b.lastSeen || '').localeCompare(a.lastSeen || ''))
 
   const totalPages = Math.max(1, Math.ceil(filteredIssues.length / pageSize))
@@ -651,210 +704,361 @@ function DashboardPage({tabs}: {tabs?: ReactNode}) {
         />
       }
       toolbar={
-        <>
-          {pagedIssues.length > 0 && (
-            <div className="flex items-center gap-2">
-              <Checkbox
-                checked={pagedIssues.length > 0 && pagedIssues.every((issue) =>
-                  selectedIssueKeys.has(issueSelectionKey(issue))
-                )}
-                onCheckedChange={handleToggleAll}
-                aria-label="Select all issues"
-              />
-              <span className="text-sm text-muted-foreground whitespace-nowrap hidden sm:inline">Select all</span>
-            </div>
-          )}
-          {selectedIssueTargets.length > 0 && (
-            <div className="flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-lg px-2 py-0.5">
-              <CheckCircle2 className="h-4 w-4 text-primary" />
-              <span className="text-sm font-medium whitespace-nowrap">{selectedIssueTargets.length} selected</span>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button disabled={bulkPending} size="sm" className="h-7 ml-1">
-                    {bulkPending ? 'Updating...' : 'Actions'}
-                    <ChevronDown className="h-3 w-3 ml-1" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={handleResolveSelected}>
-                    <CheckCircle2 className="h-4 w-4 mr-2" />
-                    Resolve
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={handleIgnoreSelected}>
-                    <EyeOff className="h-4 w-4 mr-2" />
-                    Ignore
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={handleResolveNextReleaseSelected}>
-                    <Timer className="h-4 w-4 mr-2" />
-                    Resolve in Next Release
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          )}
-          <span className="ml-auto text-sm text-muted-foreground whitespace-nowrap hidden lg:inline">
-            {filteredIssues.length} result{filteredIssues.length !== 1 ? 's' : ''}
-          </span>
-        </>
+        <IssueExplorerToolbar
+          pagedIssues={pagedIssues}
+          selectedIssueKeys={selectedIssueKeys}
+          selectedIssueCount={selectedIssueTargets.length}
+          bulkPending={bulkPending}
+          filteredIssueCount={filteredIssues.length}
+          onToggleAll={handleToggleAll}
+          onResolveSelected={handleResolveSelected}
+          onIgnoreSelected={handleIgnoreSelected}
+          onResolveNextReleaseSelected={handleResolveNextReleaseSelected}
+        />
       }
     >
-      <div className="p-4">
-        {issuesLoading ? (
-          <div className="p-6 text-muted-foreground">Loading issues...</div>
-        ) : issuesError ? (
-          <div className="p-6 text-destructive border border-destructive/30 rounded-lg bg-destructive/5">
-            Failed to load issues: {issuesErrorObj instanceof Error ? issuesErrorObj.message : 'Unknown error'}
-          </div>
-        ) : filteredIssues.length === 0 ? (
-          <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
-            <div className="max-w-md mx-auto space-y-4">
-              <div className="flex justify-center">
-                <div className="rounded-full bg-info-bg p-4">
-                  {hasActiveIssueFilters ? (
-                    <Search className="h-10 w-10 text-info-fg" />
-                  ) : (
-                    <AlertCircle className="h-10 w-10 text-info-fg" />
-                  )}
-                </div>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold mb-2">
-                  {hasActiveIssueFilters ? 'No issues match your filters' : 'No issues yet'}
-                </h3>
-                <p className="text-muted-foreground">
-                  {hasActiveIssueFilters
-                    ? 'Try adjusting your search or filters.'
-                    : 'Start sending errors to your services to see them tracked here.'}
-                </p>
-              </div>
-            </div>
-          </Card>
-        ) : (
-          <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
-            {/* Table header */}
-            <div className="hidden md:flex items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
-              <div className="w-4 shrink-0" />
-              <div className="w-[4.5rem] shrink-0">Level</div>
-              <div className="flex-1 min-w-0">Issue</div>
-              <div className="hidden lg:block w-20 shrink-0">Platform</div>
-              <div className="hidden lg:block w-20 shrink-0 text-center">Trend</div>
-              <div className="w-[55px] shrink-0 text-right">Events</div>
-              <div className="hidden sm:block w-[45px] shrink-0 text-right">Users</div>
-              <div className="w-20 shrink-0 text-right">Last Seen</div>
-            </div>
-            {/* Issue rows */}
-            <div className="divide-y divide-border/40">
-              {pagedIssues.map((issue) => (
-                <div
-                  key={issueSelectionKey(issue)}
-                  className={`hover:bg-accent/40 transition border-l-[3px] ${levelBorderClass(issue.level)}`}
-                >
-                  <div className="flex items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
-                    <Checkbox
-                      checked={selectedIssueKeys.has(issueSelectionKey(issue))}
-                      onCheckedChange={() => handleToggleIssue(issue)}
-                      onClick={(e) => e.stopPropagation()}
-                      aria-label={`Select ${issue.title}`}
-                      className="shrink-0"
-                    />
-                    <Link
-                      to="/issues/$issueId"
-                      params={{ issueId: issue.id }}
-                      search={{ projectId: issue.projectResourceId }}
-                      className="flex-1 flex items-center gap-2 sm:gap-3 min-w-0"
-                    >
-                      <div className="w-12 sm:w-[4.5rem] shrink-0">
-                        <Badge variant={levelBadgeVariant(issue.level)} className="text-[10px] sm:text-[11px] px-1.5 py-0">
-                          <span className="sm:hidden">{issue.level.toUpperCase().slice(0, 3)}</span>
-                          <span className="hidden sm:inline">{issue.level.toUpperCase()}</span>
-                        </Badge>
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-1.5 sm:gap-2 min-w-0">
-                          <span className="font-semibold truncate flex-1 min-w-0 text-sm sm:text-base" title={getIssueDisplayTitle(issue)}>
-                            {getIssueDisplayTitle(issue)}
-                          </span>
-                          <div className="flex items-center gap-2 shrink-0">
-                            {isNewIssue(issue.firstSeen) && (
-                              <span className="text-[10px] font-bold text-success-fg bg-success-bg px-1.5 py-0.5 rounded uppercase">
-                                New
-                              </span>
-                            )}
-                            {issue.status === 'resolved' && (
-                              <Badge variant="success" className="text-[11px] px-1.5 py-0">
-                                Resolved
-                              </Badge>
-                            )}
-                            {issue.status === 'ignored' && (
-                              <Badge variant="secondary" className="text-[11px] px-1.5 py-0">
-                                <EyeOff className="h-3 w-3" />
-                                Ignored
-                              </Badge>
-                            )}
-                            {issue.status === 'resolvedInNextRelease' && (
-                              <Badge variant="info" className="text-[11px] px-1.5 py-0">
-                                <Timer className="h-3 w-3" />
-                                Next Release
-                              </Badge>
-                            )}
-                          </div>
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-0.5">
-                          <Clock className="inline h-3 w-3 mr-1 -mt-0.5" />
-                          First seen {formatRelativeTime(issue.firstSeen)}
-                        </div>
-                      </div>
-                      <div className="hidden lg:block w-20 shrink-0">
-                        <Badge variant="outline" className="text-[11px] px-1.5 py-0">{issue.platform}</Badge>
-                      </div>
-                      <div className="hidden lg:flex w-20 shrink-0 justify-center">
-                        <EventSparkline eventCount={issue.eventCount} />
-                      </div>
-                      <div className="w-[55px] shrink-0 text-right">
-                        <div className="font-semibold text-foreground">{formatCount(issue.eventCount)}</div>
-                        <div className="text-xs text-muted-foreground">events</div>
-                      </div>
-                      <div className="hidden sm:block w-[45px] shrink-0 text-right">
-                        <div className="font-semibold text-foreground">{issue.userCount ?? 0}</div>
-                        <div className="text-xs text-muted-foreground">users</div>
-                      </div>
-                      <div className="hidden md:block w-20 shrink-0 text-right">
-                        <span className={`text-xs font-medium ${getLastSeenColor(issue.lastSeen)}`}>
-                          {formatRelativeTime(issue.lastSeen)}
-                        </span>
-                      </div>
-                    </Link>
-                  </div>
-                </div>
-              ))}
-            </div>
-            {totalPages > 1 && (
-              <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={currentPage <= 1}
-                  onClick={() => setPage(p => Math.max(1, p - 1))}
-                >
-                  Previous
-                </Button>
-                <span className="text-sm text-muted-foreground self-center">
-                  Page {currentPage} of {totalPages}
-                </span>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={currentPage >= totalPages}
-                  onClick={() => setPage(p => p + 1)}
-                >
-                  Next
-                </Button>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      <IssueExplorerContent
+        issuesLoading={issuesLoading}
+        issuesError={issuesError}
+        issuesErrorObj={issuesErrorObj}
+        filteredIssues={filteredIssues}
+        pagedIssues={pagedIssues}
+        selectedIssueKeys={selectedIssueKeys}
+        totalPages={totalPages}
+        currentPage={currentPage}
+        hasActiveIssueFilters={hasActiveIssueFilters}
+        onToggleIssue={handleToggleIssue}
+        onPreviousPage={() => setPage(p => Math.max(1, p - 1))}
+        onNextPage={() => setPage(p => p + 1)}
+      />
     </ExplorerShell>
+  )
+}
+
+type IssueExplorerToolbarProps = Readonly<{
+  pagedIssues: readonly SafeIssue[]
+  selectedIssueKeys: ReadonlySet<string>
+  selectedIssueCount: number
+  bulkPending: boolean
+  filteredIssueCount: number
+  onToggleAll: () => void
+  onResolveSelected: () => void
+  onIgnoreSelected: () => void
+  onResolveNextReleaseSelected: () => void
+}>
+
+function IssueExplorerToolbar({
+  pagedIssues,
+  selectedIssueKeys,
+  selectedIssueCount,
+  bulkPending,
+  filteredIssueCount,
+  onToggleAll,
+  onResolveSelected,
+  onIgnoreSelected,
+  onResolveNextReleaseSelected,
+}: IssueExplorerToolbarProps) {
+  const allPagedIssuesSelected = pagedIssues.every((issue) =>
+    selectedIssueKeys.has(issueSelectionKey(issue))
+  )
+
+  return (
+    <>
+      {pagedIssues.length > 0 && (
+        <div className="flex items-center gap-2">
+          <Checkbox
+            checked={allPagedIssuesSelected}
+            onCheckedChange={onToggleAll}
+            aria-label="Select all issues"
+          />
+          <span className="text-sm text-muted-foreground whitespace-nowrap hidden sm:inline">Select all</span>
+        </div>
+      )}
+      {selectedIssueCount > 0 && (
+        <div className="flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-lg px-2 py-0.5">
+          <CheckCircle2 className="h-4 w-4 text-primary" />
+          <span className="text-sm font-medium whitespace-nowrap">{selectedIssueCount} selected</span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button disabled={bulkPending} size="sm" className="h-7 ml-1">
+                {bulkPending ? 'Updating...' : 'Actions'}
+                <ChevronDown className="h-3 w-3 ml-1" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onResolveSelected}>
+                <CheckCircle2 className="h-4 w-4 mr-2" />
+                Resolve
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onIgnoreSelected}>
+                <EyeOff className="h-4 w-4 mr-2" />
+                Ignore
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onResolveNextReleaseSelected}>
+                <Timer className="h-4 w-4 mr-2" />
+                Resolve in Next Release
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+      <span className="ml-auto text-sm text-muted-foreground whitespace-nowrap hidden lg:inline">
+        {filteredIssueCount} result{filteredIssueCount !== 1 ? 's' : ''}
+      </span>
+    </>
+  )
+}
+
+type IssueExplorerContentProps = Readonly<{
+  issuesLoading: boolean
+  issuesError: boolean
+  issuesErrorObj: unknown
+  filteredIssues: readonly SafeIssue[]
+  pagedIssues: readonly SafeIssue[]
+  selectedIssueKeys: ReadonlySet<string>
+  totalPages: number
+  currentPage: number
+  hasActiveIssueFilters: boolean
+  onToggleIssue: (issue: SafeIssue) => void
+  onPreviousPage: () => void
+  onNextPage: () => void
+}>
+
+function IssueExplorerContent({
+  issuesLoading,
+  issuesError,
+  issuesErrorObj,
+  filteredIssues,
+  pagedIssues,
+  selectedIssueKeys,
+  totalPages,
+  currentPage,
+  hasActiveIssueFilters,
+  onToggleIssue,
+  onPreviousPage,
+  onNextPage,
+}: IssueExplorerContentProps) {
+  if (issuesLoading) {
+    return <div className="p-6 text-muted-foreground">Loading issues...</div>
+  }
+
+  if (issuesError) {
+    return (
+      <div className="p-6 text-destructive border border-destructive/30 rounded-lg bg-destructive/5">
+        Failed to load issues: {issuesErrorObj instanceof Error ? issuesErrorObj.message : 'Unknown error'}
+      </div>
+    )
+  }
+
+  if (filteredIssues.length === 0) {
+    return (
+      <div className="p-4">
+        <IssueEmptyState hasActiveIssueFilters={hasActiveIssueFilters} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4">
+      <IssueTable
+        pagedIssues={pagedIssues}
+        selectedIssueKeys={selectedIssueKeys}
+        totalPages={totalPages}
+        currentPage={currentPage}
+        onToggleIssue={onToggleIssue}
+        onPreviousPage={onPreviousPage}
+        onNextPage={onNextPage}
+      />
+    </div>
+  )
+}
+
+function IssueEmptyState({hasActiveIssueFilters}: Readonly<{hasActiveIssueFilters: boolean}>) {
+  const Icon = hasActiveIssueFilters ? Search : AlertCircle
+  const title = hasActiveIssueFilters ? 'No issues match your filters' : 'No issues yet'
+  const description = hasActiveIssueFilters
+    ? 'Try adjusting your search or filters.'
+    : 'Start sending errors to your services to see them tracked here.'
+
+  return (
+    <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
+      <div className="max-w-md mx-auto space-y-4">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-info-bg p-4">
+            <Icon className="h-10 w-10 text-info-fg" />
+          </div>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold mb-2">{title}</h3>
+          <p className="text-muted-foreground">{description}</p>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+type IssueTableProps = Readonly<{
+  pagedIssues: readonly SafeIssue[]
+  selectedIssueKeys: ReadonlySet<string>
+  totalPages: number
+  currentPage: number
+  onToggleIssue: (issue: SafeIssue) => void
+  onPreviousPage: () => void
+  onNextPage: () => void
+}>
+
+function IssueTable({
+  pagedIssues,
+  selectedIssueKeys,
+  totalPages,
+  currentPage,
+  onToggleIssue,
+  onPreviousPage,
+  onNextPage,
+}: IssueTableProps) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
+      <div className="hidden md:flex items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
+        <div className="w-4 shrink-0" />
+        <div className="w-[4.5rem] shrink-0">Level</div>
+        <div className="flex-1 min-w-0">Issue</div>
+        <div className="hidden lg:block w-20 shrink-0">Platform</div>
+        <div className="hidden lg:block w-20 shrink-0 text-center">Trend</div>
+        <div className="w-[55px] shrink-0 text-right">Events</div>
+        <div className="hidden sm:block w-[45px] shrink-0 text-right">Users</div>
+        <div className="w-20 shrink-0 text-right">Last Seen</div>
+      </div>
+      <div className="divide-y divide-border/40">
+        {pagedIssues.map((issue) => (
+          <IssueRow
+            key={issueSelectionKey(issue)}
+            issue={issue}
+            selected={selectedIssueKeys.has(issueSelectionKey(issue))}
+            onToggle={onToggleIssue}
+          />
+        ))}
+      </div>
+      {totalPages > 1 && (
+        <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={currentPage <= 1}
+            onClick={onPreviousPage}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground self-center">
+            Page {currentPage} of {totalPages}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={currentPage >= totalPages}
+            onClick={onNextPage}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function IssueStatusBadges({issue}: Readonly<{issue: SafeIssue}>) {
+  return (
+    <div className="flex items-center gap-2 shrink-0">
+      {isNewIssue(issue.firstSeen) && (
+        <span className="text-[10px] font-bold text-success-fg bg-success-bg px-1.5 py-0.5 rounded uppercase">
+          New
+        </span>
+      )}
+      {issue.status === 'resolved' && (
+        <Badge variant="success" className="text-[11px] px-1.5 py-0">
+          Resolved
+        </Badge>
+      )}
+      {issue.status === 'ignored' && (
+        <Badge variant="secondary" className="text-[11px] px-1.5 py-0">
+          <EyeOff className="h-3 w-3" />
+          Ignored
+        </Badge>
+      )}
+      {issue.status === 'resolvedInNextRelease' && (
+        <Badge variant="info" className="text-[11px] px-1.5 py-0">
+          <Timer className="h-3 w-3" />
+          Next Release
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+type IssueRowProps = Readonly<{
+  issue: SafeIssue
+  selected: boolean
+  onToggle: (issue: SafeIssue) => void
+}>
+
+function IssueRow({issue, selected, onToggle}: IssueRowProps) {
+  const title = getIssueDisplayTitle(issue)
+
+  return (
+    <div className={`hover:bg-accent/40 transition border-l-[3px] ${levelBorderClass(issue.level)}`}>
+      <div className="flex items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
+        <Checkbox
+          checked={selected}
+          onCheckedChange={() => onToggle(issue)}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Select ${issue.title}`}
+          className="shrink-0"
+        />
+        <Link
+          to="/issues/$issueId"
+          params={{ issueId: issue.id }}
+          search={{ projectId: issue.projectResourceId }}
+          className="flex-1 flex items-center gap-2 sm:gap-3 min-w-0"
+        >
+          <div className="w-12 sm:w-[4.5rem] shrink-0">
+            <Badge variant={levelBadgeVariant(issue.level)} className="text-[10px] sm:text-[11px] px-1.5 py-0">
+              <span className="sm:hidden">{issue.level.toUpperCase().slice(0, 3)}</span>
+              <span className="hidden sm:inline">{issue.level.toUpperCase()}</span>
+            </Badge>
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5 sm:gap-2 min-w-0">
+              <span className="font-semibold truncate flex-1 min-w-0 text-sm sm:text-base" title={title}>
+                {title}
+              </span>
+              <IssueStatusBadges issue={issue} />
+            </div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              <Clock className="inline h-3 w-3 mr-1 -mt-0.5" />
+              First seen {formatRelativeTime(issue.firstSeen)}
+            </div>
+          </div>
+          <div className="hidden lg:block w-20 shrink-0">
+            <Badge variant="outline" className="text-[11px] px-1.5 py-0">{issue.platform}</Badge>
+          </div>
+          <div className="hidden lg:flex w-20 shrink-0 justify-center">
+            <EventSparkline eventCount={issue.eventCount} />
+          </div>
+          <div className="w-[55px] shrink-0 text-right">
+            <div className="font-semibold text-foreground">{formatCount(issue.eventCount)}</div>
+            <div className="text-xs text-muted-foreground">events</div>
+          </div>
+          <div className="hidden sm:block w-[45px] shrink-0 text-right">
+            <div className="font-semibold text-foreground">{issue.userCount ?? 0}</div>
+            <div className="text-xs text-muted-foreground">users</div>
+          </div>
+          <div className="hidden md:block w-20 shrink-0 text-right">
+            <span className={`text-xs font-medium ${getLastSeenColor(issue.lastSeen)}`}>
+              {formatRelativeTime(issue.lastSeen)}
+            </span>
+          </div>
+        </Link>
+      </div>
+    </div>
   )
 }
 
@@ -868,21 +1072,35 @@ const APM_TIME_PRESETS: TimeRangePreset[] = [
   {label: '90d', value: '90d', minutes: 129600},
 ]
 
-function ApmErrorsTab({ isActive, tabs }: { isActive: boolean; tabs?: ReactNode }) {
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => {
-    try {
-      const raw = globalThis.localStorage?.getItem('apmErrors.facetFilters')
-      const parsed = raw ? JSON.parse(raw) : null
-      return Array.isArray(parsed)
-        ? parsed.filter(
-            (f): f is FacetFilter =>
-              !!f && typeof f.key === 'string' && typeof f.value === 'string'
-          )
-        : []
-    } catch {
-      return []
-    }
-  })
+function loadApmErrorFacetFilters(): FacetFilter[] {
+  try {
+    const raw = globalThis.localStorage?.getItem('apmErrors.facetFilters')
+    const parsed = raw ? JSON.parse(raw) : null
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (filter): filter is FacetFilter =>
+            !!filter && typeof filter.key === 'string' && typeof filter.value === 'string'
+        )
+      : []
+  } catch {
+    return []
+  }
+}
+
+function visibleApmErrors(errors: readonly ApmErrorGroup[], normalizedQuery: string): readonly ApmErrorGroup[] {
+  if (!normalizedQuery) return errors
+  return errors.filter((error) =>
+    `${error.resource} ${error.errorMessage} ${error.errorType}`.toLowerCase().includes(normalizedQuery)
+  )
+}
+
+type ApmErrorsTabProps = Readonly<{
+  isActive: boolean
+  tabs?: ReactNode
+}>
+
+function ApmErrorsTab({ isActive, tabs }: ApmErrorsTabProps) {
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(loadApmErrorFacetFilters)
   const [query, setQuery] = useState('')
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('24h')
   const [offset, setOffset] = useState(0)
@@ -945,11 +1163,7 @@ function ApmErrorsTab({ isActive, tabs }: { isActive: boolean; tabs?: ReactNode 
 
   // Free-text narrows the loaded page client-side (the trace API has no text query).
   const normalizedQuery = query.trim().toLowerCase()
-  const visibleErrors = normalizedQuery
-    ? errors.filter((e: ApmErrorGroup) =>
-        `${e.resource} ${e.errorMessage} ${e.errorType}`.toLowerCase().includes(normalizedQuery)
-      )
-    : errors
+  const visibleErrors = visibleApmErrors(errors, normalizedQuery)
 
   const schema: FacetSchema = useMemo(
     () => [{key: 'service', suggestions: services.map((s) => s.service)}],
@@ -1008,158 +1222,287 @@ function ApmErrorsTab({ isActive, tabs }: { isActive: boolean; tabs?: ReactNode 
         ) : null
       }
     >
-      <div className="p-4">
-        {!hasServices ? (
-          isLoading ? (
-            <div className="py-16 text-center text-muted-foreground">Loading APM errors...</div>
-          ) : (
-            <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
-              <div className="max-w-md mx-auto space-y-4">
-                <div className="flex justify-center">
-                  <div className="rounded-full bg-info-bg p-4">
-                    <AlertTriangle className="h-10 w-10 text-info-fg" />
-                  </div>
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold mb-2">No APM errors found</h3>
-                  <p className="text-muted-foreground">
-                    Errors from application traces will appear here when spans report errors.
-                  </p>
-                </div>
-              </div>
-            </Card>
-          )
-        ) : !hasSelection ? (
-          <Card className="p-12 text-center border-border/60">
-            <div className="max-w-md mx-auto space-y-3">
-              <div className="flex justify-center">
-                <div className="rounded-full bg-muted p-4">
-                  <Server className="h-10 w-10 text-muted-foreground" />
-                </div>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold mb-1">Select a service</h3>
-                <p className="text-muted-foreground">
-                  Pick one or more services from the search bar or the facet rail to view their errors.
-                </p>
-              </div>
-            </div>
-          </Card>
-        ) : isLoading ? (
-          <div className="py-16 text-center text-muted-foreground">Loading APM errors...</div>
-        ) : visibleErrors.length === 0 ? (
-          <Card className="p-12 text-center border-border/60">
-            <div className="max-w-md mx-auto space-y-3">
-              <div className="flex justify-center">
-                <div className="rounded-full bg-muted p-4">
-                  <AlertTriangle className="h-10 w-10 text-muted-foreground" />
-                </div>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold mb-1">
-                  {normalizedQuery ? 'No errors match your search' : 'No errors for the selected services'}
-                </h3>
-                <p className="text-muted-foreground">
-                  {normalizedQuery
-                    ? 'Try a different search or clear it.'
-                    : 'Try a different service or widen the time range.'}
-                </p>
-              </div>
-            </div>
-          </Card>
-        ) : (
-          <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
-            {totalCount > APM_ERRORS_PAGE_SIZE && !normalizedQuery && (
-              <div className="px-4 py-2 text-xs text-muted-foreground border-b border-border/40">
-                Showing {offset + 1}–{offset + errors.length} of {totalCount}
-              </div>
-            )}
-            <div className="hidden md:grid md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
-              <div>Service</div>
-              <div>Error</div>
-              <div className="text-right">Count</div>
-              <div className="text-right">Last Seen</div>
-              <div className="text-right">Trace</div>
-            </div>
-            <div className="divide-y divide-border/40">
-              {visibleErrors.map((error: ApmErrorGroup) => {
-                const traceId = normalizeApmTraceId(error.traceId)
-                const stableKey = `${error.service}|${error.resource}|${error.errorMessage}|${error.errorType}`
-                return (
-                  <div
-                    key={stableKey}
-                    className="hover:bg-accent/40 transition border-l-[3px] border-l-red-500"
-                  >
-                    <div className="grid grid-cols-[auto_1fr_auto] md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
-                      <Badge
-                        variant="outline"
-                        className="shrink-0 text-[11px] px-1.5 py-0 gap-1 w-fit"
-                      >
-                        <Server className="h-3 w-3" />
-                        {error.service}
-                      </Badge>
-                      <div className="min-w-0">
-                        <div className="font-semibold truncate text-sm">
-                          {error.errorMessage || error.resource}
-                        </div>
-                        {error.errorType && (
-                          <div className="text-xs text-muted-foreground truncate">
-                            {error.errorType}
-                          </div>
-                        )}
-                        <div className="text-xs text-muted-foreground truncate mt-0.5">
-                          {error.resource}
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <div className="font-semibold text-foreground">
-                          {formatCount(error.count)}
-                        </div>
-                        <div className="text-xs text-muted-foreground">errors</div>
-                      </div>
-                      <div className="hidden md:block text-right text-xs text-muted-foreground">
-                        {error.lastSeen ? formatRelativeTime(error.lastSeen) : '—'}
-                      </div>
-                      <div className="hidden md:block text-right">
-                        {traceId && (
-                          <Link
-                            to="/performance/traces/$traceId"
-                            params={{ traceId }}
-                            className="text-xs text-primary hover:underline"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            View trace
-                          </Link>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-            {(canPrev || canNext) && (
-              <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={!canPrev}
-                  onClick={() => setOffset(Math.max(0, offset - APM_ERRORS_PAGE_SIZE))}
-                >
-                  Previous
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={!canNext}
-                  onClick={() => setOffset(offset + APM_ERRORS_PAGE_SIZE)}
-                >
-                  Next
-                </Button>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      <ApmErrorsContent
+        hasServices={hasServices}
+        hasSelection={hasSelection}
+        isLoading={isLoading}
+        visibleErrors={visibleErrors}
+        normalizedQuery={normalizedQuery}
+        totalCount={totalCount}
+        offset={offset}
+        errorCount={errors.length}
+        canPrev={canPrev}
+        canNext={canNext}
+        onPreviousPage={() => setOffset(Math.max(0, offset - APM_ERRORS_PAGE_SIZE))}
+        onNextPage={() => setOffset(offset + APM_ERRORS_PAGE_SIZE)}
+      />
     </ExplorerShell>
+  )
+}
+
+type ApmErrorsContentProps = Readonly<{
+  hasServices: boolean
+  hasSelection: boolean
+  isLoading: boolean
+  visibleErrors: readonly ApmErrorGroup[]
+  normalizedQuery: string
+  totalCount: number
+  offset: number
+  errorCount: number
+  canPrev: boolean
+  canNext: boolean
+  onPreviousPage: () => void
+  onNextPage: () => void
+}>
+
+function ApmErrorsContent({
+  hasServices,
+  hasSelection,
+  isLoading,
+  visibleErrors,
+  normalizedQuery,
+  totalCount,
+  offset,
+  errorCount,
+  canPrev,
+  canNext,
+  onPreviousPage,
+  onNextPage,
+}: ApmErrorsContentProps) {
+  if (!hasServices) {
+    return (
+      <div className="p-4">
+        {isLoading ? <ApmErrorsLoading /> : <NoApmErrorsState />}
+      </div>
+    )
+  }
+
+  if (!hasSelection) {
+    return (
+      <div className="p-4">
+        <SelectApmServiceState />
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-4">
+        <ApmErrorsLoading />
+      </div>
+    )
+  }
+
+  if (visibleErrors.length === 0) {
+    return (
+      <div className="p-4">
+        <NoVisibleApmErrorsState hasSearch={Boolean(normalizedQuery)} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4">
+      <ApmErrorsTable
+        visibleErrors={visibleErrors}
+        totalCount={totalCount}
+        offset={offset}
+        errorCount={errorCount}
+        showRange={totalCount > APM_ERRORS_PAGE_SIZE && !normalizedQuery}
+        canPrev={canPrev}
+        canNext={canNext}
+        onPreviousPage={onPreviousPage}
+        onNextPage={onNextPage}
+      />
+    </div>
+  )
+}
+
+function ApmErrorsLoading() {
+  return <div className="py-16 text-center text-muted-foreground">Loading APM errors...</div>
+}
+
+function NoApmErrorsState() {
+  return (
+    <Card className="p-12 text-center border-info-border/50 bg-gradient-to-b from-card to-info-bg">
+      <div className="max-w-md mx-auto space-y-4">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-info-bg p-4">
+            <AlertTriangle className="h-10 w-10 text-info-fg" />
+          </div>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold mb-2">No APM errors found</h3>
+          <p className="text-muted-foreground">
+            Errors from application traces will appear here when spans report errors.
+          </p>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function SelectApmServiceState() {
+  return (
+    <Card className="p-12 text-center border-border/60">
+      <div className="max-w-md mx-auto space-y-3">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-muted p-4">
+            <Server className="h-10 w-10 text-muted-foreground" />
+          </div>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold mb-1">Select a service</h3>
+          <p className="text-muted-foreground">
+            Pick one or more services from the search bar or the facet rail to view their errors.
+          </p>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function NoVisibleApmErrorsState({hasSearch}: Readonly<{hasSearch: boolean}>) {
+  const title = hasSearch ? 'No errors match your search' : 'No errors for the selected services'
+  const description = hasSearch
+    ? 'Try a different search or clear it.'
+    : 'Try a different service or widen the time range.'
+
+  return (
+    <Card className="p-12 text-center border-border/60">
+      <div className="max-w-md mx-auto space-y-3">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-muted p-4">
+            <AlertTriangle className="h-10 w-10 text-muted-foreground" />
+          </div>
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold mb-1">{title}</h3>
+          <p className="text-muted-foreground">{description}</p>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+type ApmErrorsTableProps = Readonly<{
+  visibleErrors: readonly ApmErrorGroup[]
+  totalCount: number
+  offset: number
+  errorCount: number
+  showRange: boolean
+  canPrev: boolean
+  canNext: boolean
+  onPreviousPage: () => void
+  onNextPage: () => void
+}>
+
+function ApmErrorsTable({
+  visibleErrors,
+  totalCount,
+  offset,
+  errorCount,
+  showRange,
+  canPrev,
+  canNext,
+  onPreviousPage,
+  onNextPage,
+}: ApmErrorsTableProps) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-card overflow-hidden">
+      {showRange && (
+        <div className="px-4 py-2 text-xs text-muted-foreground border-b border-border/40">
+          Showing {offset + 1}-{offset + errorCount} of {totalCount}
+        </div>
+      )}
+      <div className="hidden md:grid md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-3 py-2 px-4 bg-muted/40 border-b border-border/40 text-[11px] font-medium text-muted-foreground uppercase tracking-wider select-none">
+        <div>Service</div>
+        <div>Error</div>
+        <div className="text-right">Count</div>
+        <div className="text-right">Last Seen</div>
+        <div className="text-right">Trace</div>
+      </div>
+      <div className="divide-y divide-border/40">
+        {visibleErrors.map((error) => (
+          <ApmErrorRow key={apmErrorRowKey(error)} error={error} />
+        ))}
+      </div>
+      {(canPrev || canNext) && (
+        <div className="flex justify-end gap-2 px-4 py-2 border-t border-border/40">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canPrev}
+            onClick={onPreviousPage}
+          >
+            Previous
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canNext}
+            onClick={onNextPage}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function apmErrorRowKey(error: ApmErrorGroup): string {
+  return `${error.service}|${error.resource}|${error.errorMessage}|${error.errorType}`
+}
+
+function ApmErrorRow({error}: Readonly<{error: ApmErrorGroup}>) {
+  const traceId = normalizeApmTraceId(error.traceId)
+
+  return (
+    <div className="hover:bg-accent/40 transition border-l-[3px] border-l-red-500">
+      <div className="grid grid-cols-[auto_1fr_auto] md:grid-cols-[8rem_1fr_4rem_6rem_4rem] items-center gap-2 sm:gap-3 py-2 sm:py-2.5 px-2 sm:px-4">
+        <Badge
+          variant="outline"
+          className="shrink-0 text-[11px] px-1.5 py-0 gap-1 w-fit"
+        >
+          <Server className="h-3 w-3" />
+          {error.service}
+        </Badge>
+        <div className="min-w-0">
+          <div className="font-semibold truncate text-sm">
+            {error.errorMessage || error.resource}
+          </div>
+          {error.errorType && (
+            <div className="text-xs text-muted-foreground truncate">
+              {error.errorType}
+            </div>
+          )}
+          <div className="text-xs text-muted-foreground truncate mt-0.5">
+            {error.resource}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="font-semibold text-foreground">
+            {formatCount(error.count)}
+          </div>
+          <div className="text-xs text-muted-foreground">errors</div>
+        </div>
+        <div className="hidden md:block text-right text-xs text-muted-foreground">
+          {error.lastSeen ? formatRelativeTime(error.lastSeen) : '-'}
+        </div>
+        <div className="hidden md:block text-right">
+          {traceId && (
+            <Link
+              to="/performance/traces/$traceId"
+              params={{ traceId }}
+              className="text-xs text-primary hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              View trace
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -21,13 +21,14 @@ import {api} from '@/lib/api'
 import type {ApmErrorGroup, ApmTimeRange, Issue, Project} from '@/lib/api'
 import {trackEvent} from '@/lib/analytics'
 import {serviceNamesForQuery} from '@/lib/service-facet-scope'
-import {formatRelativeTime, cn} from '@/lib/utils'
+import {formatRelativeTime} from '@/lib/utils'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Card} from '@/components/ui/card'
 import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {ExplorerShell} from '@/components/filters/ExplorerShell'
+import {SegmentedTabs, type SegmentedOption} from '@/components/filters/SegmentedTabs'
 import {TimeRangePicker} from '@/components/filters/TimeRangePicker'
 import type {TimeRangePreset} from '@/lib/filters/time'
 import type {FacetFilter, FacetSchema, FacetRailSection} from '@/lib/filters/types'
@@ -49,6 +50,7 @@ import {
   Timer,
 } from 'lucide-react'
 import {useEffect, useMemo, useState} from 'react'
+import type {ReactNode} from 'react'
 import {useToast} from '@/hooks/useToast'
 import {getNow} from '@/lib/demo'
 import {parseDate} from '@/lib/date-format'
@@ -247,53 +249,37 @@ export const Route = createFileRoute('/issues/')({
   component: IndexPage,
 })
 
+type IssuesView = 'issues' | 'apm-errors'
+
+const ISSUES_VIEW_TABS = [
+  {value: 'issues', label: 'Issues', icon: AlertCircle},
+  {value: 'apm-errors', label: 'APM Errors', icon: Cpu},
+] as const satisfies ReadonlyArray<SegmentedOption<IssuesView>>
+
 function IndexPage() {
-  const [activeTab, setActiveTab] = useState<'issues' | 'apm-errors'>('issues')
+  const [activeTab, setActiveTab] = useState<IssuesView>('issues')
+
+  const viewTabs = (
+    <SegmentedTabs
+      ariaLabel="Issues view"
+      value={activeTab}
+      onChange={setActiveTab}
+      options={ISSUES_VIEW_TABS}
+    />
+  )
 
   return (
-    <div className="flex h-[calc(100vh-var(--header-height,0px))] flex-col overflow-hidden">
-      <div className="shrink-0 border-b px-6">
-        <div className="flex gap-4">
-          <button
-            type="button"
-            onClick={() => setActiveTab('issues')}
-            className={cn(
-              'border-b-2 px-1 py-3 text-sm font-medium inline-flex items-center',
-              activeTab === 'issues'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <AlertCircle className="h-4 w-4 mr-1.5" />
-            Issues
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveTab('apm-errors')}
-            className={cn(
-              'border-b-2 px-1 py-3 text-sm font-medium inline-flex items-center',
-              activeTab === 'apm-errors'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <Cpu className="h-4 w-4 mr-1.5" />
-            APM Errors
-          </button>
-        </div>
-      </div>
-      <div className="min-h-0 flex-1">
-        {activeTab === 'issues' ? (
-          <DashboardPage />
-        ) : (
-          <ApmErrorsTab isActive />
-        )}
-      </div>
+    <div className="h-[calc(100vh-var(--header-height,0px))] overflow-hidden">
+      {activeTab === 'issues' ? (
+        <DashboardPage tabs={viewTabs} />
+      ) : (
+        <ApmErrorsTab isActive tabs={viewTabs} />
+      )}
     </div>
   )
 }
 
-function DashboardPage() {
+function DashboardPage({tabs}: {tabs?: ReactNode}) {
   const [searchQuery, setSearchQuery] = useState('')
   const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
   const [selectedIssueKeys, setSelectedIssueKeys] = useState<Set<string>>(new Set())
@@ -646,6 +632,7 @@ function DashboardPage() {
 
   return (
     <ExplorerShell
+      tabs={tabs}
       searchBar={
         <SearchFilterBar
           query={searchQuery}
@@ -881,7 +868,7 @@ const APM_TIME_PRESETS: TimeRangePreset[] = [
   {label: '90d', value: '90d', minutes: 129600},
 ]
 
-function ApmErrorsTab({ isActive }: { isActive: boolean }) {
+function ApmErrorsTab({ isActive, tabs }: { isActive: boolean; tabs?: ReactNode }) {
   const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => {
     try {
       const raw = globalThis.localStorage?.getItem('apmErrors.facetFilters')
@@ -983,6 +970,7 @@ function ApmErrorsTab({ isActive }: { isActive: boolean }) {
 
   return (
     <ExplorerShell
+      tabs={tabs}
       searchBar={
         <SearchFilterBar
           query={query}

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -803,7 +803,7 @@ function IssueExplorerToolbar({
         </div>
       )}
       <span className="ml-auto text-sm text-muted-foreground whitespace-nowrap hidden lg:inline">
-        {filteredIssueCount} result{filteredIssueCount !== 1 ? 's' : ''}
+        {filteredIssueCount} result{filteredIssueCount === 1 ? '' : 's'}
       </span>
     </>
   )

--- a/dashboard/src/routes/releases.tsx
+++ b/dashboard/src/routes/releases.tsx
@@ -18,13 +18,13 @@ import {createFileRoute, Link, Outlet, redirect, useMatches} from '@tanstack/rea
 import {useQuery} from '@tanstack/react-query'
 import {api, formatErrorForLogging} from '@/lib/api'
 import {type ReactNode, useMemo, useState} from 'react'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {Card, CardContent} from '@/components/ui/card'
 import {Input} from '@/components/ui/input'
 import {Badge} from '@/components/ui/badge'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue,} from '@/components/ui/select'
 import {StatsCard} from '@/components/charts/StatsCard'
-import {PageHeader} from '@/components/ui/page-header'
 import {EmptyState} from '@/components/ui/empty-state'
 import {StatusDot} from '@/components/ui/status-dot'
 import {Activity, AlertCircle, Flame, Package, Search, ShieldCheck, Users} from 'lucide-react'
@@ -371,26 +371,22 @@ function ReleasesPage() {
   }
 
   return (
-    <div className="grid gap-2 p-3 lg:grid-cols-[220px_minmax(0,1fr)]">
-      <FacetRail
-        sections={railSections}
-        facetFilters={facetFilters}
-        onFacetFiltersChange={setFacetFilters}
-        title="Releases"
-        className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
-      />
-
-      <div className="min-w-0">
-        <div className="container mx-auto px-4 py-4 space-y-3">
-          <PageHeader
-            icon={Package}
-            title="Releases"
-            description="Track release health, new issues, and telemetry by version"
-          />
-
-          {releasesContent}
-        </div>
+    <ExplorerShell
+      title="Releases"
+      icon={<Package className="h-4 w-4 text-muted-foreground" />}
+      searchBar={<div />}
+      rail={
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={setFacetFilters}
+          title="Releases"
+        />
+      }
+    >
+      <div className="space-y-3 p-3">
+        {releasesContent}
       </div>
-    </div>
+    </ExplorerShell>
   )
 }

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -21,10 +21,10 @@ import {formatRelativeTime} from '@/lib/utils'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDate as formatDateUtil, parseDate} from '@/lib/date-format'
 import {useMemo, useState} from 'react'
+import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {Badge} from '@/components/ui/badge'
 import {Input} from '@/components/ui/input'
-import {PageHeader} from '@/components/ui/page-header'
 import {StatCard} from '@/components/ui/stat-card'
 import {EmptyState} from '@/components/ui/empty-state'
 import {Avatar, AvatarFallback} from '@/components/ui/avatar'
@@ -264,46 +264,24 @@ function ReplaysPage() {
   }
 
   return (
-    <div className="grid min-h-screen gap-2 p-3 lg:grid-cols-[220px_minmax(0,1fr)]">
-      <FacetRail
-        sections={railSections}
-        facetFilters={facetFilters}
-        onFacetFiltersChange={handleFacetFiltersChange}
-        title="Replays"
-        className="h-auto max-h-[340px] rounded-md border lg:sticky lg:top-2 lg:h-[calc(100vh-8rem)] lg:max-h-none"
-      />
-
-      <div className="min-w-0">
-        <div className="container mx-auto px-4 py-4 space-y-4">
-          <PageHeader
-            icon={Video}
-            title="Session Replays"
-            description="Watch real user sessions to understand behavior and debug issues"
+    <ExplorerShell
+      title="Session Replays"
+      icon={<Video className="h-4 w-4 text-muted-foreground" />}
+      searchBar={
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input
+            placeholder="Search by user, URL, or browser..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="h-7 pl-8 text-xs"
           />
-
-          {/* Stats Cards */}
-          {replays.length > 0 && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              <StatCard label="Sessions" value={stats.total} icon={Play} tone="info" />
-              <StatCard label="Errors" value={stats.totalErrors} icon={AlertCircle} tone="danger" />
-              <StatCard label="Avg Duration" value={formatDuration(stats.avgDuration)} icon={Timer} tone="success" />
-              <StatCard label="Unique Users" value={stats.uniqueUsers} icon={User} tone="accent" />
-            </div>
-          )}
-
-          {/* Toolbar */}
-          <div className="mb-3 flex flex-wrap items-center gap-2">
-          <div className="relative flex-1 min-w-[200px]">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Search by user, URL, or browser..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10"
-            />
-          </div>
+        </div>
+      }
+      actions={
+        <>
           <Select value={effectivePeriod} onValueChange={(value) => { setPeriod(value as '24h' | '7d' | '30d' | '90d'); setPage(1) }}>
-            <SelectTrigger className="w-[140px]">
+            <SelectTrigger className="w-[140px] h-7 text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -315,7 +293,7 @@ function ReplaysPage() {
             </SelectContent>
           </Select>
           <Select value={environment} onValueChange={(v) => { setEnvironment(v); setPage(1) }}>
-            <SelectTrigger className="w-[160px]">
+            <SelectTrigger className="w-[140px] h-7 text-xs">
               <SelectValue placeholder="Environment" />
             </SelectTrigger>
             <SelectContent>
@@ -325,10 +303,30 @@ function ReplaysPage() {
               <SelectItem value="development">Development</SelectItem>
             </SelectContent>
           </Select>
+        </>
+      }
+      rail={
+        <FacetRail
+          sections={railSections}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          title="Replays"
+        />
+      }
+    >
+      <div className="space-y-3 p-3">
+        {/* Stats Cards */}
+        {replays.length > 0 && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <StatCard label="Sessions" value={stats.total} icon={Play} tone="info" />
+            <StatCard label="Errors" value={stats.totalErrors} icon={AlertCircle} tone="danger" />
+            <StatCard label="Avg Duration" value={formatDuration(stats.avgDuration)} icon={Timer} tone="success" />
+            <StatCard label="Unique Users" value={stats.uniqueUsers} icon={User} tone="accent" />
           </div>
+        )}
 
-          {/* Content */}
-          {!hasReplayScope ? (
+        {/* Content */}
+        {!hasReplayScope ? (
           <EmptyState
             icon={Play}
             title="No services match filters"
@@ -382,16 +380,13 @@ function ReplaysPage() {
                     }`}
                   >
                     <div className="flex items-center gap-3 p-3">
-                      {/* Avatar */}
                       <Avatar className="h-8 w-8 shrink-0">
                         <AvatarFallback className={`text-xs font-semibold ${avatarColor}`}>
                           {initials}
                         </AvatarFallback>
                       </Avatar>
 
-                      {/* Main Content */}
                       <div className="flex-1 min-w-0">
-                        {/* Top row: user + time */}
                         <div className="flex items-center gap-2 mb-1">
                           <span className="font-semibold text-sm truncate">{displayName}</span>
                           <Tooltip>
@@ -405,9 +400,7 @@ function ReplaysPage() {
                           </Tooltip>
                         </div>
 
-                        {/* Bottom row: badges */}
                         <div className="flex flex-wrap items-center gap-2">
-                          {/* Duration */}
                           <Tooltip>
                             <TooltipTrigger asChild>
                               <Badge variant="outline" className={`text-xs font-medium gap-1 ${durationColor}`}>
@@ -418,7 +411,6 @@ function ReplaysPage() {
                             <TooltipContent>Session duration</TooltipContent>
                           </Tooltip>
 
-                          {/* Activity */}
                           <Tooltip>
                             <TooltipTrigger asChild>
                               <Badge variant="outline" className={`text-xs font-medium gap-1.5 ${activityLevel.bgColor} ${activityLevel.color}`}>
@@ -435,7 +427,6 @@ function ReplaysPage() {
                             <TooltipContent>Activity: {replay.activity}%</TooltipContent>
                           </Tooltip>
 
-                          {/* Errors */}
                           {hasErrors && (
                             <Badge variant="danger" className="text-xs font-medium gap-1">
                               <AlertCircle className="h-3 w-3" />
@@ -443,7 +434,6 @@ function ReplaysPage() {
                             </Badge>
                           )}
 
-                          {/* URLs */}
                           {replay.urls?.length > 0 && (
                             <Tooltip>
                               <TooltipTrigger asChild>
@@ -467,7 +457,6 @@ function ReplaysPage() {
                             </Tooltip>
                           )}
 
-                          {/* Browser / OS */}
                           {(replay.browserName || replay.osName) && (
                             <Badge variant="outline" className="text-xs font-normal gap-1 text-muted-foreground">
                               <Monitor className="h-3 w-3" />
@@ -477,7 +466,6 @@ function ReplaysPage() {
                         </div>
                       </div>
 
-                      {/* Play button hint */}
                       <div className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
                         <div className="rounded-full bg-[hsl(var(--primary)/0.12)] p-2 ring-1 ring-[hsl(var(--primary)/0.3)]">
                           <Play className="h-4 w-4 text-primary" />
@@ -489,11 +477,11 @@ function ReplaysPage() {
               })}
             </div>
           </TooltipProvider>
-          )}
+        )}
 
-          {/* Pagination */}
-          {filteredReplays.length > 0 && (
-          <div className="mt-4 flex items-center justify-between">
+        {/* Pagination */}
+        {filteredReplays.length > 0 && (
+          <div className="flex items-center justify-between">
             <p className="text-xs text-muted-foreground">
               Showing {filteredReplays.length} replay{filteredReplays.length === 1 ? '' : 's'}
               {searchQuery && ' matching your search'}
@@ -525,9 +513,8 @@ function ReplaysPage() {
               </Button>
             </div>
           </div>
-          )}
-        </div>
+        )}
       </div>
-    </div>
+    </ExplorerShell>
   )
 }


### PR DESCRIPTION
## Summary
- align ExplorerShell, Sidebar, and map shell header heights behind shared chrome tokens
- add a reusable SegmentedTabs control and move Issues and Analytics view switches into the explorer header
- migrate AI, analytics, feedback, releases, and replays pages onto the shared explorer shell

## Validation
- npm test -- src/components/filters/__tests__/SegmentedTabs.test.tsx src/components/filters/__tests__/ExplorerShell.test.tsx src/routes/__tests__/analytics-index-service-facets.test.tsx
- npm run lint
- npm run typecheck
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable segmented (pill) tab control for selecting views.

* **Refactor**
  * Unified many dashboard pages to use a consistent ExplorerShell layout, moving headers/search and facet rails into the shell.
  * Standardized header/subheader sizing via new CSS variables for consistent spacing across the UI.
  * Replaced duplicated map mode control with the shared segmented tab component.

* **Tests**
  * Added tests covering the segmented tab control and its integration with the shell.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->