### PR TITLE
fix: scope current org from JWT

### DIFF
--- a/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/routes/AnalyticsRoutes.kt
@@ -19,6 +19,7 @@ package com.moneat.analytics.routes
 import com.moneat.analytics.models.AnalyticsFilter
 import com.moneat.analytics.services.AnalyticsQueryScope
 import com.moneat.analytics.services.AnalyticsService
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.EnvConfig
 import com.moneat.events.services.DashboardService
 import com.moneat.plugins.isDemoUser
@@ -372,7 +373,7 @@ private suspend fun extractOrganizationContext(
     val organizationId = if (call.isDemoUser()) {
         EnvConfig.Demo.ORG_ID.toInt()
     } else {
-        val orgId = principal.payload.getClaim("orgId").asInt()
+        val orgId = principal.currentOrgIdOrNull()
         if (orgId == null || !hasOrganizationAccess(userId, orgId)) {
             call.respond(HttpStatusCode.NotFound, ErrorResponse(ERROR_NO_ORGANIZATION_ACCESS))
             return null

--- a/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/apm/routes/ApmServiceDashboardRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.apm.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.apm.services.ApmServiceCatalogService
 import com.moneat.apm.services.ApmServiceQuery
 import com.moneat.datadog.services.DdApmQueryTimeRange
@@ -168,9 +169,7 @@ internal fun Route.apmServiceDashboardRouteHandlers() {
 }
 
 private fun ApplicationCall.organizationId(): Int? =
-    principal<JWTPrincipal>()?.payload
-        ?.getClaim("orgId")
-        ?.asInt()
+    principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private suspend fun ApplicationCall.respondUnauthorized() {
     respond(

--- a/backend/src/main/kotlin/com/moneat/auth/CurrentOrgContext.kt
+++ b/backend/src/main/kotlin/com/moneat/auth/CurrentOrgContext.kt
@@ -1,0 +1,81 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.auth
+
+import com.auth0.jwt.interfaces.DecodedJWT
+import com.moneat.utils.ErrorResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.response.respond
+
+data class CurrentOrgContext(
+    val userId: Int,
+    val orgId: Int,
+    val orgRole: String?,
+)
+
+fun JWTPrincipal.currentUserIdOrNull(): Int? =
+    payload.getClaim("userId").asInt()
+
+fun JWTPrincipal.currentOrgIdOrNull(): Int? =
+    payload.getClaim("orgId").asInt()
+
+fun JWTPrincipal.currentOrgContextOrNull(): CurrentOrgContext? {
+    val userId = currentUserIdOrNull() ?: return null
+    val orgId = currentOrgIdOrNull() ?: return null
+
+    return CurrentOrgContext(
+        userId = userId,
+        orgId = orgId,
+        orgRole = payload.getClaim("orgRole").asString(),
+    )
+}
+
+fun DecodedJWT.currentUserIdOrNull(): Int? =
+    getClaim("userId").asInt()
+
+fun DecodedJWT.currentOrgIdOrNull(): Int? =
+    getClaim("orgId").asInt()
+
+fun DecodedJWT.currentOrgContextOrNull(): CurrentOrgContext? {
+    val userId = currentUserIdOrNull() ?: return null
+    val orgId = currentOrgIdOrNull() ?: return null
+
+    return CurrentOrgContext(
+        userId = userId,
+        orgId = orgId,
+        orgRole = getClaim("orgRole").asString(),
+    )
+}
+
+fun ApplicationCall.currentOrgContextOrNull(): CurrentOrgContext? =
+    principal<JWTPrincipal>()?.currentOrgContextOrNull()
+
+fun ApplicationCall.currentOrgIdOrNull(): Int? =
+    currentOrgContextOrNull()?.orgId
+
+suspend fun ApplicationCall.requireCurrentOrg(
+    errorMessage: String = "Invalid token",
+): CurrentOrgContext? {
+    val context = currentOrgContextOrNull()
+    if (context == null) {
+        respond(HttpStatusCode.Unauthorized, ErrorResponse(errorMessage))
+    }
+    return context
+}

--- a/backend/src/main/kotlin/com/moneat/auth/CurrentOrgContext.kt
+++ b/backend/src/main/kotlin/com/moneat/auth/CurrentOrgContext.kt
@@ -30,6 +30,8 @@ data class CurrentOrgContext(
     val orgRole: String?,
 )
 
+// Current-org claims are signed access-token scope minted after org membership validation.
+// Revocation is enforced centrally through token/session lifetime and refresh validation.
 fun JWTPrincipal.currentUserIdOrNull(): Int? =
     payload.getClaim("userId").asInt()
 

--- a/backend/src/main/kotlin/com/moneat/auth/routes/AuthTokenRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/auth/routes/AuthTokenRoutes.kt
@@ -16,14 +16,13 @@
 
 package com.moneat.auth.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.auth.services.AuthTokenService
 import com.moneat.events.models.CreateAuthTokenRequest
 import com.moneat.events.models.UpdateAuthTokenRequest
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -50,13 +49,13 @@ fun Route.authTokenRoutes(
 private suspend fun io.ktor.server.routing.RoutingContext.handleCreateAuthToken(
     authTokenService: AuthTokenService,
 ) {
-    val principal = call.principal<JWTPrincipal>()
-    val userId = principal!!.payload.getClaim("userId").asInt()
+    val context = call.requireCurrentOrg() ?: return
     val request = call.receive<CreateAuthTokenRequest>()
     try {
         val tokenResponse =
             authTokenService.generateToken(
-                userId = userId,
+                userId = context.userId,
+                orgId = context.orgId,
                 name = request.name,
                 scopes = request.scopes,
                 expiresInDays = request.expiresInDays
@@ -70,23 +69,21 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleCreateAuthToken(
 private suspend fun io.ktor.server.routing.RoutingContext.handleListAuthTokens(
     authTokenService: AuthTokenService,
 ) {
-    val principal = call.principal<JWTPrincipal>()
-    val userId = principal!!.payload.getClaim("userId").asInt()
-    val tokens = authTokenService.listUserTokens(userId)
+    val context = call.requireCurrentOrg() ?: return
+    val tokens = authTokenService.listUserTokens(context.userId)
     call.respond(tokens)
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleRevokeAuthToken(
     authTokenService: AuthTokenService,
 ) {
-    val principal = call.principal<JWTPrincipal>()
-    val userId = principal!!.payload.getClaim("userId").asInt()
+    val context = call.requireCurrentOrg() ?: return
     val tokenId = call.parameters["tokenId"]?.toIntOrNull()
     if (tokenId == null) {
         call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid token ID"))
         return
     }
-    val success = authTokenService.revokeToken(userId, tokenId)
+    val success = authTokenService.revokeToken(context.userId, tokenId)
     if (success) {
         call.respond(HttpStatusCode.NoContent)
     } else {
@@ -97,8 +94,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleRevokeAuthToken(
 private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateAuthToken(
     authTokenService: AuthTokenService,
 ) {
-    val principal = call.principal<JWTPrincipal>()
-    val userId = principal!!.payload.getClaim("userId").asInt()
+    val context = call.requireCurrentOrg() ?: return
     val tokenId = call.parameters["tokenId"]?.toIntOrNull()
     if (tokenId == null) {
         call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid token ID"))
@@ -108,7 +104,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateAuthToken(
     try {
         val success =
             authTokenService.updateToken(
-                userId = userId,
+                userId = context.userId,
                 tokenId = tokenId,
                 name = request.name,
                 scopes = request.scopes

--- a/backend/src/main/kotlin/com/moneat/auth/services/AuthService.kt
+++ b/backend/src/main/kotlin/com/moneat/auth/services/AuthService.kt
@@ -18,6 +18,7 @@ package com.moneat.auth.services
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.auth.repositories.UserRepository
 import com.moneat.config.EnvConfig
 import com.moneat.events.models.AuthResponse
@@ -589,7 +590,7 @@ class AuthService(
         val decodedJWT = jwtVerifier.verify(tokenPair.accessToken)
         val userId = decodedJWT.getClaim("userId").asInt()
         val email = decodedJWT.getClaim("email").asString()
-        val orgId = decodedJWT.getClaim("orgId").asInt()
+        val orgId = decodedJWT.currentOrgIdOrNull()
         val orgRole = decodedJWT.getClaim("orgRole").asString()
 
         val user = run {

--- a/backend/src/main/kotlin/com/moneat/auth/services/AuthTokenService.kt
+++ b/backend/src/main/kotlin/com/moneat/auth/services/AuthTokenService.kt
@@ -19,15 +19,14 @@ package com.moneat.auth.services
 import com.moneat.config.EnvConfig
 import com.moneat.events.models.AuthTokenResponse
 import com.moneat.shared.models.AuthTokens
-import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.plus
-import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.isNotNull
 import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -90,6 +89,7 @@ class AuthTokenService {
      */
     fun generateToken(
         userId: Int,
+        orgId: Int,
         name: String,
         scopes: List<String>,
         expiresInDays: Int? = null
@@ -107,9 +107,9 @@ class AuthTokenService {
         // Look up the user's org slug for the token payload
         val orgSlug =
             transaction {
-                (Memberships innerJoin Organizations)
+                Organizations
                     .selectAll()
-                    .where { Memberships.user_id eq userId }
+                    .where { Organizations.id eq orgId }
                     .firstOrNull()
                     ?.get(Organizations.slug)
             } ?: "default"

--- a/backend/src/main/kotlin/com/moneat/billing/routes/BillingRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/routes/BillingRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.billing.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_DEFAULT_LIMIT
 import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_MAX_LIMIT
 import com.moneat.billing.models.APM_SPAN_USAGE_DEBUG_MIN_LIMIT
@@ -37,8 +38,6 @@ import com.moneat.utils.ErrorResponse
 import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -66,8 +65,6 @@ private const val FAILED_TO_UPDATE_ON_CALL_SEATS = "Failed to update on-call sea
 private const val FAILED_TO_UPDATE_SEATS = "Failed to update seats"
 private const val PAYG_INCREMENT_CENTS = 500
 private const val MAX_ONCALL_SEATS = 200
-private const val AUTH_REQUIRED = "Authentication required"
-private const val NO_ORG_ACCESS = "No organization access"
 
 // Public billing endpoints (no auth required)
 fun Route.publicBillingRoutes(
@@ -99,17 +96,7 @@ fun Route.billingRoutes(
 
     route("/billing") {
         get("/usage") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@get
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@get
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@get
 
             val usage = quotaService.getUsageForOrganization(orgId)
 
@@ -161,17 +148,7 @@ fun Route.billingRoutes(
                 )
                 return@get
             }
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@get
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@get
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@get
 
             val insights = insightsService.getUsageInsightsSafely(orgId)
             if (insights == null) {
@@ -186,17 +163,7 @@ fun Route.billingRoutes(
         }
 
         get("/usage/apm-spans") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@get
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@get
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@get
             val limit = call.request.queryParameters["limit"]
                 ?.toIntOrNull()
                 ?.coerceIn(APM_SPAN_USAGE_DEBUG_MIN_LIMIT, APM_SPAN_USAGE_DEBUG_MAX_LIMIT)
@@ -212,32 +179,12 @@ fun Route.billingRoutes(
         }
 
         post("/checkout") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@post
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@post
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@post
             handleBillingCheckout(call, stripeService, orgId)
         }
 
         get("/invoices") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@get
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@get
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@get
 
             suspendRunCatching {
                 call.respond(stripeService.listInvoices(orgId))
@@ -247,17 +194,7 @@ fun Route.billingRoutes(
         }
 
         get("/payment-method") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@get
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@get
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@get
 
             suspendRunCatching {
                 call.respond(stripeService.getPaymentMethod(orgId))
@@ -267,17 +204,7 @@ fun Route.billingRoutes(
         }
 
         post("/setup-intent") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@post
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@post
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@post
 
             suspendRunCatching {
                 call.respond(stripeService.createSetupIntent(orgId))
@@ -287,17 +214,7 @@ fun Route.billingRoutes(
         }
 
         post("/setup-intent/confirm") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@post
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@post
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@post
 
             suspendRunCatching {
                 val request = call.receive<Map<String, String>>()
@@ -310,47 +227,17 @@ fun Route.billingRoutes(
         }
 
         post("/cancel") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@post
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@post
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@post
             handleBillingCancel(call, stripeService, orgId)
         }
 
         put("/payg-budget") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@put
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@put
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@put
             handleBillingPaygBudget(call, pricingTierService, orgId)
         }
 
         put("/oncall-seats") {
-            val principal =
-                call.principal<JWTPrincipal>() ?: run {
-                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse(AUTH_REQUIRED))
-                    return@put
-                }
-            val userId = principal.payload.getClaim("userId").asInt()
-            val orgId =
-                pricingTierService.getPrimaryOrganizationIdForUser(userId) ?: run {
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORG_ACCESS))
-                    return@put
-                }
+            val orgId = call.requireCurrentOrg()?.orgId ?: return@put
             handleBillingOnCallSeats(call, stripeService, orgId)
         }
     }

--- a/backend/src/main/kotlin/com/moneat/billing/services/PricingTierService.kt
+++ b/backend/src/main/kotlin/com/moneat/billing/services/PricingTierService.kt
@@ -24,7 +24,6 @@ import com.moneat.billing.models.PricingTierConfigs
 import com.moneat.billing.models.TierMigrationRequest
 import com.moneat.billing.models.TierMigrationResponse
 import com.moneat.billing.models.UpdateStripePriceIdsRequest
-import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Subscriptions
 import kotlinx.datetime.TimeZone
@@ -76,17 +75,6 @@ class PricingTierService {
         val slaEnabled: Boolean,
         val customRetentionEnabled: Boolean
     )
-
-    fun getPrimaryOrganizationIdForUser(userId: Int): Int? {
-        return transaction {
-            Memberships
-                .selectAll()
-                .where { Memberships.user_id eq userId }
-                .orderBy(Memberships.id to SortOrder.ASC)
-                .firstOrNull()
-                ?.get(Memberships.organization_id)
-        }
-    }
 
     fun getCurrentPlans(): List<BillingPlanResponse> {
         return transaction {

--- a/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.dashboards.routes
 
+import com.moneat.auth.currentOrgContextOrNull
 import com.moneat.dashboards.models.BatchQueryResult
 import com.moneat.dashboards.models.CreateCustomDataSourceRequest
 import com.moneat.dashboards.models.CreateDashboardAlertRequest
@@ -46,7 +47,6 @@ import com.moneat.dashboards.translation.DashboardTranslator
 import com.moneat.dashboards.translation.DataDogTranslator
 import com.moneat.dashboards.translation.GrafanaTranslator
 import com.moneat.plugins.getDemoEpochMs
-import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Projects
 import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.shared.services.RetentionPolicyService
@@ -90,15 +90,11 @@ private const val ERR_DATA_SOURCE_NOT_FOUND = "Data source not found"
 private const val ERR_UNKNOWN_SOURCE_TYPE = "Unknown source type"
 private const val ERR_INVALID_DATA_SOURCE_ID = "Invalid data source ID"
 
-private fun getOrgIdForUser(userId: Int): Long? {
-    return transaction {
-        Memberships.selectAll()
-            .where { Memberships.user_id eq userId }
-            .firstOrNull()
-            ?.get(Memberships.organization_id)
-            ?.toLong()
-    }
-}
+private fun currentOrgIdFromPrincipal(userId: Int, principal: JWTPrincipal): Long? =
+    principal.currentOrgContextOrNull()
+        ?.takeIf { it.userId == userId }
+        ?.orgId
+        ?.toLong()
 
 private data class DashboardScope(
     val projectId: Long?
@@ -131,7 +127,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleListDashboards(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val projectId = call.request.queryParameters["projectId"]?.let(projectIdResolver::resolve)
     val dashboards = dashboardService.listDashboards(orgId, projectId, userId)
@@ -143,7 +139,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleCreateDashboard(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val request = call.receive<CreateDashboardRequest>()
     val dashboard = dashboardService.createDashboard(orgId, userId.toLong(), request)
@@ -155,7 +151,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleListFolders(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val folders = dashboardService.listFolders(orgId)
     call.respond(folders)
@@ -166,7 +162,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleCreateFolder(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val request = call.receive<CreateFolderRequest>()
     val folder = dashboardService.createFolder(orgId, request)
@@ -178,7 +174,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateFolder(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val folderId = call.parameters["folderId"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid folder ID"))
@@ -193,7 +189,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDeleteFolder(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val folderId = call.parameters["folderId"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid folder ID"))
@@ -209,7 +205,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleGetDashboard(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -223,7 +219,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleToggleFavorite(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -236,7 +232,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleMoveDashboardToF
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -253,7 +249,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateDashboard(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -268,7 +264,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDeleteDashboard(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -288,7 +284,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDashboardQuery(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -401,7 +397,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleBatchDashboardQu
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -481,7 +477,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleVariablesResolve
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -537,7 +533,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleImportDashboard(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
 
     val request = call.receive<ImportDashboardRequest>()
@@ -598,7 +594,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleExportDashboard(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -623,7 +619,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleListAlerts(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -635,7 +631,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleCreateAlert(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -653,7 +649,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateAlert(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -685,7 +681,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDeleteAlert(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DASHBOARD_ID))
@@ -704,7 +700,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleGetAvailableData
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
     if (orgId != null) {
         val customSources = dataSourceService.listDataSources(orgId)
         call.respond(queryEngine.getDataSources(customSources))
@@ -718,7 +714,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleSearch(
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val query = call.request.queryParameters["q"]?.trim().orEmpty()
     val result = dashboardService.search(orgId, userId, query)
@@ -730,7 +726,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleListCustomDataSo
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     call.respond(dataSourceService.listDataSources(orgId))
 }
@@ -740,7 +736,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleCreateCustomData
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val request = call.receive<CreateCustomDataSourceRequest>()
     try {
@@ -768,7 +764,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleGetCustomDataSou
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DATA_SOURCE_ID))
@@ -783,7 +779,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateCustomData
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DATA_SOURCE_ID))
@@ -802,7 +798,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDeleteCustomData
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(
@@ -823,7 +819,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleGetDataSourceSch
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DATA_SOURCE_ID))
@@ -851,7 +847,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleCustomDataSource
 ) {
     val principal = call.principal<JWTPrincipal>()
     val userId = principal!!.payload.getClaim("userId").asInt()
-    val orgId = getOrgIdForUser(userId)
+    val orgId = currentOrgIdFromPrincipal(userId, principal)
         ?: return call.respond(HttpStatusCode.Forbidden, ErrorResponse(ERR_NO_ORGANIZATION))
     val id = call.parameters["id"]?.toLongOrNull()
         ?: return call.respond(HttpStatusCode.BadRequest, ErrorResponse(ERR_INVALID_DATA_SOURCE_ID))

--- a/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/networkdevices/NdmQueryRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.networkdevices
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.isClickHouseError
 import com.moneat.utils.ClickHouseQueryUtils
@@ -253,7 +254,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleListPaths() {
 
 private fun io.ktor.server.routing.RoutingContext.extractOrgId(): Int? {
     val principal = call.principal<JWTPrincipal>()
-    return principal?.payload?.getClaim("orgId")?.asInt()
+    return principal?.currentOrgIdOrNull()
 }
 
 private fun io.ktor.server.routing.RoutingContext.paramLimit(): Int =

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogEventQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogEventQueryRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.ClickHouseClient
 import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
@@ -47,8 +48,7 @@ fun Route.datadogEventQueryRoutes() {
         authenticate("auth-jwt") {
             get("/events") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")
@@ -151,8 +151,7 @@ fun Route.datadogEventQueryRoutes() {
 
             get("/service-checks") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogHostRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogHostRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.ClickHouseClient
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.decompression.DecompressionService
@@ -197,8 +198,7 @@ fun Route.datadogHostQueryRoutes() {
         authenticate("auth-jwt") {
             get("/hosts") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")
@@ -217,8 +217,7 @@ fun Route.datadogHostQueryRoutes() {
 
             get("/hosts/{hostId}") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")
@@ -239,8 +238,7 @@ fun Route.datadogHostQueryRoutes() {
 
             delete("/hosts/{hostId}") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                 if (orgId == null) {
                     call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Missing org context"))
                     return@delete
@@ -261,8 +259,7 @@ fun Route.datadogHostQueryRoutes() {
 
             get("/hosts/{hostId}/metrics") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")
@@ -358,8 +355,7 @@ fun Route.datadogHostQueryRoutes() {
 
             get("/hosts/{hostId}/containers") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogInfraQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogInfraQueryRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.isClickHouseError
 import com.moneat.utils.ClickHouseQueryUtils
@@ -50,8 +51,7 @@ fun Route.datadogInfraQueryRoutes() {
         authenticate("auth-jwt") {
             get("/processes") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")
@@ -133,8 +133,7 @@ fun Route.datadogInfraQueryRoutes() {
 
             get("/containers") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")
@@ -228,8 +227,7 @@ fun Route.datadogInfraQueryRoutes() {
 
             get("/connections") {
                 val principal = call.principal<JWTPrincipal>()
-                val orgId = principal?.payload
-                    ?.getClaim("orgId")?.asInt()
+                val orgId = principal?.currentOrgIdOrNull()
                     ?: return@get call.respond(
                         HttpStatusCode.Unauthorized,
                         mapOf("error" to "Missing org context")

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DatadogRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.datadog.models.CreateDdApiKeyRequest
 import com.moneat.datadog.services.DatadogService
 import io.ktor.http.HttpStatusCode
@@ -37,8 +38,7 @@ fun Application.datadogRoutes() {
             route("/v1/agent-api-keys") {
                 get {
                     val principal = call.principal<JWTPrincipal>()
-                    val organizationId = principal?.payload
-                        ?.getClaim("orgId")?.asInt()
+                    val organizationId = principal?.currentOrgIdOrNull()
                         ?: return@get call.respond(
                             HttpStatusCode.Unauthorized,
                             mapOf("error" to "Invalid token")
@@ -49,8 +49,7 @@ fun Application.datadogRoutes() {
 
                 post {
                     val principal = call.principal<JWTPrincipal>()
-                    val organizationId = principal?.payload
-                        ?.getClaim("orgId")?.asInt()
+                    val organizationId = principal?.currentOrgIdOrNull()
                         ?: return@post call.respond(
                             HttpStatusCode.Unauthorized,
                             mapOf("error" to "Invalid token")
@@ -70,8 +69,7 @@ fun Application.datadogRoutes() {
 
                 delete("/{id}") {
                     val principal = call.principal<JWTPrincipal>()
-                    val organizationId = principal?.payload
-                        ?.getClaim("orgId")?.asInt()
+                    val organizationId = principal?.currentOrgIdOrNull()
                         ?: return@delete call.respond(
                             HttpStatusCode.Unauthorized,
                             mapOf("error" to "Invalid token")

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutes.kt
@@ -23,6 +23,7 @@ import com.moneat.datadog.models.CreateDebuggerProbeRequest
 import com.moneat.datadog.models.UpdateDebuggerProbeRequest
 import com.moneat.datadog.services.DebuggerProbeService
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
@@ -36,6 +37,8 @@ import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import java.util.UUID
 
+private const val INVALID_TOKEN_ERROR = "Invalid token"
+
 fun Route.debuggerProbeRoutes() {
     route("/v1/infra/debugger/probes") {
         authenticate("auth-jwt") {
@@ -43,11 +46,12 @@ fun Route.debuggerProbeRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal?.payload?.getClaim("userId")?.asInt()
                 if (userId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Invalid token"))
+                    call.respondInvalidToken()
                     return@get
                 }
 
                 val organizationIds = getOrgIdsForUser(userId, principal)
+                    ?: return@get call.respondInvalidToken()
                 val probes = DebuggerProbeService.listProbes(organizationIds)
                 call.respond(HttpStatusCode.OK, mapOf("probes" to probes))
             }
@@ -58,11 +62,12 @@ fun Route.debuggerProbeRoutes() {
                 val organizationId = principal?.currentOrgIdOrNull()
 
                 if (userId == null || organizationId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Invalid token"))
+                    call.respondInvalidToken()
                     return@post
                 }
 
                 val organizationIds = getOrgIdsForUser(userId, principal)
+                    ?: return@post call.respondInvalidToken()
                 if (organizationId !in organizationIds) {
                     call.respond(HttpStatusCode.Forbidden, mapOf("error" to "Access denied"))
                     return@post
@@ -81,7 +86,7 @@ fun Route.debuggerProbeRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal?.payload?.getClaim("userId")?.asInt()
                 if (userId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Invalid token"))
+                    call.respondInvalidToken()
                     return@put
                 }
 
@@ -92,6 +97,7 @@ fun Route.debuggerProbeRoutes() {
                 }
 
                 val organizationIds = getOrgIdsForUser(userId, principal)
+                    ?: return@put call.respondInvalidToken()
                 try {
                     val request = call.receive<UpdateDebuggerProbeRequest>()
                     val updatedProbe = DebuggerProbeService.updateProbe(probeId, organizationIds, request)
@@ -109,7 +115,7 @@ fun Route.debuggerProbeRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal?.payload?.getClaim("userId")?.asInt()
                 if (userId == null) {
-                    call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Invalid token"))
+                    call.respondInvalidToken()
                     return@delete
                 }
 
@@ -120,6 +126,7 @@ fun Route.debuggerProbeRoutes() {
                 }
 
                 val organizationIds = getOrgIdsForUser(userId, principal)
+                    ?: return@delete call.respondInvalidToken()
                 val deleted = DebuggerProbeService.deleteProbe(probeId, organizationIds)
                 if (!deleted) {
                     call.respond(HttpStatusCode.NotFound, mapOf("error" to "Probe not found"))
@@ -142,9 +149,12 @@ fun Route.debuggerProbeRoutes() {
     }
 }
 
-private fun getOrgIdsForUser(userId: Int, principal: JWTPrincipal?): List<Int> =
+private fun getOrgIdsForUser(userId: Int, principal: JWTPrincipal?): List<Int>? =
     principal
         ?.currentOrgContextOrNull()
         ?.takeIf { it.userId == userId }
         ?.let { listOf(it.orgId) }
-        .orEmpty()
+
+private suspend fun ApplicationCall.respondInvalidToken() {
+    respond(HttpStatusCode.Unauthorized, mapOf("error" to INVALID_TOKEN_ERROR))
+}

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutes.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.datadog.routes
 
-import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.auth.currentOrgContextOrNull
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.models.CreateDebuggerProbeRequest
@@ -43,39 +42,21 @@ fun Route.debuggerProbeRoutes() {
     route("/v1/infra/debugger/probes") {
         authenticate("auth-jwt") {
             get {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal?.payload?.getClaim("userId")?.asInt()
-                if (userId == null) {
-                    call.respondInvalidToken()
-                    return@get
-                }
-
-                val organizationIds = getOrgIdsForUser(userId, principal)
-                    ?: return@get call.respondInvalidToken()
-                val probes = DebuggerProbeService.listProbes(organizationIds)
+                val context =
+                    call.principal<JWTPrincipal>()?.currentOrgContextOrNull()
+                        ?: return@get call.respondInvalidToken()
+                val probes = DebuggerProbeService.listProbes(listOf(context.orgId))
                 call.respond(HttpStatusCode.OK, mapOf("probes" to probes))
             }
 
             post {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal?.payload?.getClaim("userId")?.asInt()
-                val organizationId = principal?.currentOrgIdOrNull()
-
-                if (userId == null || organizationId == null) {
-                    call.respondInvalidToken()
-                    return@post
-                }
-
-                val organizationIds = getOrgIdsForUser(userId, principal)
-                    ?: return@post call.respondInvalidToken()
-                if (organizationId !in organizationIds) {
-                    call.respond(HttpStatusCode.Forbidden, mapOf("error" to "Access denied"))
-                    return@post
-                }
+                val context =
+                    call.principal<JWTPrincipal>()?.currentOrgContextOrNull()
+                        ?: return@post call.respondInvalidToken()
 
                 try {
                     val request = call.receive<CreateDebuggerProbeRequest>()
-                    val createdProbe = DebuggerProbeService.createProbe(organizationId, userId, request)
+                    val createdProbe = DebuggerProbeService.createProbe(context.orgId, context.userId, request)
                     call.respond(HttpStatusCode.Created, createdProbe)
                 } catch (e: IllegalArgumentException) {
                     call.respond(HttpStatusCode.BadRequest, mapOf("error" to (e.message ?: "Invalid request")))
@@ -83,12 +64,9 @@ fun Route.debuggerProbeRoutes() {
             }
 
             put("/{id}") {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal?.payload?.getClaim("userId")?.asInt()
-                if (userId == null) {
-                    call.respondInvalidToken()
-                    return@put
-                }
+                val context =
+                    call.principal<JWTPrincipal>()?.currentOrgContextOrNull()
+                        ?: return@put call.respondInvalidToken()
 
                 val probeId = call.parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
                 if (probeId == null) {
@@ -96,11 +74,9 @@ fun Route.debuggerProbeRoutes() {
                     return@put
                 }
 
-                val organizationIds = getOrgIdsForUser(userId, principal)
-                    ?: return@put call.respondInvalidToken()
                 try {
                     val request = call.receive<UpdateDebuggerProbeRequest>()
-                    val updatedProbe = DebuggerProbeService.updateProbe(probeId, organizationIds, request)
+                    val updatedProbe = DebuggerProbeService.updateProbe(probeId, listOf(context.orgId), request)
                     if (updatedProbe == null) {
                         call.respond(HttpStatusCode.NotFound, mapOf("error" to "Probe not found"))
                         return@put
@@ -112,12 +88,9 @@ fun Route.debuggerProbeRoutes() {
             }
 
             delete("/{id}") {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal?.payload?.getClaim("userId")?.asInt()
-                if (userId == null) {
-                    call.respondInvalidToken()
-                    return@delete
-                }
+                val context =
+                    call.principal<JWTPrincipal>()?.currentOrgContextOrNull()
+                        ?: return@delete call.respondInvalidToken()
 
                 val probeId = call.parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
                 if (probeId == null) {
@@ -125,9 +98,7 @@ fun Route.debuggerProbeRoutes() {
                     return@delete
                 }
 
-                val organizationIds = getOrgIdsForUser(userId, principal)
-                    ?: return@delete call.respondInvalidToken()
-                val deleted = DebuggerProbeService.deleteProbe(probeId, organizationIds)
+                val deleted = DebuggerProbeService.deleteProbe(probeId, listOf(context.orgId))
                 if (!deleted) {
                     call.respond(HttpStatusCode.NotFound, mapOf("error" to "Probe not found"))
                     return@delete
@@ -148,12 +119,6 @@ fun Route.debuggerProbeRoutes() {
         }
     }
 }
-
-private fun getOrgIdsForUser(userId: Int, principal: JWTPrincipal?): List<Int>? =
-    principal
-        ?.currentOrgContextOrNull()
-        ?.takeIf { it.userId == userId }
-        ?.let { listOf(it.orgId) }
 
 private suspend fun ApplicationCall.respondInvalidToken() {
     respond(HttpStatusCode.Unauthorized, mapOf("error" to INVALID_TOKEN_ERROR))

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutes.kt
@@ -16,11 +16,12 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.auth.currentOrgIdOrNull
+import com.moneat.auth.currentOrgContextOrNull
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.models.CreateDebuggerProbeRequest
 import com.moneat.datadog.models.UpdateDebuggerProbeRequest
 import com.moneat.datadog.services.DebuggerProbeService
-import com.moneat.shared.models.Memberships
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -33,9 +34,6 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
 
 fun Route.debuggerProbeRoutes() {
@@ -49,7 +47,7 @@ fun Route.debuggerProbeRoutes() {
                     return@get
                 }
 
-                val organizationIds = getOrgIdsForUser(userId)
+                val organizationIds = getOrgIdsForUser(userId, principal)
                 val probes = DebuggerProbeService.listProbes(organizationIds)
                 call.respond(HttpStatusCode.OK, mapOf("probes" to probes))
             }
@@ -57,14 +55,14 @@ fun Route.debuggerProbeRoutes() {
             post {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal?.payload?.getClaim("userId")?.asInt()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
 
                 if (userId == null || organizationId == null) {
                     call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Invalid token"))
                     return@post
                 }
 
-                val organizationIds = getOrgIdsForUser(userId)
+                val organizationIds = getOrgIdsForUser(userId, principal)
                 if (organizationId !in organizationIds) {
                     call.respond(HttpStatusCode.Forbidden, mapOf("error" to "Access denied"))
                     return@post
@@ -93,7 +91,7 @@ fun Route.debuggerProbeRoutes() {
                     return@put
                 }
 
-                val organizationIds = getOrgIdsForUser(userId)
+                val organizationIds = getOrgIdsForUser(userId, principal)
                 try {
                     val request = call.receive<UpdateDebuggerProbeRequest>()
                     val updatedProbe = DebuggerProbeService.updateProbe(probeId, organizationIds, request)
@@ -121,7 +119,7 @@ fun Route.debuggerProbeRoutes() {
                     return@delete
                 }
 
-                val organizationIds = getOrgIdsForUser(userId)
+                val organizationIds = getOrgIdsForUser(userId, principal)
                 val deleted = DebuggerProbeService.deleteProbe(probeId, organizationIds)
                 if (!deleted) {
                     call.respond(HttpStatusCode.NotFound, mapOf("error" to "Probe not found"))
@@ -144,11 +142,9 @@ fun Route.debuggerProbeRoutes() {
     }
 }
 
-private fun getOrgIdsForUser(userId: Int): List<Int> {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .map { it[Memberships.organization_id] }
-    }
-}
+private fun getOrgIdsForUser(userId: Int, principal: JWTPrincipal?): List<Int> =
+    principal
+        ?.currentOrgContextOrNull()
+        ?.takeIf { it.userId == userId }
+        ?.let { listOf(it.orgId) }
+        .orEmpty()

--- a/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/routes/TraceDashboardRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.apm.routes.apmServiceDashboardRouteHandlers
 import com.moneat.datadog.services.DdApmQueryTimeRange
 import com.moneat.datadog.services.DdApmQueryTimeUnit
@@ -172,9 +173,7 @@ fun Route.traceDashboardRoutes(includeServiceDashboardRoutes: Boolean = true) {
 }
 
 private fun ApplicationCall.organizationId(): Int? =
-    principal<JWTPrincipal>()?.payload
-        ?.getClaim("orgId")
-        ?.asInt()
+    principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private suspend fun ApplicationCall.respondUnauthorized() {
     respond(

--- a/backend/src/main/kotlin/com/moneat/datadog/security/SecurityQueryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/datadog/security/SecurityQueryRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.datadog.security
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.ClickHouseQueryException
 import com.moneat.config.isClickHouseError
@@ -336,7 +337,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleComplianceTrends
  */
 private fun io.ktor.server.routing.RoutingContext.extractOrgId(): Int? {
     val principal = call.principal<JWTPrincipal>()
-    return principal?.payload?.getClaim("orgId")?.asInt()
+    return principal?.currentOrgIdOrNull()
 }
 
 /** Empty list-with-count payload returned when the caller token carries no `orgId` claim. */

--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -18,6 +18,8 @@ package com.moneat.events.routes
 
 import com.moneat.alerts.models.SuppressAlertEpisodeRequest
 import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.auth.currentOrgIdOrNull
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.auth.routes.accountDeletionRoutes
 import com.moneat.billing.routes.billingRoutes
 import com.moneat.billing.routes.publicBillingRoutes
@@ -155,8 +157,9 @@ fun Route.apiRoutes(includePublicContactRoutes: Boolean = true) {
 
                 // User profile
                 get("/user") {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context = call.requireCurrentOrg() ?: return@get
+                    val userId = context.userId
+                    val currentOrgId = context.orgId
                     val demoEpochMs = call.getDemoEpochMs()
 
                     val userResponse =
@@ -165,10 +168,13 @@ fun Route.apiRoutes(includePublicContactRoutes: Boolean = true) {
                                 ?: return@transaction null
                             val membership = Memberships
                                 .selectAll()
-                                .where { Memberships.user_id eq userId }
+                                .where {
+                                    (Memberships.user_id eq userId) and
+                                        (Memberships.organization_id eq currentOrgId)
+                                }
                                 .firstOrNull()
-                            val orgId = membership?.get(Memberships.organization_id)
-                            val orgSlug = orgId?.let { id ->
+                            val orgId = membership?.get(Memberships.organization_id) ?: currentOrgId
+                            val orgSlug = orgId.let { id ->
                                 Organizations
                                     .selectAll()
                                     .where { Organizations.id eq id }
@@ -372,41 +378,20 @@ fun Route.apiRoutes(includePublicContactRoutes: Boolean = true) {
 
                 // Update sidebar preferences
                 put("/user/sidebar-preferences") {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal!!.payload.getClaim("userId").asInt()
-                    val organizationIdClaim = principal.payload.getClaim("orgId").asInt()
+                    val context = call.requireCurrentOrg() ?: return@put
+                    val userId = context.userId
+                    val organizationId = context.orgId
                     val request = call.receive<UpdateSidebarPreferencesRequest>()
 
                     val (hiddenItems, errorStatus, errorMessage) =
                         transaction {
                             val membership =
-                                if (organizationIdClaim != null) {
-                                    Memberships
-                                        .selectAll()
-                                        .where {
-                                            (Memberships.user_id eq userId) and
-                                                (Memberships.organization_id eq organizationIdClaim)
-                                        }.firstOrNull()
-                                } else {
-                                    // Avoid cross-org writes when token is missing org context.
-                                    val memberships =
-                                        Memberships
-                                            .selectAll()
-                                            .where { Memberships.user_id eq userId }
-                                            .limit(2)
-                                            .toList()
-                                    when {
-                                        memberships.isEmpty() -> null
-
-                                        memberships.size == 1 -> memberships.first()
-
-                                        else -> return@transaction Triple<List<String>?, HttpStatusCode?, String?>(
-                                            null,
-                                            HttpStatusCode.BadRequest,
-                                            "Organization context required for users in multiple organizations"
-                                        )
-                                    }
-                                }
+                                Memberships
+                                    .selectAll()
+                                    .where {
+                                        (Memberships.user_id eq userId) and
+                                            (Memberships.organization_id eq organizationId)
+                                    }.firstOrNull()
                                     ?: return@transaction Triple<List<String>?, HttpStatusCode?, String?>(
                                         null,
                                         HttpStatusCode.NotFound,
@@ -414,7 +399,6 @@ fun Route.apiRoutes(includePublicContactRoutes: Boolean = true) {
                                     )
 
                             val membershipId = membership[Memberships.id]
-                            val organizationId = membership[Memberships.organization_id]
 
                             Triple(
                                 SidebarPreferenceService.updatePreferences(
@@ -470,21 +454,19 @@ fun Route.apiRoutes(includePublicContactRoutes: Boolean = true) {
 
                 // Projects
                 get("/projects") {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context = call.requireCurrentOrg() ?: return@get
                     val demoEpochMs = call.getDemoEpochMs()
 
-                    val projects = dashboardService.getProjects(userId, demoEpochMs)
+                    val projects = dashboardService.getProjects(context.orgId, demoEpochMs)
                     call.respond(projects)
                 }
 
                 post("/projects") {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context = call.requireCurrentOrg() ?: return@post
                     val request = call.receive<CreateProjectRequest>()
 
                     try {
-                        val project = dashboardService.createProject(userId, request)
+                        val project = dashboardService.createProject(context.orgId, request)
                         call.respond(HttpStatusCode.Created, project)
                     } catch (e: IllegalStateException) {
                         if (e.message == "project_limit_reached") {
@@ -1538,23 +1520,9 @@ fun Route.apiRoutes(includePublicContactRoutes: Boolean = true) {
 
                 // Alert Notification Preferences (Unified Alerting System)
                 get("/alert-notification-preferences") {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal!!.payload.getClaim("userId").asInt()
-
-                    // Get user's primary organization
-                    val organizationId =
-                        transaction {
-                            Memberships
-                                .selectAll()
-                                .where { Memberships.user_id eq userId }
-                                .firstOrNull()
-                                ?.get(Memberships.organization_id)
-                        }
-
-                    if (organizationId == null) {
-                        call.respond(HttpStatusCode.NotFound, "User not in any organization")
-                        return@get
-                    }
+                    val context = call.requireCurrentOrg() ?: return@get
+                    val userId = context.userId
+                    val organizationId = context.orgId
 
                     val prefsService = koin.get<AlertNotificationPreferencesService>()
                     val preferences = prefsService.getPreferences(userId, organizationId)
@@ -1563,27 +1531,13 @@ fun Route.apiRoutes(includePublicContactRoutes: Boolean = true) {
                 }
 
                 put("/alert-notification-preferences/{alertSource}") {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal!!.payload.getClaim("userId").asInt()
+                    val context = call.requireCurrentOrg() ?: return@put
+                    val userId = context.userId
+                    val organizationId = context.orgId
 
                     val alertSource = call.parameters["alertSource"]
                     if (alertSource.isNullOrBlank()) {
                         call.respond(HttpStatusCode.BadRequest, "Alert source required")
-                        return@put
-                    }
-
-                    // Get user's primary organization
-                    val organizationId =
-                        transaction {
-                            Memberships
-                                .selectAll()
-                                .where { Memberships.user_id eq userId }
-                                .firstOrNull()
-                                ?.get(Memberships.organization_id)
-                        }
-
-                    if (organizationId == null) {
-                        call.respond(HttpStatusCode.NotFound, "User not in any organization")
                         return@put
                     }
 
@@ -1762,7 +1716,7 @@ private fun ApplicationCall.queryCsvValues(name: String): List<String> =
         ?: emptyList()
 
 private suspend fun ApplicationCall.resolveSubscriptionOrganizationId(userId: Int): Int? {
-    val orgId = principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    val orgId = currentOrgIdOrNull()
     if (orgId == null || !hasOrganizationAccess(userId, orgId)) {
         respond(HttpStatusCode.NotFound, ErrorResponse(ERROR_NO_ORGANIZATION_ACCESS))
         return null

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -104,9 +104,9 @@ class DashboardService(
         accessService.getIssueIdForEvent(eventId)
 
     suspend fun getProjects(
-        userId: Int,
+        orgId: Int,
         demoEpochMs: Long? = null
-    ): List<ProjectResponse> = projectService.getProjects(userId, demoEpochMs)
+    ): List<ProjectResponse> = projectService.getProjects(orgId, demoEpochMs)
 
     fun getServiceIdsForOrganization(orgId: Int): List<Long> =
         projectRepository.getProjectsForOrganizations(listOf(orgId)).map { it.projectId }
@@ -118,9 +118,9 @@ class DashboardService(
         projectService.getProject(projectId)
 
     suspend fun createProject(
-        userId: Int,
+        orgId: Int,
         request: com.moneat.events.models.CreateProjectRequest
-    ): ProjectResponse = projectService.createProject(userId, request)
+    ): ProjectResponse = projectService.createProject(orgId, request)
 
     fun addProjectTarget(
         projectId: Long,

--- a/backend/src/main/kotlin/com/moneat/events/services/ProjectService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ProjectService.kt
@@ -39,13 +39,10 @@ class ProjectService(
     }
 
     suspend fun getProjects(
-        userId: Int,
+        orgId: Int,
         demoEpochMs: Long? = null
     ): List<ProjectResponse> {
-        val orgIds = projectRepository.getOrganizationIdsForUser(userId)
-        if (orgIds.isEmpty()) return emptyList()
-
-        val projects = projectRepository.getProjectsForOrganizations(orgIds)
+        val projects = projectRepository.getProjectsForOrganizations(listOf(orgId))
 
         return projects.map { row ->
             val issueCount = projectRepository.getIssueCountForProject(
@@ -90,12 +87,9 @@ class ProjectService(
     }
 
     suspend fun createProject(
-        userId: Int,
+        orgId: Int,
         request: CreateProjectRequest
     ): ProjectResponse {
-        val orgId = pricingTierService.getPrimaryOrganizationIdForUser(userId)
-            ?: throw IllegalStateException("User has no organization")
-
         if (billingQuotaService.isEnforcementEnabled()) {
             val tier = pricingTierService.getEffectiveTierForOrganization(orgId).tier
             tier.maxProjects?.let { max ->

--- a/backend/src/main/kotlin/com/moneat/featureflags/routes/FeatureFlagRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/featureflags/routes/FeatureFlagRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.featureflags.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.featureflags.models.CreateFeatureFlagEnvironmentRequest
 import com.moneat.featureflags.models.CreateFeatureFlagRequest
 import com.moneat.featureflags.models.FeatureFlagSdkKeyRequest
@@ -410,7 +411,7 @@ private suspend fun ApplicationCall.requireFeatureFlagAdmin(
     membershipService: OrgMembershipService,
 ): FeatureFlagManagementContext? {
     val principal = principal<JWTPrincipal>()
-    val orgId = principal?.payload?.getClaim("orgId")?.asInt()
+    val orgId = principal?.currentOrgIdOrNull()
     val userId = principal?.payload?.getClaim("userId")?.asInt()
     if (orgId == null) {
         respond(HttpStatusCode.Forbidden, ErrorResponse(MISSING_ORG_MESSAGE))

--- a/backend/src/main/kotlin/com/moneat/incident/routes/IncidentProviderRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/routes/IncidentProviderRoutes.kt
@@ -16,19 +16,17 @@
 
 package com.moneat.incident.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.incident.models.IncidentEventLog
 import com.moneat.incident.models.IncidentProviderConfigs
 import com.moneat.incident.models.IncidentRoutingRules
 import com.moneat.incident.models.ProviderConfig
 import com.moneat.incident.services.IncidentProviderRegistry
-import com.moneat.shared.models.Memberships
 import com.moneat.utils.BooleanResponse
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.response.respond
@@ -74,17 +72,7 @@ fun Route.incidentProviderRoutes() {
         authenticate("auth-jwt") {
             // List provider configs for organization
             get {
-                val principal = call.principal<JWTPrincipal>()!!
-                val userId = principal.payload.getClaim("userId").asInt()
-
-                val organizationId =
-                    transaction {
-                        Memberships
-                            .selectAll()
-                            .where { Memberships.user_id eq userId }
-                            .firstOrNull()
-                            ?.get(Memberships.organization_id)
-                    } ?: return@get call.respond(HttpStatusCode.Forbidden)
+                val organizationId = call.requireCurrentOrg()?.orgId ?: return@get
 
                 val configs =
                     transaction {
@@ -127,20 +115,11 @@ fun Route.incidentProviderRoutes() {
 
             // Test connection
             post("/{id}/test") {
-                val principal = call.principal<JWTPrincipal>()!!
-                val userId = principal.payload.getClaim("userId").asInt()
                 val configId =
                     call.parameters["id"]?.toIntOrNull()
                         ?: return@post call.respond(HttpStatusCode.BadRequest)
 
-                val organizationId =
-                    transaction {
-                        Memberships
-                            .selectAll()
-                            .where { Memberships.user_id eq userId }
-                            .firstOrNull()
-                            ?.get(Memberships.organization_id)
-                    } ?: return@post call.respond(HttpStatusCode.Forbidden)
+                val organizationId = call.requireCurrentOrg()?.orgId ?: return@post
 
                 val config =
                     transaction {
@@ -187,20 +166,11 @@ fun Route.incidentProviderRoutes() {
 
             // Get routing rules
             get("/{id}/rules") {
-                val principal = call.principal<JWTPrincipal>()!!
-                val userId = principal.payload.getClaim("userId").asInt()
                 val configId =
                     call.parameters["id"]?.toIntOrNull()
                         ?: return@get call.respond(HttpStatusCode.BadRequest)
 
-                val organizationId =
-                    transaction {
-                        Memberships
-                            .selectAll()
-                            .where { Memberships.user_id eq userId }
-                            .firstOrNull()
-                            ?.get(Memberships.organization_id)
-                    } ?: return@get call.respond(HttpStatusCode.Forbidden)
+                val organizationId = call.requireCurrentOrg()?.orgId ?: return@get
 
                 val hasAccess =
                     transaction {
@@ -243,17 +213,7 @@ fun Route.incidentProviderRoutes() {
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleCreateProviderConfig() {
-    val principal = call.principal<JWTPrincipal>()!!
-    val userId = principal.payload.getClaim("userId").asInt()
-
-    val organizationId =
-        transaction {
-            Memberships
-                .selectAll()
-                .where { Memberships.user_id eq userId }
-                .firstOrNull()
-                ?.get(Memberships.organization_id)
-        } ?: return call.respond(HttpStatusCode.Forbidden)
+    val organizationId = call.requireCurrentOrg()?.orgId ?: return
 
     val request = call.receive<CreateProviderConfigRequest>()
 
@@ -310,20 +270,11 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleCreateProviderCo
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateProviderConfig() {
-    val principal = call.principal<JWTPrincipal>()!!
-    val userId = principal.payload.getClaim("userId").asInt()
     val configId =
         call.parameters["id"]?.toIntOrNull()
             ?: return call.respond(HttpStatusCode.BadRequest)
 
-    val organizationId =
-        transaction {
-            Memberships
-                .selectAll()
-                .where { Memberships.user_id eq userId }
-                .firstOrNull()
-                ?.get(Memberships.organization_id)
-        } ?: return call.respond(HttpStatusCode.Forbidden)
+    val organizationId = call.requireCurrentOrg()?.orgId ?: return
 
     val request = call.receive<UpdateProviderConfigRequest>()
 
@@ -386,20 +337,11 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUpdateProviderCo
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleDeleteProviderConfig() {
-    val principal = call.principal<JWTPrincipal>()!!
-    val userId = principal.payload.getClaim("userId").asInt()
     val configId =
         call.parameters["id"]?.toIntOrNull()
             ?: return call.respond(HttpStatusCode.BadRequest)
 
-    val organizationId =
-        transaction {
-            Memberships
-                .selectAll()
-                .where { Memberships.user_id eq userId }
-                .firstOrNull()
-                ?.get(Memberships.organization_id)
-        } ?: return call.respond(HttpStatusCode.Forbidden)
+    val organizationId = call.requireCurrentOrg()?.orgId ?: return
 
     val deleted =
         transaction {
@@ -416,20 +358,11 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDeleteProviderCo
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleUpsertRoutingRules() {
-    val principal = call.principal<JWTPrincipal>()!!
-    val userId = principal.payload.getClaim("userId").asInt()
     val configId =
         call.parameters["id"]?.toIntOrNull()
             ?: return call.respond(HttpStatusCode.BadRequest)
 
-    val organizationId =
-        transaction {
-            Memberships
-                .selectAll()
-                .where { Memberships.user_id eq userId }
-                .firstOrNull()
-                ?.get(Memberships.organization_id)
-        } ?: return call.respond(HttpStatusCode.Forbidden)
+    val organizationId = call.requireCurrentOrg()?.orgId ?: return
 
     val hasAccess =
         transaction {
@@ -471,8 +404,6 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUpsertRoutingRul
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleGetEventLog() {
-    val principal = call.principal<JWTPrincipal>()!!
-    val userId = principal.payload.getClaim("userId").asInt()
     val configId =
         call.parameters["id"]?.toIntOrNull()
             ?: return call.respond(HttpStatusCode.BadRequest)
@@ -481,14 +412,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleGetEventLog() {
         throw BadRequestException("limit must be a positive integer")
     }
 
-    val organizationId =
-        transaction {
-            Memberships
-                .selectAll()
-                .where { Memberships.user_id eq userId }
-                .firstOrNull()
-                ?.get(Memberships.organization_id)
-        } ?: return call.respond(HttpStatusCode.Forbidden)
+    val organizationId = call.requireCurrentOrg()?.orgId ?: return
 
     val hasAccess =
         transaction {

--- a/backend/src/main/kotlin/com/moneat/llm/routes/LlmRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/llm/routes/LlmRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.llm.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.EnvConfig
 import com.moneat.events.services.DashboardService
 import com.moneat.llm.services.LlmDashboardService
@@ -119,7 +120,7 @@ private suspend fun ApplicationCall.resolveLlmOrganizationId(
 ): Int? {
     if (isDemoUser()) return EnvConfig.Demo.ORG_ID.toInt()
 
-    val organizationId = principal.payload.getClaim("orgId").asInt()
+    val organizationId = principal.currentOrgIdOrNull()
     if (organizationId != null && hasOrganizationAccess(userId, organizationId)) {
         return organizationId
     }

--- a/backend/src/main/kotlin/com/moneat/logs/routes/LogManagementRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/routes/LogManagementRoutes.kt
@@ -45,6 +45,7 @@ import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -60,6 +61,7 @@ private const val PIPELINE_NOT_FOUND_MESSAGE = "Pipeline not found"
 private const val SAVED_VIEW_NOT_FOUND_MESSAGE = "Saved view not found"
 private const val METRIC_RULE_NOT_FOUND_MESSAGE = "Metric rule not found"
 private const val LOG_MONITOR_NOT_FOUND_MESSAGE = "Log monitor not found"
+private const val INVALID_TOKEN_MESSAGE = "Invalid token"
 private const val DEFAULT_METRIC_ROLLUP_MINUTES = 5L
 private const val MAX_METRIC_ROLLUP_DAYS = 1L
 
@@ -85,11 +87,13 @@ private fun Route.registerLogIndexManagementRoutes(
         call.respondLogPermissions(membershipService)
     }
     get("/logs/indexes/usage") {
-        call.respond(HttpStatusCode.OK, mapOf("usage" to logIndexService.usageStats(call.logOrgId())))
+        val orgId = call.logOrgIdOrRespond() ?: return@get
+        call.respond(HttpStatusCode.OK, mapOf("usage" to logIndexService.usageStats(orgId)))
     }
     post("/logs/indexes/retention/run") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
-        val applied = logIndexService.enforceRetention(call.logOrgId())
+        val orgId = call.logOrgIdOrRespond() ?: return@post
+        val applied = logIndexService.enforceRetention(orgId)
         call.respond(HttpStatusCode.OK, mapOf("indexes_processed" to applied))
     }
 }
@@ -99,24 +103,28 @@ private fun Route.registerLogPipelineManagementRoutes(
     membershipService: OrgMembershipService
 ) {
     get("/logs/pipelines") {
-        call.respond(HttpStatusCode.OK, mapOf("pipelines" to logManagementService.listPipelines(call.logOrgId())))
+        val orgId = call.logOrgIdOrRespond() ?: return@get
+        call.respond(HttpStatusCode.OK, mapOf("pipelines" to logManagementService.listPipelines(orgId)))
     }
     post("/logs/pipelines") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
+        val orgId = call.logOrgIdOrRespond() ?: return@post
         call.respondCreatedOrBadRequest {
-            logManagementService.createPipeline(call.logOrgId(), call.logUserId(), call.receive())
+            logManagementService.createPipeline(orgId, call.logUserId(), call.receive())
         }
     }
     put("/logs/pipelines/{id}") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@put
+        val orgId = call.logOrgIdOrRespond() ?: return@put
         val id = call.logPathId("id") ?: return@put
-        val updated = logManagementService.updatePipeline(call.logOrgId(), id, call.receive<UpdateLogPipelineRequest>())
+        val updated = logManagementService.updatePipeline(orgId, id, call.receive<UpdateLogPipelineRequest>())
         call.respondNullable(updated, PIPELINE_NOT_FOUND_MESSAGE)
     }
     delete("/logs/pipelines/{id}") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@delete
+        val orgId = call.logOrgIdOrRespond() ?: return@delete
         val id = call.logPathId("id") ?: return@delete
-        call.respondDeleted(logManagementService.deletePipeline(call.logOrgId(), id), PIPELINE_NOT_FOUND_MESSAGE)
+        call.respondDeleted(logManagementService.deletePipeline(orgId, id), PIPELINE_NOT_FOUND_MESSAGE)
     }
     post("/logs/pipelines/preview") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
@@ -130,22 +138,25 @@ private fun Route.registerLogSavedViewManagementRoutes(
     membershipService: OrgMembershipService
 ) {
     get("/logs/saved-views") {
+        val orgId = call.logOrgIdOrRespond() ?: return@get
         call.respond(
             HttpStatusCode.OK,
-            mapOf("views" to logManagementService.listSavedViews(call.logOrgId(), call.logUserId()))
+            mapOf("views" to logManagementService.listSavedViews(orgId, call.logUserId()))
         )
     }
     post("/logs/saved-views") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@post
+        val orgId = call.logOrgIdOrRespond() ?: return@post
         call.respondCreatedOrBadRequest {
-            logManagementService.createSavedView(call.logOrgId(), call.logUserId(), call.receive())
+            logManagementService.createSavedView(orgId, call.logUserId(), call.receive())
         }
     }
     put("/logs/saved-views/{id}") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@put
+        val orgId = call.logOrgIdOrRespond() ?: return@put
         val id = call.logPathId("id") ?: return@put
         val updated = logManagementService.updateSavedView(
-            call.logOrgId(),
+            orgId,
             id,
             call.logUserId(),
             call.receive<UpdateLogSavedViewRequest>()
@@ -154,9 +165,10 @@ private fun Route.registerLogSavedViewManagementRoutes(
     }
     delete("/logs/saved-views/{id}") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MANAGE)) return@delete
+        val orgId = call.logOrgIdOrRespond() ?: return@delete
         val id = call.logPathId("id") ?: return@delete
         call.respondDeleted(
-            logManagementService.deleteSavedView(call.logOrgId(), id, call.logUserId()),
+            logManagementService.deleteSavedView(orgId, id, call.logUserId()),
             SAVED_VIEW_NOT_FOUND_MESSAGE
         )
     }
@@ -167,45 +179,81 @@ private fun Route.registerLogMetricManagementRoutes(
     logService: LogService,
     membershipService: OrgMembershipService
 ) {
-    get("/logs/metrics/rules") {
-        call.respond(HttpStatusCode.OK, mapOf("rules" to logManagementService.listMetricRules(call.logOrgId())))
-    }
-    post("/logs/metrics/rules") {
-        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@post
-        call.respondCreatedOrBadRequest {
-            logManagementService.createMetricRule(call.logOrgId(), call.logUserId(), call.receive())
-        }
-    }
-    put("/logs/metrics/rules/{id}") {
-        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@put
-        val id = call.logPathId("id") ?: return@put
-        val updated = logManagementService.updateMetricRule(
-            call.logOrgId(),
-            id,
-            call.receive<UpdateLogMetricRuleRequest>()
-        )
-        call.respondNullable(updated, METRIC_RULE_NOT_FOUND_MESSAGE)
-    }
-    delete("/logs/metrics/rules/{id}") {
-        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@delete
-        val id = call.logPathId("id") ?: return@delete
-        call.respondDeleted(logManagementService.deleteMetricRule(call.logOrgId(), id), METRIC_RULE_NOT_FOUND_MESSAGE)
-    }
-    post("/logs/metrics/preview") {
-        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@post
-        val request = call.receive<CreateLogMetricRuleRequest>()
-        val aggregate = logService.aggregateForMetricPreview(call.logOrgId().toLong(), request)
-        call.respond(HttpStatusCode.OK, aggregate)
-    }
+    get("/logs/metrics/rules") { handleListMetricRules(logManagementService) }
+    post("/logs/metrics/rules") { handleCreateMetricRule(logManagementService, membershipService) }
+    put("/logs/metrics/rules/{id}") { handleUpdateMetricRule(logManagementService, membershipService) }
+    delete("/logs/metrics/rules/{id}") { handleDeleteMetricRule(logManagementService, membershipService) }
+    post("/logs/metrics/preview") { handlePreviewMetricRule(logService, membershipService) }
     post("/logs/metrics/rules/{id}/rollup") {
-        if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return@post
-        val id = call.logPathId("id") ?: return@post
-        val rule = logManagementService.getMetricRule(call.logOrgId(), id)
-            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse(METRIC_RULE_NOT_FOUND_MESSAGE))
-        val aggregate = logService.aggregateForMetricPreview(call.logOrgId().toLong(), rule.toCreateRequest())
-        val inserted = logManagementService.recordMetricPoints(call.logOrgId().toLong(), rule, aggregate)
-        call.respond(HttpStatusCode.OK, mapOf("points_inserted" to inserted))
+        handleRollupMetricRule(logManagementService, logService, membershipService)
     }
+}
+
+private suspend fun RoutingContext.handleListMetricRules(logManagementService: LogManagementService) {
+    val orgId = call.logOrgIdOrRespond() ?: return
+    call.respond(HttpStatusCode.OK, mapOf("rules" to logManagementService.listMetricRules(orgId)))
+}
+
+private suspend fun RoutingContext.handleCreateMetricRule(
+    logManagementService: LogManagementService,
+    membershipService: OrgMembershipService
+) {
+    if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return
+    val orgId = call.logOrgIdOrRespond() ?: return
+    call.respondCreatedOrBadRequest {
+        logManagementService.createMetricRule(orgId, call.logUserId(), call.receive())
+    }
+}
+
+private suspend fun RoutingContext.handleUpdateMetricRule(
+    logManagementService: LogManagementService,
+    membershipService: OrgMembershipService
+) {
+    if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return
+    val orgId = call.logOrgIdOrRespond() ?: return
+    val id = call.logPathId("id") ?: return
+    val updated = logManagementService.updateMetricRule(
+        orgId,
+        id,
+        call.receive<UpdateLogMetricRuleRequest>()
+    )
+    call.respondNullable(updated, METRIC_RULE_NOT_FOUND_MESSAGE)
+}
+
+private suspend fun RoutingContext.handleDeleteMetricRule(
+    logManagementService: LogManagementService,
+    membershipService: OrgMembershipService
+) {
+    if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return
+    val orgId = call.logOrgIdOrRespond() ?: return
+    val id = call.logPathId("id") ?: return
+    call.respondDeleted(logManagementService.deleteMetricRule(orgId, id), METRIC_RULE_NOT_FOUND_MESSAGE)
+}
+
+private suspend fun RoutingContext.handlePreviewMetricRule(
+    logService: LogService,
+    membershipService: OrgMembershipService
+) {
+    if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return
+    val orgId = call.logOrgIdOrRespond() ?: return
+    val request = call.receive<CreateLogMetricRuleRequest>()
+    val aggregate = logService.aggregateForMetricPreview(orgId.toLong(), request)
+    call.respond(HttpStatusCode.OK, aggregate)
+}
+
+private suspend fun RoutingContext.handleRollupMetricRule(
+    logManagementService: LogManagementService,
+    logService: LogService,
+    membershipService: OrgMembershipService
+) {
+    if (!call.ensureLogAccess(membershipService, LogPermissions.METRICS)) return
+    val orgId = call.logOrgIdOrRespond() ?: return
+    val id = call.logPathId("id") ?: return
+    val rule = logManagementService.getMetricRule(orgId, id)
+        ?: return call.respond(HttpStatusCode.NotFound, ErrorResponse(METRIC_RULE_NOT_FOUND_MESSAGE))
+    val aggregate = logService.aggregateForMetricPreview(orgId.toLong(), rule.toCreateRequest())
+    val inserted = logManagementService.recordMetricPoints(orgId.toLong(), rule, aggregate)
+    call.respond(HttpStatusCode.OK, mapOf("points_inserted" to inserted))
 }
 
 private fun Route.registerLogMonitorManagementRoutes(
@@ -214,13 +262,15 @@ private fun Route.registerLogMonitorManagementRoutes(
     dashboardAlertService: DashboardAlertService
 ) {
     get("/logs/monitors") {
-        call.respond(HttpStatusCode.OK, mapOf("monitors" to logManagementService.listLogMonitors(call.logOrgId())))
+        val orgId = call.logOrgIdOrRespond() ?: return@get
+        call.respond(HttpStatusCode.OK, mapOf("monitors" to logManagementService.listLogMonitors(orgId)))
     }
     post("/logs/monitors") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@post
+        val orgId = call.logOrgIdOrRespond() ?: return@post
         call.respondCreatedOrBadRequest {
             logManagementService.createLogMonitor(
-                call.logOrgId(),
+                orgId,
                 call.logUserId(),
                 call.receive<CreateLogMonitorRequest>()
             )
@@ -228,10 +278,11 @@ private fun Route.registerLogMonitorManagementRoutes(
     }
     put("/logs/monitors/{id}") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@put
+        val orgId = call.logOrgIdOrRespond() ?: return@put
         val id = call.logPathId("id") ?: return@put
         call.respondNullableOrBadRequest(LOG_MONITOR_NOT_FOUND_MESSAGE) {
             logManagementService.updateLogMonitor(
-                call.logOrgId(),
+                orgId,
                 id,
                 call.receive<UpdateLogMonitorRequest>()
             )
@@ -239,8 +290,9 @@ private fun Route.registerLogMonitorManagementRoutes(
     }
     delete("/logs/monitors/{id}") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@delete
+        val orgId = call.logOrgIdOrRespond() ?: return@delete
         val id = call.logPathId("id") ?: return@delete
-        call.respondDeleted(logManagementService.deleteLogMonitor(call.logOrgId(), id), LOG_MONITOR_NOT_FOUND_MESSAGE)
+        call.respondDeleted(logManagementService.deleteLogMonitor(orgId, id), LOG_MONITOR_NOT_FOUND_MESSAGE)
     }
     post("/logs/monitors/from-query") {
         if (!call.ensureLogAccess(membershipService, LogPermissions.MONITORS)) return@post
@@ -251,13 +303,15 @@ private fun Route.registerLogMonitorManagementRoutes(
 }
 
 private suspend fun ApplicationCall.respondLogPermissions(membershipService: OrgMembershipService) {
+    val orgId = logOrgIdOrRespond() ?: return
+    val userId = logUserId()
     respond(
         HttpStatusCode.OK,
         mapOf(
-            "can_manage" to isLogAllowed(membershipService, LogPermissions.MANAGE),
-            "can_live_tail" to isLogAllowed(membershipService, LogPermissions.LIVE_TAIL),
-            "can_create_metrics" to isLogAllowed(membershipService, LogPermissions.METRICS),
-            "can_create_monitors" to isLogAllowed(membershipService, LogPermissions.MONITORS)
+            "can_manage" to isLogAllowed(membershipService, orgId, userId, LogPermissions.MANAGE),
+            "can_live_tail" to isLogAllowed(membershipService, orgId, userId, LogPermissions.LIVE_TAIL),
+            "can_create_metrics" to isLogAllowed(membershipService, orgId, userId, LogPermissions.METRICS),
+            "can_create_monitors" to isLogAllowed(membershipService, orgId, userId, LogPermissions.MONITORS)
         )
     )
 }
@@ -265,13 +319,14 @@ private suspend fun ApplicationCall.respondLogPermissions(membershipService: Org
 private suspend fun ApplicationCall.createLogMonitorDraft(
     request: LogMonitorDraftRequest,
     dashboardAlertService: DashboardAlertService
-): LogMonitorDraftResponse {
+): LogMonitorDraftResponse? {
     val dashboardId = request.dashboardId
     val widgetId = request.widgetId
     if (dashboardId != null && widgetId != null) {
+        val orgId = logOrgIdOrRespond() ?: return null
         val alert = dashboardAlertService.createAlert(
             dashboardId = dashboardId,
-            orgId = logOrgId().toLong(),
+            orgId = orgId.toLong(),
             createdBy = logUserId().toLong(),
             request = CreateDashboardAlertRequest(
                 widgetId = widgetId,
@@ -306,20 +361,24 @@ private suspend fun ApplicationCall.ensureLogAccess(
     membershipService: OrgMembershipService,
     permission: String
 ): Boolean {
-    val allowed = isLogAllowed(membershipService, permission)
+    val orgId = logOrgIdOrRespond() ?: return false
+    val userId = logUserId()
+    val allowed = isLogAllowed(membershipService, orgId, userId, permission)
     if (!allowed) {
         respond(HttpStatusCode.Forbidden, ErrorResponse(LOG_FORBIDDEN_MESSAGE))
     }
     return allowed
 }
 
-private suspend fun ApplicationCall.isLogAllowed(
+private suspend fun isLogAllowed(
     membershipService: OrgMembershipService,
+    orgId: Int,
+    userId: Int,
     permission: String
 ): Boolean {
-    val granular = FeatureRegistry.getPermissionBridge()?.hasPermission(logOrgId(), logUserId(), permission)
+    val granular = FeatureRegistry.getPermissionBridge()?.hasPermission(orgId, userId, permission)
     return granular ?: suspendRunCatching {
-        membershipService.requireRole(logOrgId(), logUserId(), OrgRole.ADMIN)
+        membershipService.requireRole(orgId, userId, OrgRole.ADMIN)
         true
     }.getOrElse { false }
 }
@@ -386,8 +445,13 @@ private suspend fun ApplicationCall.logPathId(name: String): Int? {
 private fun ApplicationCall.logUserId(): Int =
     principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
 
-private fun ApplicationCall.logOrgId(): Int =
-    principal<JWTPrincipal>()!!.currentOrgIdOrNull()!!
+private suspend fun ApplicationCall.logOrgIdOrRespond(): Int? {
+    val orgId = principal<JWTPrincipal>()?.currentOrgIdOrNull()
+    if (orgId == null) {
+        respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
+    }
+    return orgId
+}
 
 private suspend fun LogService.aggregateForMetricPreview(
     organizationId: Long,

--- a/backend/src/main/kotlin/com/moneat/logs/routes/LogManagementRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/routes/LogManagementRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.logs.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.dashboards.models.CreateDashboardAlertRequest
 import com.moneat.dashboards.services.DashboardAlertService
 import com.moneat.enterprise.FeatureRegistry
@@ -386,7 +387,7 @@ private fun ApplicationCall.logUserId(): Int =
     principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
 
 private fun ApplicationCall.logOrgId(): Int =
-    principal<JWTPrincipal>()!!.payload.getClaim("orgId").asInt()
+    principal<JWTPrincipal>()!!.currentOrgIdOrNull()!!
 
 private suspend fun LogService.aggregateForMetricPreview(
     organizationId: Long,

--- a/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.logs.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import kotlinx.serialization.SerializationException
 import java.io.IOException
 import java.io.Writer
@@ -563,7 +564,7 @@ private fun ApplicationCall.requiredUserId(): Int =
     principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
 
 private fun ApplicationCall.requiredOrganizationId(): Int =
-    principal<JWTPrincipal>()!!.payload.getClaim("orgId").asInt()
+    principal<JWTPrincipal>()!!.currentOrgIdOrNull()!!
 
 private suspend fun ApplicationCall.ensureLogIndexAccess(membershipService: OrgMembershipService): Boolean {
     val allowed = hasLogAccess(
@@ -594,7 +595,7 @@ private suspend fun hasLogAccess(
 private fun ApplicationCall.resolveTailIdentity(): Pair<Int, Long>? {
     val principal = principal<JWTPrincipal>()
     val principalUserId = principal?.payload?.getClaim("userId")?.asInt()
-    val principalOrgId = principal?.payload?.getClaim("orgId")?.asInt()?.toLong()
+    val principalOrgId = principal?.currentOrgIdOrNull()?.toLong()
     return if (principalUserId != null && principalOrgId != null) {
         principalUserId to principalOrgId
     } else {
@@ -668,7 +669,7 @@ private fun authenticateTailRequest(call: ApplicationCall): Pair<Int, Long>? {
 
         val decoded = verifier.verify(token)
         val userId = decoded.getClaim("userId").asInt()
-        val orgId = decoded.getClaim("orgId").asInt().toLong()
+        val orgId = decoded.currentOrgIdOrNull()?.toLong() ?: return@suspendRunCatching null
         Pair(userId, orgId)
     }.getOrElse { _ ->
         null

--- a/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/routes/LogRoutes.kt
@@ -84,6 +84,7 @@ private val json = Json { ignoreUnknownKeys = true }
 
 private const val MILLIS_IN_24_HOURS = 24L * 60 * 60 * 1000
 private const val SSE_POLL_TIMEOUT_SECONDS = 15L
+private const val INVALID_TOKEN_MESSAGE = "Invalid token"
 
 fun Route.logRoutes(
     logService: LogService = GlobalContext.get().get(),
@@ -124,6 +125,7 @@ private fun Route.registerOtlpApiKeyRoutes(otlpApiKeyService: OtlpApiKeyService)
 }
 
 private suspend fun ApplicationCall.createOtlpApiKey(otlpApiKeyService: OtlpApiKeyService) {
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
     val request = receive<CreateOtlpApiKeyRequest>()
     val name = request.name.trim()
     if (name.isBlank()) {
@@ -133,7 +135,7 @@ private suspend fun ApplicationCall.createOtlpApiKey(otlpApiKeyService: OtlpApiK
 
     val response =
         otlpApiKeyService.createKey(
-            organizationId = requiredOrganizationId(),
+            organizationId = organizationId,
             name = name,
             createdBy = requiredUserId()
         )
@@ -141,7 +143,8 @@ private suspend fun ApplicationCall.createOtlpApiKey(otlpApiKeyService: OtlpApiK
 }
 
 private suspend fun ApplicationCall.listOtlpApiKeys(otlpApiKeyService: OtlpApiKeyService) {
-    val keys = otlpApiKeyService.listKeys(requiredOrganizationId())
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
+    val keys = otlpApiKeyService.listKeys(organizationId)
     respond(HttpStatusCode.OK, mapOf("keys" to keys))
 }
 
@@ -152,7 +155,8 @@ private suspend fun ApplicationCall.deleteOtlpApiKey(otlpApiKeyService: OtlpApiK
         return
     }
 
-    val deleted = otlpApiKeyService.deleteKey(organizationId = requiredOrganizationId(), keyId = id)
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
+    val deleted = otlpApiKeyService.deleteKey(organizationId = organizationId, keyId = id)
     if (!deleted) {
         respond(HttpStatusCode.NotFound, ErrorResponse("Key not found"))
         return
@@ -169,7 +173,8 @@ private fun Route.registerOtlpServiceRoutingRoutes(otlpServiceRoutingService: Ot
 private suspend fun ApplicationCall.listOtlpObservedServices(
     otlpServiceRoutingService: OtlpServiceRoutingService
 ) {
-    val services = otlpServiceRoutingService.listObservedServices(requiredOrganizationId())
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
+    val services = otlpServiceRoutingService.listObservedServices(organizationId)
     respond(HttpStatusCode.OK, mapOf("services" to services))
 }
 
@@ -177,7 +182,7 @@ private suspend fun ApplicationCall.upsertOtlpServiceMapping(
     otlpServiceRoutingService: OtlpServiceRoutingService
 ) {
     val response = otlpServiceRoutingService.upsertMapping(
-        requiredOrganizationId(),
+        requiredOrganizationIdOrRespond() ?: return,
         receive<CreateOtlpServiceMappingRequest>()
     )
     if (response == null) {
@@ -199,7 +204,8 @@ private suspend fun ApplicationCall.deleteOtlpServiceMapping(
         return
     }
 
-    val deleted = otlpServiceRoutingService.deleteMapping(requiredOrganizationId(), id)
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
+    val deleted = otlpServiceRoutingService.deleteMapping(organizationId, id)
     if (!deleted) {
         respond(HttpStatusCode.NotFound, ErrorResponse("Mapping not found"))
         return
@@ -227,27 +233,30 @@ private fun Route.registerLogIndexRoutes(
 }
 
 private suspend fun ApplicationCall.listLogIndexes(logIndexService: LogIndexService) {
-    val indexes = logIndexService.list(requiredOrganizationId())
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
+    val indexes = logIndexService.list(organizationId)
     respond(HttpStatusCode.OK, mapOf("indexes" to indexes))
 }
 
 private suspend fun ApplicationCall.createLogIndex(logIndexService: LogIndexService) {
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
     val request = receive<CreateLogIndexRequest>()
     if (request.name.isBlank()) {
         respond(HttpStatusCode.BadRequest, ErrorResponse("Name is required"))
         return
     }
-    val index = logIndexService.create(requiredOrganizationId(), request)
+    val index = logIndexService.create(organizationId, request)
     respond(HttpStatusCode.Created, index)
 }
 
 private suspend fun ApplicationCall.updateLogIndex(logIndexService: LogIndexService) {
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
     val id = parameters["id"]?.toIntOrNull()
     if (id == null) {
         respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid index ID"))
         return
     }
-    val updated = logIndexService.update(requiredOrganizationId(), id, receive<UpdateLogIndexRequest>())
+    val updated = logIndexService.update(organizationId, id, receive<UpdateLogIndexRequest>())
     if (updated == null) {
         respond(HttpStatusCode.NotFound, ErrorResponse("Index not found"))
         return
@@ -256,12 +265,13 @@ private suspend fun ApplicationCall.updateLogIndex(logIndexService: LogIndexServ
 }
 
 private suspend fun ApplicationCall.deleteLogIndex(logIndexService: LogIndexService) {
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
     val id = parameters["id"]?.toIntOrNull()
     if (id == null) {
         respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid index ID"))
         return
     }
-    val deleted = logIndexService.delete(requiredOrganizationId(), id)
+    val deleted = logIndexService.delete(organizationId, id)
     if (!deleted) {
         respond(HttpStatusCode.NotFound, ErrorResponse("Index not found"))
         return
@@ -270,8 +280,9 @@ private suspend fun ApplicationCall.deleteLogIndex(logIndexService: LogIndexServ
 }
 
 private suspend fun ApplicationCall.testLogIndex(logIndexService: LogIndexService) {
+    val organizationId = requiredOrganizationIdOrRespond() ?: return
     val body = receive<Map<String, String>>()
-    val result = logIndexService.testFilter(requiredOrganizationId(), body["filter_query"] ?: "")
+    val result = logIndexService.testFilter(organizationId, body["filter_query"] ?: "")
     respond(HttpStatusCode.OK, result)
 }
 
@@ -285,7 +296,7 @@ private fun Route.registerLogQueryRoutes(logService: LogService) {
 }
 
 private suspend fun ApplicationCall.queryLogs(logService: LogService) {
-    val orgId = requiredOrganizationId().toLong()
+    val orgId = requiredOrganizationIdOrRespond()?.toLong() ?: return
     val range = demoAwareLogTimeRange()
     val logRequest =
         LogQueryRequest(
@@ -318,7 +329,7 @@ private suspend fun ApplicationCall.getLogTagValues(logService: LogService) {
 
     val result =
         logService.getTagValues(
-            organizationId = requiredOrganizationId().toLong(),
+            organizationId = requiredOrganizationIdOrRespond()?.toLong() ?: return,
             key = key,
             from = request.queryParameters["from"],
             to = request.queryParameters["to"],
@@ -328,10 +339,11 @@ private suspend fun ApplicationCall.getLogTagValues(logService: LogService) {
 }
 
 private suspend fun ApplicationCall.getLogFilters(logService: LogService) {
+    val organizationId = requiredOrganizationIdOrRespond()?.toLong() ?: return
     val range = demoAwareLogTimeRange()
     val result =
         logService.getFilterOptionsWithCounts(
-            organizationId = requiredOrganizationId().toLong(),
+            organizationId = organizationId,
             from = range.from,
             to = range.to
         )
@@ -339,7 +351,7 @@ private suspend fun ApplicationCall.getLogFilters(logService: LogService) {
 }
 
 private suspend fun ApplicationCall.aggregateLogs(logService: LogService) {
-    val orgId = requiredOrganizationId().toLong()
+    val orgId = requiredOrganizationIdOrRespond()?.toLong() ?: return
     val range = demoAwareLogTimeRange()
     val result =
         logService.aggregateLogs(
@@ -376,7 +388,7 @@ private suspend fun ApplicationCall.getTopLogValues(logService: LogService) {
     val range = demoAwareLogTimeRange()
     val result =
         logService.topValues(
-            organizationId = requiredOrganizationId().toLong(),
+            organizationId = requiredOrganizationIdOrRespond()?.toLong() ?: return,
             field = field,
             limit = request.queryParameters["limit"]?.toIntOrNull() ?: 10,
             from = range.from,
@@ -395,9 +407,10 @@ private suspend fun ApplicationCall.getTopLogValues(logService: LogService) {
 }
 
 private suspend fun ApplicationCall.exportLogs(logService: LogService) {
+    val organizationId = requiredOrganizationIdOrRespond()?.toLong() ?: return
     val csv =
         logService.exportCsv(
-            organizationId = requiredOrganizationId().toLong(),
+            organizationId = organizationId,
             from = request.queryParameters["from"],
             to = request.queryParameters["to"],
             query = request.queryParameters["q"] ?: request.queryParameters["query"],
@@ -563,13 +576,19 @@ private fun ApplicationCall.demoAwareLogTimeRange(): LogTimeRange {
 private fun ApplicationCall.requiredUserId(): Int =
     principal<JWTPrincipal>()!!.payload.getClaim("userId").asInt()
 
-private fun ApplicationCall.requiredOrganizationId(): Int =
-    principal<JWTPrincipal>()!!.currentOrgIdOrNull()!!
+private suspend fun ApplicationCall.requiredOrganizationIdOrRespond(): Int? {
+    val organizationId = principal<JWTPrincipal>()?.currentOrgIdOrNull()
+    if (organizationId == null) {
+        respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
+    }
+    return organizationId
+}
 
 private suspend fun ApplicationCall.ensureLogIndexAccess(membershipService: OrgMembershipService): Boolean {
+    val organizationId = requiredOrganizationIdOrRespond() ?: return false
     val allowed = hasLogAccess(
         membershipService = membershipService,
-        organizationId = requiredOrganizationId(),
+        organizationId = organizationId,
         userId = requiredUserId(),
         permission = LogPermissions.MANAGE
     )

--- a/backend/src/main/kotlin/com/moneat/mcp/routes/McpApiKeyRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/routes/McpApiKeyRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.mcp.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.mcp.models.CreateMcpApiKeyRequest
 import com.moneat.mcp.models.McpApiKeysResponse
 import com.moneat.mcp.models.UpdateMcpApiKeyRequest
@@ -29,8 +30,6 @@ import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -217,13 +216,8 @@ private data class McpClaims(
 )
 
 private suspend fun ApplicationCall.requireMcpClaims(): McpClaims? {
-    val orgId = claimIntOrNull("orgId")
-    val userId = claimIntOrNull("userId")
-    if (orgId == null || userId == null) {
-        respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_CLAIMS))
-        return null
-    }
-    return McpClaims(organizationId = orgId, userId = userId)
+    val context = requireCurrentOrg(INVALID_TOKEN_CLAIMS) ?: return null
+    return McpClaims(organizationId = context.orgId, userId = context.userId)
 }
 
 private suspend fun ApplicationCall.requireMcpAdminClaims(
@@ -243,9 +237,6 @@ private suspend fun ApplicationCall.requireMcpAdminClaims(
     }
     return claims
 }
-
-private fun ApplicationCall.claimIntOrNull(name: String): Int? =
-    runCatching { principal<JWTPrincipal>()?.payload?.getClaim(name)?.asInt() }.getOrNull()
 
 private fun validateToolSelection(
     tools: List<String>?,

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/ProjectTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/ProjectTool.kt
@@ -38,7 +38,7 @@ class ListProjectsTool : McpTool {
         context: McpContext
     ): ToolCallResult {
         val projects = projectDashboardService.getProjects(
-            context.userId
+            context.organizationId
         )
         return jsonResult(projects)
     }
@@ -70,7 +70,7 @@ class CreateProjectTool : McpTool {
             ?: return errorResult("platform is required")
 
         val project = projectDashboardService.createProject(
-            userId = context.userId,
+            orgId = context.organizationId,
             request = CreateProjectRequest(
                 name = name,
                 framework = platform

--- a/backend/src/main/kotlin/com/moneat/monitor/routes/AgentApiKeyRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/routes/AgentApiKeyRoutes.kt
@@ -16,13 +16,12 @@
 
 package com.moneat.monitor.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.monitor.models.CreateAgentApiKeyRequest
 import com.moneat.monitor.services.AgentApiKeyService
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -38,16 +37,15 @@ fun Route.agentApiKeyRoutes(
     route("/v1") {
         authenticate("auth-jwt") {
             get("/agent-api-keys") {
-                val principal = call.principal<JWTPrincipal>()
-                val orgId = principal!!.payload.getClaim("orgId").asInt()
+                val orgId = call.requireCurrentOrg()?.orgId ?: return@get
                 val keys = agentApiKeyService.listKeys(orgId)
                 call.respond(HttpStatusCode.OK, mapOf("keys" to keys))
             }
 
             post("/agent-api-keys") {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal!!.payload.getClaim("userId").asInt()
-                val orgId = principal.payload.getClaim("orgId").asInt()
+                val context = call.requireCurrentOrg() ?: return@post
+                val userId = context.userId
+                val orgId = context.orgId
 
                 val request = call.receive<CreateAgentApiKeyRequest>()
                 val name = request.name.trim()
@@ -65,8 +63,7 @@ fun Route.agentApiKeyRoutes(
             }
 
             delete("/agent-api-keys/{id}") {
-                val principal = call.principal<JWTPrincipal>()
-                val orgId = principal!!.payload.getClaim("orgId").asInt()
+                val orgId = call.requireCurrentOrg()?.orgId ?: return@delete
 
                 val id = call.parameters["id"]?.toIntOrNull()
                 if (id == null) {

--- a/backend/src/main/kotlin/com/moneat/monitor/routes/InfraRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/routes/InfraRoutes.kt
@@ -16,19 +16,17 @@
 
 package com.moneat.monitor.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.config.ClickHouseClient
 import com.moneat.monitor.models.InfrastructureMapSavedViewsResponse
 import com.moneat.monitor.models.SaveInfrastructureMapViewRequest
 import com.moneat.monitor.services.InfrastructureMapSavedViewService
 import com.moneat.monitor.services.InvalidInfrastructureMapSavedViewException
-import com.moneat.shared.models.Memberships
 import com.moneat.utils.ErrorResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -40,9 +38,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import mu.KotlinLogging
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MAX
 import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MIN
 
@@ -71,55 +66,16 @@ private data class ClickHouseListRouteConfig(
     val filters: List<ClickHouseFilter> = emptyList()
 )
 
-private sealed class OrganizationScopeResult {
-    data class Resolved(val organizationId: Int) : OrganizationScopeResult()
-    object NoAccess : OrganizationScopeResult()
-    object MissingContext : OrganizationScopeResult()
-}
-
-private fun getOrgIdsForUser(userId: Int): List<Int> {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .map { it[Memberships.organization_id] }
-    }
-}
-
 private fun orgIdsToChCondition(orgIds: List<Int>): String {
     return orgIds.joinToString(",") { "toUInt64($it)" }
 }
 
 private suspend fun ApplicationCall.resolveSavedViewScope(): SavedViewScope? {
-    val principal = principal<JWTPrincipal>()
-    val userId = principal!!.payload.getClaim("userId").asInt()
-    val organizationIdClaim = principal.payload.getClaim("orgId").asInt()
-
-    return when (val scope = resolveOrganizationId(userId, organizationIdClaim)) {
-        is OrganizationScopeResult.Resolved -> SavedViewScope(userId, scope.organizationId)
-        OrganizationScopeResult.NoAccess -> {
-            respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
-            null
-        }
-        OrganizationScopeResult.MissingContext -> {
-            respond(HttpStatusCode.BadRequest, ErrorResponse("Organization context required"))
-            null
-        }
-    }
-}
-
-private fun resolveOrganizationId(userId: Int, organizationIdClaim: Int?): OrganizationScopeResult {
-    val organizationIds = getOrgIdsForUser(userId)
-    if (organizationIds.isEmpty()) return OrganizationScopeResult.NoAccess
-    if (organizationIdClaim != null) {
-        return if (organizationIdClaim in organizationIds) {
-            OrganizationScopeResult.Resolved(organizationIdClaim)
-        } else {
-            OrganizationScopeResult.NoAccess
-        }
-    }
-    if (organizationIds.size == 1) return OrganizationScopeResult.Resolved(organizationIds.first())
-    return OrganizationScopeResult.MissingContext
+    val context = requireCurrentOrg() ?: return null
+    return SavedViewScope(
+        userId = context.userId,
+        organizationId = context.orgId
+    )
 }
 
 private fun parseLimit(limitParam: String?): Int {
@@ -127,10 +83,9 @@ private fun parseLimit(limitParam: String?): Int {
     return limit.coerceIn(1, MAX_LIMIT)
 }
 
-private fun ApplicationCall.currentUserOrganizationIds(): List<Int> {
-    val principal = principal<JWTPrincipal>()
-    val userId = principal!!.payload.getClaim("userId").asInt()
-    return getOrgIdsForUser(userId)
+private suspend fun ApplicationCall.currentUserOrganizationIds(): List<Int>? {
+    val context = requireCurrentOrg() ?: return null
+    return listOf(context.orgId)
 }
 
 /**
@@ -267,7 +222,7 @@ private fun Route.registerClickHouseListRoute(config: ClickHouseListRouteConfig)
 }
 
 private suspend fun ApplicationCall.respondClickHouseList(config: ClickHouseListRouteConfig) {
-    val orgIds = currentUserOrganizationIds()
+    val orgIds = currentUserOrganizationIds() ?: return
     val payload = if (orgIds.isEmpty()) {
         emptyList()
     } else {

--- a/backend/src/main/kotlin/com/moneat/monitor/routes/MonitorRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/routes/MonitorRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.monitor.routes
 
+import com.moneat.auth.currentOrgContextOrNull
 import com.moneat.logs.models.LogQueryRequest
 import com.moneat.logs.services.LogService
 import com.moneat.monitor.models.AllContainersResponse
@@ -29,7 +30,6 @@ import com.moneat.monitor.models.UpdateAlertRequest
 import com.moneat.monitor.models.UpdateAlertScopeRequest
 import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.monitor.services.MonitorService
-import com.moneat.shared.models.Memberships
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -44,9 +44,6 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 import io.ktor.server.routing.route
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
 
 private const val DEFAULT_PROJECT_ID = 0L
@@ -56,15 +53,12 @@ private const val DEFAULT_LIMIT = 100
  * Helper function to get organization IDs for a user from their memberships.
  * Returns the list of organization IDs the user belongs to.
  */
-private fun getOrganizationIdsForUser(userId: Int): List<Int> {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .map { it[Memberships.organization_id] }
-            .distinct()
-    }
-}
+private fun getOrganizationIdsForUser(userId: Int, principal: JWTPrincipal?): List<Int> =
+    principal
+        ?.currentOrgContextOrNull()
+        ?.takeIf { it.userId == userId }
+        ?.let { listOf(it.orgId) }
+        .orEmpty()
 
 private suspend fun ensureHostAccessible(
     call: ApplicationCall,
@@ -93,7 +87,7 @@ fun Route.monitorRoutes(
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload.getClaim("userId").asInt()
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -147,7 +141,7 @@ fun Route.monitorRoutes(
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload.getClaim("userId").asInt()
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -163,7 +157,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -208,7 +202,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@delete
@@ -239,7 +233,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -274,7 +268,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -301,7 +295,7 @@ fun Route.monitorRoutes(
                 val hostIdStr = call.parameters["id"]
                 val containerName = call.parameters["name"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -348,7 +342,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -398,7 +392,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -424,7 +418,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -450,7 +444,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@put
@@ -483,7 +477,7 @@ fun Route.monitorRoutes(
                 val userId = principal!!.payload.getClaim("userId").asInt()
                 val hostIdStr = call.parameters["id"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@post
@@ -517,7 +511,7 @@ fun Route.monitorRoutes(
                 val hostIdStr = call.parameters["hostId"]
                 val alertIdStr = call.parameters["alertId"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@put
@@ -562,7 +556,7 @@ fun Route.monitorRoutes(
                 val hostIdStr = call.parameters["hostId"]
                 val alertIdStr = call.parameters["alertId"]
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@delete
@@ -605,7 +599,7 @@ fun Route.monitorRoutes(
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload.getClaim("userId").asInt()
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@get
@@ -619,7 +613,7 @@ fun Route.monitorRoutes(
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload.getClaim("userId").asInt()
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@post
@@ -645,7 +639,7 @@ fun Route.monitorRoutes(
                     return@delete
                 }
 
-                val organizationIds = getOrganizationIdsForUser(userId)
+                val organizationIds = getOrganizationIdsForUser(userId, principal)
                 if (organizationIds.isEmpty()) {
                     call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization access"))
                     return@delete

--- a/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.org.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.config.EnvConfig
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.SlackService
@@ -27,6 +28,7 @@ import com.moneat.utils.MessageResponse
 import io.ktor.http.Headers
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parseQueryString
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
@@ -225,6 +227,14 @@ private fun validateAndDecodeState(state: String): Pair<Int, Int>? {
     }
 }
 
+private suspend fun ApplicationCall.integrationOrgIdOrRespond(): Int? {
+    val orgId = principal<JWTPrincipal>()?.currentOrgIdOrNull()
+    if (orgId == null) {
+        respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+    }
+    return orgId
+}
+
 fun Route.integrationRoutes() {
     val slackService = GlobalContext.get().get<SlackService>()
     val discordService = GlobalContext.get().get<DiscordService>()
@@ -243,14 +253,7 @@ fun Route.integrationRoutes() {
                 val userId = principal.payload.getClaim("userId").asInt()
                 logger.info("Fetching integrations for user $userId")
 
-                val organizationId =
-                    transaction {
-                        Memberships
-                            .selectAll()
-                            .where { Memberships.user_id eq userId }
-                            .firstOrNull()
-                            ?.get(Memberships.organization_id)
-                    }
+                val organizationId = principal.currentOrgIdOrNull()
 
                 if (organizationId == null) {
                     return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
@@ -288,14 +291,7 @@ fun Route.integrationRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload.getClaim("userId").asInt()
 
-                val organizationId =
-                    transaction {
-                        Memberships
-                            .selectAll()
-                            .where { Memberships.user_id eq userId }
-                            .firstOrNull()
-                            ?.get(Memberships.organization_id)
-                    }
+                val organizationId = principal.currentOrgIdOrNull()
 
                 if (organizationId == null) {
                     return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
@@ -346,17 +342,7 @@ fun Route.integrationRoutes() {
 
         // List available Slack channels
         get("/slack/channels") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@get
 
             val accessToken =
                 transaction {
@@ -375,17 +361,7 @@ fun Route.integrationRoutes() {
 
         // Update channel selection
         put("/slack/channel") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@put call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@put
 
             val request = call.receive<SlackChannelSelection>()
 
@@ -405,17 +381,7 @@ fun Route.integrationRoutes() {
 
         // List available Slack user groups
         get("/slack/usergroups") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@get
 
             val accessToken =
                 transaction {
@@ -434,17 +400,7 @@ fun Route.integrationRoutes() {
 
         // Toggle enabled status
         put("/slack/toggle") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@put call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@put
 
             val currentEnabled =
                 transaction {
@@ -475,17 +431,7 @@ fun Route.integrationRoutes() {
 
         // Delete Slack integration
         delete("/slack") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@delete call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@delete
 
             val deleted =
                 transaction {
@@ -504,17 +450,7 @@ fun Route.integrationRoutes() {
 
         // Test Slack integration
         post("/slack/test") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@post call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@post
 
             val (success, message) = slackService.testConnection(organizationId)
 
@@ -530,14 +466,7 @@ fun Route.integrationRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload.getClaim("userId").asInt()
 
-                val organizationId =
-                    transaction {
-                        Memberships
-                            .selectAll()
-                            .where { Memberships.user_id eq userId }
-                            .firstOrNull()
-                            ?.get(Memberships.organization_id)
-                    }
+                val organizationId = principal.currentOrgIdOrNull()
 
                 if (organizationId == null) {
                     return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
@@ -588,17 +517,7 @@ fun Route.integrationRoutes() {
 
         // Get Discord channels
         get("/discord/channels") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@get
 
             val guildId =
                 transaction {
@@ -626,18 +545,9 @@ fun Route.integrationRoutes() {
 
         // Update Discord channel
         put("/discord/channel") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
             val selection = call.receive<SlackChannelSelection>()
 
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@put call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@put
 
             val updated =
                 transaction {
@@ -661,17 +571,7 @@ fun Route.integrationRoutes() {
 
         // Toggle Discord integration
         put("/discord/toggle") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@put call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@put
 
             val updated =
                 transaction {
@@ -703,17 +603,7 @@ fun Route.integrationRoutes() {
 
         // Delete Discord integration
         delete("/discord") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@delete call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@delete
 
             val deleted =
                 transaction {
@@ -732,17 +622,7 @@ fun Route.integrationRoutes() {
 
         // Test Discord integration
         post("/discord/test") {
-            val principal = call.principal<JWTPrincipal>()
-            val userId = principal!!.payload.getClaim("userId").asInt()
-
-            val organizationId =
-                transaction {
-                    Memberships
-                        .selectAll()
-                        .where { Memberships.user_id eq userId }
-                        .firstOrNull()
-                        ?.get(Memberships.organization_id)
-                } ?: return@post call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+            val organizationId = call.integrationOrgIdOrRespond() ?: return@post
 
             val frontendUrl = EnvConfig.get("FRONTEND_URL") ?: "https://moneat.io"
             val (success, message) = discordService.testConnection(organizationId, frontendUrl)

--- a/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
@@ -66,6 +66,7 @@ import kotlin.time.Clock
 import com.moneat.utils.suspendRunCatching
 
 private val logger = LoggerFactory.getLogger("IntegrationRoutes")
+private const val NO_ORGANIZATION_FOUND = "No organization found"
 
 @Serializable
 data class OrganizationIntegrationResponse(
@@ -230,7 +231,7 @@ private fun validateAndDecodeState(state: String): Pair<Int, Int>? {
 private suspend fun ApplicationCall.integrationOrgIdOrRespond(): Int? {
     val orgId = principal<JWTPrincipal>()?.currentOrgIdOrNull()
     if (orgId == null) {
-        respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+        respond(HttpStatusCode.NotFound, MessageResponse(NO_ORGANIZATION_FOUND))
     }
     return orgId
 }
@@ -256,7 +257,7 @@ fun Route.integrationRoutes() {
                 val organizationId = principal.currentOrgIdOrNull()
 
                 if (organizationId == null) {
-                    return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+                    return@get call.respond(HttpStatusCode.NotFound, MessageResponse(NO_ORGANIZATION_FOUND))
                 }
 
                 val integrations =
@@ -294,7 +295,7 @@ fun Route.integrationRoutes() {
                 val organizationId = principal.currentOrgIdOrNull()
 
                 if (organizationId == null) {
-                    return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+                    return@get call.respond(HttpStatusCode.NotFound, MessageResponse(NO_ORGANIZATION_FOUND))
                 }
 
                 entitlementService.unavailableFeatureMessage(
@@ -469,7 +470,7 @@ fun Route.integrationRoutes() {
                 val organizationId = principal.currentOrgIdOrNull()
 
                 if (organizationId == null) {
-                    return@get call.respond(HttpStatusCode.NotFound, MessageResponse("No organization found"))
+                    return@get call.respond(HttpStatusCode.NotFound, MessageResponse(NO_ORGANIZATION_FOUND))
                 }
 
                 entitlementService.unavailableFeatureMessage(

--- a/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/IntegrationRoutes.kt
@@ -67,6 +67,7 @@ import com.moneat.utils.suspendRunCatching
 
 private val logger = LoggerFactory.getLogger("IntegrationRoutes")
 private const val NO_ORGANIZATION_FOUND = "No organization found"
+private const val UNAUTHORIZED_MESSAGE = "Unauthorized"
 
 @Serializable
 data class OrganizationIntegrationResponse(
@@ -229,9 +230,16 @@ private fun validateAndDecodeState(state: String): Pair<Int, Int>? {
 }
 
 private suspend fun ApplicationCall.integrationOrgIdOrRespond(): Int? {
-    val orgId = principal<JWTPrincipal>()?.currentOrgIdOrNull()
+    val principal = principal<JWTPrincipal>()
+    if (principal == null) {
+        respond(HttpStatusCode.Unauthorized, MessageResponse(UNAUTHORIZED_MESSAGE))
+        return null
+    }
+
+    val orgId = principal.currentOrgIdOrNull()
     if (orgId == null) {
         respond(HttpStatusCode.NotFound, MessageResponse(NO_ORGANIZATION_FOUND))
+        return null
     }
     return orgId
 }

--- a/backend/src/main/kotlin/com/moneat/org/routes/OrgManagementRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/OrgManagementRoutes.kt
@@ -41,6 +41,8 @@ import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import org.koin.core.context.GlobalContext
 
+private const val INVALID_TOKEN_ERROR = "Invalid token"
+
 fun Route.orgManagementRoutes(
     membershipService: OrgMembershipService = GlobalContext.get().get(),
     invitationService: OrgInvitationService = GlobalContext.get().get(),
@@ -53,7 +55,7 @@ fun Route.orgManagementRoutes(
                 val userId = principal.payload.getClaim("userId").asInt()
                 val orgId = principal.currentOrgIdOrNull() ?: return@get call.respond(
                     HttpStatusCode.Unauthorized,
-                    ErrorResponse("Invalid token")
+                    ErrorResponse(INVALID_TOKEN_ERROR)
                 )
 
                 membershipService.requireRole(orgId, userId, OrgRole.MEMBER)
@@ -70,7 +72,7 @@ fun Route.orgManagementRoutes(
                 val requestingUserId = principal.payload.getClaim("userId").asInt()
                 val orgId = principal.currentOrgIdOrNull() ?: return@put call.respond(
                     HttpStatusCode.Unauthorized,
-                    ErrorResponse("Invalid token")
+                    ErrorResponse(INVALID_TOKEN_ERROR)
                 )
                 val targetUserId =
                     call.parameters["userId"]?.toIntOrNull()
@@ -88,7 +90,7 @@ fun Route.orgManagementRoutes(
                 val requestingUserId = principal.payload.getClaim("userId").asInt()
                 val orgId = principal.currentOrgIdOrNull() ?: return@delete call.respond(
                     HttpStatusCode.Unauthorized,
-                    ErrorResponse("Invalid token")
+                    ErrorResponse(INVALID_TOKEN_ERROR)
                 )
                 val targetUserId =
                     call.parameters["userId"]?.toIntOrNull()
@@ -104,7 +106,7 @@ fun Route.orgManagementRoutes(
                 val userId = principal.payload.getClaim("userId").asInt()
                 val orgId = principal.currentOrgIdOrNull() ?: return@post call.respond(
                     HttpStatusCode.Unauthorized,
-                    ErrorResponse("Invalid token")
+                    ErrorResponse(INVALID_TOKEN_ERROR)
                 )
 
                 membershipService.requireRole(orgId, userId, OrgRole.ADMIN)
@@ -120,7 +122,7 @@ fun Route.orgManagementRoutes(
                 val userId = principal.payload.getClaim("userId").asInt()
                 val orgId = principal.currentOrgIdOrNull() ?: return@post call.respond(
                     HttpStatusCode.Unauthorized,
-                    ErrorResponse("Invalid token")
+                    ErrorResponse(INVALID_TOKEN_ERROR)
                 )
 
                 val request = call.receive<BulkInviteRequest>()
@@ -135,7 +137,7 @@ fun Route.orgManagementRoutes(
                 val userId = principal.payload.getClaim("userId").asInt()
                 val orgId = principal.currentOrgIdOrNull() ?: return@get call.respond(
                     HttpStatusCode.Unauthorized,
-                    ErrorResponse("Invalid token")
+                    ErrorResponse(INVALID_TOKEN_ERROR)
                 )
 
                 membershipService.requireRole(orgId, userId, OrgRole.ADMIN)

--- a/backend/src/main/kotlin/com/moneat/org/routes/OrgManagementRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/org/routes/OrgManagementRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.org.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.events.models.AcceptInviteRequest
 import com.moneat.events.models.BulkInviteRequest
 import com.moneat.events.models.InviteMemberRequest
@@ -50,7 +51,10 @@ fun Route.orgManagementRoutes(
             get("/members") {
                 val principal = call.principal<JWTPrincipal>()!!
                 val userId = principal.payload.getClaim("userId").asInt()
-                val orgId = principal.payload.getClaim("orgId").asInt()
+                val orgId = principal.currentOrgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    ErrorResponse("Invalid token")
+                )
 
                 membershipService.requireRole(orgId, userId, OrgRole.MEMBER)
 
@@ -64,7 +68,10 @@ fun Route.orgManagementRoutes(
             put("/members/{userId}/role") {
                 val principal = call.principal<JWTPrincipal>()!!
                 val requestingUserId = principal.payload.getClaim("userId").asInt()
-                val orgId = principal.payload.getClaim("orgId").asInt()
+                val orgId = principal.currentOrgIdOrNull() ?: return@put call.respond(
+                    HttpStatusCode.Unauthorized,
+                    ErrorResponse("Invalid token")
+                )
                 val targetUserId =
                     call.parameters["userId"]?.toIntOrNull()
                         ?: return@put call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid user ID"))
@@ -79,7 +86,10 @@ fun Route.orgManagementRoutes(
             delete("/members/{userId}") {
                 val principal = call.principal<JWTPrincipal>()!!
                 val requestingUserId = principal.payload.getClaim("userId").asInt()
-                val orgId = principal.payload.getClaim("orgId").asInt()
+                val orgId = principal.currentOrgIdOrNull() ?: return@delete call.respond(
+                    HttpStatusCode.Unauthorized,
+                    ErrorResponse("Invalid token")
+                )
                 val targetUserId =
                     call.parameters["userId"]?.toIntOrNull()
                         ?: return@delete call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid user ID"))
@@ -92,7 +102,10 @@ fun Route.orgManagementRoutes(
             post("/invitations") {
                 val principal = call.principal<JWTPrincipal>()!!
                 val userId = principal.payload.getClaim("userId").asInt()
-                val orgId = principal.payload.getClaim("orgId").asInt()
+                val orgId = principal.currentOrgIdOrNull() ?: return@post call.respond(
+                    HttpStatusCode.Unauthorized,
+                    ErrorResponse("Invalid token")
+                )
 
                 membershipService.requireRole(orgId, userId, OrgRole.ADMIN)
                 val request = call.receive<InviteMemberRequest>()
@@ -105,7 +118,10 @@ fun Route.orgManagementRoutes(
             post("/invitations/bulk") {
                 val principal = call.principal<JWTPrincipal>()!!
                 val userId = principal.payload.getClaim("userId").asInt()
-                val orgId = principal.payload.getClaim("orgId").asInt()
+                val orgId = principal.currentOrgIdOrNull() ?: return@post call.respond(
+                    HttpStatusCode.Unauthorized,
+                    ErrorResponse("Invalid token")
+                )
 
                 val request = call.receive<BulkInviteRequest>()
 
@@ -117,7 +133,10 @@ fun Route.orgManagementRoutes(
             get("/invitations") {
                 val principal = call.principal<JWTPrincipal>()!!
                 val userId = principal.payload.getClaim("userId").asInt()
-                val orgId = principal.payload.getClaim("orgId").asInt()
+                val orgId = principal.currentOrgIdOrNull() ?: return@get call.respond(
+                    HttpStatusCode.Unauthorized,
+                    ErrorResponse("Invalid token")
+                )
 
                 membershipService.requireRole(orgId, userId, OrgRole.ADMIN)
 

--- a/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/detection/DetectionRuleRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.security.detection
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.org.services.OrgMembershipService
 import com.moneat.org.services.OrgRole
 import com.moneat.utils.ErrorResponse
@@ -301,7 +302,7 @@ private suspend fun RoutingContext.respondRuleError(error: Throwable) {
 private fun RoutingContext.ruleIdFromPath(): Int? = call.parameters["ruleId"]?.toIntOrNull()
 
 private fun RoutingContext.currentOrganizationId(): Int? =
-    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private fun RoutingContext.currentUserId(): Int? =
     call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()

--- a/backend/src/main/kotlin/com/moneat/security/signals/SignalRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/signals/SignalRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.security.signals
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
@@ -93,7 +94,7 @@ private suspend fun RoutingContext.handleTriage(service: SignalService) {
 private fun RoutingContext.signalIdFromPath(): Int? = call.parameters["signalId"]?.toIntOrNull()
 
 private fun RoutingContext.currentOrganizationId(): Int? =
-    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private fun RoutingContext.currentUserId(): Int? =
     call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()

--- a/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/security/vulnerabilities/VulnerabilityRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.security.vulnerabilities
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.decompression.DecompressionService
@@ -291,7 +292,7 @@ private fun parseAgentTags(tags: List<String>): Map<String, String> =
     }
 
 private fun RoutingContext.currentOrganizationId(): Int? =
-    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private fun RoutingContext.currentUserId(): Int? =
     call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()

--- a/backend/src/main/kotlin/com/moneat/statuspage/routes/StatusPageRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/statuspage/routes/StatusPageRoutes.kt
@@ -16,7 +16,7 @@
 
 package com.moneat.statuspage.routes
 
-import com.moneat.shared.models.Memberships
+import com.moneat.auth.currentOrgContextOrNull
 import com.moneat.statuspage.models.AddCustomDomainRequest
 import com.moneat.statuspage.models.AddMonitorsRequest
 import com.moneat.statuspage.models.CreateIncidentRequest
@@ -42,9 +42,6 @@ import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import com.moneat.utils.suspendRunCatching
 import mu.KotlinLogging
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
 import java.util.UUID
 
@@ -80,14 +77,12 @@ private fun String.toUUIDOrNull(): UUID? {
 /**
  * Helper to get organization IDs for a user.
  */
-private fun getOrganizationIdsForUser(userId: Int): List<Int> {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .map { it[Memberships.organization_id] }
-    }
-}
+private fun getOrganizationIdsForUser(userId: Int, principal: JWTPrincipal?): List<Int> =
+    principal
+        ?.currentOrgContextOrNull()
+        ?.takeIf { it.userId == userId }
+        ?.let { listOf(it.orgId) }
+        .orEmpty()
 
 /**
  * Status page routes - both authenticated management and public endpoints.
@@ -113,7 +108,7 @@ fun Route.statusPageRoutes(
                         return@runStatusPageRoute
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.OK, emptyList<StatusPageResponse>())
                         return@runStatusPageRoute
@@ -140,7 +135,7 @@ fun Route.statusPageRoutes(
                         return@post
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@post
@@ -197,7 +192,7 @@ fun Route.statusPageRoutes(
                         return@runStatusPageRoute
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@runStatusPageRoute
@@ -233,7 +228,7 @@ fun Route.statusPageRoutes(
                         return@put
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@put
@@ -285,7 +280,7 @@ fun Route.statusPageRoutes(
                         return@delete
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@delete
@@ -319,7 +314,7 @@ fun Route.statusPageRoutes(
                         return@post
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@post
@@ -364,7 +359,7 @@ fun Route.statusPageRoutes(
                         return@delete
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@delete
@@ -398,7 +393,7 @@ fun Route.statusPageRoutes(
                         return@get
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@get
@@ -436,7 +431,7 @@ fun Route.statusPageRoutes(
                         return@post
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@post
@@ -481,7 +476,7 @@ fun Route.statusPageRoutes(
                         return@put
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@put
@@ -526,7 +521,7 @@ fun Route.statusPageRoutes(
                         return@post
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@post
@@ -573,7 +568,7 @@ fun Route.statusPageRoutes(
                         return@post
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@post
@@ -626,7 +621,7 @@ fun Route.statusPageRoutes(
                         return@post
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@post
@@ -661,7 +656,7 @@ fun Route.statusPageRoutes(
                         return@delete
                     }
 
-                    val organizationIds = getOrganizationIdsForUser(userId)
+                    val organizationIds = getOrganizationIdsForUser(userId, principal)
                     if (organizationIds.isEmpty()) {
                         call.respond(HttpStatusCode.Forbidden, ErrorResponse("No organization found"))
                         return@delete

--- a/backend/src/main/kotlin/com/moneat/summary/routes/SummaryRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/summary/routes/SummaryRoutes.kt
@@ -16,23 +16,18 @@
 
 package com.moneat.summary.routes
 
-import com.moneat.shared.models.Memberships
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.summary.services.SummaryService
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import com.moneat.utils.suspendRunCatching
 import mu.KotlinLogging
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
 import java.time.DateTimeException
 import java.time.ZoneId
@@ -40,17 +35,6 @@ import java.time.ZoneId
 private val logger = KotlinLogging.logger {}
 
 private val validPeriods = setOf("24h", "7d", "30d")
-private const val INVALID_TOKEN = "Invalid token"
-private const val NO_ORGANIZATION_MEMBERSHIP = "No organization membership"
-
-private fun getOrganizationIdsForUser(userId: Int): List<Int> {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .map { it[Memberships.organization_id] }
-    }
-}
 
 /**
  * Handles expected failure modes from JDBC/Exposed, ClickHouse HTTP, and JSON parsing.
@@ -81,25 +65,7 @@ fun Route.summaryRoutes(
                     "Infrastructure summary error",
                     "Failed to get summary",
                 ) {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal?.payload
-                        ?.getClaim("userId")?.asInt()
-                    if (userId == null) {
-                        call.respond(
-                            HttpStatusCode.Unauthorized,
-                            ErrorResponse(INVALID_TOKEN),
-                        )
-                        return@runSummaryServiceCall
-                    }
-
-                    val orgIds = getOrganizationIdsForUser(userId)
-                    if (orgIds.isEmpty()) {
-                        call.respond(
-                            HttpStatusCode.Forbidden,
-                            ErrorResponse(NO_ORGANIZATION_MEMBERSHIP),
-                        )
-                        return@runSummaryServiceCall
-                    }
+                    val orgId = call.requireCurrentOrg()?.orgId ?: return@runSummaryServiceCall
 
                     val period = call.parameters["period"] ?: "24h"
                     if (period !in validPeriods) {
@@ -115,7 +81,7 @@ fun Route.summaryRoutes(
 
                     val result = summaryService
                         .getInfrastructureSummary(
-                            orgIds.first(),
+                            orgId,
                             period,
                         )
                     call.respond(HttpStatusCode.OK, result)
@@ -128,25 +94,7 @@ fun Route.summaryRoutes(
                     "Overnight summary error",
                     "Failed to get summary",
                 ) {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal?.payload
-                        ?.getClaim("userId")?.asInt()
-                    if (userId == null) {
-                        call.respond(
-                            HttpStatusCode.Unauthorized,
-                            ErrorResponse(INVALID_TOKEN),
-                        )
-                        return@runSummaryServiceCall
-                    }
-
-                    val orgIds = getOrganizationIdsForUser(userId)
-                    if (orgIds.isEmpty()) {
-                        call.respond(
-                            HttpStatusCode.Forbidden,
-                            ErrorResponse(NO_ORGANIZATION_MEMBERSHIP),
-                        )
-                        return@runSummaryServiceCall
-                    }
+                    val orgId = call.requireCurrentOrg()?.orgId ?: return@runSummaryServiceCall
 
                     val timezone = call.parameters["timezone"]
                         ?: "America/New_York"
@@ -163,7 +111,7 @@ fun Route.summaryRoutes(
                     }
 
                     val result = summaryService
-                        .getOvernightSummary(orgIds.first(), timezone)
+                        .getOvernightSummary(orgId, timezone)
                     call.respond(HttpStatusCode.OK, result)
                 }
             }
@@ -174,28 +122,10 @@ fun Route.summaryRoutes(
                     "Weekly report error",
                     "Failed to get report",
                 ) {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal?.payload
-                        ?.getClaim("userId")?.asInt()
-                    if (userId == null) {
-                        call.respond(
-                            HttpStatusCode.Unauthorized,
-                            ErrorResponse(INVALID_TOKEN),
-                        )
-                        return@runSummaryServiceCall
-                    }
-
-                    val orgIds = getOrganizationIdsForUser(userId)
-                    if (orgIds.isEmpty()) {
-                        call.respond(
-                            HttpStatusCode.Forbidden,
-                            ErrorResponse(NO_ORGANIZATION_MEMBERSHIP),
-                        )
-                        return@runSummaryServiceCall
-                    }
+                    val orgId = call.requireCurrentOrg()?.orgId ?: return@runSummaryServiceCall
 
                     val result = summaryService
-                        .getWeeklyReport(orgIds.first())
+                        .getWeeklyReport(orgId)
                     call.respond(HttpStatusCode.OK, result)
                 }
             }
@@ -206,25 +136,7 @@ fun Route.summaryRoutes(
                     "Incident context error",
                     "Failed to get context",
                 ) {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal?.payload
-                        ?.getClaim("userId")?.asInt()
-                    if (userId == null) {
-                        call.respond(
-                            HttpStatusCode.Unauthorized,
-                            ErrorResponse(INVALID_TOKEN),
-                        )
-                        return@runSummaryServiceCall
-                    }
-
-                    val orgIds = getOrganizationIdsForUser(userId)
-                    if (orgIds.isEmpty()) {
-                        call.respond(
-                            HttpStatusCode.Forbidden,
-                            ErrorResponse(NO_ORGANIZATION_MEMBERSHIP),
-                        )
-                        return@runSummaryServiceCall
-                    }
+                    val orgId = call.requireCurrentOrg()?.orgId ?: return@runSummaryServiceCall
 
                     val incidentId = call.parameters["incident_id"]
                         ?.toLongOrNull()
@@ -238,7 +150,7 @@ fun Route.summaryRoutes(
 
                     val result = summaryService
                         .getIncidentContext(
-                            orgIds.first(),
+                            orgId,
                             incidentId,
                         )
                     call.respond(HttpStatusCode.OK, result)

--- a/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsRoutes.kt
@@ -16,8 +16,8 @@
 
 package com.moneat.synthetics.routes
 
+import com.moneat.auth.currentOrgContextOrNull
 import com.moneat.config.ClickHouseClient
-import com.moneat.shared.models.Memberships
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
@@ -42,9 +42,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import mu.KotlinLogging
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
 import java.util.UUID
 import com.moneat.utils.HttpConstants.HTTP_SUCCESS_MAX
@@ -57,14 +54,12 @@ private val json = Json { ignoreUnknownKeys = true }
 private const val DEFAULT_LIMIT = 100
 private const val MAX_LIMIT = 500
 
-private fun getOrgIdsForUser(userId: Int): List<Int> {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .map { it[Memberships.organization_id] }
-    }
-}
+private fun getOrgIdsForUser(userId: Int, principal: JWTPrincipal?): List<Int> =
+    principal
+        ?.currentOrgContextOrNull()
+        ?.takeIf { it.userId == userId }
+        ?.let { listOf(it.orgId) }
+        .orEmpty()
 
 private fun orgIdsToChCondition(orgIds: List<Int>): String {
     return orgIds.joinToString(",") { "toUInt64($it)" }
@@ -119,7 +114,7 @@ fun Route.syntheticsRoutes() {
             get("/synthetics/results") {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload.getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respondText(
                         """{"results":[],"totalCount":0}""",
@@ -195,7 +190,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -211,7 +206,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -246,7 +241,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respondText(
                         """{"results":[],"totalCount":0}""",
@@ -312,7 +307,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -348,7 +343,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -376,7 +371,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -413,7 +408,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -448,7 +443,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -488,7 +483,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -506,7 +501,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -526,7 +521,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,
@@ -562,7 +557,7 @@ fun Route.syntheticsRoutes() {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal!!.payload
                     .getClaim("userId").asInt()
-                val orgIds = getOrgIdsForUser(userId)
+                val orgIds = getOrgIdsForUser(userId, principal)
                 if (orgIds.isEmpty()) {
                     call.respond(
                         HttpStatusCode.Forbidden,

--- a/backend/src/main/kotlin/com/moneat/uptime/routes/UptimeRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/routes/UptimeRoutes.kt
@@ -16,8 +16,8 @@
 
 package com.moneat.uptime.routes
 
+import com.moneat.auth.currentOrgContextOrNull
 import com.moneat.alerts.models.AlertPriority
-import com.moneat.shared.models.Memberships
 import com.moneat.uptime.models.CheckResult
 import com.moneat.uptime.models.CreateUptimeMonitorRequest
 import com.moneat.uptime.models.UpdateUptimeMonitorRequest
@@ -45,9 +45,6 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
 import java.util.UUID
 import kotlin.time.Clock
@@ -57,7 +54,6 @@ import kotlin.time.Instant
 private val logger = KotlinLogging.logger {}
 
 private const val INVALID_TOKEN_MESSAGE = "Invalid token"
-private const val NO_ORGANIZATION_MESSAGE = "No organization membership"
 private const val INVALID_MONITOR_ID_MESSAGE = "Invalid monitor ID"
 private const val MONITOR_NOT_FOUND_MESSAGE = "Monitor not found"
 private const val MIN_INTERVAL_SECONDS = 10
@@ -82,19 +78,15 @@ private suspend fun runUptimeRoute(
 
 private suspend fun ApplicationCall.requireUptimeRouteContext(): UptimeRouteContext? {
     val principal = principal<JWTPrincipal>()
-    val userId = principal?.payload?.getClaim("userId")?.asInt()
-    if (userId == null) {
+    val context = principal?.currentOrgContextOrNull()
+    if (context == null) {
         respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
         return null
     }
 
-    val orgIds = getOrganizationIdsForUser(userId)
-    if (orgIds.isEmpty()) {
-        respond(HttpStatusCode.Forbidden, ErrorResponse(NO_ORGANIZATION_MESSAGE))
-        return null
-    }
-
-    return UptimeRouteContext(orgIds.first())
+    return UptimeRouteContext(
+        organizationId = context.orgId,
+    )
 }
 
 private suspend fun ApplicationCall.requireMonitorId(): UUID? {
@@ -103,18 +95,6 @@ private suspend fun ApplicationCall.requireMonitorId(): UUID? {
     } catch (_: IllegalArgumentException) {
         respond(HttpStatusCode.BadRequest, ErrorResponse(INVALID_MONITOR_ID_MESSAGE))
         null
-    }
-}
-
-/**
- * Helper to get organization IDs for a user.
- */
-private fun getOrganizationIdsForUser(userId: Int): List<Int> {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .map { it[Memberships.organization_id] }
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/routes/WorkflowRoutes.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.workflows.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.utils.ErrorResponse
 import com.moneat.utils.suspendRunCatching
 import com.moneat.enterprise.FeatureRegistry
@@ -398,7 +399,7 @@ private fun RoutingContext.instanceIdFromPath(): Int? =
 
 internal fun RoutingContext.currentOrganizationId(): Int? {
     val principal = call.principal<JWTPrincipal>() ?: return null
-    return principal.payload.getClaim("orgId").asInt()
+    return principal.currentOrgIdOrNull()
 }
 
 internal fun RoutingContext.currentUserId(): Int? {

--- a/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/apm/routes/ApmServiceRoutesTest.kt
@@ -118,7 +118,7 @@ class ApmServiceRoutesTest {
             routing { apmServiceDashboardRoutes() }
         }
 
-        val credential = RouteTestSupport.createToken(userId = 1)
+        val credential = RouteTestSupport.createToken(userId = 1, orgId = null)
         val response = client.get("/v1/services") {
             withAuth(credential)
         }

--- a/backend/src/test/kotlin/com/moneat/auth/CurrentOrgContextTest.kt
+++ b/backend/src/test/kotlin/com/moneat/auth/CurrentOrgContextTest.kt
@@ -1,0 +1,62 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.auth
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.server.auth.jwt.JWTPrincipal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class CurrentOrgContextTest {
+    private val secret = Algorithm.HMAC256("current-org-test")
+
+    @Test
+    fun `current org context is extracted from signed jwt claims`() {
+        val principal = principal(userId = 7, orgId = 42, role = "owner")
+
+        val context = principal.currentOrgContextOrNull()
+
+        assertEquals(CurrentOrgContext(userId = 7, orgId = 42, orgRole = "owner"), context)
+    }
+
+    @Test
+    fun `current org context is absent when org claim is missing`() {
+        val principal = principal(userId = 7, orgId = null, role = "owner")
+
+        assertNull(principal.currentOrgContextOrNull())
+    }
+
+    @Test
+    fun `current org context is absent when user claim is missing`() {
+        val token = JWT.create()
+            .withClaim("orgId", 42)
+            .sign(secret)
+
+        assertNull(JWTPrincipal(JWT.decode(token)).currentOrgContextOrNull())
+    }
+
+    private fun principal(userId: Int, orgId: Int?, role: String?): JWTPrincipal {
+        val token = JWT.create()
+            .withClaim("userId", userId)
+            .apply { orgId?.let { withClaim("orgId", it) } }
+            .apply { role?.let { withClaim("orgRole", it) } }
+            .sign(secret)
+        return JWTPrincipal(JWT.decode(token))
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/auth/CurrentOrgContextTest.kt
+++ b/backend/src/test/kotlin/com/moneat/auth/CurrentOrgContextTest.kt
@@ -18,13 +18,23 @@ package com.moneat.auth
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.moneat.testsupport.RouteTestSupport
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class CurrentOrgContextTest {
-    private val secret = Algorithm.HMAC256("current-org-test")
+    private val secret = Algorithm.HMAC256(SECRET_VALUE)
 
     @Test
     fun `current org context is extracted from signed jwt claims`() {
@@ -51,12 +61,84 @@ class CurrentOrgContextTest {
         assertNull(JWTPrincipal(JWT.decode(token)).currentOrgContextOrNull())
     }
 
+    @Test
+    fun `decoded jwt current org context is extracted from claims`() {
+        val decoded = JWT.decode(token(userId = 8, orgId = 44, role = "admin"))
+
+        val context = decoded.currentOrgContextOrNull()
+
+        assertEquals(CurrentOrgContext(userId = 8, orgId = 44, orgRole = "admin"), context)
+    }
+
+    @Test
+    fun `decoded jwt current org context is absent when required claims are missing`() {
+        val missingOrg = JWT.decode(token(userId = 8, orgId = null, role = "admin"))
+        val missingUserToken = JWT.create()
+            .withClaim("orgId", 44)
+            .sign(secret)
+
+        assertNull(missingOrg.currentOrgContextOrNull())
+        assertNull(JWT.decode(missingUserToken).currentOrgContextOrNull())
+    }
+
+    @Test
+    fun `application call current org helpers use authenticated jwt claims`() =
+        testApplication {
+            installCurrentOrgTestRoute()
+
+            val token = token(userId = 9, orgId = 33, role = "member")
+            val requireResponse = client.get("/require-current-org") { withAuth(token) }
+            val orgIdResponse = client.get("/current-org-id") { withAuth(token) }
+
+            assertEquals(HttpStatusCode.OK, requireResponse.status)
+            assertEquals("9:33:member", requireResponse.bodyAsText())
+            assertEquals(HttpStatusCode.OK, orgIdResponse.status)
+            assertEquals("33", orgIdResponse.bodyAsText())
+        }
+
+    @Test
+    fun `require current org rejects authenticated jwt without org claim`() =
+        testApplication {
+            installCurrentOrgTestRoute()
+
+            val response = client.get("/require-current-org") {
+                withAuth(token(userId = 9, orgId = null, role = "member"))
+            }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    private fun io.ktor.server.testing.ApplicationTestBuilder.installCurrentOrgTestRoute() {
+        application {
+            with(RouteTestSupport) { installJwtAuth(SECRET_VALUE) }
+            routing {
+                authenticate("auth-jwt") {
+                    get("/require-current-org") {
+                        val context = call.requireCurrentOrg() ?: return@get
+                        call.respondText("${context.userId}:${context.orgId}:${context.orgRole}")
+                    }
+                    get("/current-org-id") {
+                        call.respondText(call.currentOrgIdOrNull()?.toString() ?: "missing")
+                    }
+                }
+            }
+        }
+    }
+
     private fun principal(userId: Int, orgId: Int?, role: String?): JWTPrincipal {
-        val token = JWT.create()
+        return JWTPrincipal(JWT.decode(token(userId, orgId, role)))
+    }
+
+    private fun token(userId: Int, orgId: Int?, role: String?): String =
+        JWT.create()
+            .withIssuer("moneat")
+            .withAudience("moneat-users")
             .withClaim("userId", userId)
             .apply { orgId?.let { withClaim("orgId", it) } }
             .apply { role?.let { withClaim("orgRole", it) } }
             .sign(secret)
-        return JWTPrincipal(JWT.decode(token))
+
+    private companion object {
+        const val SECRET_VALUE = "current-org-test"
     }
 }

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutesTest.kt
@@ -1,0 +1,157 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.routes
+
+import com.moneat.datadog.models.DebuggerProbe
+import com.moneat.datadog.services.DebuggerProbeService
+import com.moneat.testsupport.RouteTestSupport
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import java.util.UUID
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DebuggerProbeRoutesTest {
+
+    private val probeId = UUID.fromString("00000000-0000-0000-0000-000000000001")
+
+    @BeforeTest
+    fun setup() {
+        mockkObject(DebuggerProbeService)
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkObject(DebuggerProbeService)
+    }
+
+    @Test
+    fun `GET debugger probes uses JWT org`() = testApplication {
+        every { DebuggerProbeService.listProbes(listOf(42)) } returns listOf(sampleProbe())
+
+        installRoutes()
+        val response =
+            client.get("/v1/infra/debugger/probes") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = 42))
+            }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("probe-service"))
+        verify { DebuggerProbeService.listProbes(listOf(42)) }
+    }
+
+    @Test
+    fun `POST debugger probes uses JWT org and user`() = testApplication {
+        every {
+            DebuggerProbeService.createProbe(organizationId = 42, createdBy = 7, request = any())
+        } returns sampleProbe()
+
+        installRoutes()
+        val response =
+            client.post("/v1/infra/debugger/probes") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = 42))
+                contentType(ContentType.Application.Json)
+                setBody(createProbeBody())
+            }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertTrue(response.bodyAsText().contains("probe-service"))
+        verify { DebuggerProbeService.createProbe(organizationId = 42, createdBy = 7, request = any()) }
+    }
+
+    @Test
+    fun `PUT debugger probe uses JWT org`() = testApplication {
+        every { DebuggerProbeService.updateProbe(probeId, listOf(42), any()) } returns sampleProbe()
+
+        installRoutes()
+        val response =
+            client.put("/v1/infra/debugger/probes/$probeId") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = 42))
+                contentType(ContentType.Application.Json)
+                setBody("""{"active":false}""")
+            }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        verify { DebuggerProbeService.updateProbe(probeId, listOf(42), any()) }
+    }
+
+    @Test
+    fun `DELETE debugger probe uses JWT org`() = testApplication {
+        every { DebuggerProbeService.deleteProbe(probeId, listOf(42)) } returns true
+
+        installRoutes()
+        val response =
+            client.delete("/v1/infra/debugger/probes/$probeId") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = 42))
+            }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+        verify { DebuggerProbeService.deleteProbe(probeId, listOf(42)) }
+    }
+
+    private fun io.ktor.server.testing.ApplicationTestBuilder.installRoutes() {
+        application {
+            installJwtAuth()
+            routing { debuggerProbeRoutes() }
+        }
+    }
+
+    private fun createProbeBody(): String =
+        """
+        {
+          "service":"probe-service",
+          "whereType":"method",
+          "typeName":"com.example.Worker",
+          "methodName":"run"
+        }
+        """.trimIndent()
+
+    private fun sampleProbe(): DebuggerProbe =
+        DebuggerProbe(
+            id = probeId.toString(),
+            organizationId = 42,
+            probeType = "log_probe",
+            service = "probe-service",
+            environment = "*",
+            language = "java",
+            active = true,
+            whereType = "method",
+            typeName = "com.example.Worker",
+            methodName = "run",
+            createdBy = 7,
+            createdAt = "2026-01-01T00:00:00Z",
+            updatedAt = "2026-01-01T00:00:00Z"
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/datadog/routes/DebuggerProbeRoutesTest.kt
@@ -121,6 +121,58 @@ class DebuggerProbeRoutesTest {
         verify { DebuggerProbeService.deleteProbe(probeId, listOf(42)) }
     }
 
+    @Test
+    fun `GET debugger probes rejects JWT without org`() = testApplication {
+        installRoutes()
+        val response =
+            client.get("/v1/infra/debugger/probes") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = null))
+            }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        verify(exactly = 0) { DebuggerProbeService.listProbes(any()) }
+    }
+
+    @Test
+    fun `POST debugger probes rejects JWT without org`() = testApplication {
+        installRoutes()
+        val response =
+            client.post("/v1/infra/debugger/probes") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = null))
+                contentType(ContentType.Application.Json)
+                setBody(createProbeBody())
+            }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        verify(exactly = 0) { DebuggerProbeService.createProbe(any(), any(), any()) }
+    }
+
+    @Test
+    fun `PUT debugger probe rejects JWT without org`() = testApplication {
+        installRoutes()
+        val response =
+            client.put("/v1/infra/debugger/probes/$probeId") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = null))
+                contentType(ContentType.Application.Json)
+                setBody("""{"active":false}""")
+            }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        verify(exactly = 0) { DebuggerProbeService.updateProbe(any(), any(), any()) }
+    }
+
+    @Test
+    fun `DELETE debugger probe rejects JWT without org`() = testApplication {
+        installRoutes()
+        val response =
+            client.delete("/v1/infra/debugger/probes/$probeId") {
+                withAuth(RouteTestSupport.createToken(userId = 7, orgId = null))
+            }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        verify(exactly = 0) { DebuggerProbeService.deleteProbe(any(), any()) }
+    }
+
     private fun io.ktor.server.testing.ApplicationTestBuilder.installRoutes() {
         application {
             installJwtAuth()

--- a/backend/src/test/kotlin/com/moneat/incident/IncidentRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/incident/IncidentRoutesTest.kt
@@ -393,67 +393,67 @@ class IncidentRoutesTest {
         assertEquals(HttpStatusCode.OK, response.status)
     }
 
-    // ──── No Membership Returns 403 ────
+    // ──── No current org claim returns 401 ────
 
     @Test
-    fun `GET providers returns 403 for user with no membership`() = testApplication {
+    fun `GET providers returns 401 without current org`() = testApplication {
         installRoutes()()
-        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID)
+        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID, orgId = null)
         val response = client.get("/api/incident-providers") {
             withAuth(token)
         }
-        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
-    fun `POST test returns 403 for user with no membership`() = testApplication {
+    fun `POST test returns 401 without current org`() = testApplication {
         installRoutes()()
-        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID)
+        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID, orgId = null)
         val response = client.post("/api/incident-providers/1/test") {
             withAuth(token)
         }
-        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
-    fun `GET rules returns 403 for user with no membership`() = testApplication {
+    fun `GET rules returns 401 without current org`() = testApplication {
         installRoutes()()
-        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID)
+        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID, orgId = null)
         val response = client.get("/api/incident-providers/1/rules") {
             withAuth(token)
         }
-        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
-    fun `PUT rules returns 403 for user with no membership`() = testApplication {
+    fun `PUT rules returns 401 without current org`() = testApplication {
         installRoutes()()
-        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID)
+        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID, orgId = null)
         val response = client.put("/api/incident-providers/1/rules") {
             withAuth(token)
             contentType(ContentType.Application.Json)
             setBody("[]")
         }
-        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
-    fun `GET events returns 403 for user with no membership`() = testApplication {
+    fun `GET events returns 401 without current org`() = testApplication {
         installRoutes()()
-        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID)
+        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID, orgId = null)
         val response = client.get("/api/incident-providers/1/events") {
             withAuth(token)
         }
-        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test
-    fun `DELETE returns 403 for user with no membership`() = testApplication {
+    fun `DELETE returns 401 without current org`() = testApplication {
         installRoutes()()
-        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID)
+        val token = RouteTestSupport.createToken(userId = NO_MEMBERSHIP_USER_ID, orgId = null)
         val response = client.delete("/api/incident-providers/1") {
             withAuth(token)
         }
-        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 }

--- a/backend/src/test/kotlin/com/moneat/llm/LlmRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/llm/LlmRoutesExtendedTest.kt
@@ -118,7 +118,7 @@ class LlmRoutesExtendedTest {
     fun `generations returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1)
+            val token = RouteTestSupport.createToken(userId = 1, orgId = null)
             val response = client.get("/v1/llm/generations") {
                 withAuth(token)
             }
@@ -130,7 +130,7 @@ class LlmRoutesExtendedTest {
     fun `models returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1)
+            val token = RouteTestSupport.createToken(userId = 1, orgId = null)
             val response = client.get("/v1/llm/models") {
                 withAuth(token)
             }
@@ -142,7 +142,7 @@ class LlmRoutesExtendedTest {
     fun `costs returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1)
+            val token = RouteTestSupport.createToken(userId = 1, orgId = null)
             val response = client.get("/v1/llm/costs") {
                 withAuth(token)
             }
@@ -154,7 +154,7 @@ class LlmRoutesExtendedTest {
     fun `generation detail returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1)
+            val token = RouteTestSupport.createToken(userId = 1, orgId = null)
             val response = client.get("/v1/llm/generations/abc-123") {
                 withAuth(token)
             }
@@ -166,7 +166,7 @@ class LlmRoutesExtendedTest {
     fun `traces returns 404 when organization access is missing`() =
         testApplication {
             setupApp()
-            val token = RouteTestSupport.createToken(userId = 1)
+            val token = RouteTestSupport.createToken(userId = 1, orgId = null)
             val response = client.get("/v1/llm/traces/some-trace-id") {
                 withAuth(token)
             }

--- a/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/logs/LogRoutesExtendedTest.kt
@@ -139,6 +139,36 @@ class LogRoutesExtendedTest {
         }
 
     @Test
+    fun `GET logs returns 401 when JWT has no org`() =
+        testApplication {
+            application {
+                installJwtAuth()
+                routing { logRoutes(mockLogService, mockOtlpApiKeyService, mockLogIndexService) }
+            }
+
+            val response = client.get("/v1/logs") {
+                withAuth(RouteTestSupport.createToken(userId = 1, orgId = null))
+            }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    @Test
+    fun `GET log pipelines returns 401 when JWT has no org`() =
+        testApplication {
+            application {
+                installJwtAuth()
+                routing { logRoutes(mockLogService, mockOtlpApiKeyService, mockLogIndexService) }
+            }
+
+            val response = client.get("/v1/logs/pipelines") {
+                withAuth(RouteTestSupport.createToken(userId = 1, orgId = null))
+            }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    @Test
     fun `GET logs top returns 401 without JWT`() =
         testApplication {
             application {

--- a/backend/src/test/kotlin/com/moneat/mcp/auth/McpAuthProviderTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/auth/McpAuthProviderTest.kt
@@ -60,6 +60,7 @@ class McpAuthProviderTest {
         val token = AuthTokenService()
             .generateToken(
                 userId = userId,
+                orgId = orgId,
                 name = "MCP",
                 scopes = listOf("project:read"),
             )
@@ -87,10 +88,11 @@ class McpAuthProviderTest {
 
     @Test
     fun `non bearer authorization is rejected`() {
-        val (userId, _) = seedUserInOrg("primary")
+        val (userId, orgId) = seedUserInOrg("primary")
         val token = AuthTokenService()
             .generateToken(
                 userId = userId,
+                orgId = orgId,
                 name = "MCP",
                 scopes = listOf("project:read"),
             )

--- a/backend/src/test/kotlin/com/moneat/mcp/routes/McpRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/mcp/routes/McpRoutesTest.kt
@@ -397,7 +397,7 @@ class McpRoutesTest {
         """.trimIndent()
 
     private fun seedToken(scopes: List<String>, label: String = "test"): String {
-        val userId = transaction {
+        val (userId, orgId) = transaction {
             val orgId = Organizations.insert {
                 it[name] = "$label Org"
                 it[slug] = "$label-org"
@@ -412,11 +412,12 @@ class McpRoutesTest {
                 it[organization_id] = orgId
                 it[role] = "owner"
             }
-            insertedUserId
+            insertedUserId to orgId
         }
         return AuthTokenService()
             .generateToken(
                 userId = userId,
+                orgId = orgId,
                 name = "MCP test token",
                 scopes = scopes,
             )

--- a/backend/src/test/kotlin/com/moneat/monitor/routes/AgentApiKeyRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitor/routes/AgentApiKeyRoutesTest.kt
@@ -1,0 +1,127 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.monitor.routes
+
+import com.moneat.monitor.models.AgentApiKeyResponse
+import com.moneat.monitor.models.CreateAgentApiKeyResponse
+import com.moneat.monitor.services.AgentApiKeyService
+import com.moneat.testsupport.RouteTestSupport
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import com.moneat.testsupport.RouteTestSupport.withAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AgentApiKeyRoutesTest {
+
+    private val service = mockk<AgentApiKeyService>()
+
+    @Test
+    fun `GET agent-api-keys uses JWT org`() = testApplication {
+        every { service.listKeys(42) } returns listOf(
+            AgentApiKeyResponse(
+                id = 1,
+                name = "collector",
+                keyPrefix = "magt_prefix",
+                createdAt = "2026-01-01T00:00:00Z"
+            )
+        )
+
+        installRoutes()
+        val token = RouteTestSupport.createToken(userId = 7, orgId = 42)
+        val response = client.get("/v1/agent-api-keys") { withAuth(token) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("collector"))
+        verify { service.listKeys(42) }
+    }
+
+    @Test
+    fun `POST agent-api-keys uses JWT org and user`() = testApplication {
+        every { service.createKey(organizationId = 42, name = "collector", createdBy = 7) } returns
+            CreateAgentApiKeyResponse(
+                id = 1,
+                name = "collector",
+                keyPrefix = "magt_prefix",
+                key = "magt_secret",
+                createdAt = "2026-01-01T00:00:00Z"
+            )
+
+        installRoutes()
+        val token = RouteTestSupport.createToken(userId = 7, orgId = 42)
+        val response =
+            client.post("/v1/agent-api-keys") {
+                withAuth(token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":" collector "}""")
+            }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertTrue(response.bodyAsText().contains("magt_secret"))
+        verify { service.createKey(organizationId = 42, name = "collector", createdBy = 7) }
+    }
+
+    @Test
+    fun `DELETE agent-api-keys uses JWT org`() = testApplication {
+        every { service.deleteKey(organizationId = 42, keyId = 9) } returns true
+
+        installRoutes()
+        val token = RouteTestSupport.createToken(userId = 7, orgId = 42)
+        val response = client.delete("/v1/agent-api-keys/9") { withAuth(token) }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+        verify { service.deleteKey(organizationId = 42, keyId = 9) }
+    }
+
+    @Test
+    fun `agent-api-key routes return 401 when jwt has no current org claim`() = testApplication {
+        installRoutes()
+        val token = RouteTestSupport.createToken(userId = 7, orgId = null)
+
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/agent-api-keys") { withAuth(token) }.status)
+
+        val createResponse =
+            client.post("/v1/agent-api-keys") {
+                withAuth(token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"collector"}""")
+            }
+        assertEquals(HttpStatusCode.Unauthorized, createResponse.status)
+
+        assertEquals(HttpStatusCode.Unauthorized, client.delete("/v1/agent-api-keys/9") { withAuth(token) }.status)
+    }
+
+    private fun io.ktor.server.testing.ApplicationTestBuilder.installRoutes() {
+        application {
+            installJwtAuth()
+            routing { agentApiKeyRoutes(service) }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/org/OrgRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/org/OrgRoutesExtendedTest.kt
@@ -88,6 +88,42 @@ class OrgRoutesExtendedTest {
         assertEquals(HttpStatusCode.OK, resp.status)
     }
 
+    @Test
+    fun `org routes return 401 when jwt has no current org claim`() = testApplication {
+        installRoutes()()
+        val token = RouteTestSupport.createToken(userId = 1, orgId = null)
+
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/org/members") { withAuth(token) }.status)
+
+        val roleResponse =
+            client.put("/v1/org/members/2/role") {
+                withAuth(token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"role":"admin"}""")
+            }
+        assertEquals(HttpStatusCode.Unauthorized, roleResponse.status)
+
+        assertEquals(HttpStatusCode.Unauthorized, client.delete("/v1/org/members/2") { withAuth(token) }.status)
+
+        val inviteResponse =
+            client.post("/v1/org/invitations") {
+                withAuth(token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"email":"test@example.com","role":"member"}""")
+            }
+        assertEquals(HttpStatusCode.Unauthorized, inviteResponse.status)
+
+        val bulkInviteResponse =
+            client.post("/v1/org/invitations/bulk") {
+                withAuth(token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"emails":["a@test.com"],"role":"member"}""")
+            }
+        assertEquals(HttpStatusCode.Unauthorized, bulkInviteResponse.status)
+
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/org/invitations") { withAuth(token) }.status)
+    }
+
     // ──── PUT /v1/org/members/{userId}/role ────
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/routes/ApiRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/ApiRoutesExtendedTest.kt
@@ -279,6 +279,47 @@ class ApiRoutesExtendedTest {
     }
 
     @Test
+    fun `PUT user sidebar-preferences uses JWT org membership`() = testApplication {
+        val (userId, orgId) =
+            transaction {
+                val insertedUserId =
+                    Users.insert {
+                        it[email] = "sidebar-scope@test.com"
+                        it[password_hash] = "hash"
+                        it[email_verified] = true
+                    } get Users.id
+                val insertedOrgId =
+                    Organizations.insert {
+                        it[name] = "Sidebar Org"
+                        it[slug] = "sidebar-org"
+                    } get Organizations.id
+                Memberships.insert {
+                    it[user_id] = insertedUserId
+                    it[organization_id] = insertedOrgId
+                    it[role] = "owner"
+                }
+                insertedUserId to insertedOrgId
+            }
+
+        application {
+            installJwtAuth()
+            installApiRouteRateLimits("api-routes-extended")
+            routing { apiRoutes(includePublicContactRoutes = false) }
+        }
+
+        val token = RouteTestSupport.createToken(userId = userId, orgId = orgId)
+        val response =
+            client.put("/v1/user/sidebar-preferences") {
+                withAuth(token)
+                contentType(ContentType.Application.Json)
+                setBody("""{"hiddenItems":[]}""")
+            }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("hiddenItems"))
+    }
+
+    @Test
     fun `GET projects requires auth`() = testApplication {
         application {
             installJwtAuth()

--- a/backend/src/test/kotlin/com/moneat/routes/AuthTokenRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/AuthTokenRoutesTest.kt
@@ -94,12 +94,13 @@ class AuthTokenRoutesTest {
         }
     }
 
-    private fun token(userId: Int): String =
+    private fun token(userId: Int, orgId: Int? = 1): String =
         JWT
             .create()
             .withIssuer("moneat")
             .withAudience("moneat-users")
             .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
             .sign(Algorithm.HMAC256(jwtSecret))
 
     private fun seedUser(email: String = "user@test.com"): Int =
@@ -132,7 +133,7 @@ class AuthTokenRoutesTest {
     @Test
     fun `create token returns 201 with token value`() {
         val userId = seedUser()
-        seedOrgWithMembership(userId)
+        val orgId = seedOrgWithMembership(userId)
 
         testApplication {
             application {
@@ -143,7 +144,7 @@ class AuthTokenRoutesTest {
 
             val response =
                 client.post("/v1/auth-tokens") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"name":"ci-token","scopes":["project:read"]}""")
                 }
@@ -224,7 +225,7 @@ class AuthTokenRoutesTest {
     @Test
     fun `list tokens returns created tokens`() {
         val userId = seedUser()
-        seedOrgWithMembership(userId)
+        val orgId = seedOrgWithMembership(userId)
 
         testApplication {
             application {
@@ -234,14 +235,14 @@ class AuthTokenRoutesTest {
             }
 
             client.post("/v1/auth-tokens") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"my-ci-token","scopes":["project:read","project:write"]}""")
             }
 
             val response =
                 client.get("/v1/auth-tokens") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
 
             assertEquals(HttpStatusCode.OK, response.status)
@@ -293,7 +294,7 @@ class AuthTokenRoutesTest {
     @Test
     fun `delete token removes existing token`() {
         val userId = seedUser()
-        seedOrgWithMembership(userId)
+        val orgId = seedOrgWithMembership(userId)
 
         testApplication {
             application {
@@ -304,7 +305,7 @@ class AuthTokenRoutesTest {
 
             // Create a token
             client.post("/v1/auth-tokens") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"to-delete","scopes":["project:read"]}""")
             }
@@ -312,21 +313,21 @@ class AuthTokenRoutesTest {
             // Get its ID
             val listResponse =
                 client.get("/v1/auth-tokens") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             val tokenId = Regex(""""id"\s*:\s*(\d+)""").find(listResponse.bodyAsText())!!.groupValues[1]
 
             // Delete it
             val deleteResponse =
                 client.delete("/v1/auth-tokens/$tokenId") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.NoContent, deleteResponse.status)
 
             // Verify gone
             val afterList =
                 client.get("/v1/auth-tokens") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertTrue(!afterList.bodyAsText().contains("to-delete"))
         }
@@ -380,7 +381,7 @@ class AuthTokenRoutesTest {
     @Test
     fun `update token returns 400 for invalid scopes`() {
         val userId = seedUser()
-        seedOrgWithMembership(userId)
+        val orgId = seedOrgWithMembership(userId)
 
         testApplication {
             application {
@@ -390,20 +391,20 @@ class AuthTokenRoutesTest {
             }
 
             client.post("/v1/auth-tokens") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"original","scopes":["project:read"]}""")
             }
 
             val listBody =
                 client.get("/v1/auth-tokens") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }.bodyAsText()
             val tokenId = Regex(""""id"\s*:\s*(\d+)""").find(listBody)!!.groupValues[1]
 
             val response =
                 client.put("/v1/auth-tokens/$tokenId") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"scopes":["bad:scope"]}""")
                 }
@@ -416,7 +417,7 @@ class AuthTokenRoutesTest {
     @Test
     fun `update token succeeds with valid name and scopes`() {
         val userId = seedUser()
-        seedOrgWithMembership(userId)
+        val orgId = seedOrgWithMembership(userId)
 
         testApplication {
             application {
@@ -426,20 +427,20 @@ class AuthTokenRoutesTest {
             }
 
             client.post("/v1/auth-tokens") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"original","scopes":["project:read"]}""")
             }
 
             val listBody =
                 client.get("/v1/auth-tokens") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }.bodyAsText()
             val tokenId = Regex(""""id"\s*:\s*(\d+)""").find(listBody)!!.groupValues[1]
 
             val response =
                 client.put("/v1/auth-tokens/$tokenId") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"name":"updated-name","scopes":["project:read","project:write"]}""")
                 }

--- a/backend/src/test/kotlin/com/moneat/routes/BillingRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/BillingRoutesTest.kt
@@ -143,6 +143,9 @@ class BillingRoutesTest {
 
     private fun token(userId: Int): String = RouteTestSupport.createToken(userId)
 
+    private fun tokenWithoutOrg(userId: Int): String =
+        RouteTestSupport.createToken(userId = userId, orgId = null)
+
     private fun seedUser(): Int = transaction {
         Users.insert {
             it[email] = "billing-${System.nanoTime()}@test.com"
@@ -344,80 +347,74 @@ class BillingRoutesTest {
             assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
-    // ──── Forbidden (no org) ────
+    // ──── Invalid token (no org context) ────
 
     @Test
-    fun `GET usage returns 403 when user has no org`() =
+    fun `GET usage returns 401 when token has no org context`() =
         testApplication {
             val userId = seedUser()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
             application { installRoutes(this) }
             val r = client.get(BILLING_USAGE) {
-                withAuth(token(userId))
+                withAuth(tokenWithoutOrg(userId))
             }
-            assertEquals(HttpStatusCode.Forbidden, r.status)
+            assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
     @Test
-    fun `GET usage apm spans returns 403 when user has no org`() =
+    fun `GET usage apm spans returns 401 when token has no org context`() =
         testApplication {
             val userId = seedUser()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
             application { installRoutes(this) }
             val r = client.get(BILLING_APM_SPAN_DEBUG) {
-                withAuth(token(userId))
+                withAuth(tokenWithoutOrg(userId))
             }
-            assertEquals(HttpStatusCode.Forbidden, r.status)
+            assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
     @Test
-    fun `GET usage insights returns 403 when user has no org`() =
+    fun `GET usage insights returns 401 when token has no org context`() =
         testApplication {
             val userId = seedUser()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
             application { installRoutes(this) }
             val r = client.get(BILLING_USAGE_INSIGHTS) {
-                withAuth(token(userId))
+                withAuth(tokenWithoutOrg(userId))
             }
-            assertEquals(HttpStatusCode.Forbidden, r.status)
+            assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
     @Test
-    fun `POST checkout returns 403 when user has no org`() =
+    fun `POST checkout returns 401 when token has no org context`() =
         testApplication {
             val userId = seedUser()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
             application { installRoutes(this) }
             val r = client.post(BILLING_CHECKOUT) {
-                withAuth(token(userId))
+                withAuth(tokenWithoutOrg(userId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"tierName":"PRO","successUrl":"http://x","cancelUrl":"http://y"}""")
             }
-            assertEquals(HttpStatusCode.Forbidden, r.status)
+            assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
     @Test
-    fun `GET invoices returns 403 when user has no org`() =
+    fun `GET invoices returns 401 when token has no org context`() =
         testApplication {
             val userId = seedUser()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
             application { installRoutes(this) }
             val r = client.get(BILLING_INVOICES) {
-                withAuth(token(userId))
+                withAuth(tokenWithoutOrg(userId))
             }
-            assertEquals(HttpStatusCode.Forbidden, r.status)
+            assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
     @Test
-    fun `POST cancel returns 403 when user has no org`() =
+    fun `POST cancel returns 401 when token has no org context`() =
         testApplication {
             val userId = seedUser()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns null
             application { installRoutes(this) }
             val r = client.post(BILLING_CANCEL) {
-                withAuth(token(userId))
+                withAuth(tokenWithoutOrg(userId))
             }
-            assertEquals(HttpStatusCode.Forbidden, r.status)
+            assertEquals(HttpStatusCode.Unauthorized, r.status)
         }
 
     // ──── GET /billing/usage ────
@@ -426,7 +423,6 @@ class BillingRoutesTest {
     fun `GET usage returns 200 with usage data`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockQuotaService.getUsageForOrganization(orgId) } returns makeUsageResponse(orgId)
             every {
                 mockUsageTrackingService.getTotalBytesForOrg(orgId, any(), any())
@@ -450,7 +446,6 @@ class BillingRoutesTest {
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
             val usage = makeUsageResponse(orgId)
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
             coEvery {
                 mockQuotaService.getApmSpanUsageDebug(
@@ -505,7 +500,6 @@ class BillingRoutesTest {
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
             val response = makeUsageInsightsResponse(orgId)
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             coEvery { mockInsightsService.getUsageInsights(orgId) } returns response
             application { installRoutes(this) }
 
@@ -523,7 +517,6 @@ class BillingRoutesTest {
     fun `GET usage insights returns 503 when insights are unavailable`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             coEvery { mockInsightsService.getUsageInsights(orgId) } throws IllegalStateException("boom")
             application { installRoutes(this) }
 
@@ -540,7 +533,6 @@ class BillingRoutesTest {
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
             every { EnvConfig.SelfHost.enabled } returns true
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             application { installRoutes(this) }
 
             val r = client.get(BILLING_USAGE_INSIGHTS) {
@@ -556,7 +548,6 @@ class BillingRoutesTest {
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
             val usage = makeUsageResponse(orgId)
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
             stubApmSpanDebug(orgId, usage, expectedLimit = 1)
             application { installRoutes(this) }
@@ -581,7 +572,6 @@ class BillingRoutesTest {
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
             val usage = makeUsageResponse(orgId)
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
             stubApmSpanDebug(orgId, usage, expectedLimit = 100)
             application { installRoutes(this) }
@@ -606,7 +596,6 @@ class BillingRoutesTest {
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
             val usage = makeUsageResponse(orgId)
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockQuotaService.getUsageForOrganization(orgId) } returns usage
             stubApmSpanDebug(orgId, usage, expectedLimit = 20)
             application { installRoutes(this) }
@@ -632,7 +621,6 @@ class BillingRoutesTest {
     fun `POST checkout returns 200 on success`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.createCheckoutSession(
                     organizationId = orgId,
@@ -661,7 +649,6 @@ class BillingRoutesTest {
     fun `POST checkout returns 400 on invalid request`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.createCheckoutSession(
                     organizationId = orgId,
@@ -688,7 +675,6 @@ class BillingRoutesTest {
     fun `POST checkout returns 500 on service error`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.createCheckoutSession(
                     organizationId = orgId,
@@ -717,7 +703,6 @@ class BillingRoutesTest {
     fun `GET invoices returns 200 with list`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockStripeService.listInvoices(orgId) } returns listOf(
                 InvoiceResponse(
                     id = "inv_1",
@@ -740,7 +725,6 @@ class BillingRoutesTest {
     fun `GET invoices returns 400 on service error`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockStripeService.listInvoices(orgId) } throws RuntimeException("Stripe error")
             application { installRoutes(this) }
 
@@ -756,7 +740,6 @@ class BillingRoutesTest {
     fun `GET payment-method returns 200`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockStripeService.getPaymentMethod(orgId) } returns PaymentMethodResponse(
                 brand = "visa", last4 = "4242", expMonth = 12, expYear = 2026
             )
@@ -773,7 +756,6 @@ class BillingRoutesTest {
     fun `GET payment-method returns 400 on error`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockStripeService.getPaymentMethod(orgId) } throws RuntimeException("No customer")
             application { installRoutes(this) }
 
@@ -789,7 +771,6 @@ class BillingRoutesTest {
     fun `POST setup-intent returns 200`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockStripeService.createSetupIntent(orgId) } returns SetupIntentResponse(
                 clientSecret = "seti_secret_123"
             )
@@ -806,7 +787,6 @@ class BillingRoutesTest {
     fun `POST setup-intent returns 400 on error`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockStripeService.createSetupIntent(orgId) } throws RuntimeException("Failed")
             application { installRoutes(this) }
 
@@ -822,7 +802,6 @@ class BillingRoutesTest {
     fun `POST setup-intent confirm returns 200`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.confirmSetupIntentAndUpdatePaymentMethod(orgId, "seti_123")
             } returns Unit
@@ -840,7 +819,6 @@ class BillingRoutesTest {
     fun `POST setup-intent confirm returns 400 on error`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.confirmSetupIntentAndUpdatePaymentMethod(orgId, any())
             } throws RuntimeException("Invalid intent")
@@ -860,7 +838,6 @@ class BillingRoutesTest {
     fun `POST cancel returns 200 on success`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every { mockStripeService.cancelSubscription(orgId) } returns CancelSubscriptionResponse(
                 status = "canceled",
                 cancelAtPeriodEnd = true,
@@ -879,7 +856,6 @@ class BillingRoutesTest {
     fun `POST cancel returns 400 when no subscription`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.cancelSubscription(orgId)
             } throws IllegalStateException("No cancelable subscription")
@@ -895,7 +871,6 @@ class BillingRoutesTest {
     fun `POST cancel returns 500 on unexpected error`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.cancelSubscription(orgId)
             } throws RuntimeException("Stripe outage")
@@ -913,7 +888,6 @@ class BillingRoutesTest {
     fun `PUT payg-budget returns 400 for negative budget`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             application { installRoutes(this) }
 
             val r = client.put(BILLING_PAYG_BUDGET) {
@@ -928,7 +902,6 @@ class BillingRoutesTest {
     fun `PUT payg-budget returns 400 for non-500 increment`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             application { installRoutes(this) }
 
             val r = client.put(BILLING_PAYG_BUDGET) {
@@ -943,7 +916,6 @@ class BillingRoutesTest {
     fun `PUT payg-budget returns 400 for free tier`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             val tierContext = mockk<EffectiveTierContext>(relaxed = true)
             every { tierContext.tier.paygEnabled } returns false
             every { tierContext.tier.tierName } returns "FREE"
@@ -963,7 +935,6 @@ class BillingRoutesTest {
     fun `PUT payg-budget returns 200 on valid update`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             val tierContext = mockk<EffectiveTierContext>(relaxed = true)
             every { tierContext.tier.paygEnabled } returns true
             every { tierContext.tier.tierName } returns "PRO"
@@ -992,7 +963,6 @@ class BillingRoutesTest {
     fun `PUT payg-budget returns 404 when no active subscription`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             val tierContext = mockk<EffectiveTierContext>(relaxed = true)
             every { tierContext.tier.paygEnabled } returns true
             every { tierContext.tier.tierName } returns "PRO"
@@ -1013,7 +983,6 @@ class BillingRoutesTest {
     fun `PUT oncall-seats returns 400 for negative seats`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             application { installRoutes(this) }
 
             val r = client.put(BILLING_ONCALL_SEATS) {
@@ -1029,7 +998,6 @@ class BillingRoutesTest {
     fun `PUT oncall-seats returns 400 for seats over 200`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             application { installRoutes(this) }
 
             val r = client.put(BILLING_ONCALL_SEATS) {
@@ -1045,7 +1013,6 @@ class BillingRoutesTest {
     fun `PUT oncall-seats returns 200 on success`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.updateOnCallSeats(orgId, 5)
             } returns UpdateOnCallSeatsResponse(seats = 5, proratedAmountCents = 1450)
@@ -1064,7 +1031,6 @@ class BillingRoutesTest {
     fun `PUT oncall-seats returns 400 on invalid argument`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.updateOnCallSeats(orgId, any())
             } throws IllegalArgumentException("No subscription")
@@ -1082,7 +1048,6 @@ class BillingRoutesTest {
     fun `PUT oncall-seats returns 500 on service error`() =
         testApplication {
             val (userId, orgId) = seedUserAndOrg()
-            every { mockPricingTierService.getPrimaryOrganizationIdForUser(userId) } returns orgId
             every {
                 mockStripeService.updateOnCallSeats(orgId, any())
             } throws RuntimeException("Stripe outage")

--- a/backend/src/test/kotlin/com/moneat/routes/DashboardRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DashboardRoutesTest.kt
@@ -119,8 +119,8 @@ class DashboardRoutesTest {
         installJwtAuth()
     }
 
-    private fun token(userId: Int): String =
-        RouteTestSupport.createToken(userId)
+    private fun token(userId: Int, orgId: Int? = null): String =
+        RouteTestSupport.createToken(userId, orgId)
 
     private fun seedUser(): Int = transaction {
         Users.insert {
@@ -261,7 +261,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get(DASHBOARDS_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains(TEST_DASHBOARD))
@@ -280,7 +280,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.post(DASHBOARDS_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"New Dash"}""")
             }
@@ -299,7 +299,7 @@ class DashboardRoutesTest {
         application { installRoutes(this) }
 
         val r = client.get(DASHBOARDS_1) {
-            withAuth(token(userId))
+            withAuth(token(userId, orgId))
         }
         assertEquals(HttpStatusCode.OK, r.status)
         assertTrue(r.bodyAsText().contains(TEST_DASHBOARD))
@@ -308,11 +308,11 @@ class DashboardRoutesTest {
     @Test
     fun `GET dashboard by invalid id returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.get("/v1/dashboards/abc") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -329,7 +329,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get(DASHBOARDS_99) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -347,7 +347,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put(DASHBOARDS_1) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"Updated"}""")
             }
@@ -366,7 +366,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put(DASHBOARDS_99) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"X"}""")
             }
@@ -385,7 +385,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.delete("/v1/dashboards/1") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NoContent, r.status)
         }
@@ -402,7 +402,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.delete(DASHBOARDS_99) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -420,7 +420,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get("/v1/dashboards/folders") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains("Test Folder"))
@@ -439,7 +439,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.post("/v1/dashboards/folders") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"New Folder"}""")
             }
@@ -459,7 +459,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put("/v1/dashboards/folders/1") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"Renamed"}""")
             }
@@ -478,7 +478,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put("/v1/dashboards/folders/99") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(BODY_NAME_X)
             }
@@ -488,11 +488,11 @@ class DashboardRoutesTest {
     @Test
     fun `PUT folder returns 400 for invalid id`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.put("/v1/dashboards/folders/abc") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(BODY_NAME_X)
             }
@@ -511,7 +511,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.delete("/v1/dashboards/folders/1") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NoContent, r.status)
         }
@@ -528,7 +528,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.delete("/v1/dashboards/folders/99") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -546,7 +546,7 @@ class DashboardRoutesTest {
         application { installRoutes(this) }
 
         val r = client.post("/v1/dashboards/1/favorite") {
-            withAuth(token(userId))
+            withAuth(token(userId, orgId))
         }
         assertEquals(HttpStatusCode.OK, r.status)
         assertTrue(r.bodyAsText().contains("is_favorited"))
@@ -564,7 +564,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put("/v1/dashboards/1/folder") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"folder_id":2}""")
             }
@@ -583,7 +583,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put("/v1/dashboards/99/folder") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"folder_id":2}""")
             }
@@ -595,11 +595,11 @@ class DashboardRoutesTest {
     @Test
     fun `POST query returns 400 for invalid dashboard id`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.post("/v1/dashboards/abc/query") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"queryConfig":{}}""")
             }
@@ -609,12 +609,12 @@ class DashboardRoutesTest {
     @Test
     fun `POST batch query returns 400 for invalid id`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r =
                 client.post("/v1/dashboards/abc/query/batch") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                     contentType(ContentType.Application.Json)
                     setBody("""{"queries":[]}""")
                 }
@@ -624,13 +624,13 @@ class DashboardRoutesTest {
     @Test
     fun `POST variables resolve returns 400 for invalid id`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.post(
                 "/v1/dashboards/abc/variables/resolve"
             ) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("{}")
             }
@@ -642,11 +642,11 @@ class DashboardRoutesTest {
     @Test
     fun `POST import returns 400 for invalid JSON`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.post("/v1/dashboards/import") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(
                     """{"format":"datadog","json":"not-json"}"""
@@ -658,11 +658,11 @@ class DashboardRoutesTest {
     @Test
     fun `POST import returns 400 for unsupported format`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.post("/v1/dashboards/import") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(
                     """{"format":"unknown","json":"{}"}"""
@@ -686,7 +686,7 @@ class DashboardRoutesTest {
             val r = client.get(
                 "/v1/dashboards/1/export/moneat"
             ) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
         }
@@ -705,7 +705,7 @@ class DashboardRoutesTest {
             val r = client.get(
                 "/v1/dashboards/99/export/moneat"
             ) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -725,7 +725,7 @@ class DashboardRoutesTest {
             val r = client.get(
                 "/v1/dashboards/1/export/xml"
             ) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -733,13 +733,13 @@ class DashboardRoutesTest {
     @Test
     fun `GET export returns 400 for invalid dashboard id`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.get(
                 "/v1/dashboards/abc/export/moneat"
             ) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -757,7 +757,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get("/v1/dashboards/1/alerts") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains("Test Alert"))
@@ -781,7 +781,7 @@ class DashboardRoutesTest {
                  "duration_seconds":60}
             """.trimIndent()
             val r = client.post("/v1/dashboards/1/alerts") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(body)
             }
@@ -802,7 +802,7 @@ class DashboardRoutesTest {
 
             val r =
                 client.put("/v1/dashboards/1/alerts/1") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                     contentType(ContentType.Application.Json)
                     setBody("""{"enabled":false}""")
                 }
@@ -812,12 +812,12 @@ class DashboardRoutesTest {
     @Test
     fun `PUT dashboard alert returns 400 for malformed JSON`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r =
                 client.put("/v1/dashboards/1/alerts/1") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                     contentType(ContentType.Application.Json)
                     setBody("""{"enabled":""")
                 }
@@ -837,7 +837,7 @@ class DashboardRoutesTest {
 
             val r =
                 client.put("/v1/dashboards/1/alerts/99") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                     contentType(ContentType.Application.Json)
                     setBody("""{"enabled":false}""")
                 }
@@ -857,7 +857,7 @@ class DashboardRoutesTest {
 
             val r =
                 client.delete("/v1/dashboards/1/alerts/1") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                 }
             assertEquals(HttpStatusCode.NoContent, r.status)
         }
@@ -875,7 +875,7 @@ class DashboardRoutesTest {
 
             val r =
                 client.delete("/v1/dashboards/1/alerts/99") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                 }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -883,12 +883,12 @@ class DashboardRoutesTest {
     @Test
     fun `GET dashboard alerts returns 400 for bad id`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r =
                 client.get("/v1/dashboards/abc/alerts") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                 }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -911,7 +911,7 @@ class DashboardRoutesTest {
 
             val r =
                 client.get("/v1/dashboards/datasources") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                 }
             assertEquals(HttpStatusCode.OK, r.status)
         }
@@ -919,7 +919,7 @@ class DashboardRoutesTest {
     @Test
     fun `GET dashboard templates returns 200`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             every {
                 mockDashboardService.getDefaultDashboardTemplates()
             } returns emptyList()
@@ -927,7 +927,7 @@ class DashboardRoutesTest {
 
             val r =
                 client.get("/v1/dashboards/templates") {
-                    withAuth(token(userId))
+                    withAuth(token(userId, orgId))
                 }
             assertEquals(HttpStatusCode.OK, r.status)
         }
@@ -950,7 +950,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get("/v1/search?q=test") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
         }
@@ -970,7 +970,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get("/v1/datasources") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains(TEST_DS))
@@ -993,7 +993,7 @@ class DashboardRoutesTest {
                  "host":"localhost","port":5432}
             """.trimIndent()
             val r = client.post("/v1/datasources") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(body)
             }
@@ -1003,7 +1003,7 @@ class DashboardRoutesTest {
     @Test
     fun `POST test connection returns 200`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             val result = TestConnectionResult(
                 success = true,
                 message = "OK"
@@ -1019,7 +1019,7 @@ class DashboardRoutesTest {
                  "username":"u","password":"p"}
             """.trimIndent()
             val r = client.post("/v1/datasources/test") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(body)
             }
@@ -1040,7 +1040,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get(DATASOURCES_1) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains(TEST_DS))
@@ -1058,7 +1058,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.get(DATASOURCES_99) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -1076,7 +1076,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put(DATASOURCES_1) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"Updated DS"}""")
             }
@@ -1095,7 +1095,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.put(DATASOURCES_99) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(BODY_NAME_X)
             }
@@ -1114,7 +1114,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.delete("/v1/datasources/1") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NoContent, r.status)
         }
@@ -1131,7 +1131,7 @@ class DashboardRoutesTest {
             application { installRoutes(this) }
 
             val r = client.delete(DATASOURCES_99) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -1139,11 +1139,11 @@ class DashboardRoutesTest {
     @Test
     fun `GET custom datasource returns 400 for bad id`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installRoutes(this) }
 
             val r = client.get("/v1/datasources/abc") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }

--- a/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
@@ -152,13 +152,22 @@ class EventRoutesExtendedTest {
     }
 
     private fun token(userId: Int): String =
-        RouteTestSupport.createToken(userId)
+        RouteTestSupport.createToken(userId = userId, orgId = orgIdForUser(userId))
 
     private fun token(
         userId: Int,
         orgId: Int
     ): String =
         RouteTestSupport.createToken(userId = userId, orgId = orgId)
+
+    private fun orgIdForUser(userId: Int): Int? =
+        transaction {
+            Memberships
+                .selectAll()
+                .where { Memberships.user_id eq userId }
+                .firstOrNull()
+                ?.get(Memberships.organization_id)
+        }
 
     private fun demoToken(): String =
         JWT.create().withIssuer("moneat").withAudience("moneat-users")
@@ -213,14 +222,14 @@ class EventRoutesExtendedTest {
 
     @Test
     fun `GET projects returns 200 with project list`() = testApplication {
-        val (userId, _) = seedUserWithProject()
+        val seeded = seedUserProject()
         coEvery {
-            mockDashboardService.getProjects(userId, any())
+            mockDashboardService.getProjects(seeded.orgId, any())
         } returns listOf(sampleProject())
 
         application { installTestApp() }
         val response = client.get(V1_PROJECTS) {
-            withAuth(token(userId))
+            withAuth(token(seeded.userId, seeded.orgId))
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains(TEST_PROJECT_NAME))
@@ -237,14 +246,14 @@ class EventRoutesExtendedTest {
 
     @Test
     fun `POST projects returns 201 on success`() = testApplication {
-        val (userId, _) = seedUserWithProject()
+        val seeded = seedUserProject()
         coEvery {
-            mockDashboardService.createProject(userId, any())
+            mockDashboardService.createProject(seeded.orgId, any())
         } returns sampleProject()
 
         application { installTestApp() }
         val response = client.post(V1_PROJECTS) {
-            withAuth(token(userId))
+            withAuth(token(seeded.userId, seeded.orgId))
             contentType(ContentType.Application.Json)
             setBody("""{"name":"New Project"}""")
         }
@@ -254,14 +263,14 @@ class EventRoutesExtendedTest {
 
     @Test
     fun `POST projects returns 403 when project limit reached`() = testApplication {
-        val (userId, _) = seedUserWithProject()
+        val seeded = seedUserProject()
         coEvery {
-            mockDashboardService.createProject(userId, any())
+            mockDashboardService.createProject(seeded.orgId, any())
         } throws IllegalStateException("project_limit_reached")
 
         application { installTestApp() }
         val response = client.post(V1_PROJECTS) {
-            withAuth(token(userId))
+            withAuth(token(seeded.userId, seeded.orgId))
             contentType(ContentType.Application.Json)
             setBody("""{"name":"New Project"}""")
         }
@@ -271,14 +280,14 @@ class EventRoutesExtendedTest {
 
     @Test
     fun `POST projects returns 400 on other errors`() = testApplication {
-        val (userId, _) = seedUserWithProject()
+        val seeded = seedUserProject()
         coEvery {
-            mockDashboardService.createProject(userId, any())
+            mockDashboardService.createProject(seeded.orgId, any())
         } throws IllegalStateException("Invalid project name")
 
         application { installTestApp() }
         val response = client.post(V1_PROJECTS) {
-            withAuth(token(userId))
+            withAuth(token(seeded.userId, seeded.orgId))
             contentType(ContentType.Application.Json)
             setBody("""{"name":""}""")
         }

--- a/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
@@ -18,6 +18,7 @@ package com.moneat.routes
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.moneat.events.models.AlertNotificationPreference
 import com.moneat.events.models.FeedbackDetailResponse
 import com.moneat.events.models.FeedbackListItem
 import com.moneat.events.models.ProjectKeyResponse
@@ -1178,6 +1179,37 @@ class EventRoutesExtendedTest {
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("preferences"))
+    }
+
+    @Test
+    fun `PUT alert-notification-preferences uses JWT org`() = testApplication {
+        val seeded = seedUserProject()
+        every {
+            mockAlertPrefsService.updatePreference(
+                userId = seeded.userId,
+                organizationId = seeded.orgId,
+                alertSource = "uptime",
+                emailEnabled = false,
+                slackEnabled = true,
+                discordEnabled = false
+            )
+        } returns AlertNotificationPreference(
+            alertSource = "uptime",
+            emailEnabled = false,
+            slackEnabled = true,
+            discordEnabled = false
+        )
+
+        application { installTestApp() }
+        val response =
+            client.put("/v1/alert-notification-preferences/uptime") {
+                withAuth(token(seeded.userId, seeded.orgId))
+                contentType(ContentType.Application.Json)
+                setBody("""{"emailEnabled":false,"slackEnabled":true,"discordEnabled":false}""")
+            }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("uptime"))
     }
 
     // ──── Demo user access ────

--- a/backend/src/test/kotlin/com/moneat/routes/InfraRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/InfraRoutesTest.kt
@@ -192,12 +192,12 @@ class InfraRoutesTest {
         assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
-    // ──── No membership (empty org list) ────
+    // ──── Current org with no matching data ────
 
     @Test
-    fun `GET infra events with no membership returns empty list`() =
+    fun `GET infra events with no data returns empty list`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -205,7 +205,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get(INFRA_EVENTS_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"events\":[]"))
@@ -300,29 +300,19 @@ class InfraRoutesTest {
         }
 
     @Test
-    fun `saved map views reject inaccessible or ambiguous organization context`() =
+    fun `saved map views require current organization claim`() =
         testApplication {
             val userId = seedUser()
-            val firstOrgId = seedOrg()
-            val secondOrgId = seedOrg()
-            val inaccessibleOrgId = seedOrg()
-            seedMembership(userId, firstOrgId)
-            seedMembership(userId, secondOrgId)
 
             application {
                 installAuth()
                 routing { infraRoutes() }
             }
 
-            val inaccessibleResponse = client.get(SAVED_VIEWS_PATH) {
-                withAuth(token(userId, inaccessibleOrgId))
-            }
-            assertEquals(HttpStatusCode.Forbidden, inaccessibleResponse.status)
-
-            val ambiguousResponse = client.get(SAVED_VIEWS_PATH) {
+            val response = client.get(SAVED_VIEWS_PATH) {
                 withAuth(token(userId))
             }
-            assertEquals(HttpStatusCode.BadRequest, ambiguousResponse.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
@@ -403,7 +393,7 @@ class InfraRoutesTest {
 
     @Test
     fun `GET infra events returns 200 with data`() = testApplication {
-        val (userId, _) = seedUserAndOrg()
+        val (userId, orgId) = seedUserAndOrg()
         stubClickHouseOk("""{"host":"web-01","alert_type":"cpu_high"}""")
 
         application {
@@ -412,7 +402,7 @@ class InfraRoutesTest {
         }
 
         val response = client.get(INFRA_EVENTS_PATH) {
-            withAuth(token(userId))
+            withAuth(token(userId, orgId))
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("web-01"))
@@ -421,7 +411,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra events returns empty when CH errors`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseError()
 
             application {
@@ -430,7 +420,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get(INFRA_EVENTS_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"events\":[]"))
@@ -441,7 +431,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra service-checks returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"check_name":"http_check","status":"ok"}"""
             )
@@ -452,16 +442,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/service-checks") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("http_check"))
         }
 
     @Test
-    fun `GET service-checks with no membership returns empty`() =
+    fun `GET service-checks with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -469,7 +459,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/service-checks") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(
@@ -482,7 +472,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra processes returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk("""{"process_name":"nginx","pid":"1234"}""")
 
             application {
@@ -491,16 +481,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/processes") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("nginx"))
         }
 
     @Test
-    fun `GET processes with no membership returns empty`() =
+    fun `GET processes with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -508,7 +498,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/processes") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"processes\":[]"))
@@ -519,7 +509,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra containers returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"container_name":"redis","status":"running"}"""
             )
@@ -530,16 +520,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/containers") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("redis"))
         }
 
     @Test
-    fun `GET containers with no membership returns empty`() =
+    fun `GET containers with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -547,7 +537,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/containers") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"containers\":[]"))
@@ -558,7 +548,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra connections returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"source_host":"web-01","dest_host":"db-01"}"""
             )
@@ -569,16 +559,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/connections") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("web-01"))
         }
 
     @Test
-    fun `GET connections with no membership returns empty`() =
+    fun `GET connections with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -586,7 +576,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/connections") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(
@@ -599,7 +589,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra k8s-resources returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"resource_type":"pod","name":"api-server"}"""
             )
@@ -610,16 +600,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/k8s-resources") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("api-server"))
         }
 
     @Test
-    fun `GET k8s-resources with no membership returns empty`() =
+    fun `GET k8s-resources with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -627,7 +617,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/k8s-resources") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(
@@ -640,7 +630,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra dbm queries returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"query_text":"SELECT 1","duration_ms":"42"}"""
             )
@@ -651,16 +641,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/dbm/queries") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("SELECT 1"))
         }
 
     @Test
-    fun `GET dbm queries with no membership returns empty`() =
+    fun `GET dbm queries with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -668,7 +658,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/dbm/queries") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"queries\":[]"))
@@ -679,7 +669,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra debugger logs returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"probe_id":"probe-1","message":"breakpoint hit"}"""
             )
@@ -690,16 +680,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/debugger/logs") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("probe-1"))
         }
 
     @Test
-    fun `GET debugger logs with no membership returns empty`() =
+    fun `GET debugger logs with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -707,7 +697,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/debugger/logs") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"logs\":[]"))
@@ -718,7 +708,7 @@ class InfraRoutesTest {
     @Test
     fun `GET infra debugger diagnostics returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"probe_id":"diag-1","status":"ok"}"""
             )
@@ -732,7 +722,7 @@ class InfraRoutesTest {
                 client.get("/v1/infra/debugger/diagnostics") {
                     header(
                         HttpHeaders.Authorization,
-                        "Bearer ${token(userId)}"
+                        "Bearer ${token(userId, orgId)}"
                     )
                 }
             assertEquals(HttpStatusCode.OK, response.status)
@@ -740,9 +730,9 @@ class InfraRoutesTest {
         }
 
     @Test
-    fun `GET debugger diagnostics with no membership returns empty`() =
+    fun `GET debugger diagnostics with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -753,7 +743,7 @@ class InfraRoutesTest {
                 client.get("/v1/infra/debugger/diagnostics") {
                     header(
                         HttpHeaders.Authorization,
-                        "Bearer ${token(userId)}"
+                        "Bearer ${token(userId, orgId)}"
                     )
                 }
             assertEquals(HttpStatusCode.OK, response.status)
@@ -766,7 +756,7 @@ class InfraRoutesTest {
 
     @Test
     fun `GET infra sbom returns 200 with data`() = testApplication {
-        val (userId, _) = seedUserAndOrg()
+        val (userId, orgId) = seedUserAndOrg()
         stubClickHouseOk(
             """{"package_name":"openssl","version":"3.0.1"}"""
         )
@@ -777,16 +767,16 @@ class InfraRoutesTest {
         }
 
         val response = client.get("/v1/infra/sbom") {
-            withAuth(token(userId))
+            withAuth(token(userId, orgId))
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("openssl"))
     }
 
     @Test
-    fun `GET sbom with no membership returns empty`() =
+    fun `GET sbom with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -794,7 +784,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/infra/sbom") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(
@@ -807,7 +797,7 @@ class InfraRoutesTest {
     @Test
     fun `GET network-devices returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"device_ip":"${TestIpConstants.IP_1}","vendor":"cisco"}"""
             )
@@ -818,16 +808,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains(TestIpConstants.IP_1))
         }
 
     @Test
-    fun `GET network-devices with no membership returns empty`() =
+    fun `GET network-devices with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -835,7 +825,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"devices\":[]"))
@@ -846,7 +836,7 @@ class InfraRoutesTest {
     @Test
     fun `GET network-devices flows returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"source_ip":"${TestIpConstants.IP_1}","dest_ip":"${TestIpConstants.IP_2}"}"""
             )
@@ -857,16 +847,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices/flows") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains(TestIpConstants.IP_1))
         }
 
     @Test
-    fun `GET network-devices flows with no membership returns empty`() =
+    fun `GET network-devices flows with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -874,7 +864,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices/flows") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"flows\":[]"))
@@ -885,7 +875,7 @@ class InfraRoutesTest {
     @Test
     fun `GET network-devices traps returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"trap_oid":"${TestOidConstants.OID_TRAP_TEST}","source_ip":"${TestIpConstants.IP_5}"}"""
             )
@@ -896,16 +886,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices/traps") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains(TestIpConstants.IP_5))
         }
 
     @Test
-    fun `GET network-devices traps with no membership returns empty`() =
+    fun `GET network-devices traps with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -913,7 +903,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices/traps") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"traps\":[]"))
@@ -924,7 +914,7 @@ class InfraRoutesTest {
     @Test
     fun `GET network-devices paths returns 200 with data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             stubClickHouseOk(
                 """{"destination":"${TestIpConstants.IP_PATH_DEST}","hop_count":"5"}"""
             )
@@ -935,16 +925,16 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices/paths") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains(TestIpConstants.IP_PATH_DEST))
         }
 
     @Test
-    fun `GET network-devices paths with no membership returns empty`() =
+    fun `GET network-devices paths with no data returns empty`() =
         testApplication {
-            val userId = seedUser()
+            val (userId, orgId) = seedUserAndOrg()
 
             application {
                 installAuth()
@@ -952,7 +942,7 @@ class InfraRoutesTest {
             }
 
             val response = client.get("/v1/network-devices/paths") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("\"paths\":[]"))

--- a/backend/src/test/kotlin/com/moneat/routes/IntegrationRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IntegrationRoutesTest.kt
@@ -117,6 +117,52 @@ class IntegrationRoutesTest {
     }
 
     @Test
+    fun `integration org helper returns unauthorized when principal is missing`() {
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                routing {
+                    route("/v1") {
+                        integrationRoutes()
+                    }
+                }
+            }
+
+            val response = client.get("/v1/integrations/slack/channels")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(response.bodyAsText().contains("Unauthorized"))
+        }
+    }
+
+    @Test
+    fun `integration org helper returns not found when JWT has no org`() {
+        val userId = seedUser("no-org-claim@test.com")
+
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    authenticate("auth-jwt") {
+                        route("/v1") {
+                            integrationRoutes()
+                        }
+                    }
+                }
+            }
+
+            val response =
+                client.get("/v1/integrations/slack/channels") {
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertTrue(response.bodyAsText().contains("No organization found"))
+        }
+    }
+
+    @Test
     fun `integrations list returns configured integration records`() {
         val orgId = seedOrganization("Integration Org")
         val userId = seedUser("member@test.com")

--- a/backend/src/test/kotlin/com/moneat/routes/IntegrationRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/IntegrationRoutesTest.kt
@@ -138,7 +138,7 @@ class IntegrationRoutesTest {
 
             val response =
                 client.get("/v1/integrations") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
 
             assertEquals(HttpStatusCode.OK, response.status)
@@ -197,7 +197,7 @@ class IntegrationRoutesTest {
 
             val response =
                 client.get("/v1/integrations/slack/oauth/start") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
 
             assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -227,7 +227,7 @@ class IntegrationRoutesTest {
 
             val response =
                 client.get("/v1/integrations/discord/oauth/start") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
 
             assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -357,12 +357,13 @@ class IntegrationRoutesTest {
         }
     }
 
-    private fun token(userId: Int): String {
+    private fun token(userId: Int, orgId: Int? = null): String {
         return JWT
             .create()
             .withIssuer("moneat")
             .withAudience("moneat-users")
             .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
             .withClaim("email", "user$userId@test.com")
             .sign(Algorithm.HMAC256(jwtSecret))
     }

--- a/backend/src/test/kotlin/com/moneat/routes/MonitorRoutesMockTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/MonitorRoutesMockTest.kt
@@ -103,9 +103,11 @@ class MonitorRoutesMockTest {
         }
     }
 
-    private fun token(userId: Int): String =
+    private fun token(userId: Int, orgId: Int? = null): String =
         JWT.create().withIssuer("moneat").withAudience("moneat-users")
-            .withClaim("userId", userId).sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
+            .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
+            .sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
 
     private fun seedUser(): Int =
         transaction {
@@ -181,7 +183,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("test-system"))
@@ -212,7 +214,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/${system.id}") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("test-system"))
@@ -240,7 +242,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/$systemId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -270,7 +272,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.delete("/v1/monitor/hosts/${system.id}") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NoContent, response.status)
         }
@@ -307,7 +309,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/${system.id}/metrics?from=1000&to=2000") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }
@@ -349,7 +351,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/${system.id}/containers") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("my-container"))
@@ -381,7 +383,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/${system.id}/logs") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }
@@ -423,7 +425,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/${system.id}/alerts") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("cpu_percent"))
@@ -460,7 +462,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/${system.id}/alerts/config") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("global"))
@@ -487,7 +489,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.get("/v1/monitor/hosts/not-a-uuid") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -517,7 +519,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.put("/v1/monitor/hosts/${system.id}/alerts/scope") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"scope":"host"}""")
             }
@@ -546,7 +548,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.put("/v1/monitor/hosts/${system.id}/alerts/scope") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"scope":"invalid"}""")
             }
@@ -590,7 +592,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.post("/v1/monitor/hosts/${system.id}/alerts") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"metric":"mem_percent","condition":"gt","threshold":80.0,"duration_seconds":60}""")
             }
@@ -623,7 +625,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.put("/v1/monitor/hosts/${system.id}/alerts/1") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"enabled":false}""")
             }
@@ -653,7 +655,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.put("/v1/monitor/hosts/${system.id}/alerts/99") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"enabled":false}""")
             }
@@ -685,7 +687,7 @@ class MonitorRoutesMockTest {
             }
 
             val response = client.delete("/v1/monitor/hosts/${system.id}/alerts/1") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NoContent, response.status)
         }
@@ -726,7 +728,7 @@ class MonitorRoutesMockTest {
             val response = client.get(
                 "/v1/monitor/hosts/${system.id}/containers/my-container/metrics?from=1000&to=2000"
             ) {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }

--- a/backend/src/test/kotlin/com/moneat/routes/MonitorRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/MonitorRoutesTest.kt
@@ -88,12 +88,13 @@ class MonitorRoutesTest {
         }
     }
 
-    private fun token(userId: Int): String =
+    private fun token(userId: Int, orgId: Int? = null): String =
         JWT
             .create()
             .withIssuer("moneat")
             .withAudience("moneat-users")
             .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
             .sign(Algorithm.HMAC256("test-secret"))
 
     private fun seedUser(): Int =
@@ -159,7 +160,7 @@ class MonitorRoutesTest {
             seedMembership(userId, orgId)
             val response =
                 client.get("/v1/monitor/hosts") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.OK, response.status)
             assertEquals("[]", response.bodyAsText())
@@ -183,7 +184,7 @@ class MonitorRoutesTest {
             seedMembership(userId, orgId)
             val response =
                 client.get("/v1/monitor/hosts/not-a-uuid") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -219,7 +220,7 @@ class MonitorRoutesTest {
             seedMembership(userId, orgId)
             val response =
                 client.get("/v1/monitor/hosts/2147483647") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -240,7 +241,7 @@ class MonitorRoutesTest {
             seedMembership(userId, orgId)
             val response =
                 client.delete("/v1/monitor/hosts/bad-uuid") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -278,7 +279,7 @@ class MonitorRoutesTest {
             seedMembership(userId, orgId)
             val response =
                 client.get("/v1/monitor/hosts/not-a-uuid/metrics") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -316,7 +317,7 @@ class MonitorRoutesTest {
             seedMembership(userId, orgId)
             val response =
                 client.get("/v1/monitor/hosts/not-a-uuid/containers") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }

--- a/backend/src/test/kotlin/com/moneat/routes/OrgRoutesFullCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/OrgRoutesFullCoverageTest.kt
@@ -157,9 +157,10 @@ class OrgRoutesFullCoverageTest {
         }
     }
 
-    private fun token(userId: Int, orgId: Int): String = JWT.create()
+    private fun token(userId: Int, orgId: Int?): String = JWT.create()
         .withIssuer("moneat").withAudience("moneat-users")
-        .withClaim("userId", userId).withClaim("orgId", orgId)
+        .withClaim("userId", userId)
+        .apply { if (orgId != null) withClaim("orgId", orgId) }
         .withClaim("email", "user$userId@test.com")
         .sign(Algorithm.HMAC256(JWT_SECRET))
 
@@ -1132,7 +1133,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.get("/integrations") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1170,7 +1171,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.get("/integrations/slack/channels") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1225,7 +1226,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.put("/integrations/slack/channel") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"channelId":"C2","channelName":"a"}""")
                 }.status
@@ -1263,7 +1264,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.get("/integrations/slack/usergroups") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1316,7 +1317,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.put("/integrations/slack/toggle") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1369,7 +1370,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.delete("/integrations/slack") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1423,7 +1424,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.post("/integrations/slack/test") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1461,7 +1462,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.get("/integrations/discord/channels") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1516,7 +1517,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.put("/integrations/discord/channel") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"channelId":"D2","channelName":"a"}""")
                 }.status
@@ -1573,7 +1574,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.put("/integrations/discord/toggle") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1644,7 +1645,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.delete("/integrations/discord") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }
@@ -1698,7 +1699,7 @@ class OrgRoutesFullCoverageTest {
             assertEquals(
                 HttpStatusCode.NotFound,
                 client.post("/integrations/discord/test") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(u, 1)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(u, null)}")
                 }.status
             )
         }

--- a/backend/src/test/kotlin/com/moneat/routes/StatusPageRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/StatusPageRoutesTest.kt
@@ -116,10 +116,11 @@ class StatusPageRoutesTest {
         }
     }
 
-    private fun token(userId: Int): String =
+    private fun token(userId: Int, orgId: Int? = null): String =
         JWT.create()
             .withIssuer("moneat").withAudience("moneat-users")
             .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
             .sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
 
     private fun seedUser(): Int =
@@ -214,9 +215,9 @@ class StatusPageRoutesTest {
                 installAuth()
                 routing { statusPageRoutes() }
             }
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             val response = client.get("/v1/status-pages") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }
@@ -231,7 +232,7 @@ class StatusPageRoutesTest {
             val (userId, orgId) = seedUserAndOrg()
             seedStatusPage(orgId)
             val response = client.get("/v1/status-pages") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("Test Page"))
@@ -262,10 +263,10 @@ class StatusPageRoutesTest {
                 installAuth()
                 routing { statusPageRoutes() }
             }
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             val slug = "new-page-${System.nanoTime()}"
             val response = client.post("/v1/status-pages") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"My Page","slug":"$slug"}""")
             }
@@ -284,7 +285,7 @@ class StatusPageRoutesTest {
             seedStatusPageTier(orgId, statusPagesEnabled = false, customDomainsEnabled = true)
 
             val response = client.post("/v1/status-pages") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"My Page","slug":"disabled-page"}""")
             }
@@ -300,9 +301,9 @@ class StatusPageRoutesTest {
                 installAuth()
                 routing { statusPageRoutes() }
             }
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             val response = client.post("/v1/status-pages") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"Bad","slug":"INVALID SLUG!"}""")
             }
@@ -347,9 +348,9 @@ class StatusPageRoutesTest {
                 installAuth()
                 routing { statusPageRoutes() }
             }
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             val response = client.get("/v1/status-pages/${UUID.randomUUID()}") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -364,7 +365,7 @@ class StatusPageRoutesTest {
             val (userId, orgId) = seedUserAndOrg()
             val pageId = seedStatusPage(orgId)
             val response = client.get("/v1/status-pages/$pageId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("Test Page"))
@@ -411,9 +412,9 @@ class StatusPageRoutesTest {
                 installAuth()
                 routing { statusPageRoutes() }
             }
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             val response = client.put("/v1/status-pages/${UUID.randomUUID()}") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"Updated"}""")
             }
@@ -430,7 +431,7 @@ class StatusPageRoutesTest {
             val (userId, orgId) = seedUserAndOrg()
             val pageId = seedStatusPage(orgId)
             val response = client.put("/v1/status-pages/$pageId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"Updated Name"}""")
             }
@@ -475,9 +476,9 @@ class StatusPageRoutesTest {
                 installAuth()
                 routing { statusPageRoutes() }
             }
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             val response = client.delete("/v1/status-pages/${UUID.randomUUID()}") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -492,7 +493,7 @@ class StatusPageRoutesTest {
             val (userId, orgId) = seedUserAndOrg()
             val pageId = seedStatusPage(orgId)
             val response = client.delete("/v1/status-pages/$pageId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NoContent, response.status)
         }
@@ -601,7 +602,7 @@ class StatusPageRoutesTest {
             val (userId, orgId) = seedUserAndOrg()
             val pageId = seedStatusPage(orgId)
             val response = client.post("/v1/status-pages/$pageId/incidents") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"Site down","status":"investigating","message":"We are looking into it"}""")
             }
@@ -655,7 +656,7 @@ class StatusPageRoutesTest {
 
             // First create an incident
             val createResp = client.post("/v1/status-pages/$pageId/incidents") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"Original","status":"investigating","message":"Looking into it"}""")
             }
@@ -664,7 +665,7 @@ class StatusPageRoutesTest {
                 .jsonObject["id"]!!.jsonPrimitive.content
 
             val response = client.put("/v1/status-pages/$pageId/incidents/$incidentId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"Updated"}""")
             }
@@ -684,7 +685,7 @@ class StatusPageRoutesTest {
             val incidentId = UUID.randomUUID()
 
             val response = client.put("/v1/status-pages/$pageId/incidents/$incidentId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"x"}""")
             }
@@ -705,7 +706,7 @@ class StatusPageRoutesTest {
 
             // Create incident first
             val createResp = client.post("/v1/status-pages/$pageId/incidents") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"title":"Outage","status":"investigating","message":"Investigating"}""")
             }
@@ -714,7 +715,7 @@ class StatusPageRoutesTest {
                 .jsonObject["id"]!!.jsonPrimitive.content
 
             val response = client.post("/v1/status-pages/$pageId/incidents/$incidentId/updates") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"status":"identified","message":"Root cause identified"}""")
             }
@@ -751,7 +752,7 @@ class StatusPageRoutesTest {
             val pageId = seedStatusPage(orgId)
 
             val response = client.post("/v1/status-pages/$pageId/domains") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"domain":"status.example.com"}""")
             }
@@ -771,7 +772,7 @@ class StatusPageRoutesTest {
             val pageId = seedStatusPage(orgId)
 
             val response = client.post("/v1/status-pages/$pageId/domains") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"domain":"status.example.com"}""")
             }
@@ -808,7 +809,7 @@ class StatusPageRoutesTest {
 
             // Add domain first
             val addResp = client.post("/v1/status-pages/$pageId/domains") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"domain":"status2.example.com"}""")
             }
@@ -817,7 +818,7 @@ class StatusPageRoutesTest {
                 .jsonObject["id"]!!.jsonPrimitive.content.toInt()
 
             val response = client.delete("/v1/status-pages/$pageId/domains/$domainId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NoContent, response.status)
         }
@@ -849,7 +850,7 @@ class StatusPageRoutesTest {
             val pageId = seedStatusPage(orgId)
 
             val response = client.get("/v1/status-pages/$pageId/incidents") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }

--- a/backend/src/test/kotlin/com/moneat/routes/SyntheticsRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/SyntheticsRoutesExtendedTest.kt
@@ -107,8 +107,8 @@ class SyntheticsRoutesExtendedTest {
         routing { syntheticsRoutes() }
     }
 
-    private fun token(userId: Int): String =
-        RouteTestSupport.createToken(userId)
+    private fun token(userId: Int, orgId: Int? = null): String =
+        RouteTestSupport.createToken(userId, orgId)
 
     private fun seedUser(): Int = transaction {
         Users.insert {
@@ -346,10 +346,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `GET test by invalid UUID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.get("/v1/synthetics/tests/not-a-uuid") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -357,10 +357,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `PUT test by invalid UUID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.put("/v1/synthetics/tests/bad-id") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"updated"}""")
             }
@@ -370,10 +370,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `DELETE test by invalid UUID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.delete("/v1/synthetics/tests/bad-id") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -381,10 +381,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `POST run test by invalid UUID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.post("/v1/synthetics/tests/bad-id/run") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -392,10 +392,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `GET test results by invalid UUID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.get("/v1/synthetics/tests/bad-id/results") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -403,10 +403,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `GET test summary by invalid UUID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.get("/v1/synthetics/tests/bad-id/summary") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -414,10 +414,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `PUT variable by invalid ID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.put("$SYNTHETICS_VARIABLES_PATH/abc") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(BODY_NAME_VAR_VALUE)
             }
@@ -427,10 +427,10 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `DELETE variable by invalid ID returns 400`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             application { installTestApp() }
             val r = client.delete("$SYNTHETICS_VARIABLES_PATH/abc") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.BadRequest, r.status)
         }
@@ -446,7 +446,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.get(SYNTHETICS_TESTS_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains(MY_API_TEST))
@@ -462,7 +462,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.get("/v1/synthetics/tests/$TEST_UUID") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains(MY_API_TEST))
@@ -476,7 +476,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.get("/v1/synthetics/tests/$TEST_UUID") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -491,7 +491,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.post(SYNTHETICS_TESTS_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(
                     """{"name":"$MY_API_TEST","testType":"api",""" +
@@ -512,7 +512,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.post(SYNTHETICS_TESTS_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"test","url":"https://example.com"}""")
             }
@@ -532,7 +532,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.put("/v1/synthetics/tests/$TEST_UUID") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"Updated Test"}""")
             }
@@ -552,7 +552,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.put("/v1/synthetics/tests/$TEST_UUID") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"Updated Test"}""")
             }
@@ -569,7 +569,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.delete("/v1/synthetics/tests/$TEST_UUID") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains("true"))
@@ -585,7 +585,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.delete("/v1/synthetics/tests/$TEST_UUID") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -602,7 +602,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.post("/v1/synthetics/tests/$TEST_UUID/run") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.Accepted, r.status)
         }
@@ -617,7 +617,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.post("/v1/synthetics/tests/$TEST_UUID/run") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -627,7 +627,7 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `GET test summary returns 200`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             coEvery {
                 mockService.getTestSummary(TEST_UUID, any())
             } returns SyntheticTestSummary(
@@ -641,7 +641,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.get("/v1/synthetics/tests/$TEST_UUID/summary") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains("99.5"))
@@ -650,14 +650,14 @@ class SyntheticsRoutesExtendedTest {
     @Test
     fun `GET test summary returns 404 when no data`() =
         testApplication {
-            val (userId, _) = seedUserAndOrg()
+            val (userId, orgId) = seedUserAndOrg()
             coEvery {
                 mockService.getTestSummary(TEST_UUID, any())
             } returns null
             application { installTestApp() }
 
             val r = client.get("/v1/synthetics/tests/$TEST_UUID/summary") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }
@@ -673,7 +673,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.get(SYNTHETICS_VARIABLES_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains("API_KEY"))
@@ -691,7 +691,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.post(SYNTHETICS_VARIABLES_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(
                     """{"name":"API_KEY","value":"test-key-123"}"""
@@ -714,7 +714,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.put(SYNTHETICS_VARIABLES_1_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(
                     """{"name":"API_KEY","value":"updated-key"}"""
@@ -736,7 +736,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.put("$SYNTHETICS_VARIABLES_PATH/99") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
                 contentType(ContentType.Application.Json)
                 setBody(BODY_NAME_VAR_VALUE)
             }
@@ -753,7 +753,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.delete(SYNTHETICS_VARIABLES_1_PATH) {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.OK, r.status)
             assertTrue(r.bodyAsText().contains("true"))
@@ -769,7 +769,7 @@ class SyntheticsRoutesExtendedTest {
             application { installTestApp() }
 
             val r = client.delete("$SYNTHETICS_VARIABLES_PATH/99") {
-                withAuth(token(userId))
+                withAuth(token(userId, orgId))
             }
             assertEquals(HttpStatusCode.NotFound, r.status)
         }

--- a/backend/src/test/kotlin/com/moneat/routes/UptimeRoutesMockTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/UptimeRoutesMockTest.kt
@@ -92,9 +92,11 @@ class UptimeRoutesMockTest {
         }
     }
 
-    private fun token(userId: Int): String =
+    private fun token(userId: Int, orgId: Int? = null): String =
         JWT.create().withIssuer("moneat").withAudience("moneat-users")
-            .withClaim("userId", userId).sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
+            .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
+            .sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
 
     private fun seedUser(): Int =
         transaction {
@@ -160,7 +162,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.get("/v1/uptime/monitors") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("test-monitor"))
@@ -184,7 +186,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.post("/v1/uptime/monitors") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody(
                     """{"name":"test-monitor","type":"http","url":"https://example.com",""" +
@@ -214,7 +216,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.get("/v1/uptime/monitors/$monitorId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue(response.bodyAsText().contains("test-monitor"))
@@ -236,7 +238,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.get("/v1/uptime/monitors/$monitorId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -260,7 +262,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.put("/v1/uptime/monitors/$monitorId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"updated-monitor"}""")
             }
@@ -283,7 +285,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.put("/v1/uptime/monitors/$monitorId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"name":"updated-monitor"}""")
             }
@@ -308,7 +310,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.delete("/v1/uptime/monitors/$monitorId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }
@@ -329,7 +331,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.delete("/v1/uptime/monitors/$monitorId") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -352,7 +354,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.post("/v1/uptime/monitors/$monitorId/pause") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }
@@ -375,7 +377,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.post("/v1/uptime/monitors/$monitorId/resume") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }
@@ -400,7 +402,7 @@ class UptimeRoutesMockTest {
             }
 
             val response = client.get("/v1/uptime/monitors/$monitorId/heartbeats") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
             }
             assertEquals(HttpStatusCode.OK, response.status)
         }

--- a/backend/src/test/kotlin/com/moneat/routes/UptimeRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/UptimeRoutesTest.kt
@@ -96,12 +96,13 @@ class UptimeRoutesTest {
         }
     }
 
-    private fun token(userId: Int): String =
+    private fun token(userId: Int, orgId: Int? = null): String =
         JWT
             .create()
             .withIssuer("moneat")
             .withAudience("moneat-users")
             .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
             .sign(Algorithm.HMAC256("test-secret"))
 
     private fun seedUser(): Int =
@@ -211,10 +212,10 @@ class UptimeRoutesTest {
             assertEquals("down", status)
         }
 
-    // ──── Authenticated endpoints: no org membership → 403 ────
+    // ──── Authenticated endpoints: no current org claim -> 401 ────
 
     @Test
-    fun `list monitors returns 403 when user has no organization`() =
+    fun `list monitors returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -227,11 +228,11 @@ class UptimeRoutesTest {
                 client.get("/v1/uptime/monitors") {
                     header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
-    fun `create monitor returns 403 when user has no organization`() =
+    fun `create monitor returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -249,11 +250,11 @@ class UptimeRoutesTest {
                             """"intervalSeconds":60,"timeoutSeconds":30}"""
                     )
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
-    fun `get monitor returns 403 when user has no organization`() =
+    fun `get monitor returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -266,11 +267,11 @@ class UptimeRoutesTest {
                 client.get("/v1/uptime/monitors/${UUID.randomUUID()}") {
                     header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
-    fun `update monitor returns 403 when user has no organization`() =
+    fun `update monitor returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -285,11 +286,11 @@ class UptimeRoutesTest {
                     contentType(ContentType.Application.Json)
                     setBody("""{"name":"updated"}""")
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
-    fun `delete monitor returns 403 when user has no organization`() =
+    fun `delete monitor returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -302,11 +303,11 @@ class UptimeRoutesTest {
                 client.delete("/v1/uptime/monitors/${UUID.randomUUID()}") {
                     header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
-    fun `pause monitor returns 403 when user has no organization`() =
+    fun `pause monitor returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -319,11 +320,11 @@ class UptimeRoutesTest {
                 client.post("/v1/uptime/monitors/${UUID.randomUUID()}/pause") {
                     header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
-    fun `resume monitor returns 403 when user has no organization`() =
+    fun `resume monitor returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -336,11 +337,11 @@ class UptimeRoutesTest {
                 client.post("/v1/uptime/monitors/${UUID.randomUUID()}/resume") {
                     header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     @Test
-    fun `heartbeats returns 403 when user has no organization`() =
+    fun `heartbeats returns 401 without current org`() =
         testApplication {
             application {
                 install(ContentNegotiation) { json() }
@@ -353,7 +354,7 @@ class UptimeRoutesTest {
                 client.get("/v1/uptime/monitors/${UUID.randomUUID()}/heartbeats") {
                     header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
                 }
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
 
     // ──── Authenticated endpoints: invalid UUID → 400 ────
@@ -368,10 +369,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.get("/v1/uptime/monitors/not-a-uuid") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -386,10 +387,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.put("/v1/uptime/monitors/not-a-uuid") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"name":"updated"}""")
                 }
@@ -406,10 +407,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.delete("/v1/uptime/monitors/not-a-uuid") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -424,10 +425,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors/not-a-uuid/pause") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -442,10 +443,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors/not-a-uuid/resume") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -460,10 +461,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.get("/v1/uptime/monitors/not-a-uuid/heartbeats") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.BadRequest, response.status)
         }
@@ -480,10 +481,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody(
                         """{"name":"","type":"http","url":"https://example.com",""" +
@@ -504,10 +505,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"name":"my-monitor","type":"http","intervalSeconds":60,"timeoutSeconds":30}""")
                 }
@@ -525,10 +526,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody(
                         """{"name":"my-monitor","type":"websocket","url":"not a valid url ::::",""" +
@@ -549,10 +550,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody(
                         """{"name":"my-monitor","type":"tcp","port":443,"intervalSeconds":60,"timeoutSeconds":30}"""
@@ -572,11 +573,11 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             withSelfHosted("false") {
                 val response =
                     client.post("/v1/uptime/monitors") {
-                        header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                        header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                         contentType(ContentType.Application.Json)
                         setBody(
                             """{"name":"my-monitor","type":"tcp","hostname":"127.0.0.1","port":443,""" +
@@ -598,10 +599,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.put("/v1/uptime/monitors/${UUID.randomUUID()}") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"url":"wss://93.184.216.34/socket"}""")
                 }
@@ -618,10 +619,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody(
                         """{"name":"my-monitor","type":"http","url":"https://example.com",""" +
@@ -642,10 +643,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.post("/v1/uptime/monitors") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                     contentType(ContentType.Application.Json)
                     setBody("""{"name":"my-monitor","type":"unknown-type","intervalSeconds":60,"timeoutSeconds":30}""")
                 }
@@ -665,10 +666,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.get("/v1/uptime/monitors/${UUID.randomUUID()}") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -683,10 +684,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.delete("/v1/uptime/monitors/${UUID.randomUUID()}") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.NotFound, response.status)
         }
@@ -701,10 +702,10 @@ class UptimeRoutesTest {
             }
 
             val userId = seedUser()
-            seedOrgWithMembership(userId)
+            val orgId = seedOrgWithMembership(userId)
             val response =
                 client.get("/v1/uptime/monitors") {
-                    header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                    header(HttpHeaders.Authorization, "Bearer ${token(userId, orgId)}")
                 }
             assertEquals(HttpStatusCode.OK, response.status)
         }

--- a/backend/src/test/kotlin/com/moneat/services/AuthTokenServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/AuthTokenServiceTest.kt
@@ -68,6 +68,26 @@ class AuthTokenServiceTest {
             orgId
         }
 
+    private fun generateToken(
+        userId: Int,
+        name: String,
+        scopes: List<String>,
+    ) = service.generateToken(
+        userId = userId,
+        orgId = orgIdForToken(userId),
+        name = name,
+        scopes = scopes
+    )
+
+    private fun orgIdForToken(userId: Int): Int =
+        transaction {
+            Memberships
+                .selectAll()
+                .where { Memberships.user_id eq userId }
+                .firstOrNull()
+                ?.get(Memberships.organization_id)
+        } ?: seedOrgAndMembership(userId)
+
     // ──── hasScope ────
 
     @Test
@@ -104,7 +124,7 @@ class AuthTokenServiceTest {
         val userId = seedUser()
         seedOrgAndMembership(userId)
 
-        val result = service.generateToken(userId, "my-token", listOf("project:read"))
+        val result = generateToken(userId, "my-token", listOf("project:read"))
         assertNotNull(result.token)
         assertTrue(result.token!!.startsWith("sntrys_"))
         assertEquals("my-token", result.name)
@@ -115,7 +135,7 @@ class AuthTokenServiceTest {
     fun `generateToken rejects invalid scopes`() {
         val userId = seedUser()
         assertFailsWith<IllegalArgumentException> {
-            service.generateToken(userId, "my-token", listOf("invalid:scope"))
+            generateToken(userId, "my-token", listOf("invalid:scope"))
         }
     }
 
@@ -123,7 +143,7 @@ class AuthTokenServiceTest {
     fun `generateToken rejects blank name`() {
         val userId = seedUser()
         assertFailsWith<IllegalArgumentException> {
-            service.generateToken(userId, "", listOf("project:read"))
+            generateToken(userId, "", listOf("project:read"))
         }
     }
 
@@ -133,7 +153,7 @@ class AuthTokenServiceTest {
     fun `validateToken returns user info for valid token`() {
         val userId = seedUser()
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "test", listOf("project:read"))
+        val created = generateToken(userId, "test", listOf("project:read"))
 
         val result = service.validateToken(created.token!!)
         assertNotNull(result)
@@ -155,7 +175,7 @@ class AuthTokenServiceTest {
     fun `validateToken updates last_used_at`() {
         val userId = seedUser()
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "test", listOf("project:read"))
+        val created = generateToken(userId, "test", listOf("project:read"))
 
         service.validateToken(created.token!!)
 
@@ -175,8 +195,8 @@ class AuthTokenServiceTest {
     fun `listUserTokens returns all user tokens`() {
         val userId = seedUser()
         seedOrgAndMembership(userId)
-        service.generateToken(userId, "token-1", listOf("project:read"))
-        service.generateToken(userId, "token-2", listOf("org:read"))
+        generateToken(userId, "token-1", listOf("project:read"))
+        generateToken(userId, "token-2", listOf("org:read"))
 
         val tokens = service.listUserTokens(userId)
         assertEquals(2, tokens.size)
@@ -195,7 +215,7 @@ class AuthTokenServiceTest {
     fun `revokeToken deletes the token`() {
         val userId = seedUser()
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "to-revoke", listOf("project:read"))
+        val created = generateToken(userId, "to-revoke", listOf("project:read"))
 
         assertTrue(service.revokeToken(userId, created.id))
         assertTrue(service.listUserTokens(userId).isEmpty())
@@ -206,7 +226,7 @@ class AuthTokenServiceTest {
         val userId = seedUser("user1@test.com")
         val otherUser = seedUser("user2@test.com")
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "token", listOf("project:read"))
+        val created = generateToken(userId, "token", listOf("project:read"))
 
         assertFalse(service.revokeToken(otherUser, created.id))
     }
@@ -223,7 +243,7 @@ class AuthTokenServiceTest {
     fun `updateToken updates name`() {
         val userId = seedUser()
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "old-name", listOf("project:read"))
+        val created = generateToken(userId, "old-name", listOf("project:read"))
 
         assertTrue(service.updateToken(userId, created.id, "new-name", null))
         val tokens = service.listUserTokens(userId)
@@ -234,7 +254,7 @@ class AuthTokenServiceTest {
     fun `updateToken updates scopes`() {
         val userId = seedUser()
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "token", listOf("project:read"))
+        val created = generateToken(userId, "token", listOf("project:read"))
 
         assertTrue(service.updateToken(userId, created.id, null, listOf("project:read", "org:read")))
         val tokens = service.listUserTokens(userId)
@@ -245,7 +265,7 @@ class AuthTokenServiceTest {
     fun `updateToken rejects invalid scopes`() {
         val userId = seedUser()
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "token", listOf("project:read"))
+        val created = generateToken(userId, "token", listOf("project:read"))
 
         assertFailsWith<IllegalArgumentException> {
             service.updateToken(userId, created.id, null, listOf("bad:scope"))
@@ -257,7 +277,7 @@ class AuthTokenServiceTest {
         val userId = seedUser("user1@test.com")
         val otherUser = seedUser("user2@test.com")
         seedOrgAndMembership(userId)
-        val created = service.generateToken(userId, "token", listOf("project:read"))
+        val created = generateToken(userId, "token", listOf("project:read"))
 
         assertFalse(service.updateToken(otherUser, created.id, "renamed", null))
     }

--- a/backend/src/test/kotlin/com/moneat/services/DashboardServiceProjectTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/DashboardServiceProjectTest.kt
@@ -54,7 +54,6 @@ import kotlin.test.assertTrue
  *
  * H2 setup is retained for tests exercising internal services that bypass the repository:
  *  - AccessService.hasProjectAccess queries Projects/Memberships directly.
- *  - PricingTierService.getPrimaryOrganizationIdForUser queries Memberships directly.
  * All project-level operations (create/update/delete/list) go through the mocked ProjectRepository.
  */
 class DashboardServiceProjectTest {
@@ -167,13 +166,13 @@ class DashboardServiceProjectTest {
     }
 
     // ──── createProject ────
-    // PricingTierService.getPrimaryOrganizationIdForUser queries Memberships directly.
-    // H2 seed data is required for org/membership setup; all repo calls are mocked.
+    // The caller supplies orgId from JWT; all repo calls are mocked.
 
     @Test
     fun `createProject creates project with generated slug and DSN`() = runBlocking {
         val userId = seedUser()
-        seedMembership(userId, seedOrg())
+        val orgId = seedOrg()
+        seedMembership(userId, orgId)
 
         every { mockProjectRepo.getProjectCountForOrganization(any()) } returns 0
         every { mockProjectRepo.findProjectByNameOrSlug(any(), PROJECT_NAME, PROJECT_SLUG) } returns null
@@ -188,7 +187,7 @@ class DashboardServiceProjectTest {
         coEvery { mockProjectRepo.getIssueCountForProject(42L, any(), null) } returns 0L
 
         val result = makeDashboardService().createProject(
-            userId,
+            orgId,
             CreateProjectRequest(name = PROJECT_NAME, framework = "kotlin")
         )
 
@@ -200,24 +199,17 @@ class DashboardServiceProjectTest {
     }
 
     @Test
-    fun `createProject throws when user has no organization`() = runBlocking {
-        val ex = assertFailsWith<IllegalStateException> {
-            makeDashboardService().createProject(999, CreateProjectRequest(name = "No Org Project"))
-        }
-        assertTrue(ex.message?.contains("no organization") == true)
-    }
-
-    @Test
     fun `createProject throws when project with same name already exists`() = runBlocking {
         val userId = seedUser()
-        seedMembership(userId, seedOrg())
+        val orgId = seedOrg()
+        seedMembership(userId, orgId)
 
         every { mockProjectRepo.getProjectCountForOrganization(any()) } returns 0
         every { mockProjectRepo.findProjectByNameOrSlug(any(), "Duplicate", "duplicate") } returns
             ProjectRow(1L, "Duplicate", "duplicate", null, emptyList(), "")
 
         val ex = assertFailsWith<IllegalStateException> {
-            makeDashboardService().createProject(userId, CreateProjectRequest(name = "Duplicate"))
+            makeDashboardService().createProject(orgId, CreateProjectRequest(name = "Duplicate"))
         }
         assertTrue(ex.message?.contains("already exists") == true)
     }
@@ -225,7 +217,8 @@ class DashboardServiceProjectTest {
     @Test
     fun `createProject with multiple targets creates multiple keys`() = runBlocking {
         val userId = seedUser()
-        seedMembership(userId, seedOrg())
+        val orgId = seedOrg()
+        seedMembership(userId, orgId)
 
         every { mockProjectRepo.getProjectCountForOrganization(any()) } returns 0
         every { mockProjectRepo.findProjectByNameOrSlug(any(), MULTI_TARGET_NAME, MULTI_TARGET_SLUG) } returns null
@@ -243,7 +236,7 @@ class DashboardServiceProjectTest {
         coEvery { mockProjectRepo.getIssueCountForProject(100L, any(), null) } returns 0L
 
         val result = makeDashboardService().createProject(
-            userId,
+            orgId,
             CreateProjectRequest(name = MULTI_TARGET_NAME, targets = listOf("android", "ios"))
         )
 
@@ -256,7 +249,8 @@ class DashboardServiceProjectTest {
     @Test
     fun `createProject with no targets creates single key`() = runBlocking {
         val userId = seedUser()
-        seedMembership(userId, seedOrg())
+        val orgId = seedOrg()
+        seedMembership(userId, orgId)
 
         every { mockProjectRepo.getProjectCountForOrganization(any()) } returns 0
         every { mockProjectRepo.findProjectByNameOrSlug(any(), SINGLE_KEY_NAME, SINGLE_KEY_SLUG) } returns null
@@ -270,7 +264,10 @@ class DashboardServiceProjectTest {
         )
         coEvery { mockProjectRepo.getIssueCountForProject(200L, any(), null) } returns 0L
 
-        val result = makeDashboardService().createProject(userId, CreateProjectRequest(name = SINGLE_KEY_NAME))
+        val result = makeDashboardService().createProject(
+            orgId,
+            CreateProjectRequest(name = SINGLE_KEY_NAME)
+        )
 
         assertEquals(1, result.keys.size)
         assertNull(result.keys.first().platformTarget)
@@ -279,7 +276,8 @@ class DashboardServiceProjectTest {
     @Test
     fun `createProject normalizes special characters in slug`() = runBlocking {
         val userId = seedUser()
-        seedMembership(userId, seedOrg())
+        val orgId = seedOrg()
+        seedMembership(userId, orgId)
 
         every { mockProjectRepo.getProjectCountForOrganization(any()) } returns 0
         every { mockProjectRepo.findProjectByNameOrSlug(any(), SPECIAL_CHARS_NAME, SPECIAL_CHARS_SLUG) } returns null
@@ -293,7 +291,10 @@ class DashboardServiceProjectTest {
         )
         coEvery { mockProjectRepo.getIssueCountForProject(300L, any(), null) } returns 0L
 
-        val result = makeDashboardService().createProject(userId, CreateProjectRequest(name = SPECIAL_CHARS_NAME))
+        val result = makeDashboardService().createProject(
+            orgId,
+            CreateProjectRequest(name = SPECIAL_CHARS_NAME)
+        )
         assertEquals(SPECIAL_CHARS_SLUG, result.slug)
     }
 
@@ -366,13 +367,12 @@ class DashboardServiceProjectTest {
 
     @Test
     fun `getProjects returns projects with issue counts`() = runBlocking {
-        every { mockProjectRepo.getOrganizationIdsForUser(1) } returns listOf(10)
         every { mockProjectRepo.getProjectsForOrganizations(listOf(10)) } returns listOf(
             ProjectRow(1L, PROJECT_NAME, PROJECT_SLUG, null, emptyList(), "http://k@host/1")
         )
         coEvery { mockProjectRepo.getIssueCountForProject(1L, any(), null) } returns 42L
 
-        val projects = makeDashboardService().getProjects(1)
+        val projects = makeDashboardService().getProjects(10)
 
         assertEquals(1, projects.size)
         assertEquals(PROJECT_NAME, projects.first().name)
@@ -380,20 +380,19 @@ class DashboardServiceProjectTest {
     }
 
     @Test
-    fun `getProjects returns empty list when user has no orgs`() = runBlocking {
-        every { mockProjectRepo.getOrganizationIdsForUser(1) } returns emptyList()
-        assertTrue(makeDashboardService().getProjects(1).isEmpty())
+    fun `getProjects returns empty list when current org has no projects`() = runBlocking {
+        every { mockProjectRepo.getProjectsForOrganizations(listOf(10)) } returns emptyList()
+        assertTrue(makeDashboardService().getProjects(10).isEmpty())
     }
 
     @Test
-    fun `getProjects returns only projects for user org`() = runBlocking {
-        every { mockProjectRepo.getOrganizationIdsForUser(1) } returns listOf(10)
+    fun `getProjects returns only projects for current org`() = runBlocking {
         every { mockProjectRepo.getProjectsForOrganizations(listOf(10)) } returns listOf(
             ProjectRow(1L, "Org1 Project", "org1-project", null, emptyList(), "")
         )
         coEvery { mockProjectRepo.getIssueCountForProject(any(), any(), null) } returns 0L
 
-        val projects = makeDashboardService().getProjects(1)
+        val projects = makeDashboardService().getProjects(10)
         assertEquals(1, projects.size)
         assertEquals("Org1 Project", projects.first().name)
     }

--- a/backend/src/test/kotlin/com/moneat/services/ProjectServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ProjectServiceTest.kt
@@ -42,12 +42,11 @@ class ProjectServiceTest {
             serviceName = "checkout-api"
         )
 
-        every { projectRepository.getOrganizationIdsForUser(1) } returns listOf(7)
         every { projectRepository.getProjectsForOrganizations(listOf(7)) } returns listOf(row)
         coEvery { queryHelper.getProjectRetentionDays(42L) } returns 30
         coEvery { projectRepository.getIssueCountForProject(42L, 30, 123L) } returns 4L
 
-        val projects = service.getProjects(userId = 1, demoEpochMs = 123L)
+        val projects = service.getProjects(orgId = 7, demoEpochMs = 123L)
 
         assertEquals(1, projects.size)
         assertEquals(99L, projects.single().serviceId)

--- a/backend/src/test/kotlin/com/moneat/services/StatusPageExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/StatusPageExtendedTest.kt
@@ -137,10 +137,11 @@ class StatusPageExtendedTest {
         }
     }
 
-    private fun token(userId: Int): String =
+    private fun token(userId: Int, orgId: Int? = null): String =
         JWT.create()
             .withIssuer("moneat").withAudience("moneat-users")
             .withClaim("userId", userId)
+            .apply { if (orgId != null) withClaim("orgId", orgId) }
             .sign(Algorithm.HMAC256(RouteTestSupport.TEST_JWT_SECRET))
 
     private fun seedUser(): Int =
@@ -1001,7 +1002,7 @@ class StatusPageExtendedTest {
         val pageId = seedStatusPage(localOrgId)
 
         val response = client.post("/v1/status-pages/$pageId/domains/99999/verify") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
         }
         assertEquals(HttpStatusCode.NotFound, response.status)
     }
@@ -1027,7 +1028,7 @@ class StatusPageExtendedTest {
         )
 
         val response = client.delete("/v1/status-pages/$pageId/monitors/$monitorId") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
         }
         assertEquals(HttpStatusCode.NoContent, response.status)
     }
@@ -1042,7 +1043,7 @@ class StatusPageExtendedTest {
         val pageId = seedStatusPage(localOrgId)
 
         val response = client.delete("/v1/status-pages/$pageId/monitors/${UUID.randomUUID()}") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
         }
         assertEquals(HttpStatusCode.NotFound, response.status)
     }
@@ -1107,7 +1108,7 @@ class StatusPageExtendedTest {
         val pageId = seedStatusPage(localOrgId)
 
         val response = client.delete("/v1/status-pages/$pageId/domains/99999") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
         }
         assertEquals(HttpStatusCode.NotFound, response.status)
     }
@@ -1192,7 +1193,7 @@ class StatusPageExtendedTest {
 
         val response =
             client.post("/v1/status-pages/$pageId/incidents/${UUID.randomUUID()}/updates") {
-                header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+                header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
                 contentType(ContentType.Application.Json)
                 setBody("""{"status":"resolved","message":"done"}""")
             }
@@ -1212,7 +1213,7 @@ class StatusPageExtendedTest {
         val monitorId = seedMonitor(localOrgId)
 
         val response = client.post("/v1/status-pages/$pageId/monitors") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
             contentType(ContentType.Application.Json)
             setBody("""{"monitors":[{"monitorId":"$monitorId","displayName":"API"}]}""")
         }
@@ -1233,13 +1234,13 @@ class StatusPageExtendedTest {
 
         // Create an incident first
         client.post("/v1/status-pages/$pageId/incidents") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
             contentType(ContentType.Application.Json)
             setBody("""{"title":"Test Outage","status":"investigating","message":"m"}""")
         }
 
         val response = client.get("/v1/status-pages/$pageId/incidents") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
         }
         assertEquals(HttpStatusCode.OK, response.status)
         assertTrue(response.bodyAsText().contains("Test Outage"))
@@ -1257,7 +1258,7 @@ class StatusPageExtendedTest {
         val pageId = seedStatusPage(localOrgId)
 
         val response = client.put("/v1/status-pages/$pageId") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
             contentType(ContentType.Application.Json)
             setBody("""{"slug":"INVALID SLUG!"}""")
         }
@@ -1276,7 +1277,7 @@ class StatusPageExtendedTest {
         val pageId = seedStatusPage(localOrgId)
 
         val response = client.post("/v1/status-pages/$pageId/domains") {
-            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            header(HttpHeaders.Authorization, "Bearer ${token(userId, localOrgId)}")
             contentType(ContentType.Application.Json)
             setBody("""{"domain":"-bad-domain"}""")
         }

--- a/backend/src/test/kotlin/com/moneat/testsupport/RouteTestSupport.kt
+++ b/backend/src/test/kotlin/com/moneat/testsupport/RouteTestSupport.kt
@@ -86,7 +86,7 @@ object RouteTestSupport {
      */
     fun createToken(
         userId: Int,
-        orgId: Int? = null,
+        orgId: Int? = 1,
         email: String = "user$userId@test.com"
     ): String = createToken(TEST_JWT_SECRET, userId, orgId, email)
 
@@ -96,7 +96,7 @@ object RouteTestSupport {
     fun createToken(
         secret: String,
         userId: Int,
-        orgId: Int? = null,
+        orgId: Int? = 1,
         email: String = "user$userId@test.com"
     ): String {
         return JWT.create()

--- a/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowGovernanceRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowGovernanceRoutesTest.kt
@@ -125,7 +125,7 @@ class WorkflowGovernanceRoutesTest {
 
             val unauthenticated = client.get("/v1/workflows/blueprints")
             val noOrg = client.get("/v1/workflows/blueprints") {
-                withAuth(RouteTestSupport.createToken(userId = userId))
+                withAuth(RouteTestSupport.createToken(userId = userId, orgId = null))
             }
             val list = client.get("/v1/workflows/blueprints") { withAuth(token()) }
             val detail = client.get("/v1/workflows/blueprints/${sample.key}") { withAuth(token()) }
@@ -187,7 +187,7 @@ class WorkflowGovernanceRoutesTest {
             every { governanceService.usage(organizationId, any()) } returns usageResponse()
 
             val noOrg = client.get("/v1/workflows/overview") {
-                withAuth(RouteTestSupport.createToken(userId = userId))
+                withAuth(RouteTestSupport.createToken(userId = userId, orgId = null))
             }
             val overview = client.get("/v1/workflows/overview") { withAuth(token()) }
             val usage = client.get("/v1/workflows/usage") { withAuth(token()) }

--- a/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/routes/WorkflowRoutesTest.kt
@@ -148,7 +148,7 @@ class WorkflowRoutesTest {
             setupApp()
 
             val response = client.get("/v1/workflows") {
-                withAuth(RouteTestSupport.createToken(userId = userId + 100))
+                withAuth(RouteTestSupport.createToken(userId = userId + 100, orgId = null))
             }
 
             assertEquals(HttpStatusCode.Forbidden, response.status)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/routes/AiAssistantRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/routes/AiAssistantRoutes.kt
@@ -4,20 +4,18 @@
 
 package com.moneat.enterprise.ai.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.enterprise.ai.models.AiAssistantConfirmRequest
 import com.moneat.enterprise.ai.models.AiAssistantStreamRequest
 import com.moneat.enterprise.ai.models.AssistantDoneEvent
 import com.moneat.enterprise.ai.models.AssistantErrorEvent
 import com.moneat.enterprise.ai.services.AiAssistantService
-import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Users
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondTextWriter
@@ -35,16 +33,16 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 private val logger = KotlinLogging.logger {}
 private val json = Json {
-    ignoreUnknownKeys = true
-    encodeDefaults = true
-}
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
 
 fun Route.aiAssistantRoutes(service: AiAssistantService) {
     authenticate("auth-jwt") {
         route("/v1/ai/assistant") {
             post("/stream") {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal!!.payload.getClaim("userId").asInt()
+                val context = call.requireCurrentOrg() ?: return@post
+                val userId = context.userId
 
                 val userDetails = getUserDetails(userId)
                 if (!userDetails.isAdmin) {
@@ -55,11 +53,7 @@ fun Route.aiAssistantRoutes(service: AiAssistantService) {
                     return@post
                 }
 
-                val orgId = getAssistantOrgId(userId)
-                if (orgId == null) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "No organization found"))
-                    return@post
-                }
+                val orgId = context.orgId
 
                 val request = call.receive<AiAssistantStreamRequest>()
                 if (request.message.isBlank()) {
@@ -103,8 +97,8 @@ fun Route.aiAssistantRoutes(service: AiAssistantService) {
             }
 
             post("/confirm") {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal!!.payload.getClaim("userId").asInt()
+                val context = call.requireCurrentOrg() ?: return@post
+                val userId = context.userId
 
                 if (!getUserDetails(userId).isAdmin) {
                     call.respond(
@@ -114,11 +108,7 @@ fun Route.aiAssistantRoutes(service: AiAssistantService) {
                     return@post
                 }
 
-                val orgId = getAssistantOrgId(userId)
-                if (orgId == null) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "No organization found"))
-                    return@post
-                }
+                val orgId = context.orgId
 
                 val request = call.receive<AiAssistantConfirmRequest>()
                 if (request.requestId.isBlank()) {
@@ -180,15 +170,5 @@ private fun getUserDetails(userId: Int): AssistantUserDetails {
             isAdmin = row?.get(Users.is_admin) ?: false,
             timezone = row?.get(Users.timezone),
         )
-    }
-}
-
-private fun getAssistantOrgId(userId: Int): Int? {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .firstOrNull()
-            ?.get(Memberships.organization_id)
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/routes/AiChatRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/routes/AiChatRoutes.kt
@@ -4,18 +4,16 @@
 
 package com.moneat.enterprise.ai.routes
 
+import com.moneat.auth.requireCurrentOrg
 import com.moneat.enterprise.ai.models.AiChatStreamRequest
 import com.moneat.enterprise.ai.models.AiConfirmRequest
 import com.moneat.enterprise.ai.models.SseError
 import com.moneat.enterprise.ai.services.EnterpriseAiChatService
-import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Users
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.jwt.JWTPrincipal
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondTextWriter
@@ -45,8 +43,8 @@ fun Route.aiEnterpriseRoutes(
              * Returns SSE stream with search progress and context_ready event.
              */
             post("/chat/stream") {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal!!.payload.getClaim("userId").asInt()
+                val context = call.requireCurrentOrg() ?: return@post
+                val userId = context.userId
 
                 if (!isAdmin(userId)) {
                     call.respond(
@@ -56,11 +54,7 @@ fun Route.aiEnterpriseRoutes(
                     return@post
                 }
 
-                val orgId = getOrgId(userId)
-                if (orgId == null) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "No organization found"))
-                    return@post
-                }
+                val orgId = context.orgId
 
                 val request = call.receive<AiChatStreamRequest>()
                 if (request.message.isBlank()) {
@@ -98,20 +92,14 @@ fun Route.aiEnterpriseRoutes(
              * Returns SSE stream with LLM response and cost info.
              */
             post("/chat/confirm") {
-                val principal = call.principal<JWTPrincipal>()
-                val userId = principal!!.payload.getClaim("userId").asInt()
+                val context = call.requireCurrentOrg() ?: return@post
+                val userId = context.userId
 
                 if (!isAdmin(userId)) {
                     call.respond(
                         HttpStatusCode.Forbidden,
                         mapOf("error" to "AI chat is only available for admin users")
                     )
-                    return@post
-                }
-
-                val orgId = getOrgId(userId)
-                if (orgId == null) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "No organization found"))
                     return@post
                 }
 
@@ -140,16 +128,6 @@ fun Route.aiEnterpriseRoutes(
                 }
             }
         }
-    }
-}
-
-private fun getOrgId(userId: Int): Int? {
-    return transaction {
-        Memberships
-            .selectAll()
-            .where { Memberships.user_id eq userId }
-            .firstOrNull()
-            ?.get(Memberships.organization_id)
     }
 }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/EscalationRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/EscalationRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.enterprise.oncall.services.EscalationPolicyService
 import com.moneat.utils.ErrorResponse
 import io.ktor.http.HttpStatusCode
@@ -57,7 +58,7 @@ fun Route.escalationRoutes() {
         authenticate("auth-jwt") {
             get {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
                     call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
@@ -70,7 +71,7 @@ fun Route.escalationRoutes() {
 
             post {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
                     call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
@@ -112,7 +113,7 @@ fun Route.escalationRoutes() {
 
             get("/{id}") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val policyId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {
@@ -135,7 +136,7 @@ fun Route.escalationRoutes() {
 
             put("/{id}") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val policyId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {
@@ -194,7 +195,7 @@ fun Route.escalationRoutes() {
 
             delete("/{id}") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val policyId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.alerts.models.IncidentSeverity
 import com.moneat.enterprise.oncall.services.OnCallAlertService
 import com.moneat.enterprise.oncall.services.OnCallIncidentService
@@ -116,7 +117,7 @@ private fun Route.registerDeclaredIncidentRoutes(
 }
 
 private suspend fun ApplicationCall.requireOrganizationId(): Int? {
-    val organizationId = principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    val organizationId = principal<JWTPrincipal>()?.currentOrgIdOrNull()
     if (organizationId == null) {
         respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
     }
@@ -125,7 +126,7 @@ private suspend fun ApplicationCall.requireOrganizationId(): Int? {
 
 private suspend fun ApplicationCall.requireUserContext(): OnCallUserContext? {
     val principal = principal<JWTPrincipal>()
-    val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+    val organizationId = principal?.currentOrgIdOrNull()
     val userId = principal?.payload?.getClaim("userId")?.asInt()
     if (organizationId == null || userId == null) {
         respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/NotificationPreferencesRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/NotificationPreferencesRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.enterprise.oncall.services.PushNotificationService
 import com.moneat.enterprise.oncall.services.TwilioService
 import com.moneat.enterprise.oncall.services.UserNotificationPreferencesService
@@ -245,7 +246,7 @@ fun Route.notificationPreferencesRoutes(
             put("/{category}") {
                 val principal = call.principal<JWTPrincipal>()
                 val userId = principal?.payload?.getClaim("userId")?.asInt()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val category = call.parameters["category"]
 
                 if (userId == null || organizationId == null) {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/OnCallRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/OnCallRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.enterprise.oncall.models.OnCallOverrides
 import com.moneat.enterprise.oncall.models.OnCallScheduleUsergroups
 import com.moneat.enterprise.oncall.services.OnCallScheduleService
@@ -122,7 +123,7 @@ fun Route.onCallRoutes(
         authenticate("auth-jwt") {
             get {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
                     call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
@@ -135,7 +136,7 @@ fun Route.onCallRoutes(
 
             post {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
 
                 if (organizationId == null) {
                     call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid token"))
@@ -167,7 +168,7 @@ fun Route.onCallRoutes(
 
             get("/{id}") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {
@@ -195,7 +196,7 @@ fun Route.onCallRoutes(
 
             put("/{id}") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {
@@ -243,7 +244,7 @@ fun Route.onCallRoutes(
 
             delete("/{id}") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {
@@ -271,7 +272,7 @@ fun Route.onCallRoutes(
 
             get("/{id}/current") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {
@@ -299,7 +300,7 @@ fun Route.onCallRoutes(
 
             get("/{id}/timeline") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
                 val startParam = call.request.queryParameters["start"]
                 val endParam = call.request.queryParameters["end"]
@@ -340,7 +341,7 @@ fun Route.onCallRoutes(
 
             post("/{id}/overrides") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val userId = principal?.payload?.getClaim("userId")?.asInt()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
 
@@ -402,7 +403,7 @@ fun Route.onCallRoutes(
         authenticate("auth-jwt") {
             delete("/{id}") {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val overrideId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {
@@ -435,7 +436,7 @@ fun Route.onCallRoutes(
         authenticate("auth-jwt") {
             put {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val userId = principal?.payload?.getClaim("userId")?.asInt()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
 
@@ -503,7 +504,7 @@ fun Route.onCallRoutes(
 
             delete {
                 val principal = call.principal<JWTPrincipal>()
-                val organizationId = principal?.payload?.getClaim("orgId")?.asInt()
+                val organizationId = principal?.currentOrgIdOrNull()
                 val scheduleId = call.parameters["id"]?.toIntOrNull()
 
                 if (organizationId == null) {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/PriorityRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/PriorityRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.enterprise.oncall.models.BusinessHoursWindow
 import com.moneat.enterprise.oncall.services.BusinessHoursService
 import com.moneat.enterprise.oncall.services.PriorityService
@@ -67,7 +68,7 @@ fun Route.priorityRoutes() {
 }
 
 private suspend fun ApplicationCall.requireOrganizationId(): Int? {
-    val organizationId = principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    val organizationId = principal<JWTPrincipal>()?.currentOrgIdOrNull()
     if (organizationId == null) {
         respond(HttpStatusCode.Unauthorized, ErrorResponse(INVALID_TOKEN_MESSAGE))
     }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/rbac/routes/RbacRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/rbac/routes/RbacRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.rbac.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.enterprise.rbac.models.AssignRoleRequest
 import com.moneat.enterprise.rbac.models.CreateRoleRequest
 import com.moneat.enterprise.rbac.models.UpdateRoleRequest
@@ -194,7 +195,7 @@ private suspend fun RoutingContext.requireRbacAdmin(member: RbacMember): Int? {
 }
 
 private fun RoutingContext.currentOrganizationId(): Int? =
-    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private fun RoutingContext.currentUserId(): Int? =
     call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/workflows/routes/ApprovalRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/workflows/routes/ApprovalRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.workflows.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.enterprise.workflows.models.RespondApprovalRequest
 import com.moneat.enterprise.workflows.services.WorkflowApprovalService
 import com.moneat.org.services.OrgRole
@@ -100,7 +101,7 @@ private suspend fun RoutingContext.requireApprovalAdmin(member: WorkflowApproval
 }
 
 private fun RoutingContext.currentOrganizationId(): Int? =
-    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private fun RoutingContext.currentUserId(): Int? =
     call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/workflows/routes/ConnectionRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/workflows/routes/ConnectionRoutes.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.workflows.routes
 
+import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.enterprise.workflows.models.ConnectionGroupResponse
 import com.moneat.enterprise.workflows.models.ConnectionResponse
 import com.moneat.enterprise.workflows.models.CreateConnectionGroupRequest
@@ -235,7 +236,7 @@ private suspend fun RoutingContext.requireConnectionAdmin(member: WorkflowConnec
 }
 
 private fun RoutingContext.currentOrganizationId(): Int? =
-    call.principal<JWTPrincipal>()?.payload?.getClaim("orgId")?.asInt()
+    call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
 
 private fun RoutingContext.currentUserId(): Int? =
     call.principal<JWTPrincipal>()?.payload?.getClaim("userId")?.asInt()


### PR DESCRIPTION
Routes now use the signed org context consistently. Token minting and cross-org flows keep membership validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized extraction of organization context from auth tokens across backend routes and services.
* **Bug Fixes**
  * Authenticated endpoints now consistently require an organization claim and return 401 when missing.
  * Token generation, project/dashboard, and billing flows now use explicit org context for scoping.
* **Tests**
  * Updated and added tests covering org-scoped authentication, authorization, and token behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->