### PR TITLE
feat: use dashboard template catalog in UI

### DIFF
--- a/dashboard/src/components/dashboards/DashboardsGetStarted.tsx
+++ b/dashboard/src/components/dashboards/DashboardsGetStarted.tsx
@@ -1,0 +1,688 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useId, useMemo, useRef, useState} from 'react'
+import {
+  ArrowRight,
+  FileJson,
+  LayoutTemplate,
+  SquarePlus,
+  type LucideIcon,
+} from 'lucide-react'
+import {Badge} from '@/components/ui/badge'
+import type {DashboardTemplateQuality, DashboardTemplateSummary} from '@/lib/api'
+import {cn} from '@/lib/utils'
+
+// First-run Dashboards experience: a template-gallery quickstart shown when no
+// dashboards exist yet. Three "start" tiles (blank / template / import) over a
+// filterable grid of starter dashboards, each previewed by a real mini-viz
+// thumbnail rendered on the dense dark viz canvas. Ports
+// /tmp/dashboards-empty-state-mockup.html onto the app's design tokens.
+
+type TemplateCategory =
+  | 'infrastructure'
+  | 'kubernetes'
+  | 'applications'
+  | 'databases'
+  | 'cloud'
+  | 'logs'
+type TemplateFilter = 'all' | TemplateCategory
+type ThumbKind = 'service' | 'host' | 'k8s' | 'db' | 'logs' | 'vitals'
+
+interface DashboardsGetStartedProps {
+  readonly templates: readonly DashboardTemplateSummary[]
+  readonly isLoadingTemplates?: boolean
+  readonly onCreateBlank: () => void
+  readonly onUseTemplate: (templateId: string) => void
+  readonly onImport: () => void
+}
+
+interface TemplateCardModel {
+  readonly template: DashboardTemplateSummary
+  readonly category: TemplateCategory | null
+  readonly thumb: ThumbKind
+}
+
+// The dark viz canvas is intentionally theme-independent (dense viz reads as a
+// field in either app theme — style guide), so these decorative thumbnail
+// colors are fixed values mirroring the guide's --viz-*/--scale-*/--level-*/
+// --heat-* tokens rather than theme-flipping CSS variables. Sparkline strokes
+// reuse the shared --chart-* tokens (identical across themes).
+const VIZ = {
+  panel: '#141922', // --viz-surface-2
+  border: 'rgba(255,255,255,0.09)', // hairline on the dark canvas (~ --viz-grid)
+  track: 'rgba(255,255,255,0.09)',
+  fg: '#d7e1ec', // --viz-fg
+  fgMuted: '#8a99a9', // --viz-fg-muted
+  good: '#18a07a', // --scale-good
+  warn: '#e0a100', // --scale-warn
+  bad: '#e5484d', // --scale-bad
+  levelInfo: '#7ba2ea', // --level-info
+  levelWarn: '#f0c150', // --level-warn
+  levelError: '#f2868a', // --level-error
+  heat: ['#0e1c2b', '#0d3b54', '#0e6f8f', '#19a7b0', '#6fc98a', '#e0c545', '#f27537'],
+} as const
+
+const FILTERS: ReadonlyArray<{key: TemplateFilter; label: string}> = [
+  {key: 'all', label: 'All'},
+  {key: 'infrastructure', label: 'Infrastructure'},
+  {key: 'kubernetes', label: 'Kubernetes'},
+  {key: 'applications', label: 'Applications'},
+  {key: 'databases', label: 'Databases'},
+  {key: 'cloud', label: 'Cloud'},
+  {key: 'logs', label: 'Logs'},
+]
+
+const QUALITY_LABELS: Record<DashboardTemplateQuality, string> = {
+  ready: 'Ready',
+  partial: 'Partial',
+  'needs-review': 'Review',
+}
+
+const QUALITY_VARIANTS: Record<DashboardTemplateQuality, 'success' | 'warning' | 'neutral'> = {
+  ready: 'success',
+  partial: 'warning',
+  'needs-review': 'neutral',
+}
+
+const SOURCE_BADGE_LIMIT = 2
+
+export function DashboardsGetStarted({
+  templates,
+  isLoadingTemplates = false,
+  onCreateBlank,
+  onUseTemplate,
+  onImport,
+}: DashboardsGetStartedProps) {
+  const [filter, setFilter] = useState<TemplateFilter>('all')
+  const galleryRef = useRef<HTMLElement>(null)
+
+  const scrollToGallery = () => {
+    galleryRef.current?.scrollIntoView?.({behavior: 'smooth', block: 'start'})
+  }
+
+  const galleryTemplates = useMemo(
+    () =>
+      templates.map((template) => ({
+        template,
+        category: normalizeCategory(template.category),
+        thumb: getTemplateThumb(template),
+      })),
+    [templates],
+  )
+
+  const visible = galleryTemplates.filter(
+    (t) => filter === 'all' || t.category === filter,
+  )
+
+  return (
+    <div className="mx-auto w-full max-w-[1200px]">
+      {/* Get started */}
+      <section>
+        <BlockHead
+          title="Get started"
+          hint="No dashboards yet — pick a starting point. Everything is editable after you create it."
+        />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <StartTile
+            primary
+            icon={SquarePlus}
+            title="Blank dashboard"
+            description="Start with an empty grid and drag in widgets."
+            onClick={onCreateBlank}
+          />
+          <StartTile
+            icon={LayoutTemplate}
+            title="Start from a template"
+            description="Prebuilt panel sets for common stacks — below."
+            onClick={scrollToGallery}
+          />
+          <StartTile
+            icon={FileJson}
+            title="Import JSON"
+            description="Bring a dashboard from a Grafana-compatible export."
+            onClick={onImport}
+          />
+        </div>
+      </section>
+
+      {/* Recommended templates */}
+      <section ref={galleryRef} className="mt-6 scroll-mt-4">
+        <BlockHead
+          title="Recommended templates"
+          hint="Curated, fully editable starting points."
+          tools={
+            <div
+              role="group"
+              aria-label="Filter templates by category"
+              className="inline-flex items-center gap-0.5 rounded-md border bg-muted/40 p-0.5"
+            >
+              {FILTERS.map((f) => {
+                const active = filter === f.key
+                return (
+                  <button
+                    key={f.key}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setFilter(f.key)}
+                    className={cn(
+                      'rounded-[5px] px-2 py-1 text-xs font-medium transition-colors',
+                      active
+                        ? 'bg-card text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    {f.label}
+                  </button>
+                )
+              })}
+            </div>
+          }
+        />
+        {isLoadingTemplates ? (
+          <TemplateGallerySkeleton />
+        ) : visible.length > 0 ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {visible.map((t) => (
+              <TemplateCard
+                key={t.template.id}
+                model={t}
+                onUse={() => onUseTemplate(t.template.id)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
+            No templates match this category.
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function normalizeCategory(category: string): TemplateCategory | null {
+  const normalized = category.toLowerCase()
+  switch (normalized) {
+    case 'infrastructure':
+    case 'kubernetes':
+    case 'applications':
+    case 'databases':
+    case 'cloud':
+    case 'logs':
+      return normalized
+    default:
+      return null
+  }
+}
+
+function getTemplateThumb(template: DashboardTemplateSummary): ThumbKind {
+  const category = normalizeCategory(template.category)
+  if (category === 'kubernetes') return 'k8s'
+  if (category === 'databases') return 'db'
+  if (category === 'logs') return 'logs'
+  if (category === 'applications') return 'service'
+
+  const tags = template.tags.map((tag) => tag.toLowerCase())
+  if (tags.includes('kubernetes')) return 'k8s'
+  if (tags.includes('database') || tags.includes('databases')) return 'db'
+  if (tags.includes('logs')) return 'logs'
+  if (tags.includes('browser') || tags.includes('rum')) return 'vitals'
+  return 'host'
+}
+
+function BlockHead({
+  title,
+  hint,
+  tools,
+}: {
+  title: string
+  hint: string
+  tools?: React.ReactNode
+}) {
+  return (
+    <div className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+      <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+      <span className="text-xs text-muted-foreground">{hint}</span>
+      {tools && <div className="ml-auto">{tools}</div>}
+    </div>
+  )
+}
+
+function StartTile({
+  icon: Icon,
+  title,
+  description,
+  onClick,
+  primary = false,
+}: {
+  icon: LucideIcon
+  title: string
+  description: string
+  onClick: () => void
+  primary?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'group flex items-center gap-3 rounded-lg border bg-card px-3 py-3 text-left shadow-sm transition-all hover:-translate-y-px hover:shadow-md',
+        primary ? 'border-primary/40 hover:border-primary' : 'hover:border-foreground/20',
+      )}
+    >
+      <span
+        className={cn(
+          'flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-md border',
+          primary
+            ? 'border-transparent bg-primary text-primary-foreground'
+            : 'border-border bg-muted text-muted-foreground',
+        )}
+      >
+        <Icon className="h-[18px] w-[18px]" />
+      </span>
+      <span className="flex min-w-0 flex-col gap-px">
+        <span className="text-sm font-semibold text-foreground">{title}</span>
+        <span className="text-xs leading-snug text-muted-foreground">{description}</span>
+      </span>
+      <ArrowRight className="ml-auto h-4 w-4 shrink-0 text-muted-foreground/60 transition-all group-hover:translate-x-0.5 group-hover:text-primary" />
+    </button>
+  )
+}
+
+function TemplateCard({model, onUse}: {model: TemplateCardModel; onUse: () => void}) {
+  const {template, thumb} = model
+  const sources = template.required_sources.slice(0, SOURCE_BADGE_LIMIT)
+  const extraSourceCount = template.required_sources.length - sources.length
+  const sourceSet = new Set(template.required_sources.map((source) => source.toLowerCase()))
+  const tags = template.tags.filter((tag) => !sourceSet.has(tag.toLowerCase()))
+
+  return (
+    <button
+      type="button"
+      onClick={onUse}
+      aria-label={`Use the ${template.title} template`}
+      className="group flex flex-col overflow-hidden rounded-lg border bg-card text-left shadow-sm transition-all hover:-translate-y-px hover:border-primary hover:shadow-md"
+    >
+      <div className="relative h-[116px] overflow-hidden border-b bg-[hsl(var(--viz-surface))] p-2">
+        <TemplateThumb kind={thumb} />
+        <span className="pointer-events-none absolute bottom-2 right-2 inline-flex items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-[10px] font-medium text-primary-foreground opacity-0 transition-opacity group-hover:opacity-100">
+          Use template
+          <ArrowRight className="h-2.5 w-2.5" />
+        </span>
+      </div>
+      <div className="flex flex-col gap-1.5 px-3 pb-3 pt-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold text-foreground transition-colors group-hover:text-primary">
+            {template.title}
+          </span>
+          <span className="ml-auto font-mono text-[10px] tabular-nums text-muted-foreground/80">
+            {template.widget_count} widgets
+          </span>
+        </div>
+        <p className="text-xs leading-snug text-muted-foreground">{template.description}</p>
+        <div className="mt-0.5 flex flex-wrap gap-1.5">
+          <Badge
+            variant={QUALITY_VARIANTS[template.quality]}
+            className="rounded-full px-2 py-0 text-[10px] font-medium leading-4"
+          >
+            {QUALITY_LABELS[template.quality]}
+          </Badge>
+          {sources.map((source) => (
+            <Badge
+              key={source}
+              variant="neutral"
+              className="rounded-full px-2 py-0 text-[10px] font-medium leading-4"
+            >
+              {source}
+            </Badge>
+          ))}
+          {extraSourceCount > 0 && (
+            <Badge
+              variant="neutral"
+              className="rounded-full px-2 py-0 text-[10px] font-medium leading-4"
+            >
+              +{extraSourceCount}
+            </Badge>
+          )}
+          {tags.map((tag) => (
+            <Badge
+              key={tag}
+              variant="neutral"
+              className="rounded-full px-2 py-0 text-[10px] font-medium leading-4"
+            >
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </button>
+  )
+}
+
+function TemplateGallerySkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {[1, 2, 3, 4, 5, 6].map((i) => (
+        <div key={i} className="overflow-hidden rounded-lg border bg-card">
+          <div className="h-[116px] animate-pulse border-b bg-muted" />
+          <div className="space-y-2 px-3 pb-3 pt-2.5">
+            <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-full animate-pulse rounded bg-muted" />
+            <div className="flex gap-1.5 pt-1">
+              <div className="h-4 w-14 animate-pulse rounded-full bg-muted" />
+              <div className="h-4 w-20 animate-pulse rounded-full bg-muted" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---- Mini-viz thumbnails (dark canvas) ------------------------------------
+
+const SPARKS: Record<
+  'service' | 'hostNet' | 'db' | 'vitals',
+  {stroke: string; line: string; area: string}
+> = {
+  service: {
+    stroke: 'hsl(var(--chart-1))',
+    line: '0,30 20,27 40,29 60,20 80,24 100,15 120,19 140,11 160,16 180,9 200,13 220,7 240,10',
+    area: 'M0,30 L20,27 L40,29 L60,20 L80,24 L100,15 L120,19 L140,11 L160,16 L180,9 L200,13 L220,7 L240,10 L240,40 L0,40 Z',
+  },
+  hostNet: {
+    stroke: 'hsl(var(--chart-4))',
+    line: '0,24 20,20 40,26 60,17 80,27 100,19 120,29 140,21 160,30 180,22 200,26 220,18 240,22',
+    area: 'M0,24 L20,20 L40,26 L60,17 L80,27 L100,19 L120,29 L140,21 L160,30 L180,22 L200,26 L220,18 L240,22 L240,40 L0,40 Z',
+  },
+  db: {
+    stroke: 'hsl(var(--chart-3))',
+    line: '0,20 20,18 40,19 60,15 80,17 100,13 120,15 140,12 160,14 180,11 200,13 220,10 240,12',
+    area: 'M0,20 L20,18 L40,19 L60,15 L80,17 L100,13 L120,15 L140,12 L160,14 L180,11 L200,13 L220,10 L240,12 L240,40 L0,40 Z',
+  },
+  vitals: {
+    stroke: 'hsl(var(--chart-2))',
+    line: '0,30 20,28 40,24 60,18 80,12 100,10 120,14 140,20 160,16 180,22 200,26 220,28 240,30',
+    area: 'M0,30 L20,28 L40,24 L60,18 L80,12 L100,10 L120,14 L140,20 L160,16 L180,22 L200,26 L220,28 L240,30 L240,40 L0,40 Z',
+  },
+}
+
+// Pod-saturation heat strip: 16 cols × 4 rows, column-major, biased hotter
+// toward the top-right to read like creeping saturation.
+const HEAT_CELLS: number[] = (() => {
+  const cols = 16
+  const rows = 4
+  const out: number[] = []
+  for (let c = 0; c < cols; c++) {
+    for (let r = 0; r < rows; r++) {
+      const bias = (c / cols) * 4 + (rows - r) * 0.6
+      const idx = Math.max(0, Math.min(6, Math.round(bias - 1 + (Math.sin(c * 1.7 + r) + 1))))
+      out.push(idx)
+    }
+  }
+  return out
+})()
+
+// Stacked log volume: [info, warn, error] pixel heights per column.
+const LOG_COLUMNS: ReadonlyArray<{info: number; warn: number; error: number}> = [
+  [16, 4, 0],
+  [22, 6, 2],
+  [15, 3, 0],
+  [26, 5, 1],
+  [20, 7, 0],
+  [30, 6, 3],
+  [24, 5, 1],
+  [28, 9, 5],
+  [21, 6, 2],
+  [18, 4, 1],
+  [14, 3, 0],
+  [23, 5, 1],
+].map(([info, warn, error]) => ({info, warn, error}))
+
+function TemplateThumb({kind}: {kind: ThumbKind}) {
+  const rawId = useId()
+  const gid = `sp-${rawId.replace(/:/g, '')}`
+
+  switch (kind) {
+    case 'service':
+      return (
+        <Mini>
+          <Row fixed>
+            <Tile label="req / min" value="18.2" unit="k" />
+            <Tile label="p95" value="248" unit="ms" />
+            <Tile label="errors" value="2.1" unit="%" color={VIZ.warn} />
+          </Row>
+          <Panel caption="latency · p95">
+            <Spark spec={SPARKS.service} gid={gid} />
+          </Panel>
+        </Mini>
+      )
+    case 'host':
+      return (
+        <Mini>
+          <Panel caption="cpu by host" fixed>
+            <Bars>
+              <Bar name="web-01" pct={88} color={VIZ.bad} />
+              <Bar name="web-02" pct={63} color={VIZ.warn} />
+              <Bar name="db-01" pct={41} color={VIZ.good} />
+            </Bars>
+          </Panel>
+          <Panel caption="network i/o">
+            <Spark spec={SPARKS.hostNet} gid={gid} />
+          </Panel>
+        </Mini>
+      )
+    case 'k8s':
+      return (
+        <Mini>
+          <Row fixed>
+            <Tile label="pods" value="142" />
+            <Tile label="restarts" value="3" color={VIZ.warn} />
+            <Tile label="nodes" value="9" />
+          </Row>
+          <Panel caption="pod cpu saturation">
+            <div
+              className="grid min-h-0 flex-1 gap-[2px]"
+              style={{gridAutoFlow: 'column', gridTemplateRows: 'repeat(4, 1fr)'}}
+            >
+              {HEAT_CELLS.map((idx, i) => (
+                <span
+                  key={i}
+                  className="rounded-[1px]"
+                  style={{background: VIZ.heat[idx]}}
+                />
+              ))}
+            </div>
+          </Panel>
+        </Mini>
+      )
+    case 'db':
+      return (
+        <Mini>
+          <Panel caption="queries / s">
+            <Spark spec={SPARKS.db} gid={gid} />
+          </Panel>
+          <Panel caption="latency by op · ms" fixed>
+            <Bars>
+              <Bar name="reads" pct={92} color={VIZ.bad} />
+              <Bar name="writes" pct={54} color={VIZ.warn} />
+            </Bars>
+          </Panel>
+        </Mini>
+      )
+    case 'logs':
+      return (
+        <Mini>
+          <Panel caption="log volume by level">
+            <div className="flex min-h-0 flex-1 items-end gap-[3px]">
+              {LOG_COLUMNS.map((col, i) => (
+                <span key={i} className="flex flex-1 flex-col justify-end gap-px">
+                  <Seg h={col.info} color={VIZ.levelInfo} />
+                  {col.warn > 0 && <Seg h={col.warn} color={VIZ.levelWarn} />}
+                  {col.error > 0 && <Seg h={col.error} color={VIZ.levelError} />}
+                </span>
+              ))}
+            </div>
+          </Panel>
+          <div className="flex shrink-0 gap-2">
+            <LegendChip color={VIZ.levelInfo} label="info" />
+            <LegendChip color={VIZ.levelWarn} label="warn" />
+            <LegendChip color={VIZ.levelError} label="error" />
+          </div>
+        </Mini>
+      )
+    case 'vitals':
+      return (
+        <Mini>
+          <Row fixed>
+            <Tile label="LCP" value="1.9" unit="s" color={VIZ.good} />
+            <Tile label="INP" value="180" unit="ms" color={VIZ.warn} />
+            <Tile label="CLS" value="0.04" color={VIZ.good} />
+          </Row>
+          <Panel caption="page loads">
+            <Spark spec={SPARKS.vitals} gid={gid} />
+          </Panel>
+        </Mini>
+      )
+  }
+}
+
+function Mini({children}: {children: React.ReactNode}) {
+  return <div className="flex h-full flex-col gap-[5px]">{children}</div>
+}
+
+function Row({children, fixed}: {children: React.ReactNode; fixed?: boolean}) {
+  return <div className={cn('flex min-h-0 gap-[5px]', fixed && 'shrink-0')}>{children}</div>
+}
+
+function Tile({
+  label,
+  value,
+  unit,
+  color,
+}: {
+  label: string
+  value: string
+  unit?: string
+  color?: string
+}) {
+  return (
+    <div
+      className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 rounded-sm border px-1.5 py-1"
+      style={{background: VIZ.panel, borderColor: VIZ.border}}
+    >
+      <span
+        className="truncate text-[8px] uppercase tracking-wide"
+        style={{color: VIZ.fgMuted}}
+      >
+        {label}
+      </span>
+      <span
+        className="font-mono text-[13px] font-semibold leading-none"
+        style={{color: color ?? VIZ.fg}}
+      >
+        {value}
+        {unit && (
+          <span className="ml-px text-[9px]" style={{color: VIZ.fgMuted}}>
+            {unit}
+          </span>
+        )}
+      </span>
+    </div>
+  )
+}
+
+function Panel({
+  caption,
+  children,
+  fixed,
+}: {
+  caption: string
+  children: React.ReactNode
+  fixed?: boolean
+}) {
+  return (
+    <div
+      className={cn(
+        'flex min-h-0 flex-col gap-1 rounded-sm border px-[7px] py-[5px]',
+        fixed ? 'shrink-0' : 'flex-1',
+      )}
+      style={{background: VIZ.panel, borderColor: VIZ.border}}
+    >
+      <span className="text-[8px] uppercase tracking-wide" style={{color: VIZ.fgMuted}}>
+        {caption}
+      </span>
+      {children}
+    </div>
+  )
+}
+
+function Spark({spec, gid}: {spec: {stroke: string; line: string; area: string}; gid: string}) {
+  return (
+    <svg
+      viewBox="0 0 240 40"
+      preserveAspectRatio="none"
+      className="block min-h-0 w-full flex-1"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={gid} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={spec.stroke} stopOpacity={0.3} />
+          <stop offset="1" stopColor={spec.stroke} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <path d={spec.area} fill={`url(#${gid})`} />
+      <polyline points={spec.line} fill="none" stroke={spec.stroke} strokeWidth={2} />
+    </svg>
+  )
+}
+
+function Bars({children}: {children: React.ReactNode}) {
+  return <div className="flex flex-1 flex-col justify-center gap-1">{children}</div>
+}
+
+function Bar({name, pct, color}: {name: string; pct: number; color: string}) {
+  return (
+    <div className="grid grid-cols-[38px_1fr] items-center gap-[5px]">
+      <span className="truncate font-mono text-[8px]" style={{color: VIZ.fgMuted}}>
+        {name}
+      </span>
+      <span
+        className="h-[5px] overflow-hidden rounded-[2px]"
+        style={{background: VIZ.track}}
+      >
+        <span
+          className="block h-full rounded-[2px]"
+          style={{width: `${pct}%`, background: color}}
+        />
+      </span>
+    </div>
+  )
+}
+
+function Seg({h, color}: {h: number; color: string}) {
+  return <span className="w-full rounded-[1px]" style={{height: `${h}px`, background: color}} />
+}
+
+function LegendChip({color, label}: {color: string; label: string}) {
+  return (
+    <span className="inline-flex items-center gap-1 text-[8px]" style={{color: VIZ.fgMuted}}>
+      <span className="h-1.5 w-1.5 rounded-[2px]" style={{background: color}} />
+      {label}
+    </span>
+  )
+}

--- a/dashboard/src/components/dashboards/__tests__/DashboardsGetStarted.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DashboardsGetStarted.test.tsx
@@ -1,0 +1,135 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {fireEvent, render, screen, within} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+import type {DashboardTemplateSummary} from '@/lib/api'
+import {DashboardsGetStarted} from '../DashboardsGetStarted'
+
+const SAMPLE_TEMPLATES: readonly DashboardTemplateSummary[] = [
+  {
+    id: 'node-exporter-full',
+    title: 'Node Exporter Full',
+    description: 'Prebuilt Moneat dashboard for host telemetry.',
+    category: 'infrastructure',
+    tags: ['Infrastructure', 'Prometheus'],
+    required_sources: ['Prometheus'],
+    widget_count: 140,
+    variable_count: 4,
+    quality: 'needs-review',
+    resource_path: 'dashboard-templates/community/node-exporter-full.json',
+  },
+  {
+    id: 'postgresql-overview',
+    title: 'PostgreSQL Overview',
+    description: 'Prebuilt Moneat dashboard for database telemetry.',
+    category: 'databases',
+    tags: ['Databases', 'PostgreSQL'],
+    required_sources: ['PostgreSQL'],
+    widget_count: 16,
+    variable_count: 2,
+    quality: 'ready',
+    resource_path: 'dashboard-templates/community/postgresql-overview.json',
+  },
+  {
+    id: 'log-analytics',
+    title: 'Log Analytics',
+    description: 'Prebuilt Moneat dashboard for log telemetry.',
+    category: 'logs',
+    tags: ['Logs', 'Loki'],
+    required_sources: ['Loki'],
+    widget_count: 8,
+    variable_count: 1,
+    quality: 'partial',
+    resource_path: 'dashboard-templates/community/log-analytics.json',
+  },
+]
+
+function setup(templates: readonly DashboardTemplateSummary[] = SAMPLE_TEMPLATES) {
+  const onCreateBlank = vi.fn()
+  const onUseTemplate = vi.fn()
+  const onImport = vi.fn()
+  render(
+    <DashboardsGetStarted
+      templates={templates}
+      onCreateBlank={onCreateBlank}
+      onUseTemplate={onUseTemplate}
+      onImport={onImport}
+    />,
+  )
+  return {onCreateBlank, onUseTemplate, onImport}
+}
+
+describe('DashboardsGetStarted', () => {
+  it('renders the three start tiles and wires blank + import', () => {
+    const {onCreateBlank, onImport} = setup()
+
+    fireEvent.click(screen.getByRole('button', {name: /Blank dashboard/i}))
+    expect(onCreateBlank).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', {name: /Import JSON/i}))
+    expect(onImport).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the recommended-template gallery from metadata', () => {
+    setup()
+    for (const title of [
+      'Node Exporter Full',
+      'PostgreSQL Overview',
+      'Log Analytics',
+    ]) {
+      expect(
+        screen.getByRole('button', {name: new RegExp(`Use the ${title} template`, 'i')}),
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('uses a template by id when its card is clicked', () => {
+    const {onUseTemplate} = setup()
+    fireEvent.click(
+      screen.getByRole('button', {name: /Use the Node Exporter Full template/i}),
+    )
+    expect(onUseTemplate).toHaveBeenCalledWith('node-exporter-full')
+  })
+
+  it('filters the gallery by category', () => {
+    setup()
+    const filters = screen.getByRole('group', {name: /filter templates by category/i})
+
+    fireEvent.click(within(filters).getByRole('button', {name: 'Databases'}))
+
+    expect(
+      screen.getByRole('button', {name: /Use the PostgreSQL Overview template/i}),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {name: /Use the Node Exporter Full template/i}),
+    ).not.toBeInTheDocument()
+  })
+
+  it('marks the active category filter with aria-pressed', () => {
+    setup()
+    const filters = screen.getByRole('group', {name: /filter templates by category/i})
+    const infrastructure = within(filters).getByRole('button', {name: 'Infrastructure'})
+
+    expect(infrastructure).toHaveAttribute('aria-pressed', 'false')
+    fireEvent.click(infrastructure)
+    expect(infrastructure).toHaveAttribute('aria-pressed', 'true')
+    expect(within(filters).getByRole('button', {name: 'All'})).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+  })
+})

--- a/dashboard/src/lib/api/modules/__tests__/dashboards.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/dashboards.test.ts
@@ -450,14 +450,74 @@ describe('dashboardsMethods', () => {
   })
 
   describe('getDashboardTemplates', () => {
-    it('fetches dashboard templates', async () => {
-      const mock = [{ name: 'Error Overview' }]
+    it('fetches dashboard template summaries', async () => {
+      const mock = [{
+        id: 'node-exporter-full',
+        title: 'Node Exporter Full',
+        description: 'Prebuilt Moneat dashboard for host telemetry.',
+        category: 'infrastructure',
+        tags: ['Infrastructure', 'Prometheus'],
+        required_sources: ['Prometheus'],
+        widget_count: 140,
+        variable_count: 4,
+        quality: 'needs-review',
+        resource_path: 'dashboard-templates/community/node-exporter-full.json',
+      }]
       server.use(
         http.get(`${API_BASE}/v1/dashboards/templates`, () => {
           return HttpResponse.json(mock)
         })
       )
       const result = await api.getDashboardTemplates()
+      expect(result).toEqual(mock)
+    })
+  })
+
+  describe('getDashboardTemplate', () => {
+    it('fetches a dashboard template detail by id', async () => {
+      const mock = {
+        id: 'node-exporter-full',
+        title: 'Node Exporter Full',
+        description: 'Prebuilt Moneat dashboard for host telemetry.',
+        category: 'infrastructure',
+        tags: ['Infrastructure', 'Prometheus'],
+        required_sources: ['Prometheus'],
+        widget_count: 140,
+        variable_count: 4,
+        quality: 'needs-review',
+        warnings: [],
+        dashboard: {
+          title: 'Node Exporter Full',
+          widgets: [],
+        },
+      }
+      server.use(
+        http.get(`${API_BASE}/v1/dashboards/templates/node-exporter-full`, () => {
+          return HttpResponse.json(mock)
+        })
+      )
+      const result = await api.getDashboardTemplate('node-exporter-full')
+      expect(result).toEqual(mock)
+    })
+  })
+
+  describe('createDashboardFromTemplate', () => {
+    it('creates a dashboard from a template', async () => {
+      const mock = { id: 20, title: 'Node Exporter Full' }
+      server.use(
+        http.post(
+          `${API_BASE}/v1/dashboards/templates/node-exporter-full`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>
+            expect(body.folder_id).toBe(7)
+            return HttpResponse.json(mock)
+          }
+        )
+      )
+      const result = await api.createDashboardFromTemplate(
+        'node-exporter-full',
+        {folder_id: 7}
+      )
       expect(result).toEqual(mock)
     })
   })

--- a/dashboard/src/lib/api/modules/dashboards.ts
+++ b/dashboard/src/lib/api/modules/dashboards.ts
@@ -38,6 +38,9 @@ import type {
   DataSourceField,
   DataSourceInfo,
   CustomDataSourceQueryRequest,
+  DashboardTemplateSummary,
+  DashboardTemplateDetail,
+  InstantiateDashboardTemplateRequest,
 } from '../types'
 
 export function dashboardsMethods(core: ApiClientCore) {
@@ -177,7 +180,25 @@ export function dashboardsMethods(core: ApiClientCore) {
       core.request<DataSourceInfo[]>(`${base}/dashboards/datasources`),
 
     getDashboardTemplates: () =>
-      core.request<CreateDashboardRequest[]>(`${base}/dashboards/templates`),
+      core.request<DashboardTemplateSummary[]>(`${base}/dashboards/templates`),
+
+    getDashboardTemplate: (id: string) =>
+      core.request<DashboardTemplateDetail>(
+        `${base}/dashboards/templates/${encodeURIComponent(id)}`
+      ),
+
+    createDashboardFromTemplate: (
+      id: string,
+      data: InstantiateDashboardTemplateRequest = {}
+    ) =>
+      core.request<CustomDashboard>(
+        `${base}/dashboards/templates/${encodeURIComponent(id)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        }
+      ),
 
     listDashboardAlerts: (dashboardId: number) =>
       core.request<DashboardWidgetAlert[]>(

--- a/dashboard/src/lib/api/types/dashboards.ts
+++ b/dashboard/src/lib/api/types/dashboards.ts
@@ -236,6 +236,31 @@ export interface DashboardImportResult {
   variables?: DashboardVariable[]
 }
 
+export type DashboardTemplateQuality = 'ready' | 'partial' | 'needs-review'
+
+export interface DashboardTemplateSummary {
+  id: string
+  title: string
+  description?: string | null
+  category: string
+  tags: string[]
+  required_sources: string[]
+  widget_count: number
+  variable_count: number
+  quality: DashboardTemplateQuality
+  resource_path: string
+}
+
+export interface DashboardTemplateDetail extends Omit<DashboardTemplateSummary, 'resource_path'> {
+  warnings: string[]
+  dashboard: CreateDashboardRequest
+}
+
+export interface InstantiateDashboardTemplateRequest {
+  project_id?: number | null
+  folder_id?: number | null
+}
+
 export interface DataSourceField {
   name: string
   type: string

--- a/dashboard/src/routes/dashboards.index.tsx
+++ b/dashboard/src/routes/dashboards.index.tsx
@@ -36,10 +36,6 @@ import {
   FolderPlus,
   ChevronRight,
   Pencil,
-  BarChart3,
-  LineChart,
-  PieChart,
-  Sparkles,
   ArrowRight,
 } from 'lucide-react'
 import {Button} from '@/components/ui/button'
@@ -48,6 +44,7 @@ import {PageHeader} from '@/components/ui/page-header'
 import {EmptyState} from '@/components/ui/empty-state'
 import {useState, memo, useMemo} from 'react'
 import {ImportExportModal} from '@/components/dashboards/ImportExportModal'
+import {DashboardsGetStarted} from '@/components/dashboards/DashboardsGetStarted'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -84,6 +81,16 @@ function DashboardListPage() {
     queryFn: () => api.getDashboardFolders(),
   })
 
+  // First run: no dashboards at all -> show the full-width template gallery
+  // (no folder rail to organize an empty set).
+  const isFirstRun = !isLoading && (dashboards?.length ?? 0) === 0
+
+  const {data: dashboardTemplates = [], isLoading: isTemplatesLoading} = useQuery({
+    queryKey: ['dashboard-templates'],
+    queryFn: () => api.getDashboardTemplates(),
+    enabled: isFirstRun,
+  })
+
   const filteredDashboards = useMemo(() => {
     if (!dashboards) return []
     if (selectedFolder === 'all') return dashboards
@@ -94,6 +101,17 @@ function DashboardListPage() {
 
   const createMutation = useMutation({
     mutationFn: (data: CreateDashboardRequest) => api.createDashboard(data),
+    onSuccess: (dashboard) => {
+      queryClient.invalidateQueries({queryKey: ['custom-dashboards']})
+      navigate({to: '/dashboards/$dashboardId', params: {dashboardId: String(dashboard.id)}, search: {edit: true}})
+    },
+  })
+
+  const createFromTemplateMutation = useMutation({
+    mutationFn: (templateId: string) =>
+      api.createDashboardFromTemplate(templateId, {
+        folder_id: typeof selectedFolder === 'number' ? selectedFolder : undefined,
+      }),
     onSuccess: (dashboard) => {
       queryClient.invalidateQueries({queryKey: ['custom-dashboards']})
       navigate({to: '/dashboards/$dashboardId', params: {dashboardId: String(dashboard.id)}, search: {edit: true}})
@@ -131,18 +149,8 @@ function DashboardListPage() {
     })
   }
 
-  const handleCreateFromTemplate = async () => {
-    try {
-      const templates = await api.getDashboardTemplates()
-      if (templates.length > 0) {
-        createMutation.mutate({
-          ...templates[0],
-          folder_id: typeof selectedFolder === 'number' ? selectedFolder : undefined,
-        })
-      }
-    } catch {
-      handleCreateBlank()
-    }
+  const handleUseTemplate = (templateId: string) => {
+    createFromTemplateMutation.mutate(templateId)
   }
 
   const favoritesCount = dashboards?.filter((d) => d.is_favorited).length ?? 0
@@ -163,8 +171,23 @@ function DashboardListPage() {
       <div className="border-b bg-card/50 px-3 sm:px-6 lg:px-8 py-3 sm:py-4">
         <PageHeader
           icon={LayoutDashboard}
-          title="Dashboards"
-          description="Build custom dashboards with drag-and-drop widgets"
+          title={
+            isFirstRun ? (
+              <span className="inline-flex items-baseline gap-2">
+                Dashboards
+                <span className="rounded-full border border-border bg-muted px-2 py-0.5 align-middle text-[10px] font-medium tabular-nums text-muted-foreground">
+                  0 dashboards
+                </span>
+              </span>
+            ) : (
+              'Dashboards'
+            )
+          }
+          description={
+            isFirstRun
+              ? 'Compose charts, tables, gauges and KPIs across your telemetry.'
+              : 'Build custom dashboards with drag-and-drop widgets'
+          }
           actions={
             <>
               <Button asChild variant="outline" size="sm" className="gap-1 text-xs h-8">
@@ -188,8 +211,19 @@ function DashboardListPage() {
       </div>
 
       <div className="px-3 sm:px-6 lg:px-8 py-3 sm:py-4">
-        <div className="flex flex-col md:flex-row gap-4">
-          {/* Mobile: horizontal folder pills */}
+        {isLoading ? (
+          <DashboardGridSkeleton />
+        ) : isFirstRun ? (
+          <DashboardsGetStarted
+            templates={dashboardTemplates}
+            isLoadingTemplates={isTemplatesLoading}
+            onCreateBlank={handleCreateBlank}
+            onUseTemplate={handleUseTemplate}
+            onImport={() => setShowImport(true)}
+          />
+        ) : (
+          <div className="flex flex-col md:flex-row gap-4">
+            {/* Mobile: horizontal folder pills */}
           <div className="flex md:hidden overflow-x-auto gap-1.5 pb-1 -mx-1">
             <button
               onClick={() => setSelectedFolder('all')}
@@ -314,23 +348,7 @@ function DashboardListPage() {
 
           {/* Main content */}
           <div className="flex-1 min-w-0">
-            {isLoading ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="rounded-lg border bg-card overflow-hidden">
-                    <div className="h-1.5 bg-muted animate-pulse" />
-                    <div className="p-4 space-y-3">
-                      <div className="h-5 w-3/4 bg-muted rounded animate-pulse" />
-                      <div className="h-4 w-1/2 bg-muted rounded animate-pulse" />
-                      <div className="flex gap-2 pt-2">
-                        <div className="h-5 w-16 bg-muted rounded-full animate-pulse" />
-                        <div className="h-5 w-24 bg-muted rounded-full animate-pulse" />
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : filteredDashboards.length > 0 ? (
+            {filteredDashboards.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
                 {filteredDashboards.map((dashboard) => (
                   <DashboardCard
@@ -375,12 +393,11 @@ function DashboardListPage() {
                 selectedFolder={selectedFolder}
                 folderLabel={folderLabel}
                 onCreateBlank={handleCreateBlank}
-                onCreateFromTemplate={handleCreateFromTemplate}
-                onImport={() => setShowImport(true)}
               />
             )}
           </div>
-        </div>
+          </div>
+        )}
       </div>
 
       <ImportExportModal open={showImport} onOpenChange={setShowImport} mode="import" />
@@ -438,14 +455,10 @@ function DashboardsEmptyState({
   selectedFolder,
   folderLabel,
   onCreateBlank,
-  onCreateFromTemplate,
-  onImport,
 }: {
   selectedFolder: FolderFilter
   folderLabel: string
   onCreateBlank: () => void
-  onCreateFromTemplate: () => void
-  onImport: () => void
 }) {
   if (selectedFolder === 'favorites') {
     return (
@@ -492,49 +505,36 @@ function DashboardsEmptyState({
   return (
     <EmptyState
       icon={LayoutDashboard}
-      title="Create your first dashboard"
-      description="Visualize your data with custom charts, tables, and metrics. Start from scratch, use a template, or import from Grafana and other tools."
+      title="No dashboards here"
+      description="Create a dashboard to start visualizing your telemetry."
       action={
-        <>
-          <Button variant="outline" onClick={onCreateFromTemplate}>
-            <Sparkles className="h-4 w-4 mr-2" />
-            Start from Template
-          </Button>
-          <Button variant="outline" onClick={onImport}>
-            <Import className="h-4 w-4 mr-2" />
-            Import Dashboard
-          </Button>
-          <Button onClick={onCreateBlank}>
-            <Plus className="h-4 w-4 mr-2" />
-            Blank Dashboard
-          </Button>
-        </>
+        <Button onClick={onCreateBlank}>
+          <Plus className="h-4 w-4 mr-1.5" />
+          Create Dashboard
+        </Button>
       }
-    >
-      <div className="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-2xl w-full">
-        <div className="flex flex-col items-center text-center gap-2 p-4">
-          <div className="h-10 w-10 rounded-lg bg-chart-1/15 flex items-center justify-center">
-            <BarChart3 className="h-5 w-5 text-chart-1" />
+    />
+  )
+}
+
+/** Compact loading placeholder for the dashboard grid. */
+function DashboardGridSkeleton() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="rounded-lg border bg-card overflow-hidden">
+          <div className="h-1.5 bg-muted animate-pulse" />
+          <div className="p-4 space-y-3">
+            <div className="h-5 w-3/4 bg-muted rounded animate-pulse" />
+            <div className="h-4 w-1/2 bg-muted rounded animate-pulse" />
+            <div className="flex gap-2 pt-2">
+              <div className="h-5 w-16 bg-muted rounded-full animate-pulse" />
+              <div className="h-5 w-24 bg-muted rounded-full animate-pulse" />
+            </div>
           </div>
-          <span className="text-sm font-medium">Rich Visualizations</span>
-          <span className="text-xs text-muted-foreground">Charts, tables & stats</span>
         </div>
-        <div className="flex flex-col items-center text-center gap-2 p-4">
-          <div className="h-10 w-10 rounded-lg bg-chart-3/15 flex items-center justify-center">
-            <LineChart className="h-5 w-5 text-chart-3" />
-          </div>
-          <span className="text-sm font-medium">Drag & Drop</span>
-          <span className="text-xs text-muted-foreground">Flexible grid layout</span>
-        </div>
-        <div className="flex flex-col items-center text-center gap-2 p-4">
-          <div className="h-10 w-10 rounded-lg bg-chart-2/15 flex items-center justify-center">
-            <PieChart className="h-5 w-5 text-chart-2" />
-          </div>
-          <span className="text-sm font-medium">Multiple Sources</span>
-          <span className="text-xs text-muted-foreground">ClickHouse, Postgres & more</span>
-        </div>
-      </div>
-    </EmptyState>
+      ))}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- load dashboard template summaries from the backend catalog API on first-run dashboard state
- add typed API methods for template list/detail/instantiate
- replace the static starter-gallery path with category-filtered catalog metadata and backend instantiation by template id

## Stack
- Depends on #605 for the backend catalog and template API.

## Validation
- npm ci
- npm test -- DashboardsGetStarted dashboards.test.ts
- npm run typecheck
- npx eslint src/components/dashboards/DashboardsGetStarted.tsx src/components/dashboards/__tests__/DashboardsGetStarted.test.tsx src/routes/dashboards.index.tsx src/lib/api/modules/dashboards.ts src/lib/api/modules/__tests__/dashboards.test.ts src/lib/api/types/dashboards.ts --report-unused-disable-directives --max-warnings 0
- git diff --check