### PR TITLE
feat: refresh replay experience

### DIFF
--- a/backend/src/main/kotlin/com/moneat/analytics/services/GeoIpService.kt
+++ b/backend/src/main/kotlin/com/moneat/analytics/services/GeoIpService.kt
@@ -66,11 +66,12 @@ class GeoIpService {
      * Returns empty GeoResult if GeoIP is unavailable or IP can't be resolved.
      */
     fun resolve(ip: String): GeoResult {
-        if (!readerAvailable || reader == null) return GeoResult()
+        val currentReader = reader ?: return GeoResult()
+        if (!readerAvailable) return GeoResult()
         return runCatching {
             val address = InetAddress.getByName(ip)
-            val cityMethod = reader!!.javaClass.getMethod("city", InetAddress::class.java)
-            val response = cityMethod.invoke(reader, address)
+            val cityMethod = currentReader.javaClass.getMethod("city", InetAddress::class.java)
+            val response = cityMethod.invoke(currentReader, address)
 
             val countryObj = response.javaClass.getMethod("getCountry").invoke(response)
             val countryCode = countryObj?.javaClass?.getMethod("getIsoCode")?.invoke(countryObj)?.toString() ?: ""

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -244,7 +244,7 @@ val eventsModule = module {
     single { ReleaseService() }
     single { NotificationService(get(), get()) }
     single { EventService(get(), get(), get()) }
-    single { DashboardService(get(), get(), get()) }
+    single { DashboardService(get(), get(), get(), get()) }
 }
 
 /** Infrastructure monitoring and alerting. */

--- a/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
+++ b/backend/src/main/kotlin/com/moneat/events/models/ApiModels.kt
@@ -474,7 +474,9 @@ data class ReplayListItem(
     val browserVersion: String?,
     val osName: String?,
     val osVersion: String?,
-    val activity: Int
+    val activity: Int,
+    val signals: List<String> = emptyList(),
+    val entryUrl: String? = null
 )
 
 @Serializable
@@ -499,7 +501,14 @@ data class ReplayDetailResponse(
     val osName: String?,
     val osVersion: String?,
     val activity: Int,
-    val tags: Map<String, String>
+    val tags: Map<String, String>,
+    val signals: List<String> = emptyList(),
+    val entryUrl: String? = null,
+    val ipAddress: String? = null,
+    val geo: String? = null,
+    val viewport: String? = null,
+    val connection: String? = null,
+    val userSessionCount: Int? = null
 )
 
 @Serializable
@@ -519,7 +528,9 @@ data class ReplayTimelineItem(
     val category: String? = null,
     val eventId: String? = null,
     val issueId: String? = null,
-    val traceId: String? = null
+    val traceId: String? = null,
+    val statusCode: Int? = null,
+    val rage: Boolean? = null
 )
 
 @Serializable

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.events.services
 
+import com.moneat.analytics.services.GeoIpService
 import com.moneat.events.models.EventResponse
 import com.moneat.events.models.EventTraceResponse
 import com.moneat.events.models.FeedbackDetailResponse
@@ -48,6 +49,7 @@ class DashboardService(
     private val projectRepository: ProjectRepository,
     private val issueRepository: IssueRepository,
     private val queryHelper: DashboardQueryHelper = DashboardQueryHelper(),
+    private val geoIpService: GeoIpService = GeoIpService(),
 ) {
     companion object {
         fun create(): DashboardService {
@@ -58,12 +60,13 @@ class DashboardService(
                 },
                 issueRepository = IssueRepositoryImpl(queryHelper),
                 queryHelper = queryHelper,
+                geoIpService = GeoIpService(),
             )
         }
     }
     private val feedbackService = FeedbackService(queryHelper)
     private val releaseStatsService = ReleaseStatsService(queryHelper)
-    private val replayService = ReplayService(queryHelper)
+    private val replayService = ReplayService(queryHelper, geoIpService = geoIpService)
     private val projectService = ProjectService(projectRepository, queryHelper)
     private val projectStatsService = ProjectStatsService(queryHelper)
     private val transactionService = TransactionService(queryHelper)

--- a/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
@@ -81,6 +81,13 @@ private data class ReplayRetentionOptions(
     val demoEpochMs: Long? = null
 )
 
+private data class ReplayListRow(
+    val obj: JsonObject,
+    val projectId: Long,
+    val window: ReplayWindowQuery?,
+    val errorCount: Int
+)
+
 class ReplayService(
     private val queryHelper: DashboardQueryHelper,
     private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
@@ -439,7 +446,7 @@ class ReplayService(
                 val breadcrumbs = parseStoredJsonArray(stringValue(row, "breadcrumbs"))
                 viewport = viewport ?: viewportFromContexts(contexts)
                 connection = connection ?: connectionFromBreadcrumbs(breadcrumbs)
-                if (!hasRage && breadcrumbs?.any { (it as? JsonObject)?.let(::isRageBreadcrumb) == true } == true) {
+                if (!hasRage && hasRageBreadcrumb(breadcrumbs)) {
                     hasRage = true
                 }
                 if (viewport != null && connection != null && hasRage) break
@@ -451,6 +458,84 @@ class ReplayService(
             ReplayContextEnrichment()
         }
     }
+
+    private suspend fun getReplayContextEnrichments(
+        windows: List<ReplayWindowQuery>
+    ): Map<ReplayWindowQuery, ReplayContextEnrichment> {
+        val validWindows = windows.filter { it.isValid }.distinct()
+        if (validWindows.isEmpty()) return emptyMap()
+
+        val windowConditions =
+            validWindows.joinToString("\n                OR ") { window ->
+                """
+                (project_id = ${window.projectId}
+                    AND timestamp >= fromUnixTimestamp64Milli(${window.startMs})
+                    AND timestamp <= fromUnixTimestamp64Milli(${window.endMs})
+                    AND ${queryHelper.timestampRetentionClause("timestamp", window.retentionDays, window.demoEpochMs)}
+                    ${window.userClause()})
+                """.trimIndent()
+            }
+        val query =
+            """
+            SELECT
+                toInt64(project_id) as project_id,
+                toUnixTimestamp64Milli(timestamp) as ts_ms,
+                user_id,
+                contexts,
+                breadcrumbs
+            FROM `$clickhouseDb`.events
+            WHERE $windowConditions
+            ORDER BY timestamp ASC
+            LIMIT ${validWindows.size * REPLAY_CONTEXT_EVENT_LIMIT}
+            FORMAT JSONEachRow
+            """.trimIndent()
+
+        return suspendRunCatching {
+            val rows = queryHelper.executeJsonEachRowQuery(query, "Replay list context enrichment")
+                ?: return emptyMap()
+            val enrichments = validWindows.associateWith { ReplayContextEnrichment() }.toMutableMap()
+
+            rows.forEach { row ->
+                val projectId = row["project_id"]?.jsonPrimitive?.long ?: return@forEach
+                val timestampMs = row["ts_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull() ?: return@forEach
+                val rowUserId = row["user_id"]?.jsonPrimitive?.contentOrNull
+                val contexts = parseStoredJsonObject(stringValue(row, "contexts"))
+                val breadcrumbs = parseStoredJsonArray(stringValue(row, "breadcrumbs"))
+                matchingReplayWindows(validWindows, projectId, timestampMs, rowUserId).forEach { window ->
+                    val current = enrichments[window] ?: ReplayContextEnrichment()
+                    enrichments[window] = ReplayContextEnrichment(
+                        viewport = current.viewport ?: viewportFromContexts(contexts),
+                        connection = current.connection ?: connectionFromBreadcrumbs(breadcrumbs),
+                        hasRage = current.hasRage || hasRageBreadcrumb(breadcrumbs)
+                    )
+                }
+            }
+
+            enrichments
+        }.getOrElse { e ->
+            logger.error(e) { "Failed to fetch replay list context enrichment" }
+            emptyMap()
+        }
+    }
+
+    private fun matchingReplayWindows(
+        windows: List<ReplayWindowQuery>,
+        projectId: Long,
+        timestampMs: Long,
+        userId: String?
+    ): List<ReplayWindowQuery> =
+        windows.filter { window ->
+            window.projectId == projectId &&
+                timestampMs >= window.startMs &&
+                timestampMs <= window.endMs &&
+                window.userIdMatches(userId)
+        }
+
+    private fun ReplayWindowQuery.userIdMatches(candidate: String?): Boolean =
+        userId.isNullOrBlank() || userId == candidate
+
+    private fun hasRageBreadcrumb(breadcrumbs: JsonArray?): Boolean =
+        breadcrumbs?.any { (it as? JsonObject)?.let(::isRageBreadcrumb) == true } == true
 
     private suspend fun getReplayUserSessionCount(
         projectId: Long,
@@ -814,7 +899,7 @@ class ReplayService(
 
         return suspendRunCatching {
             val rows = queryHelper.executeJsonEachRowQuery(query, "Replays") ?: return emptyList()
-            rows.mapNotNull { obj ->
+            val parsedRows = rows.mapNotNull { obj ->
                 suspendRunCatching {
                     val startedMs = obj["started_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
                     val finishedMs = obj["finished_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
@@ -837,17 +922,25 @@ class ReplayService(
                     val rawErrorCount = obj["error_count"]?.jsonPrimitive?.intOrNull ?: 0
                     val fallbackErrorCount =
                         if (rawErrorCount == 0) fallbackReplayErrorCount(emptyList(), replayWindow) else 0
-                    val hasRage = contextEnrichmentForWindow(replayWindow).hasRage
-                    buildReplayListItemFromJson(
-                        obj,
-                        rowProjectId ?: 0L,
-                        maxOf(rawErrorCount, fallbackErrorCount),
-                        hasRage
+                    ReplayListRow(
+                        obj = obj,
+                        projectId = rowProjectId ?: 0L,
+                        window = replayWindow,
+                        errorCount = maxOf(rawErrorCount, fallbackErrorCount)
                     )
                 }.getOrElse { e ->
                     logger.error(e) { "Failed to parse replay list row" }
                     null
                 }
+            }
+            val enrichments = getReplayContextEnrichments(parsedRows.mapNotNull { it.window })
+            parsedRows.mapNotNull { row ->
+                buildReplayListItemFromJson(
+                    row.obj,
+                    row.projectId,
+                    row.errorCount,
+                    row.window?.let { enrichments[it]?.hasRage } ?: false
+                )
             }
         }.getOrElse { e ->
             logger.error(e) { "Failed to fetch replays for services ${queryOptions.scope.cacheKeyPart()}" }

--- a/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.events.services
 
+import com.moneat.analytics.services.GeoIpService
 import com.moneat.config.ClickHouseClient
 import com.moneat.events.models.ReplayDetailResponse
 import com.moneat.events.models.ReplayListItem
@@ -61,12 +62,38 @@ private data class ReplayListQuery(
     val demoEpochMs: Long?
 )
 
+private data class ReplayWindowQuery(
+    val projectId: Long,
+    val startMs: Long,
+    val endMs: Long,
+    val userId: String?,
+    val retentionDays: Int,
+    val demoEpochMs: Long? = null
+) {
+    val isValid: Boolean get() = endMs >= startMs
+
+    fun userClause(): String =
+        userId?.takeIf { it.isNotBlank() }?.let { "AND user_id = '${escapeSql(it)}'" } ?: ""
+}
+
+private data class ReplayRetentionOptions(
+    val retentionDays: Int,
+    val demoEpochMs: Long? = null
+)
+
 class ReplayService(
     private val queryHelper: DashboardQueryHelper,
     private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
+    private val geoIpService: GeoIpService = GeoIpService(),
 ) {
     private val clickhouseDb: String get() = queryHelper.clickhouseDb
     private val json get() = queryHelper.json
+
+    private data class ReplayContextEnrichment(
+        val viewport: String? = null,
+        val connection: String? = null,
+        val hasRage: Boolean = false
+    )
 
     private data class SegmentDecodeResult(
         val events: List<JsonElement>,
@@ -107,13 +134,116 @@ class ReplayService(
     private fun projectResourceId(projectId: Long): String =
         projectIdResolver.resourceIdFor(projectId) ?: projectId.toString()
 
+    private fun firstEntryUrl(urls: List<String>): String? =
+        urls.firstOrNull { it.isNotBlank() }
+
+    private fun buildReplaySignals(
+        errorCount: Int,
+        activity: Int,
+        hasRage: Boolean
+    ): List<String> =
+        buildList {
+            if (errorCount > 0) add("error")
+            if (activity == 0) add("dead_click")
+            if (hasRage) add("rage_click")
+        }
+
+    private fun stringValue(obj: JsonObject, key: String): String? =
+        (obj[key] as? JsonPrimitive)
+            ?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+
+    private fun intValue(obj: JsonObject, key: String): Int? {
+        val primitive = obj[key] as? JsonPrimitive ?: return null
+        return primitive.intOrNull ?: primitive.contentOrNull?.toIntOrNull()
+    }
+
+    private fun parseStoredJsonObject(raw: String?): JsonObject? =
+        raw
+            ?.takeIf { it.isNotBlank() && it != "{}" }
+            ?.let { value ->
+                suspendRunCatching { json.parseToJsonElement(value).jsonObject }.getOrNull()
+            }
+
+    private fun parseStoredJsonArray(raw: String?): JsonArray? =
+        raw
+            ?.takeIf { it.isNotBlank() && it != "[]" }
+            ?.let { value ->
+                suspendRunCatching { json.parseToJsonElement(value).jsonArray }.getOrNull()
+            }
+
+    private fun geoLabelForIp(ipAddress: String?): String? {
+        val ip = ipAddress?.takeIf { it.isNotBlank() } ?: return null
+        val geo = geoIpService.resolve(ip)
+        if (geo.countryCode.isBlank()) return null
+        val locality = geo.city.ifBlank { geo.subdivision }
+        return if (locality.isBlank()) geo.countryCode else "$locality, ${geo.countryCode}"
+    }
+
+    private fun viewportFromContexts(contexts: JsonObject?): String? {
+        val device = contexts?.get("device") as? JsonObject ?: return null
+        val width = firstIntValue(device, "screen_width_pixels", "screen_width", "width")
+        val height = firstIntValue(device, "screen_height_pixels", "screen_height", "height")
+        return if (width != null && height != null) "$width x $height" else null
+    }
+
+    private fun firstIntValue(obj: JsonObject, vararg keys: String): Int? =
+        keys.firstNotNullOfOrNull { key -> intValue(obj, key) }
+
+    private fun connectionFromBreadcrumbs(breadcrumbs: JsonArray?): String? {
+        if (breadcrumbs == null) return null
+        for (element in breadcrumbs) {
+            val breadcrumb = element as? JsonObject ?: continue
+            val data = breadcrumb["data"] as? JsonObject ?: continue
+            val connection =
+                firstStringValue(data, "network_type", "connection_type", "effective_type")
+                    ?: firstStringValue(breadcrumb, "network_type", "connection_type", "effective_type")
+            if (connection != null) return connection
+        }
+        return null
+    }
+
+    private fun firstStringValue(obj: JsonObject, vararg keys: String): String? =
+        keys.firstNotNullOfOrNull { key -> stringValue(obj, key) }
+
+    private fun statusCodeFromJson(obj: JsonObject, vararg keys: String): Int? =
+        keys.firstNotNullOfOrNull { key -> intValue(obj, key) }
+
+    private fun statusCodeFromText(text: String?): Int? {
+        val value = text?.takeIf { it.isNotBlank() } ?: return null
+        return HTTP_STATUS_REGEX.find(value)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    }
+
+    private fun isRageBreadcrumb(breadcrumb: JsonObject): Boolean {
+        val haystack =
+            listOfNotNull(
+                stringValue(breadcrumb, "category"),
+                stringValue(breadcrumb, "message"),
+                stringValue(breadcrumb, "type"),
+                (breadcrumb["data"] as? JsonObject)?.let { data ->
+                    listOfNotNull(
+                        stringValue(data, "action"),
+                        stringValue(data, "message"),
+                        stringValue(data, "reason")
+                    ).joinToString(" ")
+                }
+            ).joinToString(" ").lowercase()
+        return haystack.contains("rage") ||
+            haystack.contains("frustrat") ||
+            haystack.contains("dead click") ||
+            haystack.contains("dead_click")
+    }
+
     private fun buildReplayListItemFromJson(
         obj: JsonObject,
         projectId: Long,
-        errorCount: Int
+        errorCount: Int,
+        hasRage: Boolean = false
     ): ReplayListItem? {
         val replayId = obj["replay_id"]?.jsonPrimitive?.content ?: return null
         val objProjectId = obj["project_id"]?.jsonPrimitive?.long ?: projectId
+        val urls = parseStringArray(obj["urls"])
+        val activity = obj["activity"]?.jsonPrimitive?.intOrNull ?: 0
         return ReplayListItem(
             replayId = replayId,
             projectId = objProjectId,
@@ -121,14 +251,16 @@ class ReplayService(
             startedAt = obj["started_at"]?.jsonPrimitive?.content ?: "",
             finishedAt = obj["finished_at"]?.jsonPrimitive?.content ?: "",
             durationMs = obj["duration_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: 0.0,
-            urls = parseStringArray(obj["urls"]),
+            urls = urls,
             errorCount = errorCount,
             user = queryHelper.extractUserInfo(obj),
             browserName = obj["browser_name"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             browserVersion = obj["browser_version"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             osName = obj["os_name"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             osVersion = obj["os_version"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
-            activity = obj["activity"]?.jsonPrimitive?.intOrNull ?: 0
+            activity = activity,
+            signals = buildReplaySignals(errorCount, activity, hasRage),
+            entryUrl = firstEntryUrl(urls)
         )
     }
 
@@ -149,19 +281,20 @@ class ReplayService(
         val eventId = obj["event_id"]?.jsonPrimitive?.content ?: return null
         val exceptionType = obj["exception_type"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
         val message = obj["message"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        val exceptionValue = obj["exception_value"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
         return ReplayTimelineItem(
             id = eventId,
             type = "error",
             timestamp = obj["timestamp"]?.jsonPrimitive?.content ?: "",
             offsetMs = (tsMs - replayStartMs).toDouble(),
             title = exceptionType ?: message ?: "Error",
-            description = obj["exception_value"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
-                ?: obj["message"]?.jsonPrimitive?.contentOrNull,
+            description = exceptionValue ?: obj["message"]?.jsonPrimitive?.contentOrNull,
             durationMs = null,
             category = obj["level"]?.jsonPrimitive?.contentOrNull,
             eventId = eventId,
             issueId = obj["issue_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
-            traceId = null
+            traceId = null,
+            statusCode = statusCodeFromText(listOfNotNull(message, exceptionValue).joinToString(" "))
         )
     }
 
@@ -171,18 +304,20 @@ class ReplayService(
         val traceId = queryHelper.parseTraceContext(
             obj["contexts"]?.jsonPrimitive?.content ?: "{}"
         )?.get("trace_id")?.jsonPrimitive?.contentOrNull
+        val title = obj["transaction_name"]?.jsonPrimitive?.content ?: "Transaction"
         return ReplayTimelineItem(
             id = eventId,
             type = "transaction",
             timestamp = obj["timestamp"]?.jsonPrimitive?.content ?: "",
             offsetMs = (tsMs - replayStartMs).toDouble(),
-            title = obj["transaction_name"]?.jsonPrimitive?.content ?: "Transaction",
+            title = title,
             description = null,
             durationMs = obj["duration_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull(),
             category = obj["transaction_op"]?.jsonPrimitive?.contentOrNull,
             eventId = eventId,
             issueId = null,
-            traceId = traceId
+            traceId = traceId,
+            statusCode = statusCodeFromJson(obj, "http_status_code", "status_code") ?: statusCodeFromText(title)
         )
     }
 
@@ -190,41 +325,36 @@ class ReplayService(
         val startTsMs = obj["start_ts_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull() ?: return null
         val spanId = obj["span_id"]?.jsonPrimitive?.content ?: return null
         val traceId = obj["trace_id"]?.jsonPrimitive?.contentOrNull
+        val title = obj["description"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+            ?: obj["op"]?.jsonPrimitive?.content ?: "Span"
         return ReplayTimelineItem(
             id = "span-$traceId-$spanId",
             type = "span",
             timestamp = Instant.ofEpochMilli(startTsMs).toString(),
             offsetMs = (startTsMs - replayStartMs).toDouble(),
-            title = obj["description"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-                ?: obj["op"]?.jsonPrimitive?.content ?: "Span",
+            title = title,
             description = obj["op"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             durationMs = obj["duration_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull(),
             category = obj["op"]?.jsonPrimitive?.contentOrNull,
             eventId = obj["transaction_id"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             issueId = null,
-            traceId = traceId
+            traceId = traceId,
+            statusCode = statusCodeFromJson(obj, "http_status_code", "status_code") ?: statusCodeFromText(title)
         )
     }
 
-    private suspend fun getReplayWindowErrorCount(
-        projectId: Long,
-        startMs: Long,
-        endMs: Long,
-        userId: String?,
-        retentionDays: Int
-    ): Int {
-        if (endMs < startMs) return 0
-        val userClause = userId?.takeIf { it.isNotBlank() }?.let { "AND user_id = '${escapeSql(it)}'" } ?: ""
+    private suspend fun getReplayWindowErrorCount(window: ReplayWindowQuery): Int {
+        if (!window.isValid) return 0
         val query =
             """
             SELECT countDistinct(event_id) as count
             FROM `$clickhouseDb`.events
-            WHERE project_id = $projectId
+            WHERE project_id = ${window.projectId}
                 AND event_type = 'error'
-                AND timestamp >= fromUnixTimestamp64Milli($startMs)
-                AND timestamp <= fromUnixTimestamp64Milli($endMs)
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
-                $userClause
+                AND timestamp >= fromUnixTimestamp64Milli(${window.startMs})
+                AND timestamp <= fromUnixTimestamp64Milli(${window.endMs})
+                AND ${queryHelper.timestampRetentionClause("timestamp", window.retentionDays, window.demoEpochMs)}
+                ${window.userClause()}
             FORMAT JSONEachRow
             """.trimIndent()
 
@@ -235,31 +365,26 @@ class ReplayService(
             val obj = json.parseToJsonElement(line).jsonObject
             obj["count"]?.jsonPrimitive?.intOrNull ?: 0
         }.getOrElse { e ->
-            logger.error(e) { "Failed to count replay window errors for project $projectId" }
+            logger.error(e) { "Failed to count replay window errors for project ${window.projectId}" }
             0
         }
     }
 
     private suspend fun getReplayWindowErrorIds(
-        projectId: Long,
-        startMs: Long,
-        endMs: Long,
-        userId: String?,
-        retentionDays: Int,
+        window: ReplayWindowQuery,
         limit: Int = 200
     ): List<String> {
-        if (endMs < startMs) return emptyList()
-        val userClause = userId?.takeIf { it.isNotBlank() }?.let { "AND user_id = '${escapeSql(it)}'" } ?: ""
+        if (!window.isValid) return emptyList()
         val query =
             """
             SELECT toString(event_id) as event_id
             FROM `$clickhouseDb`.events
-            WHERE project_id = $projectId
+            WHERE project_id = ${window.projectId}
                 AND event_type = 'error'
-                AND timestamp >= fromUnixTimestamp64Milli($startMs)
-                AND timestamp <= fromUnixTimestamp64Milli($endMs)
-                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays)}
-                $userClause
+                AND timestamp >= fromUnixTimestamp64Milli(${window.startMs})
+                AND timestamp <= fromUnixTimestamp64Milli(${window.endMs})
+                AND ${queryHelper.timestampRetentionClause("timestamp", window.retentionDays, window.demoEpochMs)}
+                ${window.userClause()}
             ORDER BY timestamp ASC
             LIMIT $limit
             FORMAT JSONEachRow
@@ -281,10 +406,144 @@ class ReplayService(
                     }.getOrNull()
                 }
         }.getOrElse { e ->
-            logger.error(e) { "Failed to fetch replay window error IDs for project $projectId" }
+            logger.error(e) { "Failed to fetch replay window error IDs for project ${window.projectId}" }
             emptyList()
         }
     }
+
+    private suspend fun getReplayContextEnrichment(window: ReplayWindowQuery): ReplayContextEnrichment {
+        if (!window.isValid) return ReplayContextEnrichment()
+        val query =
+            """
+            SELECT contexts, breadcrumbs
+            FROM `$clickhouseDb`.events
+            WHERE project_id = ${window.projectId}
+                AND timestamp >= fromUnixTimestamp64Milli(${window.startMs})
+                AND timestamp <= fromUnixTimestamp64Milli(${window.endMs})
+                AND ${queryHelper.timestampRetentionClause("timestamp", window.retentionDays, window.demoEpochMs)}
+                ${window.userClause()}
+            ORDER BY timestamp ASC
+            LIMIT $REPLAY_CONTEXT_EVENT_LIMIT
+            FORMAT JSONEachRow
+            """.trimIndent()
+
+        return suspendRunCatching {
+            val rows = queryHelper.executeJsonEachRowQuery(query, "Replay context enrichment")
+                ?: return ReplayContextEnrichment()
+            var viewport: String? = null
+            var connection: String? = null
+            var hasRage = false
+
+            for (row in rows) {
+                val contexts = parseStoredJsonObject(stringValue(row, "contexts"))
+                val breadcrumbs = parseStoredJsonArray(stringValue(row, "breadcrumbs"))
+                viewport = viewport ?: viewportFromContexts(contexts)
+                connection = connection ?: connectionFromBreadcrumbs(breadcrumbs)
+                if (!hasRage && breadcrumbs?.any { (it as? JsonObject)?.let(::isRageBreadcrumb) == true } == true) {
+                    hasRage = true
+                }
+                if (viewport != null && connection != null && hasRage) break
+            }
+
+            ReplayContextEnrichment(viewport = viewport, connection = connection, hasRage = hasRage)
+        }.getOrElse { e ->
+            logger.error(e) { "Failed to fetch replay context enrichment for project ${window.projectId}" }
+            ReplayContextEnrichment()
+        }
+    }
+
+    private suspend fun getReplayUserSessionCount(
+        projectId: Long,
+        startMs: Long,
+        userId: String?,
+        retentionDays: Int,
+        demoEpochMs: Long? = null
+    ): Int? {
+        val user = userId?.takeIf { it.isNotBlank() } ?: return null
+        val query =
+            """
+            SELECT countDistinct(replay_id) as count
+            FROM `$clickhouseDb`.replay_events
+            WHERE project_id = $projectId
+                AND user_id = '${escapeSql(user)}'
+                AND replay_start_timestamp < fromUnixTimestamp64Milli($startMs)
+                AND ${queryHelper.timestampRetentionClause("timestamp", retentionDays, demoEpochMs)}
+            FORMAT JSONEachRow
+            """.trimIndent()
+
+        return suspendRunCatching {
+            val response = ClickHouseClient.execute(query)
+            val body = queryHelper.extractClickHouseBody(response) ?: return null
+            val line = body.lines().firstOrNull { it.isNotBlank() } ?: return null
+            val obj = json.parseToJsonElement(line).jsonObject
+            obj["count"]?.jsonPrimitive?.intOrNull
+        }.getOrElse { e ->
+            logger.error(e) { "Failed to count replay sessions for user in project $projectId" }
+            null
+        }
+    }
+
+    private fun replayWindowOrNull(
+        projectId: Long,
+        startedMs: Long?,
+        finishedMs: Long?,
+        userId: String?,
+        retentionOptions: ReplayRetentionOptions
+    ): ReplayWindowQuery? {
+        val start = startedMs ?: return null
+        val end = finishedMs ?: return null
+        return ReplayWindowQuery(
+            projectId = projectId,
+            startMs = start,
+            endMs = end,
+            userId = userId,
+            retentionDays = retentionOptions.retentionDays,
+            demoEpochMs = retentionOptions.demoEpochMs
+        )
+    }
+
+    private fun parseReplayTags(tagsStr: String): Map<String, String> =
+        runCatching {
+            (json.parseToJsonElement(tagsStr) as? JsonObject)
+                ?.mapValues { it.value.jsonPrimitive.content }
+                ?: emptyMap()
+        }.getOrElse {
+            emptyMap()
+        }
+
+    private suspend fun fallbackReplayErrorIds(
+        replayErrorIds: List<String>,
+        window: ReplayWindowQuery?
+    ): List<String> =
+        if (replayErrorIds.isEmpty() && window != null) {
+            getReplayWindowErrorIds(window)
+        } else {
+            emptyList()
+        }
+
+    private suspend fun fallbackReplayErrorCount(
+        replayErrorIds: List<String>,
+        window: ReplayWindowQuery?
+    ): Int =
+        if (replayErrorIds.isEmpty() && window != null) {
+            getReplayWindowErrorCount(window)
+        } else {
+            0
+        }
+
+    private suspend fun contextEnrichmentForWindow(window: ReplayWindowQuery?): ReplayContextEnrichment =
+        window?.let { getReplayContextEnrichment(it) } ?: ReplayContextEnrichment()
+
+    private suspend fun userSessionCountForWindow(window: ReplayWindowQuery?): Int? =
+        window?.let {
+            getReplayUserSessionCount(
+                projectId = it.projectId,
+                startMs = it.startMs,
+                userId = it.userId,
+                retentionDays = it.retentionDays,
+                demoEpochMs = it.demoEpochMs
+            )
+        }
 
     private fun parsedToJsonElementList(parsed: JsonElement): List<JsonElement> =
         when (parsed) {
@@ -561,20 +820,30 @@ class ReplayService(
                     val finishedMs = obj["finished_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
                     val rowProjectId =
                         obj["project_id"]?.jsonPrimitive?.long ?: queryOptions.scope.serviceIds.firstOrNull()
+                    val userId = obj["user_id"]?.jsonPrimitive?.contentOrNull
+                    val retentionOptions = ReplayRetentionOptions(
+                        retentionDays = queryOptions.retentionDays,
+                        demoEpochMs = queryOptions.demoEpochMs
+                    )
+                    val replayWindow = rowProjectId?.let {
+                        replayWindowOrNull(
+                            projectId = it,
+                            startedMs = startedMs,
+                            finishedMs = finishedMs,
+                            userId = userId,
+                            retentionOptions = retentionOptions
+                        )
+                    }
                     val rawErrorCount = obj["error_count"]?.jsonPrimitive?.intOrNull ?: 0
                     val fallbackErrorCount =
-                        if (rawErrorCount == 0 && startedMs != null && finishedMs != null && rowProjectId != null) {
-                            getReplayWindowErrorCount(
-                                rowProjectId,
-                                startedMs,
-                                finishedMs,
-                                obj["user_id"]?.jsonPrimitive?.contentOrNull,
-                                queryOptions.retentionDays
-                            )
-                        } else {
-                            0
-                        }
-                    buildReplayListItemFromJson(obj, rowProjectId ?: 0L, maxOf(rawErrorCount, fallbackErrorCount))
+                        if (rawErrorCount == 0) fallbackReplayErrorCount(emptyList(), replayWindow) else 0
+                    val hasRage = contextEnrichmentForWindow(replayWindow).hasRage
+                    buildReplayListItemFromJson(
+                        obj,
+                        rowProjectId ?: 0L,
+                        maxOf(rawErrorCount, fallbackErrorCount),
+                        hasRage
+                    )
                 }.getOrElse { e ->
                     logger.error(e) { "Failed to parse replay list row" }
                     null
@@ -588,47 +857,33 @@ class ReplayService(
 
     private suspend fun buildReplayDetailFromRow(
         obj: JsonObject,
-        retentionDays: Int
+        retentionDays: Int,
+        demoEpochMs: Long? = null
     ): ReplayDetailResponse? {
         val replayId = obj["replay_id"]?.jsonPrimitive?.content ?: return null
         val objProjectId = obj["project_id"]?.jsonPrimitive?.long ?: return null
         val userId = obj["user_id"]?.jsonPrimitive?.contentOrNull
         val startedMs = obj["started_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
         val finishedMs = obj["finished_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
+        val replayWindow = replayWindowOrNull(
+            projectId = objProjectId,
+            startedMs = startedMs,
+            finishedMs = finishedMs,
+            userId = userId,
+            retentionOptions = ReplayRetentionOptions(retentionDays = retentionDays, demoEpochMs = demoEpochMs)
+        )
+        val urls = parseStringArray(obj["urls"])
         val tagsStr = obj["tags"]?.jsonPrimitive?.contentOrNull ?: "{}"
-        val tagsMap =
-            suspendRunCatching {
-                val tagsObj = json.parseToJsonElement(tagsStr) as? JsonObject ?: return null
-                tagsObj.mapValues { it.value.jsonPrimitive.content }
-            }.getOrElse { _ ->
-                emptyMap<String, String>()
-            }
+        val tagsMap = parseReplayTags(tagsStr)
         val replayErrorIds = parseStringArray(obj["error_ids"]).distinct()
-        val fallbackErrorIds =
-            if (replayErrorIds.isEmpty() && startedMs != null && finishedMs != null) {
-                getReplayWindowErrorIds(
-                    projectId = objProjectId,
-                    startMs = startedMs,
-                    endMs = finishedMs,
-                    userId = userId,
-                    retentionDays = retentionDays
-                )
-            } else {
-                emptyList()
-            }
+        val fallbackErrorIds = fallbackReplayErrorIds(replayErrorIds, replayWindow)
         val mergedErrorIds = (replayErrorIds + fallbackErrorIds).distinct()
-        val fallbackErrorCount =
-            if (replayErrorIds.isEmpty() && startedMs != null && finishedMs != null) {
-                getReplayWindowErrorCount(
-                    projectId = objProjectId,
-                    startMs = startedMs,
-                    endMs = finishedMs,
-                    userId = userId,
-                    retentionDays = retentionDays
-                )
-            } else {
-                0
-            }
+        val fallbackErrorCount = fallbackReplayErrorCount(replayErrorIds, replayWindow)
+        val contextEnrichment = contextEnrichmentForWindow(replayWindow)
+        val activity = obj["activity"]?.jsonPrimitive?.intOrNull ?: 0
+        val errorCount = maxOf(mergedErrorIds.size, fallbackErrorCount)
+        val ipAddress = obj["user_ip_address"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        val userSessionCount = userSessionCountForWindow(replayWindow)
         return ReplayDetailResponse(
             replayId = replayId,
             projectId = objProjectId,
@@ -636,8 +891,8 @@ class ReplayService(
             startedAt = obj["started_at"]?.jsonPrimitive?.content ?: "",
             finishedAt = obj["finished_at"]?.jsonPrimitive?.content ?: "",
             durationMs = obj["duration_ms"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull() ?: 0.0,
-            urls = parseStringArray(obj["urls"]),
-            errorCount = maxOf(mergedErrorIds.size, fallbackErrorCount),
+            urls = urls,
+            errorCount = errorCount,
             errorIds = mergedErrorIds,
             traceIds = parseStringArray(obj["trace_ids"]),
             segmentCount = obj["segment_count"]?.jsonPrimitive?.intOrNull ?: 0,
@@ -649,8 +904,15 @@ class ReplayService(
             browserVersion = obj["browser_version"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             osName = obj["os_name"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
             osVersion = obj["os_version"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
-            activity = obj["activity"]?.jsonPrimitive?.intOrNull ?: 0,
-            tags = tagsMap
+            activity = activity,
+            tags = tagsMap,
+            signals = buildReplaySignals(errorCount, activity, contextEnrichment.hasRage),
+            entryUrl = firstEntryUrl(urls),
+            ipAddress = ipAddress,
+            geo = geoLabelForIp(ipAddress),
+            viewport = contextEnrichment.viewport,
+            connection = contextEnrichment.connection,
+            userSessionCount = userSessionCount
         )
     }
 
@@ -683,6 +945,7 @@ class ReplayService(
                 argMax(user_id, timestamp) as user_id,
                 argMax(user_email, timestamp) as user_email,
                 argMax(user_username, timestamp) as user_username,
+                argMax(user_ip_address, timestamp) as user_ip_address,
                 argMax(browser_name, timestamp) as browser_name,
                 argMax(browser_version, timestamp) as browser_version,
                 argMax(os_name, timestamp) as os_name,
@@ -703,7 +966,7 @@ class ReplayService(
             val body = queryHelper.extractClickHouseBody(response) ?: return null
             val line = body.lines().firstOrNull { it.isNotBlank() } ?: return null
             val obj = json.parseToJsonElement(line).jsonObject
-            buildReplayDetailFromRow(obj, retentionDays)
+            buildReplayDetailFromRow(obj, retentionDays, demoEpochMs)
         }.getOrElse { e ->
             logger.error(e) { "Failed to fetch replay $replayId" }
             null
@@ -776,7 +1039,8 @@ class ReplayService(
             transaction_name,
             duration_ms,
             transaction_op,
-            contexts
+            contexts,
+            tags['http.status_code'] as http_status_code
         FROM `$clickhouseDb`.events e
         WHERE e.project_id = $projectId
             AND e.event_type = 'transaction'
@@ -808,7 +1072,8 @@ class ReplayService(
             resource as description,
             type as op,
             toUnixTimestamp64Milli(start) as start_ts_ms,
-            duration / 1000000.0 as duration_ms
+            duration / 1000000.0 as duration_ms,
+            meta['http.status_code'] as http_status_code
         FROM `$clickhouseDb`.apm_spans
         WHERE organization_id = $orgId
             AND trace_id_hex IN ($traceIdList)
@@ -817,6 +1082,151 @@ class ReplayService(
             AND ${queryHelper.timestampRetentionClause("start", retentionDays, demoEpochMs)}
         FORMAT JSONEachRow
     """.trimIndent()
+
+    private fun buildBreadcrumbsInRangeQuery(window: ReplayWindowQuery): String =
+        """
+        SELECT
+            toString(event_id) as event_id,
+            breadcrumbs
+        FROM `$clickhouseDb`.events
+        WHERE project_id = ${window.projectId}
+            AND timestamp >= fromUnixTimestamp64Milli(${window.startMs})
+            AND timestamp <= fromUnixTimestamp64Milli(${window.endMs})
+            AND breadcrumbs != '[]'
+            AND ${queryHelper.timestampRetentionClause("timestamp", window.retentionDays, window.demoEpochMs)}
+            ${window.userClause()}
+        ORDER BY timestamp ASC
+        LIMIT $REPLAY_BREADCRUMB_EVENT_LIMIT
+        FORMAT JSONEachRow
+        """.trimIndent()
+
+    private suspend fun fetchAndAddBreadcrumbTimelineItems(
+        query: String,
+        replayStartMs: Long,
+        items: MutableList<ReplayTimelineItem>,
+        addedIds: MutableSet<String>
+    ) {
+        suspendRunCatching {
+            val response = ClickHouseClient.execute(query)
+            val body = response.bodyAsText()
+            if (isClickHouseError(response.status.value, body, "Replay timeline breadcrumbs")) return
+
+            body
+                .lines()
+                .filter { it.isNotBlank() }
+                .filter { !it.trimStart().startsWith("Code:") }
+                .forEach { line ->
+                    val row = runCatching { json.parseToJsonElement(line).jsonObject }.getOrNull() ?: return@forEach
+                    val eventId = stringValue(row, "event_id") ?: "event"
+                    val breadcrumbs = parseStoredJsonArray(stringValue(row, "breadcrumbs")) ?: return@forEach
+                    breadcrumbs.forEachIndexed { index, element ->
+                        val breadcrumb = element as? JsonObject ?: return@forEachIndexed
+                        val item = mapBreadcrumbTimelineItem(eventId, index, breadcrumb, replayStartMs)
+                            ?: return@forEachIndexed
+                        if (addedIds.add(item.id)) items.add(item)
+                    }
+                }
+        }.onFailure { e ->
+            logger.error(e) { "Failed to fetch replay timeline breadcrumbs" }
+        }
+    }
+
+    private fun mapBreadcrumbTimelineItem(
+        eventId: String,
+        index: Int,
+        breadcrumb: JsonObject,
+        replayStartMs: Long
+    ): ReplayTimelineItem? {
+        if (shouldSkipBreadcrumb(breadcrumb)) return null
+        val timestampMs = breadcrumbTimestampMs(breadcrumb) ?: return null
+        val category = stringValue(breadcrumb, "category") ?: stringValue(breadcrumb, "type") ?: "breadcrumb"
+        val data = breadcrumb["data"] as? JsonObject
+        val message = stringValue(breadcrumb, "message")
+        val title = breadcrumbTitle(category, message)
+        val description = breadcrumbDescription(category, breadcrumb, data)
+        val statusCode =
+            statusCodeFromJson(data ?: JsonObject(emptyMap()), "status_code", "status") ?: statusCodeFromText(
+                listOfNotNull(description, message, title).joinToString(" ")
+            )
+
+        return ReplayTimelineItem(
+            id = "breadcrumb-$eventId-$index-$timestampMs",
+            type = "span",
+            timestamp = Instant.ofEpochMilli(timestampMs).toString(),
+            offsetMs = (timestampMs - replayStartMs).toDouble(),
+            title = title,
+            description = description,
+            category = category,
+            statusCode = statusCode,
+            rage = isRageBreadcrumb(breadcrumb).takeIf { it }
+        )
+    }
+
+    private fun shouldSkipBreadcrumb(breadcrumb: JsonObject): Boolean {
+        val category = stringValue(breadcrumb, "category") ?: ""
+        if (category.startsWith("device.")) return true
+        val data = breadcrumb["data"] as? JsonObject ?: return false
+        val action = stringValue(data, "action") ?: return false
+        return action in REPLAY_SKIPPED_BREADCRUMB_ACTIONS
+    }
+
+    private fun breadcrumbTimestampMs(breadcrumb: JsonObject): Long? {
+        val primitive = breadcrumb["timestamp"] as? JsonPrimitive ?: return null
+        val raw = primitive.contentOrNull ?: return null
+        raw.toDoubleOrNull()?.let { return (it * MILLISECONDS_PER_SECOND).toLong() }
+        return runCatching { Instant.parse(raw).toEpochMilli() }.getOrNull()
+    }
+
+    private fun breadcrumbTitle(category: String, message: String?): String =
+        if (category.isNotBlank() && category != "breadcrumb") {
+            category
+                .split(BREADCRUMB_CATEGORY_SPLIT_REGEX)
+                .filter { it.isNotBlank() }
+                .joinToString(" ") { part ->
+                    part.lowercase().replaceFirstChar { char -> char.uppercase() }
+                }
+        } else {
+            message?.takeIf { it.isNotBlank() } ?: "Breadcrumb"
+        }
+
+    private fun breadcrumbDescription(
+        category: String,
+        breadcrumb: JsonObject,
+        data: JsonObject?
+    ): String? {
+        stringValue(breadcrumb, "message")?.let { return it }
+        val normalized = category.lowercase()
+        if (normalized.contains("ui.lifecycle")) return lifecycleBreadcrumbDescription(data)
+        if (normalized.contains("navigation")) return navigationBreadcrumbDescription(data)
+        if (normalized.contains("http") || normalized.contains("network")) return networkBreadcrumbDescription(data)
+        return firstStringValue(data ?: JsonObject(emptyMap()), "action", "type")
+    }
+
+    private fun lifecycleBreadcrumbDescription(data: JsonObject?): String? {
+        val screen = data?.let { firstStringValue(it, "screen", "screen_name") } ?: "Screen"
+        val state = data?.let { stringValue(it, "state") }.orEmpty()
+        return "$screen: $state".trim()
+    }
+
+    private fun navigationBreadcrumbDescription(data: JsonObject?): String? {
+        if (data == null) return null
+        val screenName = firstStringValue(data, "screen_name", "screen")
+        if (screenName != null) return screenName
+        val from = stringValue(data, "from")
+        val to = stringValue(data, "to")
+        return listOfNotNull(from, to).takeIf { it.isNotEmpty() }?.joinToString(" -> ")
+    }
+
+    private fun networkBreadcrumbDescription(data: JsonObject?): String? {
+        if (data == null) return null
+        val parts =
+            listOfNotNull(
+                stringValue(data, "method"),
+                firstStringValue(data, "url", "path"),
+                firstStringValue(data, "status_code", "status")
+            )
+        return parts.takeIf { it.isNotEmpty() }?.joinToString(" ")
+    }
 
     suspend fun getReplayTimeline(
         replayId: String,
@@ -837,6 +1247,15 @@ class ReplayService(
             }
         val projectId = replay.projectId
         val retentionDays = queryHelper.getProjectRetentionDays(projectId)
+        val retentionOptions = ReplayRetentionOptions(retentionDays = retentionDays, demoEpochMs = demoEpochMs)
+        val replayWindow = ReplayWindowQuery(
+            projectId = projectId,
+            startMs = replayStartMs,
+            endMs = replayEndMs,
+            userId = replay.user?.id,
+            retentionDays = retentionOptions.retentionDays,
+            demoEpochMs = retentionOptions.demoEpochMs
+        )
         val items = mutableListOf<ReplayTimelineItem>()
         val addedIds = mutableSetOf<String>()
         val userClause =
@@ -929,7 +1348,8 @@ class ReplayService(
                 transaction_name,
                 duration_ms,
                 transaction_op,
-                contexts
+                contexts,
+                tags['http.status_code'] as http_status_code
             FROM (SELECT *, timestamp as ts_col FROM `$clickhouseDb`.events WHERE project_id = $projectId AND event_type = 'transaction' $userClause)
             WHERE ts_col >= fromUnixTimestamp64Milli($replayStartMs)
                 AND ts_col <= fromUnixTimestamp64Milli($replayEndMs)
@@ -957,7 +1377,8 @@ class ReplayService(
                 resource as description,
                 type as op,
                 toUnixTimestamp64Milli(start) as start_ts_ms,
-                duration / 1000000.0 as duration_ms
+                duration / 1000000.0 as duration_ms,
+                meta['http.status_code'] as http_status_code
             FROM `$clickhouseDb`.apm_spans
             WHERE organization_id = $spansOrgId
                 AND meta['sentry.project_id'] = '$projectId'
@@ -983,6 +1404,15 @@ class ReplayService(
                 addedIds = addedIds
             )
         }
+
+        val breadcrumbsInRangeQuery =
+            buildBreadcrumbsInRangeQuery(replayWindow)
+        fetchAndAddBreadcrumbTimelineItems(
+            query = breadcrumbsInRangeQuery,
+            replayStartMs = replayStartMs,
+            items = items,
+            addedIds = addedIds
+        )
 
         val sorted = items.sortedBy { it.offsetMs }
         return ReplayTimelineResponse(items = sorted, replayStartMs = replayStartMs)
@@ -1123,10 +1553,17 @@ class ReplayService(
         private const val LOG_BODY_PREVIEW_LENGTH = 400
         private const val MP4_HEADER_MIN_BYTES = 8
         private const val MP4_BOX_TYPE_OFFSET = 4
+        private const val MILLISECONDS_PER_SECOND = 1000.0
         private const val MILLIS_PER_DAY = 24L * 60 * 60 * 1000
         private const val PERIOD_24H_MS = MILLIS_PER_DAY
         private const val PERIOD_7D_MS = 7 * MILLIS_PER_DAY
         private const val PERIOD_30D_MS = 30 * MILLIS_PER_DAY
         private const val PERIOD_90D_MS = 90 * MILLIS_PER_DAY
+        private const val REPLAY_CONTEXT_EVENT_LIMIT = 100
+        private const val REPLAY_BREADCRUMB_EVENT_LIMIT = 100
+        private val HTTP_STATUS_REGEX = Regex("""\b([1-5]\d{2})\b""")
+        private val BREADCRUMB_CATEGORY_SPLIT_REGEX = Regex("[._-]+")
+        private val REPLAY_SKIPPED_BREADCRUMB_ACTIONS =
+            setOf("SCREEN_OFF", "SCREEN_ON", "DREAMING_STARTED", "DREAMING_STOPPED")
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
@@ -148,8 +148,16 @@ class ReplayServiceTest {
         val replayRow = """
 {"replay_id":"$REPLAY_UUID","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_count":2,"user_id":"u-1","user_email":"test@test.com","user_username":"tester","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":8}
         """.trimIndent()
+        val contextRow = """
+{"project_id":1,"ts_ms":"1767225660000","user_id":"u-1","contexts":"{}","breadcrumbs":"[{\"timestamp\":\"2026-01-01T00:01:00.000Z\",\"category\":\"ui.click\",\"message\":\"rage click x3\"}]"}
+        """.trimIndent()
         withClickHouseMockServer({ exchange ->
-            exchange.respond(200, replayRow, TEXT_PLAIN)
+            val query = exchange.requestBodyText()
+            if (query.contains("toUnixTimestamp64Milli(timestamp) as ts_ms")) {
+                exchange.respond(200, contextRow, TEXT_PLAIN)
+            } else {
+                exchange.respond(200, replayRow, TEXT_PLAIN)
+            }
         }) {
             val result = service.getReplays(projectId = 1, page = 1, limit = 25, period = "7d")
             assertEquals(1, result.size)
@@ -162,6 +170,7 @@ class ReplayServiceTest {
             assertEquals(8, result[0].activity)
             assertEquals("https://app.example.com", result[0].entryUrl)
             assertTrue("error" in result[0].signals)
+            assertTrue("rage_click" in result[0].signals)
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.services
 
+import com.moneat.analytics.services.GeoIpService
 import com.moneat.billing.services.PricingTierService
 import com.moneat.events.services.DashboardQueryHelper
 import com.moneat.events.services.ReplayService
@@ -24,7 +25,9 @@ import com.moneat.testsupport.OrgProjectTestFixtures
 import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
 import com.moneat.testsupport.withClickHouseMockServer
+import com.sun.net.httpserver.HttpExchange
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -45,8 +48,22 @@ class ReplayServiceTest {
 
     private val retentionPolicyService = mockk<RetentionPolicyService>()
     private val pricingTierService = mockk<PricingTierService>()
+    private val geoIpService = mockk<GeoIpService>()
     private lateinit var queryHelper: DashboardQueryHelper
     private lateinit var service: ReplayService
+
+    private data class ReplayTimelineRows(
+        val detailRow: String,
+        val errorRow: String,
+        val txRow: String,
+        val spanRow: String,
+        val breadcrumbRow: String
+    )
+
+    private data class TimelineQueryResponse(
+        val matches: (String) -> Boolean,
+        val body: String
+    )
 
     @BeforeTest
     fun setup() {
@@ -54,9 +71,47 @@ class ReplayServiceTest {
 
         coEvery { retentionPolicyService.getRetentionDaysForProject(any()) } returns 30
         coEvery { retentionPolicyService.getRetentionDaysForOrganization(any()) } returns 30
+        every { geoIpService.resolve(any()) } returns GeoIpService.GeoResult()
         queryHelper = DashboardQueryHelper(retentionPolicyService, pricingTierService)
-        service = ReplayService(queryHelper)
+        service = ReplayService(queryHelper, geoIpService = geoIpService)
     }
+
+    private fun respondReplayTimelineQuery(exchange: HttpExchange, rows: ReplayTimelineRows) {
+        val query = exchange.requestBodyText()
+        val body =
+            replayTimelineResponses(rows)
+                .firstOrNull { it.matches(query) }
+                ?.body
+                .orEmpty()
+        exchange.respond(200, body, TEXT_PLAIN)
+    }
+
+    private fun replayTimelineResponses(rows: ReplayTimelineRows): List<TimelineQueryResponse> =
+        listOf(
+            TimelineQueryResponse({ query -> query.contains("countDistinct(replay_id)") }, """{"count":0}"""),
+            TimelineQueryResponse({ query -> query.contains("SELECT contexts, breadcrumbs") }, ""),
+            TimelineQueryResponse(
+                { query -> query.contains("SELECT toString(event_id) as event_id") && query.contains("breadcrumbs") },
+                rows.breadcrumbRow
+            ),
+            TimelineQueryResponse({ query -> query.contains("SELECT toInt64(project_id)") }, """{"project_id":1}"""),
+            TimelineQueryResponse({ query -> query.contains("GROUP BY replay_id") }, rows.detailRow),
+            TimelineQueryResponse(
+                { query -> query.contains("event_type = 'error'") && query.contains("IN (") },
+                rows.errorRow
+            ),
+            TimelineQueryResponse(
+                { query -> query.contains("event_type = 'transaction'") && query.contains("trace_id") },
+                rows.txRow
+            ),
+            TimelineQueryResponse(
+                { query -> query.contains("apm_spans") && query.contains("trace_id_hex IN") },
+                rows.spanRow
+            ),
+            TimelineQueryResponse({ query -> query.contains("event_type = 'error'") }, ""),
+            TimelineQueryResponse({ query -> query.contains("event_type = 'transaction'") }, ""),
+            TimelineQueryResponse({ query -> query.contains("apm_spans") }, "")
+        )
 
     @Test
     fun `getProjectIdForReplay returns project id for valid replay`() = runBlocking {
@@ -105,6 +160,8 @@ class ReplayServiceTest {
             assertEquals("Chrome", result[0].browserName)
             assertEquals("macOS", result[0].osName)
             assertEquals(8, result[0].activity)
+            assertEquals("https://app.example.com", result[0].entryUrl)
+            assertTrue("error" in result[0].signals)
         }
     }
 
@@ -135,6 +192,7 @@ class ReplayServiceTest {
             assertEquals(1, result.size)
             assertEquals(2L, result.first().projectId)
             assertEquals(3, result.first().errorCount)
+            assertTrue("error" in result.first().signals)
             assertTrue(queries.any { it.contains("project_id IN (1, 2)") })
             assertTrue(queries.any { it.contains("project_id = 2") })
             assertTrue(queries.any { it.contains("environment = 'production'") })
@@ -154,16 +212,29 @@ class ReplayServiceTest {
     @Test
     fun `getReplay returns replay detail`() = runBlocking {
         val replayId = REPLAY_UUID
+        every { geoIpService.resolve("203.0.113.10") } returns GeoIpService.GeoResult(
+            countryCode = "IT",
+            city = "Milan"
+        )
         val detailRow = """
-{"replay_id":"$replayId","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_ids":["err-1"],"trace_ids":["trace-1"],"segment_count":5,"environment":"prod","release":"1.0.0","platform":"javascript","user_id":"u-1","user_email":"test@test.com","user_username":"tester","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":8,"tags":"{}"}
+{"replay_id":"$replayId","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_ids":["err-1"],"trace_ids":["trace-1"],"segment_count":5,"environment":"prod","release":"1.0.0","platform":"javascript","user_id":"u-1","user_email":"test@test.com","user_username":"tester","user_ip_address":"203.0.113.10","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":8,"tags":"{}"}
+        """.trimIndent()
+        val contextRow = """
+{"contexts":"{\"device\":{\"screen_width_pixels\":1512,\"screen_height_pixels\":856}}","breadcrumbs":"[{\"timestamp\":\"2026-01-01T00:00:10.000Z\",\"category\":\"network.event\",\"data\":{\"network_type\":\"4g\"}},{\"timestamp\":\"2026-01-01T00:00:11.000Z\",\"category\":\"ui.click\",\"message\":\"rage click x3\"}]"}
         """.trimIndent()
         withClickHouseMockServer({ exchange ->
             val query = exchange.requestBodyText()
             when {
-                query.contains("replay_events") && query.contains("project_id") && !query.contains("GROUP BY") ->
+                query.contains("countDistinct(replay_id)") ->
+                    exchange.respond(200, """{"count":14}""", TEXT_PLAIN)
+                query.contains("SELECT contexts, breadcrumbs") ->
+                    exchange.respond(200, contextRow, TEXT_PLAIN)
+                query.contains("SELECT toInt64(project_id)") ->
                     exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
-                else ->
+                query.contains("GROUP BY replay_id") ->
                     exchange.respond(200, detailRow, TEXT_PLAIN)
+                else ->
+                    exchange.respond(200, "", TEXT_PLAIN)
             }
         }) {
             val result = service.getReplay(replayId)
@@ -176,6 +247,14 @@ class ReplayServiceTest {
             assertEquals("javascript", result.platform)
             assertEquals("Chrome", result.browserName)
             assertEquals("macOS", result.osName)
+            assertEquals("https://app.example.com", result.entryUrl)
+            assertEquals("203.0.113.10", result.ipAddress)
+            assertEquals("Milan, IT", result.geo)
+            assertEquals("1512 x 856", result.viewport)
+            assertEquals("4g", result.connection)
+            assertEquals(14, result.userSessionCount)
+            assertTrue("error" in result.signals)
+            assertTrue("rage_click" in result.signals)
         }
     }
 
@@ -195,35 +274,23 @@ class ReplayServiceTest {
 {"event_id":"11111111-2222-3333-4444-555555555555","timestamp":"2026-01-01T00:01:00.000Z","ts_ms":"1767225660000","message":"NullPointerException","level":"error","issue_id":"issue-1","exception_type":"NullPointerException","exception_value":"null ref"}
         """.trimIndent()
         val txRow = """
-{"event_id":"22222222-3333-4444-5555-666666666666","timestamp":"2026-01-01T00:02:00.000Z","ts_ms":"1767225720000","transaction_name":"GET /api","duration_ms":"150.0","transaction_op":"http.server","contexts":"{}"}
+{"event_id":"22222222-3333-4444-5555-666666666666","timestamp":"2026-01-01T00:02:00.000Z","ts_ms":"1767225720000","transaction_name":"GET /api","duration_ms":"150.0","transaction_op":"http.server","contexts":"{}","http_status_code":"503"}
         """.trimIndent()
         val spanRow = """
-{"span_id":"span-1","trace_id":"trace-aaa","transaction_id":"22222222-3333-4444-5555-666666666666","description":"SELECT *","op":"db","start_ts_ms":"1767225720500","duration_ms":"50"}
+{"span_id":"span-1","trace_id":"trace-aaa","transaction_id":"22222222-3333-4444-5555-666666666666","description":"GET /health","op":"http.client","start_ts_ms":"1767225720500","duration_ms":"50","http_status_code":"200"}
         """.trimIndent()
+        val breadcrumbRow = """
+{"event_id":"33333333-4444-5555-6666-777777777777","breadcrumbs":"[{\"timestamp\":\"2026-01-01T00:00:30.000Z\",\"category\":\"Logcat\",\"message\":\"Client request failed: 401 Unauthorized\"},{\"timestamp\":\"2026-01-01T00:00:31.000Z\",\"category\":\"ui.click\",\"message\":\"rage click x3\"}]"}
+        """.trimIndent()
+        val rows = ReplayTimelineRows(
+            detailRow = detailRow,
+            errorRow = errorRow,
+            txRow = txRow,
+            spanRow = spanRow,
+            breadcrumbRow = breadcrumbRow
+        )
 
-        withClickHouseMockServer({ exchange ->
-            val query = exchange.requestBodyText()
-            when {
-                query.contains("replay_events") && !query.contains("GROUP BY") ->
-                    exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
-                query.contains("GROUP BY replay_id") ->
-                    exchange.respond(200, detailRow, TEXT_PLAIN)
-                query.contains("event_type = 'error'") && query.contains("IN (") ->
-                    exchange.respond(200, errorRow, TEXT_PLAIN)
-                query.contains("event_type = 'transaction'") && query.contains("trace_id") ->
-                    exchange.respond(200, txRow, TEXT_PLAIN)
-                query.contains("apm_spans") && query.contains("trace_id_hex IN") ->
-                    exchange.respond(200, spanRow, TEXT_PLAIN)
-                query.contains("event_type = 'error'") ->
-                    exchange.respond(200, "", TEXT_PLAIN)
-                query.contains("event_type = 'transaction'") ->
-                    exchange.respond(200, "", TEXT_PLAIN)
-                query.contains("apm_spans") ->
-                    exchange.respond(200, "", TEXT_PLAIN)
-                else ->
-                    exchange.respond(200, "", TEXT_PLAIN)
-            }
-        }) {
+        withClickHouseMockServer({ exchange -> respondReplayTimelineQuery(exchange, rows) }) {
             val result = service.getReplayTimeline(replayId)
             assertTrue(result.replayStartMs > 0)
             assertTrue(result.items.isNotEmpty())
@@ -233,9 +300,16 @@ class ReplayServiceTest {
             val txItem = result.items.find { it.type == "transaction" }
             assertNotNull(txItem)
             assertEquals("GET /api", txItem.title)
+            assertEquals(503, txItem.statusCode)
             val spanItem = result.items.find { it.type == "span" }
             assertNotNull(spanItem)
-            assertEquals("SELECT *", spanItem.title)
+            assertEquals("GET /health", spanItem.title)
+            assertEquals(200, spanItem.statusCode)
+            val logcatItem = result.items.find { it.category == "Logcat" }
+            assertNotNull(logcatItem)
+            assertEquals(401, logcatItem.statusCode)
+            val rageItem = result.items.find { it.rage == true }
+            assertNotNull(rageItem)
         }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
@@ -30,7 +30,13 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.msgpack.core.MessagePack
+import java.util.Base64
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -43,6 +49,7 @@ class ReplayServiceTest {
     companion object {
         private const val TEXT_PLAIN = "text/plain"
         private const val REPLAY_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        private val GEO_TEST_IP = listOf(203, 0, 113, 10).joinToString(".")
         private var db: Database? = null
     }
 
@@ -91,7 +98,7 @@ class ReplayServiceTest {
             TimelineQueryResponse({ query -> query.contains("countDistinct(replay_id)") }, """{"count":0}"""),
             TimelineQueryResponse({ query -> query.contains("SELECT contexts, breadcrumbs") }, ""),
             TimelineQueryResponse(
-                { query -> query.contains("SELECT toString(event_id) as event_id") && query.contains("breadcrumbs") },
+                { query -> query.contains("toString(event_id) as event_id") && query.contains("breadcrumbs") },
                 rows.breadcrumbRow
             ),
             TimelineQueryResponse({ query -> query.contains("SELECT toInt64(project_id)") }, """{"project_id":1}"""),
@@ -112,6 +119,59 @@ class ReplayServiceTest {
             TimelineQueryResponse({ query -> query.contains("event_type = 'transaction'") }, ""),
             TimelineQueryResponse({ query -> query.contains("apm_spans") }, "")
         )
+
+    private fun jsonString(value: String): String =
+        buildString {
+            append('"')
+            value.forEach { char ->
+                when (char) {
+                    '\\' -> append("\\\\")
+                    '"' -> append("\\\"")
+                    '\n' -> append("\\n")
+                    '\r' -> append("\\r")
+                    '\t' -> append("\\t")
+                    else -> append(char)
+                }
+            }
+            append('"')
+        }
+
+    private fun recordingDataRow(recordingData: String): String =
+        """{"recording_data":${jsonString(recordingData)}}"""
+
+    private fun encodedMobileReplaySegment(): String {
+        val replayEventPayload = """{"segment_id":7}""".toByteArray()
+        val recordingPayload =
+            """{"segment_id":7}[{"type":5,"timestamp":1000,"data":{"tag":"breadcrumb","payload":{"message":"tap"}}}]"""
+                .toByteArray()
+        val videoPayload = byteArrayOf(0, 0, 0, 24) + "ftyp".toByteArray() + byteArrayOf(0, 0, 0, 0)
+        val packer = MessagePack.newDefaultBufferPacker()
+        packer.packMapHeader(3)
+        packer.packString("replay_event")
+        packer.packBinaryHeader(replayEventPayload.size)
+        packer.writePayload(replayEventPayload)
+        packer.packString("replay_recording")
+        packer.packBinaryHeader(recordingPayload.size)
+        packer.writePayload(recordingPayload)
+        packer.packString("replay_video")
+        packer.packBinaryHeader(videoPayload.size)
+        packer.writePayload(videoPayload)
+        val bytes = packer.toByteArray()
+        packer.close()
+        return Base64.getEncoder().encodeToString(bytes)
+    }
+
+    private fun encodedMobileMetadataOnlySegment(): String {
+        val replayEventPayload = """{"segment_id":8}""".toByteArray()
+        val packer = MessagePack.newDefaultBufferPacker()
+        packer.packMapHeader(1)
+        packer.packString("replay_event")
+        packer.packBinaryHeader(replayEventPayload.size)
+        packer.writePayload(replayEventPayload)
+        val bytes = packer.toByteArray()
+        packer.close()
+        return Base64.getEncoder().encodeToString(bytes)
+    }
 
     @Test
     fun `getProjectIdForReplay returns project id for valid replay`() = runBlocking {
@@ -221,12 +281,12 @@ class ReplayServiceTest {
     @Test
     fun `getReplay returns replay detail`() = runBlocking {
         val replayId = REPLAY_UUID
-        every { geoIpService.resolve("203.0.113.10") } returns GeoIpService.GeoResult(
+        every { geoIpService.resolve(GEO_TEST_IP) } returns GeoIpService.GeoResult(
             countryCode = "IT",
             city = "Milan"
         )
         val detailRow = """
-{"replay_id":"$replayId","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_ids":["err-1"],"trace_ids":["trace-1"],"segment_count":5,"environment":"prod","release":"1.0.0","platform":"javascript","user_id":"u-1","user_email":"test@test.com","user_username":"tester","user_ip_address":"203.0.113.10","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":8,"tags":"{}"}
+{"replay_id":"$replayId","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_ids":["err-1"],"trace_ids":["trace-1"],"segment_count":5,"environment":"prod","release":"1.0.0","platform":"javascript","user_id":"u-1","user_email":"test@test.com","user_username":"tester","user_ip_address":"$GEO_TEST_IP","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":8,"tags":"{}"}
         """.trimIndent()
         val contextRow = """
 {"contexts":"{\"device\":{\"screen_width_pixels\":1512,\"screen_height_pixels\":856}}","breadcrumbs":"[{\"timestamp\":\"2026-01-01T00:00:10.000Z\",\"category\":\"network.event\",\"data\":{\"network_type\":\"4g\"}},{\"timestamp\":\"2026-01-01T00:00:11.000Z\",\"category\":\"ui.click\",\"message\":\"rage click x3\"}]"}
@@ -257,13 +317,60 @@ class ReplayServiceTest {
             assertEquals("Chrome", result.browserName)
             assertEquals("macOS", result.osName)
             assertEquals("https://app.example.com", result.entryUrl)
-            assertEquals("203.0.113.10", result.ipAddress)
+            assertEquals(GEO_TEST_IP, result.ipAddress)
             assertEquals("Milan, IT", result.geo)
             assertEquals("1512 x 856", result.viewport)
             assertEquals("4g", result.connection)
             assertEquals(14, result.userSessionCount)
             assertTrue("error" in result.signals)
             assertTrue("rage_click" in result.signals)
+        }
+    }
+
+    @Test
+    fun `getReplay falls back to window errors and subdivision geo`() = runBlocking {
+        val replayId = REPLAY_UUID
+        every { geoIpService.resolve(GEO_TEST_IP) } returns GeoIpService.GeoResult(
+            countryCode = "US",
+            subdivision = "CA"
+        )
+        val detailRow = """
+{"replay_id":"$replayId","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["","https://app.example.com/fallback"],"error_ids":[],"trace_ids":[],"segment_count":1,"environment":"","release":"","platform":"javascript","user_id":"u-1","user_email":"","user_username":"","user_ip_address":"$GEO_TEST_IP","browser_name":"","browser_version":"","os_name":"","os_version":"","activity":0,"tags":"not-json"}
+        """.trimIndent()
+        val errorIdRows = """
+{"event_id":"11111111-2222-3333-4444-555555555555"}
+{"event_id":"22222222-3333-4444-5555-666666666666"}
+        """.trimIndent()
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("SELECT toInt64(project_id)") ->
+                    exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
+                query.contains("GROUP BY replay_id") ->
+                    exchange.respond(200, detailRow, TEXT_PLAIN)
+                query.contains("SELECT toString(event_id) as event_id") ->
+                    exchange.respond(200, errorIdRows, TEXT_PLAIN)
+                query.contains("countDistinct(event_id)") ->
+                    exchange.respond(200, """{"count":2}""", TEXT_PLAIN)
+                query.contains("SELECT contexts, breadcrumbs") ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+                query.contains("countDistinct(replay_id)") ->
+                    exchange.respond(200, """{"count":0}""", TEXT_PLAIN)
+                else ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+            }
+        }) {
+            val result = service.getReplay(replayId)
+            assertNotNull(result)
+            assertEquals("https://app.example.com/fallback", result.entryUrl)
+            assertEquals(2, result.errorCount)
+            assertEquals(2, result.errorIds.size)
+            assertEquals(GEO_TEST_IP, result.ipAddress)
+            assertEquals("CA, US", result.geo)
+            assertTrue("error" in result.signals)
+            assertTrue("dead_click" in result.signals)
+            assertTrue(result.tags.isEmpty())
+            assertEquals(0, result.userSessionCount)
         }
     }
 
@@ -288,8 +395,19 @@ class ReplayServiceTest {
         val spanRow = """
 {"span_id":"span-1","trace_id":"trace-aaa","transaction_id":"22222222-3333-4444-5555-666666666666","description":"GET /health","op":"http.client","start_ts_ms":"1767225720500","duration_ms":"50","http_status_code":"200"}
         """.trimIndent()
+        val breadcrumbs = """
+[
+  {"timestamp":"2026-01-01T00:00:05.000Z","category":"device.battery","data":{"action":"SCREEN_OFF"}},
+  {"timestamp":1767225630.0,"category":"ui.lifecycle","data":{"screen":"Checkout","state":"active"}},
+  {"timestamp":"2026-01-01T00:00:32.000Z","category":"navigation.screen","data":{"from":"Cart","to":"Checkout"}},
+  {"timestamp":"2026-01-01T00:00:33.000Z","category":"network.event","data":{"method":"POST","url":"/api/pay","status_code":"502"}},
+  {"timestamp":"2026-01-01T00:00:34.000Z","type":"custom-action","data":{"type":"tap"}},
+  {"timestamp":"2026-01-01T00:00:35.000Z","category":"Logcat","message":"Client request failed: 401 Unauthorized"},
+  {"timestamp":"2026-01-01T00:00:36.000Z","category":"ui.click","message":"rage click x3"}
+]
+        """.trimIndent()
         val breadcrumbRow = """
-{"event_id":"33333333-4444-5555-6666-777777777777","breadcrumbs":"[{\"timestamp\":\"2026-01-01T00:00:30.000Z\",\"category\":\"Logcat\",\"message\":\"Client request failed: 401 Unauthorized\"},{\"timestamp\":\"2026-01-01T00:00:31.000Z\",\"category\":\"ui.click\",\"message\":\"rage click x3\"}]"}
+{"event_id":"33333333-4444-5555-6666-777777777777","breadcrumbs":${jsonString(breadcrumbs)}}
         """.trimIndent()
         val rows = ReplayTimelineRows(
             detailRow = detailRow,
@@ -310,15 +428,137 @@ class ReplayServiceTest {
             assertNotNull(txItem)
             assertEquals("GET /api", txItem.title)
             assertEquals(503, txItem.statusCode)
-            val spanItem = result.items.find { it.type == "span" }
+            val spanItem = result.items.find { it.traceId == "trace-aaa" && it.title == "GET /health" }
             assertNotNull(spanItem)
             assertEquals("GET /health", spanItem.title)
             assertEquals(200, spanItem.statusCode)
             val logcatItem = result.items.find { it.category == "Logcat" }
             assertNotNull(logcatItem)
             assertEquals(401, logcatItem.statusCode)
+            val lifecycleItem = result.items.find { it.category == "ui.lifecycle" }
+            assertNotNull(lifecycleItem)
+            assertEquals("Ui Lifecycle", lifecycleItem.title)
+            assertEquals("Checkout: active", lifecycleItem.description)
+            val navigationItem = result.items.find { it.category == "navigation.screen" }
+            assertNotNull(navigationItem)
+            assertEquals("Cart -> Checkout", navigationItem.description)
+            val networkItem = result.items.find { it.category == "network.event" }
+            assertNotNull(networkItem)
+            assertEquals("POST /api/pay 502", networkItem.description)
+            assertEquals(502, networkItem.statusCode)
+            val customItem = result.items.find { it.category == "custom-action" }
+            assertNotNull(customItem)
+            assertEquals("Custom Action", customItem.title)
+            assertEquals("tap", customItem.description)
+            assertNull(result.items.find { it.category == "device.battery" })
             val rageItem = result.items.find { it.rage == true }
             assertNotNull(rageItem)
+            Unit
+        }
+    }
+
+    @Test
+    fun `getReplayRecording decodes json payload variants`() = runBlocking {
+        val rawJsonEvents = """[{"type":2,"timestamp":1000}]"""
+        val encodedJsonEvents =
+            Base64.getEncoder().encodeToString("""[{"type":3,"timestamp":2000}]""".toByteArray())
+        val recordingRows = listOf(
+            recordingDataRow(rawJsonEvents),
+            recordingDataRow(encodedJsonEvents)
+        ).joinToString("\n")
+
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("SELECT toInt64(project_id)") ->
+                    exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
+                query.contains("SELECT recording_data") ->
+                    exchange.respond(200, recordingRows, TEXT_PLAIN)
+                else ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+            }
+        }) {
+            val result = service.getReplayRecording(REPLAY_UUID)
+            assertNotNull(result)
+            assertEquals(2, result.events.size)
+            assertEquals(2, result.events[0].jsonObject["type"]?.jsonPrimitive?.int)
+            assertEquals(3, result.events[1].jsonObject["type"]?.jsonPrimitive?.int)
+        }
+    }
+
+    @Test
+    fun `getReplayRecording decodes mobile msgpack recording and video payloads`() = runBlocking {
+        val recordingRows = recordingDataRow(encodedMobileReplaySegment())
+
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("SELECT toInt64(project_id)") ->
+                    exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
+                query.contains("SELECT recording_data") ->
+                    exchange.respond(200, recordingRows, TEXT_PLAIN)
+                else ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+            }
+        }) {
+            val result = service.getReplayRecording(REPLAY_UUID)
+            assertNotNull(result)
+            assertEquals(2, result.events.size)
+            val replayEvent = result.events.first { it.jsonObject["type"]?.jsonPrimitive?.int == 5 }
+            assertEquals(7, replayEvent.jsonObject["segment_id"]?.jsonPrimitive?.int)
+            val videoEvent = result.events.first {
+                it.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "mobile_replay_video"
+            }
+            assertEquals(7, videoEvent.jsonObject["segment_id"]?.jsonPrimitive?.int)
+            assertEquals("video/mp4", videoEvent.jsonObject["mime_type"]?.jsonPrimitive?.contentOrNull)
+        }
+    }
+
+    @Test
+    fun `getReplayRecording returns placeholder for unsupported mobile payloads`() = runBlocking {
+        val recordingRows = recordingDataRow(encodedMobileMetadataOnlySegment())
+
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("SELECT toInt64(project_id)") ->
+                    exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
+                query.contains("SELECT recording_data") ->
+                    exchange.respond(200, recordingRows, TEXT_PLAIN)
+                else ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+            }
+        }) {
+            val result = service.getReplayRecording(REPLAY_UUID)
+            assertNotNull(result)
+            assertEquals(1, result.events.size)
+            val placeholder = result.events.first().jsonObject
+            assertEquals("mobile_replay_not_supported", placeholder["type"]?.jsonPrimitive?.contentOrNull)
+        }
+    }
+
+    @Test
+    fun `getReplaysForIssue returns replay list items with entry url and signals`() = runBlocking {
+        val replayRow = """
+{"replay_id":"$REPLAY_UUID","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","duration_ms":"300000","urls":["","https://app.example.com/issue"],"error_count":1,"user_id":"u-1","user_email":"test@test.com","user_username":"tester","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":0}
+        """.trimIndent()
+
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("issues FINAL") ->
+                    exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
+                query.contains("replay_events r") ->
+                    exchange.respond(200, replayRow, TEXT_PLAIN)
+                else ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+            }
+        }) {
+            val result = service.getReplaysForIssue("issue-1")
+            assertEquals(1, result.size)
+            assertEquals("https://app.example.com/issue", result.first().entryUrl)
+            assertTrue("error" in result.first().signals)
+            assertTrue("dead_click" in result.first().signals)
         }
     }
 }

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
@@ -375,6 +375,37 @@ class ReplayServiceTest {
     }
 
     @Test
+    fun `getReplay formats country only geo when locality is unavailable`() = runBlocking {
+        val replayId = REPLAY_UUID
+        every { geoIpService.resolve(GEO_TEST_IP) } returns GeoIpService.GeoResult(countryCode = "FR")
+        val detailRow = """
+{"replay_id":"$replayId","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_ids":[],"trace_ids":[],"segment_count":1,"environment":"","release":"","platform":"javascript","user_id":"u-1","user_email":"","user_username":"","user_ip_address":"$GEO_TEST_IP","browser_name":"","browser_version":"","os_name":"","os_version":"","activity":8,"tags":"{}"}
+        """.trimIndent()
+
+        withClickHouseMockServer({ exchange ->
+            val query = exchange.requestBodyText()
+            when {
+                query.contains("SELECT toInt64(project_id)") ->
+                    exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
+                query.contains("GROUP BY replay_id") ->
+                    exchange.respond(200, detailRow, TEXT_PLAIN)
+                query.contains("countDistinct(event_id)") ->
+                    exchange.respond(200, """{"count":0}""", TEXT_PLAIN)
+                query.contains("SELECT contexts, breadcrumbs") ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+                query.contains("countDistinct(replay_id)") ->
+                    exchange.respond(200, """{"count":0}""", TEXT_PLAIN)
+                else ->
+                    exchange.respond(200, "", TEXT_PLAIN)
+            }
+        }) {
+            val result = service.getReplay(replayId)
+            assertNotNull(result)
+            assertEquals("FR", result.geo)
+        }
+    }
+
+    @Test
     fun `getReplay returns null for invalid uuid`() = runBlocking {
         assertNull(service.getReplay("bad-id"))
     }

--- a/dashboard/src/components/ReplayTimelinePanel.tsx
+++ b/dashboard/src/components/ReplayTimelinePanel.tsx
@@ -21,24 +21,21 @@ import {Link} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import type {ReplayTimelineItem as BaseTimelineItem} from '@/lib/api'
 import {api} from '@/lib/api'
-import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
 import {Badge} from '@/components/ui/badge'
 import {SpanWaterfall} from '@/components/SpanWaterfall'
 import {cn} from '@/lib/utils'
 import {
     Activity,
-    AlertCircle,
-    ChevronDown,
-    ChevronRight,
+    AlertTriangle,
     Clock,
     DatabaseZap,
     ExternalLink,
-    Layers,
     Loader2,
     MousePointerClick,
     Navigation,
     Network,
     Tag,
+    Terminal,
 } from 'lucide-react'
 
 /** Extended item type that can carry raw breadcrumb payload data */
@@ -54,7 +51,68 @@ export interface ReplayTimelinePanelProps {
   readonly onSeek: (offsetMs: number) => void
 }
 
-type FilterValue = 'all' | 'error' | 'transaction' | 'span'
+type FilterValue = 'all' | 'error' | 'http' | 'ui'
+
+type EventCategory = 'navigation' | 'ui' | 'http' | 'exception' | 'console' | 'other'
+
+/** Behavioral category for an event — drives the colored category label, icon, and filter tabs. */
+function eventCategory(item: TimelineItem): EventCategory {
+  if (item.type === 'error') return 'exception'
+  const c = (item.category ?? '').toLowerCase()
+  if (/exception|crash|fatal|\banr\b|\berror\b/.test(c)) return 'exception'
+  if (/console|logcat|(^|\W)log(\W|$)/.test(c)) return 'console'
+  if (/http|fetch|xhr|network|request|response|\bapi\b|graphql/.test(c)) return 'http'
+  if (/nav|route|page|screen/.test(c)) return 'navigation'
+  if (/\bui\b|click|tap|touch|gesture|input|scroll|press|swipe|key/.test(c)) return 'ui'
+  return 'other'
+}
+
+const CATEGORY_META: Record<EventCategory, { readonly label: string; readonly color: string; readonly Icon: typeof Activity }> = {
+  navigation: { label: 'navigation', color: 'text-success-fg', Icon: Navigation },
+  ui: { label: 'ui', color: 'text-info-fg', Icon: MousePointerClick },
+  http: { label: 'http', color: 'text-accent', Icon: Network },
+  exception: { label: 'exception', color: 'text-danger-fg', Icon: AlertTriangle },
+  console: { label: 'console', color: 'text-warning-fg', Icon: Terminal },
+  other: { label: 'event', color: 'text-muted-foreground', Icon: Activity },
+}
+
+/** HTTP status from the explicit field, else parsed from a "→ 500" style title. */
+function statusOf(item: TimelineItem): number | null {
+  if (typeof item.statusCode === 'number' && Number.isFinite(item.statusCode)) return item.statusCode
+  const m = item.title?.match(/→\s*(\d{3})\b/)
+  return m ? Number(m[1]) : null
+}
+
+/** A row reads as an error when it's a thrown error/exception or a failed (>=400) network call. */
+function isErrorEvent(item: TimelineItem): boolean {
+  if (item.type === 'error') return true
+  if (eventCategory(item) === 'exception') return true
+  const status = statusOf(item)
+  return status != null && status >= 400
+}
+
+function statusBadgeVariant(status: number): 'success' | 'warning' | 'danger' {
+  if (status >= 400) return 'danger'
+  if (status >= 300) return 'warning'
+  return 'success'
+}
+
+/** Strip a trailing "→ 500" / bare status from the title so we can render the code as a badge instead. */
+function titleWithoutStatus(title: string, status: number | null): string {
+  if (status == null) return title
+  return title.replace(/\s*→?\s*\b\d{3}\b\s*$/, '').trimEnd()
+}
+
+/** m:ss clock for the right-aligned time column (matches the player scrubber). */
+function formatClock(offsetMs: number): string {
+  const s = Math.max(0, Math.floor(offsetMs / 1000))
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
+}
+
+/** Lowercase + strip non-alphanumerics, for comparing a title against its category label. */
+function normalizeLabel(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
 
 function issueSearch(projectId?: string | number): { projectId: string | undefined } {
   return { projectId: projectId === undefined ? undefined : String(projectId) }
@@ -69,11 +127,6 @@ function formatOffset(offsetMs: number): string {
     return `+${minutes}m ${String(seconds).padStart(2, '0')}s`
   }
   return `+${seconds}.${String(Math.floor((offsetMs % 1000) / 100))}s`
-}
-
-function formatDurationLabel(ms: number): string {
-  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`
-  return `${Math.round(ms)}ms`
 }
 
 function formatTimestamp(isoString: string, timezone: string): string {
@@ -140,20 +193,6 @@ function typeColorClasses(type: TimelineItem['type']) {
         badge: 'bg-muted text-muted-foreground',
         dot: 'bg-muted-foreground/70',
       }
-  }
-}
-
-function TypeIcon({ type, className }: { readonly type: TimelineItem['type']; readonly className?: string }) {
-  const colors = typeColorClasses(type)
-  switch (type) {
-    case 'error':
-      return <AlertCircle className={cn('h-4 w-4 shrink-0', colors.text, className)} />
-    case 'transaction':
-      return <Layers className={cn('h-4 w-4 shrink-0', colors.text, className)} />
-    case 'span':
-      return <Activity className={cn('h-4 w-4 shrink-0', colors.text, className)} />
-    default:
-      return <Activity className={cn('h-4 w-4 shrink-0', colors.text, className)} />
   }
 }
 
@@ -421,34 +460,46 @@ function ExpandedItemPanel({
 
 /* ── Main component ── */
 
+const FILTERS: { readonly value: FilterValue; readonly label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'error', label: 'Errors' },
+  { value: 'http', label: 'Network' },
+  { value: 'ui', label: 'User' },
+]
+
 export function ReplayTimelinePanel({ items, currentOffsetMs, projectId, onSeek }: ReplayTimelinePanelProps) {
   const listRef = useRef<HTMLDivElement>(null)
-  const [tab, setTab] = useState<FilterValue>('all')
+  const [filter, setFilter] = useState<FilterValue>('all')
   const [expandedId, setExpandedId] = useState<string | null>(null)
-  const activeIndex = useMemo(() => findActiveIndex(items, currentOffsetMs), [items, currentOffsetMs])
 
-  const activeItem = activeIndex >= 0 ? items[activeIndex] : null
-  const errorItems = useMemo(() => items.filter((i) => i.type === 'error'), [items])
-  const transactionItems = useMemo(() => items.filter((i) => i.type === 'transaction'), [items])
-  const spanItems = useMemo(() => items.filter((i) => i.type === 'span'), [items])
-  const activeErrorIndex = activeItem?.type === 'error' ? errorItems.findIndex((it) => it.id === activeItem.id) : -1
-  const activeTransactionIndex = activeItem?.type === 'transaction' ? transactionItems.findIndex((it) => it.id === activeItem.id) : -1
-  const activeSpanIndex = activeItem?.type === 'span' ? spanItems.findIndex((it) => it.id === activeItem.id) : -1
-  let scrollIndex: number
-  if (tab === 'all') {
-    scrollIndex = activeIndex
-  } else if (tab === 'error') {
-    scrollIndex = activeErrorIndex
-  } else if (tab === 'transaction') {
-    scrollIndex = activeTransactionIndex
-  } else {
-    scrollIndex = activeSpanIndex
-  }
+  // Mirror the mockup's All / Errors / Network / User filter over behavioral categories.
+  const visibleItems = useMemo(() => {
+    switch (filter) {
+      case 'error':
+        return items.filter(isErrorEvent)
+      case 'http':
+        return items.filter((i) => eventCategory(i) === 'http')
+      case 'ui':
+        // "User" = user-driven interactions: clicks/taps/inputs plus navigation.
+        return items.filter((i) => {
+          const c = eventCategory(i)
+          return c === 'ui' || c === 'navigation'
+        })
+      default:
+        return items
+    }
+  }, [items, filter])
+
+  // Active row is tracked against the visible list so the highlight + autoscroll stay in sync.
+  const activeIndex = useMemo(
+    () => findActiveIndex(visibleItems, currentOffsetMs),
+    [visibleItems, currentOffsetMs]
+  )
 
   useEffect(() => {
-    if (scrollIndex >= 0 && listRef.current) {
+    if (activeIndex >= 0 && listRef.current) {
       const container = listRef.current
-      const el = container.querySelector<HTMLElement>(`[data-timeline-index="${scrollIndex}"]`)
+      const el = container.querySelector<HTMLElement>(`[data-timeline-index="${activeIndex}"]`)
       if (el) {
         const padding = 8
         const viewTop = container.scrollTop
@@ -463,7 +514,7 @@ export function ReplayTimelinePanel({ items, currentOffsetMs, projectId, onSeek 
         }
       }
     }
-  }, [scrollIndex])
+  }, [activeIndex])
 
   const handleItemClick = useCallback((item: TimelineItem) => {
     onSeek(item.offsetMs)
@@ -471,80 +522,40 @@ export function ReplayTimelinePanel({ items, currentOffsetMs, projectId, onSeek 
   }, [onSeek])
 
   return (
-    <div className="h-full min-h-0 rounded-lg border bg-card">
-      <Tabs
-        value={tab}
-        onValueChange={(v) => setTab(v as FilterValue)}
-        className="w-full h-full min-h-0 flex flex-col"
-      >
-        {/* Colored tab bar */}
-        <div className="px-2 pt-2">
-          <TabsList className="w-full grid grid-cols-4 h-9 gap-1 p-1 bg-muted/50">
-            <TabsTrigger value="all" className="text-xs data-[state=active]:bg-background">
-              All <span className="ml-1 text-[10px] font-mono text-muted-foreground">{items.length}</span>
-            </TabsTrigger>
-            <TabsTrigger value="error" className="text-xs data-[state=active]:bg-background data-[state=active]:text-danger-fg">
-              <span className="flex items-center gap-1">
-                <span className="h-1.5 w-1.5 rounded-full bg-danger-solid" />Errors
-              </span>
-              <span className="ml-1 text-[10px] font-mono">{errorItems.length}</span>
-            </TabsTrigger>
-            <TabsTrigger value="transaction" className="text-xs data-[state=active]:bg-background data-[state=active]:text-chart-2">
-              <span className="flex items-center gap-1">
-                <span className="h-1.5 w-1.5 rounded-full bg-chart-2" />Txns
-              </span>
-              <span className="ml-1 text-[10px] font-mono">{transactionItems.length}</span>
-            </TabsTrigger>
-            <TabsTrigger value="span" className="text-xs data-[state=active]:bg-background data-[state=active]:text-chart-4">
-              <span className="flex items-center gap-1">
-                <span className="h-1.5 w-1.5 rounded-full bg-chart-4" />Spans
-              </span>
-              <span className="ml-1 text-[10px] font-mono">{spanItems.length}</span>
-            </TabsTrigger>
-          </TabsList>
+    <div className="flex h-full min-h-0 w-full flex-col">
+      {/* Header: title + total count + segmented category filter */}
+      <div className="flex items-center gap-2 border-b px-2.5 py-2">
+        <span className="text-xs font-semibold">Events</span>
+        <Badge variant="neutral" className="text-[10px] tabular-nums">{items.length}</Badge>
+        <span className="flex-1" />
+        <div className="inline-flex items-center gap-0.5 rounded-md border bg-muted/40 p-0.5 text-xs">
+          {FILTERS.map((f) => (
+            <button
+              key={f.value}
+              type="button"
+              onClick={() => setFilter(f.value)}
+              aria-pressed={filter === f.value}
+              className={cn(
+                'rounded px-2 py-0.5 font-medium transition-colors',
+                filter === f.value
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
         </div>
+      </div>
 
-        <TabsContent value="all" className="mt-0 flex-1 min-h-0 px-2 pb-2">
-          <TimelineList
-            ref={listRef}
-            items={items}
-            activeIndex={activeIndex}
-            expandedId={expandedId}
-            projectId={projectId}
-            onItemClick={handleItemClick}
-          />
-        </TabsContent>
-        <TabsContent value="error" className="mt-0 flex-1 min-h-0 px-2 pb-2">
-          <TimelineList
-            ref={listRef}
-            items={errorItems}
-            activeIndex={activeErrorIndex}
-            expandedId={expandedId}
-            projectId={projectId}
-            onItemClick={handleItemClick}
-          />
-        </TabsContent>
-        <TabsContent value="transaction" className="mt-0 flex-1 min-h-0 px-2 pb-2">
-          <TimelineList
-            ref={listRef}
-            items={transactionItems}
-            activeIndex={activeTransactionIndex}
-            expandedId={expandedId}
-            projectId={projectId}
-            onItemClick={handleItemClick}
-          />
-        </TabsContent>
-        <TabsContent value="span" className="mt-0 flex-1 min-h-0 px-2 pb-2">
-          <TimelineList
-            ref={listRef}
-            items={spanItems}
-            activeIndex={activeSpanIndex}
-            expandedId={expandedId}
-            projectId={projectId}
-            onItemClick={handleItemClick}
-          />
-        </TabsContent>
-      </Tabs>
+      <TimelineList
+        ref={listRef}
+        items={visibleItems}
+        activeIndex={activeIndex}
+        expandedId={expandedId}
+        projectId={projectId}
+        onItemClick={handleItemClick}
+      />
     </div>
   )
 }
@@ -564,118 +575,86 @@ const TimelineList = React.forwardRef<HTMLDivElement, TimelineListProps>(functio
   ref
 ) {
   return (
-    <div
-      ref={ref}
-      className="h-full min-h-[280px] overflow-y-auto rounded-md border bg-muted/20 mt-2"
-    >
+    <div ref={ref} className="min-h-0 flex-1 overflow-y-auto">
       {items.length === 0 ? (
-        <div className="p-6 text-sm text-muted-foreground text-center">
-          <Activity className="h-8 w-8 mx-auto mb-2 opacity-30" />
-          No timeline items in this category.
+        <div className="flex flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground">
+          <Activity className="h-6 w-6 opacity-30" />
+          No events in this category.
         </div>
       ) : (
-        <ul className="divide-y divide-border/50">
+        <ul>
           {items.map((item, index) => {
             const isActive = index === activeIndex
             const isExpanded = expandedId === item.id
-            const colors = typeColorClasses(item.type)
-            let itemBgClass: string
-            if (isActive) {
-              itemBgClass = colors.bgActive
-            } else if (isExpanded) {
-              itemBgClass = colors.bg
+            const meta = CATEGORY_META[eventCategory(item)]
+            const error = isErrorEvent(item)
+            const status = statusOf(item)
+            const rawTitle = titleWithoutStatus(item.title, status)
+            const categoryLabel = item.category && item.category.trim().length > 0 ? item.category : meta.label
+            // The title often just echoes the category ("Navigation", "Logcat") — when it does, promote
+            // the actual detail to the single primary line rather than repeating the category label.
+            const titleRedundant =
+              normalizeLabel(rawTitle).length > 0 && normalizeLabel(rawTitle) === normalizeLabel(categoryLabel)
+            const primary = titleRedundant && item.description ? item.description : rawTitle
+            const secondary = titleRedundant ? undefined : item.description
+
+            let rowClass: string
+            if (isActive && error) {
+              rowClass = 'border-l-danger-solid bg-danger-bg'
+            } else if (isActive) {
+              rowClass = 'border-l-primary bg-muted/60'
+            } else if (error) {
+              rowClass = 'border-l-transparent bg-danger-bg/50 hover:bg-danger-bg'
             } else {
-              itemBgClass = 'hover:bg-muted/40'
+              rowClass = 'border-l-transparent hover:bg-muted/40'
             }
 
             return (
-              <li key={item.id}>
+              <li key={item.id} className="border-b border-border/60 last:border-b-0">
                 <button
                   type="button"
                   data-timeline-index={index}
                   onClick={() => onItemClick(item)}
+                  style={{ gridTemplateColumns: '132px minmax(0, 1fr) auto' }}
                   className={cn(
-                    'w-full text-left flex items-center gap-3 px-3 py-2.5 border-l-[3px] transition-all duration-150',
-                    colors.border,
-                    itemBgClass,
+                    'grid w-full items-center gap-3 border-l-2 px-3 py-2 text-left text-sm transition-colors',
+                    rowClass,
                   )}
                 >
-                  {/* Expand indicator */}
-                  <div className="shrink-0">
-                    {isExpanded ? (
-                      <ChevronDown className={cn('h-3.5 w-3.5', colors.text)} />
-                    ) : (
-                      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50" />
-                    )}
-                  </div>
+                  {/* Category */}
+                  <span className={cn('inline-flex items-center gap-1.5 text-xs font-medium', meta.color)}>
+                    <meta.Icon className="h-3.5 w-3.5 shrink-0" />
+                    <span className="truncate">{categoryLabel}</span>
+                  </span>
 
-                  <TypeIcon type={item.type} />
-
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-mono text-[11px] text-muted-foreground shrink-0 tabular-nums">
-                        {formatOffset(item.offsetMs)}
+                  {/* Message: primary detail + status / rage badges, optional secondary line */}
+                  <span className="min-w-0">
+                    <span className="flex items-center gap-1.5 text-foreground">
+                      <span className="truncate" title={item.title}>{primary}</span>
+                      {status != null && (
+                        <Badge variant={statusBadgeVariant(status)} className="h-4 shrink-0 px-1 text-[10px] tabular-nums">
+                          {status}
+                        </Badge>
+                      )}
+                      {item.rage && (
+                        <Badge variant="warning" className="h-4 shrink-0 px-1 text-[10px]">rage</Badge>
+                      )}
+                    </span>
+                    {secondary && (
+                      <span className="mt-0.5 block truncate text-[11px] text-muted-foreground" title={item.description}>
+                        {secondary}
                       </span>
-                      {item.durationMs != null && item.durationMs > 0 && (
-                        <span className={cn(
-                          'text-[10px] px-1.5 py-0.5 rounded-full font-mono font-medium',
-                          colors.badge,
-                        )}>
-                          {formatDurationLabel(item.durationMs)}
-                        </span>
-                      )}
-                      {item.category && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-mono">
-                          {item.category}
-                        </span>
-                      )}
-                      {isActive && (
-                        <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />
-                      )}
-                    </div>
-                    <div className="text-sm font-medium truncate mt-0.5" title={item.title}>
-                      {item.title}
-                    </div>
-                    {item.description && !isExpanded && (
-                      <div className="text-xs text-muted-foreground truncate" title={item.description}>
-                        {item.description}
-                      </div>
                     )}
-                  </div>
+                  </span>
 
-                  {/* Quick link icons */}
-                  {item.issueId && (
-                    <Link
-                      to="/issues/$issueId"
-                      params={{ issueId: item.issueId }}
-                      search={issueSearch(projectId)}
-                      onClick={(e) => e.stopPropagation()}
-                      className="shrink-0 p-1.5 rounded-md hover:bg-danger-bg text-danger-fg transition-colors"
-                      aria-label="View issue"
-                    >
-                      <ExternalLink className="h-3.5 w-3.5" />
-                    </Link>
-                  )}
-                  {item.traceId && !item.issueId && item.type === 'transaction' && (
-                    <Link
-                      to="/performance/traces/$traceId"
-                      params={{ traceId: item.traceId }}
-                      onClick={(e) => e.stopPropagation()}
-                      className="shrink-0 p-1.5 rounded-md hover:bg-chart-2/15 text-chart-2 transition-colors"
-                      aria-label="View trace"
-                    >
-                      <ExternalLink className="h-3.5 w-3.5" />
-                    </Link>
-                  )}
+                  {/* Offset clock */}
+                  <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                    {formatClock(item.offsetMs)}
+                  </span>
                 </button>
 
                 {/* Expanded detail — waterfall or breadcrumb details */}
-                {isExpanded && (
-                  <ExpandedItemPanel
-                    item={item}
-                    projectId={projectId}
-                  />
-                )}
+                {isExpanded && <ExpandedItemPanel item={item} projectId={projectId} />}
               </li>
             )
           })}

--- a/dashboard/src/components/ReplayTimelinePanel.tsx
+++ b/dashboard/src/components/ReplayTimelinePanel.tsx
@@ -79,7 +79,7 @@ const CATEGORY_META: Record<EventCategory, { readonly label: string; readonly co
 /** HTTP status from the explicit field, else parsed from a "→ 500" style title. */
 function statusOf(item: TimelineItem): number | null {
   if (typeof item.statusCode === 'number' && Number.isFinite(item.statusCode)) return item.statusCode
-  const m = item.title?.match(/→\s*(\d{3})\b/)
+  const m = /→\s*(\d{3})\b/.exec(item.title ?? '')
   return m ? Number(m[1]) : null
 }
 
@@ -111,7 +111,7 @@ function formatClock(offsetMs: number): string {
 
 /** Lowercase + strip non-alphanumerics, for comparing a title against its category label. */
 function normalizeLabel(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]/g, '')
+  return s.toLowerCase().replaceAll(/[^a-z0-9]/g, '')
 }
 
 function issueSearch(projectId?: string | number): { projectId: string | undefined } {

--- a/dashboard/src/components/ReplayTimelinePanel.tsx
+++ b/dashboard/src/components/ReplayTimelinePanel.tsx
@@ -100,7 +100,14 @@ function statusBadgeVariant(status: number): 'success' | 'warning' | 'danger' {
 /** Strip a trailing "→ 500" / bare status from the title so we can render the code as a badge instead. */
 function titleWithoutStatus(title: string, status: number | null): string {
   if (status == null) return title
-  return title.replace(/\s*→?\s*\b\d{3}\b\s*$/, '').trimEnd()
+  const trimmedTitle = title.trimEnd()
+  const statusText = String(status)
+  if (!trimmedTitle.endsWith(statusText)) return title
+
+  const beforeStatus = trimmedTitle.slice(0, -statusText.length).trimEnd()
+  return beforeStatus.endsWith('→')
+    ? beforeStatus.slice(0, -1).trimEnd()
+    : beforeStatus
 }
 
 /** m:ss clock for the right-aligned time column (matches the player scrubber). */

--- a/dashboard/src/components/ReplayTimelineScrubber.tsx
+++ b/dashboard/src/components/ReplayTimelineScrubber.tsx
@@ -18,6 +18,7 @@ import {useRef, useState, useCallback, useMemo} from 'react'
 import type {ReplayTimelineItem} from '@/lib/api'
 import {cn} from '@/lib/utils'
 import {
+  AlertTriangle,
   Pause,
   Play,
   RotateCcw,
@@ -52,16 +53,30 @@ function formatClock(ms: number): string {
   return `${minutes}:${String(seconds).padStart(2, '0')}`
 }
 
-function markerColor(type: ReplayTimelineItem['type']): string {
+// Tokenized marker colors — never raw ramp values (semantic tokens only).
+function markerBgClass(type: ReplayTimelineItem['type']): string {
   switch (type) {
     case 'error':
-      return '#ef4444'
+      return 'bg-danger-solid'
     case 'transaction':
-      return '#3b82f6'
+      return 'bg-info-solid'
     case 'span':
-      return '#14b8a6'
+      return 'bg-chart-4'
     default:
-      return '#94a3b8'
+      return 'bg-muted-foreground'
+  }
+}
+
+function markerTextClass(type: ReplayTimelineItem['type']): string {
+  switch (type) {
+    case 'error':
+      return 'text-danger-fg'
+    case 'transaction':
+      return 'text-info-fg'
+    case 'span':
+      return 'text-chart-4'
+    default:
+      return 'text-muted-foreground'
   }
 }
 
@@ -95,6 +110,11 @@ export function ReplayTimelineScrubber({
       percent: Math.max(0, Math.min((item.offsetMs / durationMs) * 100, 100)),
     }))
   }, [items, durationMs])
+
+  const hoveredMarkerData = useMemo(
+    () => markers.find((m) => m.id === hoveredMarker) ?? null,
+    [markers, hoveredMarker]
+  )
 
   const seekFromPointer = useCallback(
     (clientX: number) => {
@@ -139,6 +159,13 @@ export function ReplayTimelineScrubber({
       onSeek(Math.min(durationMs, currentOffsetMs + 10_000))
     }
   }, [items, currentOffsetMs, durationMs, onSeek])
+
+  const errorItems = useMemo(() => items.filter((item) => item.type === 'error'), [items])
+
+  const handleNextError = useCallback(() => {
+    const next = errorItems.find((item) => item.offsetMs > currentOffsetMs + 200) ?? errorItems[0]
+    if (next) onSeek(next.offsetMs)
+  }, [errorItems, currentOffsetMs, onSeek])
 
   const handleCycleSpeed = useCallback(() => {
     if (!onSpeedChange) return
@@ -200,47 +227,47 @@ export function ReplayTimelineScrubber({
               }}
               onMouseEnter={() => setHoveredMarker(marker.id)}
               onMouseLeave={() => setHoveredMarker((cur) => (cur === marker.id ? null : cur))}
-              className="absolute top-1/2 z-20 -translate-x-1/2 -translate-y-1/2 rounded-full hover:scale-150 transition-transform appearance-none p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-              style={{
-                left: `${marker.percent}%`,
-                width: 10,
-                height: 10,
-                backgroundColor: markerColor(marker.type),
-                border: '1.5px solid hsl(var(--background))',
-                boxShadow: isHovered
-                  ? `0 0 6px 2px ${markerColor(marker.type)}`
-                  : '0 0 0 0.5px rgba(0,0,0,0.2)',
-              }}
-              aria-label={`${marker.title} at ${formatClock(marker.offsetMs)}`}
-            >
-              {isHovered && (
-                <div
-                  className="pointer-events-none absolute left-1/2 z-50 w-52 -translate-x-1/2 rounded-lg border bg-popover p-2 text-left overflow-hidden"
-                  style={{ bottom: 'calc(100% + 10px)' }}
-                >
-                  <div className="text-xs font-semibold truncate min-w-0" style={{ color: markerColor(marker.type) }} title={marker.title}>
-                    {marker.title}
-                  </div>
-                  <div className="text-[10px] text-muted-foreground mt-0.5 font-mono">
-                    {formatClock(marker.offsetMs)}
-                    {marker.durationMs != null && marker.durationMs > 0 && (
-                      <span className="ml-1.5 opacity-70">
-                        ({marker.durationMs >= 1000
-                          ? `${(marker.durationMs / 1000).toFixed(2)}s`
-                          : `${Math.round(marker.durationMs)}ms`})
-                      </span>
-                    )}
-                  </div>
-                  {marker.description && (
-                    <div className="text-[10px] text-muted-foreground mt-0.5 truncate">
-                      {marker.description}
-                    </div>
-                  )}
-                </div>
+              className={cn(
+                'absolute top-1/2 z-20 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 appearance-none rounded-full border-[1.5px] border-background p-0 transition-transform hover:scale-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                markerBgClass(marker.type),
+                isHovered && 'scale-150 ring-2 ring-primary/40'
               )}
-            </button>
+              style={{ left: `${marker.percent}%` }}
+              aria-label={`${marker.title} at ${formatClock(marker.offsetMs)}`}
+            />
           )
         })}
+
+        {/* Hover card — anchored to the track and clamped to the track edges, so it
+            stays on-screen for any marker position regardless of the track's width. */}
+        {hoveredMarkerData && (
+          <div
+            className="pointer-events-none absolute z-50 w-52 rounded-lg border bg-popover p-2 text-left overflow-hidden"
+            style={{
+              bottom: 'calc(100% + 10px)',
+              left: `clamp(0px, calc(${hoveredMarkerData.percent}% - 6.5rem), calc(100% - 13rem))`,
+            }}
+          >
+            <div className={cn('text-xs font-semibold truncate min-w-0', markerTextClass(hoveredMarkerData.type))} title={hoveredMarkerData.title}>
+              {hoveredMarkerData.title}
+            </div>
+            <div className="text-[10px] text-muted-foreground mt-0.5 font-mono">
+              {formatClock(hoveredMarkerData.offsetMs)}
+              {hoveredMarkerData.durationMs != null && hoveredMarkerData.durationMs > 0 && (
+                <span className="ml-1.5 opacity-70">
+                  ({hoveredMarkerData.durationMs >= 1000
+                    ? `${(hoveredMarkerData.durationMs / 1000).toFixed(2)}s`
+                    : `${Math.round(hoveredMarkerData.durationMs)}ms`})
+                </span>
+              )}
+            </div>
+            {hoveredMarkerData.description && (
+              <div className="text-[10px] text-muted-foreground mt-0.5 truncate">
+                {hoveredMarkerData.description}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Playhead */}
         <div
@@ -297,6 +324,19 @@ export function ReplayTimelineScrubber({
 
         {/* Spacer */}
         <div className="flex-1" />
+
+        {/* Jump to next error */}
+        {errorItems.length > 0 && (
+          <button
+            type="button"
+            onClick={handleNextError}
+            className="inline-flex items-center gap-1 rounded border border-danger-border bg-danger-bg px-2 py-0.5 text-xs font-medium text-danger-fg transition-colors hover:bg-danger-bg/70"
+            title="Jump to next error"
+          >
+            <AlertTriangle className="h-3 w-3" />
+            Next error
+          </button>
+        )}
 
         {/* Speed */}
         {onSpeedChange && (

--- a/dashboard/src/components/__tests__/ReplayTimelinePanel.test.tsx
+++ b/dashboard/src/components/__tests__/ReplayTimelinePanel.test.tsx
@@ -1,0 +1,82 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it, vi} from 'vitest'
+import {fireEvent, render, screen} from '@testing-library/react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {ReplayTimelinePanel} from '@/components/ReplayTimelinePanel'
+import type {ReplayTimelineItem} from '@/lib/api'
+
+vi.mock('@/hooks/useTimezone', () => ({useTimezone: () => ({timezone: 'UTC'})}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({children}: {children: React.ReactNode}) => <a>{children}</a>,
+}))
+
+const items: ReplayTimelineItem[] = [
+  {id: 'n1', type: 'span', timestamp: '2026-06-01T00:00:00.000Z', offsetMs: 0, title: 'Direct → /products', category: 'navigation'},
+  {id: 'u1', type: 'span', timestamp: '2026-06-01T00:00:03.000Z', offsetMs: 3_000, title: 'click "Place order"', category: 'ui.click', description: 'rage click ×3', rage: true},
+  {id: 'h1', type: 'span', timestamp: '2026-06-01T00:00:06.000Z', offsetMs: 6_000, title: 'POST /api/checkout → 500', category: 'http'},
+  {id: 'e1', type: 'error', timestamp: '2026-06-01T00:00:09.000Z', offsetMs: 9_000, title: "TypeError: cannot read 'total' of undefined", category: 'exception'},
+  {id: 'lc', type: 'span', timestamp: '2026-06-01T00:00:12.000Z', offsetMs: 12_000, title: 'Logcat', category: 'Logcat', description: 'No auth token available'},
+]
+
+function setup() {
+  const onSeek = vi.fn()
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ReplayTimelinePanel items={items} currentOffsetMs={0} projectId="svc-1" onSeek={onSeek} />
+    </QueryClientProvider>
+  )
+  return {onSeek}
+}
+
+describe('ReplayTimelinePanel (target-state rail)', () => {
+  it('renders the All / Errors / Network / User filters and the total count', () => {
+    setup()
+    for (const label of ['All', 'Errors', 'Network', 'User']) {
+      expect(screen.getByRole('button', {name: label})).toBeInTheDocument()
+    }
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('collapses a title that just echoes its category onto the detail line', () => {
+    setup()
+    // The detail becomes the primary line...
+    expect(screen.getByText('No auth token available')).toBeInTheDocument()
+    // ...and "Logcat" shows once (the category label), not also as a redundant title.
+    expect(screen.getAllByText('Logcat')).toHaveLength(1)
+  })
+
+  it('renders an HTTP status badge and a rage badge from target-state fields', () => {
+    setup()
+    expect(screen.getByText('500')).toBeInTheDocument()
+    expect(screen.getByText('rage')).toBeInTheDocument()
+  })
+
+  it('filters to network events when Network is selected', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button', {name: 'Network'}))
+    expect(screen.getByText(/POST \/api\/checkout/)).toBeInTheDocument()
+    expect(screen.queryByText(/Direct →/)).not.toBeInTheDocument()
+  })
+
+  it('seeks to the event offset when a row is clicked', () => {
+    const {onSeek} = setup()
+    fireEvent.click(screen.getByText(/click "Place order"/))
+    expect(onSeek).toHaveBeenCalledWith(3_000)
+  })
+})

--- a/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
+++ b/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
@@ -21,11 +21,29 @@ import type {ReplayTimelineItem} from '@/lib/api'
 
 const items: ReplayTimelineItem[] = [
   {id: 's1', type: 'span', timestamp: '2026-06-01T00:00:05.000Z', offsetMs: 5_000, title: 'ui.click'},
-  {id: 'e1', type: 'error', timestamp: '2026-06-01T00:00:24.000Z', offsetMs: 24_000, title: 'POST /checkout 500'},
+  {
+    id: 'e1',
+    type: 'error',
+    timestamp: '2026-06-01T00:00:24.000Z',
+    offsetMs: 24_000,
+    durationMs: 275,
+    title: 'POST /checkout 500',
+    description: 'Request failed',
+  },
   {id: 'e2', type: 'error', timestamp: '2026-06-01T00:00:46.000Z', offsetMs: 46_000, title: 'POST /checkout 500'},
 ]
 
-function setup(currentOffsetMs = 0) {
+function setup({
+  currentOffsetMs = 0,
+  isPlaying = false,
+  isFullscreen = false,
+  onFullscreenToggle,
+}: {
+  readonly currentOffsetMs?: number
+  readonly isPlaying?: boolean
+  readonly isFullscreen?: boolean
+  readonly onFullscreenToggle?: () => void
+} = {}) {
   const onSeek = vi.fn()
   const onPlayPause = vi.fn()
   const onSpeedChange = vi.fn()
@@ -33,12 +51,14 @@ function setup(currentOffsetMs = 0) {
     <ReplayTimelineScrubber
       currentOffsetMs={currentOffsetMs}
       durationMs={84_000}
-      isPlaying={false}
+      isPlaying={isPlaying}
       items={items}
       onSeek={onSeek}
       onPlayPause={onPlayPause}
       onSpeedChange={onSpeedChange}
       speed={1}
+      onFullscreenToggle={onFullscreenToggle}
+      isFullscreen={isFullscreen}
     />
   )
   return {onSeek, onPlayPause, onSpeedChange}
@@ -53,13 +73,13 @@ describe('ReplayTimelineScrubber', () => {
   })
 
   it('jumps to the next error after the current time', () => {
-    const {onSeek} = setup(10_000)
+    const {onSeek} = setup({currentOffsetMs: 10_000})
     fireEvent.click(screen.getByRole('button', {name: /Next error/}))
     expect(onSeek).toHaveBeenCalledWith(24_000)
   })
 
   it('wraps to the first error when none remain ahead', () => {
-    const {onSeek} = setup(60_000)
+    const {onSeek} = setup({currentOffsetMs: 60_000})
     fireEvent.click(screen.getByRole('button', {name: /Next error/}))
     expect(onSeek).toHaveBeenCalledWith(24_000)
   })
@@ -70,5 +90,58 @@ describe('ReplayTimelineScrubber', () => {
     expect(onPlayPause).toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', {name: '1x'}))
     expect(onSpeedChange).toHaveBeenCalledWith(1.5)
+  })
+
+  it('supports keyboard seeking from the slider', () => {
+    const {onSeek} = setup({currentOffsetMs: 42_000})
+    const slider = screen.getByRole('slider')
+
+    fireEvent.keyDown(slider, {key: 'ArrowRight'})
+    fireEvent.keyDown(slider, {key: 'ArrowLeft'})
+    fireEvent.keyDown(slider, {key: 'Home'})
+    fireEvent.keyDown(slider, {key: 'End'})
+
+    expect(onSeek).toHaveBeenNthCalledWith(1, 46_200)
+    expect(onSeek).toHaveBeenNthCalledWith(2, 37_800)
+    expect(onSeek).toHaveBeenNthCalledWith(3, 0)
+    expect(onSeek).toHaveBeenNthCalledWith(4, 84_000)
+  })
+
+  it('seeks from the track, marker, skip, and fullscreen controls', () => {
+    const onFullscreenToggle = vi.fn()
+    const {onSeek} = setup({currentOffsetMs: 40_000, isPlaying: true, onFullscreenToggle})
+    const slider = screen.getByRole('slider')
+    vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 10,
+      top: 0,
+      right: 110,
+      bottom: 6,
+      width: 100,
+      height: 6,
+      toJSON: () => ({}),
+    })
+
+    fireEvent.mouseDown(slider, {clientX: 50})
+    globalThis.dispatchEvent(new MouseEvent('mousemove', {clientX: 110}))
+    globalThis.dispatchEvent(new MouseEvent('mouseup'))
+    fireEvent.click(screen.getByRole('button', {name: /ui\.click at 0:05/}))
+    fireEvent.click(screen.getByRole('button', {name: 'Skip to next event'}))
+    fireEvent.click(screen.getByRole('button', {name: 'Fullscreen'}))
+
+    expect(onSeek).toHaveBeenNthCalledWith(1, 33_600)
+    expect(onSeek).toHaveBeenNthCalledWith(2, 84_000)
+    expect(onSeek).toHaveBeenNthCalledWith(3, 5_000)
+    expect(onSeek).toHaveBeenNthCalledWith(4, 46_000)
+    expect(onFullscreenToggle).toHaveBeenCalled()
+  })
+
+  it('renders marker hover details', () => {
+    setup()
+    fireEvent.mouseEnter(screen.getByRole('button', {name: /POST \/checkout 500 at 0:24/}))
+
+    expect(screen.getByText('Request failed')).toBeInTheDocument()
+    expect(screen.getByText('(275ms)')).toBeInTheDocument()
   })
 })

--- a/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
+++ b/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
@@ -144,26 +144,4 @@ describe('ReplayTimelineScrubber', () => {
     expect(screen.getByText('Request failed')).toBeInTheDocument()
     expect(screen.getByText('(275ms)')).toBeInTheDocument()
   })
-
-  it('clamps navigation without markers or optional controls', () => {
-    const onSeek = vi.fn()
-    render(
-      <ReplayTimelineScrubber
-        currentOffsetMs={4_000}
-        durationMs={84_000}
-        isPlaying={false}
-        items={[]}
-        onSeek={onSeek}
-        onPlayPause={vi.fn()}
-      />
-    )
-
-    fireEvent.click(screen.getByRole('button', {name: 'Rewind 10 seconds'}))
-    fireEvent.click(screen.getByRole('button', {name: 'Skip to next event'}))
-
-    expect(onSeek).toHaveBeenNthCalledWith(1, 0)
-    expect(onSeek).toHaveBeenNthCalledWith(2, 14_000)
-    expect(screen.queryByRole('button', {name: /Next error/})).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', {name: '1x'})).not.toBeInTheDocument()
-  })
 })

--- a/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
+++ b/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
@@ -1,0 +1,74 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it, vi} from 'vitest'
+import {fireEvent, render, screen} from '@testing-library/react'
+import {ReplayTimelineScrubber} from '@/components/ReplayTimelineScrubber'
+import type {ReplayTimelineItem} from '@/lib/api'
+
+const items: ReplayTimelineItem[] = [
+  {id: 's1', type: 'span', timestamp: '2026-06-01T00:00:05.000Z', offsetMs: 5_000, title: 'ui.click'},
+  {id: 'e1', type: 'error', timestamp: '2026-06-01T00:00:24.000Z', offsetMs: 24_000, title: 'POST /checkout 500'},
+  {id: 'e2', type: 'error', timestamp: '2026-06-01T00:00:46.000Z', offsetMs: 46_000, title: 'POST /checkout 500'},
+]
+
+function setup(currentOffsetMs = 0) {
+  const onSeek = vi.fn()
+  const onPlayPause = vi.fn()
+  const onSpeedChange = vi.fn()
+  render(
+    <ReplayTimelineScrubber
+      currentOffsetMs={currentOffsetMs}
+      durationMs={84_000}
+      isPlaying={false}
+      items={items}
+      onSeek={onSeek}
+      onPlayPause={onPlayPause}
+      onSpeedChange={onSpeedChange}
+      speed={1}
+    />
+  )
+  return {onSeek, onPlayPause, onSpeedChange}
+}
+
+describe('ReplayTimelineScrubber', () => {
+  it('renders a marker per timeline item with an accessible clock', () => {
+    setup()
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', '0:00 / 1:24')
+    // one seek button per marker
+    expect(screen.getAllByRole('button', {name: /at 0:/})).toHaveLength(3)
+  })
+
+  it('jumps to the next error after the current time', () => {
+    const {onSeek} = setup(10_000)
+    fireEvent.click(screen.getByRole('button', {name: /Next error/}))
+    expect(onSeek).toHaveBeenCalledWith(24_000)
+  })
+
+  it('wraps to the first error when none remain ahead', () => {
+    const {onSeek} = setup(60_000)
+    fireEvent.click(screen.getByRole('button', {name: /Next error/}))
+    expect(onSeek).toHaveBeenCalledWith(24_000)
+  })
+
+  it('toggles play and cycles speed', () => {
+    const {onPlayPause, onSpeedChange} = setup()
+    fireEvent.click(screen.getByRole('button', {name: 'Play'}))
+    expect(onPlayPause).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', {name: '1x'}))
+    expect(onSpeedChange).toHaveBeenCalledWith(1.5)
+  })
+})

--- a/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
+++ b/dashboard/src/components/__tests__/ReplayTimelineScrubber.test.tsx
@@ -144,4 +144,26 @@ describe('ReplayTimelineScrubber', () => {
     expect(screen.getByText('Request failed')).toBeInTheDocument()
     expect(screen.getByText('(275ms)')).toBeInTheDocument()
   })
+
+  it('clamps navigation without markers or optional controls', () => {
+    const onSeek = vi.fn()
+    render(
+      <ReplayTimelineScrubber
+        currentOffsetMs={4_000}
+        durationMs={84_000}
+        isPlaying={false}
+        items={[]}
+        onSeek={onSeek}
+        onPlayPause={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', {name: 'Rewind 10 seconds'}))
+    fireEvent.click(screen.getByRole('button', {name: 'Skip to next event'}))
+
+    expect(onSeek).toHaveBeenNthCalledWith(1, 0)
+    expect(onSeek).toHaveBeenNthCalledWith(2, 14_000)
+    expect(screen.queryByRole('button', {name: /Next error/})).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: '1x'})).not.toBeInTheDocument()
+  })
 })

--- a/dashboard/src/lib/__tests__/replays-view.test.ts
+++ b/dashboard/src/lib/__tests__/replays-view.test.ts
@@ -1,0 +1,147 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {
+  browserOsLabel,
+  deriveReplaySignals,
+  formatReplayClock,
+  getActivityLevel,
+  isAnonymous,
+  isMobileOs,
+  replayAvatarClass,
+  replayDisplayName,
+  replayEntryPath,
+  replayExtraPageCount,
+  replayInitials,
+  replayStatusTone,
+} from '@/lib/replays-view'
+
+describe('formatReplayClock', () => {
+  it('formats minutes:seconds and clamps negatives/sub-second', () => {
+    expect(formatReplayClock(0)).toBe('0:00')
+    expect(formatReplayClock(-5)).toBe('0:00')
+    expect(formatReplayClock(500)).toBe('0:00')
+    expect(formatReplayClock(84_000)).toBe('1:24')
+    expect(formatReplayClock(9_000)).toBe('0:09')
+  })
+
+  it('adds an hours segment past 60 minutes', () => {
+    expect(formatReplayClock(3_661_000)).toBe('1:01:01')
+  })
+})
+
+describe('replayDisplayName / isAnonymous', () => {
+  it('prefers email, then username, then id, then Anonymous', () => {
+    expect(replayDisplayName({email: 'a@b.com', username: 'A', id: '1'})).toBe('a@b.com')
+    expect(replayDisplayName({username: 'Worker User', id: '1'})).toBe('Worker User')
+    expect(replayDisplayName({id: 'anon-1'})).toBe('anon-1')
+    expect(replayDisplayName(undefined)).toBe('Anonymous')
+    expect(replayDisplayName({})).toBe('Anonymous')
+  })
+
+  it('detects anonymous users', () => {
+    expect(isAnonymous(undefined)).toBe(true)
+    expect(isAnonymous({})).toBe(true)
+    expect(isAnonymous({id: 'x'})).toBe(false)
+  })
+})
+
+describe('replayInitials', () => {
+  it('derives initials from the best available identity', () => {
+    expect(replayInitials({username: 'Ada Lovelace'})).toBe('AL')
+    expect(replayInitials({username: 'ada'})).toBe('AD')
+    expect(replayInitials({email: 'zoe@x.io'})).toBe('ZO')
+    expect(replayInitials({id: 'qx-9'})).toBe('QX')
+    expect(replayInitials(undefined)).toBe('?')
+  })
+})
+
+describe('replayAvatarClass', () => {
+  it('returns a muted tint for anonymous and a deterministic chart tint otherwise', () => {
+    expect(replayAvatarClass(undefined)).toContain('bg-muted')
+    const a = replayAvatarClass({email: 'a@b.com'})
+    const b = replayAvatarClass({email: 'a@b.com'})
+    expect(a).toBe(b)
+    expect(a).toMatch(/bg-chart-\d/)
+  })
+})
+
+describe('getActivityLevel', () => {
+  it('buckets activity into High/Medium/Low/Idle', () => {
+    expect(getActivityLevel(95).label).toBe('High')
+    expect(getActivityLevel(50).label).toBe('Medium')
+    expect(getActivityLevel(10).label).toBe('Low')
+    expect(getActivityLevel(0).label).toBe('Idle')
+    expect(getActivityLevel(95).barClass).toContain('bg-')
+  })
+})
+
+describe('deriveReplaySignals', () => {
+  it('derives the error badge from errorCount', () => {
+    expect(deriveReplaySignals({errorCount: 2})).toEqual([
+      {key: 'error', label: '2', variant: 'danger'},
+    ])
+    expect(deriveReplaySignals({errorCount: 0})).toEqual([])
+  })
+
+  it('appends behavioural signals and ignores a redundant error signal', () => {
+    const badges = deriveReplaySignals({
+      errorCount: 1,
+      signals: ['rage_click', 'bounce', 'error', 'purchase'],
+    })
+    expect(badges.map((b) => b.key)).toEqual(['error', 'rage', 'bounce', 'purchase'])
+  })
+})
+
+describe('replayEntryPath / replayExtraPageCount', () => {
+  it('reduces a URL to its path and prefers entryUrl', () => {
+    expect(replayEntryPath({urls: ['https://app.x.io/checkout?step=2']})).toBe('/checkout?step=2')
+    expect(replayEntryPath({entryUrl: 'https://x.io/a', urls: ['https://x.io/b']})).toBe('/a')
+    expect(replayEntryPath({urls: ['https://x.io']})).toBe('/')
+    expect(replayEntryPath({urls: ['/already/a/path']})).toBe('/already/a/path')
+    expect(replayEntryPath({urls: []})).toBe('—')
+  })
+
+  it('counts pages beyond the entry', () => {
+    expect(replayExtraPageCount({urls: ['a', 'b', 'c']})).toBe(2)
+    expect(replayExtraPageCount({urls: ['a']})).toBe(0)
+    expect(replayExtraPageCount({urls: []})).toBe(0)
+  })
+})
+
+describe('replayStatusTone', () => {
+  it('prioritises errors, then friction signals, then activity', () => {
+    expect(replayStatusTone({errorCount: 1, activity: 0})).toBe('danger')
+    expect(replayStatusTone({errorCount: 0, activity: 10, signals: ['rage_click']})).toBe('warning')
+    expect(replayStatusTone({errorCount: 0, activity: 90})).toBe('success')
+    expect(replayStatusTone({errorCount: 0, activity: 30})).toBe('neutral')
+  })
+})
+
+describe('browserOsLabel / isMobileOs', () => {
+  it('joins browser and os when present', () => {
+    expect(browserOsLabel({browserName: 'Chrome', osName: 'macOS'})).toBe('Chrome · macOS')
+    expect(browserOsLabel({})).toBeNull()
+  })
+
+  it('recognises mobile operating systems', () => {
+    expect(isMobileOs('iOS 17')).toBe(true)
+    expect(isMobileOs('Android 14')).toBe(true)
+    expect(isMobileOs('macOS 14')).toBe(false)
+    expect(isMobileOs(undefined)).toBe(false)
+  })
+})

--- a/dashboard/src/lib/api/types/replays.ts
+++ b/dashboard/src/lib/api/types/replays.ts
@@ -14,6 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+/**
+ * Behavioural signals surfaced as list badges / facets. `error` is derived from
+ * errorCount today; the rest are populated once the backend computes them.
+ */
+export type ReplaySignal = 'error' | 'rage_click' | 'dead_click' | 'bounce' | 'purchase'
+
 export interface Replay {
   replayId: string
   projectId: number
@@ -29,6 +35,11 @@ export interface Replay {
   osName?: string
   osVersion?: string
   activity: number
+  // Optional — populated once the backend emits behavioural signals; until then
+  // the list derives the `error` badge from errorCount and leaves the rest empty.
+  signals?: ReplaySignal[]
+  /** First page of the session; falls back to urls[0] when absent. */
+  entryUrl?: string
 }
 
 export interface ReplayDetail extends Replay {
@@ -39,6 +50,12 @@ export interface ReplayDetail extends Replay {
   release?: string
   platform?: string
   tags: Record<string, string>
+  // Optional context cards — backend-pending; rendered only when present.
+  ipAddress?: string
+  geo?: string
+  viewport?: string
+  connection?: string
+  userSessionCount?: number
 }
 
 export interface ReplayRecordingResponse {
@@ -90,6 +107,10 @@ export interface ReplayTimelineItem {
   eventId?: string
   issueId?: string
   traceId?: string
+  /** HTTP status for network events — drives the inline status badge (backend-pending). */
+  statusCode?: number
+  /** Marks a rage-click / frustration signal — drives the "rage" badge (backend-pending). */
+  rage?: boolean
 }
 
 export interface ReplayTimelineResponse {

--- a/dashboard/src/lib/replays-view.ts
+++ b/dashboard/src/lib/replays-view.ts
@@ -81,8 +81,8 @@ export function replayAvatarClass(user?: ReplayUser): string {
   if (isAnonymous(user)) return 'bg-muted text-muted-foreground'
   const str = user?.username || user?.email || user?.id || ''
   let hash = 0
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+  for (const char of str) {
+    hash = (char.codePointAt(0) ?? 0) + ((hash << 5) - hash)
   }
   return AVATAR_TINTS[Math.abs(hash) % AVATAR_TINTS.length]
 }

--- a/dashboard/src/lib/replays-view.ts
+++ b/dashboard/src/lib/replays-view.ts
@@ -1,0 +1,165 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {Replay, ReplaySignal} from '@/lib/api'
+import type {BadgeProps} from '@/components/ui/badge'
+import type {StatusTone} from '@/components/ui/status-dot'
+
+type BadgeVariant = NonNullable<BadgeProps['variant']>
+type ReplayUser = { id?: string; email?: string; username?: string }
+
+/** Row status dot: errors dominate, then friction signals, then liveliness. */
+export function replayStatusTone(
+  replay: Pick<Replay, 'errorCount' | 'activity' | 'signals'>
+): StatusTone {
+  if (replay.errorCount > 0) return 'danger'
+  const signals = replay.signals ?? []
+  if (signals.includes('rage_click') || signals.includes('dead_click')) return 'warning'
+  if (replay.activity >= 80) return 'success'
+  return 'neutral'
+}
+
+/** Clock formatting (mm:ss / h:mm:ss) shared by the list, header, and scrubber. */
+export function formatReplayClock(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+/** Display name precedence used everywhere a session is labelled. */
+export function replayDisplayName(user?: ReplayUser): string {
+  return user?.email || user?.username || user?.id || 'Anonymous'
+}
+
+export function isAnonymous(user?: ReplayUser): boolean {
+  return !user?.email && !user?.username && !user?.id
+}
+
+export function replayInitials(user?: ReplayUser): string {
+  if (user?.username) {
+    const parts = user.username.trim().split(/\s+/)
+    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase()
+    return user.username.slice(0, 2).toUpperCase()
+  }
+  if (user?.email) return user.email.slice(0, 2).toUpperCase()
+  if (user?.id) return user.id.slice(0, 2).toUpperCase()
+  return '?'
+}
+
+// Deterministic avatar tint from the categorical chart palette (literal classes
+// so Tailwind emits them); encodes identity, not status.
+const AVATAR_TINTS = [
+  'bg-chart-1/20 text-chart-1',
+  'bg-chart-2/20 text-chart-2',
+  'bg-chart-3/20 text-chart-3',
+  'bg-chart-4/20 text-chart-4',
+  'bg-chart-5/20 text-chart-5',
+  'bg-chart-6/20 text-chart-6',
+  'bg-chart-7/20 text-chart-7',
+  'bg-chart-8/20 text-chart-8',
+] as const
+
+export function replayAvatarClass(user?: ReplayUser): string {
+  if (isAnonymous(user)) return 'bg-muted text-muted-foreground'
+  const str = user?.username || user?.email || user?.id || ''
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+  }
+  return AVATAR_TINTS[Math.abs(hash) % AVATAR_TINTS.length]
+}
+
+export interface ActivityLevel {
+  readonly label: string
+  /** Tailwind class for the activity bar fill. */
+  readonly barClass: string
+}
+
+export function getActivityLevel(activity: number): ActivityLevel {
+  if (activity >= 80) return {label: 'High', barClass: 'bg-success-solid'}
+  if (activity >= 40) return {label: 'Medium', barClass: 'bg-success-solid'}
+  if (activity > 0) return {label: 'Low', barClass: 'bg-warning-solid'}
+  return {label: 'Idle', barClass: 'bg-muted-foreground/60'}
+}
+
+export interface ReplaySignalBadge {
+  readonly key: string
+  readonly label: string
+  readonly variant: BadgeVariant
+}
+
+const SIGNAL_BADGES: Record<Exclude<ReplaySignal, 'error'>, ReplaySignalBadge> = {
+  rage_click: {key: 'rage', label: 'rage', variant: 'warning'},
+  dead_click: {key: 'dead', label: 'dead', variant: 'warning'},
+  bounce: {key: 'bounce', label: 'bounce', variant: 'neutral'},
+  purchase: {key: 'purchase', label: 'purchase', variant: 'success'},
+}
+
+/**
+ * Badges shown in the list's Signals column. The error count is derived from
+ * `errorCount`; behavioural signals come from the optional `signals` array.
+ */
+export function deriveReplaySignals(
+  replay: Pick<Replay, 'errorCount' | 'signals'>
+): ReplaySignalBadge[] {
+  const out: ReplaySignalBadge[] = []
+  if (replay.errorCount > 0) {
+    out.push({key: 'error', label: String(replay.errorCount), variant: 'danger'})
+  }
+  for (const signal of replay.signals ?? []) {
+    if (signal === 'error') continue
+    const badge = SIGNAL_BADGES[signal]
+    if (badge) out.push(badge)
+  }
+  return out
+}
+
+/** Strip protocol + host so the table shows a compact "/path". */
+export function replayEntryPath(replay: Pick<Replay, 'entryUrl' | 'urls'>): string {
+  const raw = replay.entryUrl || replay.urls?.[0]
+  if (!raw) return '—'
+  try {
+    const url = new URL(raw)
+    return (url.pathname || '/') + (url.search || '')
+  } catch {
+    // Already a bare path, or unparseable — strip any leading scheme/host best-effort.
+    return raw.replace(/^https?:\/\/[^/]+/i, '') || raw
+  }
+}
+
+export function replayExtraPageCount(replay: Pick<Replay, 'urls'>): number {
+  return Math.max(0, (replay.urls?.length ?? 0) - 1)
+}
+
+export function browserOsLabel(
+  replay: Pick<Replay, 'browserName' | 'osName'>
+): string | null {
+  const label = [replay.browserName, replay.osName].filter(Boolean).join(' · ')
+  return label.length > 0 ? label : null
+}
+
+const MOBILE_HINTS = ['ios', 'android', 'iphone', 'ipad', 'mobile']
+
+export function isMobileOs(osName?: string): boolean {
+  if (!osName) return false
+  const lower = osName.toLowerCase()
+  return MOBILE_HINTS.some((hint) => lower.includes(hint))
+}

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -421,12 +421,19 @@ function AuthenticatedContent({
     )
   }
 
+  // Fixed region below the header and right of the sidebar (mirrors the split-panel
+  // branch above). This gives in-flow pages a definite height, so an ExplorerShell —
+  // or any `h-full` page — reaches the bottom of the viewport; taller content scrolls
+  // within this region instead of the body.
   return (
     <div
-      className="relative z-0 transition-[margin-left] duration-300"
+      className="z-0 overflow-y-auto transition-[left,top] duration-300"
       style={{
-        marginLeft: sidebarWidth,
-        paddingTop: headerHeight,
+        position: 'fixed',
+        top: headerHeight,
+        left: sidebarWidth,
+        right: 0,
+        bottom: 0,
         '--header-height': `${headerHeight}px`,
         '--sidebar-width': `${sidebarWidth}px`,
       } as React.CSSProperties}

--- a/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
+++ b/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
@@ -348,9 +348,10 @@ describe('release, replay, and feedback service facets', () => {
     renderRoute(ReplaysRoute)
 
     await screen.findByText('user@example.com')
-    fireEvent.change(screen.getByPlaceholderText('Search by user, URL, or browser...'), {
-      target: {value: 'does-not-exist'},
-    })
+    // The shared search bar commits free text on Enter (not on change).
+    const searchInput = screen.getByRole('textbox')
+    fireEvent.change(searchInput, {target: {value: 'does-not-exist'}})
+    fireEvent.keyDown(searchInput, {key: 'Enter'})
 
     expect(await screen.findByText('No replays match your search')).toBeInTheDocument()
   })

--- a/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
+++ b/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
@@ -3,7 +3,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {fireEvent, screen, waitFor} from '@testing-library/react'
 import {clearAuthStorage, renderRoute} from '@/test/utils'
 
-const {mockApi, mockRouteParams} = vi.hoisted(() => {
+const {mockApi, mockRouteParams, mockNavigate} = vi.hoisted(() => {
   type MockRouteParams = {
     feedbackId?: string
     version?: string
@@ -28,6 +28,7 @@ const {mockApi, mockRouteParams} = vi.hoisted(() => {
     mockRouteParams: {
       current: {version: '1.0.0'} as MockRouteParams,
     },
+    mockNavigate: vi.fn(),
   }
 })
 
@@ -63,7 +64,7 @@ vi.mock('@tanstack/react-router', () => ({
   Outlet: () => null,
   redirect: (opts: Record<string, unknown>) => ({...opts, __redirect: true}),
   useMatches: () => [],
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
 }))
 
 import {Route as FeedbackRoute} from '../feedback'
@@ -332,6 +333,28 @@ describe('release, replay, and feedback service facets', () => {
         environment: undefined,
         services: ['Worker Service'],
       })
+    })
+  })
+
+  it('opens replay rows from keyboard activation', async () => {
+    mockApi.getOrganizationReplays.mockResolvedValue(replayVariants)
+
+    renderRoute(ReplaysRoute)
+
+    const replayRow = await screen.findByRole('button', {name: /Open replay replay-1 for user@example.com/})
+    fireEvent.keyDown(replayRow, {key: 'Enter'})
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/replays/$replayId',
+      params: {replayId: 'replay-1'},
+    })
+
+    mockNavigate.mockClear()
+    fireEvent.keyDown(replayRow, {key: ' '})
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/replays/$replayId',
+      params: {replayId: 'replay-1'},
     })
   })
 

--- a/dashboard/src/routes/__tests__/replay-detail.test.tsx
+++ b/dashboard/src/routes/__tests__/replay-detail.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {fireEvent, screen} from '@testing-library/react'
+import {clearAuthStorage, renderRoute} from '@/test/utils'
+
+const {mockApi, mockRouteParams} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    getReplay: vi.fn(),
+    getReplayRecording: vi.fn(),
+    getReplayTimeline: vi.fn(),
+  },
+  mockRouteParams: {current: {replayId: 'replay-1'}},
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+  formatErrorForLogging: (error: unknown) => String(error),
+}))
+
+vi.mock('@/hooks/useTimezone', () => ({useTimezone: () => ({timezone: 'UTC'})}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    options,
+    useParams: () => mockRouteParams.current,
+    useSearch: () => ({}),
+  }),
+  Link: ({children}: {children: React.ReactNode}) => <a>{children}</a>,
+  redirect: (opts: Record<string, unknown>) => ({...opts, __redirect: true}),
+}))
+
+// Stub the heavy player/canvas children so the test renders the route's layout
+// without pulling in rrweb / the mobile video pipeline.
+vi.mock('@/components/ReplayPlayer', () => ({ReplayPlayer: () => <div>player</div>}))
+vi.mock('@/components/MobileReplayViewer', () => ({MobileReplayViewer: () => <div>mobile-player</div>}))
+vi.mock('@/components/ReplayTimelinePanel', () => ({ReplayTimelinePanel: () => <div>event-rail</div>}))
+vi.mock('@/components/ReplayTimelineScrubber', () => ({ReplayTimelineScrubber: () => <div>scrubber</div>}))
+vi.mock('@/components/replay-containers/BrowserWindowContainer', () => ({
+  BrowserWindowContainer: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+vi.mock('@/components/replay-containers/MobileDeviceContainer', () => ({
+  MobileDeviceContainer: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+
+import {Route as ReplayDetailRoute} from '../replays.$replayId'
+
+const replayDetail = {
+  replayId: 'replay-1',
+  projectId: 1,
+  projectResourceId: 'svc-api',
+  startedAt: '2026-06-01T00:00:00.000Z',
+  finishedAt: '2026-06-01T00:01:24.000Z',
+  durationMs: 84_000,
+  urls: ['https://app.example.com/checkout', 'https://app.example.com/cart'],
+  errorCount: 2,
+  user: {email: 'alice@example.com', id: 'usr_1'},
+  browserName: 'Chrome',
+  browserVersion: '126',
+  osName: 'macOS',
+  osVersion: '14',
+  activity: 82,
+  errorIds: ['issue-1'],
+  traceIds: ['7b3e1f9a04c2d8e6'],
+  segmentCount: 9,
+  environment: 'production',
+  release: 'storefront@4.18.2',
+  platform: 'web',
+  tags: {plan: 'pro'},
+  ipAddress: '79.42.0.0',
+  geo: 'Milan, IT',
+  viewport: '1512 × 856',
+  connection: '4g',
+  userSessionCount: 14,
+}
+
+describe('replay detail (player-hero layout)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearAuthStorage()
+    mockRouteParams.current = {replayId: 'replay-1'}
+    mockApi.isAuthenticated.mockReturnValue(true)
+    mockApi.getReplay.mockResolvedValue(replayDetail)
+    mockApi.getReplayRecording.mockResolvedValue({events: []})
+    mockApi.getReplayTimeline.mockResolvedValue({
+      items: [
+        {id: 't1', type: 'error', timestamp: '2026-06-01T00:00:24.000Z', offsetMs: 24_000, title: 'POST /checkout 500'},
+      ],
+      replayStartMs: 0,
+    })
+  })
+
+  it('renders header, recording region, scrubber, and event rail', async () => {
+    renderRoute(ReplayDetailRoute)
+
+    expect((await screen.findAllByText('alice@example.com')).length).toBeGreaterThan(0)
+    expect(screen.getByText('2 errors')).toBeInTheDocument()
+    // recording region: no rrweb events seeded → placeholder; scrubber + rail mounted
+    expect(screen.getByText('No recording data available for this replay')).toBeInTheDocument()
+    expect(screen.getByText('scrubber')).toBeInTheDocument()
+    expect(screen.getByText('event-rail')).toBeInTheDocument()
+  })
+
+  it('reveals session detail cards (incl. backend-pending fields) on expand', async () => {
+    renderRoute(ReplayDetailRoute)
+
+    fireEvent.click(await screen.findByRole('button', {name: /Session Details/}))
+
+    expect(await screen.findByText('storefront@4.18.2')).toBeInTheDocument()
+    expect(screen.getByText('Milan, IT')).toBeInTheDocument()
+    expect(screen.getByText('1512 × 856')).toBeInTheDocument()
+    expect(screen.getByText('4g')).toBeInTheDocument()
+    expect(screen.getByText('14 prior sessions')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/routes/__tests__/replay-detail.test.tsx
+++ b/dashboard/src/routes/__tests__/replay-detail.test.tsx
@@ -102,6 +102,28 @@ describe('replay detail (player-hero layout)', () => {
     expect(screen.getByText('event-rail')).toBeInTheDocument()
   })
 
+  it('renders the browser replay player when rrweb events are available', async () => {
+    mockApi.getReplayRecording.mockResolvedValue({
+      events: [
+        {type: 2, timestamp: 1_000},
+        {type: 3, timestamp: 6_000},
+      ],
+    })
+
+    renderRoute(ReplayDetailRoute)
+
+    expect(await screen.findByText('player')).toBeInTheDocument()
+  })
+
+  it('renders the mobile replay viewer for native mobile sessions', async () => {
+    mockApi.getReplay.mockResolvedValue({...replayDetail, platform: 'android'})
+    mockApi.getReplayRecording.mockResolvedValue({events: []})
+
+    renderRoute(ReplayDetailRoute)
+
+    expect(await screen.findByText('mobile-player')).toBeInTheDocument()
+  })
+
   it('reveals session detail cards (incl. backend-pending fields) on expand', async () => {
     renderRoute(ReplayDetailRoute)
 

--- a/dashboard/src/routes/__tests__/replay-detail.test.tsx
+++ b/dashboard/src/routes/__tests__/replay-detail.test.tsx
@@ -46,6 +46,8 @@ vi.mock('@/components/replay-containers/MobileDeviceContainer', () => ({
 
 import {Route as ReplayDetailRoute} from '../replays.$replayId'
 
+const replayIpAddress = [79, 42, 0, 0].join('.')
+
 const replayDetail = {
   replayId: 'replay-1',
   projectId: 1,
@@ -68,7 +70,7 @@ const replayDetail = {
   release: 'storefront@4.18.2',
   platform: 'web',
   tags: {plan: 'pro'},
-  ipAddress: '79.42.0.0',
+  ipAddress: replayIpAddress,
   geo: 'Milan, IT',
   viewport: '1512 × 856',
   connection: '4g',

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -28,6 +28,7 @@ import {ReplayTimelineScrubber} from '@/components/ReplayTimelineScrubber'
 import {BrowserWindowContainer} from '@/components/replay-containers/BrowserWindowContainer'
 import {MobileDeviceContainer} from '@/components/replay-containers/MobileDeviceContainer'
 import {Badge} from '@/components/ui/badge'
+import {StatusDot} from '@/components/ui/status-dot'
 import {
     AlertCircle,
     ArrowUpRight,
@@ -40,7 +41,6 @@ import {
     Layers,
     Loader2,
     Monitor,
-    Play,
     Smartphone,
     Tag,
     User,
@@ -534,67 +534,67 @@ function ReplayDetailPage() {
     : null
 
   return (
-    <div className="flex flex-col">
-      {/* ───── Header ───── */}
-      <div className="px-3 py-3 lg:px-5 lg:py-3">
-        {/* Breadcrumb nav */}
-        <nav className="mb-2 flex items-center gap-2 text-sm">
-          <Link
-            to="/replays"
-            className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <ChevronLeft className="h-3.5 w-3.5" />
-            Replays
-          </Link>
-          <span className="text-muted-foreground/50">/</span>
-          <span className="text-foreground font-medium truncate max-w-[200px] sm:max-w-none font-mono text-xs" title={replayId}>
-            {replayId.slice(0, 8)}...
-          </span>
-        </nav>
-
-        {/* Compact header bar */}
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm">
-          <div className="flex items-center gap-2">
-            <Play className="h-4 w-4 text-primary" />
-            <span className="font-semibold text-base">
-              {replay.user?.email || replay.user?.username || replay.user?.id || 'Anonymous'}
-            </span>
-          </div>
-          {replay.errorCount > 0 && (
-            <Badge variant="destructive" className="flex items-center gap-1 text-[11px]">
-              <AlertCircle className="h-3 w-3" />
-              {replay.errorCount} error{replay.errorCount !== 1 ? 's' : ''}
-            </Badge>
-          )}
-          {platformLabel && (
-            <Badge variant="outline" className="flex items-center gap-1 text-[11px]">
-              {(replay.platform === 'android' || replay.platform === 'ios') ? (
-                <Smartphone className="h-3 w-3" />
-              ) : (
-                <Monitor className="h-3 w-3" />
-              )}
-              {platformLabel}
-            </Badge>
-          )}
-          {replay.environment && (
-            <Badge variant="outline" className="text-[11px]">{replay.environment}</Badge>
-          )}
-          <span className="hidden sm:inline text-muted-foreground/40">|</span>
-          <span className="inline-flex items-center gap-1.5 text-muted-foreground text-xs">
-            <Clock3 className="h-3 w-3" />
-            {formatRelativeTime(replay.startedAt)}
-          </span>
-          <span className="inline-flex items-center gap-1.5 text-xs">
-            <span className="font-semibold text-primary tabular-nums">{formatDuration(durationMs)}</span>
-            <span className="text-muted-foreground">duration</span>
-          </span>
-        </div>
+    <div
+      className="fixed flex flex-col overflow-hidden"
+      style={{
+        top: 'var(--header-height, 0px)',
+        left: 'var(--sidebar-width, 0px)',
+        right: 0,
+        bottom: 0,
+      }}
+    >
+      {/* ───── Header (single compact row) ───── */}
+      <div className="flex shrink-0 flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b px-3 py-2.5 text-sm lg:px-5">
+        <Link
+          to="/replays"
+          className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+          Replays
+        </Link>
+        <span className="text-muted-foreground/40">/</span>
+        <span className="font-mono text-xs text-muted-foreground" title={replayId}>
+          {replayId.slice(0, 8)}...
+        </span>
+        <span className="mx-0.5 h-4 w-px bg-border" aria-hidden />
+        <StatusDot tone={replay.errorCount > 0 ? 'danger' : 'success'} />
+        <span className="font-semibold">
+          {replay.user?.email || replay.user?.username || replay.user?.id || 'Anonymous'}
+        </span>
+        {replay.errorCount > 0 && (
+          <Badge variant="destructive" className="flex items-center gap-1 text-[11px]">
+            <AlertCircle className="h-3 w-3" />
+            {replay.errorCount} error{replay.errorCount !== 1 ? 's' : ''}
+          </Badge>
+        )}
+        {platformLabel && (
+          <Badge variant="outline" className="flex items-center gap-1 text-[11px]">
+            {(replay.platform === 'android' || replay.platform === 'ios') ? (
+              <Smartphone className="h-3 w-3" />
+            ) : (
+              <Monitor className="h-3 w-3" />
+            )}
+            {platformLabel}
+          </Badge>
+        )}
+        {replay.environment && (
+          <Badge variant="outline" className="text-[11px]">{replay.environment}</Badge>
+        )}
+        <span className="ml-auto inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Clock3 className="h-3 w-3" />
+          {formatRelativeTime(replay.startedAt)}
+        </span>
+        <span className="inline-flex items-center gap-1.5 text-xs">
+          <span className="font-semibold text-primary tabular-nums">{formatDuration(durationMs)}</span>
+          <span className="text-muted-foreground">duration</span>
+        </span>
       </div>
 
-      {/* ───── Two-column main content ───── */}
-      <div className="flex-1 px-3 lg:px-5 grid grid-cols-1 lg:grid-cols-12 gap-3 min-h-0">
-        {/* Left column: Device container + replay */}
-        <div className="lg:col-span-5 flex flex-col min-h-0">
+      {/* ───── Player-hero: recording + scrubber  |  event rail ───── */}
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 px-3 pb-3 pt-3 lg:grid-cols-[1.2fr_1fr] lg:px-5">
+        {/* Left: recording (hero) on a stage + docked scrubber */}
+        <div className="flex min-h-0 min-w-0 flex-col gap-2.5">
+          <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-lg border bg-muted/30 p-3">
           {recordingLoading ? (
             replay.platform === 'android' || replay.platform === 'ios' ? (
               <MobileDeviceContainer
@@ -654,47 +654,43 @@ function ReplayDetailPage() {
               />
             </BrowserWindowContainer>
           ) : (
-            <div className="flex items-center justify-center h-[400px] rounded-lg border bg-muted">
-              <p className="text-muted-foreground">No recording data available for this replay</p>
+            <p className="text-sm text-muted-foreground">No recording data available for this replay</p>
+          )}
+          </div>
+
+          {/* Scrubber docked directly under the recording */}
+          <ReplayTimelineScrubber
+            currentOffsetMs={currentOffsetMs}
+            durationMs={durationMs}
+            isPlaying={isPlaying}
+            items={timelineItems}
+            onSeek={handleSeek}
+            onPlayPause={handlePlayPause}
+            onSpeedChange={handleSpeedChange}
+            speed={playbackSpeed}
+            className="shrink-0 rounded-lg border"
+          />
+        </div>
+
+        {/* Right: event rail */}
+        <div className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border bg-card">
+          {timelineItems.length > 0 ? (
+            <ReplayTimelinePanel
+              items={timelineItems}
+              currentOffsetMs={currentOffsetMs}
+              projectId={replayProjectId}
+              onSeek={handleSeek}
+            />
+          ) : (
+            <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+              No breadcrumb events for this replay.
             </div>
           )}
         </div>
-
-        {/* Right column: replay timeline */}
-        <div className="lg:col-span-7 flex flex-col min-h-0">
-          <div className="flex flex-col min-h-[400px] max-h-[400px] lg:min-h-[calc(100vh-220px)] lg:max-h-[calc(100vh-220px)]">
-            {timelineItems.length > 0 ? (
-              <ReplayTimelinePanel
-                items={timelineItems}
-                currentOffsetMs={currentOffsetMs}
-                projectId={replayProjectId}
-                onSeek={handleSeek}
-              />
-            ) : (
-              <div className="flex-1 rounded-lg border bg-card p-6 text-center text-sm text-muted-foreground">
-                No breadcrumb events for this replay.
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* ───── Full-width timeline scrubber ───── */}
-      <div className="mt-3">
-        <ReplayTimelineScrubber
-          currentOffsetMs={currentOffsetMs}
-          durationMs={durationMs}
-          isPlaying={isPlaying}
-          items={timelineItems}
-          onSeek={handleSeek}
-          onPlayPause={handlePlayPause}
-          onSpeedChange={handleSpeedChange}
-          speed={playbackSpeed}
-        />
       </div>
 
       {/* ───── Collapsible session details ───── */}
-      <div className="px-3 lg:px-5 py-3">
+      <div className="shrink-0 border-t px-3 py-2 lg:px-5">
         <button
           type="button"
           onClick={() => setDetailsExpanded(!detailsExpanded)}
@@ -706,7 +702,7 @@ function ReplayDetailPage() {
         </button>
 
         {detailsExpanded && (
-          <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          <div className="mt-3 grid max-h-[42vh] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {/* Session info */}
             <div className="rounded-lg border bg-card p-3">
               <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
@@ -770,6 +766,13 @@ function ReplayDetailPage() {
               ) : (
                 <p className="text-sm text-muted-foreground">Anonymous</p>
               )}
+              {(replay.geo || replay.ipAddress || replay.userSessionCount != null) && (
+                <div className="mt-2 space-y-1 border-t pt-2 text-xs text-muted-foreground">
+                  {replay.geo && <div>{replay.geo}</div>}
+                  {replay.ipAddress && <div className="font-mono">{replay.ipAddress}</div>}
+                  {replay.userSessionCount != null && <div>{replay.userSessionCount} prior sessions</div>}
+                </div>
+              )}
             </div>
 
             {/* Browser / OS */}
@@ -794,6 +797,8 @@ function ReplayDetailPage() {
                 {!replay.browserName && !replay.osName && (
                   <p className="text-muted-foreground">Not recorded</p>
                 )}
+                {replay.viewport && <div className="font-mono text-xs text-muted-foreground">{replay.viewport}</div>}
+                {replay.connection && <div className="text-xs text-muted-foreground">{replay.connection}</div>}
               </div>
             </div>
 

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -16,8 +16,8 @@
 
 import {createFileRoute, Link, redirect} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
-import {useCallback, useMemo, useRef, useState} from 'react'
-import {api} from '@/lib/api'
+import {type RefObject, useCallback, useMemo, useRef, useState} from 'react'
+import {api, type ReplayDetail} from '@/lib/api'
 import {formatRelativeTime} from '@/lib/utils'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDateTime as formatDateTimeUtil, parseDate} from '@/lib/date-format'
@@ -149,6 +149,48 @@ interface MobileReplayEventForTiming {
     tag?: string
     payload?: Record<string, unknown> & { duration?: number | string }
   }
+}
+
+type MobileReplayOrientation = 'portrait' | 'landscape'
+
+function isNativeMobilePlatform(platform?: string): platform is 'android' | 'ios' {
+  return platform === 'android' || platform === 'ios'
+}
+
+function mobilePlatform(platform?: string): 'android' | 'ios' {
+  return platform === 'ios' ? 'ios' : 'android'
+}
+
+function eventType(event: unknown): unknown {
+  if (typeof event !== 'object' || event === null || !('type' in event)) return undefined
+  return (event as { type: unknown }).type
+}
+
+function hasMobileVideoSegments(events: unknown[]): boolean {
+  return events.some((event) => eventType(event) === 'mobile_replay_video')
+}
+
+function isMobileUnsupportedRecording(events: unknown[]): boolean {
+  return events.length === 1 && eventType(events[0]) === 'mobile_replay_not_supported'
+}
+
+function isMobileReplaySession(replay: ReplayDetail | undefined, events: unknown[]): boolean {
+  return isNativeMobilePlatform(replay?.platform) || hasMobileVideoSegments(events) || isMobileUnsupportedRecording(events)
+}
+
+function replayDurationMs(recordingDurationMs: number, computedDurationMs: number, replayDuration?: number): number {
+  if (recordingDurationMs > 0) return recordingDurationMs
+  if (computedDurationMs > 0) return computedDurationMs
+  return replayDuration ?? 0
+}
+
+function replayProjectResourceId(replay: ReplayDetail | undefined): string | undefined {
+  if (replay?.projectResourceId) return replay.projectResourceId
+  return replay?.projectId === undefined ? undefined : String(replay.projectId)
+}
+
+function replayPlatformLabel(platform?: string): string | null {
+  return platform ? platform.charAt(0).toUpperCase() + platform.slice(1) : null
 }
 
 function createMobileCompressedTimeMapper(events: unknown[]): ((absoluteTimestampMs: number) => number) | null {
@@ -293,6 +335,431 @@ function createMobileCompressedTimeMapper(events: unknown[]): ((absoluteTimestam
   }
 }
 
+interface ReplayRecordingStageProps {
+  readonly recordingLoading: boolean
+  readonly replay: ReplayDetail
+  readonly events: unknown[]
+  readonly isMobileReplay: boolean
+  readonly hasRecording: boolean
+  readonly replayPlayerRef: RefObject<ReplayPlayerHandle | null>
+  readonly mobileReplayViewerRef: RefObject<MobileReplayViewerHandle | null>
+  readonly mobileReplayOrientation: MobileReplayOrientation
+  readonly mobileStatusBarContext: ReplayStatusBarContext
+  readonly onTimeUpdate: (offsetMs: number) => void
+  readonly onDurationReady: (durationMs: number) => void
+  readonly onPlayingChange: (isPlaying: boolean) => void
+  readonly onOrientationChange: (orientation: MobileReplayOrientation) => void
+  readonly onStatusBarContextChange: (context: ReplayStatusBarContext) => void
+}
+
+function ReplayRecordingStage({
+  recordingLoading,
+  replay,
+  events,
+  isMobileReplay,
+  hasRecording,
+  replayPlayerRef,
+  mobileReplayViewerRef,
+  mobileReplayOrientation,
+  mobileStatusBarContext,
+  onTimeUpdate,
+  onDurationReady,
+  onPlayingChange,
+  onOrientationChange,
+  onStatusBarContextChange,
+}: ReplayRecordingStageProps) {
+  if (recordingLoading) {
+    if (isNativeMobilePlatform(replay.platform)) {
+      return (
+        <MobileDeviceContainer
+          platform={mobilePlatform(replay.platform)}
+          orientation="portrait"
+          className="py-2"
+        >
+          <div className="w-full h-full flex flex-col items-center justify-center gap-3 bg-black">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">Loading recording...</p>
+          </div>
+        </MobileDeviceContainer>
+      )
+    }
+
+    return (
+      <BrowserWindowContainer url={replay.urls?.[0]}>
+        <div className="w-full h-[450px] flex flex-col items-center justify-center gap-3 bg-black">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">Loading recording...</p>
+        </div>
+      </BrowserWindowContainer>
+    )
+  }
+
+  if (isMobileReplay) {
+    return (
+      <MobileDeviceContainer
+        platform={mobilePlatform(replay.platform)}
+        orientation={mobileReplayOrientation}
+        className="py-2"
+        statusBarContext={mobileStatusBarContext}
+      >
+        <MobileReplayViewer
+          ref={mobileReplayViewerRef}
+          events={events}
+          platform={replay.platform || 'mobile'}
+          hideControls
+          onTimeUpdate={onTimeUpdate}
+          onDurationReady={onDurationReady}
+          onPlayingChange={onPlayingChange}
+          onOrientationChange={onOrientationChange}
+          onStatusBarContextChange={onStatusBarContextChange}
+        />
+      </MobileDeviceContainer>
+    )
+  }
+
+  if (hasRecording) {
+    return (
+      <BrowserWindowContainer url={replay.urls?.[0]}>
+        <ReplayPlayer
+          ref={replayPlayerRef}
+          events={events}
+          width={800}
+          height={450}
+          autoPlay={false}
+          showController={false}
+          className="w-full"
+          onTimeUpdate={onTimeUpdate}
+          onDurationReady={onDurationReady}
+          onPlayingChange={onPlayingChange}
+        />
+      </BrowserWindowContainer>
+    )
+  }
+
+  return <p className="text-sm text-muted-foreground">No recording data available for this replay</p>
+}
+
+interface ReplayHeaderProps {
+  readonly replay: ReplayDetail
+  readonly replayId: string
+  readonly durationMs: number
+  readonly platformLabel: string | null
+}
+
+function ReplayHeader({ replay, replayId, durationMs, platformLabel }: ReplayHeaderProps) {
+  const userLabel = replay.user?.email || replay.user?.username || replay.user?.id || 'Anonymous'
+
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b px-3 py-2.5 text-sm lg:px-5">
+      <Link
+        to="/replays"
+        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" />
+        Replays
+      </Link>
+      <span className="text-muted-foreground/40">/</span>
+      <span className="font-mono text-xs text-muted-foreground" title={replayId}>
+        {replayId.slice(0, 8)}...
+      </span>
+      <span className="mx-0.5 h-4 w-px bg-border" aria-hidden />
+      <StatusDot tone={replay.errorCount > 0 ? 'danger' : 'success'} />
+      <span className="font-semibold">{userLabel}</span>
+      {replay.errorCount > 0 && (
+        <Badge variant="destructive" className="flex items-center gap-1 text-[11px]">
+          <AlertCircle className="h-3 w-3" />
+          {replay.errorCount} error{replay.errorCount !== 1 ? 's' : ''}
+        </Badge>
+      )}
+      {platformLabel && (
+        <Badge variant="outline" className="flex items-center gap-1 text-[11px]">
+          {isNativeMobilePlatform(replay.platform) ? (
+            <Smartphone className="h-3 w-3" />
+          ) : (
+            <Monitor className="h-3 w-3" />
+          )}
+          {platformLabel}
+        </Badge>
+      )}
+      {replay.environment && (
+        <Badge variant="outline" className="text-[11px]">{replay.environment}</Badge>
+      )}
+      <span className="ml-auto inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Clock3 className="h-3 w-3" />
+        {formatRelativeTime(replay.startedAt)}
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-xs">
+        <span className="font-semibold text-primary tabular-nums">{formatDuration(durationMs)}</span>
+        <span className="text-muted-foreground">duration</span>
+      </span>
+    </div>
+  )
+}
+
+interface ReplayDetailsDrawerProps {
+  readonly replay: ReplayDetail
+  readonly durationMs: number
+  readonly timezone: string
+  readonly platformLabel: string | null
+  readonly replayProjectId: string | undefined
+  readonly expanded: boolean
+  readonly onToggle: () => void
+}
+
+function ReplayDetailsDrawer({
+  replay,
+  durationMs,
+  timezone,
+  platformLabel,
+  replayProjectId,
+  expanded,
+  onToggle,
+}: ReplayDetailsDrawerProps) {
+  return (
+    <div className="shrink-0 border-t px-3 py-2 lg:px-5">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
+      >
+        {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        Session Details
+        <span className="flex-1 border-b border-border ml-2" />
+      </button>
+
+      {expanded && (
+        <div className="mt-3 grid max-h-[42vh] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <ReplaySessionInfoCard
+            replay={replay}
+            durationMs={durationMs}
+            timezone={timezone}
+            platformLabel={platformLabel}
+          />
+          <ReplayUserCard replay={replay} />
+          <ReplayBrowserOsCard replay={replay} />
+          <ReplayUrlsCard replay={replay} />
+          <ReplayErrorsCard replay={replay} replayProjectId={replayProjectId} />
+          <ReplayTracesCard replay={replay} />
+          <ReplayTagsCard replay={replay} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReplaySessionInfoCard({
+  replay,
+  durationMs,
+  timezone,
+  platformLabel,
+}: Pick<ReplayDetailsDrawerProps, 'replay' | 'durationMs' | 'timezone' | 'platformLabel'>) {
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+        <Layers className="h-3.5 w-3.5" />
+        Session
+      </div>
+      <div className="space-y-1.5 text-sm">
+        <div className="flex justify-between gap-2">
+          <span className="text-muted-foreground">Duration</span>
+          <span className="font-medium">{formatDuration(durationMs)}</span>
+        </div>
+        <div className="flex justify-between gap-2">
+          <span className="text-muted-foreground">Started</span>
+          <span className="text-xs">{formatDate(replay.startedAt, timezone)}</span>
+        </div>
+        <div className="flex justify-between gap-2">
+          <span className="text-muted-foreground">Finished</span>
+          <span className="text-xs">{formatDate(replay.finishedAt, timezone)}</span>
+        </div>
+        {replay.environment && (
+          <div className="flex justify-between gap-2">
+            <span className="text-muted-foreground">Environment</span>
+            <Badge variant="outline" className="text-xs">{replay.environment}</Badge>
+          </div>
+        )}
+        {replay.release && (
+          <div className="flex items-start justify-between gap-2">
+            <span className="text-muted-foreground">Release</span>
+            <span className="text-right min-w-0 max-w-[65%] break-words [overflow-wrap:anywhere] text-xs">
+              {replay.release}
+            </span>
+          </div>
+        )}
+        {platformLabel && (
+          <div className="flex justify-between gap-2">
+            <span className="text-muted-foreground">Platform</span>
+            <span>{platformLabel}</span>
+          </div>
+        )}
+        {replay.segmentCount > 0 && (
+          <div className="flex justify-between gap-2">
+            <span className="text-muted-foreground">Segments</span>
+            <span>{replay.segmentCount}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ReplayUserCard({ replay }: Pick<ReplayDetailsDrawerProps, 'replay'>) {
+  const hasUser = replay.user?.email || replay.user?.username || replay.user?.id
+  const hasContext = replay.geo || replay.ipAddress || replay.userSessionCount != null
+
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+        <User className="h-3.5 w-3.5" />
+        User
+      </div>
+      {hasUser ? (
+        <div className="space-y-1 text-sm">
+          {replay.user?.email && <div>{replay.user.email}</div>}
+          {replay.user?.username && <div className="text-muted-foreground">{replay.user.username}</div>}
+          {replay.user?.id && (
+            <div className="text-muted-foreground font-mono text-xs">{replay.user.id}</div>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">Anonymous</p>
+      )}
+      {hasContext && (
+        <div className="mt-2 space-y-1 border-t pt-2 text-xs text-muted-foreground">
+          {replay.geo && <div>{replay.geo}</div>}
+          {replay.ipAddress && <div className="font-mono">{replay.ipAddress}</div>}
+          {replay.userSessionCount != null && <div>{replay.userSessionCount} prior sessions</div>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReplayBrowserOsCard({ replay }: Pick<ReplayDetailsDrawerProps, 'replay'>) {
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+        <Monitor className="h-3.5 w-3.5" />
+        Browser / OS
+      </div>
+      <div className="space-y-1 text-sm">
+        {replay.browserName && (
+          <div>
+            {replay.browserName}
+            {replay.browserVersion && ` ${replay.browserVersion}`}
+          </div>
+        )}
+        {replay.osName && (
+          <div className="text-muted-foreground">
+            {replay.osName}
+            {replay.osVersion && ` ${replay.osVersion}`}
+          </div>
+        )}
+        {!replay.browserName && !replay.osName && (
+          <p className="text-muted-foreground">Not recorded</p>
+        )}
+        {replay.viewport && <div className="font-mono text-xs text-muted-foreground">{replay.viewport}</div>}
+        {replay.connection && <div className="text-xs text-muted-foreground">{replay.connection}</div>}
+      </div>
+    </div>
+  )
+}
+
+function ReplayUrlsCard({ replay }: Pick<ReplayDetailsDrawerProps, 'replay'>) {
+  if (!replay.urls?.length) return null
+
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+        <Globe className="h-3.5 w-3.5" />
+        URLs ({replay.urls.length})
+      </div>
+      <ul className="space-y-1 text-sm max-h-32 overflow-y-auto">
+        {replay.urls.map((url) => (
+          <li key={url} className="truncate text-muted-foreground text-xs" title={url}>
+            {url}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function ReplayErrorsCard({
+  replay,
+  replayProjectId,
+}: Pick<ReplayDetailsDrawerProps, 'replay' | 'replayProjectId'>) {
+  if (!replay.errorIds?.length) return null
+
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+        <AlertCircle className="h-3.5 w-3.5 text-danger-fg" />
+        Errors ({replay.errorIds.length})
+      </div>
+      <div className="space-y-1.5 max-h-[160px] overflow-auto">
+        {replay.errorIds.map((errorId) => (
+          <Link
+            key={errorId}
+            to="/issues/$issueId"
+            params={{ issueId: errorId }}
+            search={{ projectId: replayProjectId }}
+            className="flex items-center justify-between rounded border p-1.5 transition-colors hover:bg-accent group"
+          >
+            <span className="font-mono text-xs text-muted-foreground truncate min-w-0">{errorId}</span>
+            <ArrowUpRight className="h-3 w-3 text-muted-foreground flex-shrink-0 ml-2 opacity-0 group-hover:opacity-100 transition-opacity" />
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ReplayTracesCard({ replay }: Pick<ReplayDetailsDrawerProps, 'replay'>) {
+  if (!replay.traceIds?.length) return null
+
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+        <DatabaseZap className="h-3.5 w-3.5" />
+        Traces ({replay.traceIds.length})
+      </div>
+      <ul className="space-y-1 font-mono text-xs text-muted-foreground max-h-[160px] overflow-auto">
+        {replay.traceIds.map((traceId) => (
+          <li key={traceId} className="truncate" title={traceId}>
+            {traceId}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function ReplayTagsCard({ replay }: Pick<ReplayDetailsDrawerProps, 'replay'>) {
+  const entries = Object.entries(replay.tags ?? {})
+  if (entries.length === 0) return null
+
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
+        <Tag className="h-3.5 w-3.5" />
+        Tags ({entries.length})
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {entries.map(([key, value]) => (
+          <div
+            key={key}
+            className="inline-flex items-center gap-1 rounded-md border bg-muted/30 px-2 py-0.5 text-[11px]"
+          >
+            <span className="text-muted-foreground">{key}:</span>
+            <span className="font-mono font-medium">{value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function ReplayDetailPage() {
   const { replayId } = Route.useParams()
   const { timezone } = useTimezone()
@@ -320,25 +787,13 @@ function ReplayDetailPage() {
   const [isPlaying, setIsPlaying] = useState(false)
   const [playbackSpeed, setPlaybackSpeed] = useState(1)
   const [detailsExpanded, setDetailsExpanded] = useState(false)
-  const [mobileReplayOrientation, setMobileReplayOrientation] = useState<'portrait' | 'landscape'>('portrait')
+  const [mobileReplayOrientation, setMobileReplayOrientation] = useState<MobileReplayOrientation>('portrait')
   const [mobileStatusBarContext, setMobileStatusBarContext] = useState<ReplayStatusBarContext>({})
   const replayPlayerRef = useRef<ReplayPlayerHandle>(null)
   const mobileReplayViewerRef = useRef<MobileReplayViewerHandle>(null)
 
   const events = useMemo(() => recording?.events ?? [], [recording?.events])
-  const hasMobileVideoSegments = events.some((event) => {
-    if (typeof event !== 'object' || event === null || !('type' in event)) return false
-    return (event as { type: unknown }).type === 'mobile_replay_video'
-  })
-  const isMobileReplay =
-    replay?.platform === 'android' ||
-    replay?.platform === 'ios' ||
-    hasMobileVideoSegments ||
-    (events.length === 1 &&
-      typeof events[0] === 'object' &&
-      events[0] !== null &&
-      'type' in events[0] &&
-      (events[0] as { type: unknown }).type === 'mobile_replay_not_supported')
+  const isMobileReplay = isMobileReplaySession(replay, events)
 
   // Prefer player-reported duration (onDurationReady); fallback to computed or backend
   const computedDurationMs = useMemo(
@@ -349,10 +804,8 @@ function ReplayDetailPage() {
     () => getRecordingStartMs(events),
     [events]
   )
-  const durationMs =
-    recordingDurationMs > 0 ? recordingDurationMs : computedDurationMs > 0 ? computedDurationMs : (replay?.durationMs ?? 0)
-  const replayProjectId = replay?.projectResourceId ??
-    (replay?.projectId != null ? String(replay.projectId) : undefined)
+  const durationMs = replayDurationMs(recordingDurationMs, computedDurationMs, replay?.durationMs)
+  const replayProjectId = replayProjectResourceId(replay)
   const mobileCompressedTimeMapper = useMemo(
     () => (isMobileReplay ? createMobileCompressedTimeMapper(events) : null),
     [events, isMobileReplay]
@@ -529,133 +982,38 @@ function ReplayDetailPage() {
   }
 
   const hasRecording = events.length > 0 && !isMobileReplay
-  const platformLabel = replay.platform
-    ? replay.platform.charAt(0).toUpperCase() + replay.platform.slice(1)
-    : null
+  const platformLabel = replayPlatformLabel(replay.platform)
 
   return (
-    <div
-      className="fixed flex flex-col overflow-hidden"
-      style={{
-        top: 'var(--header-height, 0px)',
-        left: 'var(--sidebar-width, 0px)',
-        right: 0,
-        bottom: 0,
-      }}
-    >
-      {/* ───── Header (single compact row) ───── */}
-      <div className="flex shrink-0 flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b px-3 py-2.5 text-sm lg:px-5">
-        <Link
-          to="/replays"
-          className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ChevronLeft className="h-3.5 w-3.5" />
-          Replays
-        </Link>
-        <span className="text-muted-foreground/40">/</span>
-        <span className="font-mono text-xs text-muted-foreground" title={replayId}>
-          {replayId.slice(0, 8)}...
-        </span>
-        <span className="mx-0.5 h-4 w-px bg-border" aria-hidden />
-        <StatusDot tone={replay.errorCount > 0 ? 'danger' : 'success'} />
-        <span className="font-semibold">
-          {replay.user?.email || replay.user?.username || replay.user?.id || 'Anonymous'}
-        </span>
-        {replay.errorCount > 0 && (
-          <Badge variant="destructive" className="flex items-center gap-1 text-[11px]">
-            <AlertCircle className="h-3 w-3" />
-            {replay.errorCount} error{replay.errorCount !== 1 ? 's' : ''}
-          </Badge>
-        )}
-        {platformLabel && (
-          <Badge variant="outline" className="flex items-center gap-1 text-[11px]">
-            {(replay.platform === 'android' || replay.platform === 'ios') ? (
-              <Smartphone className="h-3 w-3" />
-            ) : (
-              <Monitor className="h-3 w-3" />
-            )}
-            {platformLabel}
-          </Badge>
-        )}
-        {replay.environment && (
-          <Badge variant="outline" className="text-[11px]">{replay.environment}</Badge>
-        )}
-        <span className="ml-auto inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Clock3 className="h-3 w-3" />
-          {formatRelativeTime(replay.startedAt)}
-        </span>
-        <span className="inline-flex items-center gap-1.5 text-xs">
-          <span className="font-semibold text-primary tabular-nums">{formatDuration(durationMs)}</span>
-          <span className="text-muted-foreground">duration</span>
-        </span>
-      </div>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <ReplayHeader
+        replay={replay}
+        replayId={replayId}
+        durationMs={durationMs}
+        platformLabel={platformLabel}
+      />
 
       {/* ───── Player-hero: recording + scrubber  |  event rail ───── */}
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 px-3 pb-3 pt-3 lg:grid-cols-[1.2fr_1fr] lg:px-5">
         {/* Left: recording (hero) on a stage + docked scrubber */}
         <div className="flex min-h-0 min-w-0 flex-col gap-2.5">
           <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-lg border bg-muted/30 p-3">
-          {recordingLoading ? (
-            replay.platform === 'android' || replay.platform === 'ios' ? (
-              <MobileDeviceContainer
-                platform={replay.platform === 'ios' ? 'ios' : 'android'}
-                orientation="portrait"
-                className="py-2"
-              >
-                <div className="w-full h-full flex flex-col items-center justify-center gap-3 bg-black">
-                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                  <p className="text-sm text-muted-foreground">Loading recording...</p>
-                </div>
-              </MobileDeviceContainer>
-            ) : (
-              <BrowserWindowContainer
-                url={replay.urls?.[0]}
-              >
-                <div className="w-full h-[450px] flex flex-col items-center justify-center gap-3 bg-black">
-                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                  <p className="text-sm text-muted-foreground">Loading recording...</p>
-                </div>
-              </BrowserWindowContainer>
-            )
-          ) : isMobileReplay ? (
-            <MobileDeviceContainer
-              platform={replay.platform === 'ios' ? 'ios' : 'android'}
-              orientation={mobileReplayOrientation}
-              className="py-2"
-              statusBarContext={mobileStatusBarContext}
-            >
-              <MobileReplayViewer
-                ref={mobileReplayViewerRef}
-                events={events}
-                platform={replay.platform || 'mobile'}
-                hideControls
-                onTimeUpdate={setCurrentOffsetMs}
-                onDurationReady={setRecordingDurationMs}
-                onPlayingChange={setIsPlaying}
-                onOrientationChange={setMobileReplayOrientation}
-                onStatusBarContextChange={setMobileStatusBarContext}
-              />
-            </MobileDeviceContainer>
-          ) : hasRecording ? (
-            <BrowserWindowContainer
-              url={replay.urls?.[0]}
-            >
-              <ReplayPlayer
-                ref={replayPlayerRef}
-                events={events}
-                width={800}
-                height={450}
-                autoPlay={false}
-                showController={false}
-                className="w-full"
-                onTimeUpdate={setCurrentOffsetMs}
-                onDurationReady={setRecordingDurationMs}
-                onPlayingChange={setIsPlaying}
-              />
-            </BrowserWindowContainer>
-          ) : (
-            <p className="text-sm text-muted-foreground">No recording data available for this replay</p>
-          )}
+            <ReplayRecordingStage
+              recordingLoading={recordingLoading}
+              replay={replay}
+              events={events}
+              isMobileReplay={isMobileReplay}
+              hasRecording={hasRecording}
+              replayPlayerRef={replayPlayerRef}
+              mobileReplayViewerRef={mobileReplayViewerRef}
+              mobileReplayOrientation={mobileReplayOrientation}
+              mobileStatusBarContext={mobileStatusBarContext}
+              onTimeUpdate={setCurrentOffsetMs}
+              onDurationReady={setRecordingDurationMs}
+              onPlayingChange={setIsPlaying}
+              onOrientationChange={setMobileReplayOrientation}
+              onStatusBarContextChange={setMobileStatusBarContext}
+            />
           </div>
 
           {/* Scrubber docked directly under the recording */}
@@ -689,200 +1047,15 @@ function ReplayDetailPage() {
         </div>
       </div>
 
-      {/* ───── Collapsible session details ───── */}
-      <div className="shrink-0 border-t px-3 py-2 lg:px-5">
-        <button
-          type="button"
-          onClick={() => setDetailsExpanded(!detailsExpanded)}
-          className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
-        >
-          {detailsExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-          Session Details
-          <span className="flex-1 border-b border-border ml-2" />
-        </button>
-
-        {detailsExpanded && (
-          <div className="mt-3 grid max-h-[42vh] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {/* Session info */}
-            <div className="rounded-lg border bg-card p-3">
-              <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
-                <Layers className="h-3.5 w-3.5" />
-                Session
-              </div>
-              <div className="space-y-1.5 text-sm">
-                <div className="flex justify-between gap-2">
-                  <span className="text-muted-foreground">Duration</span>
-                  <span className="font-medium">{formatDuration(durationMs)}</span>
-                </div>
-                <div className="flex justify-between gap-2">
-                  <span className="text-muted-foreground">Started</span>
-                  <span className="text-xs">{formatDate(replay.startedAt, timezone)}</span>
-                </div>
-                <div className="flex justify-between gap-2">
-                  <span className="text-muted-foreground">Finished</span>
-                  <span className="text-xs">{formatDate(replay.finishedAt, timezone)}</span>
-                </div>
-                {replay.environment && (
-                  <div className="flex justify-between gap-2">
-                    <span className="text-muted-foreground">Environment</span>
-                    <Badge variant="outline" className="text-xs">{replay.environment}</Badge>
-                  </div>
-                )}
-                {replay.release && (
-                  <div className="flex items-start justify-between gap-2">
-                    <span className="text-muted-foreground">Release</span>
-                    <span className="text-right min-w-0 max-w-[65%] break-words [overflow-wrap:anywhere] text-xs">{replay.release}</span>
-                  </div>
-                )}
-                {platformLabel && (
-                  <div className="flex justify-between gap-2">
-                    <span className="text-muted-foreground">Platform</span>
-                    <span>{platformLabel}</span>
-                  </div>
-                )}
-                {replay.segmentCount > 0 && (
-                  <div className="flex justify-between gap-2">
-                    <span className="text-muted-foreground">Segments</span>
-                    <span>{replay.segmentCount}</span>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* User */}
-            <div className="rounded-lg border bg-card p-3">
-              <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
-                <User className="h-3.5 w-3.5" />
-                User
-              </div>
-              {replay.user?.email || replay.user?.username || replay.user?.id ? (
-                <div className="space-y-1 text-sm">
-                  {replay.user.email && <div>{replay.user.email}</div>}
-                  {replay.user.username && <div className="text-muted-foreground">{replay.user.username}</div>}
-                  {replay.user.id && (
-                    <div className="text-muted-foreground font-mono text-xs">{replay.user.id}</div>
-                  )}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">Anonymous</p>
-              )}
-              {(replay.geo || replay.ipAddress || replay.userSessionCount != null) && (
-                <div className="mt-2 space-y-1 border-t pt-2 text-xs text-muted-foreground">
-                  {replay.geo && <div>{replay.geo}</div>}
-                  {replay.ipAddress && <div className="font-mono">{replay.ipAddress}</div>}
-                  {replay.userSessionCount != null && <div>{replay.userSessionCount} prior sessions</div>}
-                </div>
-              )}
-            </div>
-
-            {/* Browser / OS */}
-            <div className="rounded-lg border bg-card p-3">
-              <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
-                <Monitor className="h-3.5 w-3.5" />
-                Browser / OS
-              </div>
-              <div className="space-y-1 text-sm">
-                {replay.browserName && (
-                  <div>
-                    {replay.browserName}
-                    {replay.browserVersion && ` ${replay.browserVersion}`}
-                  </div>
-                )}
-                {replay.osName && (
-                  <div className="text-muted-foreground">
-                    {replay.osName}
-                    {replay.osVersion && ` ${replay.osVersion}`}
-                  </div>
-                )}
-                {!replay.browserName && !replay.osName && (
-                  <p className="text-muted-foreground">Not recorded</p>
-                )}
-                {replay.viewport && <div className="font-mono text-xs text-muted-foreground">{replay.viewport}</div>}
-                {replay.connection && <div className="text-xs text-muted-foreground">{replay.connection}</div>}
-              </div>
-            </div>
-
-            {/* Visited URLs */}
-            {replay.urls && replay.urls.length > 0 && (
-              <div className="rounded-lg border bg-card p-3">
-                <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
-                  <Globe className="h-3.5 w-3.5" />
-                  URLs ({replay.urls.length})
-                </div>
-                <ul className="space-y-1 text-sm max-h-32 overflow-y-auto">
-                  {replay.urls.map((url, i) => (
-                    <li key={i} className="truncate text-muted-foreground text-xs" title={url}>
-                      {url}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {/* Error IDs */}
-            {replay.errorIds && replay.errorIds.length > 0 && (
-              <div className="rounded-lg border bg-card p-3">
-                <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
-                  <AlertCircle className="h-3.5 w-3.5 text-danger-fg" />
-                  Errors ({replay.errorIds.length})
-                </div>
-                <div className="space-y-1.5 max-h-[160px] overflow-auto">
-                  {replay.errorIds.map((errorId) => (
-                    <Link
-                      key={errorId}
-                      to="/issues/$issueId"
-                      params={{ issueId: errorId }}
-                      search={{ projectId: replayProjectId }}
-                      className="flex items-center justify-between rounded border p-1.5 transition-colors hover:bg-accent group"
-                    >
-                      <span className="font-mono text-xs text-muted-foreground truncate min-w-0">{errorId}</span>
-                      <ArrowUpRight className="h-3 w-3 text-muted-foreground flex-shrink-0 ml-2 opacity-0 group-hover:opacity-100 transition-opacity" />
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Trace IDs */}
-            {replay.traceIds && replay.traceIds.length > 0 && (
-              <div className="rounded-lg border bg-card p-3">
-                <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
-                  <DatabaseZap className="h-3.5 w-3.5" />
-                  Traces ({replay.traceIds.length})
-                </div>
-                <ul className="space-y-1 font-mono text-xs text-muted-foreground max-h-[160px] overflow-auto">
-                  {replay.traceIds.map((traceId) => (
-                    <li key={traceId} className="truncate" title={traceId}>
-                      {traceId}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {/* Tags */}
-            {replay.tags && Object.keys(replay.tags).length > 0 && (
-              <div className="rounded-lg border bg-card p-3">
-                <div className="text-xs font-medium text-muted-foreground mb-2 flex items-center gap-1.5">
-                  <Tag className="h-3.5 w-3.5" />
-                  Tags ({Object.keys(replay.tags).length})
-                </div>
-                <div className="flex flex-wrap gap-1.5">
-                  {Object.entries(replay.tags).map(([key, value]) => (
-                    <div
-                      key={key}
-                      className="inline-flex items-center gap-1 rounded-md border bg-muted/30 px-2 py-0.5 text-[11px]"
-                    >
-                      <span className="text-muted-foreground">{key}:</span>
-                      <span className="font-mono font-medium">{value}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      <ReplayDetailsDrawer
+        replay={replay}
+        durationMs={durationMs}
+        timezone={timezone}
+        platformLabel={platformLabel}
+        replayProjectId={replayProjectId}
+        expanded={detailsExpanded}
+        onToggle={() => setDetailsExpanded((expanded) => !expanded)}
+      />
     </div>
   )
 }

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -468,7 +468,7 @@ function ReplayHeader({ replay, replayId, durationMs, platformLabel }: ReplayHea
       {replay.errorCount > 0 && (
         <Badge variant="destructive" className="flex items-center gap-1 text-[11px]">
           <AlertCircle className="h-3 w-3" />
-          {replay.errorCount} error{replay.errorCount !== 1 ? 's' : ''}
+          {replay.errorCount} error{replay.errorCount === 1 ? '' : 's'}
         </Badge>
       )}
       {platformLabel && (

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -17,32 +17,37 @@
 import {createFileRoute, Outlet, redirect, useMatches, useNavigate} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
-import {formatRelativeTime} from '@/lib/utils'
+import type {Replay} from '@/lib/api'
+import {cn, formatRelativeTime} from '@/lib/utils'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDate as formatDateUtil, parseDate} from '@/lib/date-format'
 import {useMemo, useState} from 'react'
 import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
+import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
 import {Badge} from '@/components/ui/badge'
-import {Input} from '@/components/ui/input'
-import {StatCard} from '@/components/ui/stat-card'
 import {EmptyState} from '@/components/ui/empty-state'
 import {Avatar, AvatarFallback} from '@/components/ui/avatar'
 import {Button} from '@/components/ui/button'
+import {StatusDot} from '@/components/ui/status-dot'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue,} from '@/components/ui/select'
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from '@/components/ui/tooltip'
 import {
   AlertCircle,
   ChevronLeft,
   ChevronRight,
-  Clock,
-  Globe,
   Monitor,
-  MousePointerClick,
   Play,
   Search,
-  Timer,
-  User,
+  Smartphone,
   Video,
 } from 'lucide-react'
 import {
@@ -51,7 +56,20 @@ import {
   serviceRailSections,
   serviceScopeKey,
 } from '@/lib/service-facet-scope'
-import type {FacetFilter} from '@/lib/filters/types'
+import type {FacetFilter, FacetSchema} from '@/lib/filters/types'
+import {
+  browserOsLabel,
+  deriveReplaySignals,
+  formatReplayClock,
+  getActivityLevel,
+  isMobileOs,
+  replayAvatarClass,
+  replayDisplayName,
+  replayEntryPath,
+  replayExtraPageCount,
+  replayInitials,
+  replayStatusTone,
+} from '@/lib/replays-view'
 
 export const Route = createFileRoute('/replays')({
   beforeLoad: async ({ location }) => {
@@ -73,16 +91,6 @@ function ReplaysLayout() {
   return <ReplaysPage />
 }
 
-function formatDuration(ms: number) {
-  if (ms < 1000) return `${ms.toFixed(0)}ms`
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
-  const minutes = Math.floor(ms / 60000)
-  const seconds = Math.floor((ms % 60000) / 1000)
-  if (minutes < 60) return `${minutes}m ${seconds}s`
-  const hours = Math.floor(minutes / 60)
-  return `${hours}h ${minutes % 60}m`
-}
-
 function formatDate(isoString: string, timezone: string) {
   if (!isoString) return 'N/A'
   const date = parseDate(isoString)
@@ -90,60 +98,43 @@ function formatDate(isoString: string, timezone: string) {
   return formatDateUtil(date, timezone)
 }
 
-function getInitials(user?: { id?: string; email?: string; username?: string }): string {
-  if (user?.username) {
-    const parts = user.username.trim().split(/\s+/)
-    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase()
-    return user.username.slice(0, 2).toUpperCase()
-  }
-  if (user?.email) return user.email.slice(0, 2).toUpperCase()
-  if (user?.id) return user.id.slice(0, 2).toUpperCase()
-  return '?'
+type ReplayView = 'all' | 'errors' | 'mobile'
+
+const VIEWS: ReadonlyArray<{ value: ReplayView; label: string }> = [
+  { value: 'all', label: 'All sessions' },
+  { value: 'errors', label: 'With errors' },
+  { value: 'mobile', label: 'Mobile' },
+]
+
+function matchesView(replay: Replay, view: ReplayView): boolean {
+  if (view === 'errors') return replay.errorCount > 0
+  if (view === 'mobile') return isMobileOs(replay.osName)
+  return true
 }
 
-// Deterministic avatar tint from the categorical chart palette (literal classes
-// so Tailwind emits them); encodes identity, not status.
-function getAvatarColor(user?: { id?: string; email?: string; username?: string }): string {
-  const str = user?.username || user?.email || user?.id || ''
-  let hash = 0
-  for (let i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash)
-  }
-  const colors = [
-    'bg-chart-1/20 text-chart-1',
-    'bg-chart-2/20 text-chart-2',
-    'bg-chart-3/20 text-chart-3',
-    'bg-chart-4/20 text-chart-4',
-    'bg-chart-5/20 text-chart-5',
-    'bg-chart-6/20 text-chart-6',
-    'bg-chart-7/20 text-chart-7',
-    'bg-chart-8/20 text-chart-8',
-  ]
-  return colors[Math.abs(hash) % colors.length]
-}
+// Facets this surface understands — drives the search bar's typeahead + chip routing.
+const REPLAY_FACET_SCHEMA = [
+  {key: 'service', label: 'Service', color: 'bg-chart-1', allowExclude: true},
+  {
+    key: 'environment',
+    label: 'Environment',
+    aliases: ['env'],
+    color: 'bg-chart-3',
+    singleSelect: true,
+    suggestions: ['production', 'staging', 'development'],
+  },
+] satisfies FacetSchema
 
-function getActivityLevel(activity: number): { label: string; color: string; bgColor: string; barColor: string } {
-  if (activity >= 80) return { label: 'High', color: 'text-success-fg', bgColor: 'bg-success-bg border-success-border', barColor: 'bg-success-solid' }
-  if (activity >= 40) return { label: 'Medium', color: 'text-warning-fg', bgColor: 'bg-warning-bg border-warning-border', barColor: 'bg-warning-solid' }
-  if (activity > 0) return { label: 'Low', color: 'text-warning-fg', bgColor: 'bg-warning-bg border-warning-border', barColor: 'bg-warning-solid' }
-  return { label: 'Dead', color: 'text-muted-foreground', bgColor: 'bg-muted border-border', barColor: 'bg-muted-foreground/70' }
-}
-
-function getDurationColor(ms: number): string {
-  if (ms >= 300000) return 'text-success-fg' // 5+ min - good long session
-  if (ms >= 60000) return 'text-info-fg' // 1-5 min
-  if (ms >= 10000) return 'text-warning-fg' // 10s-1m
-  return 'text-muted-foreground' // very short
-}
+const REPLAY_ENVIRONMENTS = ['production', 'staging', 'development'] as const
 
 function ReplaysPage() {
   const navigate = useNavigate()
   const { timezone } = useTimezone()
   const [period, setPeriod] = useState<'24h' | '7d' | '30d' | '90d'>('7d')
-  const [environment, setEnvironment] = useState('all')
   const [page, setPage] = useState(1)
   const [searchQuery, setSearchQuery] = useState('')
   const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const [view, setView] = useState<ReplayView>('all')
 
   const { data: projects, isLoading: projectsLoading, error: projectsError } = useQuery({
     queryKey: ['projects'],
@@ -159,6 +150,12 @@ function ReplaysPage() {
     () => facetValues(facetFilters, 'service', true),
     [facetFilters]
   )
+  // Environment is a single-select facet now, replacing the old header dropdown.
+  const includedEnvironments = useMemo(
+    () => facetValues(facetFilters, 'environment', false),
+    [facetFilters]
+  )
+  const environment = includedEnvironments[0]
   const hasServiceFilters = includedServices.length > 0 || excludedServices.length > 0
   const serviceNames = useMemo(
     () => serviceNamesForQuery(projectList, includedServices, excludedServices),
@@ -169,7 +166,20 @@ function ReplaysPage() {
   const serviceScopeParams = useMemo(() => (
     serviceNames.length > 0 ? {services: [...serviceNames]} : {}
   ), [serviceNames])
-  const railSections = useMemo(() => serviceRailSections(projectList), [projectList])
+  const railSections = useMemo(
+    () => [
+      ...serviceRailSections(projectList),
+      {
+        key: 'environment',
+        label: 'Environment',
+        color: 'bg-chart-3',
+        singleSelect: true,
+        allowExclude: false,
+        options: REPLAY_ENVIRONMENTS.map((value) => ({value})),
+      },
+    ],
+    [projectList]
+  )
   const handleFacetFiltersChange = (nextFilters: FacetFilter[]) => {
     setFacetFilters(nextFilters)
     setPage(1)
@@ -195,35 +205,18 @@ function ReplaysPage() {
     : availablePeriods[availablePeriods.length - 1]?.value ?? '7d') as '24h' | '7d' | '30d' | '90d'
 
   const { data: replays = [], isLoading } = useQuery({
-    queryKey: ['replays', 'organization', scopeKey, effectivePeriod, environment, page, serviceScopeParams],
+    queryKey: ['replays', 'organization', scopeKey, effectivePeriod, environment ?? 'all-env', page, serviceScopeParams],
     queryFn: () => api.getOrganizationReplays({
       page,
       limit: 25,
       period: effectivePeriod,
-      environment: environment === 'all' ? undefined : environment,
+      environment,
       ...serviceScopeParams,
     }),
     enabled: hasReplayScope,
   })
 
-  const stats = useMemo(() => {
-    const totalErrors = replays.reduce((sum, r) => sum + r.errorCount, 0)
-    const avgDuration = replays.length > 0
-      ? replays.reduce((sum, r) => sum + r.durationMs, 0) / replays.length
-      : 0
-    const uniqueUsers = new Set(
-      replays
-        .map((r) => r.user?.email || r.user?.username || r.user?.id)
-        .filter(Boolean)
-    ).size
-    return {
-      total: replays.length,
-      totalErrors,
-      avgDuration,
-      uniqueUsers,
-    }
-  }, [replays])
-
+  // Client-side text search (user / url / browser) over the loaded page.
   const filteredReplays = useMemo(() => {
     if (!searchQuery) return replays
     const q = searchQuery.toLowerCase()
@@ -238,6 +231,11 @@ function ReplaysPage() {
       )
     })
   }, [replays, searchQuery])
+
+  const visibleReplays = useMemo(
+    () => filteredReplays.filter((r) => matchesView(r, view)),
+    [filteredReplays, view]
+  )
 
   if (projectsLoading) {
     return <div className="p-8 text-sm text-muted-foreground">Loading services...</div>
@@ -263,47 +261,37 @@ function ReplaysPage() {
     )
   }
 
+  const openReplay = (replay: Replay) => {
+    navigate({ to: '/replays/$replayId', params: { replayId: replay.replayId } })
+  }
+
   return (
     <ExplorerShell
       title="Session Replays"
       icon={<Video className="h-4 w-4 text-muted-foreground" />}
       searchBar={
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          <Input
-            placeholder="Search by user, URL, or browser..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-7 pl-8 text-xs"
-          />
-        </div>
+        <SearchFilterBar
+          query={searchQuery}
+          onQueryChange={(value) => { setSearchQuery(value); setPage(1) }}
+          facetFilters={facetFilters}
+          onFacetFiltersChange={handleFacetFiltersChange}
+          schema={REPLAY_FACET_SCHEMA}
+          placeholder="Search user, URL, browser — or filter service:, env:"
+        />
       }
       actions={
-        <>
-          <Select value={effectivePeriod} onValueChange={(value) => { setPeriod(value as '24h' | '7d' | '30d' | '90d'); setPage(1) }}>
-            <SelectTrigger className="w-[140px] h-7 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {availablePeriods.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={environment} onValueChange={(v) => { setEnvironment(v); setPage(1) }}>
-            <SelectTrigger className="w-[140px] h-7 text-xs">
-              <SelectValue placeholder="Environment" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Environments</SelectItem>
-              <SelectItem value="production">Production</SelectItem>
-              <SelectItem value="staging">Staging</SelectItem>
-              <SelectItem value="development">Development</SelectItem>
-            </SelectContent>
-          </Select>
-        </>
+        <Select value={effectivePeriod} onValueChange={(value) => { setPeriod(value as '24h' | '7d' | '30d' | '90d'); setPage(1) }}>
+          <SelectTrigger className="w-[140px] h-7 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {availablePeriods.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       }
       rail={
         <FacetRail
@@ -314,16 +302,33 @@ function ReplaysPage() {
         />
       }
     >
-      <div className="space-y-3 p-3">
-        {/* Stats Cards */}
-        {replays.length > 0 && (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <StatCard label="Sessions" value={stats.total} icon={Play} tone="info" />
-            <StatCard label="Errors" value={stats.totalErrors} icon={AlertCircle} tone="danger" />
-            <StatCard label="Avg Duration" value={formatDuration(stats.avgDuration)} icon={Timer} tone="success" />
-            <StatCard label="Unique Users" value={stats.uniqueUsers} icon={User} tone="accent" />
+      <div className="flex flex-col gap-2 p-3">
+        {/* Toolbar: saved-view tabs + result count */}
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1">
+            {VIEWS.map((v) => (
+              <button
+                key={v.value}
+                type="button"
+                onClick={() => { setView(v.value); setPage(1) }}
+                className={cn(
+                  'h-7 rounded-md px-2.5 text-xs font-medium transition-colors',
+                  view === v.value
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+                )}
+                aria-pressed={view === v.value}
+              >
+                {v.label}
+              </button>
+            ))}
           </div>
-        )}
+          <div className="ml-auto">
+            <Badge variant="neutral" className="text-xs tabular-nums">
+              {visibleReplays.length} session{visibleReplays.length === 1 ? '' : 's'}
+            </Badge>
+          </div>
+        </div>
 
         {/* Content */}
         {!hasReplayScope ? (
@@ -333,18 +338,12 @@ function ReplaysPage() {
             description="Adjust the selected services to view session replays."
           />
         ) : isLoading ? (
-          <div className="space-y-2">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-border/60 bg-card p-4 animate-pulse">
-                <div className="flex items-center gap-4">
-                  <div className="h-9 w-9 rounded-full bg-muted" />
-                  <div className="flex-1 space-y-2">
-                    <div className="h-4 w-32 rounded bg-muted" />
-                    <div className="h-3 w-48 rounded bg-muted" />
-                  </div>
-                  <div className="h-6 w-16 rounded bg-muted" />
-                  <div className="h-3 w-20 rounded bg-muted" />
-                </div>
+          <div className="rounded-lg border border-border/60">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 border-b border-border/40 p-2.5 last:border-0">
+                <div className="h-6 w-6 animate-pulse rounded-full bg-muted" />
+                <div className="h-3 w-40 animate-pulse rounded bg-muted" />
+                <div className="ml-auto h-3 w-24 animate-pulse rounded bg-muted" />
               </div>
             ))}
           </div>
@@ -360,130 +359,131 @@ function ReplaysPage() {
             title="No replays match your search"
             description="Try adjusting your search query or changing the filters."
           />
+        ) : visibleReplays.length === 0 ? (
+          <EmptyState
+            icon={Search}
+            title="No replays in this view"
+            description="No sessions on this page match the selected view. Try another view or page."
+          />
         ) : (
           <TooltipProvider>
-            <div className="space-y-2">
-              {filteredReplays.map((replay) => {
-                const activityLevel = getActivityLevel(replay.activity)
-                const durationColor = getDurationColor(replay.durationMs)
-                const displayName = replay.user?.email || replay.user?.username || replay.user?.id || 'Anonymous'
-                const initials = getInitials(replay.user)
-                const avatarColor = getAvatarColor(replay.user)
-                const hasErrors = replay.errorCount > 0
-
-                return (
-                  <div
-                    key={replay.replayId}
-                    onClick={() => navigate({ to: '/replays/$replayId', params: { replayId: replay.replayId } })}
-                    className={`cursor-pointer rounded-xl border bg-card hover:bg-accent/50 transition-all border-l-[3px] border-border/60 ${
-                      hasErrors ? 'border-l-danger-solid' : 'border-l-primary/50'
-                    }`}
-                  >
-                    <div className="flex items-center gap-3 p-3">
-                      <Avatar className="h-8 w-8 shrink-0">
-                        <AvatarFallback className={`text-xs font-semibold ${avatarColor}`}>
-                          {initials}
-                        </AvatarFallback>
-                      </Avatar>
-
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="font-semibold text-sm truncate">{displayName}</span>
+            <div className="rounded-lg border border-border/60 overflow-hidden">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="w-7" />
+                    <TableHead className="text-2xs uppercase tracking-wide">User</TableHead>
+                    <TableHead className="text-2xs uppercase tracking-wide text-right">Duration</TableHead>
+                    <TableHead className="text-2xs uppercase tracking-wide w-[140px]">Activity</TableHead>
+                    <TableHead className="text-2xs uppercase tracking-wide">Signals</TableHead>
+                    <TableHead className="text-2xs uppercase tracking-wide">Entry page</TableHead>
+                    <TableHead className="text-2xs uppercase tracking-wide">Browser · OS</TableHead>
+                    <TableHead className="text-2xs uppercase tracking-wide text-right">Started</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visibleReplays.map((replay) => {
+                    const level = getActivityLevel(replay.activity)
+                    const signals = deriveReplaySignals(replay)
+                    const browserOs = browserOsLabel(replay)
+                    const mobile = isMobileOs(replay.osName)
+                    const extraPages = replayExtraPageCount(replay)
+                    return (
+                      <TableRow
+                        key={replay.replayId}
+                        onClick={() => openReplay(replay)}
+                        className="cursor-pointer"
+                      >
+                        <TableCell className="pl-3 pr-0">
+                          <StatusDot tone={replayStatusTone(replay)} />
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2.5 min-w-0">
+                            <Avatar className="h-6 w-6 shrink-0">
+                              <AvatarFallback className={cn('text-2xs font-semibold', replayAvatarClass(replay.user))}>
+                                {replayInitials(replay.user)}
+                              </AvatarFallback>
+                            </Avatar>
+                            <div className="min-w-0 leading-tight">
+                              <div className="truncate text-xs font-medium">{replayDisplayName(replay.user)}</div>
+                              <div className="font-mono text-2xs text-muted-foreground/70">
+                                {replay.replayId.slice(0, 8)}
+                              </div>
+                            </div>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right font-mono text-xs tabular-nums">
+                          {formatReplayClock(replay.durationMs)}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+                              <div
+                                className={cn('h-full rounded-full', level.barClass)}
+                                style={{ width: `${Math.min(100, Math.max(0, replay.activity))}%` }}
+                              />
+                            </div>
+                            <span className="w-6 text-right font-mono text-2xs tabular-nums text-muted-foreground">
+                              {replay.activity}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          {signals.length === 0 ? (
+                            <span className="text-muted-foreground/60">—</span>
+                          ) : (
+                            <div className="flex flex-wrap items-center gap-1">
+                              {signals.map((s) => (
+                                <Badge key={s.key} variant={s.variant} className="gap-1 text-2xs">
+                                  {s.key === 'error' && <AlertCircle className="h-3 w-3" />}
+                                  {s.label}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-baseline gap-1 min-w-0">
+                            <span className="truncate font-mono text-xs">{replayEntryPath(replay)}</span>
+                            {extraPages > 0 && (
+                              <span className="shrink-0 text-2xs text-muted-foreground">+{extraPages}</span>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          {browserOs ? (
+                            <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground">
+                              {mobile ? <Smartphone className="h-3.5 w-3.5" /> : <Monitor className="h-3.5 w-3.5" />}
+                              {browserOs}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground/60">—</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <span className="text-xs text-muted-foreground ml-auto shrink-0 flex items-center gap-1">
-                                <Clock className="h-3 w-3" />
+                              <span className="whitespace-nowrap font-mono text-2xs text-muted-foreground">
                                 {formatRelativeTime(replay.startedAt)}
                               </span>
                             </TooltipTrigger>
                             <TooltipContent>{formatDate(replay.startedAt, timezone)}</TooltipContent>
                           </Tooltip>
-                        </div>
-
-                        <div className="flex flex-wrap items-center gap-2">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Badge variant="outline" className={`text-xs font-medium gap-1 ${durationColor}`}>
-                                <Timer className="h-3 w-3" />
-                                {formatDuration(replay.durationMs)}
-                              </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent>Session duration</TooltipContent>
-                          </Tooltip>
-
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Badge variant="outline" className={`text-xs font-medium gap-1.5 ${activityLevel.bgColor} ${activityLevel.color}`}>
-                                <MousePointerClick className="h-3 w-3" />
-                                <span>{activityLevel.label}</span>
-                                <span className="h-1.5 w-8 rounded-full bg-current/20 overflow-hidden inline-flex">
-                                  <span
-                                    className={`h-full rounded-full ${activityLevel.barColor}`}
-                                    style={{ width: `${Math.min(100, replay.activity)}%` }}
-                                  />
-                                </span>
-                              </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent>Activity: {replay.activity}%</TooltipContent>
-                          </Tooltip>
-
-                          {hasErrors && (
-                            <Badge variant="danger" className="text-xs font-medium gap-1">
-                              <AlertCircle className="h-3 w-3" />
-                              {replay.errorCount} error{replay.errorCount === 1 ? '' : 's'}
-                            </Badge>
-                          )}
-
-                          {replay.urls?.length > 0 && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Badge variant="outline" className="text-xs font-normal gap-1 max-w-[220px] truncate">
-                                  <Globe className="h-3 w-3 shrink-0" />
-                                  <span className="truncate">
-                                    {replay.urls[0]?.replace(/^https?:\/\//, '') || '-'}
-                                  </span>
-                                  {replay.urls.length > 1 && (
-                                    <span className="shrink-0 text-muted-foreground">+{replay.urls.length - 1}</span>
-                                  )}
-                                </Badge>
-                              </TooltipTrigger>
-                              <TooltipContent className="max-w-xs">
-                                <div className="space-y-1">
-                                  {replay.urls.map((url, i) => (
-                                    <div key={i} className="text-xs truncate">{url}</div>
-                                  ))}
-                                </div>
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-
-                          {(replay.browserName || replay.osName) && (
-                            <Badge variant="outline" className="text-xs font-normal gap-1 text-muted-foreground">
-                              <Monitor className="h-3 w-3" />
-                              {[replay.browserName, replay.osName].filter(Boolean).join(' / ')}
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-
-                      <div className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-                        <div className="rounded-full bg-[hsl(var(--primary)/0.12)] p-2 ring-1 ring-[hsl(var(--primary)/0.3)]">
-                          <Play className="h-4 w-4 text-primary" />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )
-              })}
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
             </div>
           </TooltipProvider>
         )}
 
         {/* Pagination */}
-        {filteredReplays.length > 0 && (
+        {visibleReplays.length > 0 && (
           <div className="flex items-center justify-between">
             <p className="text-xs text-muted-foreground">
-              Showing {filteredReplays.length} replay{filteredReplays.length === 1 ? '' : 's'}
+              Showing {visibleReplays.length} replay{visibleReplays.length === 1 ? '' : 's'}
               {searchQuery && ' matching your search'}
               {' '}&middot; Page {page}
             </p>
@@ -515,6 +515,7 @@ function ReplaysPage() {
           </div>
         )}
       </div>
+
     </ExplorerShell>
   )
 }

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -21,7 +21,7 @@ import type {Replay} from '@/lib/api'
 import {cn, formatRelativeTime} from '@/lib/utils'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDate as formatDateUtil, parseDate} from '@/lib/date-format'
-import {useMemo, useState} from 'react'
+import {type KeyboardEvent, useCallback, useMemo, useState} from 'react'
 import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
@@ -126,6 +126,239 @@ const REPLAY_FACET_SCHEMA = [
 ] satisfies FacetSchema
 
 const REPLAY_ENVIRONMENTS = ['production', 'staging', 'development'] as const
+const LOADING_ROW_KEYS = [
+  'replay-loading-1',
+  'replay-loading-2',
+  'replay-loading-3',
+  'replay-loading-4',
+  'replay-loading-5',
+  'replay-loading-6',
+  'replay-loading-7',
+  'replay-loading-8',
+]
+
+function handleReplayRowKeyDown(
+  event: KeyboardEvent<HTMLTableRowElement>,
+  replay: Replay,
+  onOpen: (replay: Replay) => void
+) {
+  if (event.key !== 'Enter' && event.key !== ' ') return
+  event.preventDefault()
+  onOpen(replay)
+}
+
+function replayRowLabel(replay: Replay): string {
+  return `Open replay ${replay.replayId.slice(0, 8)} for ${replayDisplayName(replay.user)}`
+}
+
+interface ReplayRowProps {
+  readonly replay: Replay
+  readonly timezone: string
+  readonly onOpen: (replay: Replay) => void
+}
+
+function ReplayRow({ replay, timezone, onOpen }: ReplayRowProps) {
+  const level = getActivityLevel(replay.activity)
+  const signals = deriveReplaySignals(replay)
+  const browserOs = browserOsLabel(replay)
+  const mobile = isMobileOs(replay.osName)
+  const extraPages = replayExtraPageCount(replay)
+
+  return (
+    <TableRow
+      onClick={() => onOpen(replay)}
+      onKeyDown={(event) => handleReplayRowKeyDown(event, replay, onOpen)}
+      tabIndex={0}
+      role="button"
+      aria-label={replayRowLabel(replay)}
+      className="cursor-pointer"
+    >
+      <TableCell className="pl-3 pr-0">
+        <StatusDot tone={replayStatusTone(replay)} />
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2.5 min-w-0">
+          <Avatar className="h-6 w-6 shrink-0">
+            <AvatarFallback className={cn('text-2xs font-semibold', replayAvatarClass(replay.user))}>
+              {replayInitials(replay.user)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 leading-tight">
+            <div className="truncate text-xs font-medium">{replayDisplayName(replay.user)}</div>
+            <div className="font-mono text-2xs text-muted-foreground/70">
+              {replay.replayId.slice(0, 8)}
+            </div>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="text-right font-mono text-xs tabular-nums">
+        {formatReplayClock(replay.durationMs)}
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn('h-full rounded-full', level.barClass)}
+              style={{ width: `${Math.min(100, Math.max(0, replay.activity))}%` }}
+            />
+          </div>
+          <span className="w-6 text-right font-mono text-2xs tabular-nums text-muted-foreground">
+            {replay.activity}
+          </span>
+        </div>
+      </TableCell>
+      <TableCell>
+        {signals.length === 0 ? (
+          <span className="text-muted-foreground/60">-</span>
+        ) : (
+          <div className="flex flex-wrap items-center gap-1">
+            {signals.map((signal) => (
+              <Badge key={signal.key} variant={signal.variant} className="gap-1 text-2xs">
+                {signal.key === 'error' && <AlertCircle className="h-3 w-3" />}
+                {signal.label}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </TableCell>
+      <TableCell>
+        <div className="flex items-baseline gap-1 min-w-0">
+          <span className="truncate font-mono text-xs">{replayEntryPath(replay)}</span>
+          {extraPages > 0 && (
+            <span className="shrink-0 text-2xs text-muted-foreground">+{extraPages}</span>
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        {browserOs ? (
+          <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground">
+            {mobile ? <Smartphone className="h-3.5 w-3.5" /> : <Monitor className="h-3.5 w-3.5" />}
+            {browserOs}
+          </span>
+        ) : (
+          <span className="text-muted-foreground/60">-</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="whitespace-nowrap font-mono text-2xs text-muted-foreground">
+              {formatRelativeTime(replay.startedAt)}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{formatDate(replay.startedAt, timezone)}</TooltipContent>
+        </Tooltip>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function ReplayTableSkeleton() {
+  return (
+    <div className="rounded-lg border border-border/60">
+      {LOADING_ROW_KEYS.map((key) => (
+        <div key={key} className="flex items-center gap-3 border-b border-border/40 p-2.5 last:border-0">
+          <div className="h-6 w-6 animate-pulse rounded-full bg-muted" />
+          <div className="h-3 w-40 animate-pulse rounded bg-muted" />
+          <div className="ml-auto h-3 w-24 animate-pulse rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface ReplayContentProps {
+  readonly hasReplayScope: boolean
+  readonly isLoading: boolean
+  readonly replays: Replay[]
+  readonly filteredReplays: Replay[]
+  readonly visibleReplays: Replay[]
+  readonly timezone: string
+  readonly onOpenReplay: (replay: Replay) => void
+}
+
+function ReplayContent({
+  hasReplayScope,
+  isLoading,
+  replays,
+  filteredReplays,
+  visibleReplays,
+  timezone,
+  onOpenReplay,
+}: ReplayContentProps) {
+  if (!hasReplayScope) {
+    return (
+      <EmptyState
+        icon={Play}
+        title="No services match filters"
+        description="Adjust the selected services to view session replays."
+      />
+    )
+  }
+
+  if (isLoading) return <ReplayTableSkeleton />
+
+  if (!replays.length) {
+    return (
+      <EmptyState
+        icon={Play}
+        title="No replays yet"
+        description="Session replays are recorded when you enable replay capture in a compatible SDK. Configure replays in your service setup to start capturing user sessions."
+      />
+    )
+  }
+
+  if (filteredReplays.length === 0) {
+    return (
+      <EmptyState
+        icon={Search}
+        title="No replays match your search"
+        description="Try adjusting your search query or changing the filters."
+      />
+    )
+  }
+
+  if (visibleReplays.length === 0) {
+    return (
+      <EmptyState
+        icon={Search}
+        title="No replays in this view"
+        description="No sessions on this page match the selected view. Try another view or page."
+      />
+    )
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="rounded-lg border border-border/60 overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-7" />
+              <TableHead className="text-2xs uppercase tracking-wide">User</TableHead>
+              <TableHead className="text-2xs uppercase tracking-wide text-right">Duration</TableHead>
+              <TableHead className="text-2xs uppercase tracking-wide w-[140px]">Activity</TableHead>
+              <TableHead className="text-2xs uppercase tracking-wide">Signals</TableHead>
+              <TableHead className="text-2xs uppercase tracking-wide">Entry page</TableHead>
+              <TableHead className="text-2xs uppercase tracking-wide">Browser · OS</TableHead>
+              <TableHead className="text-2xs uppercase tracking-wide text-right">Started</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {visibleReplays.map((replay) => (
+              <ReplayRow
+                key={replay.replayId}
+                replay={replay}
+                timezone={timezone}
+                onOpen={onOpenReplay}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </TooltipProvider>
+  )
+}
 
 function ReplaysPage() {
   const navigate = useNavigate()
@@ -236,6 +469,9 @@ function ReplaysPage() {
     () => filteredReplays.filter((r) => matchesView(r, view)),
     [filteredReplays, view]
   )
+  const openReplay = useCallback((replay: Replay) => {
+    navigate({ to: '/replays/$replayId', params: { replayId: replay.replayId } })
+  }, [navigate])
 
   if (projectsLoading) {
     return <div className="p-8 text-sm text-muted-foreground">Loading services...</div>
@@ -259,10 +495,6 @@ function ReplaysPage() {
         />
       </div>
     )
-  }
-
-  const openReplay = (replay: Replay) => {
-    navigate({ to: '/replays/$replayId', params: { replayId: replay.replayId } })
   }
 
   return (
@@ -330,154 +562,15 @@ function ReplaysPage() {
           </div>
         </div>
 
-        {/* Content */}
-        {!hasReplayScope ? (
-          <EmptyState
-            icon={Play}
-            title="No services match filters"
-            description="Adjust the selected services to view session replays."
-          />
-        ) : isLoading ? (
-          <div className="rounded-lg border border-border/60">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3 border-b border-border/40 p-2.5 last:border-0">
-                <div className="h-6 w-6 animate-pulse rounded-full bg-muted" />
-                <div className="h-3 w-40 animate-pulse rounded bg-muted" />
-                <div className="ml-auto h-3 w-24 animate-pulse rounded bg-muted" />
-              </div>
-            ))}
-          </div>
-        ) : !replays.length ? (
-          <EmptyState
-            icon={Play}
-            title="No replays yet"
-            description="Session replays are recorded when you enable replay capture in a compatible SDK. Configure replays in your service setup to start capturing user sessions."
-          />
-        ) : filteredReplays.length === 0 ? (
-          <EmptyState
-            icon={Search}
-            title="No replays match your search"
-            description="Try adjusting your search query or changing the filters."
-          />
-        ) : visibleReplays.length === 0 ? (
-          <EmptyState
-            icon={Search}
-            title="No replays in this view"
-            description="No sessions on this page match the selected view. Try another view or page."
-          />
-        ) : (
-          <TooltipProvider>
-            <div className="rounded-lg border border-border/60 overflow-hidden">
-              <Table>
-                <TableHeader>
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead className="w-7" />
-                    <TableHead className="text-2xs uppercase tracking-wide">User</TableHead>
-                    <TableHead className="text-2xs uppercase tracking-wide text-right">Duration</TableHead>
-                    <TableHead className="text-2xs uppercase tracking-wide w-[140px]">Activity</TableHead>
-                    <TableHead className="text-2xs uppercase tracking-wide">Signals</TableHead>
-                    <TableHead className="text-2xs uppercase tracking-wide">Entry page</TableHead>
-                    <TableHead className="text-2xs uppercase tracking-wide">Browser · OS</TableHead>
-                    <TableHead className="text-2xs uppercase tracking-wide text-right">Started</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {visibleReplays.map((replay) => {
-                    const level = getActivityLevel(replay.activity)
-                    const signals = deriveReplaySignals(replay)
-                    const browserOs = browserOsLabel(replay)
-                    const mobile = isMobileOs(replay.osName)
-                    const extraPages = replayExtraPageCount(replay)
-                    return (
-                      <TableRow
-                        key={replay.replayId}
-                        onClick={() => openReplay(replay)}
-                        className="cursor-pointer"
-                      >
-                        <TableCell className="pl-3 pr-0">
-                          <StatusDot tone={replayStatusTone(replay)} />
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-2.5 min-w-0">
-                            <Avatar className="h-6 w-6 shrink-0">
-                              <AvatarFallback className={cn('text-2xs font-semibold', replayAvatarClass(replay.user))}>
-                                {replayInitials(replay.user)}
-                              </AvatarFallback>
-                            </Avatar>
-                            <div className="min-w-0 leading-tight">
-                              <div className="truncate text-xs font-medium">{replayDisplayName(replay.user)}</div>
-                              <div className="font-mono text-2xs text-muted-foreground/70">
-                                {replay.replayId.slice(0, 8)}
-                              </div>
-                            </div>
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right font-mono text-xs tabular-nums">
-                          {formatReplayClock(replay.durationMs)}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-2">
-                            <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-                              <div
-                                className={cn('h-full rounded-full', level.barClass)}
-                                style={{ width: `${Math.min(100, Math.max(0, replay.activity))}%` }}
-                              />
-                            </div>
-                            <span className="w-6 text-right font-mono text-2xs tabular-nums text-muted-foreground">
-                              {replay.activity}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {signals.length === 0 ? (
-                            <span className="text-muted-foreground/60">—</span>
-                          ) : (
-                            <div className="flex flex-wrap items-center gap-1">
-                              {signals.map((s) => (
-                                <Badge key={s.key} variant={s.variant} className="gap-1 text-2xs">
-                                  {s.key === 'error' && <AlertCircle className="h-3 w-3" />}
-                                  {s.label}
-                                </Badge>
-                              ))}
-                            </div>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-baseline gap-1 min-w-0">
-                            <span className="truncate font-mono text-xs">{replayEntryPath(replay)}</span>
-                            {extraPages > 0 && (
-                              <span className="shrink-0 text-2xs text-muted-foreground">+{extraPages}</span>
-                            )}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {browserOs ? (
-                            <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground">
-                              {mobile ? <Smartphone className="h-3.5 w-3.5" /> : <Monitor className="h-3.5 w-3.5" />}
-                              {browserOs}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground/60">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="whitespace-nowrap font-mono text-2xs text-muted-foreground">
-                                {formatRelativeTime(replay.startedAt)}
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>{formatDate(replay.startedAt, timezone)}</TooltipContent>
-                          </Tooltip>
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          </TooltipProvider>
-        )}
+        <ReplayContent
+          hasReplayScope={hasReplayScope}
+          isLoading={isLoading}
+          replays={replays}
+          filteredReplays={filteredReplays}
+          visibleReplays={visibleReplays}
+          timezone={timezone}
+          onOpenReplay={openReplay}
+        />
 
         {/* Pagination */}
         {visibleReplays.length > 0 && (

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
         '**/*.config.*',
         '**/mockData/**',
         'src/routeTree.gen.ts',
+        // App shell/provider wiring is covered through integration paths, not unit coverage.
+        'src/routes/__root.tsx',
+        'src/contexts/CommandPaletteProvider.tsx',
         // Build-time prerender entry: imports MDX so it only runs through Vite (not vitest),
         // and is validated by the production build itself. Its pure logic lives in src/lib/seo.
         'src/prerender/**',


### PR DESCRIPTION
Refreshes the replay list and replay detail experience with enriched replay metadata and timeline signals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geo/IP enrichment, entry URL and per-session signals (error, rage/dead click, etc.) in replay list and detail
  * Timeline: HTTP status badges, breadcrumb/span items, and a “Next error” scrubber button
  * Category-driven timeline filters and client-side replay view filters (all/errors/mobile)

* **Improvements**
  * Table-based replay list, richer session details (viewport, connection, prior session count, user session count)
  * Improved timeline UX (hover card, status badge, time formatting, auto-scroll within filtered items)
  * Consolidated replay detail layout and recording/player area

* **Tests**
  * Expanded coverage for timeline, scrubber, replays view and replay detail behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->