### PR TITLE
fix: label template filter group

### DIFF
--- a/dashboard/src/components/dashboards/DashboardsGetStarted.tsx
+++ b/dashboard/src/components/dashboards/DashboardsGetStarted.tsx
@@ -244,9 +244,9 @@ export function DashboardsGetStarted({
           hint="Curated, fully editable starting points."
           tools={
             <fieldset
-              aria-label="Filter templates by category"
               className="inline-flex items-center gap-0.5 rounded-md border bg-muted/40 p-0.5"
             >
+              <legend className="sr-only">Filter templates by category</legend>
               {FILTERS.map((f) => {
                 const active = filter === f.key
                 return (

--- a/dashboard/src/components/dashboards/__tests__/DashboardsGetStarted.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DashboardsGetStarted.test.tsx
@@ -142,6 +142,15 @@ describe('DashboardsGetStarted', () => {
     )
   })
 
+  it('uses a native labelled group for category filters', () => {
+    setup()
+
+    const filters = screen.getByRole('group', {name: /filter templates by category/i})
+
+    expect(filters.tagName.toLowerCase()).toBe('fieldset')
+    expect(within(filters).getByText('Filter templates by category')).toHaveClass('sr-only')
+  })
+
   it('shows a loading gallery while template metadata is pending', () => {
     const {container} = setup([], true)
 


### PR DESCRIPTION
## Summary
- Add a hidden legend to the template category filter group.
- Cover the native group label in tests.

## Checks
- npm test -- --run src/components/dashboards/__tests__/DashboardsGetStarted.test.tsx
- npm run typecheck
- npm run lint
- git diff --check
