### PR TITLE
fix: repair resources catalog data and event layout

### DIFF
--- a/backend/src/main/kotlin/com/moneat/monitor/models/MonitorModels.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/models/MonitorModels.kt
@@ -251,6 +251,7 @@ data class HostData(
     val processor: String? = null,
     val cpuCores: Int? = null,
     val memoryTotalKb: Long? = null,
+    val tags: Map<String, String> = emptyMap(),
     @Serializable(with = KotlinInstantSerializer::class)
     val firstSeenAt: kotlin.time.Instant,
     @Serializable(with = KotlinInstantSerializer::class)

--- a/backend/src/main/kotlin/com/moneat/monitor/models/ResourceCatalogModels.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/models/ResourceCatalogModels.kt
@@ -59,8 +59,8 @@ data class CatalogCostItem(
 
 @Serializable
 data class CatalogResourceTelemetry(
-    val cpuPct: Int,
-    val memPct: Int,
+    val cpuPct: Int? = null,
+    val memPct: Int? = null,
     val latencyMs: Int? = null,
     val errorRatePct: Double? = null,
     val throughput: String? = null

--- a/backend/src/main/kotlin/com/moneat/monitor/repositories/HostRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/repositories/HostRepositoryImpl.kt
@@ -21,11 +21,10 @@ import com.moneat.monitor.models.HostData
 import com.moneat.shared.models.Hosts
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -114,18 +113,17 @@ class HostRepositoryImpl : HostRepository {
 
 private fun parseHostTags(rawTags: String): Map<String, String> {
     if (rawTags.isBlank()) return emptyMap()
-    return try {
+    return runCatching {
         hostTagsJson
             .parseToJsonElement(rawTags)
             .jsonObject
             .entries
             .mapNotNull { (key, value) ->
-                value.jsonPrimitive.contentOrNull?.takeIf { it.isNotBlank() }?.let { key to it }
+                (value as? JsonPrimitive)
+                    ?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { key to it }
             }
             .toMap()
-    } catch (_: SerializationException) {
-        emptyMap()
-    } catch (_: IllegalArgumentException) {
-        emptyMap()
-    }
+    }.getOrDefault(emptyMap())
 }

--- a/backend/src/main/kotlin/com/moneat/monitor/repositories/HostRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/repositories/HostRepositoryImpl.kt
@@ -21,6 +21,11 @@ import com.moneat.monitor.models.HostData
 import com.moneat.shared.models.Hosts
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -31,6 +36,7 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 private val logger = KotlinLogging.logger {}
+private val hostTagsJson = Json { ignoreUnknownKeys = true }
 
 class HostRepositoryImpl : HostRepository {
 
@@ -100,7 +106,26 @@ class HostRepositoryImpl : HostRepository {
             processor = row[Hosts.processor].takeIf { it.isNotBlank() },
             cpuCores = row[Hosts.cpu_cores].takeIf { it > 0 },
             memoryTotalKb = row[Hosts.memory_total_kb].takeIf { it > 0 },
+            tags = parseHostTags(row[Hosts.tags]),
             firstSeenAt = row[Hosts.first_seen_at],
             createdAt = row[Hosts.first_seen_at]
         )
+}
+
+private fun parseHostTags(rawTags: String): Map<String, String> {
+    if (rawTags.isBlank()) return emptyMap()
+    return try {
+        hostTagsJson
+            .parseToJsonElement(rawTags)
+            .jsonObject
+            .entries
+            .mapNotNull { (key, value) ->
+                value.jsonPrimitive.contentOrNull?.takeIf { it.isNotBlank() }?.let { key to it }
+            }
+            .toMap()
+    } catch (_: SerializationException) {
+        emptyMap()
+    } catch (_: IllegalArgumentException) {
+        emptyMap()
+    }
 }

--- a/backend/src/main/kotlin/com/moneat/monitor/services/ResourceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/ResourceCatalogService.kt
@@ -85,20 +85,21 @@ class ResourceCatalogService(
             .toMap()
 
     private fun hostResource(host: HostData, metrics: LatestMetrics?): CatalogResource {
-        val tags = listOf("source:host-agent")
+        val tags = host.tags.toCatalogTags() + "source:host-agent"
+        val cloud = tags.cloudFromTags()
         return CatalogResource(
             id = stableId("host", "${host.organizationId}:${host.id}"),
             name = host.displayName ?: host.hostname,
             kind = "host",
             health = host.status.toCatalogHealth(),
-            environment = "prod",
-            region = "unknown",
-            cloud = CLOUD_ON_PREM,
+            environment = tags.envFromTags(),
+            region = tags.regionFromTags(cloud),
+            cloud = cloud,
             owner = null,
             tags = tags,
             telemetry = CatalogResourceTelemetry(
-                cpuPct = metrics?.cpuPercent.toPct(),
-                memPct = metrics?.memPercent.toPct()
+                cpuPct = metrics?.cpuPercent?.toPct(),
+                memPct = metrics?.memPercent?.toPct()
             ),
             vulns = CatalogVulnerabilityCounts(),
             sbomComponents = 0,
@@ -124,13 +125,11 @@ class ResourceCatalogService(
             kind = "service",
             health = serviceHealth(spanCount, errorRate),
             environment = row.s("env").toEnvironment(),
-            region = "unknown",
+            region = "global",
             cloud = CLOUD_ON_PREM,
             owner = null,
             tags = listOf("source:apm"),
             telemetry = CatalogResourceTelemetry(
-                cpuPct = 0,
-                memPct = 0,
                 latencyMs = row.i("latency_ms"),
                 errorRatePct = errorRate,
                 throughput = row.s("span_count")?.let { "$it spans/24h" }
@@ -158,20 +157,21 @@ class ResourceCatalogService(
         val host = row.s("host")
         val memLimit = row.d("mem_limit") ?: 0.0
         val memUsage = row.d("mem_usage") ?: 0.0
-        val memPct = if (memLimit > 0) (memUsage / memLimit * PERCENT_SCALE).roundToInt() else 0
+        val memPct = if (memLimit > 0) (memUsage / memLimit * PERCENT_SCALE).roundToInt() else null
+        val cloud = tags.cloudFromTags()
         return CatalogResource(
             id = organizationScopedId("container", row.s("organization_id"), id),
             name = row.s("name") ?: row.s("image") ?: id,
             kind = "container",
             health = row.s("state").containerHealth(),
             environment = tags.envFromTags(),
-            region = "unknown",
-            cloud = tags.cloudFromTags(),
+            region = tags.regionFromTags(cloud),
+            cloud = cloud,
             owner = null,
             tags = tags,
             telemetry = CatalogResourceTelemetry(
-                cpuPct = row.d("cpu_percent").toPct(),
-                memPct = memPct.coerceIn(ZERO_PERCENT, FULL_PERCENT)
+                cpuPct = row.d("cpu_percent")?.toPct(),
+                memPct = memPct?.coerceIn(ZERO_PERCENT, FULL_PERCENT)
             ),
             vulns = CatalogVulnerabilityCounts(),
             sbomComponents = 0,
@@ -196,17 +196,18 @@ class ResourceCatalogService(
     private fun podResource(row: JsonObject): CatalogResource? {
         val id = row.s("id") ?: return null
         val tags = row.tags() + row.labels().map { "label:$it" } + "source:kubernetes"
+        val cloud = tags.cloudFromTags()
         return CatalogResource(
             id = organizationScopedId("pod", row.s("organization_id"), id),
             name = row.s("name") ?: id,
             kind = "pod",
             health = row.s("status").podHealth(),
             environment = tags.envFromTags(),
-            region = "unknown",
-            cloud = tags.cloudFromTags(),
+            region = tags.regionFromTags(cloud),
+            cloud = cloud,
             owner = null,
             tags = tags,
-            telemetry = CatalogResourceTelemetry(cpuPct = 0, memPct = 0),
+            telemetry = CatalogResourceTelemetry(),
             vulns = CatalogVulnerabilityCounts(),
             sbomComponents = 0,
             posture = emptyList(),
@@ -234,11 +235,11 @@ class ResourceCatalogService(
             kind = "network-device",
             health = row.s("reachability")?.toCatalogHealth() ?: row.s("status").toCatalogHealth(),
             environment = tags.envFromTags(),
-            region = "unknown",
+            region = tags.regionFromTags(CLOUD_ON_PREM),
             cloud = CLOUD_ON_PREM,
             owner = null,
             tags = tags,
-            telemetry = CatalogResourceTelemetry(cpuPct = 0, memPct = 0),
+            telemetry = CatalogResourceTelemetry(),
             vulns = CatalogVulnerabilityCounts(),
             sbomComponents = 0,
             posture = emptyList(),
@@ -274,8 +275,8 @@ class ResourceCatalogService(
             owner = null,
             tags = tags,
             telemetry = CatalogResourceTelemetry(
-                cpuPct = row.d("cpu_percent").toPct(),
-                memPct = row.d("mem_percent").toPct()
+                cpuPct = row.d("cpu_percent")?.toPct(),
+                memPct = row.d("mem_percent")?.toPct()
             ),
             vulns = CatalogVulnerabilityCounts(),
             sbomComponents = 0,
@@ -399,6 +400,16 @@ private fun List<String>.cloudFromTags(): String =
         else -> CLOUD_ON_PREM
     }
 
+private fun List<String>.regionFromTags(cloud: String): String =
+    firstTagValue("region")
+        ?: firstTagValue("cloud.region")
+        ?: firstTagValue("datacenter")
+        ?: firstTagValue("dc")
+        ?: firstTagValue("availability_zone")
+        ?: firstTagValue("availability-zone")
+        ?: firstTagValue("az")
+        ?: if (cloud == CLOUD_ON_PREM) "local" else "global"
+
 private fun String?.toCloudProvider(): String =
     when (this?.lowercase()) {
         "aws" -> "aws"
@@ -410,11 +421,20 @@ private fun String?.toCloudProvider(): String =
 private fun List<String>.firstTagValue(key: String): String? =
     firstOrNull { it.startsWith("$key:") }?.substringAfter(":")?.takeIf { it.isNotBlank() }
 
-private fun Float?.toPct(): Int =
-    this?.roundToInt()?.coerceIn(ZERO_PERCENT, FULL_PERCENT) ?: ZERO_PERCENT
+private fun Map<String, String>.toCatalogTags(): List<String> =
+    entries
+        .sortedBy { it.key }
+        .mapNotNull { (key, value) ->
+            val cleanKey = key.takeIf { it.isNotBlank() }
+            val cleanValue = value.takeIf { it.isNotBlank() }
+            if (cleanKey == null || cleanValue == null) null else "$cleanKey:$cleanValue"
+        }
 
-private fun Double?.toPct(): Int =
-    this?.roundToInt()?.coerceIn(ZERO_PERCENT, FULL_PERCENT) ?: ZERO_PERCENT
+private fun Float.toPct(): Int =
+    roundToInt().coerceIn(ZERO_PERCENT, FULL_PERCENT)
+
+private fun Double.toPct(): Int =
+    roundToInt().coerceIn(ZERO_PERCENT, FULL_PERCENT)
 
 private fun Instant.toCatalogIso(): String {
     val text = toString()

--- a/backend/src/test/kotlin/com/moneat/monitor/services/ResourceCatalogServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitor/services/ResourceCatalogServiceTest.kt
@@ -55,7 +55,13 @@ class ResourceCatalogServiceTest {
             id = HOST_ID,
             organizationId = ORGANIZATION_ID,
             hostname = HOSTNAME,
-            status = "online"
+            status = "online",
+            tags = mapOf(
+                "env" to "staging",
+                "region" to "sfo3",
+                "cloud.provider" to "aws",
+                "team" to "payments"
+            )
         )
         val metrics = LatestMetrics(
             cpuPercent = 37.5f,
@@ -93,11 +99,14 @@ class ResourceCatalogServiceTest {
         assertEquals(HOSTNAME, resource.name)
         assertEquals("host", resource.kind)
         assertEquals("healthy", resource.health)
-        assertEquals("prod", resource.environment)
-        assertEquals("on-prem", resource.cloud)
+        assertEquals("staging", resource.environment)
+        assertEquals("sfo3", resource.region)
+        assertEquals("aws", resource.cloud)
         assertEquals(38, resource.telemetry.cpuPct)
         assertEquals(50, resource.telemetry.memPct)
         assertTrue(resource.tags.contains("source:host-agent"))
+        assertTrue(resource.tags.contains("region:sfo3"))
+        assertTrue(resource.tags.contains("team:payments"))
         assertTrue(resource.metadata.any { it.label == "Agent" && it.value == "7.63.0" })
     }
 
@@ -190,7 +199,7 @@ class ResourceCatalogServiceTest {
                       "cpu_percent": 12.4,
                       "mem_usage": 256000000,
                       "mem_limit": 512000000,
-                      "tags": {"env": "staging", "team": "payments"},
+                      "tags": {"env": "staging", "team": "payments", "region": "us-east-2"},
                       "last_seen": "$LAST_SEEN"
                     }
                     """
@@ -218,6 +227,7 @@ class ResourceCatalogServiceTest {
         assertEquals("container:7:abc123", containerResource.id)
         assertEquals(SERVICE_NAME, containerResource.name)
         assertEquals("healthy", containerResource.health)
+        assertEquals("us-east-2", containerResource.region)
         assertEquals(12, containerResource.telemetry.cpuPct)
         assertEquals(50, containerResource.telemetry.memPct)
         assertTrue(containerResource.relationships.any { it.relation == "Runs on" && it.name == HOSTNAME })
@@ -263,7 +273,7 @@ class ResourceCatalogServiceTest {
                       "name": "checkout-api-7f9d",
                       "cluster_name": "prod-us-east",
                       "status": "Pending",
-                      "tags": {"env": "prod", "cloud.provider": "aws"},
+                      "tags": {"env": "prod", "cloud.provider": "aws", "region": "eu-west-1"},
                       "labels": {"app": "checkout"},
                       "first_seen": "$FIRST_SEEN",
                       "last_seen": "$LAST_SEEN"
@@ -285,7 +295,7 @@ class ResourceCatalogServiceTest {
                       "device_type": "switch",
                       "status": "up",
                       "reachability": "unreachable",
-                      "tags": {"env": "dev"},
+                      "tags": {"env": "dev", "region": "dc-east"},
                       "last_seen": "$LAST_SEEN"
                     }
                     """
@@ -302,6 +312,7 @@ class ResourceCatalogServiceTest {
         assertEquals("warn", pod.health)
         assertEquals("prod", pod.environment)
         assertEquals("aws", pod.cloud)
+        assertEquals("eu-west-1", pod.region)
         assertTrue(pod.tags.contains("label:app:checkout"))
         assertTrue(pod.metadata.any { it.label == "Cluster" && it.value == "prod-us-east" })
 
@@ -310,6 +321,7 @@ class ResourceCatalogServiceTest {
         assertEquals("edge-switch-01", networkDevice.name)
         assertEquals("critical", networkDevice.health)
         assertEquals("dev", networkDevice.environment)
+        assertEquals("dc-east", networkDevice.region)
         assertTrue(networkDevice.metadata.any { it.label == "Vendor" && it.value == "Arista" })
     }
 
@@ -384,6 +396,7 @@ class ResourceCatalogServiceTest {
         organizationId: Int,
         hostname: String,
         status: String,
+        tags: Map<String, String> = emptyMap(),
     ): HostData =
         HostData(
             id = id,
@@ -399,6 +412,7 @@ class ResourceCatalogServiceTest {
             processor = "x86_64",
             cpuCores = 8,
             memoryTotalKb = 16_000_000,
+            tags = tags,
             firstSeenAt = Instant.parse("2026-06-01T00:00:00Z"),
             createdAt = Instant.parse("2026-06-01T00:00:00Z")
         )

--- a/backend/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
@@ -109,7 +109,7 @@ class MonitorServiceTest {
             } get PricingTierConfigs.id
         }
 
-    private fun seedHost(orgId: Int, name: String = "test-server"): Int =
+    private fun seedHost(orgId: Int, name: String = "test-server", rawTags: String = "{}"): Int =
         transaction {
             val now = kotlin.time.Clock.System.now()
             val hostId = Hosts.insert {
@@ -117,6 +117,7 @@ class MonitorServiceTest {
                 it[display_name] = name
                 it[hostname] = name
                 it[status] = "pending"
+                it[tags] = rawTags
                 it[first_seen_at] = now
                 it[last_seen_at] = now
             } get Hosts.id
@@ -156,6 +157,28 @@ class MonitorServiceTest {
         val hosts1 = service.listHosts(org1)
         assertEquals(1, hosts1.size)
         assertEquals("server-1", hosts1[0].displayName)
+    }
+
+    @Test
+    fun `listHosts ignores nested host tag values`() {
+        val orgId = seedOrg()
+        seedHost(
+            orgId = orgId,
+            name = "server-with-tags",
+            rawTags = """
+                {
+                  "env": "production",
+                  "team": "infra",
+                  "blank": "",
+                  "roles": ["web"],
+                  "cloud": {"region": "sfo3"}
+                }
+            """.trimIndent()
+        )
+
+        val host = service.listHosts(orgId).single()
+
+        assertEquals(mapOf("env" to "production", "team" to "infra"), host.tags)
     }
 
     // ──── getHostById ────

--- a/dashboard/src/components/CommandPalette.tsx
+++ b/dashboard/src/components/CommandPalette.tsx
@@ -88,7 +88,7 @@ const PAGE_ITEMS: Array<{
   {label: 'Logs', description: 'Search and explore log events', href: '/logs', icon: ScrollText, keywords: ['logging']},
   {label: 'Dashboards', description: 'Custom metrics and visualizations', href: '/dashboards', icon: LayoutDashboard, keywords: ['widgets']},
   {label: 'Feature Flags', description: 'OpenFeature flags and experiments', href: '/feature-flags', icon: Flag, keywords: ['flags', 'openfeature', 'ofrep', 'experiments']},
-  {label: 'Resources', description: 'Infrastructure resource catalog', href: '/monitoring', icon: Server, keywords: ['infrastructure', 'monitoring', 'catalog', 'inventory', 'systems', 'servers', 'hosts', 'containers']},
+  {label: 'Resources', description: 'Infrastructure resource catalog', href: '/resources', icon: Server, keywords: ['infrastructure', 'monitoring', 'catalog', 'inventory', 'systems', 'servers', 'hosts', 'containers']},
   {label: 'Infrastructure – Map', description: 'Visual map for services, hosts, and containers', href: '/monitoring/map?scope=services', icon: MapIcon, keywords: ['infrastructure map', 'host map', 'containers', 'tags', 'topology', 'monitoring']},
   {label: 'Service Map', description: 'Service dependency topology', href: '/monitoring/map?scope=services', icon: Network, keywords: ['service map', 'dependencies', 'traces', 'topology']},
   {label: 'Infrastructure – Hosts', description: 'Host metrics and system resources', href: '/monitoring/hosts', icon: Server, keywords: ['infrastructure', 'servers', 'cpu', 'memory', 'disk', 'monitoring']},

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -224,7 +224,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
     { key: 'logs', icon: ScrollText, label: 'Logs', href: '/logs', requiresProject: false, group: 'core' },
     ...datadogCoreNavItems,
     // Infrastructure & Uptime
-    { key: 'monitoring', icon: Boxes, label: 'Resources', href: '/monitoring', requiresProject: false, group: 'infrastructure' },
+    { key: 'monitoring', icon: Boxes, label: 'Resources', href: '/resources', requiresProject: false, group: 'infrastructure' },
     { key: 'uptime', icon: Activity, label: 'Uptime', href: '/uptime', requiresProject: false, group: 'infrastructure' },
     {
       key: 'status-pages',

--- a/dashboard/src/components/monitoring/EventStream.tsx
+++ b/dashboard/src/components/monitoring/EventStream.tsx
@@ -250,16 +250,16 @@ export function EventStream() {
       ) : (
         <Card className="overflow-hidden border-border/60">
           <CardContent className="p-0">
-            <Table className="min-w-[800px]">
+            <Table className="min-w-[980px] table-fixed">
               <TableHeader>
                 <TableRow className="hover:bg-transparent bg-muted/30">
                   <TableHead className="pl-4 w-8" />
-                  <TableHead>Event</TableHead>
-                  <TableHead>Alert</TableHead>
-                  <TableHead>Priority</TableHead>
-                  <TableHead>Host</TableHead>
-                  <TableHead>Source</TableHead>
-                  <TableHead className="text-right pr-4">Time</TableHead>
+                  <TableHead className="w-[46%]">Event</TableHead>
+                  <TableHead className="w-[140px]">Alert</TableHead>
+                  <TableHead className="w-[110px]">Priority</TableHead>
+                  <TableHead className="w-[180px]">Host</TableHead>
+                  <TableHead className="w-[220px]">Source</TableHead>
+                  <TableHead className="w-[100px] text-right pr-4">Time</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -290,12 +290,12 @@ export function EventStream() {
                         ) : null}
                       </TableCell>
 
-                      <TableCell className="max-w-md">
+                      <TableCell className="max-w-0">
                         <div className="min-w-0">
                           <TooltipProvider delayDuration={300}>
                             <Tooltip>
                               <TooltipTrigger asChild>
-                                <p className="font-medium text-sm truncate max-w-[350px]">{event.title}</p>
+                                <p className="truncate text-sm font-medium">{event.title}</p>
                               </TooltipTrigger>
                               <TooltipContent side="top" className="max-w-md">
                                 <p className="text-xs break-all">{event.title}</p>
@@ -303,7 +303,7 @@ export function EventStream() {
                             </Tooltip>
                           </TooltipProvider>
                           {!isExpanded && event.text && (
-                            <p className="text-[11px] text-muted-foreground truncate max-w-[350px] mt-0.5">
+                            <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
                               {event.text}
                             </p>
                           )}
@@ -315,17 +315,17 @@ export function EventStream() {
                                 </p>
                               )}
                               {(event.aggregationKey || event.deviceName) && (
-                                <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+                                <div className="space-y-1 text-[11px] text-muted-foreground">
                                   {event.aggregationKey && (
-                                    <span>
-                                      <span className="font-medium text-foreground/70">agg:</span>{' '}
-                                      <span className="font-mono">{event.aggregationKey}</span>
+                                    <span className="block min-w-0">
+                                      <span className="mr-1 font-medium text-foreground/70">agg:</span>
+                                      <span className="break-all font-mono">{event.aggregationKey}</span>
                                     </span>
                                   )}
                                   {event.deviceName && (
-                                    <span>
-                                      <span className="font-medium text-foreground/70">device:</span>{' '}
-                                      <span className="font-mono">{event.deviceName}</span>
+                                    <span className="block min-w-0">
+                                      <span className="mr-1 font-medium text-foreground/70">device:</span>
+                                      <span className="break-all font-mono">{event.deviceName}</span>
                                     </span>
                                   )}
                                 </div>
@@ -348,31 +348,31 @@ export function EventStream() {
                         </div>
                       </TableCell>
 
-                      <TableCell>
+                      <TableCell className="w-[140px]">
                         <Badge
                           variant={alertBadgeVariant(event.alertType)}
-                          className="text-[11px] gap-1.5 font-medium"
+                          className="gap-1.5 whitespace-nowrap text-[11px] font-medium"
                         >
                           {alertIcon(event.alertType)}
                           {event.alertType}
                         </Badge>
                       </TableCell>
 
-                      <TableCell>
+                      <TableCell className="w-[110px]">
                         <span className="text-xs capitalize text-muted-foreground">
                           {priorityLabel(event.priority)}
                         </span>
                       </TableCell>
 
-                      <TableCell>
-                        <span className="font-mono text-xs">{event.host || '—'}</span>
+                      <TableCell className="w-[180px]">
+                        <span className="block truncate font-mono text-xs">{event.host || '—'}</span>
                       </TableCell>
 
-                      <TableCell>
-                        <span className="text-xs">{event.sourceTypeName || '—'}</span>
+                      <TableCell className="w-[220px]">
+                        <span className="block truncate text-xs">{event.sourceTypeName || '—'}</span>
                       </TableCell>
 
-                      <TableCell className="text-right pr-4 text-xs text-muted-foreground">
+                      <TableCell className="w-[100px] text-right pr-4 text-xs text-muted-foreground">
                         {formatRelativeTime(event.timestamp)}
                       </TableCell>
                     </TableRow>

--- a/dashboard/src/components/monitoring/EventStream.tsx
+++ b/dashboard/src/components/monitoring/EventStream.tsx
@@ -28,7 +28,7 @@ import {
   Tag,
   Zap,
 } from 'lucide-react'
-import {useState, useMemo} from 'react'
+import {useState, useMemo, type ReactNode} from 'react'
 import {cn} from '@/lib/utils'
 import {formatRelativeTime} from '@/lib/utils'
 
@@ -107,6 +107,192 @@ function filterTone(alertType: AlertFilter): StatusTone {
   }
 }
 
+function LoadingEvents() {
+  return (
+    <div className="flex items-center justify-center py-16">
+      <div className="flex flex-col items-center gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <p className="text-muted-foreground text-sm">Loading events...</p>
+      </div>
+    </div>
+  )
+}
+
+function EmptyEvents() {
+  return (
+    <Card className="border-dashed">
+      <CardContent className="py-16 text-center">
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
+          <Zap className="h-10 w-10" />
+        </div>
+        <h3 className="text-xl font-semibold mb-2">No events found</h3>
+        <p className="text-muted-foreground mb-2 max-w-sm mx-auto">
+          Events will appear when an agent sends event data.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmptyFilteredEvents() {
+  return (
+    <div className="text-center py-12 text-muted-foreground">
+      <p className="font-medium">No events match your filters</p>
+      <p className="text-sm mt-1">Try adjusting your search or alert type filter.</p>
+    </div>
+  )
+}
+
+function eventDetailToggleIcon(hasDetails: boolean, isExpanded: boolean): ReactNode {
+  if (hasDetails) {
+    if (isExpanded) return <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+    return (
+      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+    )
+  }
+  return null
+}
+
+function EventTable({
+  events,
+  expandedId,
+  onToggleExpanded,
+}: {
+  readonly events: readonly DdEventResponse[]
+  readonly expandedId: string | null
+  readonly onToggleExpanded: (eventId: string | null) => void
+}) {
+  return (
+    <Card className="overflow-hidden border-border/60">
+      <CardContent className="p-0">
+        <Table className="min-w-[980px] table-fixed">
+          <TableHeader>
+            <TableRow className="hover:bg-transparent bg-muted/30">
+              <TableHead className="pl-4 w-8" />
+              <TableHead className="w-[46%]">Event</TableHead>
+              <TableHead className="w-[140px]">Alert</TableHead>
+              <TableHead className="w-[110px]">Priority</TableHead>
+              <TableHead className="w-[180px]">Host</TableHead>
+              <TableHead className="w-[220px]">Source</TableHead>
+              <TableHead className="w-[100px] text-right pr-4">Time</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {events.map((event: DdEventResponse) => {
+              const isExpanded = expandedId === event.eventId
+              const tagEntries = event.tags ? Object.entries(event.tags) : []
+              const hasDetails = Boolean(event.text || tagEntries.length > 0 || event.aggregationKey || event.deviceName)
+
+              return (
+                <TableRow
+                  key={event.eventId}
+                  className={cn(
+                    'group transition-colors border-l-2',
+                    alertAccentColor(event.alertType),
+                    hasDetails ? 'cursor-pointer' : '',
+                    isExpanded ? 'bg-muted/40' : 'hover:bg-muted/50'
+                  )}
+                  onClick={() => hasDetails && onToggleExpanded(isExpanded ? null : event.eventId)}
+                >
+                  <TableCell className="pl-4 pr-0 w-8">
+                    {eventDetailToggleIcon(hasDetails, isExpanded)}
+                  </TableCell>
+
+                  <TableCell className="max-w-0">
+                    <div className="min-w-0">
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <p className="truncate text-sm font-medium">{event.title}</p>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-md">
+                            <p className="text-xs break-all">{event.title}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      {!isExpanded && event.text && (
+                        <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                          {event.text}
+                        </p>
+                      )}
+                      {isExpanded && (
+                        <div className="mt-2 space-y-2">
+                          {event.text && (
+                            <p className="text-xs text-muted-foreground whitespace-pre-wrap break-words max-w-lg">
+                              {event.text}
+                            </p>
+                          )}
+                          {(event.aggregationKey || event.deviceName) && (
+                            <div className="space-y-1 text-[11px] text-muted-foreground">
+                              {event.aggregationKey && (
+                                <span className="block min-w-0">
+                                  <span className="mr-1 font-medium text-foreground/70">agg:</span>
+                                  <span className="break-all font-mono">{event.aggregationKey}</span>
+                                </span>
+                              )}
+                              {event.deviceName && (
+                                <span className="block min-w-0">
+                                  <span className="mr-1 font-medium text-foreground/70">device:</span>
+                                  <span className="break-all font-mono">{event.deviceName}</span>
+                                </span>
+                              )}
+                            </div>
+                          )}
+                          {tagEntries.length > 0 && (
+                            <div className="flex flex-wrap gap-1.5 pt-0.5">
+                              {tagEntries.map(([k, v]) => (
+                                <span
+                                  key={k}
+                                  className="inline-flex items-center rounded-md bg-muted/80 px-2 py-0.5 text-[11px] font-mono text-muted-foreground border border-border/40"
+                                >
+                                  <span className="text-foreground/60">{k}:</span>
+                                  <span className="ml-0.5">{v}</span>
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </TableCell>
+
+                  <TableCell className="w-[140px]">
+                    <Badge
+                      variant={alertBadgeVariant(event.alertType)}
+                      className="gap-1.5 whitespace-nowrap text-[11px] font-medium"
+                    >
+                      {alertIcon(event.alertType)}
+                      {event.alertType}
+                    </Badge>
+                  </TableCell>
+
+                  <TableCell className="w-[110px]">
+                    <span className="text-xs capitalize text-muted-foreground">
+                      {priorityLabel(event.priority)}
+                    </span>
+                  </TableCell>
+
+                  <TableCell className="w-[180px]">
+                    <span className="block truncate font-mono text-xs">{event.host || '—'}</span>
+                  </TableCell>
+
+                  <TableCell className="w-[220px]">
+                    <span className="block truncate text-xs">{event.sourceTypeName || '—'}</span>
+                  </TableCell>
+
+                  <TableCell className="w-[100px] text-right pr-4 text-xs text-muted-foreground">
+                    {formatRelativeTime(event.timestamp)}
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}
+
 export function EventStream() {
   const [hostFilter, setHostFilter] = useState('')
   const [alertTypeFilter, setAlertTypeFilter] = useState<AlertFilter>('all')
@@ -153,6 +339,23 @@ export function EventStream() {
     warning: warningCount,
     info: infoCount,
     success: successCount,
+  }
+
+  let eventContent: ReactNode
+  if (isLoading) {
+    eventContent = <LoadingEvents />
+  } else if (events.length === 0) {
+    eventContent = <EmptyEvents />
+  } else if (filtered.length === 0) {
+    eventContent = <EmptyFilteredEvents />
+  } else {
+    eventContent = (
+      <EventTable
+        events={filtered}
+        expandedId={expandedId}
+        onToggleExpanded={setExpandedId}
+      />
+    )
   }
 
   return (
@@ -223,166 +426,7 @@ export function EventStream() {
         </div>
       </div>
 
-      {isLoading ? (
-        <div className="flex items-center justify-center py-16">
-          <div className="flex flex-col items-center gap-3">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            <p className="text-muted-foreground text-sm">Loading events...</p>
-          </div>
-        </div>
-      ) : events.length === 0 ? (
-        <Card className="border-dashed">
-          <CardContent className="py-16 text-center">
-            <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
-              <Zap className="h-10 w-10" />
-            </div>
-            <h3 className="text-xl font-semibold mb-2">No events found</h3>
-            <p className="text-muted-foreground mb-2 max-w-sm mx-auto">
-              Events will appear when an agent sends event data.
-            </p>
-          </CardContent>
-        </Card>
-      ) : filtered.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">
-          <p className="font-medium">No events match your filters</p>
-          <p className="text-sm mt-1">Try adjusting your search or alert type filter.</p>
-        </div>
-      ) : (
-        <Card className="overflow-hidden border-border/60">
-          <CardContent className="p-0">
-            <Table className="min-w-[980px] table-fixed">
-              <TableHeader>
-                <TableRow className="hover:bg-transparent bg-muted/30">
-                  <TableHead className="pl-4 w-8" />
-                  <TableHead className="w-[46%]">Event</TableHead>
-                  <TableHead className="w-[140px]">Alert</TableHead>
-                  <TableHead className="w-[110px]">Priority</TableHead>
-                  <TableHead className="w-[180px]">Host</TableHead>
-                  <TableHead className="w-[220px]">Source</TableHead>
-                  <TableHead className="w-[100px] text-right pr-4">Time</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filtered.map((event: DdEventResponse) => {
-                  const isExpanded = expandedId === event.eventId
-                  const hasTags = event.tags && Object.keys(event.tags).length > 0
-                  const hasDetails = event.text || hasTags || event.aggregationKey || event.deviceName
-                  const tagEntries = hasTags ? Object.entries(event.tags) : []
-
-                  return (
-                    <TableRow
-                      key={event.eventId}
-                      className={cn(
-                        'group transition-colors border-l-2',
-                        alertAccentColor(event.alertType),
-                        hasDetails ? 'cursor-pointer' : '',
-                        isExpanded ? 'bg-muted/40' : 'hover:bg-muted/50'
-                      )}
-                      onClick={() => hasDetails && setExpandedId(isExpanded ? null : event.eventId)}
-                    >
-                      <TableCell className="pl-4 pr-0 w-8">
-                        {hasDetails ? (
-                          isExpanded ? (
-                            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                          ) : (
-                            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
-                          )
-                        ) : null}
-                      </TableCell>
-
-                      <TableCell className="max-w-0">
-                        <div className="min-w-0">
-                          <TooltipProvider delayDuration={300}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <p className="truncate text-sm font-medium">{event.title}</p>
-                              </TooltipTrigger>
-                              <TooltipContent side="top" className="max-w-md">
-                                <p className="text-xs break-all">{event.title}</p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                          {!isExpanded && event.text && (
-                            <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
-                              {event.text}
-                            </p>
-                          )}
-                          {isExpanded && (
-                            <div className="mt-2 space-y-2">
-                              {event.text && (
-                                <p className="text-xs text-muted-foreground whitespace-pre-wrap break-words max-w-lg">
-                                  {event.text}
-                                </p>
-                              )}
-                              {(event.aggregationKey || event.deviceName) && (
-                                <div className="space-y-1 text-[11px] text-muted-foreground">
-                                  {event.aggregationKey && (
-                                    <span className="block min-w-0">
-                                      <span className="mr-1 font-medium text-foreground/70">agg:</span>
-                                      <span className="break-all font-mono">{event.aggregationKey}</span>
-                                    </span>
-                                  )}
-                                  {event.deviceName && (
-                                    <span className="block min-w-0">
-                                      <span className="mr-1 font-medium text-foreground/70">device:</span>
-                                      <span className="break-all font-mono">{event.deviceName}</span>
-                                    </span>
-                                  )}
-                                </div>
-                              )}
-                              {tagEntries.length > 0 && (
-                                <div className="flex flex-wrap gap-1.5 pt-0.5">
-                                  {tagEntries.map(([k, v]) => (
-                                    <span
-                                      key={k}
-                                      className="inline-flex items-center rounded-md bg-muted/80 px-2 py-0.5 text-[11px] font-mono text-muted-foreground border border-border/40"
-                                    >
-                                      <span className="text-foreground/60">{k}:</span>
-                                      <span className="ml-0.5">{v}</span>
-                                    </span>
-                                  ))}
-                                </div>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                      </TableCell>
-
-                      <TableCell className="w-[140px]">
-                        <Badge
-                          variant={alertBadgeVariant(event.alertType)}
-                          className="gap-1.5 whitespace-nowrap text-[11px] font-medium"
-                        >
-                          {alertIcon(event.alertType)}
-                          {event.alertType}
-                        </Badge>
-                      </TableCell>
-
-                      <TableCell className="w-[110px]">
-                        <span className="text-xs capitalize text-muted-foreground">
-                          {priorityLabel(event.priority)}
-                        </span>
-                      </TableCell>
-
-                      <TableCell className="w-[180px]">
-                        <span className="block truncate font-mono text-xs">{event.host || '—'}</span>
-                      </TableCell>
-
-                      <TableCell className="w-[220px]">
-                        <span className="block truncate text-xs">{event.sourceTypeName || '—'}</span>
-                      </TableCell>
-
-                      <TableCell className="w-[100px] text-right pr-4 text-xs text-muted-foreground">
-                        {formatRelativeTime(event.timestamp)}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
-      )}
+      {eventContent}
     </div>
   )
 }

--- a/dashboard/src/components/monitoring/__tests__/EventStream.test.tsx
+++ b/dashboard/src/components/monitoring/__tests__/EventStream.test.tsx
@@ -13,29 +13,117 @@ vi.mock('@/lib/api', () => ({
   api: mockApi,
 }))
 
+function eventResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    totalCount: 1,
+    events: [
+      {
+        eventId: 'evt-1',
+        title: 'Datadog container lifecycle delete: container 3eca...',
+        text: 'container 3eca142d7f7f1e3f287f9cc4449f9a1b9fb68d5afb83b9d20e955ffea8f2e11e lifecycle event',
+        timestamp: new Date().toISOString(),
+        priority: 'normal',
+        host: 'moneat-prod-01',
+        tags: {event_type: 'delete', object_kind: 'container'},
+        alertType: 'info',
+        aggregationKey:
+          'datadog_container_lifecycle:container:3eca142d7f7f1e3f287f9cc4449f9a1b9fb68d5afb83b9d20e955ffea8f2e11e',
+        sourceTypeName: 'datadog_container_lifecycle',
+        deviceName: '',
+        ...overrides,
+      },
+    ],
+  }
+}
+
 describe('EventStream', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockApi.isAuthenticated.mockReturnValue(true)
+    mockApi.getEvents.mockResolvedValue(eventResponse())
+  })
+
+  it('shows a loading state while events are pending', () => {
+    mockApi.getEvents.mockReturnValue(new Promise(() => undefined))
+
+    renderWithQueryClient(<EventStream />)
+
+    expect(screen.getByText('Loading events...')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no events are returned', async () => {
+    mockApi.getEvents.mockResolvedValue({totalCount: 0, events: []})
+
+    renderWithQueryClient(<EventStream />)
+
+    expect(await screen.findByText('No events found')).toBeInTheDocument()
+    expect(screen.getByText('Events will appear when an agent sends event data.')).toBeInTheDocument()
+  })
+
+  it('shows an empty filtered state when search removes every event', async () => {
+    const user = userEvent.setup()
+    renderWithQueryClient(<EventStream />)
+
+    await screen.findByText(/Datadog container lifecycle delete/)
+    await user.type(screen.getByPlaceholderText('Search by host, title, or source...'), 'missing-host')
+
+    expect(screen.getByText('No events match your filters')).toBeInTheDocument()
+  })
+
+  it('renders events without expandable details', async () => {
+    mockApi.getEvents.mockResolvedValue(
+      eventResponse({
+        text: '',
+        tags: {},
+        aggregationKey: '',
+        deviceName: '',
+      }),
+    )
+
+    renderWithQueryClient(<EventStream />)
+
+    expect(await screen.findByText(/Datadog container lifecycle delete/)).toBeInTheDocument()
+    expect(screen.queryByText('agg:')).not.toBeInTheDocument()
+  })
+
+  it('renders fallback variants and applies alert filters', async () => {
+    const user = userEvent.setup()
     mockApi.getEvents.mockResolvedValue({
-      totalCount: 1,
+      totalCount: 2,
       events: [
-        {
-          eventId: 'evt-1',
-          title: 'Datadog container lifecycle delete: container 3eca...',
-          text: 'container 3eca142d7f7f1e3f287f9cc4449f9a1b9fb68d5afb83b9d20e955ffea8f2e11e lifecycle event',
-          timestamp: new Date().toISOString(),
-          priority: 'normal',
-          host: 'moneat-prod-01',
-          tags: {event_type: 'delete', object_kind: 'container'},
-          alertType: 'info',
-          aggregationKey:
-            'datadog_container_lifecycle:container:3eca142d7f7f1e3f287f9cc4449f9a1b9fb68d5afb83b9d20e955ffea8f2e11e',
-          sourceTypeName: 'datadog_container_lifecycle',
-          deviceName: '',
-        },
+        eventResponse({
+          eventId: 'evt-low',
+          title: 'Low priority warning',
+          priority: 'low',
+          alertType: 'warning',
+          text: '',
+          tags: {},
+          aggregationKey: '',
+        }).events[0],
+        eventResponse({
+          eventId: 'evt-custom',
+          title: 'Custom alert event',
+          priority: '',
+          alertType: 'notice',
+          text: '',
+          tags: {},
+          aggregationKey: '',
+        }).events[0],
       ],
     })
+
+    renderWithQueryClient(<EventStream />)
+
+    expect(await screen.findByText('Low priority warning')).toBeInTheDocument()
+    expect(screen.getByText('Low')).toBeInTheDocument()
+    expect(screen.getByText('Custom alert event')).toBeInTheDocument()
+    expect(screen.getByText('Normal')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', {name: /warning/i}))
+
+    expect(mockApi.getEvents).toHaveBeenLastCalledWith(
+      expect.objectContaining({alertType: 'warning'}),
+    )
   })
 
   it('keeps expanded event metadata out of the alert column', async () => {

--- a/dashboard/src/components/monitoring/__tests__/EventStream.test.tsx
+++ b/dashboard/src/components/monitoring/__tests__/EventStream.test.tsx
@@ -1,0 +1,53 @@
+import {screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {renderWithQueryClient} from '@/test/utils'
+import {EventStream} from '../EventStream'
+
+const mockApi = vi.hoisted(() => ({
+  getEvents: vi.fn(),
+  isAuthenticated: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+}))
+
+describe('EventStream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.isAuthenticated.mockReturnValue(true)
+    mockApi.getEvents.mockResolvedValue({
+      totalCount: 1,
+      events: [
+        {
+          eventId: 'evt-1',
+          title: 'Datadog container lifecycle delete: container 3eca...',
+          text: 'container 3eca142d7f7f1e3f287f9cc4449f9a1b9fb68d5afb83b9d20e955ffea8f2e11e lifecycle event',
+          timestamp: new Date().toISOString(),
+          priority: 'normal',
+          host: 'moneat-prod-01',
+          tags: {event_type: 'delete', object_kind: 'container'},
+          alertType: 'info',
+          aggregationKey:
+            'datadog_container_lifecycle:container:3eca142d7f7f1e3f287f9cc4449f9a1b9fb68d5afb83b9d20e955ffea8f2e11e',
+          sourceTypeName: 'datadog_container_lifecycle',
+          deviceName: '',
+        },
+      ],
+    })
+  })
+
+  it('keeps expanded event metadata out of the alert column', async () => {
+    const user = userEvent.setup()
+    renderWithQueryClient(<EventStream />)
+
+    await user.click(await screen.findByText(/Datadog container lifecycle delete/))
+
+    const aggregationValue = screen.getByText(/datadog_container_lifecycle:container/)
+    expect(aggregationValue).toHaveClass('break-all')
+    const alertBadge = screen.getAllByText('info').find((element) => element.closest('td') !== null)
+
+    expect(alertBadge?.closest('td')).toHaveClass('w-[140px]')
+  })
+})

--- a/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
@@ -400,13 +400,13 @@ function ResourceTable({
                   </div>
                 </TableCell>
                 <TableCell className="hidden lg:table-cell">
-                  {r.telemetry.cpuPct != null ? (
+                  {r.telemetry.cpuPct == null ? (
+                    <span className="text-xs text-muted-foreground">—</span>
+                  ) : (
                     <div className="flex items-center gap-2">
                       <Sparkline seed={`${r.id}-cpu`} tone={utilTone(r.telemetry.cpuPct)} className="h-5 w-14" />
                       <span className="text-xs tabular-nums text-muted-foreground">{r.telemetry.cpuPct}%</span>
                     </div>
-                  ) : (
-                    <span className="text-xs text-muted-foreground">—</span>
                   )}
                 </TableCell>
                 <TableCell>

--- a/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
@@ -400,7 +400,7 @@ function ResourceTable({
                   </div>
                 </TableCell>
                 <TableCell className="hidden lg:table-cell">
-                  {r.telemetry.cpuPct > 0 ? (
+                  {r.telemetry.cpuPct != null ? (
                     <div className="flex items-center gap-2">
                       <Sparkline seed={`${r.id}-cpu`} tone={utilTone(r.telemetry.cpuPct)} className="h-5 w-14" />
                       <span className="text-xs tabular-nums text-muted-foreground">{r.telemetry.cpuPct}%</span>

--- a/dashboard/src/components/monitoring/catalog/ResourceDetailPanel.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceDetailPanel.tsx
@@ -53,7 +53,7 @@ import {Button} from '@/components/ui/button'
 import {EmptyState} from '@/components/ui/empty-state'
 import {StatusDot, type StatusTone} from '@/components/ui/status-dot'
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
-import {HealthBadge, KindIcon, Meter, Sparkline, TagChip, VulnBar} from './CatalogPrimitives'
+import {HealthBadge, KindIcon, Meter, TagChip, VulnBar} from './CatalogPrimitives'
 import {
   CHANGE_ICON,
   CHANGE_TONE,
@@ -102,11 +102,9 @@ function getMetricsHostId(resource: Resource): string | null {
 
 function metricTileVisual({
   pct,
-  seed,
   tone,
 }: {
   readonly pct?: number
-  readonly seed?: string
   readonly tone: StatusTone
 }) {
   if (pct !== undefined) {
@@ -115,9 +113,6 @@ function metricTileVisual({
         <Meter value={pct} tone={tone} />
       </div>
     )
-  }
-  if (seed) {
-    return <Sparkline seed={seed} tone={tone} className="mt-1 h-6 w-full" />
   }
   return null
 }
@@ -156,7 +151,6 @@ function MetricTile({
   icon: Icon,
   pct,
   tone,
-  seed,
 }: {
   readonly label: string
   readonly value: string
@@ -164,7 +158,6 @@ function MetricTile({
   readonly icon: ComponentType<{className?: string}>
   readonly pct?: number
   readonly tone: StatusTone
-  readonly seed?: string
 }) {
   return (
     <div className="rounded-md border border-border/70 bg-background/40 p-2.5">
@@ -176,9 +169,17 @@ function MetricTile({
         <span className="text-lg font-semibold tabular-nums">{value}</span>
         {unit && <span className="text-[11px] text-muted-foreground">{unit}</span>}
       </div>
-      {metricTileVisual({pct, seed, tone})}
+      {metricTileVisual({pct, tone})}
     </div>
   )
+}
+
+function metricNumber(value: number | null | undefined): string {
+  return value === null || value === undefined ? 'No data' : String(value)
+}
+
+function metricUnit(value: number | null | undefined, unit: string): string | undefined {
+  return value === null || value === undefined ? undefined : unit
 }
 
 function OverviewTab({resource}: {readonly resource: Resource}) {
@@ -186,10 +187,24 @@ function OverviewTab({resource}: {readonly resource: Resource}) {
   return (
     <div className="space-y-3">
       <div className="grid grid-cols-2 gap-2">
-        <MetricTile label="CPU" value={`${t.cpuPct}`} unit="%" icon={Cpu} pct={t.cpuPct} tone={utilTone(t.cpuPct)} />
-        <MetricTile label="Memory" value={`${t.memPct}`} unit="%" icon={MemoryStick} pct={t.memPct} tone={utilTone(t.memPct)} />
+        <MetricTile
+          label="CPU"
+          value={metricNumber(t.cpuPct)}
+          unit={metricUnit(t.cpuPct, '%')}
+          icon={Cpu}
+          pct={t.cpuPct ?? undefined}
+          tone={t.cpuPct == null ? 'neutral' : utilTone(t.cpuPct)}
+        />
+        <MetricTile
+          label="Memory"
+          value={metricNumber(t.memPct)}
+          unit={metricUnit(t.memPct, '%')}
+          icon={MemoryStick}
+          pct={t.memPct ?? undefined}
+          tone={t.memPct == null ? 'neutral' : utilTone(t.memPct)}
+        />
         {t.latencyMs !== undefined && (
-          <MetricTile label="p99 latency" value={`${t.latencyMs}`} unit="ms" icon={Activity} tone="info" seed={`${resource.id}-lat`} />
+          <MetricTile label="p99 latency" value={`${t.latencyMs}`} unit="ms" icon={Activity} tone="info" />
         )}
         {t.errorRatePct !== undefined && (
           <MetricTile
@@ -198,7 +213,6 @@ function OverviewTab({resource}: {readonly resource: Resource}) {
             unit="%"
             icon={AlertTriangle}
             tone={errorRateTone(t.errorRatePct)}
-            seed={`${resource.id}-err`}
           />
         )}
       </div>
@@ -251,31 +265,42 @@ function TelemetryChart({
   suffix,
   current,
   tone,
-  seed,
 }: {
   readonly label: string
   readonly suffix: string
-  readonly current: number | string
+  readonly current: number | string | null | undefined
   readonly tone: StatusTone
-  readonly seed: string
 }) {
+  const hasValue = current !== null && current !== undefined && current !== ''
   return (
     <div className="rounded-md border border-border/70 bg-background/40 p-3">
       <div className="flex items-center justify-between">
         <span className="text-xs text-muted-foreground">{label}</span>
-        <span className={cn('text-sm font-semibold tabular-nums', TONE_TEXT[tone])}>
-          {current}
-          {suffix}
+        <span className={cn('text-sm font-semibold tabular-nums', hasValue ? TONE_TEXT[tone] : 'text-muted-foreground')}>
+          {hasValue ? `${current}${suffix}` : 'No data'}
         </span>
       </div>
-      <Sparkline seed={seed} tone={tone} className="mt-2 h-12 w-full" />
+      <div className="mt-2 flex h-12 items-center rounded bg-muted/30 px-3 text-xs text-muted-foreground">
+        {hasValue ? 'Current sample only' : 'No samples received'}
+      </div>
     </div>
   )
+}
+
+function hasTelemetryValue(value: number | string | null | undefined): boolean {
+  return value !== null && value !== undefined && value !== ''
 }
 
 function TelemetryTab({resource}: {readonly resource: Resource}) {
   const t = resource.telemetry
   const metricsHostId = getMetricsHostId(resource)
+  const hasAnyTelemetry = [
+    t.cpuPct,
+    t.memPct,
+    t.latencyMs,
+    t.errorRatePct,
+    t.throughput,
+  ].some(hasTelemetryValue)
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -288,25 +313,43 @@ function TelemetryTab({resource}: {readonly resource: Resource}) {
           </Button>
         )}
       </div>
-      <div className="grid grid-cols-1 gap-2">
-        <TelemetryChart label="CPU utilization" suffix="%" current={t.cpuPct} tone={utilTone(t.cpuPct)} seed={`${resource.id}-cpu`} />
-        <TelemetryChart label="Memory utilization" suffix="%" current={t.memPct} tone={utilTone(t.memPct)} seed={`${resource.id}-mem`} />
-        {t.latencyMs !== undefined && (
-          <TelemetryChart label="p99 latency" suffix=" ms" current={t.latencyMs} tone="info" seed={`${resource.id}-lat`} />
-        )}
-        {t.errorRatePct !== undefined && (
+      {hasAnyTelemetry ? (
+        <div className="grid grid-cols-1 gap-2">
           <TelemetryChart
-            label="Error rate"
+            label="CPU utilization"
             suffix="%"
-            current={t.errorRatePct}
-            tone={t.errorRatePct >= 2 ? 'danger' : 'warning'}
-            seed={`${resource.id}-err`}
+            current={t.cpuPct}
+            tone={t.cpuPct == null ? 'neutral' : utilTone(t.cpuPct)}
           />
-        )}
-        {t.throughput !== undefined && (
-          <TelemetryChart label="Throughput" suffix="" current={t.throughput} tone="accent" seed={`${resource.id}-tput`} />
-        )}
-      </div>
+          <TelemetryChart
+            label="Memory utilization"
+            suffix="%"
+            current={t.memPct}
+            tone={t.memPct == null ? 'neutral' : utilTone(t.memPct)}
+          />
+          {t.latencyMs !== undefined && (
+            <TelemetryChart label="p99 latency" suffix=" ms" current={t.latencyMs} tone="info" />
+          )}
+          {t.errorRatePct !== undefined && (
+            <TelemetryChart
+              label="Error rate"
+              suffix="%"
+              current={t.errorRatePct}
+              tone={t.errorRatePct >= 2 ? 'danger' : 'warning'}
+            />
+          )}
+          {t.throughput !== undefined && (
+            <TelemetryChart label="Throughput" suffix="" current={t.throughput} tone="accent" />
+          )}
+        </div>
+      ) : (
+        <EmptyState
+          icon={Activity}
+          title="No telemetry data"
+          description="CPU, memory, latency, and throughput samples have not been received for this resource yet."
+          className="py-10"
+        />
+      )}
     </div>
   )
 }
@@ -396,8 +439,10 @@ function OwnershipTab({resource}: {readonly resource: Resource}) {
           title="No owner assigned"
           description="This resource has no team, on-call, or escalation path. Unowned resources are a common source of orphaned cost and slow incident response."
           action={
-            <Button type="button" size="sm" className="gap-1">
-              <Plus className="h-3.5 w-3.5" /> Claim ownership
+            <Button type="button" size="sm" className="gap-1" asChild>
+              <Link to="/settings" search={{tab: 'team'}}>
+                <Plus className="h-3.5 w-3.5" /> Claim ownership
+              </Link>
             </Button>
           }
         />
@@ -503,7 +548,11 @@ function CostTab({resource}: {readonly resource: Resource}) {
     [resource],
   )
   const maxMonth = Math.max(...months, 1)
-  const lowUtil = resource.telemetry.cpuPct > 0 && resource.telemetry.cpuPct < 35 && resource.monthlyUsd >= 120
+  const lowUtil =
+    resource.telemetry.cpuPct != null &&
+    resource.telemetry.cpuPct > 0 &&
+    resource.telemetry.cpuPct < 35 &&
+    resource.monthlyUsd >= 120
   return (
     <div className="space-y-3">
       <PanelSection title="Estimated monthly cost">

--- a/dashboard/src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx
+++ b/dashboard/src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx
@@ -50,7 +50,7 @@ const emptyResource: Resource = {
   health: 'unknown',
   owner: null,
   tags: [],
-  telemetry: {cpuPct: 18, memPct: 24},
+  telemetry: {cpuPct: null, memPct: null},
   vulns: {critical: 0, high: 0, medium: 0, low: 0},
   posture: [],
   monthlyUsd: 0,
@@ -124,12 +124,14 @@ describe('ResourceCatalog', () => {
 
     await user.click(screen.getByRole('tab', {name: 'Telemetry'}))
     expect(screen.getByRole('link', {name: /Open in Metrics/})).toHaveAttribute('href', '/monitoring/hosts/$hostId')
+    expect(screen.getByText('No telemetry data')).toBeInTheDocument()
 
     await user.click(screen.getByRole('tab', {name: 'Relationships'}))
     expect(screen.getByText('No mapped relationships')).toBeInTheDocument()
 
     await user.click(screen.getByRole('tab', {name: 'Ownership & Tags'}))
     expect(screen.getByText('No owner assigned')).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /Claim ownership/})).toHaveAttribute('href', '/settings')
     expect(screen.getByText('No tags.')).toBeInTheDocument()
 
     await user.click(screen.getByRole('tab', {name: 'Security'}))

--- a/dashboard/src/components/monitoring/catalog/resourceCatalogData.ts
+++ b/dashboard/src/components/monitoring/catalog/resourceCatalogData.ts
@@ -81,8 +81,8 @@ export interface CostItem {
 }
 
 export interface Telemetry {
-  readonly cpuPct: number
-  readonly memPct: number
+  readonly cpuPct: number | null
+  readonly memPct: number | null
   readonly latencyMs?: number
   readonly errorRatePct?: number
   readonly throughput?: string

--- a/dashboard/src/components/overview/widgets/InfraSummaryWidget.tsx
+++ b/dashboard/src/components/overview/widgets/InfraSummaryWidget.tsx
@@ -29,7 +29,7 @@ export function InfraSummaryWidget() {
       title="Infrastructure"
       icon={Boxes}
       count={d.upLabel}
-      actions={<PanelLink to="/monitoring">Map</PanelLink>}
+      actions={<PanelLink to="/monitoring/map">Map</PanelLink>}
     >
       <div className="space-y-1.5">
         {d.gauges.map((g) => (

--- a/dashboard/src/lib/telemetry-sources.ts
+++ b/dashboard/src/lib/telemetry-sources.ts
@@ -78,8 +78,8 @@ export const TELEMETRY_SOURCES: TelemetrySource[] = [
     description: 'Point a compatible agent at Moneat for infrastructure, logs, APM, and profiling data.',
     setupTitle: 'Connect a Datadog Agent',
     setupDescription: 'Create an agent key and configure the agent intake URLs.',
-    productHref: '/monitoring',
-    productLabel: 'View monitoring',
+    productHref: '/resources',
+    productLabel: 'View resources',
   },
 ]
 

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as ServicesRouteImport } from './routes/services'
 import { Route as SentryAlternativeRouteImport } from './routes/sentry-alternative'
 import { Route as SecuritySbomRouteImport } from './routes/security-sbom'
 import { Route as SecurityRouteImport } from './routes/security'
+import { Route as ResourcesRouteImport } from './routes/resources'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as ReplaysRouteImport } from './routes/replays'
 import { Route as ReleasesRouteImport } from './routes/releases'
@@ -76,7 +77,6 @@ import { Route as SecurityIndexRouteImport } from './routes/security.index'
 import { Route as ProfilesIndexRouteImport } from './routes/profiles.index'
 import { Route as PerformanceIndexRouteImport } from './routes/performance.index'
 import { Route as OnCallIndexRouteImport } from './routes/on-call.index'
-import { Route as MonitoringIndexRouteImport } from './routes/monitoring.index'
 import { Route as IssuesIndexRouteImport } from './routes/issues.index'
 import { Route as DocsIndexRouteImport } from './routes/docs.index'
 import { Route as DashboardsIndexRouteImport } from './routes/dashboards.index'
@@ -239,6 +239,11 @@ const SecuritySbomRoute = SecuritySbomRouteImport.update({
 const SecurityRoute = SecurityRouteImport.update({
   id: '/security',
   path: '/security',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ResourcesRoute = ResourcesRouteImport.update({
+  id: '/resources',
+  path: '/resources',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
@@ -496,11 +501,6 @@ const OnCallIndexRoute = OnCallIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => OnCallRoute,
-} as any)
-const MonitoringIndexRoute = MonitoringIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => MonitoringRoute,
 } as any)
 const IssuesIndexRoute = IssuesIndexRouteImport.update({
   id: '/',
@@ -975,6 +975,7 @@ export interface FileRoutesByFullPath {
   '/releases': typeof ReleasesRouteWithChildren
   '/replays': typeof ReplaysRouteWithChildren
   '/reset-password': typeof ResetPasswordRoute
+  '/resources': typeof ResourcesRoute
   '/security': typeof SecurityRouteWithChildren
   '/security-sbom': typeof SecuritySbomRoute
   '/sentry-alternative': typeof SentryAlternativeRoute
@@ -1055,7 +1056,6 @@ export interface FileRoutesByFullPath {
   '/dashboards/': typeof DashboardsIndexRoute
   '/docs/': typeof DocsIndexRoute
   '/issues/': typeof IssuesIndexRoute
-  '/monitoring/': typeof MonitoringIndexRoute
   '/on-call/': typeof OnCallIndexRoute
   '/performance/': typeof PerformanceIndexRoute
   '/profiles/': typeof ProfilesIndexRoute
@@ -1105,6 +1105,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/logs': typeof LogsRoute
   '/mcp-server': typeof McpServerRoute
+  '/monitoring': typeof MonitoringRouteWithChildren
   '/on-call-management': typeof OnCallManagementRoute
   '/onboarding': typeof OnboardingRoute
   '/performance-monitoring': typeof PerformanceMonitoringRoute
@@ -1117,6 +1118,7 @@ export interface FileRoutesByTo {
   '/releases': typeof ReleasesRouteWithChildren
   '/replays': typeof ReplaysRouteWithChildren
   '/reset-password': typeof ResetPasswordRoute
+  '/resources': typeof ResourcesRoute
   '/security-sbom': typeof SecuritySbomRoute
   '/sentry-alternative': typeof SentryAlternativeRoute
   '/session-replay': typeof SessionReplayRoute
@@ -1192,7 +1194,6 @@ export interface FileRoutesByTo {
   '/dashboards': typeof DashboardsIndexRoute
   '/docs': typeof DocsIndexRoute
   '/issues': typeof IssuesIndexRoute
-  '/monitoring': typeof MonitoringIndexRoute
   '/on-call': typeof OnCallIndexRoute
   '/performance': typeof PerformanceIndexRoute
   '/profiles': typeof ProfilesIndexRoute
@@ -1266,6 +1267,7 @@ export interface FileRoutesById {
   '/releases': typeof ReleasesRouteWithChildren
   '/replays': typeof ReplaysRouteWithChildren
   '/reset-password': typeof ResetPasswordRoute
+  '/resources': typeof ResourcesRoute
   '/security': typeof SecurityRouteWithChildren
   '/security-sbom': typeof SecuritySbomRoute
   '/sentry-alternative': typeof SentryAlternativeRoute
@@ -1346,7 +1348,6 @@ export interface FileRoutesById {
   '/dashboards/': typeof DashboardsIndexRoute
   '/docs/': typeof DocsIndexRoute
   '/issues/': typeof IssuesIndexRoute
-  '/monitoring/': typeof MonitoringIndexRoute
   '/on-call/': typeof OnCallIndexRoute
   '/performance/': typeof PerformanceIndexRoute
   '/profiles/': typeof ProfilesIndexRoute
@@ -1421,6 +1422,7 @@ export interface FileRouteTypes {
     | '/releases'
     | '/replays'
     | '/reset-password'
+    | '/resources'
     | '/security'
     | '/security-sbom'
     | '/sentry-alternative'
@@ -1501,7 +1503,6 @@ export interface FileRouteTypes {
     | '/dashboards/'
     | '/docs/'
     | '/issues/'
-    | '/monitoring/'
     | '/on-call/'
     | '/performance/'
     | '/profiles/'
@@ -1551,6 +1552,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/logs'
     | '/mcp-server'
+    | '/monitoring'
     | '/on-call-management'
     | '/onboarding'
     | '/performance-monitoring'
@@ -1563,6 +1565,7 @@ export interface FileRouteTypes {
     | '/releases'
     | '/replays'
     | '/reset-password'
+    | '/resources'
     | '/security-sbom'
     | '/sentry-alternative'
     | '/session-replay'
@@ -1638,7 +1641,6 @@ export interface FileRouteTypes {
     | '/dashboards'
     | '/docs'
     | '/issues'
-    | '/monitoring'
     | '/on-call'
     | '/performance'
     | '/profiles'
@@ -1711,6 +1713,7 @@ export interface FileRouteTypes {
     | '/releases'
     | '/replays'
     | '/reset-password'
+    | '/resources'
     | '/security'
     | '/security-sbom'
     | '/sentry-alternative'
@@ -1791,7 +1794,6 @@ export interface FileRouteTypes {
     | '/dashboards/'
     | '/docs/'
     | '/issues/'
-    | '/monitoring/'
     | '/on-call/'
     | '/performance/'
     | '/profiles/'
@@ -1865,6 +1867,7 @@ export interface RootRouteChildren {
   ReleasesRoute: typeof ReleasesRouteWithChildren
   ReplaysRoute: typeof ReplaysRouteWithChildren
   ResetPasswordRoute: typeof ResetPasswordRoute
+  ResourcesRoute: typeof ResourcesRoute
   SecurityRoute: typeof SecurityRouteWithChildren
   SecuritySbomRoute: typeof SecuritySbomRoute
   SentryAlternativeRoute: typeof SentryAlternativeRoute
@@ -2008,6 +2011,13 @@ declare module '@tanstack/react-router' {
       path: '/security'
       fullPath: '/security'
       preLoaderRoute: typeof SecurityRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/resources': {
+      id: '/resources'
+      path: '/resources'
+      fullPath: '/resources'
+      preLoaderRoute: typeof ResourcesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reset-password': {
@@ -2366,13 +2376,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/on-call/'
       preLoaderRoute: typeof OnCallIndexRouteImport
       parentRoute: typeof OnCallRoute
-    }
-    '/monitoring/': {
-      id: '/monitoring/'
-      path: '/'
-      fullPath: '/monitoring/'
-      preLoaderRoute: typeof MonitoringIndexRouteImport
-      parentRoute: typeof MonitoringRoute
     }
     '/issues/': {
       id: '/issues/'
@@ -3135,7 +3138,6 @@ interface MonitoringRouteChildren {
   MonitoringProcessesRoute: typeof MonitoringProcessesRoute
   MonitoringSbomRoute: typeof MonitoringSbomRoute
   MonitoringServiceMapRoute: typeof MonitoringServiceMapRoute
-  MonitoringIndexRoute: typeof MonitoringIndexRoute
   MonitoringHostsHostIdRoute: typeof MonitoringHostsHostIdRoute
   MonitoringHostsIndexRoute: typeof MonitoringHostsIndexRoute
 }
@@ -3152,7 +3154,6 @@ const MonitoringRouteChildren: MonitoringRouteChildren = {
   MonitoringProcessesRoute: MonitoringProcessesRoute,
   MonitoringSbomRoute: MonitoringSbomRoute,
   MonitoringServiceMapRoute: MonitoringServiceMapRoute,
-  MonitoringIndexRoute: MonitoringIndexRoute,
   MonitoringHostsHostIdRoute: MonitoringHostsHostIdRoute,
   MonitoringHostsIndexRoute: MonitoringHostsIndexRoute,
 }
@@ -3419,6 +3420,7 @@ const rootRouteChildren: RootRouteChildren = {
   ReleasesRoute: ReleasesRouteWithChildren,
   ReplaysRoute: ReplaysRouteWithChildren,
   ResetPasswordRoute: ResetPasswordRoute,
+  ResourcesRoute: ResourcesRoute,
   SecurityRoute: SecurityRouteWithChildren,
   SecuritySbomRoute: SecuritySbomRoute,
   SentryAlternativeRoute: SentryAlternativeRoute,

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -78,6 +78,7 @@ const STATIC_TITLES: Record<string, string> = {
   '/replays': 'Session Replays',
   '/logs': 'Logs',
   '/usage-insights': 'Usage Insights',
+  '/resources': 'Resources',
   '/monitoring': 'Infrastructure Monitoring',
   '/monitoring/hosts': 'Hosts',
   '/monitoring/map': 'Map Explorer',

--- a/dashboard/src/routes/__tests__/-monitoring-route.test.tsx
+++ b/dashboard/src/routes/__tests__/-monitoring-route.test.tsx
@@ -53,7 +53,7 @@ import {Route as MonitoringRoute} from '../monitoring'
 let monitoringNavWidth = 900
 
 const tabWidths: Record<string, number> = {
-  Catalog: 84,
+  Resources: 96,
   Map: 66,
   Processes: 106,
   Network: 98,
@@ -118,9 +118,11 @@ describe('monitoring route shell', () => {
   })
 
   it('renders core monitoring tabs and hides Datadog tabs without the module', () => {
+    mockRouteState.pathname = '/monitoring/map'
+
     renderMonitoringRoute()
 
-    expect(screen.getByRole('link', {name: /Catalog/})).toHaveAttribute('href', '/monitoring')
+    expect(screen.getByRole('link', {name: /Resources/})).toHaveAttribute('href', '/resources')
     expect(screen.getByRole('link', {name: /Map/})).toHaveAttribute('href', '/monitoring/map')
     expect(screen.queryByRole('link', {name: /Containers/})).not.toBeInTheDocument()
     expect(screen.queryByRole('link', {name: /Processes/})).not.toBeInTheDocument()
@@ -139,7 +141,7 @@ describe('monitoring route shell', () => {
     await waitFor(() => expect(screen.queryByRole('link', {name: /Debugger/})).toBeInTheDocument())
 
     expect(moreButton).toHaveClass('text-primary')
-    expect(screen.getByRole('link', {name: /Catalog/})).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /Resources/})).toBeInTheDocument()
     expect(screen.getByRole('link', {name: /Map/})).toBeInTheDocument()
     expect(screen.getByRole('link', {name: /Debugger/})).toHaveClass('text-primary')
     expect(screen.getByRole('link', {name: /Network Devices/})).toHaveAttribute(
@@ -161,7 +163,7 @@ describe('monitoring route shell', () => {
     mockRouteState.pathname = '/monitoring/system-42'
     rerender(<Component />)
 
-    expect(screen.getByRole('link', {name: /Back to Infrastructure/})).toHaveAttribute('href', '/monitoring')
+    expect(screen.getByRole('link', {name: /Back to Resources/})).toHaveAttribute('href', '/resources')
     expect(screen.queryByLabelText('Monitoring tabs')).not.toBeInTheDocument()
   })
 })

--- a/dashboard/src/routes/monitoring.tsx
+++ b/dashboard/src/routes/monitoring.tsx
@@ -265,7 +265,7 @@ const TAB_DOCS_URLS: Record<string, string> = {
 }
 
 const allTabs: MonitoringTab[] = [
-  {id: 'catalog', label: 'Catalog', href: '/monitoring', icon: Boxes},
+  {id: 'catalog', label: 'Resources', href: '/resources', icon: Boxes},
   {id: 'map', label: 'Map', href: '/monitoring/map', icon: MapIcon},
   {id: 'processes', label: 'Processes', href: '/monitoring/processes', icon: Terminal, requiresDatadog: true},
   {id: 'network', label: 'Network', href: '/monitoring/network', icon: Network, requiresDatadog: true},
@@ -305,9 +305,9 @@ function MonitoringLayout() {
         <div className="border-b bg-card/50">
           <div className="container mx-auto px-4 py-4">
             <Button variant="ghost" size="sm" asChild className="gap-2 text-muted-foreground hover:text-foreground">
-              <Link to="/monitoring">
+              <Link to="/resources">
                 <ArrowLeft className="h-4 w-4" />
-                Back to Infrastructure
+                Back to Resources
               </Link>
             </Button>
           </div>

--- a/dashboard/src/routes/resources.tsx
+++ b/dashboard/src/routes/resources.tsx
@@ -14,19 +14,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-// The Infrastructure landing is the source-neutral Resource Catalog: a unified
-// inventory of hosts, containers, pods, services, cloud resources and network
-// devices. Per-kind browsing is a facet of the catalog; the classic host
-// inventory now lives at /monitoring/hosts.
-
 import {createFileRoute, redirect} from '@tanstack/react-router'
 import {api} from '@/lib/api'
 import {ResourceCatalog} from '@/components/monitoring/catalog/ResourceCatalog'
 
-export const Route = createFileRoute('/monitoring/')({
-  beforeLoad: () => {
+export const Route = createFileRoute('/resources')({
+  beforeLoad: async () => {
     if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
+      const hasSession = await api.checkAuth()
+      if (!hasSession) throw redirect({to: '/login'})
     }
   },
   component: ResourceCatalog,


### PR DESCRIPTION
## Summary
- Move the resource catalog to `/resources`
- Use catalog metadata and telemetry without placeholder values
- Keep Events alert badges and aggregation text from overlapping

## Validation
- `./gradlew :test --tests com.moneat.monitor.services.ResourceCatalogServiceTest`
- `./gradlew detekt`
- `npm test -- src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx src/components/monitoring/__tests__/EventStream.test.tsx src/routes/__tests__/-monitoring-route.test.tsx`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resource tagging support; resources now derive environment, region, and cloud from tags.

* **Bug Fixes**
  * CPU metrics with 0% now display correctly instead of appearing unavailable.
  * Resources with missing telemetry now show a “No telemetry data” empty state instead of default values.

* **UI Improvements**
  * Moved resources catalog to a new /resources route and updated related navigation links.
  * Simplified resource detail panel, improved event stream table layout, and adjusted overview/map link targets.

* **Tests**
  * Updated tests/fixtures to exercise tag-derived metadata and sparse-telemetry cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->