### PR TITLE
fix: show overview alerts separately from incidents

### DIFF
--- a/backend/src/main/kotlin/com/moneat/alerts/models/AlertEpisodeModels.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/models/AlertEpisodeModels.kt
@@ -28,6 +28,9 @@ object AlertEpisodes : IntIdTable("alert_episodes") {
     val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
     val sourceName = varchar("source", 64)
     val deduplicationKey = text("deduplication_key")
+    val title = text("title").nullable()
+    val description = text("description").nullable()
+    val priority = varchar("priority", 20).nullable()
     val episodeSeq = integer("episode_seq")
     val episodeKey = text("episode_key")
     val status = varchar("status", 20)
@@ -51,6 +54,9 @@ data class AlertEpisodeResponse(
     @SerialName("organization_id") val organizationId: Int,
     val source: String,
     @SerialName("deduplication_key") val deduplicationKey: String,
+    val title: String? = null,
+    val description: String? = null,
+    val priority: String? = null,
     @SerialName("episode_seq") val episodeSeq: Int,
     @SerialName("episode_key") val episodeKey: String,
     val status: String,

--- a/backend/src/main/kotlin/com/moneat/alerts/services/AlertEpisodeService.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/services/AlertEpisodeService.kt
@@ -40,15 +40,44 @@ private const val RESOLVED_NOTIFICATION_KIND = "resolved"
 private const val MAX_SUPPRESS_REASON_CHARS = 255
 private val ALERT_REMINDER_INTERVAL = 24.hours
 
+private data class AlertEpisodeIdentity(
+    val organizationId: Int,
+    val source: String,
+    val deduplicationKey: String,
+)
+
+private data class AlertEpisodeDisplayMetadata(
+    val title: String?,
+    val description: String?,
+    val priority: String?,
+) {
+    companion object {
+        val EMPTY = AlertEpisodeDisplayMetadata(title = null, description = null, priority = null)
+    }
+}
+
+private fun AlertLifecycleEvent.displayMetadata(): AlertEpisodeDisplayMetadata =
+    AlertEpisodeDisplayMetadata(
+        title = title,
+        description = description,
+        priority = priority.wire,
+    )
+
+private fun AlertLifecycleEvent.episodeIdentity(): AlertEpisodeIdentity =
+    AlertEpisodeIdentity(
+        organizationId = organizationId,
+        source = source.name,
+        deduplicationKey = deduplicationKey,
+    )
+
 class AlertEpisodeService {
     fun recordFiring(
         event: AlertLifecycleEvent,
         now: Instant = Clock.System.now()
     ): AlertEpisodeDecision? =
         recordFiring(
-            organizationId = event.organizationId,
-            source = event.source.name,
-            deduplicationKey = event.deduplicationKey,
+            identity = event.episodeIdentity(),
+            metadata = event.displayMetadata(),
             now = now,
             reservePublication = true
         )
@@ -58,9 +87,8 @@ class AlertEpisodeService {
         now: Instant = Clock.System.now()
     ): AlertEpisodeContext? {
         val decision = recordFiring(
-            organizationId = event.organizationId,
-            source = event.source.name,
-            deduplicationKey = event.deduplicationKey,
+            identity = event.episodeIdentity(),
+            metadata = event.displayMetadata(),
             now = now,
             reservePublication = false
         )
@@ -122,9 +150,8 @@ class AlertEpisodeService {
         now: Instant = Clock.System.now()
     ): AlertEpisodeContext? =
         recordFiring(
-            organizationId = organizationId,
-            source = source.name,
-            deduplicationKey = deduplicationKey,
+            identity = AlertEpisodeIdentity(organizationId, source.name, deduplicationKey),
+            metadata = AlertEpisodeDisplayMetadata.EMPTY,
             now = now,
             reservePublication = false
         )?.episode
@@ -213,20 +240,22 @@ class AlertEpisodeService {
         }
 
     private fun recordFiring(
-        organizationId: Int,
-        source: String,
-        deduplicationKey: String,
+        identity: AlertEpisodeIdentity,
+        metadata: AlertEpisodeDisplayMetadata,
         now: Instant,
         reservePublication: Boolean
     ): AlertEpisodeDecision? {
         repeat(OPEN_EPISODE_ATTEMPTS) {
             val decision =
                 transaction {
-                    val row = findOpenEpisodeForUpdate(organizationId, source, deduplicationKey)
-                        ?: createOpenEpisode(organizationId, source, deduplicationKey, now)
+                    val row = findOpenEpisodeForUpdate(
+                        identity.organizationId,
+                        identity.source,
+                        identity.deduplicationKey,
+                    ) ?: createOpenEpisode(identity, metadata, now)
                         ?: return@transaction null
-                    updateLastSeen(row[AlertEpisodes.id].value, now)
-                    val current = findEpisode(row[AlertEpisodes.id].value, organizationId)
+                    updateLastSeen(row[AlertEpisodes.id].value, metadata, now)
+                    val current = findEpisode(row[AlertEpisodes.id].value, identity.organizationId)
                         ?.toContext()
                         ?: return@transaction null
                     if (!reservePublication) {
@@ -305,18 +334,24 @@ class AlertEpisodeService {
     }
 
     private fun createOpenEpisode(
-        organizationId: Int,
-        source: String,
-        deduplicationKey: String,
+        identity: AlertEpisodeIdentity,
+        metadata: AlertEpisodeDisplayMetadata,
         now: Instant
     ): ResultRow? {
-        val nextSeq = nextEpisodeSequence(organizationId, source, deduplicationKey)
+        val nextSeq = nextEpisodeSequence(
+            identity.organizationId,
+            identity.source,
+            identity.deduplicationKey
+        )
         AlertEpisodes.insertIgnore {
-            it[AlertEpisodes.organizationId] = organizationId
-            it[AlertEpisodes.sourceName] = source
-            it[AlertEpisodes.deduplicationKey] = deduplicationKey
+            it[AlertEpisodes.organizationId] = identity.organizationId
+            it[AlertEpisodes.sourceName] = identity.source
+            it[AlertEpisodes.deduplicationKey] = identity.deduplicationKey
+            it[AlertEpisodes.title] = metadata.title
+            it[AlertEpisodes.description] = metadata.description
+            it[AlertEpisodes.priority] = metadata.priority
             it[AlertEpisodes.episodeSeq] = nextSeq
-            it[AlertEpisodes.episodeKey] = episodeKey(deduplicationKey, nextSeq)
+            it[AlertEpisodes.episodeKey] = episodeKey(identity.deduplicationKey, nextSeq)
             it[AlertEpisodes.status] = FIRING_STATUS
             it[AlertEpisodes.openedAt] = now
             it[AlertEpisodes.lastSeenAt] = now
@@ -324,7 +359,11 @@ class AlertEpisodeService {
             it[AlertEpisodes.createdAt] = now
             it[AlertEpisodes.updatedAt] = now
         }
-        return findOpenEpisodeForUpdate(organizationId, source, deduplicationKey)
+        return findOpenEpisodeForUpdate(
+            identity.organizationId,
+            identity.source,
+            identity.deduplicationKey
+        )
     }
 
     private fun nextEpisodeSequence(
@@ -355,9 +394,19 @@ class AlertEpisodeService {
 
     private fun updateLastSeen(
         episodeId: Int,
+        metadata: AlertEpisodeDisplayMetadata,
         now: Instant
     ) {
         AlertEpisodes.update({ AlertEpisodes.id eq episodeId }) {
+            if (metadata.title != null) {
+                it[AlertEpisodes.title] = metadata.title
+            }
+            if (metadata.description != null) {
+                it[AlertEpisodes.description] = metadata.description
+            }
+            if (metadata.priority != null) {
+                it[AlertEpisodes.priority] = metadata.priority
+            }
             it[lastSeenAt] = now
             it[updatedAt] = now
         }
@@ -424,6 +473,9 @@ class AlertEpisodeService {
             organizationId = this[AlertEpisodes.organizationId],
             source = this[AlertEpisodes.sourceName],
             deduplicationKey = this[AlertEpisodes.deduplicationKey],
+            title = this[AlertEpisodes.title],
+            description = this[AlertEpisodes.description],
+            priority = this[AlertEpisodes.priority],
             episodeSeq = this[AlertEpisodes.episodeSeq],
             episodeKey = this[AlertEpisodes.episodeKey],
             status = this[AlertEpisodes.status],
@@ -444,6 +496,9 @@ class AlertEpisodeService {
             organizationId = context.organizationId,
             source = context.source,
             deduplicationKey = context.deduplicationKey,
+            title = context.title,
+            description = context.description,
+            priority = context.priority,
             episodeSeq = context.episodeSeq,
             episodeKey = context.episodeKey,
             status = context.status,
@@ -473,6 +528,9 @@ data class AlertEpisodeContext(
     val organizationId: Int,
     val source: String,
     val deduplicationKey: String,
+    val title: String? = null,
+    val description: String? = null,
+    val priority: String? = null,
     val episodeSeq: Int,
     val episodeKey: String,
     val status: String,

--- a/backend/src/main/kotlin/com/moneat/overview/services/OverviewService.kt
+++ b/backend/src/main/kotlin/com/moneat/overview/services/OverviewService.kt
@@ -19,6 +19,9 @@ package com.moneat.overview.services
 import com.moneat.alerts.models.AlertEpisodes
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.config.ClickHouseClient
+import com.moneat.dashboards.models.DashboardWidgetAlerts
+import com.moneat.dashboards.models.DashboardWidgets
+import com.moneat.dashboards.models.Dashboards
 import com.moneat.monitor.models.HostData
 import com.moneat.monitor.models.LatestMetrics
 import com.moneat.monitor.repositories.HostAlertRepositoryImpl
@@ -44,8 +47,6 @@ import com.moneat.overview.models.OverviewTelemetryData
 import com.moneat.overview.models.OverviewTriageData
 import com.moneat.overview.models.OverviewUptimeData
 import com.moneat.overview.models.OverviewUptimeMonitor
-import com.moneat.shared.models.HostAlerts
-import com.moneat.shared.models.Hosts
 import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Releases
 import com.moneat.statuspage.models.StatusPages
@@ -53,6 +54,7 @@ import com.moneat.uptime.models.UptimeMonitorResponse
 import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
 import com.moneat.uptime.services.UptimeService
 import com.moneat.utils.ClickHouseQueryUtils
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.suspendRunCatching
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -67,7 +69,8 @@ import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.innerJoin
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.Locale
@@ -112,6 +115,25 @@ private const val UPTIME_SLO_LABEL = "SLO 99.9"
 private const val DEFAULT_DEPLOY_LABEL = "No deploys"
 private const val LIVE_TRACE_WINDOW_HOURS = 2
 private const val DATETIME64_MILLIS_PRECISION = 3
+private const val DASHBOARD_ALERT_SOURCE = "DASHBOARD_ALERT"
+private const val DASHBOARD_ALERT_DEDUP_PREFIX = "moneat-dashboard-alert-"
+private const val ERROR_ALERT_SOURCE = "ERROR_ALERT"
+private const val ERROR_ALERT_DEDUP_PREFIX = "moneat-error-"
+
+private data class AlertDisplayFallback(
+    val title: String,
+    val detail: String,
+    val priority: String?,
+)
+
+private data class AlertEpisodeOverviewRow(
+    val source: String,
+    val deduplicationKey: String,
+    val title: String?,
+    val description: String?,
+    val priority: String?,
+    val ageLabel: String,
+)
 
 class OverviewService(
     private val monitorService: MonitorService = MonitorService(
@@ -142,9 +164,7 @@ class OverviewService(
         val containersDeferred = async { loadContainerCounts(organizationId, demoEpochMs) }
         val deploysDeferred = async { loadDeploys(organizationId) }
         val alertsDeferred = async { loadAlertItems(organizationId) }
-        val incidentsDeferred = async { loadIncidentItems(organizationId) }
         val alertCountDeferred = async { loadAlertCount(organizationId) }
-        val incidentCountDeferred = async { loadIncidentCount(organizationId) }
         val statusPageCountDeferred = async { loadStatusPageCount(organizationId) }
         val syntheticFailingDeferred = async { loadSyntheticFailing(organizationId, demoEpochMs) }
 
@@ -157,11 +177,11 @@ class OverviewService(
         val issueItems = issueItemsDeferred.await()
         val deploys = deploysDeferred.await()
         val alertItems = alertsDeferred.await()
-        val incidents = incidentsDeferred.await()
+        val incidents = emptyList<OverviewIncidentItem>()
         val serviceRows = serviceRowsDeferred.await()
 
         val counts = overviewCounts(
-            incidents = incidentCountDeferred.await(),
+            incidents = incidents.size,
             alerts = alertCountDeferred.await(),
             serviceRows = serviceRows,
             hosts = hosts,
@@ -209,9 +229,11 @@ class OverviewService(
             "warn" -> "Degraded"
             else -> "Healthy"
         }
-        val summary = when (severity) {
-            "bad" -> "Active incidents or offline hosts need attention."
-            "warn" -> "Some services or alerts are degraded in the current workspace."
+        val summary = when {
+            counts.incidents > 0 -> "Active incidents need attention."
+            counts.hostsOffline > 0 -> "Offline hosts need attention."
+            counts.alerts > 0 -> "Firing alerts need attention."
+            counts.degraded > 0 -> "Some services are degraded in the current workspace."
             else -> "No active incidents, firing alerts, degraded services, or offline hosts."
         }
         return OverviewSystemStatus(
@@ -440,8 +462,8 @@ class OverviewService(
                 .toInt()
         }
 
-    private fun loadIncidentItems(organizationId: Int): List<OverviewIncidentItem> =
-        transaction {
+    private suspend fun loadAlertItems(organizationId: Int): List<OverviewAlertItem> {
+        val episodes = transaction {
             AlertEpisodes
                 .selectAll()
                 .where {
@@ -451,60 +473,118 @@ class OverviewService(
                 .orderBy(AlertEpisodes.openedAt to SortOrder.DESC)
                 .limit(MAX_ATTENTION_ROWS)
                 .map { row ->
-                    OverviewIncidentItem(
-                        id = "INC-${row[AlertEpisodes.id].value}",
-                        title = row[AlertEpisodes.sourceName],
-                        priority = "P2",
-                        status = row[AlertEpisodes.status],
-                        owner = "On-call",
+                    AlertEpisodeOverviewRow(
+                        source = row[AlertEpisodes.sourceName],
+                        deduplicationKey = row[AlertEpisodes.deduplicationKey],
+                        title = row[AlertEpisodes.title],
+                        description = row[AlertEpisodes.description],
+                        priority = row[AlertEpisodes.priority],
                         ageLabel = ageLabel(row[AlertEpisodes.openedAt].toEpochMilliseconds()),
                     )
                 }
         }
+        return episodes.map { episode ->
+            val source = humanizeAlertSource(episode.source)
+            val fallback = alertDisplayFallback(
+                source = episode.source,
+                deduplicationKey = episode.deduplicationKey,
+                organizationId = organizationId,
+            ) ?: errorAlertDisplayFallback(
+                source = episode.source,
+                deduplicationKey = episode.deduplicationKey,
+                organizationId = organizationId,
+            )
+            OverviewAlertItem(
+                title = episode.title ?: fallback?.title ?: source,
+                detail = episode.description ?: fallback?.detail ?: source,
+                level = alertLevel(episode.priority ?: fallback?.priority),
+                ageLabel = episode.ageLabel,
+            )
+        }
+    }
 
-    private fun loadIncidentCount(organizationId: Int): Int =
+    private fun alertDisplayFallback(
+        source: String,
+        deduplicationKey: String,
+        organizationId: Int,
+    ): AlertDisplayFallback? {
+        if (source != DASHBOARD_ALERT_SOURCE) return null
+        val alertId = deduplicationKey.removePrefix(DASHBOARD_ALERT_DEDUP_PREFIX)
+            .takeIf { suffix -> suffix.length != deduplicationKey.length }
+            ?.toLongOrNull()
+            ?: return null
+
+        return transaction {
+            DashboardWidgetAlerts
+                .innerJoin(DashboardWidgets, { widgetId }, { DashboardWidgets.id })
+                .innerJoin(Dashboards, { DashboardWidgetAlerts.dashboardId }, { Dashboards.id })
+                .select(
+                    DashboardWidgetAlerts.name,
+                    DashboardWidgetAlerts.condition,
+                    DashboardWidgetAlerts.threshold,
+                    DashboardWidgetAlerts.alertPriority,
+                    DashboardWidgets.title,
+                    Dashboards.title,
+                )
+                .where {
+                    (DashboardWidgetAlerts.id eq alertId) and
+                        (DashboardWidgetAlerts.orgId eq organizationId.toLong())
+                }
+                .firstOrNull()
+                ?.let { row ->
+                    val widgetTitle = row[DashboardWidgets.title] ?: "Widget"
+                    val dashboardTitle = row[Dashboards.title]
+                    val condition = row[DashboardWidgetAlerts.condition]
+                    val threshold = row[DashboardWidgetAlerts.threshold]
+                    AlertDisplayFallback(
+                        title = row[DashboardWidgetAlerts.name],
+                        detail = "$widgetTitle on $dashboardTitle: $condition $threshold",
+                        priority = row[DashboardWidgetAlerts.alertPriority],
+                    )
+                }
+        }
+    }
+
+    private suspend fun errorAlertDisplayFallback(
+        source: String,
+        deduplicationKey: String,
+        organizationId: Int,
+    ): AlertDisplayFallback? {
+        if (source != ERROR_ALERT_SOURCE) return null
+        val issueId = deduplicationKey.removePrefix(ERROR_ALERT_DEDUP_PREFIX)
+            .takeIf { suffix -> suffix.length != deduplicationKey.length }
+            ?: return null
+        val escapedIssueId = escapeSql(issueId)
+        val orgClause = ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+        val row = firstRow(
+            """
+            SELECT
+                title,
+                toString(level) AS level,
+                event_count AS eventCount
+            FROM issues FINAL
+            WHERE $orgClause
+              AND issue_id = '$escapedIssueId'
+            LIMIT 1
+            """.trimIndent(),
+        )
+        val title = row.string("title").ifBlank { return null }
+        val eventCount = row.long("eventCount")
+        val detail = if (eventCount > 0) "$eventCount events" else "Issue $issueId"
+        return AlertDisplayFallback(
+            title = title,
+            detail = detail,
+            priority = priorityForIssueLevel(row.string("level")),
+        )
+    }
+
+    private fun loadAlertCount(organizationId: Int): Int =
         transaction {
             AlertEpisodes
                 .selectAll()
                 .where {
                     (AlertEpisodes.organizationId eq organizationId) and
                         (AlertEpisodes.status eq "FIRING")
-                }
-                .count()
-                .toInt()
-        }
-
-    private fun loadAlertItems(organizationId: Int): List<OverviewAlertItem> =
-        transaction {
-            HostAlerts
-                .innerJoin(Hosts)
-                .selectAll()
-                .where {
-                    (HostAlerts.organization_id eq organizationId) and
-                        (HostAlerts.enabled eq true) and
-                        HostAlerts.last_triggered_at.isNotNull()
-                }
-                .orderBy(HostAlerts.last_triggered_at to SortOrder.DESC)
-                .limit(MAX_ATTENTION_ROWS)
-                .map { row ->
-                    val host = row[Hosts.display_name] ?: row[Hosts.hostname]
-                    OverviewAlertItem(
-                        title = "${row[HostAlerts.metric]} ${row[HostAlerts.condition]} ${row[HostAlerts.threshold]}",
-                        detail = host,
-                        level = alertLevel(row[HostAlerts.alert_priority]),
-                        ageLabel = row[HostAlerts.last_triggered_at]?.let { ageLabel(it.toEpochMilliseconds()) } ?: "",
-                    )
-                }
-        }
-
-    private fun loadAlertCount(organizationId: Int): Int =
-        transaction {
-            HostAlerts
-                .selectAll()
-                .where {
-                    (HostAlerts.organization_id eq organizationId) and
-                        (HostAlerts.enabled eq true) and
-                        HostAlerts.last_triggered_at.isNotNull()
                 }
                 .count()
                 .toInt()
@@ -958,10 +1038,25 @@ class OverviewService(
         }
 
     private fun alertLevel(priority: String?): String =
-        when (priority?.lowercase(Locale.US)) {
-            "p1", "critical" -> "error"
+        when (priority?.uppercase(Locale.US)) {
+            "P0", "P1", "P2", "CRITICAL", "HIGH", "MEDIUM" -> "error"
             else -> "warn"
         }
+
+    private fun priorityForIssueLevel(level: String): String? =
+        when (level.lowercase(Locale.US)) {
+            "fatal", "error" -> "P1"
+            "warning" -> "P2"
+            else -> null
+        }
+
+    private fun humanizeAlertSource(source: String): String =
+        source
+            .lowercase(Locale.US)
+            .split('_')
+            .filter { part -> part.isNotBlank() }
+            .joinToString(" ") { part -> part.replaceFirstChar { char -> char.uppercase(Locale.US) } }
+            .ifBlank { "Alert" }
 
     private fun normalizeIssueLevel(level: String): String =
         when (level.lowercase(Locale.US)) {

--- a/backend/src/main/resources/db/migration/V134__add_alert_episode_display_metadata.sql
+++ b/backend/src/main/resources/db/migration/V134__add_alert_episode_display_metadata.sql
@@ -1,0 +1,4 @@
+ALTER TABLE alert_episodes
+    ADD COLUMN title TEXT,
+    ADD COLUMN description TEXT,
+    ADD COLUMN priority VARCHAR(20);

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
@@ -86,6 +86,18 @@ class AlertEpisodeServiceTest {
     }
 
     @Test
+    fun `firing episode persists alert display metadata`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+
+        service.recordFiring(alertEvent(), now)
+
+        val episode = service.listEpisodes(orgId).single()
+        assertEquals("CPU saturation", episode.title)
+        assertEquals("CPU has crossed the threshold", episode.description)
+        assertEquals("P0", episode.priority)
+    }
+
+    @Test
     fun `firing reminder is due after 24 hours while episode remains open`() {
         val now = Instant.parse("2026-06-02T12:00:00Z")
 

--- a/backend/src/test/kotlin/com/moneat/overview/OverviewServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/overview/OverviewServiceTest.kt
@@ -63,10 +63,10 @@ class OverviewServiceTest {
 
         assertEquals("Action needed", overview.systemStatus.state)
         assertEquals("bad", overview.systemStatus.severity)
-        assertEquals(1, overview.systemStatus.counts.incidents)
+        assertEquals(0, overview.systemStatus.counts.incidents)
         assertEquals(1, overview.systemStatus.counts.alerts)
         assertEquals(1, overview.systemStatus.counts.hostsOffline)
-        assertTrue(overview.systemStatus.ai.summary.contains("need attention"))
+        assertTrue(overview.systemStatus.ai.summary.contains("Offline hosts need attention"))
 
         assertEquals("1/2 up", overview.infra.upLabel)
         assertEquals("db-node-1", overview.infra.offlineNode)
@@ -86,9 +86,9 @@ class OverviewServiceTest {
         assertEquals("v1.2.3", overview.telemetry.deployLabel)
         assertEquals(100, overview.telemetry.deployAtPct)
 
-        assertEquals("Checkout unavailable", overview.triage.incidents.single().title)
+        assertTrue(overview.triage.incidents.isEmpty())
         assertEquals("error", overview.triage.alerts.single().level)
-        assertEquals("cpu > 90.0", overview.triage.alerts.single().title)
+        assertEquals("Checkout 5xx budget", overview.triage.alerts.single().title)
         assertTrue(overview.triage.issues.isEmpty())
         assertTrue(overview.triage.security.isEmpty())
 
@@ -97,8 +97,7 @@ class OverviewServiceTest {
         assertEquals("bad", uptimeKpi.status)
         assertEquals(6, overview.kpis.size)
 
-        assertEquals(listOf("incident", "deploy"), overview.activity.map { item -> item.kind })
-        assertTrue(overview.activity.first().text.contains("Checkout unavailable"))
+        assertEquals(listOf("deploy"), overview.activity.map { item -> item.kind })
         assertTrue(overview.serviceHealth.isEmpty())
     }
 
@@ -130,6 +129,25 @@ class OverviewServiceTest {
             assertEquals("checkout synthetic", overview.uptime.syntheticFailing)
             assertTrue(overview.telemetry.latency.any { value -> value > 0 })
             assertTrue(overview.telemetry.throughput.any { value -> value > 0 })
+        } finally {
+            unmockkObject(ClickHouseClient)
+        }
+    }
+
+    @Test
+    fun `overview resolves legacy error alert episode title from issue analytics`() = runBlocking {
+        val orgId = seedOverviewData()
+        seedLegacyErrorAlertEpisode()
+        stubOverviewClickHouse()
+
+        try {
+            val overview = OverviewService().getOverview(orgId, demoEpochMs = DEMO_EPOCH_MS)
+
+            val alert = assertNotNull(
+                overview.triage.alerts.find { item -> item.title == "Payment capture failed" },
+            )
+            assertEquals("error", alert.level)
+            assertEquals("12 events", alert.detail)
         } finally {
             unmockkObject(ClickHouseClient)
         }
@@ -186,6 +204,11 @@ class OverviewServiceTest {
         private const val DEMO_EPOCH_MS = 1_709_312_400_000L
         private const val ORGANIZATION_ID = 101
         private const val EMPTY_ORGANIZATION_ID = 202
+        private const val DASHBOARD_ID = 301L
+        private const val DASHBOARD_WIDGET_ID = 302L
+        private const val DASHBOARD_ALERT_ID = 303L
+        private const val DASHBOARD_ALERT_THRESHOLD = 2.0
+        private const val ERROR_ALERT_ISSUE_ID = "issue-legacy-1"
         private const val HOUR_MILLIS = 3_600_000L
         private const val TRACE_CURRENT_ROW =
             """{"currentTraces":2880,"currentErrors":40,"p95Ms":800,"satisfied":1000,"tolerated":2000}"""
@@ -196,6 +219,8 @@ class OverviewServiceTest {
         private const val LOG_COUNT_ROW = """{"currentErrors":200,"previousErrors":100}"""
         private const val CONTAINER_COUNT_ROW = """{"containers":5,"pods":2}"""
         private const val SYNTHETIC_FAILING_ROW = """{"name":"checkout synthetic"}"""
+        private const val ERROR_ALERT_ISSUE_ROW =
+            """{"title":"Payment capture failed","level":"error","eventCount":12}"""
         private val SERVICE_ROWS = listOf(
             """{"service":"checkout-api","env":"","traces":1440,"errors":40,"p95Ms":800,""" +
                 """"satisfied":200,"tolerated":400}""",
@@ -270,10 +295,11 @@ class OverviewServiceTest {
                 it[version] = "v1.2.3"
                 it[created_at] = Clock.System.now().toEpochMilliseconds() - HOUR_MILLIS
             }
+            seedDashboardAlertTablesForFallbackTest()
             AlertEpisodes.insert {
                 it[organizationId] = ORGANIZATION_ID
-                it[sourceName] = "Checkout unavailable"
-                it[deduplicationKey] = "checkout-unavailable"
+                it[sourceName] = "DASHBOARD_ALERT"
+                it[deduplicationKey] = "moneat-dashboard-alert-$DASHBOARD_ALERT_ID"
                 it[episodeSeq] = 1
                 it[episodeKey] = "checkout-unavailable-1"
                 it[status] = "FIRING"
@@ -293,6 +319,86 @@ class OverviewServiceTest {
             seedMonitor("Website", "up")
         }
         return ORGANIZATION_ID
+    }
+
+    private fun seedDashboardAlertTablesForFallbackTest() {
+        val statements = listOf(
+            """
+            CREATE TABLE dashboards (
+                id BIGINT PRIMARY KEY,
+                org_id BIGINT NOT NULL,
+                title VARCHAR(255) NOT NULL
+            )
+            """.trimIndent(),
+            """
+            CREATE TABLE dashboard_widgets (
+                id BIGINT PRIMARY KEY,
+                dashboard_id BIGINT NOT NULL,
+                title VARCHAR(255)
+            )
+            """.trimIndent(),
+            """
+            CREATE TABLE dashboard_widget_alerts (
+                id BIGINT PRIMARY KEY,
+                widget_id BIGINT NOT NULL,
+                dashboard_id BIGINT NOT NULL,
+                org_id BIGINT NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                condition VARCHAR(5) NOT NULL,
+                threshold DOUBLE PRECISION NOT NULL,
+                alert_priority VARCHAR(20)
+            )
+            """.trimIndent(),
+            """
+            INSERT INTO dashboards (id, org_id, title)
+            VALUES ($DASHBOARD_ID, $ORGANIZATION_ID, 'Checkout Overview')
+            """.trimIndent(),
+            """
+            INSERT INTO dashboard_widgets (id, dashboard_id, title)
+            VALUES ($DASHBOARD_WIDGET_ID, $DASHBOARD_ID, 'Checkout health')
+            """.trimIndent(),
+            """
+            INSERT INTO dashboard_widget_alerts (
+                id,
+                widget_id,
+                dashboard_id,
+                org_id,
+                name,
+                condition,
+                threshold,
+                alert_priority
+            )
+            VALUES (
+                $DASHBOARD_ALERT_ID,
+                $DASHBOARD_WIDGET_ID,
+                $DASHBOARD_ID,
+                $ORGANIZATION_ID,
+                'Checkout 5xx budget',
+                '>',
+                $DASHBOARD_ALERT_THRESHOLD,
+                'P1'
+            )
+            """.trimIndent(),
+        )
+        statements.forEach { statement -> TransactionManager.current().exec(statement) }
+    }
+
+    private fun seedLegacyErrorAlertEpisode() {
+        val now = Clock.System.now()
+        transaction {
+            AlertEpisodes.insert {
+                it[organizationId] = ORGANIZATION_ID
+                it[sourceName] = "ERROR_ALERT"
+                it[deduplicationKey] = "moneat-error-$ERROR_ALERT_ISSUE_ID"
+                it[episodeSeq] = 1
+                it[episodeKey] = "error-alert-legacy-1"
+                it[status] = "FIRING"
+                it[openedAt] = now
+                it[lastSeenAt] = now
+                it[createdAt] = now
+                it[updatedAt] = now
+            }
+        }
     }
 
     private fun seedEmptyOrganization(): Int {
@@ -384,6 +490,7 @@ class OverviewServiceTest {
             QueryStub(::isTraceThroughputSeriesQuery, seriesRows(1, 2)),
             QueryStub(::isEventCountQuery, EVENT_COUNT_ROW),
             QueryStub(::isIssueCountQuery, ISSUE_COUNT_ROW),
+            QueryStub(::isErrorAlertIssueLookupQuery, ERROR_ALERT_ISSUE_ROW),
             QueryStub(::isIssueRowsQuery, ISSUE_ROWS),
             QueryStub(::isEventSeriesQuery, seriesRows(4, 12)),
             QueryStub(::isIssueSeriesQuery, seriesRows(1, 2)),
@@ -408,6 +515,9 @@ class OverviewServiceTest {
 
     private fun isIssueRowsQuery(query: String): Boolean =
         query.contains("FROM issues FINAL") && query.contains("eventCount")
+
+    private fun isErrorAlertIssueLookupQuery(query: String): Boolean =
+        query.contains("FROM issues FINAL") && query.contains("issue_id = '$ERROR_ALERT_ISSUE_ID'")
 
     private fun isEventSeriesQuery(query: String): Boolean =
         query.contains("FROM events") && query.contains("GROUP BY bucket")

--- a/dashboard/src/components/overview/__tests__/overviewTestData.ts
+++ b/dashboard/src/components/overview/__tests__/overviewTestData.ts
@@ -20,10 +20,10 @@ export const overviewTestData: OverviewResponse = {
   systemStatus: {
     state: 'Action needed',
     severity: 'bad',
-    counts: {incidents: 1, alerts: 3, degraded: 2, hostsOffline: 1},
+    counts: {incidents: 0, alerts: 3, degraded: 2, hostsOffline: 1},
     ai: {
       summary: 'checkout-api is degraded after deploy v2.4.1.',
-      incidentId: 'INC-204',
+      incidentId: null,
     },
   },
   kpis: [
@@ -77,17 +77,10 @@ export const overviewTestData: OverviewResponse = {
     deployLabel: 'v2.4.1',
   },
   triage: {
-    incidents: [{
-      id: 'INC-204',
-      title: 'Elevated 5xx on checkout-api',
-      priority: 'P1',
-      status: 'TRIGGERED',
-      owner: 'Payments',
-      ageLabel: '9m',
-    }],
+    incidents: [],
     alerts: [{
-      title: '5xx > 2%',
-      detail: 'checkout-api',
+      title: 'Elevated 5xx on checkout-api',
+      detail: 'checkout-api reported 1.2k server errors',
       level: 'error',
       ageLabel: '6m',
     }],
@@ -128,8 +121,8 @@ export const overviewTestData: OverviewResponse = {
     ageLabel: '14m',
   }],
   activity: [{
-    kind: 'incident',
-    text: 'Alert 5xx>2% triggered INC-204',
-    meta: '9m ago',
+    kind: 'deploy',
+    text: 'v2.4.1 released to checkout-api',
+    meta: '14m ago',
   }],
 }

--- a/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
+++ b/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
@@ -48,7 +48,8 @@ describe('SystemStatusWidget', () => {
     renderWithOverview(<SystemStatusWidget />)
     expect(screen.getByTestId('widget-system_status')).toBeInTheDocument()
     expect(screen.getByText('Action needed')).toBeInTheDocument()
-    expect(screen.getByText('View incident')).toBeInTheDocument()
+    const action = screen.getByRole('link', {name: 'View alerts'})
+    expect(action).toHaveAttribute('href', '/on-call/alerts')
   })
 })
 
@@ -90,7 +91,11 @@ describe('TriageWidget', () => {
     renderWithOverview(<TriageWidget />)
     expect(screen.getByTestId('widget-triage')).toBeInTheDocument()
     expect(screen.getByText('Needs attention')).toBeInTheDocument()
+    expect(screen.queryByText('Active incidents')).not.toBeInTheDocument()
+    expect(screen.getByText('Alerts firing')).toBeInTheDocument()
     expect(screen.getByText('Elevated 5xx on checkout-api')).toBeInTheDocument()
+    const action = screen.getByRole('link', {name: 'View all'})
+    expect(action).toHaveAttribute('href', '/on-call/alerts')
   })
 })
 
@@ -125,6 +130,6 @@ describe('ActivityWidget', () => {
   it('renders the activity feed', () => {
     renderWithOverview(<ActivityWidget />)
     expect(screen.getByTestId('widget-activity')).toBeInTheDocument()
-    expect(screen.getByText('Alert 5xx>2% triggered INC-204')).toBeInTheDocument()
+    expect(screen.getByText('v2.4.1 released to checkout-api')).toBeInTheDocument()
   })
 })

--- a/dashboard/src/components/overview/widgets/SystemStatusWidget.tsx
+++ b/dashboard/src/components/overview/widgets/SystemStatusWidget.tsx
@@ -18,13 +18,41 @@ import {AlertTriangle, CheckCircle} from 'lucide-react'
 import {Link} from '@tanstack/react-router'
 import {cn} from '@/lib/utils'
 import {Button} from '@/components/ui/button'
+import type {OverviewCounts} from '@/lib/api/types'
 import {useSystemStatus} from '../overviewData'
 import {toneBgSolid, toneBorder, toneSoftBg, toneText} from '../overviewTone'
+
+type StatusAction = Readonly<{
+  to: string
+  label: string
+  ariaLabel: string
+}>
+
+function nounLabel(count: number, singular: string, plural = `${singular}s`) {
+  return count === 1 ? singular : plural
+}
+
+function statusAction(counts: OverviewCounts): StatusAction | null {
+  if (counts.incidents > 0) {
+    return {to: '/on-call/incidents', label: 'View incidents', ariaLabel: 'View active incidents'}
+  }
+  if (counts.alerts > 0) {
+    return {to: '/on-call/alerts', label: 'View alerts', ariaLabel: 'View firing alerts'}
+  }
+  if (counts.hostsOffline > 0) {
+    return {to: '/monitoring/hosts', label: 'View hosts', ariaLabel: 'View offline hosts'}
+  }
+  if (counts.degraded > 0) {
+    return {to: '/services', label: 'View services', ariaLabel: 'View degraded services'}
+  }
+  return null
+}
 
 /** Hero status bar — the triage line + AI summary at the top of the overview. */
 export function SystemStatusWidget() {
   const s = useSystemStatus()
   const sev = s.severity
+  const action = statusAction(s.counts)
   return (
     <div
       data-testid="widget-system_status"
@@ -47,28 +75,32 @@ export function SystemStatusWidget() {
             <span className="text-sm font-semibold text-foreground">{s.state}</span>
             <span className="flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
               <span>
-                <b className="tabular-nums text-foreground">{s.counts.incidents}</b> active incident
+                <b className="tabular-nums text-foreground">{s.counts.incidents}</b>{' '}
+                {nounLabel(s.counts.incidents, 'active incident')}
               </span>
               <span className="text-muted-foreground/60">·</span>
               <span>
-                <b className="tabular-nums text-foreground">{s.counts.alerts}</b> alerts firing
+                <b className="tabular-nums text-foreground">{s.counts.alerts}</b>{' '}
+                {nounLabel(s.counts.alerts, 'alert')} firing
               </span>
               <span className="text-muted-foreground/60">·</span>
               <span>
-                <b className="tabular-nums text-foreground">{s.counts.degraded}</b> services degraded
+                <b className="tabular-nums text-foreground">{s.counts.degraded}</b>{' '}
+                {nounLabel(s.counts.degraded, 'service')} degraded
               </span>
               <span className="text-muted-foreground/60">·</span>
               <span>
-                <b className="tabular-nums text-foreground">{s.counts.hostsOffline}</b> host offline
+                <b className="tabular-nums text-foreground">{s.counts.hostsOffline}</b>{' '}
+                {nounLabel(s.counts.hostsOffline, 'host')} offline
               </span>
             </span>
           </div>
         </div>
-        {sev !== 'good' && (
+        {action && (
           <div className="flex shrink-0 items-center gap-1.5">
             <Button asChild size="sm" className="h-6 px-2 text-[11px]">
-              <Link to="/on-call/incidents" aria-label="View active incidents">
-                View incident
+              <Link to={action.to} aria-label={action.ariaLabel}>
+                {action.label}
               </Link>
             </Button>
           </div>

--- a/dashboard/src/components/overview/widgets/TriageWidget.tsx
+++ b/dashboard/src/components/overview/widgets/TriageWidget.tsx
@@ -39,6 +39,19 @@ type TriageRowProps = Readonly<{
   ageLabel: string
 }>
 
+type AttentionRouteInput = Readonly<{
+  incidents: readonly unknown[]
+  alerts: readonly unknown[]
+  issues: readonly unknown[]
+}>
+
+function attentionRouteFor(triage: AttentionRouteInput): string {
+  if (triage.incidents.length > 0) return '/on-call/incidents'
+  if (triage.alerts.length > 0) return '/on-call/alerts'
+  if (triage.issues.length > 0) return '/issues'
+  return '/security/signals'
+}
+
 function borderForLevel(level: TriageLevel): string {
   switch (level) {
     case 'fatal':
@@ -95,53 +108,58 @@ function TriageRow({
 export function TriageWidget() {
   const t = useTriage()
   const total = t.incidents.length + t.alerts.length + t.issues.length + t.security.length
+  const attentionRoute = attentionRouteFor(t)
   return (
     <OverviewPanel
       testId="widget-triage"
       title="Needs attention"
       icon={ListChecks}
       count={total}
-      actions={<PanelLink to="/on-call/incidents">View all</PanelLink>}
+      actions={total > 0 ? <PanelLink to={attentionRoute}>View all</PanelLink> : undefined}
       flush
     >
-      <TriageSection icon={Siren} label="Active incidents" count={t.incidents.length}>
-        {t.incidents.map((inc) => (
-          <div
-            key={inc.id}
-            className="flex items-start gap-1.5 rounded-md border border-danger-border bg-danger-bg px-2 py-1.5"
-          >
-            <StatusDot tone="danger" pulse className="mt-0.5" />
-            <div className="min-w-0 flex-1">
-              <div className="text-xs font-semibold text-foreground">{inc.title}</div>
-              <div className="mt-0.5 flex flex-wrap items-center gap-1">
-                <Badge variant="dangerSolid" className="px-1 py-0 text-[9px]">
-                  {inc.priority}
-                </Badge>
-                <Badge variant="danger" className="px-1 py-0 text-[9px]">
-                  {inc.status}
-                </Badge>
-                <span className="font-mono text-[9px] text-muted-foreground/70">{inc.id}</span>
-                <span className="text-[10px] text-muted-foreground">{inc.owner}</span>
-                <span className="ml-auto font-mono text-[9px] text-muted-foreground/70">
-                  {inc.ageLabel}
-                </span>
+      {t.incidents.length > 0 && (
+        <TriageSection icon={Siren} label="Active incidents" count={t.incidents.length}>
+          {t.incidents.map((inc) => (
+            <div
+              key={inc.id}
+              className="flex items-start gap-1.5 rounded-md border border-danger-border bg-danger-bg px-2 py-1.5"
+            >
+              <StatusDot tone="danger" pulse className="mt-0.5" />
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-semibold text-foreground">{inc.title}</div>
+                <div className="mt-0.5 flex flex-wrap items-center gap-1">
+                  <Badge variant="dangerSolid" className="px-1 py-0 text-[9px]">
+                    {inc.priority}
+                  </Badge>
+                  <Badge variant="danger" className="px-1 py-0 text-[9px]">
+                    {inc.status}
+                  </Badge>
+                  <span className="font-mono text-[9px] text-muted-foreground/70">{inc.id}</span>
+                  <span className="text-[10px] text-muted-foreground">{inc.owner}</span>
+                  <span className="ml-auto font-mono text-[9px] text-muted-foreground/70">
+                    {inc.ageLabel}
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
-      </TriageSection>
+          ))}
+        </TriageSection>
+      )}
 
-      <TriageSection icon={Bell} label="Alerts firing" count={t.alerts.length}>
-        {t.alerts.map((a) => (
-          <TriageRow
-            key={`${a.level}:${a.title}:${a.detail}:${a.ageLabel}`}
-            level={a.level === 'error' ? 'error' : 'warn'}
-            title={<span className="font-semibold">{a.title}</span>}
-            detail={a.detail}
-            ageLabel={a.ageLabel}
-          />
-        ))}
-      </TriageSection>
+      {t.alerts.length > 0 && (
+        <TriageSection icon={Bell} label="Alerts firing" count={t.alerts.length}>
+          {t.alerts.map((a) => (
+            <TriageRow
+              key={`${a.level}:${a.title}:${a.detail}:${a.ageLabel}`}
+              level={a.level === 'error' ? 'error' : 'warn'}
+              title={<span className="font-semibold">{a.title}</span>}
+              detail={a.detail}
+              ageLabel={a.ageLabel}
+            />
+          ))}
+        </TriageSection>
+      )}
 
       <TriageSection icon={CircleAlert} label="New issues" count={t.issues.length}>
         {t.issues.map((iss) => (


### PR DESCRIPTION
## Summary
- separate overview alert episodes from declared incidents
- persist alert episode display metadata and use fallbacks for legacy rows
- route alert-only overview actions to alerts

## Validation
- `git diff --check`
- `npm test -- overviewWidgets.test.tsx`
- `npm run build`
- `./gradlew :test --tests com.moneat.alerts.AlertEpisodeServiceTest --tests com.moneat.overview.OverviewServiceTest`
- `./gradlew detekt`