### PR TITLE
fix(landing): source pricing from billing API, drop stale tiers and live badges

### DIFF
--- a/dashboard/src/components/auth/AuthShell.tsx
+++ b/dashboard/src/components/auth/AuthShell.tsx
@@ -122,7 +122,7 @@ function AuthShowcase({headline, lede}: {readonly headline: ReactNode; readonly 
           aria-hidden
           className="pointer-events-none absolute -inset-x-8 -bottom-10 top-6 bg-[radial-gradient(closest-side,rgba(124,92,246,0.3),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
         />
-        <WindowFrame title="moneat · api-prod" live className="relative">
+        <WindowFrame title="moneat · api-prod" className="relative">
           <div className="grid gap-3">
             <div className="flex items-center justify-between">
               <span className="font-brandmono text-[11px] uppercase tracking-[0.12em] text-slate-500">

--- a/dashboard/src/components/landing/CompetitorComparisonPage.tsx
+++ b/dashboard/src/components/landing/CompetitorComparisonPage.tsx
@@ -791,24 +791,6 @@ export function CompareHubPage() {
           </div>
         </section>
 
-        {/* Why alternative URLs */}
-        <section className="px-4 py-20 sm:px-6 lg:px-8">
-          <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[0.8fr_1fr] lg:items-center">
-            <div>
-              <h2 className="text-3xl font-bold tracking-[-0.03em] text-white sm:text-4xl">
-                Why these pages use alternative URLs
-              </h2>
-              <p className="mt-4 text-base leading-7 text-slate-400">
-                People search for direct alternatives when they feel pricing pressure, migration pressure,
-                or workflow friction. Each canonical page is named for that intent.
-              </p>
-            </div>
-            <div className="rounded-lg border border-white/[0.08] bg-[#0c0e16] p-6 text-sm leading-6 text-slate-400">
-              Canonical pages: /datadog-alternative, /sentry-alternative, /better-stack-alternative,
-              and /signoz-alternative. The hub stays at /compare.
-            </div>
-          </div>
-        </section>
       </main>
       <LandingFooter tone="dark" />
     </article>

--- a/dashboard/src/components/landing/FeaturePageTemplate.tsx
+++ b/dashboard/src/components/landing/FeaturePageTemplate.tsx
@@ -70,13 +70,12 @@ function FeatureHeroDashboard({config}: {readonly config: FeaturePageConfig}) {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title={`moneat · ${config.tagline}`} live className="relative">
+      <WindowFrame title={`moneat · ${config.tagline}`} className="relative">
         <div className="grid gap-3">
           <div className="flex items-center justify-between">
             <span className="font-brandmono text-[11px] uppercase tracking-[0.12em] text-slate-500">
               {config.title}
             </span>
-            <span className="font-brandmono text-[11px] text-slate-500">live</span>
           </div>
           <SignalChart heightClass="h-36 sm:h-44" />
           <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">

--- a/dashboard/src/components/landing/Landing.tsx
+++ b/dashboard/src/components/landing/Landing.tsx
@@ -16,6 +16,7 @@
 
 import {useEffect, useId, useRef} from 'react'
 import {Link} from '@tanstack/react-router'
+import {useQuery} from '@tanstack/react-query'
 import {
   Activity,
   ArrowRight,
@@ -31,6 +32,8 @@ import {
 } from 'lucide-react'
 import {Button} from '@/components/ui/button'
 import {cn} from '@/lib/utils'
+import {api} from '@/lib/api'
+import {buildPricingCardModel, type PricingCardModel} from '@/lib/pricing-display'
 import {compareColumns, compareRows, SOURCE_REVIEW_DATE, type CellValue} from './competitorComparisonData'
 
 // ── Brand signal: one violet→indigo→cyan gradient (style-guide) ──────────────
@@ -105,12 +108,10 @@ export function ScreenshotFrame({
 // ─────────────────────────────────────────────────────────────────────────────
 function WindowFrame({
   title,
-  live,
   children,
   className,
 }: {
   readonly title: string
-  readonly live?: boolean
   readonly children: React.ReactNode
   readonly className?: string
 }) {
@@ -126,12 +127,6 @@ function WindowFrame({
       <div className="flex items-center gap-2 border-b border-white/[0.06] bg-[#0a0b12] px-3.5 py-2.5">
         <span className={cn('size-2.5 shrink-0 rounded-[3px]', GRADIENT_BG)} />
         <span className="truncate font-brandmono text-[11px] text-slate-400">{title}</span>
-        {live ? (
-          <span className="ml-auto inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 font-brandmono text-[10px] tracking-wide text-emerald-300">
-            <span className="size-1.5 rounded-full bg-emerald-400" />
-            live
-          </span>
-        ) : null}
       </div>
       <div className="p-3.5">{children}</div>
     </div>
@@ -1080,51 +1075,127 @@ function OpenSourceSection() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Condensed pricing — the free tier up front, paid tiers summarized.
+// Condensed pricing — same /billing/plans API as the full /pricing page,
+// summarized to the free tier up front with the paid tiers behind it. Prices and
+// the per-tier ingestion limit come straight from the API so they never drift.
 // ─────────────────────────────────────────────────────────────────────────────
-const pricingTiers: Array<{
+interface CondensedTier {
   name: string
   price: string
   cadence: string
   blurb: string
   points: string[]
   highlight: boolean
-}> = [
-  {
-    name: 'Free',
-    price: '$0',
-    cadence: '',
-    blurb: 'Side projects and getting started',
-    points: ['1 GB ingest / month', 'Every signal type included', 'Community support'],
-    highlight: false,
-  },
-  {
-    name: 'Pro',
-    price: '$29',
-    cadence: '/mo',
-    blurb: 'Growing teams shipping to production',
-    points: ['More ingest & retention', '$0.40 / GB overage', 'Slack & Discord alerts'],
-    highlight: true,
-  },
-  {
-    name: 'Team',
-    price: '$79',
-    cadence: '/mo',
-    blurb: 'Teams that need scale and compliance',
-    points: ['Higher limits', 'SSO (SAML / OIDC)', 'Priority support'],
-    highlight: false,
-  },
-  {
-    name: 'Enterprise',
-    price: 'Custom',
-    cadence: '',
-    blurb: 'Scale, compliance, and a dedicated partner',
-    points: ['Volume discounts', 'Dedicated support & SLA', 'Everything in Team'],
-    highlight: false,
-  },
-]
+}
+
+// Tiers above this price are sold as custom Enterprise, not self-serve (mirrors PricingSection).
+const SELF_SERVE_HIDDEN_TIERS = new Set(['BUSINESS'])
+
+// One stable, non-numeric highlight per tier. Numbers (price, ingestion, retention) come from the API.
+const TIER_HIGHLIGHTS: Record<string, string> = {
+  FREE: 'Every signal type included',
+  PRO: 'Slack & Discord alerts',
+  TEAM: 'SSO (SAML / OIDC)',
+}
+
+const ENTERPRISE_TIER: CondensedTier = {
+  name: 'Enterprise',
+  price: 'Custom',
+  cadence: '',
+  blurb: 'Scale, compliance, and a dedicated partner',
+  points: ['Volume discounts', 'Dedicated support & SLA', 'Everything in Team'],
+  highlight: false,
+}
+
+function toCondensedTier(model: PricingCardModel): CondensedTier {
+  const ingestion = model.includedLimits[0]
+  const retention = model.includedLimits.find((limit) => limit.includes('retention'))
+  const points = [ingestion, retention, TIER_HIGHLIGHTS[model.tierName]].filter(
+    (point): point is string => Boolean(point),
+  )
+  return {
+    name: model.name,
+    price: model.displayPrice === 0 ? '$0' : `$${model.displayPrice.toFixed(0)}`,
+    cadence: model.displayPrice === 0 ? '' : '/mo',
+    blurb: model.description,
+    points,
+    highlight: model.highlight,
+  }
+}
+
+function PricingBandCard({tier}: {readonly tier: CondensedTier}) {
+  return (
+    <div
+      className={cn(
+        'relative rounded-lg border bg-[#0c0e16] p-6',
+        tier.highlight ? 'border-indigo-400/40' : 'border-white/[0.08]',
+      )}
+    >
+      {tier.highlight ? <div className={cn('absolute inset-x-0 top-0 h-px', GRADIENT_BAR)} /> : null}
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-lg font-semibold text-white">{tier.name}</h3>
+        <div className="text-right">
+          <span className={cn('font-brandmono text-2xl font-bold', tier.highlight ? GRADIENT_TEXT : 'text-white')}>
+            {tier.price}
+          </span>
+          <span className="font-brandmono text-xs text-slate-500">{tier.cadence}</span>
+        </div>
+      </div>
+      <p className="mt-2 min-h-10 text-sm leading-6 text-slate-400">{tier.blurb}</p>
+      <div className="mt-5 grid gap-2.5">
+        {tier.points.map((point) => (
+          <div key={point} className="flex items-center gap-2.5 text-sm text-slate-300">
+            <Check className="size-4 shrink-0 text-emerald-400" />
+            {point}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function PricingBandSkeleton() {
+  return (
+    <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+      {Array.from({length: 4}, (_, idx) => `pricing-skeleton-${idx}`).map((id) => (
+        <div key={id} className="rounded-lg border border-white/[0.08] bg-[#0c0e16] p-6">
+          <div className="flex items-baseline justify-between">
+            <div className="h-5 w-16 animate-pulse rounded bg-white/[0.06]" />
+            <div className="h-7 w-14 animate-pulse rounded bg-white/[0.06]" />
+          </div>
+          <div className="mt-3 h-4 w-40 animate-pulse rounded bg-white/[0.06]" />
+          <div className="mt-6 space-y-2.5">
+            {Array.from({length: 3}, (_, pointIdx) => `${id}-point-${pointIdx}`).map((pointId) => (
+              <div key={pointId} className="h-3.5 w-full animate-pulse rounded bg-white/[0.06]" />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
 
 function PricingBand() {
+  const {
+    data: billingPlans,
+    isPending: isBillingPlansLoading,
+    isError: isBillingPlansError,
+  } = useQuery({
+    queryKey: ['billing-plans'],
+    queryFn: () => api.getBillingPlans(),
+  })
+
+  const apiTiers: CondensedTier[] =
+    billingPlans?.plans
+      .filter((plan) => !SELF_SERVE_HIDDEN_TIERS.has(plan.tier.tierName))
+      .map((plan) =>
+        toCondensedTier(
+          buildPricingCardModel({...plan.tier, trialDays: plan.trialDays ?? plan.tier.trialDays}, 'monthly'),
+        ),
+      ) ?? []
+
+  const tiers = [...apiTiers, ENTERPRISE_TIER]
+
   return (
     <section className="border-y border-white/[0.06] bg-[#0a0b12] px-4 py-24 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
@@ -1133,37 +1204,29 @@ function PricingBand() {
           title="Pay only for what you ingest."
           lead="Pricing is based on ingestion volume, with no per-host fees. Send the telemetry you need and scale usage as your systems grow."
         />
-        <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-          {pricingTiers.map((tier) => (
-            <div
-              key={tier.name}
-              className={cn(
-                'relative rounded-lg border bg-[#0c0e16] p-6',
-                tier.highlight ? 'border-indigo-400/40' : 'border-white/[0.08]',
-              )}
-            >
-              {tier.highlight ? <div className={cn('absolute inset-x-0 top-0 h-px', GRADIENT_BAR)} /> : null}
-              <div className="flex items-baseline justify-between">
-                <h3 className="text-lg font-semibold text-white">{tier.name}</h3>
-                <div className="text-right">
-                  <span className={cn('font-brandmono text-2xl font-bold', tier.highlight ? GRADIENT_TEXT : 'text-white')}>
-                    {tier.price}
-                  </span>
-                  <span className="font-brandmono text-xs text-slate-500">{tier.cadence}</span>
-                </div>
+        {(() => {
+          if (isBillingPlansLoading) return <PricingBandSkeleton />
+          if (isBillingPlansError) {
+            return (
+              <div className="mt-12 rounded-lg border border-white/[0.08] bg-[#0c0e16] p-6 text-center">
+                <p className="text-sm text-slate-400">
+                  Pricing is taking a moment to load —{' '}
+                  <Link to="/pricing" className="text-indigo-300 hover:text-white">
+                    see full pricing
+                  </Link>
+                  .
+                </p>
               </div>
-              <p className="mt-2 min-h-10 text-sm leading-6 text-slate-400">{tier.blurb}</p>
-              <div className="mt-5 grid gap-2.5">
-                {tier.points.map((point) => (
-                  <div key={point} className="flex items-center gap-2.5 text-sm text-slate-300">
-                    <Check className="size-4 shrink-0 text-emerald-400" />
-                    {point}
-                  </div>
-                ))}
-              </div>
+            )
+          }
+          return (
+            <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+              {tiers.map((tier) => (
+                <PricingBandCard key={tier.name} tier={tier} />
+              ))}
             </div>
-          ))}
-        </div>
+          )
+        })()}
         <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
           <Button asChild variant="ghost" className="text-indigo-300 hover:bg-white/[0.05] hover:text-white">
             <Link to="/pricing">

--- a/dashboard/src/components/landing/__tests__/Landing.test.tsx
+++ b/dashboard/src/components/landing/__tests__/Landing.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {render, screen} from '@testing-library/react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -10,7 +11,50 @@ vi.mock('@tanstack/react-router', () => ({
   ),
 }))
 
+// PricingBand pulls plans from /billing/plans; stub the API so it renders deterministically.
+const {mockGetBillingPlans} = vi.hoisted(() => ({mockGetBillingPlans: vi.fn()}))
+vi.mock('@/lib/api', () => ({api: {getBillingPlans: mockGetBillingPlans}}))
+
 import {Landing} from '../Landing'
+
+const GB = 1024 * 1024 * 1024
+
+function makeTier(tierName: string, monthlyPriceCents: number, monthlyGbLimit: number) {
+  return {
+    tier: {
+      tierName,
+      monthlyPriceCents,
+      yearlyPriceCents: monthlyPriceCents * 10,
+      monthlyGbLimit,
+      retentionDays: 3,
+      maxProjects: null,
+      maxSystems: 10,
+      monitorIntervalSeconds: 60,
+      sessionReplayEnabled: true,
+      statusPagesEnabled: true,
+      statusPageCustomDomainEnabled: true,
+      slackEnabled: true,
+      discordEnabled: true,
+      incidentIoEnabled: true,
+      samlEnabled: tierName === 'TEAM',
+      oidcEnabled: tierName === 'TEAM',
+      prioritySupportEnabled: tierName === 'TEAM',
+      slaEnabled: false,
+      customRetentionEnabled: false,
+      overageRateCentsPerGb: 40,
+    },
+    trialDays: 14,
+  }
+}
+
+function renderLanding() {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}})
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Landing />
+    </QueryClientProvider>,
+  )
+}
 
 const serviceMapLabel = 'Live service map: Datadog, Sentry, and OTLP telemetry flowing into one platform'
 const originalMatchMedia = Object.getOwnPropertyDescriptor(globalThis.window, 'matchMedia')
@@ -41,6 +85,15 @@ function stubReducedMotion(matches: boolean) {
 describe('Landing', () => {
   beforeEach(() => {
     stubReducedMotion(false)
+    mockGetBillingPlans.mockResolvedValue({
+      plans: [
+        makeTier('FREE', 0, 1 * GB),
+        makeTier('PRO', 2900, 50 * GB),
+        makeTier('TEAM', 7900, 200 * GB),
+        makeTier('BUSINESS', 49900, 1000 * GB),
+      ],
+      stripeEnabled: false,
+    })
   })
 
   afterEach(() => {
@@ -50,7 +103,7 @@ describe('Landing', () => {
   })
 
   it('renders the hero service map with deterministic source and service wiring', () => {
-    const {container} = render(<Landing />)
+    const {container} = renderLanding()
 
     expect(
       screen.getByRole('heading', {
@@ -84,8 +137,28 @@ describe('Landing', () => {
     })
     stubReducedMotion(true)
 
-    render(<Landing />)
+    renderLanding()
 
     expect(pauseAnimations).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the condensed pricing band from the billing API', async () => {
+    renderLanding()
+
+    // Ingestion figures and prices come straight from /billing/plans, like the /pricing page.
+    expect(await screen.findByText('1 GB ingestion')).toBeInTheDocument()
+    expect(screen.getByText('50 GB ingestion')).toBeInTheDocument()
+    expect(screen.getByText('200 GB ingestion')).toBeInTheDocument()
+    expect(screen.getByText('$29')).toBeInTheDocument()
+    expect(screen.getByText('$79')).toBeInTheDocument()
+
+    // One stable highlight per tier.
+    expect(screen.getByText('Every signal type included')).toBeInTheDocument()
+    expect(screen.getByText('Slack & Discord alerts')).toBeInTheDocument()
+    expect(screen.getByText('SSO (SAML / OIDC)')).toBeInTheDocument()
+
+    // Static Enterprise card is appended; BUSINESS is filtered out of the self-serve band.
+    expect(screen.getByText('Volume discounts')).toBeInTheDocument()
+    expect(screen.queryByText('$499')).not.toBeInTheDocument()
   })
 })

--- a/dashboard/src/routes/ai-observability.tsx
+++ b/dashboard/src/routes/ai-observability.tsx
@@ -46,7 +46,7 @@ function AiObservabilityHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · ai" live className="relative">
+      <WindowFrame title="moneat · ai" className="relative">
         <div className="grid gap-3">
           {/* Toolbar row */}
           <div className="flex items-center justify-between gap-3">

--- a/dashboard/src/routes/alerting.tsx
+++ b/dashboard/src/routes/alerting.tsx
@@ -36,7 +36,7 @@ function AlertingHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(244,63,94,0.22),rgba(34,211,238,0.04)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · alerts" live className="relative">
+      <WindowFrame title="moneat · alerts" className="relative">
         <div className="grid gap-3">
           {/* Chart panel with threshold overlay */}
           <div className="overflow-hidden rounded-md border border-white/[0.07] bg-white/[0.02] px-3 pb-2 pt-2">

--- a/dashboard/src/routes/custom-dashboards.tsx
+++ b/dashboard/src/routes/custom-dashboards.tsx
@@ -39,7 +39,7 @@ function CustomDashboardsHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · dashboard" live className="relative">
+      <WindowFrame title="moneat · dashboard" className="relative">
         <div className="grid gap-3">
           {/* Toolbar row */}
           <div className="flex items-center justify-between gap-3">

--- a/dashboard/src/routes/error-tracking.tsx
+++ b/dashboard/src/routes/error-tracking.tsx
@@ -39,7 +39,7 @@ function ErrorTrackingHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · issues" live className="relative">
+      <WindowFrame title="moneat · issues" className="relative">
         <div className="grid gap-3">
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-2">

--- a/dashboard/src/routes/infrastructure-monitoring.tsx
+++ b/dashboard/src/routes/infrastructure-monitoring.tsx
@@ -65,11 +65,10 @@ function InfrastructureMonitoringHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · hosts" live className="relative">
+      <WindowFrame title="moneat · hosts" className="relative">
         <div className="grid gap-3">
           <div className="flex items-center justify-between gap-3">
             <span className="font-brandmono text-[11px] text-slate-500">128 hosts · 6 shown</span>
-            <span className="font-brandmono text-[11px] text-slate-500">live</span>
           </div>
           <div className="overflow-hidden rounded-md border border-white/[0.07]">
             {/* header */}

--- a/dashboard/src/routes/log-management.tsx
+++ b/dashboard/src/routes/log-management.tsx
@@ -50,7 +50,7 @@ function LogManagementHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(99,102,241,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · logs" live className="relative">
+      <WindowFrame title="moneat · logs" className="relative">
         <div className="grid gap-3">
           {/* search bar + tail indicator */}
           <div className="flex items-center justify-between gap-3">

--- a/dashboard/src/routes/on-call-management.tsx
+++ b/dashboard/src/routes/on-call-management.tsx
@@ -38,7 +38,7 @@ function OnCallHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · on-call" live className="relative">
+      <WindowFrame title="moneat · on-call" className="relative">
         <div className="grid gap-3">
           {/* On call now */}
           <div className="flex items-center gap-3 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-2.5">

--- a/dashboard/src/routes/performance-monitoring.tsx
+++ b/dashboard/src/routes/performance-monitoring.tsx
@@ -51,7 +51,7 @@ function PerformanceMonitoringHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(99,102,241,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · transactions" live className="relative">
+      <WindowFrame title="moneat · transactions" className="relative">
         <div className="grid gap-3">
           {/* Transaction header */}
           <div className="flex items-baseline justify-between gap-3">

--- a/dashboard/src/routes/profiling.tsx
+++ b/dashboard/src/routes/profiling.tsx
@@ -76,7 +76,7 @@ function ProfilingHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · profile" live className="relative">
+      <WindowFrame title="moneat · profile" className="relative">
         <div className="grid gap-3">
           {/* flamegraph label row */}
           <div className="flex items-center justify-between gap-2">

--- a/dashboard/src/routes/public-status-pages.tsx
+++ b/dashboard/src/routes/public-status-pages.tsx
@@ -86,7 +86,7 @@ function StatusPageHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(16,185,129,0.22),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · status" live className="relative">
+      <WindowFrame title="moneat · status" className="relative">
         <div className="grid gap-3">
           {/* Banner */}
           <div className="flex items-center justify-between gap-3 rounded-md border border-white/[0.07] bg-white/[0.02] px-3 py-2">

--- a/dashboard/src/routes/security-sbom.tsx
+++ b/dashboard/src/routes/security-sbom.tsx
@@ -41,7 +41,7 @@ function SbomHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(16,185,129,0.22),rgba(16,185,129,0.04)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · sbom" live className="relative">
+      <WindowFrame title="moneat · sbom" className="relative">
         <div className="grid gap-3">
           <div className="flex items-center justify-between gap-3">
             <span className="font-brandmono text-[12px] text-slate-200">

--- a/dashboard/src/routes/session-replay.tsx
+++ b/dashboard/src/routes/session-replay.tsx
@@ -39,7 +39,7 @@ function SessionReplayHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(124,92,246,0.28),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · replay" live className="relative">
+      <WindowFrame title="moneat · replay" className="relative">
         <div className="grid gap-3">
           {/* Faux recorded viewport */}
           <div className="relative overflow-hidden rounded-md border border-white/[0.08] bg-white/[0.02] px-4 pb-4 pt-3">

--- a/dashboard/src/routes/uptime-monitoring.tsx
+++ b/dashboard/src/routes/uptime-monitoring.tsx
@@ -107,7 +107,7 @@ function UptimeMonitoringHero() {
         aria-hidden
         className="pointer-events-none absolute -inset-x-10 -bottom-12 top-8 bg-[radial-gradient(closest-side,rgba(16,185,129,0.22),rgba(34,211,238,0.05)_60%,transparent)] blur-2xl"
       />
-      <WindowFrame title="moneat · uptime" live className="relative">
+      <WindowFrame title="moneat · uptime" className="relative">
         <div className="grid gap-3">
           {/* column header */}
           <div className="flex items-center gap-2 px-0.5">


### PR DESCRIPTION
## What

The landing page pricing was hardcoded (`$29` / `$79` / `1 GB ingest / month`) and could drift from the real `/pricing` page. This wires the home page's condensed pricing band to the **same data path** as `/pricing` and removes some stale/decorative marketing chrome.

## Changes

- **Pricing band is now API-driven.** `PricingBand` (home) consumes `/billing/plans` via `buildPricingCardModel` — the same path `PricingSection` (`/pricing`) uses — so price and per-tier ingestion figures come straight from the billing API. Includes a loading skeleton and an error fallback. `BUSINESS` is filtered out of the self-serve band; a static `Enterprise` card is appended (mirrors `PricingSection`).
- **Removed the "Why these pages use alternative URLs" section** from the comparison/`*-alternative` pages.
- **Removed the decorative "live" badge + dot** from the shared `WindowFrame` primitive and stripped the `live` prop from all call sites (14 feature pages + auth shell); dropped two redundant "live" text labels in the feature/infra product mocks. Functional live indicators (log live-tail, profiling "receiving" dot) are untouched.
- **Tests:** added a `Landing.test.tsx` case asserting the band renders ingestion figures + prices from the API, filters `BUSINESS`, and appends `Enterprise`; existing hero tests now render inside a `QueryClientProvider` (required by the new `useQuery`).

## Notes

- No backend/pricing changes: the free tier still shows whatever the API returns (currently `1 GB`), identical to `/pricing`. If the free-tier allotment is bumped server-side later, both pages update automatically.

## Verification

- `npm run lint` — clean
- `npm run build` — passes (tsc + vite + prerender)
- Landing + pricing unit suites — 50/50 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing plans now fetch dynamically from billing API with loading and error fallback states.

* **Refactor**
  * Removed `live` prop from hero component frames across dashboard pages.
  * Updated pricing tier rendering with condensed model based on API data.

* **Documentation**
  * Removed explanatory section about alternative URLs from comparison page.

* **Tests**
  * Enhanced Landing tests with mocked billing API and improved deterministic pricing rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->