### PR TITLE
fix: render unmapped overview activity kinds without crashing

### DIFF
--- a/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
+++ b/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
@@ -18,6 +18,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {fireEvent, render, screen} from '@testing-library/react'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import type {ReactElement, ReactNode} from 'react'
+import type {OverviewActivityItem, OverviewResponse} from '@/lib/api/types'
 import {OverviewDataProvider} from '../OverviewDataProvider'
 import {SystemStatusWidget} from '../widgets/SystemStatusWidget'
 import {KpiWidget} from '../widgets/KpiWidget'
@@ -34,11 +35,11 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({children, to}: {children: ReactNode; to?: string}) => <a href={to}>{children}</a>,
 }))
 
-function renderWithOverview(ui: ReactElement) {
+function renderWithOverview(ui: ReactElement, overrides: Partial<OverviewResponse> = {}) {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}})
   return render(
     <QueryClientProvider client={queryClient}>
-      <OverviewDataProvider data={overviewTestData}>{ui}</OverviewDataProvider>
+      <OverviewDataProvider data={{...overviewTestData, ...overrides}}>{ui}</OverviewDataProvider>
     </QueryClientProvider>,
   )
 }
@@ -131,5 +132,20 @@ describe('ActivityWidget', () => {
     renderWithOverview(<ActivityWidget />)
     expect(screen.getByTestId('widget-activity')).toBeInTheDocument()
     expect(screen.getByText('v2.4.1 released to checkout-api')).toBeInTheDocument()
+  })
+
+  it('renders issue activity items emitted by the backend', () => {
+    renderWithOverview(<ActivityWidget />, {
+      activity: [{kind: 'issue', text: 'NullPointerException in checkout', meta: '2m ago'}],
+    })
+    expect(screen.getByText('NullPointerException in checkout')).toBeInTheDocument()
+  })
+
+  it('renders an unrecognized activity kind instead of crashing', () => {
+    // The backend sends kind as a free-form string, so an unmapped value must
+    // degrade gracefully rather than throw while destructuring its style.
+    const unknown = [{kind: 'mystery', text: 'Future activity', meta: 'now'}] as unknown as OverviewActivityItem[]
+    renderWithOverview(<ActivityWidget />, {activity: unknown})
+    expect(screen.getByText('Future activity')).toBeInTheDocument()
   })
 })

--- a/dashboard/src/components/overview/widgets/ActivityWidget.tsx
+++ b/dashboard/src/components/overview/widgets/ActivityWidget.tsx
@@ -32,8 +32,9 @@ const KIND: Record<ActivityKind, ActivityStyle> = {
   feedback: {icon: MessageSquare, cls: 'bg-muted text-muted-foreground'},
 }
 
-// Activity kinds come from the backend as a free-form string, so render any
-// value we don't recognize with a neutral style rather than crashing the panel.
+// `OverviewActivityKind` is a typed union, but the backend serializes `kind` as a
+// plain string and may emit values outside that union at runtime, so render any
+// unrecognized kind with a neutral style rather than crashing the panel.
 const FALLBACK_KIND: ActivityStyle = {icon: Activity, cls: 'bg-muted text-muted-foreground'}
 
 /** Recent activity feed across the workspace. */

--- a/dashboard/src/components/overview/widgets/ActivityWidget.tsx
+++ b/dashboard/src/components/overview/widgets/ActivityWidget.tsx
@@ -15,19 +15,26 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import type {ComponentType} from 'react'
-import {Clock, Flag, MessageSquare, PlayCircle, Rocket, Siren, Workflow} from 'lucide-react'
+import {Activity, AlertCircle, Clock, Flag, MessageSquare, PlayCircle, Rocket, Siren, Workflow} from 'lucide-react'
 import {cn} from '@/lib/utils'
 import {useActivity, type ActivityKind} from '../overviewData'
 import {OverviewPanel, PanelLink} from '../OverviewPanel'
 
-const KIND: Record<ActivityKind, {icon: ComponentType<{className?: string}>; cls: string}> = {
+type ActivityStyle = {icon: ComponentType<{className?: string}>; cls: string}
+
+const KIND: Record<ActivityKind, ActivityStyle> = {
   incident: {icon: Siren, cls: 'bg-danger-bg text-danger-fg'},
+  issue: {icon: AlertCircle, cls: 'bg-warning-bg text-warning-fg'},
   flag: {icon: Flag, cls: 'bg-[hsl(var(--primary)/0.12)] text-primary'},
   deploy: {icon: Rocket, cls: 'bg-info-bg text-info-fg'},
   workflow: {icon: Workflow, cls: 'bg-warning-bg text-warning-fg'},
   replay: {icon: PlayCircle, cls: 'bg-muted text-muted-foreground'},
   feedback: {icon: MessageSquare, cls: 'bg-muted text-muted-foreground'},
 }
+
+// Activity kinds come from the backend as a free-form string, so render any
+// value we don't recognize with a neutral style rather than crashing the panel.
+const FALLBACK_KIND: ActivityStyle = {icon: Activity, cls: 'bg-muted text-muted-foreground'}
 
 /** Recent activity feed across the workspace. */
 export function ActivityWidget() {
@@ -41,7 +48,7 @@ export function ActivityWidget() {
     >
       <div>
         {items.map((it) => {
-          const {icon: Icon, cls} = KIND[it.kind]
+          const {icon: Icon, cls} = KIND[it.kind] ?? FALLBACK_KIND
           const itemKey = `${it.kind}:${it.text}:${it.meta}`
           return (
             <div key={itemKey} className="flex gap-1.5 border-b border-border/40 py-1 last:border-0">

--- a/dashboard/src/lib/api/types/overview.ts
+++ b/dashboard/src/lib/api/types/overview.ts
@@ -16,7 +16,7 @@
 
 export type OverviewTone = 'good' | 'warn' | 'bad' | 'neutral'
 export type OverviewSeriesKey = 'errors' | 'latency' | 'throughput' | 'logs'
-export type OverviewActivityKind = 'incident' | 'flag' | 'deploy' | 'workflow' | 'replay' | 'feedback'
+export type OverviewActivityKind = 'incident' | 'issue' | 'flag' | 'deploy' | 'workflow' | 'replay' | 'feedback'
 export type OverviewHeartbeatState = 'up' | 'warn' | 'down'
 
 export interface OverviewResponse {


### PR DESCRIPTION
## Problem

Production overview page crashes with:

> `Cannot destructure property 'icon' of 'DCt[e.kind]' as it is undefined.`

The activity feed (`ActivityWidget`) looks up a per-kind icon/style via `KIND[it.kind]` and immediately destructures `icon`/`cls`. The backend's `OverviewService.activity()` emits three kinds — `incident`, `deploy`, and **`issue`** — but the frontend `KIND` map (and the `OverviewActivityKind` type) only covered `incident`, `flag`, `deploy`, `workflow`, `replay`, `feedback`. There was **no `issue` entry**, so `KIND["issue"]` was `undefined` and destructuring threw, taking down the entire overview page. Because the triage feed almost always contains issues, this fired constantly in production.

## Fix

- Add the missing `issue` mapping (`AlertCircle`, matching how Issues are iconified in the sidebar/command palette).
- Add `'issue'` to the `OverviewActivityKind` union so the type matches what the backend actually sends.
- Fall back to a neutral style for **any** unrecognized kind. The backend models `kind` as a free-form `String`, so the frontend should degrade gracefully on future/unknown values instead of hard-crashing the panel.

## Testing

- `npm run typecheck`, `npm run lint`, `npm test` (2116 tests), `vite build` — all green.
- New regression tests in `overviewWidgets.test.tsx`:
  - renders an `issue` activity item (the exact value that was crashing prod), and
  - renders an unrecognized kind via the fallback instead of throwing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Issue activities are now displayed in the activity widget.

* **Bug Fixes**
  * The activity widget now gracefully handles unknown or unrecognized activity types without crashing.

* **Tests**
  * Expanded test coverage for activity widget rendering, including tests for issue activities and unknown activity type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->