### PR TITLE
fix: handle optional ClickHouse migration alters

### DIFF
--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseMigrations.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseMigrations.kt
@@ -46,7 +46,7 @@ object ClickHouseMigrations {
     private val optionalAlterTableIfExistsPattern =
         Regex(
             pattern = """^ALTER\s+TABLE\s+IF\s+EXISTS\s+([A-Za-z0-9_`.]+)\s+(MODIFY\s+SETTING\s+.+?)\s*;?$""",
-            option = RegexOption.IGNORE_CASE
+            options = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
         )
 
     data class Migration(

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseMigrations.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseMigrations.kt
@@ -42,6 +42,12 @@ object ClickHouseMigrations {
     private const val MIGRATIONS_TABLE = "schema_migrations"
     private const val MIGRATIONS_PATH = "db/clickhouse_migration"
     private const val ERROR_BODY_MAX_LEN = 500
+    private const val CLICKHOUSE_UNKNOWN_TABLE_CODE = "60"
+    private val optionalAlterTableIfExistsPattern =
+        Regex(
+            pattern = """^ALTER\s+TABLE\s+IF\s+EXISTS\s+([A-Za-z0-9_`.]+)\s+(MODIFY\s+SETTING\s+.+?)\s*;?$""",
+            option = RegexOption.IGNORE_CASE
+        )
 
     data class Migration(
         val version: Int,
@@ -229,10 +235,22 @@ object ClickHouseMigrations {
         for ((index, statement) in statements.withIndex()) {
             if (statement.isBlank()) continue
 
-            val response = ClickHouseClient.executeMigration(statement)
+            val preparedStatement = prepareClickHouseMigrationStatement(statement)
+            val response = ClickHouseClient.executeMigration(preparedStatement.sql)
             val body = response.bodyAsText()
 
             if (response.isClickHouseError(body)) {
+                if (
+                    preparedStatement.optionalTableName != null &&
+                    isUnknownTableError(body)
+                ) {
+                    logger.info(
+                        "Skipping optional ClickHouse migration statement for missing table " +
+                            preparedStatement.optionalTableName
+                    )
+                    continue
+                }
+
                 throw RuntimeException(
                     "Migration V${migration.version} failed at statement ${index + 1}/${statements.size}: $body"
                 )
@@ -255,6 +273,28 @@ object ClickHouseMigrations {
 
         logger.info("Applied V${migration.version}__${migration.description}")
     }
+
+    internal data class PreparedMigrationStatement(
+        val sql: String,
+        val optionalTableName: String? = null
+    )
+
+    internal fun prepareClickHouseMigrationStatement(statement: String): PreparedMigrationStatement {
+        val trimmedStatement = statement.trim()
+        val match = optionalAlterTableIfExistsPattern.matchEntire(trimmedStatement)
+            ?: return PreparedMigrationStatement(trimmedStatement)
+        val tableName = match.groupValues[1]
+        val alterCommand = match.groupValues[2].trim()
+
+        return PreparedMigrationStatement(
+            sql = "ALTER TABLE $tableName $alterCommand",
+            optionalTableName = tableName
+        )
+    }
+
+    private fun isUnknownTableError(body: String): Boolean =
+        body.startsWith("Code: $CLICKHOUSE_UNKNOWN_TABLE_CODE") ||
+            body.contains("UNKNOWN_TABLE")
 
     /**
      * Split SQL file into individual statements.

--- a/backend/src/main/resources/db/clickhouse_migration/V58__enable_network_paths_insert_deduplication.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V58__enable_network_paths_insert_deduplication.sql
@@ -1,0 +1,3 @@
+-- Enable query-token based insert deduplication for NDM network path retries.
+
+ALTER TABLE network_paths MODIFY SETTING non_replicated_deduplication_window = 1000;

--- a/backend/src/main/resources/db/clickhouse_migration/V58__enable_network_paths_insert_deduplication.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V58__enable_network_paths_insert_deduplication.sql
@@ -1,3 +1,3 @@
 -- Enable query-token based insert deduplication for NDM network path retries.
 
-ALTER TABLE network_paths MODIFY SETTING non_replicated_deduplication_window = 1000;
+ALTER TABLE IF EXISTS network_paths MODIFY SETTING non_replicated_deduplication_window = 1000;

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseInsertDeduplicationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseInsertDeduplicationTest.kt
@@ -19,10 +19,39 @@ package com.moneat.config
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ClickHouseInsertDeduplicationTest {
+
+    @Test
+    fun `optional alter table statements are rewritten for ClickHouse modify setting`() {
+        val preparedStatement =
+            ClickHouseMigrations.prepareClickHouseMigrationStatement(
+                "ALTER TABLE IF EXISTS events MODIFY SETTING non_replicated_deduplication_window = 1000;"
+            )
+
+        assertEquals(
+            "ALTER TABLE events MODIFY SETTING non_replicated_deduplication_window = 1000",
+            preparedStatement.sql
+        )
+        assertEquals("events", preparedStatement.optionalTableName)
+    }
+
+    @Test
+    fun `network paths deduplication migration targets real ClickHouse table`() {
+        val migrationSql =
+            requireNotNull(
+                Thread.currentThread().contextClassLoader.getResource(
+                    "db/clickhouse_migration/V58__enable_network_paths_insert_deduplication.sql"
+                )
+            ).readText()
+
+        assertFalse(migrationSql.contains("ndm_paths"), "NDM paths table is named network_paths")
+        assertTrue(migrationSql.contains("ALTER TABLE network_paths MODIFY SETTING"))
+    }
 
     @Test
     fun `token is scoped to ingestion seed and normalized query`() = runBlocking {

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseInsertDeduplicationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseInsertDeduplicationTest.kt
@@ -50,7 +50,7 @@ class ClickHouseInsertDeduplicationTest {
             ).readText()
 
         assertFalse(migrationSql.contains("ndm_paths"), "NDM paths table is named network_paths")
-        assertTrue(migrationSql.contains("ALTER TABLE network_paths MODIFY SETTING"))
+        assertTrue(migrationSql.contains("ALTER TABLE IF EXISTS network_paths MODIFY SETTING"))
     }
 
     @Test


### PR DESCRIPTION
Fix ClickHouse migration startup for optional table setting changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled token-based insert deduplication for network path retries to reduce duplicate operations.

* **Bug Fixes**
  * Migration system now gracefully skips optional table-setting changes when the target table is absent, avoiding failed migrations.

* **Tests**
  * Added tests verifying migration statement handling and that the network-paths deduplication migration targets the correct table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->