### PR TITLE
fix: resolve dashboard alert template data sources

### DIFF
--- a/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/routes/DashboardRoutes.kt
@@ -419,7 +419,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleDashboardQuery(
     } else {
         request.queryConfig
     }
-    val effectiveQuery = dependencies.queryEngine.resolvePrometheusDataSource(
+    val effectiveQuery = dependencies.queryEngine.resolveTemplateDataSource(
         dependencies.queryEngine.applyVariables(withTimeRange, request.variables),
         queryContext.orgId,
         dependencies.dataSourceService
@@ -613,7 +613,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleBatchDashboardQu
         } else {
             query
         }
-        val effectiveQuery = dependencies.queryEngine.resolvePrometheusDataSource(
+        val effectiveQuery = dependencies.queryEngine.resolveTemplateDataSource(
             dependencies.queryEngine.applyVariables(withTimeRange, request.variables),
             queryContext.orgId,
             dependencies.dataSourceService

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -563,30 +563,34 @@ class DashboardAlertService(
         projectId: Long?,
         queryDsl: QueryDsl
     ): List<Map<String, JsonElement>> {
-        val customDataSource = resolveCustomDataSource(orgId, queryDsl.dataSource)
+        val effectiveQueryDsl = queryEngine.resolveTemplateDataSource(
+            dsl = queryDsl,
+            orgId = orgId,
+            dataSourceService = dataSourceService,
+            logMissing = false,
+        )
+        if (queryEngine.isTemplateDataSourceMarker(effectiveQueryDsl.dataSource)) {
+            logger.debug {
+                "Skipping dashboard alert query for unresolved template data source ${effectiveQueryDsl.dataSource}"
+            }
+            return emptyList()
+        }
+
+        val customDataSource = resolveCustomDataSource(orgId, effectiveQueryDsl.dataSource)
         if (customDataSource != null) {
-            return executeCustomDataSourceQuery(orgId, customDataSource, queryDsl)
+            return executeCustomDataSourceQuery(orgId, customDataSource, effectiveQueryDsl)
         }
 
         val builtInProjectId = projectId ?: return emptyList()
         val retentionDays =
             retentionPolicyService.getRetentionDaysForProject(builtInProjectId) ?: DEFAULT_RETENTION_DAYS
-        return queryEngine.executeQuery(queryDsl, builtInProjectId, null, retentionDays, orgId)
+        return queryEngine.executeQuery(effectiveQueryDsl, builtInProjectId, null, retentionDays, orgId)
     }
 
     private fun resolveCustomDataSource(
         orgId: Long,
         dataSource: String
     ): CustomDataSourceResponse? {
-        if (dataSource == "__prometheus") {
-            return checkNotNull(
-                dataSourceService.listDataSources(orgId)
-                    .firstOrNull { source ->
-                        source.enabled &&
-                            CustomDataSourceType.fromString(source.sourceType) == CustomDataSourceType.PROMETHEUS
-                    }
-            ) { "No enabled Prometheus data source configured" }
-        }
         if (!dataSource.startsWith("custom:")) return null
 
         val sourceId = dataSource.removePrefix("custom:")

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -413,7 +413,16 @@ class DashboardAlertService(
         val queryDsl = queryConfigs.getOrNull(queryIndex) ?: return null
 
         val results = suspendRunCatching {
-            executeQueryForAlert(alert.orgId, alert.projectId, queryDsl)
+            executeQueryForAlert(
+                orgId = alert.orgId,
+                projectId = alert.projectId,
+                queryDsl = queryDsl,
+                logContext = AlertQueryLogContext(
+                    alertId = alert.alertId,
+                    dashboardId = alert.dashboardId,
+                    widgetId = alert.widgetId,
+                ),
+            )
         }.getOrElse { e ->
             logger.warn(e) { "Failed to execute query for dashboard alert ${alert.alertId}" }
             return null
@@ -558,10 +567,24 @@ class DashboardAlertService(
         sendAlertNotification(alert, currentValue, trigger)
     }
 
+    private data class AlertQueryLogContext(
+        val alertId: Long,
+        val dashboardId: Long,
+        val widgetId: Long,
+    )
+
     internal suspend fun executeQueryForAlert(
         orgId: Long,
         projectId: Long?,
         queryDsl: QueryDsl
+    ): List<Map<String, JsonElement>> =
+        executeQueryForAlert(orgId, projectId, queryDsl, logContext = null)
+
+    private suspend fun executeQueryForAlert(
+        orgId: Long,
+        projectId: Long?,
+        queryDsl: QueryDsl,
+        logContext: AlertQueryLogContext?,
     ): List<Map<String, JsonElement>> {
         val effectiveQueryDsl = queryEngine.resolveTemplateDataSource(
             dsl = queryDsl,
@@ -570,8 +593,10 @@ class DashboardAlertService(
             logMissing = false,
         )
         if (queryEngine.isTemplateDataSourceMarker(effectiveQueryDsl.dataSource)) {
-            logger.debug {
-                "Skipping dashboard alert query for unresolved template data source ${effectiveQueryDsl.dataSource}"
+            logger.warn {
+                "Skipping dashboard alert ${logContext?.alertId ?: "unknown"} query because template data source " +
+                    "${effectiveQueryDsl.dataSource} is unresolved for org $orgId, " +
+                    "dashboard ${logContext?.dashboardId ?: "unknown"}, widget ${logContext?.widgetId ?: "unknown"}"
             }
             return emptyList()
         }

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
@@ -223,23 +223,29 @@ class DashboardQueryEngine {
         }
     }
 
+    fun isTemplateDataSourceMarker(dataSource: String): Boolean =
+        dataSource in TEMPLATE_DATA_SOURCE_MARKERS
+
     fun resolveTemplateDataSource(
         dsl: QueryDsl,
         orgId: Long,
         dataSourceService: CustomDataSourceService,
+        logMissing: Boolean = true,
     ): QueryDsl {
         val sourceType = TEMPLATE_DATA_SOURCE_MARKERS[dsl.dataSource] ?: return dsl
         val sources = dataSourceService.listDataSources(orgId)
         val matchingSource = sources.firstOrNull {
             it.enabled && it.sourceType.equals(sourceType, ignoreCase = true)
         }
-        if (matchingSource == null) {
+        if (matchingSource == null && logMissing) {
             logger.warn {
                 val sourcesList = sources.map { "${it.id}:${it.sourceType}" }
                 val shortQuery = dsl.rawQuery?.take(QUERY_PREVIEW_LENGTH) ?: ""
                 "No enabled $sourceType datasource found for org $orgId (${sources.size} sources: $sourcesList), " +
                     "cannot resolve ${dsl.dataSource} for rawQuery=$shortQuery"
             }
+        }
+        if (matchingSource == null) {
             return dsl
         }
         val rawQueryPreview = dsl.rawQuery?.take(QUERY_PREVIEW_LENGTH)
@@ -248,12 +254,6 @@ class DashboardQueryEngine {
         }
         return dsl.copy(dataSource = "custom:${matchingSource.id}")
     }
-
-    fun resolvePrometheusDataSource(
-        dsl: QueryDsl,
-        orgId: Long,
-        dataSourceService: CustomDataSourceService,
-    ): QueryDsl = resolveTemplateDataSource(dsl, orgId, dataSourceService)
 
     fun buildQuery(
         dsl: QueryDsl,

--- a/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
+++ b/backend/src/main/kotlin/com/moneat/mcp/tools/DashboardWidgetTool.kt
@@ -462,7 +462,7 @@ class PreviewDashboardWidgetQueryTool : McpTool {
         val withTimeRange = previewArgs.timeRange?.let {
             previewArgs.queryConfig.copy(timeRange = it)
         } ?: previewArgs.queryConfig
-        val effectiveQuery = dashboardWidgetQueryEngine.resolvePrometheusDataSource(
+        val effectiveQuery = dashboardWidgetQueryEngine.resolveTemplateDataSource(
             dashboardWidgetQueryEngine.applyVariables(withTimeRange, previewArgs.variables),
             orgId,
             dashboardWidgetDataSourceService

--- a/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -119,6 +119,14 @@ class DashboardAlertServiceTest {
             DashboardWidgets,
             DashboardWidgetAlerts
         )
+        every {
+            queryEngine.resolveTemplateDataSource(any(), any(), any(), any())
+        } answers {
+            firstArg()
+        }
+        every { queryEngine.isTemplateDataSourceMarker(any()) } answers {
+            firstArg<String>().startsWith("__")
+        }
         transaction {
             exec(
                 """
@@ -1247,6 +1255,17 @@ class DashboardAlertServiceTest {
         runBlocking {
             val source = customDataSource(id = 11)
             every { dataSourceService.listDataSources(ORG_ID) } returns listOf(source)
+            every { dataSourceService.getDataSource(source.id, ORG_ID) } returns source
+            every {
+                queryEngine.resolveTemplateDataSource(
+                    match { it.dataSource == "__prometheus" },
+                    ORG_ID,
+                    dataSourceService,
+                    false,
+                )
+            } answers {
+                firstArg<QueryDsl>().copy(dataSource = "custom:${source.id}")
+            }
             every { dataSourceService.getDecryptedCredentials(11, ORG_ID) } returns null
             coEvery {
                 dataSourceExecutor.executeQuery(
@@ -1272,6 +1291,52 @@ class DashboardAlertServiceTest {
             )
 
             assertEquals(0.25, result.single()["value"]?.jsonPrimitive?.content?.toDouble())
+        }
+
+    @Test
+    fun `executeQueryForAlert resolves non prometheus template alias to custom datasource`() =
+        runBlocking {
+            val source = customDataSource(
+                id = 13,
+                sourceType = CustomDataSourceType.LOKI.name.lowercase(),
+            )
+            every { dataSourceService.listDataSources(ORG_ID) } returns listOf(source)
+            every { dataSourceService.getDataSource(source.id, ORG_ID) } returns source
+            every {
+                queryEngine.resolveTemplateDataSource(
+                    match { it.dataSource == "__loki" },
+                    ORG_ID,
+                    dataSourceService,
+                    false,
+                )
+            } answers {
+                firstArg<QueryDsl>().copy(dataSource = "custom:${source.id}")
+            }
+            every { dataSourceService.getDecryptedCredentials(13, ORG_ID) } returns null
+            coEvery {
+                dataSourceExecutor.executeQuery(
+                    sourceId = 13,
+                    sourceType = CustomDataSourceType.LOKI,
+                    host = source.host,
+                    port = source.port,
+                    databaseName = source.databaseName,
+                    credentials = any(),
+                    query = """{app="api"}""",
+                    limit = any(),
+                    timeRange = any(),
+                )
+            } returns listOf(mapOf("value" to JsonPrimitive(2.0)))
+
+            val result = service.executeQueryForAlert(
+                orgId = ORG_ID,
+                projectId = DEFAULT_PROJECT_ID,
+                queryDsl = QueryDsl(
+                    dataSource = "__loki",
+                    rawQuery = """{app="api"}""",
+                ),
+            )
+
+            assertEquals(2.0, result.single()["value"]?.jsonPrimitive?.content?.toDouble())
         }
 
     @Test
@@ -1311,18 +1376,34 @@ class DashboardAlertServiceTest {
         }
 
     @Test
-    fun `executeQueryForAlert rejects prometheus alias without enabled source`() =
+    fun `executeQueryForAlert skips unresolved template alias without enabled source`() =
         runBlocking {
             every { dataSourceService.listDataSources(ORG_ID) } returns emptyList()
 
-            assertFailsWith<IllegalStateException> {
-                service.executeQueryForAlert(
-                    orgId = ORG_ID,
-                    projectId = null,
-                    queryDsl = QueryDsl(
-                        dataSource = "__prometheus",
-                        rawQuery = "up",
-                    ),
+            val result = service.executeQueryForAlert(
+                orgId = ORG_ID,
+                projectId = DEFAULT_PROJECT_ID,
+                queryDsl = QueryDsl(
+                    dataSource = "__prometheus",
+                    rawQuery = "up",
+                ),
+            )
+
+            assertTrue(result.isEmpty())
+            coVerify(exactly = 0) {
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
+            }
+            coVerify(exactly = 0) {
+                dataSourceExecutor.executeQuery(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
                 )
             }
         }
@@ -1341,6 +1422,17 @@ class DashboardAlertServiceTest {
                 postgres,
                 prometheus,
             )
+            every { dataSourceService.getDataSource(prometheus.id, ORG_ID) } returns prometheus
+            every {
+                queryEngine.resolveTemplateDataSource(
+                    match { it.dataSource == "__prometheus" },
+                    ORG_ID,
+                    dataSourceService,
+                    false,
+                )
+            } answers {
+                firstArg<QueryDsl>().copy(dataSource = "custom:${prometheus.id}")
+            }
             every { dataSourceService.getDecryptedCredentials(12, ORG_ID) } returns null
             coEvery {
                 dataSourceExecutor.executeQuery(

--- a/backend/src/test/kotlin/com/moneat/routes/DashboardRoutesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/DashboardRoutesTest.kt
@@ -951,7 +951,7 @@ class DashboardRoutesTest {
             coEvery { mockRetentionService.getRetentionDaysForProject(projectId) } returns null
             every { mockQueryEngine.applyVariables(any(), any()) } answers { firstArg() }
             every {
-                mockQueryEngine.resolvePrometheusDataSource(any(), orgId.toLong(), any())
+                mockQueryEngine.resolveTemplateDataSource(any(), orgId.toLong(), any())
             } answers { firstArg() }
             every { mockQueryEngine.isCustomDataSource("events") } returns false
             coEvery {
@@ -990,7 +990,7 @@ class DashboardRoutesTest {
             coEvery { mockRetentionService.getRetentionDaysForProject(projectId) } returns null
             every { mockQueryEngine.applyVariables(any(), any()) } answers { firstArg() }
             every {
-                mockQueryEngine.resolvePrometheusDataSource(any(), orgId.toLong(), any())
+                mockQueryEngine.resolveTemplateDataSource(any(), orgId.toLong(), any())
             } answers { firstArg() }
             every { mockQueryEngine.isCustomDataSource(sourceName) } returns true
             every { mockQueryEngine.parseCustomDataSourceId(sourceName) } returns DATA_SOURCE_RESOURCE_ID
@@ -1037,7 +1037,7 @@ class DashboardRoutesTest {
             coEvery { mockRetentionService.getRetentionDaysForProject(projectId) } returns null
             every { mockQueryEngine.applyVariables(any(), any()) } answers { firstArg() }
             every {
-                mockQueryEngine.resolvePrometheusDataSource(any(), orgId.toLong(), any())
+                mockQueryEngine.resolveTemplateDataSource(any(), orgId.toLong(), any())
             } answers { firstArg() }
             every { mockQueryEngine.isCustomDataSource(sourceName) } returns true
             every { mockQueryEngine.parseCustomDataSourceId(sourceName) } returns DATA_SOURCE_RESOURCE_ID
@@ -1077,7 +1077,7 @@ class DashboardRoutesTest {
             coEvery { mockRetentionService.getRetentionDaysForProject(projectId) } returns null
             every { mockQueryEngine.applyVariables(any(), any()) } answers { firstArg() }
             every {
-                mockQueryEngine.resolvePrometheusDataSource(any(), orgId.toLong(), any())
+                mockQueryEngine.resolveTemplateDataSource(any(), orgId.toLong(), any())
             } answers { firstArg() }
             every { mockQueryEngine.isCustomDataSource(sourceName) } returns true
             every { mockQueryEngine.parseCustomDataSourceId(sourceName) } returns DATA_SOURCE_RESOURCE_ID
@@ -1121,7 +1121,7 @@ class DashboardRoutesTest {
             coEvery { mockRetentionService.getRetentionDaysForProject(projectId) } returns null
             every { mockQueryEngine.applyVariables(any(), any()) } answers { firstArg() }
             every {
-                mockQueryEngine.resolvePrometheusDataSource(any(), orgId.toLong(), any())
+                mockQueryEngine.resolveTemplateDataSource(any(), orgId.toLong(), any())
             } answers { firstArg() }
             every { mockQueryEngine.isCustomDataSource("events") } returns false
             coEvery {
@@ -1172,7 +1172,7 @@ class DashboardRoutesTest {
             coEvery { mockRetentionService.getRetentionDaysForProject(projectId) } returns null
             every { mockQueryEngine.applyVariables(any(), any()) } answers { firstArg() }
             every {
-                mockQueryEngine.resolvePrometheusDataSource(any(), orgId.toLong(), any())
+                mockQueryEngine.resolveTemplateDataSource(any(), orgId.toLong(), any())
             } answers { firstArg() }
             every { mockQueryEngine.isCustomDataSource(sourceName) } returns true
             every { mockQueryEngine.parseCustomDataSourceId(sourceName) } returns MISSING_DATA_SOURCE_RESOURCE_ID


### PR DESCRIPTION
## Summary
- resolve dashboard alert template data sources before evaluation
- remove the stale Prometheus-only resolver wrapper
- cover alert, route, and MCP preview paths

## Checks
- backend focused tests
- backend compile and detekt
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dashboard query and alert execution to use a more flexible, template-based data source resolution approach instead of Prometheus-specific handling, improving consistency across query execution paths.

* **Tests**
  * Expanded test coverage for template data source resolution scenarios, including handling of unresolved data sources and custom datasource mapping for alerts and dashboard queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->