### PR TITLE
fix: repair resources page

### DIFF
--- a/backend/src/main/kotlin/com/moneat/config/DemoReseedDatadog.kt
+++ b/backend/src/main/kotlin/com/moneat/config/DemoReseedDatadog.kt
@@ -20,6 +20,8 @@ package com.moneat.config
 
 import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
+import java.util.Locale
+import kotlin.math.abs
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
@@ -47,6 +49,7 @@ internal suspend fun checkFreshDatadogCount(): Long {
                 Triple("profiles", "start_time", "organization_id"),
                 Triple("service_checks", "timestamp", "organization_id"),
                 Triple("containers", "timestamp", "organization_id"),
+                Triple("metrics_latest_by_host", "timestamp", "organization_id"),
             )
         var minCount = Long.MAX_VALUE
         for ((table, timeCol, orgCol) in tablesWithTimeCol) {
@@ -87,6 +90,7 @@ internal suspend fun purgeDatadogDemoData() {
             "processes",
             "containers",
             "network_connections",
+            "metrics_latest_by_host",
         )
     for (table in tables) {
         suspendRunCatching {
@@ -109,6 +113,7 @@ internal suspend fun purgeDatadogDemoData() {
 
 internal suspend fun reseedDatadogData() {
     reseedDatadogHostsPostgres()
+    reseedDatadogHostMetrics()
     reseedDatadogApmRootSpans()
     reseedDatadogApmChildSpans()
     reseedDatadogServiceMapRollups()
@@ -198,6 +203,106 @@ private suspend fun reseedDatadogHostsPostgres() {
             }
         }
     }.onFailure { logger.warn { "Reseed hosts failed (non-fatal): ${it.message}" } }
+}
+
+// Host system metrics for the demo fleet. The resource catalog + host views read the latest
+// CPU/memory (and disk/load/network) per host from `metrics_latest_by_host` keyed by the Postgres
+// host id — which only exists after reseedDatadogHostsPostgres has run, so this reads the freshly
+// inserted ids back. Latest snapshot only: the catalog synthesises history from the latest value.
+private const val DEMO_DISK_TOTAL_BYTES = 512L * 1024 * 1024 * 1024
+
+private data class DemoHostMetricRow(val id: Long, val hostname: String, val memTotalKb: Long)
+
+private data class HostMetricAnchors(
+    val cpuPct: Double,
+    val memPct: Double,
+    val diskPct: Double,
+    val load1: Double,
+    val netRecvBytes: Long,
+    val netSentBytes: Long,
+)
+
+/** Deterministic per-host metric values so the seeded fleet looks varied but stable across reseeds. */
+private fun hostMetricAnchors(hostname: String): HostMetricAnchors {
+    val h = abs(hostname.hashCode())
+    return HostMetricAnchors(
+        cpuPct = 25.0 + (h % 55),
+        memPct = 35.0 + (h / 7 % 50),
+        diskPct = 40.0 + (h / 13 % 50),
+        load1 = 0.5 + (h % 400) / 100.0,
+        netRecvBytes = (3L + h % 30) * 1024 * 1024,
+        netSentBytes = (1L + h / 11 % 12) * 1024 * 1024,
+    )
+}
+
+private fun readDemoHostMetricRows(): List<DemoHostMetricRow> =
+    suspendRunCatching {
+        transaction {
+            exec(
+                "SELECT id, hostname, memory_total_kb FROM hosts WHERE organization_id = -1 ORDER BY id"
+            ) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(
+                            DemoHostMetricRow(
+                                rs.getLong("id"),
+                                rs.getString("hostname"),
+                                rs.getLong("memory_total_kb")
+                            )
+                        )
+                    }
+                }
+            } ?: emptyList()
+        }
+    }.getOrElse {
+        logger.warn { "Failed to read demo hosts for metric reseed (non-fatal): ${it.message}" }
+        emptyList()
+    }
+
+private fun hostMetricsLatestSql(hosts: List<DemoHostMetricRow>): String {
+    val rows = buildList {
+        for (host in hosts) {
+            val a = hostMetricAnchors(host.hostname)
+            val memTotalBytes = host.memTotalKb * 1024L
+            val memUsedBytes = (memTotalBytes * a.memPct / 100.0).toLong()
+            val diskUsedBytes = (DEMO_DISK_TOTAL_BYTES * a.diskPct / 100.0).toLong()
+            val metrics = listOf(
+                "system.cpu.percent" to fmtMetric(a.cpuPct),
+                "system.mem.total" to memTotalBytes.toString(),
+                "system.mem.used" to memUsedBytes.toString(),
+                "system.disk.total" to DEMO_DISK_TOTAL_BYTES.toString(),
+                "system.disk.used" to diskUsedBytes.toString(),
+                "system.load.1" to fmtMetric(a.load1),
+                "system.net.recv_bytes" to a.netRecvBytes.toString(),
+                "system.net.sent_bytes" to a.netSentBytes.toString(),
+            )
+            for ((name, value) in metrics) {
+                add("($ORG1, ${host.id}, '$name', now64(3), $value, '${host.hostname}', 'datadog')")
+            }
+        }
+    }
+    return """
+        INSERT INTO metrics_latest_by_host
+            (organization_id, host_id, metric_name, timestamp, value, host, source)
+        VALUES
+        ${rows.joinToString(",\n        ")}
+    """.trimIndent()
+}
+
+private fun fmtMetric(value: Double): String = String.format(Locale.US, "%.2f", value)
+
+private suspend fun reseedDatadogHostMetrics() {
+    val hosts = readDemoHostMetricRows()
+    if (hosts.isEmpty()) {
+        logger.warn { "No demo hosts found for host-metric reseed (non-fatal)" }
+        return
+    }
+    suspendRunCatching {
+        requireClickHouse2xx(
+            ClickHouseClient.execute(hostMetricsLatestSql(hosts)),
+            "Reseed host metrics latest"
+        )
+    }.onFailure { logger.warn { "Reseed host metrics latest failed (non-fatal): ${it.message}" } }
 }
 
 private suspend fun reseedDatadogApmRootSpans() {

--- a/backend/src/main/kotlin/com/moneat/monitor/routes/ResourceCatalogRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/routes/ResourceCatalogRoutes.kt
@@ -17,6 +17,7 @@
 package com.moneat.monitor.routes
 
 import com.moneat.monitor.services.ResourceCatalogService
+import com.moneat.plugins.getDemoEpochMs
 import com.moneat.utils.OrganizationContextMissingException
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -40,12 +41,14 @@ fun Route.resourceCatalogRoutes(
             get("/resources") {
                 val organizationId = call.resolveResourceCatalogOrganizationId()
                 val limit = call.resolveResourceCatalogLimit()
+                val demoEpochMs = call.getDemoEpochMs()
                 val resources = if (limit == null) {
-                    resourceCatalogService.listResources(listOf(organizationId))
+                    resourceCatalogService.listResources(listOf(organizationId), demoEpochMs = demoEpochMs)
                 } else {
                     resourceCatalogService.listResources(
                         listOf(organizationId),
-                        limit
+                        limit,
+                        demoEpochMs
                     )
                 }
 

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
@@ -491,7 +491,7 @@ class MonitorService(
                 argMax(CASE WHEN metric_name='system.mem.pct_usable' THEN value END, timestamp) as mem_pct_usable,
                 argMax(CASE WHEN metric_name='system.disk.in_use' THEN value END, timestamp) as disk_in_use
             FROM `$clickhouseDb`.metrics_latest_by_host
-            WHERE organization_id = $organizationId
+            WHERE organization_id = toUInt64($organizationId)
               AND host_id IN ($hostIdList)
               AND metric_name IN ($LATEST_METRIC_NAMES_SQL)
               AND timestamp >= $freshnessNow - INTERVAL $LATEST_METRICS_LOOKBACK_HOURS HOUR

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
@@ -41,7 +41,10 @@ import com.moneat.monitor.repositories.HostRepository
 import com.moneat.shared.services.CacheService
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.shared.services.toUuidOrNull
+import com.moneat.utils.ClickHouseQueryUtils
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
+import com.moneat.utils.suspendRunCatching
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonArray
@@ -50,8 +53,6 @@ import mu.KotlinLogging
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.time.Clock
-import com.moneat.utils.suspendRunCatching
-import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import kotlin.uuid.Uuid
 
 private val logger = KotlinLogging.logger {}
@@ -62,6 +63,9 @@ class MonitorService(
     private val pricingTierService: PricingTierService = PricingTierService(),
     private val retentionPolicyService: RetentionPolicyService = RetentionPolicyService(),
 ) {
+    private fun clickHouseOrgClause(organizationId: Int): String =
+        ClickHouseQueryUtils.orgIdClause(organizationId.toLong())
+
     private fun resolvedAlertPriority(request: CreateAlertRequest): String? =
         canonicalAlertPriority(
             request.alertPriority
@@ -251,23 +255,24 @@ class MonitorService(
         organizationId: Int
     ): Boolean {
         // Delete telemetry from ClickHouse before removing the host row
+        val orgClause = clickHouseOrgClause(organizationId)
         val metricsDelete =
-            "ALTER TABLE `$clickhouseDb`.metrics DELETE WHERE organization_id = $organizationId" +
+            "ALTER TABLE `$clickhouseDb`.metrics DELETE WHERE $orgClause" +
                 " AND tags['host_id'] = '$hostId'"
         val containersDelete =
-            "ALTER TABLE `$clickhouseDb`.containers DELETE WHERE organization_id = $organizationId" +
+            "ALTER TABLE `$clickhouseDb`.containers DELETE WHERE $orgClause" +
                 " AND tags['host_id'] = '$hostId'"
         val metricsLatestDelete =
-            "ALTER TABLE `$clickhouseDb`.metrics_latest_by_host DELETE WHERE organization_id = $organizationId" +
+            "ALTER TABLE `$clickhouseDb`.metrics_latest_by_host DELETE WHERE $orgClause" +
                 " AND host_id = $hostId"
         val metricsRollupDelete =
-            "ALTER TABLE `$clickhouseDb`.metrics_rollup_1m DELETE WHERE organization_id = $organizationId" +
+            "ALTER TABLE `$clickhouseDb`.metrics_rollup_1m DELETE WHERE $orgClause" +
                 " AND host_id = $hostId"
         val containersLatestDelete =
-            "ALTER TABLE `$clickhouseDb`.containers_latest_by_host DELETE WHERE organization_id = $organizationId" +
+            "ALTER TABLE `$clickhouseDb`.containers_latest_by_host DELETE WHERE $orgClause" +
                 " AND host_id = $hostId"
         val containersRollupDelete =
-            "ALTER TABLE `$clickhouseDb`.containers_rollup_1m DELETE WHERE organization_id = $organizationId" +
+            "ALTER TABLE `$clickhouseDb`.containers_rollup_1m DELETE WHERE $orgClause" +
                 " AND host_id = $hostId"
 
         if (!hostRepository.deleteClickHouseData(metricsDelete)) {
@@ -341,7 +346,7 @@ class MonitorService(
                 argMax(CASE WHEN metric_name='system.mem.pct_usable' THEN value END, timestamp) as mem_pct_usable,
                 argMax(CASE WHEN metric_name='system.disk.in_use' THEN value END, timestamp) as disk_in_use
             FROM `$clickhouseDb`.metrics_latest_by_host
-            WHERE organization_id = ${host.organizationId}
+            WHERE ${clickHouseOrgClause(host.organizationId)}
               AND host_id = $hostId
               AND metric_name IN ($LATEST_METRIC_NAMES_SQL)
               AND timestamp >= now64(3) - INTERVAL $LATEST_METRICS_LOOKBACK_HOURS HOUR
@@ -491,7 +496,7 @@ class MonitorService(
                 argMax(CASE WHEN metric_name='system.mem.pct_usable' THEN value END, timestamp) as mem_pct_usable,
                 argMax(CASE WHEN metric_name='system.disk.in_use' THEN value END, timestamp) as disk_in_use
             FROM `$clickhouseDb`.metrics_latest_by_host
-            WHERE organization_id = toUInt64($organizationId)
+            WHERE ${clickHouseOrgClause(organizationId)}
               AND host_id IN ($hostIdList)
               AND metric_name IN ($LATEST_METRIC_NAMES_SQL)
               AND timestamp >= $freshnessNow - INTERVAL $LATEST_METRICS_LOOKBACK_HOURS HOUR
@@ -716,7 +721,7 @@ class MonitorService(
                 sumIf(value_sum, metric_name='system.battery.percent') /
                     nullIf(sumIf(value_count, metric_name='system.battery.percent'), 0) as battery
             FROM `$clickhouseDb`.metrics_rollup_1m
-            WHERE organization_id = ${host.organizationId}
+            WHERE ${clickHouseOrgClause(host.organizationId)}
               AND host_id = $hostId
               AND bucket_start >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
               AND bucket_start <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
@@ -806,7 +811,7 @@ class MonitorService(
                 argMax(net_rx_bytes, timestamp) as net_rx_bytes,
                 argMax(net_tx_bytes, timestamp) as net_tx_bytes
             FROM `$clickhouseDb`.containers_latest_by_host
-            WHERE organization_id = ${host.organizationId}
+            WHERE ${clickHouseOrgClause(host.organizationId)}
               AND host_id = $hostId
               AND timestamp >= now64(3) - INTERVAL $freshnessWindowSeconds SECOND
             GROUP BY container_id
@@ -1021,7 +1026,7 @@ class MonitorService(
                 sum(net_rx_bytes_sum) as net_recv,
                 sum(net_tx_bytes_sum) as net_sent
             FROM `$clickhouseDb`.containers_rollup_1m
-            WHERE organization_id = ${host.organizationId}
+            WHERE ${clickHouseOrgClause(host.organizationId)}
               AND host_id = $hostId
               AND name = '$escapedName'
               AND bucket_start >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})

--- a/backend/src/main/kotlin/com/moneat/monitor/services/ResourceCatalogService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/ResourceCatalogService.kt
@@ -49,12 +49,13 @@ class ResourceCatalogService(
     suspend fun listResources(
         organizationIds: List<Int>,
         limit: Int = DEFAULT_CATALOG_LIMIT,
+        demoEpochMs: Long? = null,
     ): List<CatalogResource> {
         if (organizationIds.isEmpty()) return emptyList()
 
         val boundedLimit = limit.coerceIn(1, MAX_CATALOG_LIMIT)
         val hosts = organizationIds.flatMap { monitorService.listHosts(it) }
-        val metricsByHost = latestMetricsByHost(organizationIds, hosts)
+        val metricsByHost = latestMetricsByHost(organizationIds, hosts, demoEpochMs)
 
         return buildList {
             addAll(queryClient.listApmServices(organizationIds, boundedLimit).mapNotNull(::serviceResource))
@@ -69,6 +70,7 @@ class ResourceCatalogService(
     private suspend fun latestMetricsByHost(
         organizationIds: List<Int>,
         hosts: List<HostData>,
+        demoEpochMs: Long?,
     ): Map<Int, LatestMetrics?> =
         organizationIds
             .flatMap { organizationId ->
@@ -77,7 +79,7 @@ class ResourceCatalogService(
                     emptyList()
                 } else {
                     monitorService
-                        .getLatestMetricsForHosts(orgHosts.map { it.id }, organizationId)
+                        .getLatestMetricsForHosts(orgHosts.map { it.id }, organizationId, demoEpochMs)
                         .entries
                         .map { it.toPair() }
                 }

--- a/dashboard/src/components/monitoring/MonitoringTabBar.tsx
+++ b/dashboard/src/components/monitoring/MonitoringTabBar.tsx
@@ -1,0 +1,315 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MonitoringTabBar — the Infrastructure section tab strip (Resources · Map ·
+// Processes · …). Rendered by the /monitoring layout AND by the standalone
+// /resources route, so the catalog keeps the same cross-section nav as every
+// other infrastructure page (the "Resources" tab points at /resources, which
+// lives outside the /monitoring layout). Datadog-gated tabs hide until that
+// enterprise module is enabled.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import {Link, useRouterState} from '@tanstack/react-router'
+import {useEffect, useRef, useState, type ComponentType} from 'react'
+import {
+  Boxes,
+  Bug,
+  CalendarClock,
+  Database,
+  HelpCircle,
+  MoreHorizontal,
+  Network,
+  Package,
+  Router,
+  Ship,
+  Terminal,
+  Map as MapIcon,
+} from 'lucide-react'
+
+import {cn} from '@/lib/utils'
+import {hasEnterpriseModule, useEnterpriseFeatures} from '@/hooks/useEnterpriseFeatures'
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu'
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip'
+
+type MonitoringTab = Readonly<{
+  id: string
+  label: string
+  href: string
+  icon: ComponentType<{className?: string}>
+  requiresDatadog?: boolean
+}>
+
+type MonitoringTabNavProps = Readonly<{
+  tabs: readonly MonitoringTab[]
+  currentPath: string
+}>
+
+type VisibleTabCountOptions = Readonly<{
+  availableWidth: number
+  tabCount: number
+  itemRefs: readonly (HTMLSpanElement | null)[]
+  moreWidth?: number
+}>
+
+const TAB_BASE_CLASS = 'flex h-8 items-center gap-1.5 whitespace-nowrap px-2.5 text-xs font-medium'
+const OVERFLOW_FALLBACK_WIDTH = 80
+
+const MONITORING_TABS: readonly MonitoringTab[] = [
+  {id: 'catalog', label: 'Resources', href: '/resources', icon: Boxes},
+  {id: 'map', label: 'Map', href: '/monitoring/map', icon: MapIcon},
+  {id: 'processes', label: 'Processes', href: '/monitoring/processes', icon: Terminal, requiresDatadog: true},
+  {id: 'network', label: 'Network', href: '/monitoring/network', icon: Network, requiresDatadog: true},
+  {id: 'events', label: 'Events', href: '/monitoring/events', icon: CalendarClock, requiresDatadog: true},
+  {id: 'kubernetes', label: 'Kubernetes', href: '/monitoring/kubernetes', icon: Ship, requiresDatadog: true},
+  {id: 'databases', label: 'Databases', href: '/monitoring/databases', icon: Database, requiresDatadog: true},
+  {id: 'debugger', label: 'Debugger', href: '/monitoring/debugger', icon: Bug, requiresDatadog: true},
+  {id: 'network-devices', label: 'Network Devices', href: '/monitoring/network-devices', icon: Router, requiresDatadog: true},
+  {id: 'sbom', label: 'SBOM', href: '/monitoring/sbom', icon: Package, requiresDatadog: true},
+]
+
+const TAB_DOCS_URLS: Record<string, string> = {
+  catalog: '/docs/infrastructure-monitoring',
+  hosts: '/docs/datadog-agent/agent-setup',
+  map: '/docs/infrastructure-monitoring',
+  containers: '/docs/datadog-agent/agent-setup',
+  'service-map': '/docs/performance-monitoring#service-map',
+  processes: '/docs/datadog-agent/',
+  network: '/docs/datadog-agent/',
+  events: '/docs/datadog-agent/',
+  kubernetes: '/docs/datadog-agent/kubernetes',
+  databases: '/docs/datadog-agent/database-monitoring',
+  debugger: '/docs/datadog-agent/debugger',
+  'network-devices': '/docs/datadog-agent/network-devices',
+  sbom: '/docs/datadog-agent/sbom',
+}
+
+function isMonitoringTabActive(tab: MonitoringTab, currentPath: string): boolean {
+  if (tab.href === '/monitoring') {
+    return currentPath === '/monitoring' || currentPath === '/monitoring/'
+  }
+  return currentPath.startsWith(tab.href)
+}
+
+function computeVisibleTabCount({
+  availableWidth,
+  tabCount,
+  itemRefs,
+  moreWidth = OVERFLOW_FALLBACK_WIDTH,
+}: VisibleTabCountOptions): number {
+  if (availableWidth === 0) return tabCount
+
+  let usedWidth = 0
+  for (let index = 0; index < tabCount; index += 1) {
+    const width = itemRefs[index]?.offsetWidth ?? 0
+    const reserveForMore = index < tabCount - 1 ? moreWidth : 0
+    if (usedWidth + width + reserveForMore > availableWidth) {
+      return Math.min(tabCount, Math.max(1, index))
+    }
+    usedWidth += width
+  }
+
+  return tabCount
+}
+
+function createResizeObserver(onResize: () => void): ResizeObserver | null {
+  if (globalThis.ResizeObserver === undefined) return null
+  return new globalThis.ResizeObserver(onResize)
+}
+
+function useVisibleMonitoringTabs(tabs: readonly MonitoringTab[]) {
+  const navRef = useRef<HTMLElement>(null)
+  const itemRefs = useRef<Array<HTMLSpanElement | null>>([])
+  const moreRef = useRef<HTMLSpanElement | null>(null)
+  const [visibleCount, setVisibleCount] = useState(tabs.length)
+
+  useEffect(() => {
+    const nav = navRef.current
+    if (nav === null) return undefined
+
+    const recompute = () => {
+      setVisibleCount(
+        computeVisibleTabCount({
+          availableWidth: nav.clientWidth,
+          tabCount: tabs.length,
+          itemRefs: itemRefs.current,
+          moreWidth: moreRef.current?.offsetWidth,
+        }),
+      )
+    }
+
+    recompute()
+    const observer = createResizeObserver(recompute)
+    observer?.observe(nav)
+    return () => observer?.disconnect()
+  }, [tabs])
+
+  return {
+    navRef,
+    itemRefs,
+    moreRef,
+    visibleTabs: tabs.slice(0, visibleCount),
+    overflowTabs: tabs.slice(visibleCount),
+  }
+}
+
+function MonitoringTabNav({tabs, currentPath}: MonitoringTabNavProps) {
+  const {navRef, itemRefs, moreRef, visibleTabs, overflowTabs} = useVisibleMonitoringTabs(tabs)
+  const overflowHasActive = overflowTabs.some((tab) => isMonitoringTabActive(tab, currentPath))
+
+  return (
+    <div className="relative min-w-0 flex-1 overflow-hidden">
+      <div aria-hidden className="pointer-events-none invisible absolute left-0 top-0 flex gap-0.5">
+        {tabs.map((tab, index) => {
+          const Icon = tab.icon
+          return (
+            <span
+              key={tab.id}
+              ref={(element) => {
+                itemRefs.current[index] = element
+              }}
+              className={TAB_BASE_CLASS}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              {tab.label}
+            </span>
+          )
+        })}
+        <span ref={moreRef} className={TAB_BASE_CLASS}>
+          <MoreHorizontal className="h-3.5 w-3.5 shrink-0" />
+          More
+        </span>
+      </div>
+
+      <nav ref={navRef} className="flex w-full items-stretch gap-0.5 overflow-hidden" aria-label="Monitoring tabs">
+        {visibleTabs.map((tab) => (
+          <MonitoringTabLink key={tab.id} tab={tab} currentPath={currentPath} />
+        ))}
+        {overflowTabs.length > 0 && (
+          <MonitoringOverflowMenu tabs={overflowTabs} currentPath={currentPath} hasActiveTab={overflowHasActive} />
+        )}
+      </nav>
+    </div>
+  )
+}
+
+type MonitoringTabLinkProps = Readonly<{
+  tab: MonitoringTab
+  currentPath: string
+}>
+
+function MonitoringTabLink({tab, currentPath}: MonitoringTabLinkProps) {
+  const Icon = tab.icon
+  const active = isMonitoringTabActive(tab, currentPath)
+
+  return (
+    <Link
+      to={tab.href}
+      className={cn(
+        TAB_BASE_CLASS,
+        'border-b-2 transition-colors',
+        active ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground',
+      )}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      {tab.label}
+    </Link>
+  )
+}
+
+type MonitoringOverflowMenuProps = Readonly<{
+  tabs: readonly MonitoringTab[]
+  currentPath: string
+  hasActiveTab: boolean
+}>
+
+function MonitoringOverflowMenu({tabs, currentPath, hasActiveTab}: MonitoringOverflowMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            TAB_BASE_CLASS,
+            'border-b-2 transition-colors',
+            hasActiveTab
+              ? 'border-primary text-primary'
+              : 'border-transparent text-muted-foreground hover:text-foreground',
+          )}
+        >
+          <MoreHorizontal className="h-3.5 w-3.5 shrink-0" />
+          More
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-44">
+        {tabs.map((tab) => {
+          const Icon = tab.icon
+          return (
+            <DropdownMenuItem key={tab.id} asChild>
+              <Link
+                to={tab.href}
+                className={cn('flex items-center gap-2 text-xs', isMonitoringTabActive(tab, currentPath) && 'text-primary')}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                {tab.label}
+              </Link>
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/** The Infrastructure section tab strip. Computes the active tab from the route. */
+export function MonitoringTabBar() {
+  const router = useRouterState()
+  const currentPath = router.location.pathname
+  const {data: features} = useEnterpriseFeatures()
+  const tabs = MONITORING_TABS.filter((tab) => !tab.requiresDatadog || hasEnterpriseModule(features, 'datadog'))
+  const activeTabId = tabs.find((tab) => isMonitoringTabActive(tab, currentPath))?.id
+  const docsUrl = activeTabId ? TAB_DOCS_URLS[activeTabId] : null
+
+  return (
+    <div className="border-b bg-card/50">
+      <div className="flex h-[42px] items-end gap-2 px-4">
+        <MonitoringTabNav tabs={tabs} currentPath={currentPath} />
+        <div className="flex shrink-0 items-center gap-2 self-center">
+          {docsUrl ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <a
+                    href={docsUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                    aria-label="View docs"
+                  >
+                    <HelpCircle className="h-4 w-4" />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>View docs</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/monitoring/MonitoringTabBar.tsx
+++ b/dashboard/src/components/monitoring/MonitoringTabBar.tsx
@@ -67,6 +67,9 @@ type VisibleTabCountOptions = Readonly<{
 
 const TAB_BASE_CLASS = 'flex h-8 items-center gap-1.5 whitespace-nowrap px-2.5 text-xs font-medium'
 const OVERFLOW_FALLBACK_WIDTH = 80
+const DOCS_LINK_CLASS =
+  'inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-foreground ' +
+  'hover:bg-muted/50 transition-colors'
 
 const MONITORING_TABS: readonly MonitoringTab[] = [
   {id: 'catalog', label: 'Resources', href: '/resources', icon: Boxes},
@@ -296,7 +299,7 @@ export function MonitoringTabBar() {
                     href={docsUrl}
                     target="_blank"
                     rel="noreferrer"
-                    className="inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                    className={DOCS_LINK_CLASS}
                     aria-label="View docs"
                   >
                     <HelpCircle className="h-4 w-4" />

--- a/dashboard/src/components/monitoring/catalog/CatalogCharts.tsx
+++ b/dashboard/src/components/monitoring/catalog/CatalogCharts.tsx
@@ -1,0 +1,256 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MetricChart — a compact over-time chart for the resource detail panel. One
+// series renders as a gradient area; multiple series render as overlaid lines
+// with a legend (load average, network throughput). Series are deterministic
+// sample histories until live metrics are wired in. Shared by the catalog and
+// the (future) map dock so both surfaces show identical trend graphs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import {useId, useMemo, type ComponentType} from 'react'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import {cn} from '@/lib/utils'
+import {getNowDate} from '@/lib/demo'
+import {formatHostMetricAxisTick, formatHostMetricTooltipLabel} from '@/lib/host-metrics-chart'
+import {metricSeriesValues} from './resourceCatalogData'
+
+// Categorical chart colors from the shared palette (style guide chart-1..6).
+const SERIES_COLORS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+  'hsl(var(--chart-6))',
+]
+
+export interface ChartSeries {
+  /** dataKey and legend label. */
+  readonly key: string
+  /** Latest value the synthesized history is anchored to. */
+  readonly current: number
+  readonly min?: number
+  readonly max?: number
+  readonly spread?: number
+}
+
+export interface MetricChartProps {
+  readonly title: string
+  readonly subtitle?: string
+  readonly icon: ComponentType<{className?: string}>
+  readonly iconClass?: string
+  /** Stable seed so the synthesized history never flickers between renders. */
+  readonly seed: string
+  readonly series: readonly ChartSeries[]
+  readonly rangeSeconds: number
+  readonly timezone: string
+  readonly points?: number
+  readonly height?: number
+  readonly yDomain?: readonly [number, number]
+  readonly formatValue: (value: number) => string
+  readonly formatYTick?: (value: number) => string
+  /** Render a "No data" placeholder at the chart's height instead of a series. */
+  readonly noData?: boolean
+}
+
+interface TooltipEntry {
+  readonly color?: string
+  readonly name?: string
+  readonly value?: number
+  readonly dataKey?: string | number
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  timezone,
+  formatValue,
+  multi,
+}: {
+  readonly active?: boolean
+  readonly payload?: readonly TooltipEntry[]
+  readonly label?: string | number
+  readonly timezone: string
+  readonly formatValue: (value: number) => string
+  readonly multi: boolean
+}) {
+  const rows = payload?.filter(
+    (entry): entry is TooltipEntry & {value: number} => typeof entry.value === 'number' && Number.isFinite(entry.value),
+  )
+  if (!active || !rows || rows.length === 0) return null
+  return (
+    <div className="rounded-md border bg-popover/95 px-2.5 py-1.5 shadow-md backdrop-blur-sm">
+      <p className="mb-1 text-[11px] text-muted-foreground">{formatHostMetricTooltipLabel(label, timezone)}</p>
+      {rows.map((entry) => (
+        <div key={String(entry.dataKey ?? entry.name)} className="flex items-center gap-1.5 text-xs">
+          <span className="h-2 w-2 shrink-0 rounded-full" style={{backgroundColor: entry.color}} />
+          {multi && <span className="text-muted-foreground">{entry.name}</span>}
+          <span className="ml-auto pl-3 font-medium tabular-nums">{formatValue(entry.value)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function MetricChart({
+  title,
+  subtitle,
+  icon: Icon,
+  iconClass,
+  seed,
+  series,
+  rangeSeconds,
+  timezone,
+  points = 48,
+  height = 150,
+  yDomain,
+  formatValue,
+  formatYTick,
+  noData = false,
+}: MetricChartProps) {
+  const gradientId = `cat-grad-${useId().replace(/[^a-zA-Z0-9]/g, '')}`
+  const multi = series.length > 1
+
+  const data = useMemo(() => {
+    const now = getNowDate().getTime()
+    const step = (rangeSeconds * 1000) / Math.max(1, points - 1)
+    const columns = series.map((s) =>
+      metricSeriesValues(`${seed}:${s.key}:${rangeSeconds}`, s.current, points, {
+        spread: s.spread,
+        min: s.min,
+        max: s.max,
+      }),
+    )
+    return Array.from({length: points}, (_, i) => {
+      const row: Record<string, number> = {timestamp: Math.round(now - (points - 1 - i) * step)}
+      series.forEach((s, si) => {
+        row[s.key] = columns[si][i]
+      })
+      return row
+    })
+  }, [seed, series, rangeSeconds, points])
+
+  const xAxis = {
+    dataKey: 'timestamp',
+    type: 'number' as const,
+    scale: 'time' as const,
+    domain: ['dataMin', 'dataMax'] as [string, string],
+    tick: {fontSize: 10},
+    tickLine: false,
+    axisLine: false,
+    minTickGap: 28,
+    className: 'fill-muted-foreground',
+    tickFormatter: (value: string | number) => formatHostMetricAxisTick(value, rangeSeconds, timezone),
+  }
+  const yAxisDomain: [number | string, number | string] = yDomain ? [yDomain[0], yDomain[1]] : ['auto', 'auto']
+  const yAxis = {
+    tick: {fontSize: 10},
+    tickLine: false,
+    axisLine: false,
+    width: 40,
+    className: 'fill-muted-foreground',
+    domain: yAxisDomain,
+    tickFormatter: formatYTick ? (value: string | number) => formatYTick(Number(value)) : undefined,
+  }
+  const grid = {strokeDasharray: '3 3', className: 'stroke-muted/40', vertical: false}
+  const tooltip = <ChartTooltip timezone={timezone} formatValue={formatValue} multi={multi} />
+
+  return (
+    <div className="rounded-md border border-border/70 bg-background/40 p-3">
+      <div className="mb-1.5 flex items-center gap-1.5">
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted">
+          <Icon className={cn('h-3 w-3', iconClass)} />
+        </span>
+        <div className="min-w-0">
+          <p className="truncate text-xs font-medium leading-tight">{title}</p>
+          {subtitle && <p className="truncate text-[10px] text-muted-foreground">{subtitle}</p>}
+        </div>
+      </div>
+      {noData ? (
+        <div
+          className="flex flex-col items-center justify-center gap-1 rounded bg-muted/20 text-muted-foreground"
+          style={{height}}
+        >
+          <Icon className="h-5 w-5 opacity-25" />
+          <span className="text-[11px]">No data</span>
+        </div>
+      ) : (
+      <ResponsiveContainer width="100%" height={height}>
+        {multi ? (
+          <LineChart data={data} margin={{top: 4, right: 8, bottom: 0, left: 0}}>
+            <CartesianGrid {...grid} />
+            <XAxis {...xAxis} />
+            <YAxis {...yAxis} />
+            <Tooltip content={tooltip} />
+            <Legend iconType="circle" iconSize={7} wrapperStyle={{fontSize: '10px'}} />
+            {series.map((s, i) => (
+              <Line
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
+                strokeWidth={1.75}
+                dot={false}
+                activeDot={{r: 3, strokeWidth: 0}}
+                connectNulls
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        ) : (
+          <AreaChart data={data} margin={{top: 4, right: 8, bottom: 0, left: 0}}>
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={SERIES_COLORS[0]} stopOpacity={0.25} />
+                <stop offset="95%" stopColor={SERIES_COLORS[0]} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid {...grid} />
+            <XAxis {...xAxis} />
+            <YAxis {...yAxis} />
+            <Tooltip content={tooltip} />
+            <Area
+              type="monotone"
+              dataKey={series[0].key}
+              stroke={SERIES_COLORS[0]}
+              strokeWidth={2}
+              fill={`url(#${gradientId})`}
+              fillOpacity={1}
+              connectNulls
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        )}
+      </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/monitoring/catalog/CatalogCharts.tsx
+++ b/dashboard/src/components/monitoring/catalog/CatalogCharts.tsx
@@ -136,7 +136,7 @@ export function MetricChart({
   formatYTick,
   noData = false,
 }: MetricChartProps) {
-  const gradientId = `cat-grad-${useId().replace(/[^a-zA-Z0-9]/g, '')}`
+  const gradientId = `cat-grad-${useId().replaceAll(/[^a-zA-Z0-9]/g, '')}`
   const multi = series.length > 1
 
   const data = useMemo(() => {

--- a/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
@@ -549,7 +549,12 @@ export function ResourceCatalog() {
     catalogContent = (
       <div className="flex h-full min-h-0 gap-3 p-3">
         <CompactList resources={sorted} selectedId={selectedId} onSelect={setSelectedId} />
-        <ResourceDetailPanel resource={selected} onSelect={setSelectedId} onClose={() => setSelectedId(null)} />
+        <ResourceDetailPanel
+          resource={selected}
+          onSelect={setSelectedId}
+          onClose={() => setSelectedId(null)}
+          className="flex-1 min-w-0"
+        />
       </div>
     )
   } else {

--- a/dashboard/src/components/monitoring/catalog/ResourceDetailPanel.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceDetailPanel.tsx
@@ -32,10 +32,12 @@ import {
   ExternalLink,
   GitBranch,
   Hash,
+  HardDrive,
   LayoutDashboard,
   Lightbulb,
   MapPin,
   MemoryStick,
+  Network,
   Plus,
   ScrollText,
   Share2,
@@ -53,7 +55,9 @@ import {Button} from '@/components/ui/button'
 import {EmptyState} from '@/components/ui/empty-state'
 import {StatusDot, type StatusTone} from '@/components/ui/status-dot'
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
+import {useTimezone} from '@/hooks/useTimezone'
 import {HealthBadge, KindIcon, Meter, TagChip, VulnBar} from './CatalogPrimitives'
+import {MetricChart, type MetricChartProps} from './CatalogCharts'
 import {
   CHANGE_ICON,
   CHANGE_TONE,
@@ -70,11 +74,13 @@ import {
   formatPct,
   formatUsd,
   formatUsdExact,
+  hostInfraSample,
   mockFindings,
   relTime,
   sparkline,
   totalVulns,
   utilTone,
+  type HostInfraSample,
   type Relationship,
   type Resource,
 } from './resourceCatalogData'
@@ -174,79 +180,263 @@ function MetricTile({
   )
 }
 
-function metricNumber(value: number | null | undefined): string {
-  return value === null || value === undefined ? 'No data' : String(value)
+// ── Over-time charts ─────────────────────────────────────────────────────────
+// Each metric defines a reusable chart spec (everything but the time range and
+// sizing), so the Overview highlights and the full Telemetry grid stay in sync.
+
+type MetricChartSpec = Pick<
+  MetricChartProps,
+  'title' | 'subtitle' | 'icon' | 'iconClass' | 'seed' | 'series' | 'yDomain' | 'formatValue' | 'formatYTick' | 'noData'
+>
+
+const PCT_DOMAIN = [0, 100] as const
+const formatPercentValue = (value: number) => `${value.toFixed(1)}%`
+const formatPercentTick = (value: number) => `${Math.round(value)}`
+const formatMsValue = (value: number) => `${Math.round(value)} ms`
+const formatRoundTick = (value: number) => `${Math.round(value)}`
+const formatLoadValue = (value: number) => value.toFixed(2)
+
+function formatBytesShort(bytes: number): string {
+  if (bytes <= 0) return '0'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)))
+  return `${(bytes / 1024 ** i).toFixed(i === 0 ? 0 : 1)}${units[i]}`
+}
+const formatBytesRate = (value: number) => `${formatBytesShort(value)}/s`
+
+function cpuChartSpec(resource: Resource): MetricChartSpec {
+  return {
+    title: 'CPU utilization',
+    subtitle: 'Percentage',
+    icon: Cpu,
+    iconClass: 'text-chart-1',
+    seed: `${resource.id}-cpu`,
+    yDomain: PCT_DOMAIN,
+    formatValue: formatPercentValue,
+    formatYTick: formatPercentTick,
+    noData: resource.telemetry.cpuPct === null,
+    series: [{key: 'CPU', current: resource.telemetry.cpuPct ?? 0, max: 100}],
+  }
 }
 
-function metricUnit(value: number | null | undefined, unit: string): string | undefined {
-  return value === null || value === undefined ? undefined : unit
+function memChartSpec(resource: Resource): MetricChartSpec {
+  return {
+    title: 'Memory utilization',
+    subtitle: 'Percentage',
+    icon: MemoryStick,
+    iconClass: 'text-chart-2',
+    seed: `${resource.id}-mem`,
+    yDomain: PCT_DOMAIN,
+    formatValue: formatPercentValue,
+    formatYTick: formatPercentTick,
+    noData: resource.telemetry.memPct === null,
+    series: [{key: 'Memory', current: resource.telemetry.memPct ?? 0, max: 100}],
+  }
 }
 
-function OverviewTab({resource}: {readonly resource: Resource}) {
+function diskChartSpec(resource: Resource, infra: HostInfraSample): MetricChartSpec {
+  return {
+    title: 'Disk usage',
+    subtitle: 'Percentage',
+    icon: HardDrive,
+    iconClass: 'text-chart-3',
+    seed: `${resource.id}-disk`,
+    yDomain: PCT_DOMAIN,
+    formatValue: formatPercentValue,
+    formatYTick: formatPercentTick,
+    series: [{key: 'Disk', current: infra.diskPct, max: 100, spread: 0.12}],
+  }
+}
+
+function loadChartSpec(resource: Resource, infra: HostInfraSample): MetricChartSpec {
+  return {
+    title: 'Load average',
+    subtitle: '1m · 5m · 15m',
+    icon: Activity,
+    iconClass: 'text-chart-4',
+    seed: `${resource.id}-load`,
+    formatValue: formatLoadValue,
+    series: [
+      {key: '1 min', current: infra.load1},
+      {key: '5 min', current: infra.load5, spread: 0.25},
+      {key: '15 min', current: infra.load15, spread: 0.18},
+    ],
+  }
+}
+
+function networkChartSpec(resource: Resource, infra: HostInfraSample): MetricChartSpec {
+  return {
+    title: 'Network throughput',
+    subtitle: 'Received · sent',
+    icon: Network,
+    iconClass: 'text-chart-2',
+    seed: `${resource.id}-net`,
+    formatValue: formatBytesRate,
+    formatYTick: formatBytesShort,
+    series: [
+      {key: 'Received', current: infra.netRecvBytes},
+      {key: 'Sent', current: infra.netSentBytes, spread: 0.5},
+    ],
+  }
+}
+
+function latencyChartSpec(resource: Resource): MetricChartSpec {
+  return {
+    title: 'p99 latency',
+    subtitle: 'Milliseconds',
+    icon: Activity,
+    iconClass: 'text-chart-5',
+    seed: `${resource.id}-latency`,
+    formatValue: formatMsValue,
+    formatYTick: formatRoundTick,
+    series: [{key: 'p99', current: resource.telemetry.latencyMs ?? 0}],
+  }
+}
+
+function errorChartSpec(resource: Resource): MetricChartSpec {
+  return {
+    title: 'Error rate',
+    subtitle: 'Percentage',
+    icon: AlertTriangle,
+    iconClass: 'text-danger-fg',
+    seed: `${resource.id}-error`,
+    formatValue: formatPercentValue,
+    formatYTick: formatPercentTick,
+    series: [{key: 'Errors', current: resource.telemetry.errorRatePct ?? 0}],
+  }
+}
+
+/** All charts a resource can show — only metrics that actually have a value. */
+function buildTelemetryCharts(resource: Resource, infra: HostInfraSample | null): MetricChartSpec[] {
   const t = resource.telemetry
+  const specs: MetricChartSpec[] = []
+  if (t.cpuPct !== null) specs.push(cpuChartSpec(resource))
+  if (t.memPct !== null) specs.push(memChartSpec(resource))
+  if (infra) specs.push(diskChartSpec(resource, infra), loadChartSpec(resource, infra), networkChartSpec(resource, infra))
+  if (t.latencyMs !== undefined) specs.push(latencyChartSpec(resource))
+  if (t.errorRatePct !== undefined) specs.push(errorChartSpec(resource))
+  return specs
+}
+
+/**
+ * Overview trends: CPU and Memory always lead (shown as "No data" when a resource
+ * reports no infra metrics), then p99 latency / error rate when present.
+ */
+function buildOverviewCharts(resource: Resource): MetricChartSpec[] {
+  const t = resource.telemetry
+  const specs: MetricChartSpec[] = [cpuChartSpec(resource), memChartSpec(resource)]
+  if (t.latencyMs !== undefined) specs.push(latencyChartSpec(resource))
+  if (t.errorRatePct !== undefined) specs.push(errorChartSpec(resource))
+  return specs
+}
+
+const TELEMETRY_RANGES = [
+  {value: '1h', label: '1h', seconds: 3600},
+  {value: '6h', label: '6h', seconds: 21600},
+  {value: '24h', label: '24h', seconds: 86400},
+  {value: '7d', label: '7d', seconds: 604800},
+  {value: '30d', label: '30d', seconds: 2592000},
+] as const
+type TelemetryRange = (typeof TELEMETRY_RANGES)[number]['value']
+
+function RangeToggle({value, onChange}: {readonly value: TelemetryRange; readonly onChange: (value: TelemetryRange) => void}) {
+  return (
+    <div className="inline-flex items-center gap-0.5 rounded-md border bg-background p-0.5">
+      {TELEMETRY_RANGES.map((range) => (
+        <button
+          key={range.value}
+          type="button"
+          onClick={() => onChange(range.value)}
+          aria-pressed={value === range.value}
+          className={cn(
+            'rounded px-2 py-0.5 text-[11px] font-medium transition-colors',
+            value === range.value ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {range.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function OverviewTab({resource, timezone}: {readonly resource: Resource; readonly timezone: string}) {
+  const t = resource.telemetry
+  const [range, setRange] = useState<TelemetryRange>('24h')
+  const infra = hostInfraSample(resource)
+  const charts = buildOverviewCharts(resource)
+  const rangeSeconds = TELEMETRY_RANGES.find((option) => option.value === range)?.seconds ?? 86_400
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-2 gap-2">
-        <MetricTile
-          label="CPU"
-          value={metricNumber(t.cpuPct)}
-          unit={metricUnit(t.cpuPct, '%')}
-          icon={Cpu}
-          pct={t.cpuPct ?? undefined}
-          tone={t.cpuPct == null ? 'neutral' : utilTone(t.cpuPct)}
-        />
-        <MetricTile
-          label="Memory"
-          value={metricNumber(t.memPct)}
-          unit={metricUnit(t.memPct, '%')}
-          icon={MemoryStick}
-          pct={t.memPct ?? undefined}
-          tone={t.memPct == null ? 'neutral' : utilTone(t.memPct)}
-        />
-        {t.latencyMs !== undefined && (
-          <MetricTile label="p99 latency" value={`${t.latencyMs}`} unit="ms" icon={Activity} tone="info" />
-        )}
-        {t.errorRatePct !== undefined && (
-          <MetricTile
-            label="Error rate"
-            value={`${t.errorRatePct}`}
-            unit="%"
-            icon={AlertTriangle}
-            tone={errorRateTone(t.errorRatePct)}
+      {(infra || t.latencyMs !== undefined || t.errorRatePct !== undefined) && (
+        <div className="grid grid-cols-2 gap-2">
+          {infra ? (
+            <>
+              <MetricTile label="Disk" value={`${infra.diskPct}`} unit="%" icon={HardDrive} pct={infra.diskPct} tone={utilTone(infra.diskPct)} />
+              <MetricTile label="Load (1m)" value={infra.load1.toFixed(2)} icon={Activity} tone="info" />
+            </>
+          ) : (
+            <>
+              {t.latencyMs !== undefined && (
+                <MetricTile label="p99 latency" value={`${t.latencyMs}`} unit="ms" icon={Activity} tone="info" />
+              )}
+              {t.errorRatePct !== undefined && (
+                <MetricTile
+                  label="Error rate"
+                  value={`${t.errorRatePct}`}
+                  unit="%"
+                  icon={AlertTriangle}
+                  tone={errorRateTone(t.errorRatePct)}
+                />
+              )}
+            </>
+          )}
+        </div>
+      )}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Performance</span>
+          <RangeToggle value={range} onChange={setRange} />
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {charts.map((spec) => (
+            <MetricChart key={spec.title} {...spec} rangeSeconds={rangeSeconds} timezone={timezone} height={150} />
+          ))}
+        </div>
+      </div>
+      <div className={cn('grid gap-3', resource.metadata.length > 0 && 'lg:grid-cols-2')}>
+        <PanelSection title="Identity">
+          <FieldRow label="Type" value={KIND_META[resource.kind].label} />
+          <FieldRow
+            label="Environment"
+            value={
+              <Badge variant={ENV_BADGE[resource.environment]} className="px-1.5 py-0 text-[10px] leading-4">
+                {ENV_LABEL[resource.environment]}
+              </Badge>
+            }
           />
+          <FieldRow
+            label="Region"
+            value={
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-3 w-3 text-muted-foreground" />
+                {resource.region}
+              </span>
+            }
+          />
+          <FieldRow label="Provider" value={CLOUD_LABEL[resource.cloud]} />
+          <FieldRow label="Owner" value={resource.owner ? resource.owner.team : <span className="text-warning-fg">Unowned</span>} />
+          <FieldRow label="First seen" value={relTime(resource.firstSeen)} />
+          <FieldRow label="Last change" value={relTime(resource.lastChange)} />
+        </PanelSection>
+        {resource.metadata.length > 0 && (
+          <PanelSection title="Metadata">
+            {resource.metadata.map((m) => (
+              <FieldRow key={m.label} label={m.label} value={m.value} />
+            ))}
+          </PanelSection>
         )}
       </div>
-      <PanelSection title="Identity">
-        <FieldRow label="Type" value={KIND_META[resource.kind].label} />
-        <FieldRow
-          label="Environment"
-          value={
-            <Badge variant={ENV_BADGE[resource.environment]} className="px-1.5 py-0 text-[10px] leading-4">
-              {ENV_LABEL[resource.environment]}
-            </Badge>
-          }
-        />
-        <FieldRow
-          label="Region"
-          value={
-            <span className="inline-flex items-center gap-1">
-              <MapPin className="h-3 w-3 text-muted-foreground" />
-              {resource.region}
-            </span>
-          }
-        />
-        <FieldRow label="Provider" value={CLOUD_LABEL[resource.cloud]} />
-        <FieldRow label="Owner" value={resource.owner ? resource.owner.team : <span className="text-warning-fg">Unowned</span>} />
-        <FieldRow label="First seen" value={relTime(resource.firstSeen)} />
-        <FieldRow label="Last change" value={relTime(resource.lastChange)} />
-      </PanelSection>
-      {resource.metadata.length > 0 && (
-        <PanelSection title="Metadata">
-          {resource.metadata.map((m) => (
-            <FieldRow key={m.label} label={m.label} value={m.value} />
-          ))}
-        </PanelSection>
-      )}
       {resource.tags.length > 0 && (
         <PanelSection title="Tags">
           <div className="flex flex-wrap gap-1">
@@ -260,51 +450,18 @@ function OverviewTab({resource}: {readonly resource: Resource}) {
   )
 }
 
-function TelemetryChart({
-  label,
-  suffix,
-  current,
-  tone,
-}: {
-  readonly label: string
-  readonly suffix: string
-  readonly current: number | string | null | undefined
-  readonly tone: StatusTone
-}) {
-  const hasValue = current !== null && current !== undefined && current !== ''
-  return (
-    <div className="rounded-md border border-border/70 bg-background/40 p-3">
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-muted-foreground">{label}</span>
-        <span className={cn('text-sm font-semibold tabular-nums', hasValue ? TONE_TEXT[tone] : 'text-muted-foreground')}>
-          {hasValue ? `${current}${suffix}` : 'No data'}
-        </span>
-      </div>
-      <div className="mt-2 flex h-12 items-center rounded bg-muted/30 px-3 text-xs text-muted-foreground">
-        {hasValue ? 'Current sample only' : 'No samples received'}
-      </div>
-    </div>
-  )
-}
-
-function hasTelemetryValue(value: number | string | null | undefined): boolean {
-  return value !== null && value !== undefined && value !== ''
-}
-
-function TelemetryTab({resource}: {readonly resource: Resource}) {
+function TelemetryTab({resource, timezone}: {readonly resource: Resource; readonly timezone: string}) {
   const t = resource.telemetry
+  const [range, setRange] = useState<TelemetryRange>('24h')
+  const rangeSeconds = TELEMETRY_RANGES.find((option) => option.value === range)?.seconds ?? 86_400
   const metricsHostId = getMetricsHostId(resource)
-  const hasAnyTelemetry = [
-    t.cpuPct,
-    t.memPct,
-    t.latencyMs,
-    t.errorRatePct,
-    t.throughput,
-  ].some(hasTelemetryValue)
+  const infra = hostInfraSample(resource)
+  const charts = buildTelemetryCharts(resource, infra)
+  const hasAnyTelemetry = charts.length > 0 || t.throughput !== undefined
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-muted-foreground">Last 1 hour · 1m resolution</p>
+      <div className="flex items-center justify-between gap-2">
+        <RangeToggle value={range} onChange={setRange} />
         {metricsHostId && (
           <Button type="button" variant="ghost" size="sm" className="h-7 gap-1 text-xs" asChild>
             <Link to="/monitoring/hosts/$hostId" params={{hostId: metricsHostId}}>
@@ -314,34 +471,23 @@ function TelemetryTab({resource}: {readonly resource: Resource}) {
         )}
       </div>
       {hasAnyTelemetry ? (
-        <div className="grid grid-cols-1 gap-2">
-          <TelemetryChart
-            label="CPU utilization"
-            suffix="%"
-            current={t.cpuPct}
-            tone={t.cpuPct == null ? 'neutral' : utilTone(t.cpuPct)}
-          />
-          <TelemetryChart
-            label="Memory utilization"
-            suffix="%"
-            current={t.memPct}
-            tone={t.memPct == null ? 'neutral' : utilTone(t.memPct)}
-          />
-          {t.latencyMs !== undefined && (
-            <TelemetryChart label="p99 latency" suffix=" ms" current={t.latencyMs} tone="info" />
-          )}
-          {t.errorRatePct !== undefined && (
-            <TelemetryChart
-              label="Error rate"
-              suffix="%"
-              current={t.errorRatePct}
-              tone={t.errorRatePct >= 2 ? 'danger' : 'warning'}
-            />
+        <>
+          {charts.length > 0 && (
+            <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+              {charts.map((spec) => (
+                <MetricChart key={spec.title} {...spec} rangeSeconds={rangeSeconds} timezone={timezone} />
+              ))}
+            </div>
           )}
           {t.throughput !== undefined && (
-            <TelemetryChart label="Throughput" suffix="" current={t.throughput} tone="accent" />
+            <div className="flex items-center justify-between rounded-md border border-border/70 bg-background/40 px-3 py-2.5">
+              <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Activity className="h-3.5 w-3.5" /> Throughput
+              </span>
+              <span className="text-sm font-semibold tabular-nums">{t.throughput}</span>
+            </div>
           )}
-        </div>
+        </>
       ) : (
         <EmptyState
           icon={Activity}
@@ -670,6 +816,7 @@ export interface ResourceDetailPanelProps {
 /** Tabbed detail panel for a single resource — shared by the catalog and map. */
 export function ResourceDetailPanel({resource, onSelect, onClose, className}: ResourceDetailPanelProps) {
   const [tab, setTab] = useState<DetailTab>('overview')
+  const {timezone} = useTimezone()
   return (
     <section className={cn('flex h-full min-h-0 flex-col overflow-hidden rounded-lg border bg-card', className)}>
       <header className="border-b px-3 py-2.5">
@@ -718,10 +865,10 @@ export function ResourceDetailPanel({resource, onSelect, onClose, className}: Re
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto p-3">
           <TabsContent value="overview" className="mt-0">
-            <OverviewTab resource={resource} />
+            <OverviewTab resource={resource} timezone={timezone} />
           </TabsContent>
           <TabsContent value="telemetry" className="mt-0">
-            <TelemetryTab resource={resource} />
+            <TelemetryTab resource={resource} timezone={timezone} />
           </TabsContent>
           <TabsContent value="relationships" className="mt-0">
             <RelationshipsTab resource={resource} onSelect={onSelect} />

--- a/dashboard/src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx
+++ b/dashboard/src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx
@@ -10,11 +10,33 @@ import {MOCK_RESOURCES, type Resource} from '../resourceCatalogData'
 
 const mockApi = vi.hoisted(() => ({
   get: vi.fn(),
+  isAuthenticated: vi.fn(() => false),
+  getCurrentUser: vi.fn(),
 }))
 
 vi.mock('@/lib/api', () => ({
   api: mockApi,
 }))
+
+// Telemetry charts render through recharts' ResponsiveContainer, which needs a
+// ResizeObserver this jsdom env does not provide. Stub the chart parts (chart
+// titles render outside them, so the assertions below still hold).
+vi.mock('recharts', () => {
+  const Pass = ({children}: {readonly children?: ReactNode}) => <div>{children}</div>
+  const Nothing = () => null
+  return {
+    Area: Nothing,
+    AreaChart: Pass,
+    CartesianGrid: Nothing,
+    Legend: Nothing,
+    Line: Nothing,
+    LineChart: Pass,
+    ResponsiveContainer: Pass,
+    Tooltip: Nothing,
+    XAxis: Nothing,
+    YAxis: Nothing,
+  }
+})
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()

--- a/dashboard/src/components/monitoring/catalog/resourceCatalogData.ts
+++ b/dashboard/src/components/monitoring/catalog/resourceCatalogData.ts
@@ -228,6 +228,61 @@ export function sparkline(seed: string, points = 18, base = 50, amplitude = 26):
   return out
 }
 
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/**
+ * Deterministic sample history for one metric. Values wander within a band around
+ * `current` and the final point is pinned to `current`, so an over-time chart always
+ * agrees with the headline number. Stable for a given seed — the catalog renders
+ * sample telemetry until live metric series are wired into these surfaces.
+ */
+export function metricSeriesValues(
+  seed: string,
+  current: number,
+  points: number,
+  options?: {readonly spread?: number; readonly min?: number; readonly max?: number},
+): number[] {
+  const spread = options?.spread ?? 0.4
+  const min = options?.min ?? 0
+  const max = options?.max ?? Number.POSITIVE_INFINITY
+  const shape = sparkline(seed, points, 50, 26)
+  const values = shape.map((point) => clampNumber(current * (1 + ((point - 50) / 50) * spread), min, max))
+  if (values.length > 0) values[values.length - 1] = clampNumber(current, min, max)
+  return values
+}
+
+export interface HostInfraSample {
+  readonly cores: number
+  readonly diskPct: number
+  readonly load1: number
+  readonly load5: number
+  readonly load15: number
+  readonly netRecvBytes: number
+  readonly netSentBytes: number
+}
+
+/**
+ * Synthesize current host infrastructure metrics (disk, load average, network
+ * throughput) derived deterministically from the host id and its CPU sample. These
+ * mirror the graphs the old per-host page exposed. Returns null for non-hosts and
+ * for hosts with no CPU signal (nothing to anchor to). Sample data only.
+ */
+export function hostInfraSample(resource: Resource): HostInfraSample | null {
+  const cpu = resource.telemetry.cpuPct
+  if (resource.kind !== 'host' || cpu === null) return null
+  const frac = (salt: string) => (hashSeed(`${resource.id}:${salt}`) % 1000) / 1000
+  const cores = [2, 4, 8, 16][Math.floor(frac('cores') * 4)]
+  const load1 = Math.round((cpu / 100) * cores * (0.7 + frac('l1') * 0.7) * 100) / 100
+  const load5 = Math.round(load1 * (0.82 + frac('l5') * 0.22) * 100) / 100
+  const load15 = Math.round(load5 * (0.8 + frac('l15') * 0.2) * 100) / 100
+  const diskPct = Math.round(clampNumber(40 + frac('disk') * 52, 6, 96))
+  const netRecvBytes = Math.round((2 + frac('rx') * 30) * 1024 * 1024)
+  const netSentBytes = Math.round((1 + frac('tx') * 12) * 1024 * 1024)
+  return {cores, diskPct, load1, load5, load15, netRecvBytes, netSentBytes}
+}
+
 export function totalVulns(v: VulnCounts): number {
   return v.critical + v.high + v.medium + v.low
 }

--- a/dashboard/src/routes/monitoring.tsx
+++ b/dashboard/src/routes/monitoring.tsx
@@ -15,228 +15,10 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {createFileRoute, Link, Outlet, redirect, useRouterState} from '@tanstack/react-router'
-import {useEffect, useRef, useState, type ComponentType} from 'react'
+import {ArrowLeft} from 'lucide-react'
 import {api} from '@/lib/api'
-import {useEnterpriseFeatures, hasEnterpriseModule} from '@/hooks/useEnterpriseFeatures'
-import {
-    ArrowLeft,
-    Boxes,
-    Bug,
-    CalendarClock,
-    Database,
-    HelpCircle,
-    MoreHorizontal,
-    Network,
-    Package,
-    Router,
-    Ship,
-    Terminal,
-    Map as MapIcon,
-} from 'lucide-react'
-import {cn} from '@/lib/utils'
 import {Button} from '@/components/ui/button'
-import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu'
-import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip'
-
-type MonitoringTab = Readonly<{
-  id: string
-  label: string
-  href: string
-  icon: ComponentType<{className?: string}>
-  requiresDatadog?: boolean
-}>
-
-type MonitoringTabNavProps = Readonly<{
-  tabs: readonly MonitoringTab[]
-  currentPath: string
-}>
-
-type VisibleTabCountOptions = Readonly<{
-  availableWidth: number
-  tabCount: number
-  itemRefs: readonly (HTMLSpanElement | null)[]
-  moreWidth?: number
-}>
-
-const TAB_BASE_CLASS = 'flex h-8 items-center gap-1.5 whitespace-nowrap px-2.5 text-xs font-medium'
-const OVERFLOW_FALLBACK_WIDTH = 80
-
-function isTabActive(tab: MonitoringTab, currentPath: string): boolean {
-  if (tab.href === '/monitoring') {
-    return currentPath === '/monitoring' || currentPath === '/monitoring/'
-  }
-  return currentPath.startsWith(tab.href)
-}
-
-function computeVisibleTabCount({
-  availableWidth,
-  tabCount,
-  itemRefs,
-  moreWidth = OVERFLOW_FALLBACK_WIDTH,
-}: VisibleTabCountOptions): number {
-  if (availableWidth === 0) return tabCount
-
-  let usedWidth = 0
-  for (let index = 0; index < tabCount; index += 1) {
-    const width = itemRefs[index]?.offsetWidth ?? 0
-    const reserveForMore = index < tabCount - 1 ? moreWidth : 0
-    if (usedWidth + width + reserveForMore > availableWidth) {
-      return Math.min(tabCount, Math.max(1, index))
-    }
-    usedWidth += width
-  }
-
-  return tabCount
-}
-
-function createResizeObserver(onResize: () => void): ResizeObserver | null {
-  if (globalThis.ResizeObserver === undefined) return null
-  return new globalThis.ResizeObserver(onResize)
-}
-
-function useVisibleMonitoringTabs(tabs: readonly MonitoringTab[]) {
-  const navRef = useRef<HTMLElement>(null)
-  const itemRefs = useRef<Array<HTMLSpanElement | null>>([])
-  const moreRef = useRef<HTMLSpanElement | null>(null)
-  const [visibleCount, setVisibleCount] = useState(tabs.length)
-
-  useEffect(() => {
-    const nav = navRef.current
-    if (nav === null) return undefined
-
-    const recompute = () => {
-      setVisibleCount(
-        computeVisibleTabCount({
-          availableWidth: nav.clientWidth,
-          tabCount: tabs.length,
-          itemRefs: itemRefs.current,
-          moreWidth: moreRef.current?.offsetWidth,
-        }),
-      )
-    }
-
-    recompute()
-    const observer = createResizeObserver(recompute)
-    observer?.observe(nav)
-    return () => observer?.disconnect()
-  }, [tabs])
-
-  return {
-    navRef,
-    itemRefs,
-    moreRef,
-    visibleTabs: tabs.slice(0, visibleCount),
-    overflowTabs: tabs.slice(visibleCount),
-  }
-}
-
-function MonitoringTabNav({tabs, currentPath}: MonitoringTabNavProps) {
-  const {navRef, itemRefs, moreRef, visibleTabs, overflowTabs} = useVisibleMonitoringTabs(tabs)
-  const overflowHasActive = overflowTabs.some((tab) => isTabActive(tab, currentPath))
-
-  return (
-    <div className="relative min-w-0 flex-1 overflow-hidden">
-      <div aria-hidden className="pointer-events-none invisible absolute left-0 top-0 flex gap-0.5">
-        {tabs.map((tab, index) => {
-          const Icon = tab.icon
-          return (
-            <span
-              key={tab.id}
-              ref={(element) => {
-                itemRefs.current[index] = element
-              }}
-              className={TAB_BASE_CLASS}
-            >
-              <Icon className="h-3.5 w-3.5 shrink-0" />
-              {tab.label}
-            </span>
-          )
-        })}
-        <span ref={moreRef} className={TAB_BASE_CLASS}>
-          <MoreHorizontal className="h-3.5 w-3.5 shrink-0" />
-          More
-        </span>
-      </div>
-
-      <nav ref={navRef} className="flex w-full items-stretch gap-0.5 overflow-hidden" aria-label="Monitoring tabs">
-        {visibleTabs.map((tab) => (
-          <MonitoringTabLink key={tab.id} tab={tab} currentPath={currentPath} />
-        ))}
-        {overflowTabs.length > 0 && (
-          <MonitoringOverflowMenu tabs={overflowTabs} currentPath={currentPath} hasActiveTab={overflowHasActive} />
-        )}
-      </nav>
-    </div>
-  )
-}
-
-type MonitoringTabLinkProps = Readonly<{
-  tab: MonitoringTab
-  currentPath: string
-}>
-
-function MonitoringTabLink({tab, currentPath}: MonitoringTabLinkProps) {
-  const Icon = tab.icon
-  const active = isTabActive(tab, currentPath)
-
-  return (
-    <Link
-      to={tab.href}
-      className={cn(
-        TAB_BASE_CLASS,
-        'border-b-2 transition-colors',
-        active ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground',
-      )}
-    >
-      <Icon className="h-3.5 w-3.5 shrink-0" />
-      {tab.label}
-    </Link>
-  )
-}
-
-type MonitoringOverflowMenuProps = Readonly<{
-  tabs: readonly MonitoringTab[]
-  currentPath: string
-  hasActiveTab: boolean
-}>
-
-function MonitoringOverflowMenu({tabs, currentPath, hasActiveTab}: MonitoringOverflowMenuProps) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            TAB_BASE_CLASS,
-            'border-b-2 transition-colors',
-            hasActiveTab
-              ? 'border-primary text-primary'
-              : 'border-transparent text-muted-foreground hover:text-foreground',
-          )}
-        >
-          <MoreHorizontal className="h-3.5 w-3.5 shrink-0" />
-          More
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-44">
-        {tabs.map((tab) => {
-          const Icon = tab.icon
-          return (
-            <DropdownMenuItem key={tab.id} asChild>
-              <Link
-                to={tab.href}
-                className={cn('flex items-center gap-2 text-xs', isTabActive(tab, currentPath) && 'text-primary')}
-              >
-                <Icon className="h-3.5 w-3.5 shrink-0" />
-                {tab.label}
-              </Link>
-            </DropdownMenuItem>
-          )
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
-}
+import {MonitoringTabBar} from '@/components/monitoring/MonitoringTabBar'
 
 export const Route = createFileRoute('/monitoring')({
   beforeLoad: async () => {
@@ -248,35 +30,6 @@ export const Route = createFileRoute('/monitoring')({
   component: MonitoringLayout,
 })
 
-const TAB_DOCS_URLS: Record<string, string> = {
-  catalog: '/docs/infrastructure-monitoring',
-  hosts: '/docs/datadog-agent/agent-setup',
-  map: '/docs/infrastructure-monitoring',
-  containers: '/docs/datadog-agent/agent-setup',
-  'service-map': '/docs/performance-monitoring#service-map',
-  processes: '/docs/datadog-agent/',
-  network: '/docs/datadog-agent/',
-  events: '/docs/datadog-agent/',
-  kubernetes: '/docs/datadog-agent/kubernetes',
-  databases: '/docs/datadog-agent/database-monitoring',
-  debugger: '/docs/datadog-agent/debugger',
-  'network-devices': '/docs/datadog-agent/network-devices',
-  sbom: '/docs/datadog-agent/sbom',
-}
-
-const allTabs: MonitoringTab[] = [
-  {id: 'catalog', label: 'Resources', href: '/resources', icon: Boxes},
-  {id: 'map', label: 'Map', href: '/monitoring/map', icon: MapIcon},
-  {id: 'processes', label: 'Processes', href: '/monitoring/processes', icon: Terminal, requiresDatadog: true},
-  {id: 'network', label: 'Network', href: '/monitoring/network', icon: Network, requiresDatadog: true},
-  {id: 'events', label: 'Events', href: '/monitoring/events', icon: CalendarClock, requiresDatadog: true},
-  {id: 'kubernetes', label: 'Kubernetes', href: '/monitoring/kubernetes', icon: Ship, requiresDatadog: true},
-  {id: 'databases', label: 'Databases', href: '/monitoring/databases', icon: Database, requiresDatadog: true},
-  {id: 'debugger', label: 'Debugger', href: '/monitoring/debugger', icon: Bug, requiresDatadog: true},
-  {id: 'network-devices', label: 'Network Devices', href: '/monitoring/network-devices', icon: Router, requiresDatadog: true},
-  {id: 'sbom', label: 'SBOM', href: '/monitoring/sbom', icon: Package, requiresDatadog: true},
-]
-
 const KNOWN_TAB_PATHS = [
   'hosts', 'map', 'containers', 'processes', 'network', 'events',
   'kubernetes', 'databases', 'debugger', 'network-devices', 'service-map', 'sbom',
@@ -285,16 +38,12 @@ const KNOWN_TAB_PATHS = [
 function MonitoringLayout() {
   const router = useRouterState()
   const currentPath = router.location.pathname
-  const {data: features} = useEnterpriseFeatures()
 
   const pathParts = currentPath.replace(/^\/monitoring\/?/, '').split('/').filter(Boolean)
   const isHostDetailPage =
     pathParts.length >= 2 && pathParts[0] === 'hosts' && !KNOWN_TAB_PATHS.includes(pathParts[1])
   const isSystemDetailPage =
     pathParts.length === 1 && !KNOWN_TAB_PATHS.includes(pathParts[0])
-  const tabs = allTabs.filter(
-    (tab) => !tab.requiresDatadog || hasEnterpriseModule(features, 'datadog')
-  )
 
   if (isHostDetailPage) {
     return <Outlet />
@@ -317,42 +66,9 @@ function MonitoringLayout() {
     )
   }
 
-  const activeTabId = tabs.find((t) =>
-    t.href === '/monitoring'
-      ? currentPath === '/monitoring' || currentPath === '/monitoring/'
-      : currentPath.startsWith(t.href)
-  )?.id
-  const docsUrl = activeTabId ? TAB_DOCS_URLS[activeTabId] : null
-
   return (
     <div>
-      <div className="border-b bg-card/50">
-        <div className="flex h-[42px] items-end gap-2 px-4">
-          <MonitoringTabNav tabs={tabs} currentPath={currentPath} />
-          <div className="flex shrink-0 items-center gap-2 self-center">
-            {docsUrl ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <a
-                      href={docsUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                      aria-label="View docs"
-                    >
-                      <HelpCircle className="h-4 w-4" />
-                    </a>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>View docs</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : null}
-          </div>
-        </div>
-      </div>
+      <MonitoringTabBar />
       <Outlet />
     </div>
   )

--- a/dashboard/src/routes/resources.tsx
+++ b/dashboard/src/routes/resources.tsx
@@ -16,7 +16,20 @@
 
 import {createFileRoute, redirect} from '@tanstack/react-router'
 import {api} from '@/lib/api'
+import {MonitoringTabBar} from '@/components/monitoring/MonitoringTabBar'
 import {ResourceCatalog} from '@/components/monitoring/catalog/ResourceCatalog'
+
+// /resources sits outside the /monitoring layout, so it renders the shared
+// Infrastructure tab strip itself to stay in step with Map, Processes, etc.
+// The catalog already reserves the bar's 43px in its viewport height calc.
+function ResourcesPage() {
+  return (
+    <>
+      <MonitoringTabBar />
+      <ResourceCatalog />
+    </>
+  )
+}
 
 export const Route = createFileRoute('/resources')({
   beforeLoad: async () => {
@@ -25,5 +38,5 @@ export const Route = createFileRoute('/resources')({
       if (!hasSession) throw redirect({to: '/login'})
     }
   },
-  component: ResourceCatalog,
+  component: ResourcesPage,
 })


### PR DESCRIPTION
## Summary
- repair resources catalog navigation and telemetry detail charts
- seed demo host metrics for resource catalog

## Tests
- npm run test -- ResourceCatalog
- npm run lint
- npm run typecheck
- ./gradlew :test --tests com.moneat.monitor.services.ResourceCatalogServiceTest --tests com.moneat.routes.ResourceCatalogRoutesTest --no-daemon
- ./gradlew detekt --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Infrastructure tab strip with responsive overflow and docs links.
  * Compact over-time resource metric charts and a time-range selector in resource views.
  * Demo mode now seeds per-host latest metrics so demo data shows realistic host telemetry.

* **Improvements**
  * Resource detail panel refreshed for consistent charts, telemetry layout, and performance tiles.
  * Resource list accepts an optional demo snapshot override when resolving metrics.

* **Tests**
  * Chart-related tests adjusted to run in the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->