### PR TITLE
fix: V143 foreign key references services(id), not the projects view

### DIFF
--- a/backend/src/main/resources/db/migration/V143__add_project_debug_files.sql
+++ b/backend/src/main/resources/db/migration/V143__add_project_debug_files.sql
@@ -6,7 +6,9 @@
 CREATE TABLE IF NOT EXISTS project_debug_files (
     id SERIAL PRIMARY KEY,
     resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
-    project_id BIGINT NOT NULL REFERENCES projects(id),
+    -- FK targets the real table `services` (V125 renamed projects -> services and left
+    -- `projects` as a view; a foreign key cannot reference a view).
+    project_id BIGINT NOT NULL REFERENCES services(id) ON DELETE CASCADE,
     debug_id VARCHAR(64),
     checksum VARCHAR(40) NOT NULL,
     file_type VARCHAR(32) NOT NULL DEFAULT 'proguard',


### PR DESCRIPTION
## Problem

The `v2.0.0-beta.5` production deploy failed at app startup. `V143` (merged in #648) runs `REFERENCES projects(id)`, but `V125__rename_projects_to_services.sql` renamed the `projects` table to `services` and replaced `projects` with a **view**. A foreign key can't reference a view, so Flyway aborted (`ERROR: referenced relation "projects" is not a table`) and the blue/green deploy rolled back to the previous version (no outage).

## Fix

`V143` now references **`services(id)`** (the real table; its PK was preserved as `services_pkey` in V125) with `ON DELETE CASCADE`.

Editing `V143` in place is safe: it never applied successfully anywhere — it fails on every post-V125 database — so no Flyway checksum is recorded for it. Tests are unaffected because they build the H2 schema from the Exposed model (Flyway doesn't run under H2), which is why this slipped through originally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to maintain referential integrity following internal restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->