### PR TITLE
fix: COPY new backend feature modules into the Docker build stage

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,9 +18,17 @@ COPY ee/backend/build.gradle.kts \
      ee/backend/detekt-format.yml \
      ee/backend/license-header.txt \
      /ee/backend/
+# settings.gradle.kts also includes :feature-spi, :ingest-common and :features:datadog;
+# their project directories must exist before Gradle configures the build.
+COPY backend/feature-spi/build.gradle.kts ./feature-spi/
+COPY backend/ingest-common/build.gradle.kts ./ingest-common/
+COPY backend/features/datadog/build.gradle.kts ./features/datadog/
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle dependencies --no-daemon --build-cache || true
 COPY backend/src ./src
+COPY backend/feature-spi/src ./feature-spi/src
+COPY backend/ingest-common/src ./ingest-common/src
+COPY backend/features/datadog/src ./features/datadog/src
 # Copy built email templates from email-builder stage into src so they're processed as resources
 COPY --from=email-builder /emails/build/templates/email ./src/main/resources/email-templates/
 # Copy enterprise (ee/) backend sources


### PR DESCRIPTION
## Problem

The backend image build (`gradle shadowJar` in `backend/Dockerfile`) fails on `develop`:

```
> Make sure the project directory exists and is writable.
> ...multi_project_builds.html#include_existing_projects_only
```

#649 added `:feature-spi`, `:ingest-common`, and `:features:datadog` to `backend/settings.gradle.kts`, but the Dockerfile was not updated to COPY those module directories into the build stage. Gradle configures all included projects, so `shadowJar` aborts when those directories are absent.

This passes PR CI (which runs Gradle on the full checkout where the directories exist) and only fails in the **image build**, which runs on tag push — so it blocks **every** release/beta off `develop`. It surfaced while cutting `v2.0.0-beta.6`.

## Fix

COPY each new module's `build.gradle.kts` (before `gradle dependencies`, so the project directories exist at configuration time) and `src` (before `shadowJar`), mirroring the existing `:ee` and `backend/src` handling.

Validated by construction against the `settings.gradle.kts` project paths (`/app/feature-spi`, `/app/ingest-common`, `/app/features/datadog`); the next beta's Release build exercises it end-to-end (no local Docker daemon available to pre-validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
