### PR TITLE
fix: stabilize disk alert evaluation

### DIFF
--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -76,6 +76,16 @@ private val logger = KotlinLogging.logger {}
 
 private const val CURRENT_METRIC_LOOKBACK_MINUTES = 10
 private const val EMAIL_FRONTEND_URL_CONFIG = "email.frontendUrl"
+private const val LATEST_METRIC_VALUE_EXPR = "argMax(value, timestamp)"
+private const val DISK_ID_EXPRESSION = """
+    multiIf(
+        tags['device_name'] != '', tags['device_name'],
+        tags['device'] != '', tags['device'],
+        tags['mount_point'] != '', tags['mount_point'],
+        tags['filesystem'] != '', tags['filesystem'],
+        'default'
+    )
+"""
 
 private fun String.escapeHtml(): String =
     replace("&", "&amp;")
@@ -564,43 +574,12 @@ class MonitorAlertService(
     /**
      * Get the current value of a metric for a host from metrics table.
      */
-    private suspend fun getCurrentMetricValue(
+    internal suspend fun getCurrentMetricValue(
         hostId: Int,
         organizationId: Int,
         metric: String
     ): Double? {
-        val (selectExpr, metricFilter) =
-            when (metric) {
-                "cpu_percent" -> "argMax(value, timestamp)" to "metric_name = 'system.cpu.percent'"
-                "mem_percent" ->
-                    "(1 - argMax(CASE WHEN metric_name='system.mem.available' THEN value END, timestamp) / " +
-                        "nullIf(argMax(CASE WHEN metric_name='system.mem.total' THEN value END, timestamp), 0)) * " +
-                        "100" to
-                        "metric_name IN ('system.mem.available','system.mem.total')"
-                "disk_percent" ->
-                    "argMax(CASE WHEN metric_name='system.disk.used' THEN value END, timestamp) / " +
-                        "nullIf(argMax(CASE WHEN metric_name='system.disk.total' THEN value END, timestamp), 0) * " +
-                        "100" to
-                        "metric_name IN ('system.disk.used','system.disk.total')"
-                "load_1" -> "argMax(value, timestamp)" to "metric_name = 'system.load.1'"
-                "load_5" -> "argMax(value, timestamp)" to "metric_name = 'system.load.5'"
-                "load_15" -> "argMax(value, timestamp)" to "metric_name = 'system.load.15'"
-                "temp_max" -> "argMax(value, timestamp)" to "metric_name = 'system.temp.max'"
-                "gpu_percent" -> "argMax(value, timestamp)" to "metric_name = 'system.gpu.percent'"
-                "battery_percent" -> "argMax(value, timestamp)" to "metric_name = 'system.battery.percent'"
-                else -> return null
-            }
-
-        val query =
-            """
-            SELECT $selectExpr as value
-            FROM `$clickhouseDb`.metrics_latest_by_host
-            WHERE organization_id = $organizationId
-              AND host_id = $hostId
-              AND $metricFilter
-              AND timestamp >= now64(3) - INTERVAL $CURRENT_METRIC_LOOKBACK_MINUTES MINUTE
-            FORMAT JSONCompact
-            """.trimIndent()
+        val query = currentMetricValueQuery(hostId, organizationId, metric) ?: return null
 
         return suspendRunCatching {
             val response = ClickHouseClient.execute(query)
@@ -623,6 +602,65 @@ class MonitorAlertService(
             null
         }
     }
+
+    internal fun currentMetricValueQuery(
+        hostId: Int,
+        organizationId: Int,
+        metric: String
+    ): String? {
+        if (metric == "disk_percent") {
+            return diskPercentCurrentMetricQuery(hostId, organizationId)
+        }
+
+        val (selectExpr, metricFilter) =
+            when (metric) {
+                "cpu_percent" -> LATEST_METRIC_VALUE_EXPR to "metric_name = 'system.cpu.percent'"
+                "mem_percent" ->
+                    "(1 - argMaxIf(value, timestamp, metric_name='system.mem.available') / " +
+                        "nullIf(argMaxIf(value, timestamp, metric_name='system.mem.total'), 0)) * " +
+                        "100" to
+                        "metric_name IN ('system.mem.available','system.mem.total')"
+                "load_1" -> LATEST_METRIC_VALUE_EXPR to "metric_name = 'system.load.1'"
+                "load_5" -> LATEST_METRIC_VALUE_EXPR to "metric_name = 'system.load.5'"
+                "load_15" -> LATEST_METRIC_VALUE_EXPR to "metric_name = 'system.load.15'"
+                "temp_max" -> LATEST_METRIC_VALUE_EXPR to "metric_name = 'system.temp.max'"
+                "gpu_percent" -> LATEST_METRIC_VALUE_EXPR to "metric_name = 'system.gpu.percent'"
+                "battery_percent" -> LATEST_METRIC_VALUE_EXPR to "metric_name = 'system.battery.percent'"
+                else -> return null
+            }
+
+        return """
+            SELECT $selectExpr as value
+            FROM `$clickhouseDb`.metrics_latest_by_host
+            WHERE organization_id = $organizationId
+              AND host_id = $hostId
+              AND $metricFilter
+              AND timestamp >= now64(3) - INTERVAL $CURRENT_METRIC_LOOKBACK_MINUTES MINUTE
+            FORMAT JSONCompact
+        """.trimIndent()
+    }
+
+    private fun diskPercentCurrentMetricQuery(
+        hostId: Int,
+        organizationId: Int
+    ): String =
+        """
+        SELECT
+            max(used / nullIf(total, 0) * 100) AS value
+        FROM (
+            SELECT
+                $DISK_ID_EXPRESSION AS disk_identity,
+                argMaxIf(value, timestamp, metric_name = 'system.disk.used') AS used,
+                argMaxIf(value, timestamp, metric_name = 'system.disk.total') AS total
+            FROM `$clickhouseDb`.metrics_latest_by_host
+            WHERE organization_id = $organizationId
+              AND host_id = $hostId
+              AND metric_name IN ('system.disk.used','system.disk.total')
+              AND timestamp >= now64(3) - INTERVAL $CURRENT_METRIC_LOOKBACK_MINUTES MINUTE
+            GROUP BY disk_identity
+        )
+        FORMAT JSONCompact
+        """.trimIndent()
 
     /**
      * Check if the alert condition has been sustained for the required duration.

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -66,6 +66,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -245,7 +246,7 @@ class MonitorAlertServiceCoverageTest {
                 http
             }
 
-            val v = callPrivateSuspend("getCurrentMetricValue", 1, 99, "cpu_percent") as Double?
+            val v = service.getCurrentMetricValue(1, 99, "cpu_percent")
             assertEquals(42.25, v!!, 0.001)
             assertTrue(
                 queries.single().contains("timestamp >= now64(3) - INTERVAL 10 MINUTE")
@@ -255,9 +256,125 @@ class MonitorAlertServiceCoverageTest {
         }
 
     @Test
+    fun `currentMetricValueQuery calculates disk percent per disk identity`() {
+        val query = service.currentMetricValueQuery(153, 1, "disk_percent")
+
+        assertNotNull(query)
+        assertTrue(query.contains("metric_name IN ('system.disk.used','system.disk.total')"))
+        assertTrue(query.contains("GROUP BY disk_identity"))
+        assertTrue(query.contains("tags['device_name']"))
+        assertTrue(query.contains("max(used / nullIf(total, 0) * 100)"))
+        assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.used')"))
+        assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.total')"))
+        assertFalse(query.contains("system.disk.in_use"))
+        assertFalse(query.contains("CASE WHEN metric_name='system.disk.used'"))
+    }
+
+    @Test
+    fun `currentMetricValueQuery calculates memory percent from available and total`() {
+        val query = service.currentMetricValueQuery(153, 1, "mem_percent")
+
+        assertNotNull(query)
+        assertTrue(query.contains("system.mem.available"))
+        assertTrue(query.contains("system.mem.total"))
+        assertTrue(query.contains("argMaxIf(value, timestamp, metric_name='system.mem.available')"))
+    }
+
+    @Test
+    fun `currentMetricValueQuery builds latest value queries for scalar metrics`() {
+        val metrics =
+            mapOf(
+                "cpu_percent" to "system.cpu.percent",
+                "load_1" to "system.load.1",
+                "load_5" to "system.load.5",
+                "load_15" to "system.load.15",
+                "temp_max" to "system.temp.max",
+                "gpu_percent" to "system.gpu.percent",
+                "battery_percent" to "system.battery.percent",
+            )
+
+        metrics.forEach { (metric, metricName) ->
+            val query = service.currentMetricValueQuery(153, 1, metric)
+
+            assertNotNull(query)
+            assertTrue(query.contains("argMax(value, timestamp)"))
+            assertTrue(query.contains("metric_name = '$metricName'"))
+        }
+    }
+
+    @Test
+    fun `getCurrentMetricValue parses disk_percent JSONCompact response`() =
+        runBlocking {
+            val body = """{"data":[["87.5"]]}"""
+            val http = mockk<HttpResponse>()
+            val queries = mutableListOf<String>()
+            every { http.status } returns HttpStatusCode.OK
+            coEvery { http.bodyAsText(any()) } returns body
+            coEvery { ClickHouseClient.execute(any()) } coAnswers {
+                queries.add(firstArg())
+                http
+            }
+
+            val v = service.getCurrentMetricValue(153, 1, "disk_percent")
+
+            assertEquals(87.5, v!!, 0.001)
+            assertFalse(queries.single().contains("system.disk.in_use"))
+            assertTrue(queries.single().contains("GROUP BY disk_identity"))
+            assertTrue(queries.single().contains("max(used / nullIf(total, 0) * 100)"))
+        }
+
+    @Test
+    fun `getCurrentMetricValue returns null for unsuccessful ClickHouse response`() =
+        runBlocking {
+            val http = mockk<HttpResponse>()
+            every { http.status } returns HttpStatusCode.InternalServerError
+            coEvery { ClickHouseClient.execute(any()) } returns http
+
+            val v = service.getCurrentMetricValue(1, 99, "cpu_percent")
+
+            assertNull(v)
+        }
+
+    @Test
+    fun `getCurrentMetricValue returns null when ClickHouse execution fails`() =
+        runBlocking {
+            coEvery { ClickHouseClient.execute(any()) } throws IllegalStateException("boom")
+
+            val v = service.getCurrentMetricValue(1, 99, "cpu_percent")
+
+            assertNull(v)
+        }
+
+    @Test
+    fun `getCurrentMetricValue returns null for blank ClickHouse body`() =
+        runBlocking {
+            val http = mockk<HttpResponse>()
+            every { http.status } returns HttpStatusCode.OK
+            coEvery { http.bodyAsText(any()) } returns ""
+            coEvery { ClickHouseClient.execute(any()) } returns http
+
+            val v = service.getCurrentMetricValue(1, 99, "cpu_percent")
+
+            assertNull(v)
+        }
+
+    @Test
+    fun `getCurrentMetricValue returns null for missing ClickHouse data`() =
+        runBlocking {
+            val http = mockk<HttpResponse>()
+            every { http.status } returns HttpStatusCode.OK
+            coEvery { http.bodyAsText(any()) } returns """{"data":[]}"""
+            coEvery { ClickHouseClient.execute(any()) } returns http
+
+            val v = service.getCurrentMetricValue(1, 99, "cpu_percent")
+
+            assertNull(v)
+        }
+
+    @Test
     fun `getCurrentMetricValue returns null for unknown metric`() =
         runBlocking {
-            val v = callPrivateSuspend("getCurrentMetricValue", 1, 1, "not_a_metric") as Double?
+            val v = service.getCurrentMetricValue(1, 1, "not_a_metric")
             assertNull(v)
         }
 


### PR DESCRIPTION
## Summary
- evaluate disk alerts from per-disk utilization samples
- fall back to per-disk used/total calculation

## Validation
- ./gradlew detekt --no-daemon
- ./gradlew :test --tests com.moneat.services.MonitorAlertServiceCoverageTest -x :ee:test --no-daemon
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized metric retrieval with safer parsing: returns null for non-success, empty, malformed, or error responses.
  * Disk usage now computes percentages per derived disk identity for accurate per-disk reporting.
  * Memory percentage computation updated to use a more robust latest-value selection while preserving semantics.
  * Scalar metrics standardized to use latest-value selection for consistency.

* **Tests**
  * Expanded coverage for disk-percent, mem-percent and scalar query generation, parsing, and negative-paths (non-OK responses, blank/missing data, and execution failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->