### PR TITLE
fix: copy backend feature modules in release image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,17 +18,16 @@ COPY ee/backend/build.gradle.kts \
      ee/backend/detekt-format.yml \
      ee/backend/license-header.txt \
      /ee/backend/
-# settings.gradle.kts also includes :feature-spi, :ingest-common and :features:datadog;
+# settings.gradle.kts also includes :feature-spi, :ingest-common and :features:*;
 # their project directories must exist before Gradle configures the build.
 COPY backend/feature-spi/build.gradle.kts ./feature-spi/
 COPY backend/ingest-common/build.gradle.kts ./ingest-common/
-COPY backend/features/datadog/build.gradle.kts ./features/datadog/
+COPY backend/features ./features
 RUN --mount=type=cache,target=/home/gradle/.gradle \
     gradle dependencies --no-daemon --build-cache || true
 COPY backend/src ./src
 COPY backend/feature-spi/src ./feature-spi/src
 COPY backend/ingest-common/src ./ingest-common/src
-COPY backend/features/datadog/src ./features/datadog/src
 # Copy built email templates from email-builder stage into src so they're processed as resources
 COPY --from=email-builder /emails/build/templates/email ./src/main/resources/email-templates/
 # Copy enterprise (ee/) backend sources


### PR DESCRIPTION
## Summary
- copy the full backend feature-module tree into the backend release Docker build
- keep Gradle release image configuration in sync with all :features:* modules

## Testing
- git diff --check
- verified every :features:* project in backend/settings.gradle.kts has a matching feature directory, build file, and src directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure to improve support for the project's multi-module structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->