### PR TITLE
fix: extend release test timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 


### PR DESCRIPTION
## Summary
- increase the release workflow test job timeout from 15 to 30 minutes
- unblock beta release runs now that the combined backend/frontend release test job exceeds 15 minutes

## Testing
- git diff --check