### PR TITLE
fix: recover redis stream workers

### DIFF
--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
@@ -30,6 +30,7 @@ import io.lettuce.core.XGroupCreateArgs
 import io.lettuce.core.XReadArgs
 import io.lettuce.core.XReadArgs.StreamOffset
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -44,12 +45,92 @@ import java.time.Duration
 
 private const val ERROR_RETRY_DELAY_MS = 1_000L
 private const val REDIS_GROUP_EXISTS = "BUSYGROUP"
+private const val REDIS_GROUP_MISSING = "NOGROUP"
 
 data class QueuedIngestionMessage(
     val id: String?,
     val payload: String,
     val deliveryCount: Long = 1L,
 )
+
+internal object RedisStreamQueueOperations {
+    fun readMessages(
+        redis: RedisCommands<String, String>,
+        spec: IngestionQueueSpec,
+        consumer: Consumer<String>,
+        logger: KLogger,
+    ): List<StreamMessage<String, String>> =
+        try {
+            readMessagesOrThrow(redis, spec, consumer)
+        } catch (e: RedisCommandExecutionException) {
+            if (!isMissingConsumerGroup(e)) throw e
+            ensureConsumerGroup(redis, spec.streamKey, spec.consumerGroup)
+            logger.warn(e) {
+                "Recreated missing Redis stream consumer group ${spec.consumerGroup} for ${spec.streamKey}"
+            }
+            emptyList()
+        }
+
+    fun ensureConsumerGroup(
+        redis: RedisCommands<String, String>,
+        streamKey: String,
+        consumerGroup: String,
+    ) {
+        try {
+            redis.xgroupCreate(
+                StreamOffset.from(streamKey, "0-0"),
+                consumerGroup,
+                XGroupCreateArgs().mkstream(true),
+            )
+        } catch (e: RedisCommandExecutionException) {
+            if (!e.message.orEmpty().contains(REDIS_GROUP_EXISTS, ignoreCase = true)) {
+                throw e
+            }
+        }
+    }
+
+    fun acknowledge(
+        redis: RedisCommands<String, String>,
+        streamKey: String,
+        consumerGroup: String,
+        ids: Array<String>,
+        logger: KLogger,
+    ) {
+        if (ids.isEmpty()) return
+        redis.xack(streamKey, consumerGroup, *ids)
+        runCatching {
+            redis.xdel(streamKey, *ids)
+        }.onFailure { e ->
+            logger.warn(e) { "Failed to delete acknowledged Redis stream entries from $streamKey" }
+        }
+    }
+
+    private fun readMessagesOrThrow(
+        redis: RedisCommands<String, String>,
+        spec: IngestionQueueSpec,
+        consumer: Consumer<String>,
+    ): List<StreamMessage<String, String>> {
+        val claimed = redis.xautoclaim(
+            spec.streamKey,
+            XAutoClaimArgs<String>()
+                .consumer(consumer)
+                .minIdleTime(Duration.ofMillis(spec.claimIdleMs))
+                .startId("0-0")
+                .count(spec.batchSize.toLong())
+        ).messages
+        if (claimed.isNotEmpty()) return claimed
+        return redis.xreadgroup(
+            consumer,
+            XReadArgs()
+                .block(Duration.ofMillis(spec.readTimeoutMs))
+                .count(spec.batchSize.toLong()),
+            StreamOffset.lastConsumed(spec.streamKey),
+        )
+    }
+
+    private fun isMissingConsumerGroup(e: RedisCommandExecutionException): Boolean =
+        e.message.orEmpty().contains(REDIS_GROUP_MISSING, ignoreCase = true)
+}
 
 class RedisQueueWorker(
     private val spec: IngestionQueueSpec,
@@ -165,22 +246,7 @@ class RedisQueueWorker(
     ): List<StreamMessage<String, String>> {
         val redis = conn.sync()
         val consumer = Consumer.from(spec.consumerGroup, consumerName(workerId))
-        val claimed = redis.xautoclaim(
-            spec.streamKey,
-            XAutoClaimArgs<String>()
-                .consumer(consumer)
-                .minIdleTime(Duration.ofMillis(spec.claimIdleMs))
-                .startId("0-0")
-                .count(spec.batchSize.toLong())
-        ).messages
-        if (claimed.isNotEmpty()) return claimed
-        return redis.xreadgroup(
-            consumer,
-            XReadArgs()
-                .block(Duration.ofMillis(spec.readTimeoutMs))
-                .count(spec.batchSize.toLong()),
-            StreamOffset.lastConsumed(spec.streamKey),
-        )
+        return RedisStreamQueueOperations.readMessages(redis, spec, consumer, logger)
     }
 
     private suspend fun processStreamBatch(
@@ -250,9 +316,7 @@ class RedisQueueWorker(
         messages: List<QueuedIngestionMessage>,
     ) {
         val ids = messages.mapNotNull { it.id }.toTypedArray()
-        if (ids.isNotEmpty()) {
-            conn.sync().xack(spec.streamKey, spec.consumerGroup, *ids)
-        }
+        RedisStreamQueueOperations.acknowledge(conn.sync(), spec.streamKey, spec.consumerGroup, ids, logger)
     }
 
     private suspend fun onQueueLoopFailure(
@@ -265,17 +329,7 @@ class RedisQueueWorker(
     }
 
     private fun ensureConsumerGroup(conn: StatefulRedisConnection<String, String>) {
-        try {
-            conn.sync().xgroupCreate(
-                StreamOffset.from(spec.streamKey, "0-0"),
-                spec.consumerGroup,
-                XGroupCreateArgs().mkstream(true),
-            )
-        } catch (e: RedisCommandExecutionException) {
-            if (!e.message.orEmpty().contains(REDIS_GROUP_EXISTS, ignoreCase = true)) {
-                throw e
-            }
-        }
+        RedisStreamQueueOperations.ensureConsumerGroup(conn.sync(), spec.streamKey, spec.consumerGroup)
     }
 
     private fun registerQueues() {

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/RedisStreamQueueOperationsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/RedisStreamQueueOperationsTest.kt
@@ -1,0 +1,128 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.ingestion.queue
+
+import io.lettuce.core.Consumer
+import io.lettuce.core.RedisCommandExecutionException
+import io.lettuce.core.XAutoClaimArgs
+import io.lettuce.core.XGroupCreateArgs
+import io.lettuce.core.XReadArgs.StreamOffset
+import io.lettuce.core.api.sync.RedisCommands
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import mu.KLogger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RedisStreamQueueOperationsTest {
+    private val redis = mockk<RedisCommands<String, String>>()
+    private val logger = mockk<KLogger>(relaxed = true)
+
+    @Test
+    fun `ensureConsumerGroup ignores an existing group`() {
+        every {
+            redis.xgroupCreate(any<StreamOffset<String>>(), "moneat:logs:workers", any<XGroupCreateArgs>())
+        } throws RedisCommandExecutionException("BUSYGROUP Consumer Group name already exists")
+
+        RedisStreamQueueOperations.ensureConsumerGroup(
+            redis,
+            streamKey = "moneat:logs:queue:stream",
+            consumerGroup = "moneat:logs:workers",
+        )
+
+        verify(exactly = 1) {
+            redis.xgroupCreate(any<StreamOffset<String>>(), "moneat:logs:workers", any<XGroupCreateArgs>())
+        }
+    }
+
+    @Test
+    fun `readMessages recreates a missing stream consumer group`() {
+        val spec = logQueueSpec()
+        every {
+            redis.xautoclaim("moneat:logs:queue:stream", any<XAutoClaimArgs<String>>())
+        } throws RedisCommandExecutionException(
+            "NOGROUP No such key 'moneat:logs:queue:stream' or consumer group 'moneat:logs:workers'",
+        )
+        every {
+            redis.xgroupCreate(any<StreamOffset<String>>(), "moneat:logs:workers", any<XGroupCreateArgs>())
+        } returns "OK"
+
+        val messages = RedisStreamQueueOperations.readMessages(
+            redis,
+            spec,
+            Consumer.from("moneat:logs:workers", "logs-host-1"),
+            logger,
+        )
+
+        assertEquals(emptyList(), messages)
+        verify(exactly = 1) {
+            redis.xgroupCreate(any<StreamOffset<String>>(), "moneat:logs:workers", any<XGroupCreateArgs>())
+        }
+    }
+
+    @Test
+    fun `acknowledge deletes acknowledged stream entries`() {
+        every { redis.xack("moneat:logs:queue:stream", "moneat:logs:workers", "1-0", "2-0") } returns 2L
+        every { redis.xdel("moneat:logs:queue:stream", "1-0", "2-0") } returns 2L
+
+        RedisStreamQueueOperations.acknowledge(
+            redis,
+            streamKey = "moneat:logs:queue:stream",
+            consumerGroup = "moneat:logs:workers",
+            ids = arrayOf("1-0", "2-0"),
+            logger = logger,
+        )
+
+        verify(exactly = 1) { redis.xack("moneat:logs:queue:stream", "moneat:logs:workers", "1-0", "2-0") }
+        verify(exactly = 1) { redis.xdel("moneat:logs:queue:stream", "1-0", "2-0") }
+    }
+
+    @Test
+    fun `acknowledge keeps stream processing successful when cleanup fails`() {
+        every { redis.xack("moneat:logs:queue:stream", "moneat:logs:workers", "1-0") } returns 1L
+        every {
+            redis.xdel("moneat:logs:queue:stream", "1-0")
+        } throws RedisCommandExecutionException("READONLY cleanup failed")
+
+        RedisStreamQueueOperations.acknowledge(
+            redis,
+            streamKey = "moneat:logs:queue:stream",
+            consumerGroup = "moneat:logs:workers",
+            ids = arrayOf("1-0"),
+            logger = logger,
+        )
+
+        verify(exactly = 1) { redis.xack("moneat:logs:queue:stream", "moneat:logs:workers", "1-0") }
+        verify(exactly = 1) { redis.xdel("moneat:logs:queue:stream", "1-0") }
+    }
+
+    private fun logQueueSpec(): IngestionQueueSpec =
+        IngestionQueueSpec(
+            pipeline = IngestionPipeline.LOGS,
+            queueKey = "moneat:logs:queue",
+            dlqKey = "moneat:logs:dlq",
+            workerCount = 1,
+            streamKey = "moneat:logs:queue:stream",
+            dlqStreamKey = "moneat:logs:dlq:stream",
+            consumerGroup = "moneat:logs:workers",
+            batchSize = 50,
+            claimIdleMs = 300_000,
+            maxDeliveries = 5,
+            readTimeoutMs = 5_000,
+        )
+}


### PR DESCRIPTION
## Summary
- recreate Redis stream consumer groups after eviction
- delete acknowledged stream entries after successful processing
- cover recovery and cleanup behavior

## Tests
- `./gradlew :test --tests com.moneat.ingestion.queue.RedisStreamQueueOperationsTest --no-daemon`
- `./gradlew detekt --no-daemon`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue processing resilience by automatically recovering from missing consumer group errors
  * Enhanced stream entry cleanup to ensure thorough removal of processed messages

* **Tests**
  * Added comprehensive test coverage for queue operations and error handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->