### PR TITLE
fix: cap redis stream queues

### DIFF
--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
@@ -50,7 +50,7 @@ object IngestionQueueClient {
                 null
             }
             IngestionQueueBackend.REDIS_STREAMS ->
-                RedisConfig.sync().xadd(spec.streamKey, streamBody(pipeline, payload))
+                RedisConfig.sync().xadd(spec.streamKey, streamAddArgs(spec.streamMaxLen), streamBody(pipeline, payload))
         }
     }
 
@@ -69,7 +69,7 @@ object IngestionQueueClient {
                 IngestionQueueBackend.REDIS_STREAMS -> {
                     RedisConfig.sync().xadd(
                         spec.dlqStreamKey,
-                        XAddArgs(),
+                        streamAddArgs(spec.dlqStreamMaxLen),
                         streamDlqBody(spec.pipeline, request.payload, request.cause, request.streamId)
                     )
                     1L
@@ -96,6 +96,11 @@ object IngestionQueueClient {
             FIELD_PIPELINE to pipeline.id,
             FIELD_ENQUEUED_AT to System.currentTimeMillis().toString(),
         )
+
+    private fun streamAddArgs(maxLen: Long): XAddArgs =
+        XAddArgs()
+            .maxlen(maxLen)
+            .approximateTrimming()
 
     private fun streamDlqBody(
         pipeline: IngestionPipeline,

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueSettings.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueSettings.kt
@@ -23,6 +23,8 @@ private const val DEFAULT_STREAM_BATCH_SIZE = 50
 private const val DEFAULT_CLAIM_IDLE_MS = 300_000L
 private const val DEFAULT_MAX_DELIVERIES = 5
 private const val DEFAULT_READ_TIMEOUT_MS = 5_000L
+private const val DEFAULT_STREAM_MAX_LEN = 250_000L
+private const val DEFAULT_DLQ_STREAM_MAX_LEN = 10_000L
 private const val MIN_STREAM_BATCH_SIZE = 1
 
 enum class IngestionQueueBackend {
@@ -66,6 +68,8 @@ data class IngestionQueueSpec(
     val claimIdleMs: Long,
     val maxDeliveries: Int,
     val readTimeoutMs: Long,
+    val streamMaxLen: Long,
+    val dlqStreamMaxLen: Long,
 )
 
 object IngestionQueueSettings {
@@ -97,6 +101,8 @@ object IngestionQueueSettings {
             claimIdleMs = positiveLong("INGESTION_${prefix}_CLAIM_IDLE_MS", DEFAULT_CLAIM_IDLE_MS),
             maxDeliveries = positiveInt("INGESTION_${prefix}_MAX_DELIVERIES", DEFAULT_MAX_DELIVERIES),
             readTimeoutMs = positiveLong("INGESTION_${prefix}_READ_TIMEOUT_MS", DEFAULT_READ_TIMEOUT_MS),
+            streamMaxLen = positiveLong("INGESTION_${prefix}_STREAM_MAXLEN", DEFAULT_STREAM_MAX_LEN),
+            dlqStreamMaxLen = positiveLong("INGESTION_${prefix}_DLQ_STREAM_MAXLEN", DEFAULT_DLQ_STREAM_MAX_LEN),
         )
     }
 

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
@@ -46,6 +46,7 @@ import java.time.Duration
 private const val ERROR_RETRY_DELAY_MS = 1_000L
 private const val REDIS_GROUP_EXISTS = "BUSYGROUP"
 private const val REDIS_GROUP_MISSING = "NOGROUP"
+private const val REDIS_STREAM_START_ID = "0-0"
 
 data class QueuedIngestionMessage(
     val id: String?,
@@ -54,6 +55,9 @@ data class QueuedIngestionMessage(
 )
 
 internal object RedisStreamQueueOperations {
+    /**
+     * Redis Streams consumer groups can disappear if Redis evicts or trims the stream key.
+     */
     fun readMessages(
         redis: RedisCommands<String, String>,
         spec: IngestionQueueSpec,
@@ -78,7 +82,7 @@ internal object RedisStreamQueueOperations {
     ) {
         try {
             redis.xgroupCreate(
-                StreamOffset.from(streamKey, "0-0"),
+                StreamOffset.from(streamKey, REDIS_STREAM_START_ID),
                 consumerGroup,
                 XGroupCreateArgs().mkstream(true),
             )
@@ -97,7 +101,15 @@ internal object RedisStreamQueueOperations {
         logger: KLogger,
     ) {
         if (ids.isEmpty()) return
-        redis.xack(streamKey, consumerGroup, *ids)
+        try {
+            redis.xack(streamKey, consumerGroup, *ids)
+        } catch (e: RedisCommandExecutionException) {
+            if (!isMissingConsumerGroup(e)) throw e
+            logger.warn(e) {
+                "Redis stream consumer group $consumerGroup disappeared before ack for $streamKey"
+            }
+            return
+        }
         runCatching {
             redis.xdel(streamKey, *ids)
         }.onFailure { e ->
@@ -115,7 +127,7 @@ internal object RedisStreamQueueOperations {
             XAutoClaimArgs<String>()
                 .consumer(consumer)
                 .minIdleTime(Duration.ofMillis(spec.claimIdleMs))
-                .startId("0-0")
+                .startId(REDIS_STREAM_START_ID)
                 .count(spec.batchSize.toLong())
         ).messages
         if (claimed.isNotEmpty()) return claimed

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
@@ -72,11 +72,14 @@ class IngestionQueueClientTest {
     fun `enqueue writes structured body to redis stream`() {
         every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns "redis-streams"
         val bodySlot = slot<Map<String, String>>()
-        every { redis.xadd("logs:queue:stream", capture(bodySlot)) } returns "1-0"
+        val argsSlot = slot<XAddArgs>()
+        every { redis.xadd("logs:queue:stream", capture(argsSlot), capture(bodySlot)) } returns "1-0"
 
         val streamId = IngestionQueueClient.enqueue(IngestionPipeline.LOGS, "logs:queue", "payload")
 
         assertEquals("1-0", streamId)
+        assertEquals(250_000L, xaddMaxLen(argsSlot.captured))
+        assertTrue(xaddApproximateTrimming(argsSlot.captured))
         assertEquals("payload", bodySlot.captured["payload"])
         assertEquals("logs", bodySlot.captured["pipeline"])
         assertNotNull(bodySlot.captured["enqueued_at_ms"]?.toLongOrNull())
@@ -102,7 +105,8 @@ class IngestionQueueClientTest {
         every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns "redis-streams"
         val spec = IngestionQueueSettings.spec(IngestionPipeline.LOGS, "logs:queue", "logs:dlq", workerCount = 1)
         val bodySlot = slot<Map<String, String>>()
-        every { redis.xadd("logs:dlq:stream", any<XAddArgs>(), capture(bodySlot)) } returns "2-0"
+        val argsSlot = slot<XAddArgs>()
+        every { redis.xadd("logs:dlq:stream", capture(argsSlot), capture(bodySlot)) } returns "2-0"
 
         val pushed =
             IngestionQueueClient.pushToDlq(
@@ -117,6 +121,8 @@ class IngestionQueueClientTest {
             )
 
         assertTrue(pushed)
+        assertEquals(10_000L, xaddMaxLen(argsSlot.captured))
+        assertTrue(xaddApproximateTrimming(argsSlot.captured))
         assertEquals("payload", bodySlot.captured["payload"])
         assertEquals("logs", bodySlot.captured["pipeline"])
         assertEquals("RedisException", bodySlot.captured["error_type"])
@@ -143,4 +149,14 @@ class IngestionQueueClientTest {
         assertEquals("payload", IngestionQueueClient.payloadField(mapOf("payload" to "payload")))
         assertNull(IngestionQueueClient.payloadField(mapOf("pipeline" to "logs")))
     }
+
+    private fun xaddMaxLen(args: XAddArgs): Long? =
+        args.javaClass.getDeclaredField("maxlen")
+            .also { field -> field.isAccessible = true }
+            .get(args) as? Long
+
+    private fun xaddApproximateTrimming(args: XAddArgs): Boolean =
+        args.javaClass.getDeclaredField("approximateTrimming")
+            .also { field -> field.isAccessible = true }
+            .getBoolean(args)
 }

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueSettingsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueSettingsTest.kt
@@ -125,6 +125,8 @@ class IngestionQueueSettingsTest {
         every { EnvConfig.get("INGESTION_LOGS_CLAIM_IDLE_MS") } returns "1234"
         every { EnvConfig.get("INGESTION_LOGS_MAX_DELIVERIES") } returns "9"
         every { EnvConfig.get("INGESTION_LOGS_READ_TIMEOUT_MS") } returns "321"
+        every { EnvConfig.get("INGESTION_LOGS_STREAM_MAXLEN") } returns "12345"
+        every { EnvConfig.get("INGESTION_LOGS_DLQ_STREAM_MAXLEN") } returns "5678"
 
         val spec = IngestionQueueSettings.spec(IngestionPipeline.LOGS, "logs:q", "logs:dlq", workerCount = 0)
 
@@ -136,6 +138,8 @@ class IngestionQueueSettingsTest {
         assertEquals(1_234L, spec.claimIdleMs)
         assertEquals(9, spec.maxDeliveries)
         assertEquals(321L, spec.readTimeoutMs)
+        assertEquals(12_345L, spec.streamMaxLen)
+        assertEquals(5_678L, spec.dlqStreamMaxLen)
     }
 
     @Test
@@ -146,6 +150,8 @@ class IngestionQueueSettingsTest {
         every { EnvConfig.get("INGESTION_LOGS_CLAIM_IDLE_MS") } returns "-1"
         every { EnvConfig.get("INGESTION_LOGS_MAX_DELIVERIES") } returns "not-a-number"
         every { EnvConfig.get("INGESTION_LOGS_READ_TIMEOUT_MS") } returns "0"
+        every { EnvConfig.get("INGESTION_LOGS_STREAM_MAXLEN") } returns "-1"
+        every { EnvConfig.get("INGESTION_LOGS_DLQ_STREAM_MAXLEN") } returns "0"
 
         val spec = IngestionQueueSettings.spec(IngestionPipeline.LOGS, "logs:q", "logs:dlq", workerCount = 2)
 
@@ -156,6 +162,8 @@ class IngestionQueueSettingsTest {
         assertEquals(300_000L, spec.claimIdleMs)
         assertEquals(5, spec.maxDeliveries)
         assertEquals(5_000L, spec.readTimeoutMs)
+        assertEquals(250_000L, spec.streamMaxLen)
+        assertEquals(10_000L, spec.dlqStreamMaxLen)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/RedisStreamQueueOperationsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/RedisStreamQueueOperationsTest.kt
@@ -111,6 +111,26 @@ class RedisStreamQueueOperationsTest {
         verify(exactly = 1) { redis.xdel("moneat:logs:queue:stream", "1-0") }
     }
 
+    @Test
+    fun `acknowledge ignores missing consumer group during ack`() {
+        every {
+            redis.xack("moneat:logs:queue:stream", "moneat:logs:workers", "1-0")
+        } throws RedisCommandExecutionException(
+            "NOGROUP No such key 'moneat:logs:queue:stream' or consumer group 'moneat:logs:workers'",
+        )
+
+        RedisStreamQueueOperations.acknowledge(
+            redis,
+            streamKey = "moneat:logs:queue:stream",
+            consumerGroup = "moneat:logs:workers",
+            ids = arrayOf("1-0"),
+            logger = logger,
+        )
+
+        verify(exactly = 1) { redis.xack("moneat:logs:queue:stream", "moneat:logs:workers", "1-0") }
+        verify(exactly = 0) { redis.xdel("moneat:logs:queue:stream", "1-0") }
+    }
+
     private fun logQueueSpec(): IngestionQueueSpec =
         IngestionQueueSpec(
             pipeline = IngestionPipeline.LOGS,
@@ -124,5 +144,7 @@ class RedisStreamQueueOperationsTest {
             claimIdleMs = 300_000,
             maxDeliveries = 5,
             readTimeoutMs = 5_000,
+            streamMaxLen = 250_000,
+            dlqStreamMaxLen = 10_000,
         )
 }


### PR DESCRIPTION
## Summary
- cap Redis stream writes for ingestion queues and DLQs
- tolerate a missing consumer group during ack cleanup

## Verification
- `./gradlew :test --tests com.moneat.ingestion.queue.IngestionQueueClientTest --tests com.moneat.ingestion.queue.IngestionQueueSettingsTest --tests com.moneat.ingestion.queue.RedisStreamQueueOperationsTest --no-daemon`
- `./gradlew detekt --no-daemon`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable Redis stream maximum length limits via environment variables to enable automatic stream trimming and prevent unbounded growth.

* **Bug Fixes**
  * Improved error handling for missing consumer groups during stream acknowledgment to prevent worker loop failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->