### PR TITLE
fix: remove legacy ingestion queue modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,9 +179,8 @@ The required PR workflow is `.github/workflows/test.yml`.
   debugging, and reprocessing.
 - New ingestion pipelines should have explicit queue keys, DLQ behavior,
   operational metrics, and focused tests for enqueue/worker/failure paths.
-- If Redis Streams queue support is present, preserve list, streams, and dual
-  read modes for transition. Stream redelivery must remain idempotent for
-  ClickHouse inserts and usage accounting.
+- Redis Streams are the ingestion queue. Stream redelivery must remain
+  idempotent for ClickHouse inserts and usage accounting.
 - Process-role controls such as API-only, scheduler, ingestion worker, and
   workflow egress must not accidentally start unrelated background jobs.
 

--- a/ESSENTIAL_ENV_VARS.md
+++ b/ESSENTIAL_ENV_VARS.md
@@ -36,17 +36,17 @@ Workflow secrets must be distinct from `JWT_SECRET` and `DATA_SOURCE_ENCRYPTION_
 
 ## Operational Rollout Controls
 
-These variables are optional and default to the legacy all-in-one/list-backed behavior.
+These variables are optional. Ingestion queues use Redis Streams by default.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `MONEAT_PROCESS_ROLE` | `all` | Start only one deployable role: `all`, `api`, `scheduler`, `ingestion-worker`, or `workflow-egress`. |
 | `INGESTION_PIPELINES` | `all` | Comma-separated ingestion workers to run on an `ingestion-worker`, for example `logs,otlp-traces`. |
-| `INGESTION_QUEUE_BACKEND` | `redis-list` | Producer backend. Set to `redis-streams` after consumers are ready for stream reads. |
-| `INGESTION_QUEUE_READ_MODE` | backend-derived | Consumer mode: `list`, `streams`, or `dual` for transition draining. |
 | `INGESTION_<PIPELINE>_BATCH_SIZE` | `50` | Redis Streams `XREADGROUP COUNT` batch size for a pipeline. |
 | `INGESTION_<PIPELINE>_CLAIM_IDLE_MS` | `300000` | Minimum idle time before `XAUTOCLAIM`; keep above worst-case batch processing time. |
 | `INGESTION_<PIPELINE>_MAX_DELIVERIES` | `5` | Delivery count before a stream message is written to the DLQ stream. |
+| `INGESTION_<PIPELINE>_STREAM_MAXLEN` | `250000` | Approximate maximum length for the primary stream before Redis trims old acknowledged entries. |
+| `INGESTION_<PIPELINE>_DLQ_STREAM_MAXLEN` | `10000` | Approximate maximum length for the DLQ stream. |
 
-When `INGESTION_QUEUE_BACKEND=redis-streams`, Redis becomes the durable ingestion buffer. Run Redis with
-persistence and HA appropriate for production, and alert on pending entries, oldest pending age, and DLQ growth.
+Redis Streams are the durable ingestion buffer. Run Redis with persistence and HA appropriate for production, and
+alert on pending entries, oldest pending age, and DLQ growth.

--- a/backend/features/analytics/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
+++ b/backend/features/analytics/src/main/kotlin/com/moneat/analytics/services/AnalyticsIngestionWorker.kt
@@ -18,18 +18,15 @@ package com.moneat.analytics.services
 
 import com.moneat.analytics.models.EnrichedAnalyticsEvent
 import com.moneat.config.ClickHouseClient
-import com.moneat.config.RedisConfig
 import com.moneat.config.isClickHouseError
-import com.moneat.ingestion.queue.IngestionDlqRequest
 import com.moneat.ingestion.queue.IngestionPipeline
-import com.moneat.ingestion.queue.IngestionQueueClient
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.pushToDlq
 import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
-import io.lettuce.core.RedisException
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
 import java.io.IOException
@@ -51,19 +48,7 @@ class AnalyticsIngestionWorker(
     fun start() {
         logger.info { "Starting AnalyticsIngestionWorker with $workerCount workers, queue=$queueKey" }
         val spec = IngestionQueueSettings.spec(IngestionPipeline.ANALYTICS, queueKey, dlqKey, workerCount)
-        queueWorker = RedisQueueWorker(spec, logger, processMessage = { workerId, payload ->
-            processMessage(workerId, payload) { message ->
-                IngestionQueueClient.pushToDlq(
-                    logger = logger,
-                    request = IngestionDlqRequest(
-                        spec = spec,
-                        payload = message,
-                        workerId = workerId,
-                        cause = IllegalStateException("Analytics processing failed"),
-                    ),
-                )
-            }
-        }).also { it.start() }
+        queueWorker = RedisQueueWorker(spec, logger, processMessage = ::processMessage).also { it.start() }
     }
 
     fun stop() {
@@ -74,14 +59,13 @@ class AnalyticsIngestionWorker(
     internal suspend fun processMessage(
         workerId: Int,
         value: String,
-        onDlq: (String) -> Unit = { message -> RedisConfig.sync().rpush(dlqKey, message) },
     ) {
         suspendRunCatching {
             val event = json.decodeFromString<EnrichedAnalyticsEvent>(value)
             insertEvent(event)
             OperationalMetrics.recordWorkerMessageProcessed("Analytics", workerId)
         }.getOrElse { e ->
-            logProcessFailureAndDlq(workerId, value, e, onDlq)
+            logProcessFailureAndDlq(workerId, value, e)
         }
     }
 
@@ -89,25 +73,9 @@ class AnalyticsIngestionWorker(
         workerId: Int,
         value: String,
         e: Throwable,
-        onDlq: (String) -> Unit,
     ) {
         logger.error(e) { "Analytics worker $workerId failed to process message, sending to DLQ" }
-        OperationalMetrics.recordWorkerProcessingFailure("Analytics", workerId, e)
-        pushToAnalyticsDlq(workerId, value, onDlq)
-    }
-
-    private fun pushToAnalyticsDlq(
-        workerId: Int,
-        value: String,
-        onDlq: (String) -> Unit,
-    ) {
-        try {
-            onDlq(value)
-            OperationalMetrics.recordDlqPush("Analytics", dlqKey, "success")
-        } catch (e: RedisException) {
-            OperationalMetrics.recordDlqPush("Analytics", dlqKey, "failure")
-            logger.error(e) { "Failed to push to analytics DLQ (worker $workerId)" }
-        }
+        pushToDlq(logger, dlqKey, value, workerId, "Analytics", e)
     }
 
     private suspend fun insertEvent(event: EnrichedAnalyticsEvent) {

--- a/backend/features/analytics/src/test/kotlin/com/moneat/analytics/AnalyticsIngestionWorkerTest.kt
+++ b/backend/features/analytics/src/test/kotlin/com/moneat/analytics/AnalyticsIngestionWorkerTest.kt
@@ -24,6 +24,7 @@ import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
 import com.moneat.testsupport.withClickHouseMockServer
 import com.moneat.utils.ClickHouseSqlUtils
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.every
 import io.mockk.mockk
@@ -46,7 +47,7 @@ class AnalyticsIngestionWorkerTest {
     fun setup() {
         mockkObject(RedisConfig)
         every { RedisConfig.sync() } returns mockRedis
-        every { mockRedis.rpush(any(), any<String>()) } returns 1L
+        every { mockRedis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
     }
 
     @AfterTest

--- a/backend/features/analytics/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
+++ b/backend/features/analytics/src/test/kotlin/com/moneat/analytics/AnalyticsServerIngestRoutesTest.kt
@@ -23,6 +23,7 @@ import com.moneat.otlp.services.OtlpApiKeyService
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
 import com.moneat.testsupport.TestDatabaseHelper
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -152,8 +153,12 @@ class AnalyticsServerIngestRoutesTest {
         val mockRedis = mockk<RedisCommands<String, String>>()
         mockkObject(RedisConfig)
         every {
-            mockRedis.lpush(AnalyticsIngestionWorker.QUEUE_KEY, *anyVararg())
-        } returns 2L
+            mockRedis.xadd(
+                "${AnalyticsIngestionWorker.QUEUE_KEY}:stream",
+                any<XAddArgs>(),
+                any<Map<String, String>>(),
+            )
+        } returns "1-0"
         every { RedisConfig.sync() } returns mockRedis
 
         application {
@@ -180,7 +185,11 @@ class AnalyticsServerIngestRoutesTest {
 
         assertEquals(HttpStatusCode.Accepted, response.status, response.bodyAsText())
         verify(exactly = 2) {
-            mockRedis.lpush(AnalyticsIngestionWorker.QUEUE_KEY, *anyVararg())
+            mockRedis.xadd(
+                "${AnalyticsIngestionWorker.QUEUE_KEY}:stream",
+                any<XAddArgs>(),
+                any<Map<String, String>>(),
+            )
         }
     }
 

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/networkdevices/NdmIngestionWorker.kt
@@ -16,36 +16,21 @@
 
 package com.moneat.datadog.networkdevices
 
-import com.moneat.config.RedisConfig
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
-
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 
 class NdmIngestionWorker(
     private val queueKey: String = "moneat:dd:ndm:queue",
     private val dlqKey: String = "moneat:dd:ndm:dlq",
     private val workerCount: Int = 1,
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -61,42 +46,7 @@ class NdmIngestionWorker(
         queueWorker?.stop()
         logger.info { "NdmIngestionWorker stopped" }
     }
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "NDM",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "NDM",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
-    }
+
     internal suspend fun processMessage(
         workerId: Int,
         payload: String,

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/security/SecurityIngestionWorker.kt
@@ -16,29 +16,16 @@
 
 package com.moneat.datadog.security
 
-import com.moneat.config.RedisConfig
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import com.moneat.workflows.services.WorkflowService
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
-
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 
 class SecurityIngestionWorker(
     private val queueKey: String = "moneat:dd:security:queue",
@@ -46,8 +33,6 @@ class SecurityIngestionWorker(
     private val workerCount: Int = 1,
     private val workflowService: WorkflowService = WorkflowService()
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -63,42 +48,7 @@ class SecurityIngestionWorker(
         queueWorker?.stop()
         logger.info { "SecurityIngestionWorker stopped" }
     }
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Security",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Security",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
-    }
+
     internal suspend fun processMessage(
         workerId: Int,
         payload: String,

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DatadogEventIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DatadogEventIngestionWorker.kt
@@ -16,29 +16,17 @@
 
 package com.moneat.datadog.workers
 
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogEventService
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 private const val WORKER_NAME = "DD event"
 
 class DatadogEventIngestionWorker(
@@ -46,9 +34,6 @@ class DatadogEventIngestionWorker(
     private val dlqKey: String,
     private val workerCount: Int
 ) {
-    private val scope =
-        CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -63,43 +48,6 @@ class DatadogEventIngestionWorker(
     fun stop() {
         queueWorker?.stop()
         logger.info { "DatadogEventIngestionWorker stopped" }
-    }
-
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        WORKER_NAME,
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        WORKER_NAME,
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
     }
 
     internal suspend fun processMessage(

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DatadogInfraIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DatadogInfraIngestionWorker.kt
@@ -16,29 +16,17 @@
 
 package com.moneat.datadog.workers
 
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogInfraService
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 private const val WORKER_NAME = "DD infra"
 
 class DatadogInfraIngestionWorker(
@@ -46,9 +34,6 @@ class DatadogInfraIngestionWorker(
     private val dlqKey: String,
     private val workerCount: Int
 ) {
-    private val scope =
-        CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -63,43 +48,6 @@ class DatadogInfraIngestionWorker(
     fun stop() {
         queueWorker?.stop()
         logger.info { "DatadogInfraIngestionWorker stopped" }
-    }
-
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        WORKER_NAME,
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        WORKER_NAME,
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
     }
 
     internal suspend fun processMessage(

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorker.kt
@@ -17,31 +17,17 @@
 package com.moneat.datadog.workers
 
 import com.moneat.config.EnvConfig
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DatadogMetricService
 import com.moneat.datadog.services.QueuedMetricBatch
 import com.moneat.ingestion.queue.IngestionPipeline
-import com.moneat.ingestion.queue.IngestionQueueReadMode
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.QueuedIngestionMessage
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
 import com.moneat.utils.suspendRunCatching
-import io.lettuce.core.RedisException
-import io.lettuce.core.api.sync.RedisCommands
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
 import mu.KotlinLogging
-import java.io.IOException
 
 private val logger = KotlinLogging.logger {}
 
@@ -49,8 +35,6 @@ private const val COMBINED_INSERT_MODE = "combined"
 private const val SINGLE_INSERT_MODE = "single"
 private const val SUCCESS_STATUS = "success"
 private const val FAILURE_STATUS = "failure"
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 private const val WORKER_NAME = "DD metric"
 private const val DEFAULT_MAX_ROWS = 20_000
 private const val DEFAULT_MAX_PAYLOADS = 100
@@ -66,86 +50,28 @@ class DatadogMetricIngestionWorker(
     private val queueKey: String,
     private val dlqKey: String,
     private val workerCount: Int,
-    private val processingQueueKey: String = "$queueKey:processing",
     private val maxRows: Int = configuredPositiveInt(MAX_ROWS_ENV, DEFAULT_MAX_ROWS),
     private val maxPayloads: Int = configuredPositiveInt(MAX_PAYLOADS_ENV, DEFAULT_MAX_PAYLOADS),
 ) {
-    private val scope =
-        CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
-        registerQueues()
-        recoverProcessingQueue()
         logger.info {
             "Starting DatadogMetricIngestionWorker with " +
                 "$workerCount workers, queue=$queueKey"
         }
-        if (IngestionQueueSettings.readMode() != IngestionQueueReadMode.LIST) {
-            val spec = IngestionQueueSettings.spec(IngestionPipeline.DD_METRICS, queueKey, dlqKey, workerCount)
-            queueWorker = RedisQueueWorker(
-                spec = spec,
-                logger = logger,
-                processMessage = ::processMessage,
-                processBatch = ::processQueuedMessages,
-            ).also { it.start() }
-            return
-        }
-        jobs = (1..workerCount).map { workerId ->
-            scope.launch {
-                runWorker(workerId)
-            }
-        }
+        val spec = IngestionQueueSettings.spec(IngestionPipeline.DD_METRICS, queueKey, dlqKey, workerCount)
+        queueWorker = RedisQueueWorker(
+            spec = spec,
+            logger = logger,
+            processMessage = ::processMessage,
+            processBatch = ::processQueuedMessages,
+        ).also { it.start() }
     }
 
     fun stop() {
         queueWorker?.stop()
-        jobs.forEach { it.cancel() }
-        if (jobs.isNotEmpty()) {
-            scope.cancel()
-        }
         logger.info { "DatadogMetricIngestionWorker stopped" }
-    }
-
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val payload = redis.brpoplpush(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey,
-                        processingQueueKey,
-                    ) ?: continue
-                    processPayloads(
-                        workerId,
-                        collectPayloadsForProcessing(redis, payload)
-                    )
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        WORKER_NAME,
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        WORKER_NAME,
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
     }
 
     internal suspend fun processMessage(
@@ -162,18 +88,6 @@ class DatadogMetricIngestionWorker(
         processPayloads(workerId, messages.map { it.payload })
     }
 
-    internal fun collectPayloadsForProcessing(
-        redis: RedisCommands<String, String>,
-        firstPayload: String,
-    ): List<String> {
-        val payloads = ArrayList<String>(maxPayloads)
-        payloads.add(firstPayload)
-
-        val drainedPayloads = drainQueuedPayloads(redis)
-        payloads.addAll(drainedPayloads)
-        return payloads
-    }
-
     internal suspend fun processPayloads(
         workerId: Int,
         payloads: List<String>,
@@ -182,27 +96,6 @@ class DatadogMetricIngestionWorker(
             decodePayload(workerId, payload)
         }
         processDecodedPayloads(workerId, decodedPayloads)
-    }
-
-    private fun drainQueuedPayloads(
-        redis: RedisCommands<String, String>,
-    ): List<String> {
-        val count = maxPayloads - 1
-        if (count <= 0) return emptyList()
-        return try {
-            val drainedPayloads = mutableListOf<String>()
-            repeat(count) {
-                val payload = redis.rpoplpush(queueKey, processingQueueKey)
-                    ?: return drainedPayloads
-                drainedPayloads.add(payload)
-            }
-            drainedPayloads
-        } catch (e: RedisException) {
-            logger.warn(e) {
-                "Failed to drain additional Datadog metric payloads; processing BRPOP payload only"
-            }
-            emptyList()
-        }
     }
 
     private fun decodePayload(
@@ -215,10 +108,10 @@ class DatadogMetricIngestionWorker(
                 batch = DatadogMetricService.decodeMetricBatch(payload),
             )
         } catch (e: SerializationException) {
-            pushToDlqAndAck(payload, workerId, e)
+            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
             null
         } catch (e: IllegalArgumentException) {
-            pushToDlqAndAck(payload, workerId, e)
+            pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, e)
             null
         }
     }
@@ -274,13 +167,13 @@ class DatadogMetricIngestionWorker(
 
         val nonEmptyBatches = payloads.map { it.batch }.filter { it.metrics.isNotEmpty() }
         if (nonEmptyBatches.isEmpty()) {
-            markProcessed(workerId, payloads)
+            markProcessed(workerId, payloads.size)
             return
         }
 
         val combinedResult = insertCombinedBatch(nonEmptyBatches)
         if (combinedResult.isSuccess) {
-            markProcessed(workerId, payloads)
+            markProcessed(workerId, payloads.size)
             return
         }
 
@@ -330,88 +223,23 @@ class DatadogMetricIngestionWorker(
             cause = result.exceptionOrNull(),
         )
         result.onSuccess {
-            markProcessed(workerId, listOf(payload))
+            markProcessed(workerId, 1)
         }.onFailure { e ->
-            pushToDlqAndAck(payload.originalPayload, workerId, e)
+            pushToDlq(logger, dlqKey, payload.originalPayload, workerId, WORKER_NAME, e)
         }
     }
 
     private fun markProcessed(
         workerId: Int,
-        payloads: List<DecodedMetricPayload>,
+        count: Int,
     ) {
-        payloads.forEach { payload ->
-            acknowledgePayload(payload.originalPayload, workerId)
+        repeat(count) {
             recordProcessed(workerId)
-        }
-    }
-
-    private fun pushToDlqAndAck(
-        payload: String,
-        workerId: Int,
-        cause: Throwable,
-    ) {
-        if (pushToDlq(logger, dlqKey, payload, workerId, WORKER_NAME, cause)) {
-            acknowledgePayload(payload, workerId)
-        }
-    }
-
-    private fun acknowledgePayload(
-        payload: String,
-        workerId: Int,
-    ) {
-        runCatching {
-            RedisConfig.sync().lrem(processingQueueKey, 1, payload)
-        }.onSuccess {
-            OperationalMetrics.recordDatadogMetricPayloadAck(SUCCESS_STATUS)
-        }.onFailure { e ->
-            OperationalMetrics.recordDatadogMetricPayloadAck(FAILURE_STATUS)
-            logger.warn(e) {
-                "Failed to acknowledge Datadog metric payload for worker $workerId; " +
-                    "payload will be recovered on restart"
-            }
         }
     }
 
     private fun recordProcessed(workerId: Int) {
         OperationalMetrics.recordWorkerMessageProcessed(WORKER_NAME, workerId)
-    }
-
-    private fun recoverProcessingQueue() {
-        runCatching {
-            val redis = RedisConfig.sync()
-            var recovered = 0
-            while (true) {
-                redis.rpoplpush(processingQueueKey, queueKey) ?: break
-                recovered += 1
-            }
-            recovered
-        }.onSuccess { recovered ->
-            OperationalMetrics.recordDatadogMetricProcessingRecovery(
-                recoveredPayloads = recovered,
-                status = SUCCESS_STATUS,
-            )
-            if (recovered > 0) {
-                logger.warn {
-                    "Recovered $recovered unacknowledged Datadog metric payloads from $processingQueueKey"
-                }
-            }
-        }.onFailure { e ->
-            OperationalMetrics.recordDatadogMetricProcessingRecovery(
-                recoveredPayloads = 0,
-                status = FAILURE_STATUS,
-                cause = e,
-            )
-            logger.warn(e) {
-                "Failed to recover Datadog metric processing queue $processingQueueKey"
-            }
-        }
-    }
-
-    private fun registerQueues() {
-        OperationalMetrics.registerQueue(WORKER_NAME, queueKey, "primary")
-        OperationalMetrics.registerQueue(WORKER_NAME, processingQueueKey, "processing")
-        OperationalMetrics.registerDlq(WORKER_NAME, dlqKey)
     }
 }
 

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DbmIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DbmIngestionWorker.kt
@@ -16,37 +16,22 @@
 
 package com.moneat.datadog.workers
 
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DbmIngestionService
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
-
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 
 class DbmIngestionWorker(
     private val queueKey: String = "moneat:dd:dbm:queue",
     private val dlqKey: String = "moneat:dd:dbm:dlq",
     private val workerCount: Int = 1,
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -62,42 +47,7 @@ class DbmIngestionWorker(
         queueWorker?.stop()
         logger.info { "DbmIngestionWorker stopped" }
     }
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "DBM",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "DBM",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
-    }
+
     internal suspend fun processMessage(
         workerId: Int,
         payload: String,

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DebuggerIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/DebuggerIngestionWorker.kt
@@ -16,37 +16,22 @@
 
 package com.moneat.datadog.workers
 
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.DebuggerIngestionService
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
-
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 
 class DebuggerIngestionWorker(
     private val queueKey: String = "moneat:dd:debugger:queue",
     private val dlqKey: String = "moneat:dd:debugger:dlq",
     private val workerCount: Int = 1,
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -62,42 +47,7 @@ class DebuggerIngestionWorker(
         queueWorker?.stop()
         logger.info { "DebuggerIngestionWorker stopped" }
     }
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Debugger",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Debugger",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
-    }
+
     internal suspend fun processMessage(
         workerId: Int,
         payload: String,

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/MiscIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/MiscIngestionWorker.kt
@@ -16,37 +16,22 @@
 
 package com.moneat.datadog.workers
 
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.MiscIngestionService
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
-
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 
 class MiscIngestionWorker(
     private val queueKey: String = "moneat:dd:misc:queue",
     private val dlqKey: String = "moneat:dd:misc:dlq",
     private val workerCount: Int = 1,
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -62,42 +47,7 @@ class MiscIngestionWorker(
         queueWorker?.stop()
         logger.info { "MiscIngestionWorker stopped" }
     }
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Misc",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Misc",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
-    }
+
     internal suspend fun processMessage(
         workerId: Int,
         payload: String,

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/OrchestratorIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/OrchestratorIngestionWorker.kt
@@ -16,37 +16,22 @@
 
 package com.moneat.datadog.workers
 
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.OrchestratorIngestionService
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import mu.KotlinLogging
-import java.io.IOException
 import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
-
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 
 class OrchestratorIngestionWorker(
     private val queueKey: String = "moneat:dd:orchestrator:queue",
     private val dlqKey: String = "moneat:dd:orchestrator:dlq",
     private val workerCount: Int = 1,
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -62,42 +47,7 @@ class OrchestratorIngestionWorker(
         queueWorker?.stop()
         logger.info { "OrchestratorIngestionWorker stopped" }
     }
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Orchestrator",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Orchestrator",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
-    }
+
     internal suspend fun processMessage(
         workerId: Int,
         payload: String,

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/TraceIngestionWorker.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/workers/TraceIngestionWorker.kt
@@ -16,44 +16,29 @@
 
 package com.moneat.datadog.workers
 
-import com.moneat.config.RedisConfig
 import com.moneat.datadog.services.TraceIngestionService
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
-import com.moneat.utils.brpopLoopBackoff
 import com.moneat.utils.pushToDlq
-import io.lettuce.core.RedisException
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
+import com.moneat.utils.suspendRunCatching
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
-import java.io.IOException
 import java.util.Base64
-import com.moneat.utils.suspendRunCatching
 
 private val logger = KotlinLogging.logger {}
-
-private const val BRPOP_TIMEOUT_SECONDS = 5L
-private const val ERROR_DELAY_MS = 1000L
 
 class TraceIngestionWorker(
     private val queueKey: String = "moneat:traces:queue",
     private val dlqKey: String = "moneat:traces:dlq",
     private val workerCount: Int = 2,
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val json = Json { ignoreUnknownKeys = true }
-    private var jobs: List<Job> = emptyList()
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
@@ -69,42 +54,7 @@ class TraceIngestionWorker(
         queueWorker?.stop()
         logger.info { "TraceIngestionWorker stopped" }
     }
-    private suspend fun runWorker(workerId: Int) {
-        val conn = RedisConfig.newBlockingConnection()
-        try {
-            val redis = conn.sync()
-            while (scope.isActive) {
-                try {
-                    val result = redis.brpop(
-                        BRPOP_TIMEOUT_SECONDS,
-                        queueKey
-                    )
-                    val payload = result?.value ?: continue
-                    processMessage(workerId, payload)
-                } catch (e: CancellationException) {
-                    break
-                } catch (e: RedisException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Trace",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                } catch (e: IOException) {
-                    brpopLoopBackoff(
-                        logger,
-                        workerId,
-                        "Trace",
-                        ERROR_DELAY_MS,
-                        e,
-                    )
-                }
-            }
-        } finally {
-            RedisConfig.closeBlockingConnection(conn)
-        }
-    }
+
     internal suspend fun processMessage(
         workerId: Int,
         payload: String,

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -26,6 +26,7 @@ import com.moneat.datadog.models.DatadogSketchPoint
 import com.moneat.monitoring.OperationalMetrics
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.every
@@ -203,7 +204,7 @@ class DatadogMetricServiceTest {
     @Test
     fun `enqueueMetrics serializes project id in queued batch`() = runBlocking {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
         val payload = DatadogMetricSeriesV1(
             series = listOf(
                 DatadogMetricV1(
@@ -216,7 +217,7 @@ class DatadogMetricServiceTest {
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush("test:dd:metric:queue", capture(queuedPayload)) } returns 1L
+            every { redis.xadd("test:dd:metric:queue:stream", any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = DatadogMetricService.enqueueMetrics(
                 organizationId = 42L,
@@ -225,7 +226,7 @@ class DatadogMetricServiceTest {
                 queueKey = "test:dd:metric:queue",
             )
 
-            val batch = DatadogMetricService.decodeMetricBatch(queuedPayload.captured)
+            val batch = DatadogMetricService.decodeMetricBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(1, count)
             assertEquals(42L, batch.organizationId)
             assertEquals(7L, batch.projectId)

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DbmIngestionServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DbmIngestionServiceTest.kt
@@ -25,6 +25,7 @@ import com.moneat.datadog.models.DdDbmMetricRow
 import com.moneat.datadog.models.DdDbmMetricsPayload
 import com.moneat.datadog.models.DdDbmQueryPayload
 import com.moneat.datadog.models.DdDbmQueryRow
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.every
 import io.mockk.mockk
@@ -281,12 +282,12 @@ class DbmIngestionServiceTest {
     @Test
     fun `enqueueQueryPayloads writes one combined Redis batch`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+            every { redis.xadd(any<String>(), any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = DbmIngestionService.enqueueQueryPayloads(
                 organizationId = 42,
@@ -302,12 +303,12 @@ class DbmIngestionServiceTest {
                 ),
             )
 
-            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = DbmIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(2, count)
             assertEquals(42, batch.organizationId)
             assertEquals("queries", batch.batchType)
             assertEquals(listOf("sig-a", "sig-b"), batch.queries.map { it.querySignature })
-            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+            verify(exactly = 1) { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -326,7 +327,7 @@ class DbmIngestionServiceTest {
 
             assertEquals(0, count)
             verify(exactly = 0) { RedisConfig.sync() }
-            verify(exactly = 0) { redis.lpush(any<String>(), any<String>()) }
+            verify(exactly = 0) { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -335,12 +336,12 @@ class DbmIngestionServiceTest {
     @Test
     fun `enqueueMetricPayloads writes one combined Redis batch`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+            every { redis.xadd(any<String>(), any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = DbmIngestionService.enqueueMetricPayloads(
                 organizationId = 42,
@@ -356,12 +357,12 @@ class DbmIngestionServiceTest {
                 ),
             )
 
-            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = DbmIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(2, count)
             assertEquals("metrics", batch.batchType)
             assertEquals(listOf("sig-a", "sig-b"), batch.metrics.map { it.querySignature })
             assertEquals(listOf(10L, 20L), batch.metrics.map { it.calls })
-            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+            verify(exactly = 1) { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -370,12 +371,12 @@ class DbmIngestionServiceTest {
     @Test
     fun `enqueueActivityPayloads writes one combined Redis batch`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+            every { redis.xadd(any<String>(), any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = DbmIngestionService.enqueueActivityPayloads(
                 organizationId = 42,
@@ -395,12 +396,12 @@ class DbmIngestionServiceTest {
                 ),
             )
 
-            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = DbmIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(2, count)
             assertEquals("activity", batch.batchType)
             assertEquals(listOf("sig-a", "sig-b"), batch.activity.map { it.querySignature })
             assertEquals(listOf("active", "idle"), batch.activity.map { it.state })
-            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+            verify(exactly = 1) { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -409,12 +410,12 @@ class DbmIngestionServiceTest {
     @Test
     fun `enqueueMetadataPayloads writes one combined Redis batch`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+            every { redis.xadd(any<String>(), any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = DbmIngestionService.enqueueMetadataPayloads(
                 organizationId = 42,
@@ -424,12 +425,12 @@ class DbmIngestionServiceTest {
                 ),
             )
 
-            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = DbmIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(2, count)
             assertEquals("metadata", batch.batchType)
             assertEquals(listOf("pg-a", "pg-b"), batch.metadata.map { it.host })
             assertEquals("plan-b", batch.metadata[1].explainPlanHash)
-            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+            verify(exactly = 1) { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -438,12 +439,12 @@ class DbmIngestionServiceTest {
     @Test
     fun `enqueueHealthPayloads writes one combined Redis batch`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(any<String>(), capture(queuedPayload)) } returns 1L
+            every { redis.xadd(any<String>(), any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = DbmIngestionService.enqueueHealthPayloads(
                 organizationId = 42,
@@ -453,12 +454,12 @@ class DbmIngestionServiceTest {
                 ),
             )
 
-            val batch = DbmIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = DbmIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(2, count)
             assertEquals("health", batch.batchType)
             assertEquals(listOf("pg-a", "pg-b"), batch.health.map { it.host })
             assertEquals(listOf("ok", "degraded"), batch.health.map { it.status })
-            verify(exactly = 1) { redis.lpush(any<String>(), any<String>()) }
+            verify(exactly = 1) { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -471,7 +472,7 @@ class DbmIngestionServiceTest {
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(TEST_DBM_QUEUE, any<String>()) } returns 1L
+            every { redis.xadd("$TEST_DBM_QUEUE:stream", any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
 
             val counts = listOf(
                 DbmIngestionService.enqueueQueries(
@@ -502,7 +503,9 @@ class DbmIngestionServiceTest {
             )
 
             assertEquals(listOf(1, 1, 1, 1, 1), counts)
-            verify(exactly = 5) { redis.lpush(TEST_DBM_QUEUE, any<String>()) }
+            verify(exactly = 5) {
+                redis.xadd("$TEST_DBM_QUEUE:stream", any<XAddArgs>(), any<Map<String, String>>())
+            }
         } finally {
             unmockkObject(RedisConfig)
         }

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorkerTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/workers/DatadogMetricIngestionWorkerTest.kt
@@ -21,14 +21,12 @@ import com.moneat.datadog.services.DatadogMetricService
 import com.moneat.datadog.services.QueuedMetricBatch
 import com.moneat.datadog.services.QueuedMetricEntry
 import com.moneat.monitoring.OperationalMetrics
-import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.XAddArgs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerializationException
 import kotlin.test.AfterTest
@@ -89,49 +87,7 @@ class DatadogMetricIngestionWorkerTest {
     }
 
     @Test
-    fun `collectPayloadsForProcessing drains additional payloads with bounded rpop count`() {
-        val redis = mockk<RedisCommands<String, String>>()
-        every {
-            redis.rpoplpush("test:dd:metric:queue", "test:dd:metric:queue:processing")
-        } returnsMany listOf("payload-2", "payload-3")
-        val worker =
-            DatadogMetricIngestionWorker(
-                "test:dd:metric:queue",
-                "test:dd:metric:dlq",
-                1,
-                maxPayloads = 3,
-            )
-
-        val payloads = worker.collectPayloadsForProcessing(redis, "payload-1")
-
-        assertEquals(listOf("payload-1", "payload-2", "payload-3"), payloads)
-        verify(exactly = 2) {
-            redis.rpoplpush("test:dd:metric:queue", "test:dd:metric:queue:processing")
-        }
-    }
-
-    @Test
-    fun `collectPayloadsForProcessing does not drain when max payloads is one`() {
-        val redis = mockk<RedisCommands<String, String>>()
-        val worker =
-            DatadogMetricIngestionWorker(
-                "test:dd:metric:queue",
-                "test:dd:metric:dlq",
-                1,
-                maxPayloads = 1,
-            )
-
-        val payloads = worker.collectPayloadsForProcessing(redis, "payload-1")
-
-        assertEquals(listOf("payload-1"), payloads)
-        verify(exactly = 0) { redis.rpoplpush(any<String>(), any<String>()) }
-    }
-
-    // ──── Insert Batching ────
-
-    @Test
     fun `processPayloads combines valid payloads and pushes malformed payloads individually to dlq`() = runBlocking {
-        val redis = mockk<RedisCommands<String, String>>(relaxed = true)
         val firstBatch = metricBatch(1L, "cpu")
         val secondBatch = metricBatch(2L, "mem")
         val worker =
@@ -148,8 +104,7 @@ class DatadogMetricIngestionWorkerTest {
             every { DatadogMetricService.decodeMetricBatch("bad-payload") } throws
                 SerializationException("bad payload")
             every { DatadogMetricService.decodeMetricBatch("payload-2") } returns secondBatch
-            every { RedisConfig.sync() } returns redis
-            every { redis.rpush("test:dd:metric:dlq", "bad-payload") } returns 1L
+            every { RedisConfig.sync().xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) } returns "2-0"
             coEvery { DatadogMetricService.insertMetricBatches(any()) } returns Unit
 
             worker.processPayloads(1, listOf("payload-1", "bad-payload", "payload-2"))
@@ -157,26 +112,13 @@ class DatadogMetricIngestionWorkerTest {
             coVerify(exactly = 1) {
                 DatadogMetricService.insertMetricBatches(listOf(firstBatch, secondBatch))
             }
-            verify(exactly = 1) {
-                redis.rpush("test:dd:metric:dlq", "bad-payload")
-            }
-            verify(exactly = 1) {
-                redis.lrem("test:dd:metric:queue:processing", 1, "payload-1")
-            }
-            verify(exactly = 1) {
-                redis.lrem("test:dd:metric:queue:processing", 1, "bad-payload")
-            }
-            verify(exactly = 1) {
-                redis.lrem("test:dd:metric:queue:processing", 1, "payload-2")
-            }
-
             val rendered = OperationalMetrics.scrape()
             assertContains(rendered, "moneat_datadog_metric_insert_chunks_total")
             assertContains(rendered, "mode=\"combined\"")
             assertContains(rendered, "status=\"success\"")
             assertContains(rendered, "moneat_datadog_metric_insert_rows_count")
             assertContains(rendered, "moneat_datadog_metric_insert_payloads_count")
-            assertContains(rendered, "moneat_datadog_metric_payload_acks_total")
+            assertContains(rendered, "moneat_worker_dlq_pushes_total")
         } finally {
             unmockkObject(DatadogMetricService)
             unmockkObject(RedisConfig)
@@ -185,7 +127,6 @@ class DatadogMetricIngestionWorkerTest {
 
     @Test
     fun `processPayloads flushes chunks at configured max rows`() = runBlocking {
-        val redis = mockk<RedisCommands<String, String>>(relaxed = true)
         val firstBatch = metricBatch(1L, "cpu")
         val secondBatch = metricBatch(2L, "mem")
         val worker =
@@ -201,19 +142,12 @@ class DatadogMetricIngestionWorkerTest {
         try {
             every { DatadogMetricService.decodeMetricBatch("payload-1") } returns firstBatch
             every { DatadogMetricService.decodeMetricBatch("payload-2") } returns secondBatch
-            every { RedisConfig.sync() } returns redis
             coEvery { DatadogMetricService.insertMetricBatches(any()) } returns Unit
 
             worker.processPayloads(1, listOf("payload-1", "payload-2"))
 
             coVerify(exactly = 1) { DatadogMetricService.insertMetricBatches(listOf(firstBatch)) }
             coVerify(exactly = 1) { DatadogMetricService.insertMetricBatches(listOf(secondBatch)) }
-            verify(exactly = 1) {
-                redis.lrem("test:dd:metric:queue:processing", 1, "payload-1")
-            }
-            verify(exactly = 1) {
-                redis.lrem("test:dd:metric:queue:processing", 1, "payload-2")
-            }
 
             val rendered = OperationalMetrics.scrape()
             assertContains(rendered, "moneat_datadog_metric_insert_chunks_total")
@@ -228,7 +162,6 @@ class DatadogMetricIngestionWorkerTest {
 
     @Test
     fun `processPayloads falls back per payload after combined insert failure`() = runBlocking {
-        val redis = mockk<RedisCommands<String, String>>(relaxed = true)
         val firstBatch = metricBatch(1L, "cpu")
         val secondBatch = metricBatch(2L, "mem")
         val worker =
@@ -243,7 +176,6 @@ class DatadogMetricIngestionWorkerTest {
         try {
             every { DatadogMetricService.decodeMetricBatch("payload-1") } returns firstBatch
             every { DatadogMetricService.decodeMetricBatch("payload-2") } returns secondBatch
-            every { RedisConfig.sync() } returns redis
             coEvery { DatadogMetricService.insertMetricBatches(listOf(firstBatch, secondBatch)) } throws
                 IllegalStateException("combined insert failed")
             coEvery { DatadogMetricService.insertMetricBatch(firstBatch) } returns Unit
@@ -256,14 +188,6 @@ class DatadogMetricIngestionWorkerTest {
             }
             coVerify(exactly = 1) { DatadogMetricService.insertMetricBatch(firstBatch) }
             coVerify(exactly = 1) { DatadogMetricService.insertMetricBatch(secondBatch) }
-            verify(exactly = 0) { redis.rpush("test:dd:metric:dlq", "payload-1") }
-            verify(exactly = 0) { redis.rpush("test:dd:metric:dlq", "payload-2") }
-            verify(exactly = 1) {
-                redis.lrem("test:dd:metric:queue:processing", 1, "payload-1")
-            }
-            verify(exactly = 1) {
-                redis.lrem("test:dd:metric:queue:processing", 1, "payload-2")
-            }
 
             val rendered = OperationalMetrics.scrape()
             assertContains(rendered, "moneat_datadog_metric_insert_fallbacks_total")

--- a/backend/features/datadog/src/test/kotlin/com/moneat/services/MiscIngestionServiceCoverageTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/services/MiscIngestionServiceCoverageTest.kt
@@ -30,6 +30,7 @@ import com.moneat.datadog.services.QueuedPipelineStatEntry
 import com.moneat.datadog.services.QueuedSbomEntry
 import com.moneat.datadog.services.QueuedSymbolDbEntry
 import com.moneat.datadog.services.QueuedSyntheticEntry
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.every
@@ -92,12 +93,12 @@ class MiscIngestionServiceCoverageTest {
     @Test
     fun `enqueueContainerImages writes one Redis batch with parsed tags`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(MISC_QUEUE_KEY, capture(queuedPayload)) } returns 1L
+            every { redis.xadd("$MISC_QUEUE_KEY:stream", any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = MiscIngestionService.enqueueContainerImages(
                 orgId = 42,
@@ -127,7 +128,7 @@ class MiscIngestionServiceCoverageTest {
                 ),
             )
 
-            val batch = MiscIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = MiscIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(2, count)
             assertEquals(42, batch.organizationId)
             assertEquals("container_images", batch.batchType)
@@ -136,7 +137,7 @@ class MiscIngestionServiceCoverageTest {
             assertEquals("prod", batch.containerImages.first().tags["env"])
             assertEquals("", batch.containerImages.first().tags["standalone"])
             assertEquals(batch.containerImages.first().timestampMs, batch.containerImages.last().timestampMs)
-            verify(exactly = 1) { redis.lpush(MISC_QUEUE_KEY, any<String>()) }
+            verify(exactly = 1) { redis.xadd("$MISC_QUEUE_KEY:stream", any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -145,12 +146,12 @@ class MiscIngestionServiceCoverageTest {
     @Test
     fun `enqueueContainerImage delegates to a single-entry Redis batch`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(MISC_QUEUE_KEY, capture(queuedPayload)) } returns 1L
+            every { redis.xadd("$MISC_QUEUE_KEY:stream", any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             MiscIngestionService.enqueueContainerImage(
                 orgId = 7,
@@ -163,13 +164,13 @@ class MiscIngestionServiceCoverageTest {
                 ),
             )
 
-            val batch = MiscIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = MiscIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(7, batch.organizationId)
             assertEquals("container_images", batch.batchType)
             assertEquals(1, batch.containerImages.size)
             assertEquals("api", batch.containerImages.single().imageName)
             assertEquals("api", batch.containerImages.single().tags["service"])
-            verify(exactly = 1) { redis.lpush(MISC_QUEUE_KEY, any<String>()) }
+            verify(exactly = 1) { redis.xadd("$MISC_QUEUE_KEY:stream", any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }
@@ -191,12 +192,12 @@ class MiscIngestionServiceCoverageTest {
     @Test
     fun `enqueueSbom writes package rows in one Redis batch`() {
         val redis = mockk<RedisCommands<String, String>>()
-        val queuedPayload = slot<String>()
+        val queuedBody = slot<Map<String, String>>()
 
         mockkObject(RedisConfig)
         try {
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(MISC_QUEUE_KEY, capture(queuedPayload)) } returns 1L
+            every { redis.xadd("$MISC_QUEUE_KEY:stream", any<XAddArgs>(), capture(queuedBody)) } returns "1-0"
 
             val count = MiscIngestionService.enqueueSbom(
                 orgId = 99,
@@ -222,7 +223,7 @@ class MiscIngestionServiceCoverageTest {
                 ),
             )
 
-            val batch = MiscIngestionService.decodeBatch(queuedPayload.captured)
+            val batch = MiscIngestionService.decodeBatch(requireNotNull(queuedBody.captured["payload"]))
             assertEquals(2, count)
             assertEquals(99, batch.organizationId)
             assertEquals("sbom_packages", batch.batchType)
@@ -231,7 +232,7 @@ class MiscIngestionServiceCoverageTest {
             assertEquals(listOf("CVE-2024-0001"), batch.sbomPackages.first().cveIds)
             assertEquals("prod", batch.sbomPackages.first().tags["env"])
             assertEquals(batch.sbomPackages.first().timestampMs, batch.sbomPackages.last().timestampMs)
-            verify(exactly = 1) { redis.lpush(MISC_QUEUE_KEY, any<String>()) }
+            verify(exactly = 1) { redis.xadd("$MISC_QUEUE_KEY:stream", any<XAddArgs>(), any<Map<String, String>>()) }
         } finally {
             unmockkObject(RedisConfig)
         }

--- a/backend/features/datadog/src/test/kotlin/com/moneat/services/NetworkDevicesTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/services/NetworkDevicesTest.kt
@@ -36,6 +36,7 @@ import com.moneat.testsupport.TestIpConstants
 import com.moneat.testsupport.TestOidConstants
 import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.every
 import io.mockk.mockkObject
@@ -73,7 +74,7 @@ class NetworkDevicesTest {
         @Suppress("UNCHECKED_CAST")
         mockRedis = io.mockk.mockk<RedisCommands<String, String>>()
         every { RedisConfig.sync() } returns mockRedis
-        every { mockRedis.lpush(any(), any<String>()) } returns 1L
+        every { mockRedis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
     }
 
     @AfterTest
@@ -151,9 +152,9 @@ class NetworkDevicesTest {
         val count = NdmIngestionService.enqueue(orgId, payload)
 
         assertEquals(1, count)
-        val pushed = slot<String>()
-        verify { mockRedis.lpush(MONET_NDM_QUEUE, capture(pushed)) }
-        val batch = json.decodeFromString<QueuedNdmBatch>(pushed.captured)
+        val pushed = slot<Map<String, String>>()
+        verify { mockRedis.xadd("$MONET_NDM_QUEUE:stream", any<XAddArgs>(), capture(pushed)) }
+        val batch = json.decodeFromString<QueuedNdmBatch>(requireNotNull(pushed.captured["payload"]))
         assertEquals("devices", batch.batchType)
         assertEquals(orgId, batch.organizationId)
         assertEquals(1, batch.devices.size)
@@ -192,9 +193,9 @@ class NetworkDevicesTest {
         val count = NdmIngestionService.enqueue(orgId, payload)
 
         assertEquals(1, count)
-        val pushed = slot<String>()
-        verify { mockRedis.lpush(MONET_NDM_QUEUE, capture(pushed)) }
-        val batch = json.decodeFromString<QueuedNdmBatch>(pushed.captured)
+        val pushed = slot<Map<String, String>>()
+        verify { mockRedis.xadd("$MONET_NDM_QUEUE:stream", any<XAddArgs>(), capture(pushed)) }
+        val batch = json.decodeFromString<QueuedNdmBatch>(requireNotNull(pushed.captured["payload"]))
         assertEquals("traps", batch.batchType)
         assertEquals(1, batch.traps.size)
         assertEquals(TestIpConstants.IP_1, batch.traps[0].deviceIp)
@@ -228,9 +229,9 @@ class NetworkDevicesTest {
         val count = NdmIngestionService.enqueue(orgId, payload)
 
         assertEquals(1, count)
-        val pushed = slot<String>()
-        verify { mockRedis.lpush(MONET_NDM_QUEUE, capture(pushed)) }
-        val batch = json.decodeFromString<QueuedNdmBatch>(pushed.captured)
+        val pushed = slot<Map<String, String>>()
+        verify { mockRedis.xadd("$MONET_NDM_QUEUE:stream", any<XAddArgs>(), capture(pushed)) }
+        val batch = json.decodeFromString<QueuedNdmBatch>(requireNotNull(pushed.captured["payload"]))
         assertEquals("flows", batch.batchType)
         assertEquals(1, batch.flows.size)
         assertEquals(TestIpConstants.IP_10, batch.flows[0].srcIp)
@@ -261,9 +262,9 @@ class NetworkDevicesTest {
         val count = NdmIngestionService.enqueue(orgId, payload)
 
         assertEquals(1, count)
-        val pushed = slot<String>()
-        verify { mockRedis.lpush(MONET_NDM_QUEUE, capture(pushed)) }
-        val batch = json.decodeFromString<QueuedNdmBatch>(pushed.captured)
+        val pushed = slot<Map<String, String>>()
+        verify { mockRedis.xadd("$MONET_NDM_QUEUE:stream", any<XAddArgs>(), capture(pushed)) }
+        val batch = json.decodeFromString<QueuedNdmBatch>(requireNotNull(pushed.captured["payload"]))
         assertEquals("paths", batch.batchType)
         assertEquals(1, batch.paths.size)
         assertEquals(TestIpConstants.IP_1, batch.paths[0].source)
@@ -292,9 +293,9 @@ class NetworkDevicesTest {
         val count = NdmIngestionService.enqueue(orgId, payload)
 
         assertEquals(1, count)
-        val pushed = slot<String>()
-        verify { mockRedis.lpush(MONET_NDM_QUEUE, capture(pushed)) }
-        val batch = json.decodeFromString<QueuedNdmBatch>(pushed.captured)
+        val pushed = slot<Map<String, String>>()
+        verify { mockRedis.xadd("$MONET_NDM_QUEUE:stream", any<XAddArgs>(), capture(pushed)) }
+        val batch = json.decodeFromString<QueuedNdmBatch>(requireNotNull(pushed.captured["payload"]))
         assertEquals("configs", batch.batchType)
         assertEquals(1, batch.configs.size)
         assertEquals("dev1", batch.configs[0].deviceId)
@@ -986,10 +987,10 @@ class NetworkDevicesTest {
 
     @Test
     fun `full round-trip enqueue then decode and insert`() = runBlocking {
-        val pushed = slot<String>()
+        val pushed = slot<Map<String, String>>()
         every {
-            mockRedis.lpush(MONET_NDM_QUEUE, capture(pushed))
-        } returns 1L
+            mockRedis.xadd("$MONET_NDM_QUEUE:stream", any<XAddArgs>(), capture(pushed))
+        } returns "1-0"
 
         val payload = DdNdmPayload(
             type = "ndm",
@@ -1005,7 +1006,7 @@ class NetworkDevicesTest {
 
         NdmIngestionService.enqueue(orgId, payload)
 
-        val batch = NdmIngestionService.decodeBatch(pushed.captured)
+        val batch = NdmIngestionService.decodeBatch(requireNotNull(pushed.captured["payload"]))
         assertEquals("devices", batch.batchType)
         assertEquals(orgId, batch.organizationId)
         assertEquals(ROUNDTRIP_DEV, batch.devices[0].deviceId)

--- a/backend/features/datadog/src/test/kotlin/com/moneat/services/SecurityServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/services/SecurityServiceTest.kt
@@ -29,6 +29,7 @@ import com.moneat.datadog.security.SecurityIngestionService
 import com.moneat.testsupport.MockHttpServer
 import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.every
 import io.mockk.mockk
@@ -57,6 +58,9 @@ class SecurityServiceTest {
     fun setup() {
         mockkObject(RedisConfig)
         every { RedisConfig.sync() } returns mockRedisCommands
+        every {
+            mockRedisCommands.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>())
+        } returns "1-0"
     }
 
     @AfterTest
@@ -220,14 +224,15 @@ class SecurityServiceTest {
         val count = SecurityIngestionService.enqueueSecurityEvents(1, payload)
 
         assertEquals(2, count)
-        val captured = slot<String>()
+        val captured = slot<Map<String, String>>()
         verify {
-            mockRedisCommands.lpush(
-                "moneat:dd:security:queue",
-                capture(captured)
+            mockRedisCommands.xadd(
+                "moneat:dd:security:queue:stream",
+                any<XAddArgs>(),
+                capture(captured),
             )
         }
-        val decoded = SecurityIngestionService.decodeBatch(captured.captured)
+        val decoded = SecurityIngestionService.decodeBatch(requireNotNull(captured.captured["payload"]))
         assertEquals("events", decoded.batchType)
         assertEquals(1, decoded.organizationId)
         assertEquals(2, decoded.events.size)
@@ -240,7 +245,9 @@ class SecurityServiceTest {
         val payload = DdSecurityEventPayload(events = emptyList())
         val count = SecurityIngestionService.enqueueSecurityEvents(1, payload)
         assertEquals(0, count)
-        verify(exactly = 0) { mockRedisCommands.lpush(any(), any<String>()) }
+        verify(exactly = 0) {
+            mockRedisCommands.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>())
+        }
     }
 
     @Test
@@ -256,9 +263,9 @@ class SecurityServiceTest {
 
         SecurityIngestionService.enqueueSecurityEvents(5, payload)
 
-        val captured = slot<String>()
-        verify { mockRedisCommands.lpush(any(), capture(captured)) }
-        val decoded = SecurityIngestionService.decodeBatch(captured.captured)
+        val captured = slot<Map<String, String>>()
+        verify { mockRedisCommands.xadd(any<String>(), any<XAddArgs>(), capture(captured)) }
+        val decoded = SecurityIngestionService.decodeBatch(requireNotNull(captured.captured["payload"]))
         val tags = decoded.events[0].tags
         assertEquals("staging", tags["env"])
         assertEquals("us-east-1", tags["region"])
@@ -284,9 +291,9 @@ class SecurityServiceTest {
         val count = SecurityIngestionService.enqueueActivityDumps(2, payload)
 
         assertEquals(1, count)
-        val captured = slot<String>()
-        verify { mockRedisCommands.lpush(any(), capture(captured)) }
-        val decoded = SecurityIngestionService.decodeBatch(captured.captured)
+        val captured = slot<Map<String, String>>()
+        verify { mockRedisCommands.xadd(any<String>(), any<XAddArgs>(), capture(captured)) }
+        val decoded = SecurityIngestionService.decodeBatch(requireNotNull(captured.captured["payload"]))
         assertEquals("dumps", decoded.batchType)
         assertEquals(2, decoded.organizationId)
         assertEquals("exec", decoded.dumps[0].activityType)
@@ -298,7 +305,9 @@ class SecurityServiceTest {
         val payload = DdActivityDumpPayload(dumps = emptyList())
         val count = SecurityIngestionService.enqueueActivityDumps(2, payload)
         assertEquals(0, count)
-        verify(exactly = 0) { mockRedisCommands.lpush(any(), any<String>()) }
+        verify(exactly = 0) {
+            mockRedisCommands.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>())
+        }
     }
 
     // ──── enqueueCompliance ────
@@ -329,9 +338,9 @@ class SecurityServiceTest {
         val count = SecurityIngestionService.enqueueCompliance(3, payload)
 
         assertEquals(2, count)
-        val captured = slot<String>()
-        verify { mockRedisCommands.lpush(any(), capture(captured)) }
-        val decoded = SecurityIngestionService.decodeBatch(captured.captured)
+        val captured = slot<Map<String, String>>()
+        verify { mockRedisCommands.xadd(any<String>(), any<XAddArgs>(), capture(captured)) }
+        val decoded = SecurityIngestionService.decodeBatch(requireNotNull(captured.captured["payload"]))
         assertEquals("findings", decoded.batchType)
         assertEquals(3, decoded.organizationId)
         assertEquals(2, decoded.findings.size)
@@ -344,7 +353,9 @@ class SecurityServiceTest {
         val payload = DdCompliancePayload(findings = emptyList())
         val count = SecurityIngestionService.enqueueCompliance(3, payload)
         assertEquals(0, count)
-        verify(exactly = 0) { mockRedisCommands.lpush(any(), any<String>()) }
+        verify(exactly = 0) {
+            mockRedisCommands.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>())
+        }
     }
 
     // ──── insertBatch ────

--- a/backend/features/llm/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
+++ b/backend/features/llm/src/main/kotlin/com/moneat/llm/services/LlmIngestionWorker.kt
@@ -17,10 +17,7 @@
 package com.moneat.llm.services
 
 import com.moneat.config.ClickHouseClient
-import com.moneat.config.RedisConfig
-import com.moneat.ingestion.queue.IngestionDlqRequest
 import com.moneat.ingestion.queue.IngestionPipeline
-import com.moneat.ingestion.queue.IngestionQueueClient
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.QueuedIngestionMessage
 import com.moneat.ingestion.queue.RedisQueueWorker
@@ -29,6 +26,7 @@ import com.moneat.llm.models.LlmIngestPayload
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseSqlUtils
+import com.moneat.utils.pushToDlq
 import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
@@ -61,19 +59,7 @@ class LlmIngestionWorker(
         queueWorker = RedisQueueWorker(
             spec = spec,
             logger = logger,
-            processMessage = { workerId, payload ->
-                processMessageForTest(workerId, payload) { message ->
-                    IngestionQueueClient.pushToDlq(
-                        logger = logger,
-                        request = IngestionDlqRequest(
-                            spec = spec,
-                            payload = message,
-                            workerId = workerId,
-                            cause = IllegalStateException("LLM processing failed"),
-                        ),
-                    )
-                }
-            },
+            processMessage = ::processMessageForTest,
             processBatch = ::processBatch,
         ).also { it.start() }
     }
@@ -86,7 +72,6 @@ class LlmIngestionWorker(
     internal suspend fun processMessageForTest(
         workerId: Int,
         value: String,
-        onDlq: (String) -> Unit = { message -> RedisConfig.sync().rpush(dlqKey, message) }
     ) {
         suspendRunCatching {
             val (projectId, payloadBytes) = decodeMessage(value)
@@ -95,7 +80,7 @@ class LlmIngestionWorker(
             usageTracker.recordUsage(projectId, "llm", payloadBytes.size)
             OperationalMetrics.recordWorkerMessageProcessed("LLM", workerId)
         }.getOrElse { e ->
-            handleLlmDlq(workerId, value, e, onDlq)
+            handleLlmDlq(workerId, value, e)
         }
     }
 
@@ -103,18 +88,9 @@ class LlmIngestionWorker(
         workerId: Int,
         value: String,
         e: Throwable,
-        onDlq: (String) -> Unit,
     ) {
         logger.error(e) { "LLM worker $workerId failed to process message, sending to DLQ" }
-        OperationalMetrics.recordWorkerProcessingFailure("LLM", workerId, e)
-        suspendRunCatching {
-            onDlq(value)
-        }.onSuccess {
-            OperationalMetrics.recordDlqPush("LLM", dlqKey, "success")
-        }.onFailure { dlqErr ->
-            OperationalMetrics.recordDlqPush("LLM", dlqKey, "failure")
-            logger.error(dlqErr) { "Failed to push LLM message to DLQ" }
-        }.getOrThrow()
+        pushToDlq(logger, dlqKey, value, workerId, "LLM", e)
     }
 
     private suspend fun processBatch(

--- a/backend/features/llm/src/test/kotlin/com/moneat/services/LlmIngestionWorkerTest.kt
+++ b/backend/features/llm/src/test/kotlin/com/moneat/services/LlmIngestionWorkerTest.kt
@@ -17,11 +17,19 @@
 package com.moneat.services
 
 import com.moneat.config.ClickHouseClient
+import com.moneat.config.RedisConfig
 import com.moneat.llm.models.LlmGenerationIngest
 import com.moneat.llm.services.LlmIngestionWorker
 import com.moneat.testsupport.MockHttpServer
 import com.moneat.testsupport.requestBodyText
 import com.moneat.testsupport.respond
+import io.lettuce.core.XAddArgs
+import io.lettuce.core.api.sync.RedisCommands
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -68,12 +76,18 @@ class LlmIngestionWorkerTest {
     fun `processMessageForTest sends bad payload to DLQ`() =
         runBlocking {
             val worker = LlmIngestionWorker("llm:q", "llm:dlq", 1)
-            val dlq = mutableListOf<String>()
+            val redis = mockDlqStream()
             val bad = "not-base64"
 
-            worker.processMessageForTest(workerId = 3, value = bad) { dlq.add(it) }
+            try {
+                worker.processMessageForTest(workerId = 3, value = bad)
 
-            assertEquals(listOf(bad), dlq)
+                verify(exactly = 1) {
+                    redis.xadd("llm:dlq:stream", any<XAddArgs>(), any<Map<String, String>>())
+                }
+            } finally {
+                unmockkObject(RedisConfig)
+            }
         }
 
     @Test
@@ -132,12 +146,26 @@ class LlmIngestionWorkerTest {
     fun `processMessageForTest routes invalid json payload to DLQ`() =
         runBlocking {
             val worker = LlmIngestionWorker("llm:q", "llm:dlq", 1)
-            val dlq = mutableListOf<String>()
+            val redis = mockDlqStream()
             val invalidJsonPayload = "not-json".toByteArray()
             val encoded = LlmIngestionWorker.encodeMessage(7, invalidJsonPayload)
 
-            worker.processMessageForTest(workerId = 4, value = encoded) { dlq.add(it) }
+            try {
+                worker.processMessageForTest(workerId = 4, value = encoded)
 
-            assertEquals(listOf(encoded), dlq)
+                verify(exactly = 1) {
+                    redis.xadd("llm:dlq:stream", any<XAddArgs>(), any<Map<String, String>>())
+                }
+            } finally {
+                unmockkObject(RedisConfig)
+            }
         }
+
+    private fun mockDlqStream(): RedisCommands<String, String> {
+        val redis = mockk<RedisCommands<String, String>>()
+        mockkObject(RedisConfig)
+        every { RedisConfig.sync() } returns redis
+        every { redis.xadd("llm:dlq:stream", any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
+        return redis
+    }
 }

--- a/backend/features/logs/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
+++ b/backend/features/logs/src/main/kotlin/com/moneat/logs/services/LogIngestionWorker.kt
@@ -16,14 +16,12 @@
 
 package com.moneat.logs.services
 
-import com.moneat.config.RedisConfig
-import com.moneat.ingestion.queue.IngestionDlqRequest
 import com.moneat.ingestion.queue.IngestionPipeline
-import com.moneat.ingestion.queue.IngestionQueueClient
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.logs.repositories.LogRepositoryImpl
 import com.moneat.monitoring.OperationalMetrics
+import com.moneat.utils.pushToDlq
 import com.moneat.utils.suspendRunCatching
 import mu.KotlinLogging
 import kotlin.random.Random
@@ -45,19 +43,7 @@ class LogIngestionWorker(
     fun start() {
         logger.info { "Starting LogIngestionWorker with $workerCount workers, queue=$queueKey" }
         val spec = IngestionQueueSettings.spec(IngestionPipeline.LOGS, queueKey, dlqKey, workerCount)
-        queueWorker = RedisQueueWorker(spec, logger, processMessage = { workerId, payload ->
-            processMessageForTest(workerId, payload) { message ->
-                IngestionQueueClient.pushToDlq(
-                    logger = logger,
-                    request = IngestionDlqRequest(
-                        spec = spec,
-                        payload = message,
-                        workerId = workerId,
-                        cause = IllegalStateException("Log processing failed"),
-                    ),
-                )
-            }
-        }).also { it.start() }
+        queueWorker = RedisQueueWorker(spec, logger, processMessage = ::processMessageForTest).also { it.start() }
     }
 
     fun stop() {
@@ -68,7 +54,6 @@ class LogIngestionWorker(
     internal suspend fun processMessageForTest(
         workerId: Int,
         payload: String,
-        onDlq: (String) -> Unit = { message -> RedisConfig.sync().rpush(dlqKey, message) }
     ) {
         suspendRunCatching {
             val batch = logService.decodeQueueMessage(payload)
@@ -106,15 +91,7 @@ class LogIngestionWorker(
             OperationalMetrics.recordWorkerMessageProcessed("Log", workerId)
         }.getOrElse { e ->
             logger.error(e) { "Log worker $workerId failed to process message, pushing to DLQ" }
-            OperationalMetrics.recordWorkerProcessingFailure("Log", workerId, e)
-            suspendRunCatching {
-                onDlq(payload)
-            }.onSuccess {
-                OperationalMetrics.recordDlqPush("Log", dlqKey, "success")
-            }.onFailure { dlqErr ->
-                OperationalMetrics.recordDlqPush("Log", dlqKey, "failure")
-                logger.error(dlqErr) { "Failed to push log message to DLQ" }
-            }.getOrThrow()
+            pushToDlq(logger, dlqKey, payload, workerId, "Log", e)
         }
     }
 

--- a/backend/features/logs/src/test/kotlin/com/moneat/services/LogIngestionWorkerTest.kt
+++ b/backend/features/logs/src/test/kotlin/com/moneat/services/LogIngestionWorkerTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.services
 
+import com.moneat.config.RedisConfig
 import com.moneat.logs.models.QueuedLogBatch
 import com.moneat.logs.models.QueuedLogEntry
 import com.moneat.logs.models.LogEntryResponse
@@ -27,17 +28,20 @@ import com.moneat.logs.services.LogIngestionWorker
 import com.moneat.logs.services.LogManagementService
 import com.moneat.logs.services.LogService
 import com.moneat.monitoring.OperationalMetrics
+import io.lettuce.core.XAddArgs
+import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 class LogIngestionWorkerTest {
     @BeforeTest
@@ -54,19 +58,25 @@ class LogIngestionWorkerTest {
     fun `processMessageForTest sends malformed payload to DLQ`() =
         runBlocking {
             val worker = LogIngestionWorker("log:q", "log:dlq", 1)
-            val dlq = mutableListOf<String>()
+            val redis = mockDlqStream()
             val malformed = "not-json"
 
-            worker.processMessageForTest(workerId = 1, payload = malformed) { dlq.add(it) }
+            try {
+                worker.processMessageForTest(workerId = 1, payload = malformed)
 
-            assertEquals(listOf(malformed), dlq)
+                verify(exactly = 1) {
+                    redis.xadd("log:dlq:stream", any<XAddArgs>(), any<Map<String, String>>())
+                }
+            } finally {
+                unmockkObject(RedisConfig)
+            }
         }
 
     @Test
     fun `processMessageForTest sends payload to DLQ when insert fails`() =
         runBlocking {
             val worker = LogIngestionWorker("log:q", "log:dlq", 1)
-            val dlq = mutableListOf<String>()
+            val redis = mockDlqStream()
             val message =
                 LogService(LogRepositoryImpl()).encodeQueueMessage(
                     QueuedLogBatch(
@@ -94,9 +104,15 @@ class LogIngestionWorkerTest {
                     )
                 )
 
-            worker.processMessageForTest(workerId = 2, payload = message) { dlq.add(it) }
+            try {
+                worker.processMessageForTest(workerId = 2, payload = message)
 
-            assertEquals(listOf(message), dlq)
+                verify(exactly = 1) {
+                    redis.xadd("log:dlq:stream", any<XAddArgs>(), any<Map<String, String>>())
+                }
+            } finally {
+                unmockkObject(RedisConfig)
+            }
         }
 
     @Test
@@ -112,7 +128,6 @@ class LogIngestionWorkerTest {
             val payload = LogService(LogRepositoryImpl()).encodeQueueMessage(batch)
             val index = logIndexResponse(name = "errors", filterQuery = "level:error")
             val pipeline = logPipelineResponse(name = "Cleanup")
-            val dlq = mutableListOf<String>()
 
             every { logService.decodeQueueMessage(payload) } returns batch
             coEvery { logIndexService.getActiveIndexesCached(99) } returns listOf(index)
@@ -136,9 +151,8 @@ class LogIngestionWorkerTest {
                 logManagementService = logManagementService
             )
 
-            worker.processMessageForTest(workerId = 4, payload = payload) { dlq.add(it) }
+            worker.processMessageForTest(workerId = 4, payload = payload)
 
-            assertEquals(emptyList(), dlq)
             coVerify {
                 logService.insertBatch(
                     match { insertedBatch ->
@@ -217,23 +231,35 @@ class LogIngestionWorkerTest {
         }
 
     @Test
-    fun `processMessageForTest records DLQ failure when callback throws`() =
+    fun `processMessageForTest records DLQ failure when stream write fails`() =
         runBlocking {
             val worker = LogIngestionWorker("log:q", "log:dlq", 1)
             val malformed = "not-json"
 
-            assertFailsWith<IllegalStateException> {
-                worker.processMessageForTest(workerId = 3, payload = malformed) {
-                    error("dlq down")
-                }
+            mockkObject(RedisConfig)
+            try {
+                every { RedisConfig.sync().xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) } throws
+                    IllegalStateException("dlq down")
+
+                worker.processMessageForTest(workerId = 3, payload = malformed)
+            } finally {
+                unmockkObject(RedisConfig)
             }
 
             val rendered = OperationalMetrics.scrape()
             assertContains(rendered, "moneat_worker_dlq_pushes_total")
             assertContains(rendered, "worker=\"Log\"")
-            assertContains(rendered, "dlq_key=\"log:dlq\"")
+            assertContains(rendered, "dlq_key=\"log:dlq:stream\"")
             assertContains(rendered, "status=\"failure\"")
         }
+
+    private fun mockDlqStream(): RedisCommands<String, String> {
+        val redis = mockk<RedisCommands<String, String>>()
+        mockkObject(RedisConfig)
+        every { RedisConfig.sync() } returns redis
+        every { redis.xadd("log:dlq:stream", any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
+        return redis
+    }
 
     private fun queuedEntry(
         logId: String,

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -29,10 +29,10 @@ import io.lettuce.core.resource.ClientResources
 import io.netty.resolver.DefaultAddressResolverGroup
 import java.time.Duration
 
-const val BRPOP_TIMEOUT_SECONDS = 5L
+private const val BLOCKING_COMMAND_TIMEOUT_SECONDS = 15L
 
-// Blocking command timeout — must exceed BRPOP wait time. Each worker gets its own connection.
-private val BLOCKING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(BRPOP_TIMEOUT_SECONDS + 10)
+// Blocking command timeout for workers using XREADGROUP BLOCK. Each worker gets its own connection.
+private val BLOCKING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(BLOCKING_COMMAND_TIMEOUT_SECONDS)
 
 object RedisConfig {
     @Volatile

--- a/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/IngestionWorker.kt
@@ -16,18 +16,16 @@
 
 package com.moneat.events.services
 
-import com.moneat.config.RedisConfig
 import com.moneat.events.models.SentryEnvelope
 import com.moneat.events.repositories.EventRepositoryImpl
-import com.moneat.ingestion.queue.IngestionDlqRequest
 import com.moneat.ingestion.queue.IngestionPipeline
-import com.moneat.ingestion.queue.IngestionQueueClient
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.ingestion.queue.RedisQueueWorker
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.utils.SentryUtils
+import com.moneat.utils.pushToDlq
 import com.moneat.utils.suspendRunCatching
 import io.sentry.Sentry
 import mu.KotlinLogging
@@ -37,9 +35,9 @@ import java.util.Base64
 private val logger = KotlinLogging.logger {}
 
 /**
- * Background worker that drains the ingestion queue (Redis list),
+ * Background worker that drains the ingestion stream,
  * deserializes envelope messages, and processes them via EventService.
- * On failure, messages are pushed to a dead-letter queue.
+ * On failure, messages are pushed to a dead-letter stream.
  */
 class IngestionWorker(
     private val queueKey: String,
@@ -56,19 +54,7 @@ class IngestionWorker(
     fun start() {
         logger.info { "Starting IngestionWorker with $workerCount workers, queue=$queueKey" }
         val spec = IngestionQueueSettings.spec(IngestionPipeline.EVENTS, queueKey, dlqKey, workerCount)
-        queueWorker = RedisQueueWorker(spec, logger, processMessage = { workerId, payload ->
-            processMessageForTest(workerId, payload) { message ->
-                IngestionQueueClient.pushToDlq(
-                    logger = logger,
-                    request = IngestionDlqRequest(
-                        spec = spec,
-                        payload = message,
-                        workerId = workerId,
-                        cause = IllegalStateException("Event processing failed"),
-                    ),
-                )
-            }
-        }).also { it.start() }
+        queueWorker = RedisQueueWorker(spec, logger, processMessage = ::processMessageForTest).also { it.start() }
         SentryUtils.breadcrumb(
             "worker",
             "IngestionWorker starting",
@@ -92,7 +78,6 @@ class IngestionWorker(
     internal suspend fun processMessageForTest(
         workerId: Int,
         value: String,
-        onDlq: (String) -> Unit = { message -> RedisConfig.sync().rpush(dlqKey, message) }
     ) {
         suspendRunCatching {
             val (projectId, envelopeBytes) = decodeMessage(value)
@@ -111,15 +96,7 @@ class IngestionWorker(
             OperationalMetrics.recordWorkerMessageProcessed("Event", workerId)
         }.onFailure { e ->
             logger.error(e) { "Worker $workerId failed to process message, sending to DLQ" }
-            OperationalMetrics.recordWorkerProcessingFailure("Event", workerId, e)
-            suspendRunCatching {
-                onDlq(value)
-            }.onSuccess {
-                OperationalMetrics.recordDlqPush("Event", dlqKey, "success")
-            }.onFailure { dlqErr ->
-                OperationalMetrics.recordDlqPush("Event", dlqKey, "failure")
-                logger.error(dlqErr) { "Failed to push event message to DLQ" }
-            }.getOrThrow()
+            pushToDlq(logger, dlqKey, value, workerId, "Event", e)
             Sentry.captureException(e) { scope ->
                 scope.setTag("worker.operation", "process_message")
                 scope.setTag("worker.id", workerId.toString())

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
@@ -44,14 +44,7 @@ object IngestionQueueClient {
         payload: String,
     ): String? {
         val spec = IngestionQueueSettings.spec(pipeline, queueKey, "$queueKey:dlq", workerCount = 1)
-        return when (IngestionQueueSettings.backend()) {
-            IngestionQueueBackend.REDIS_LIST -> {
-                RedisConfig.sync().lpush(queueKey, payload)
-                null
-            }
-            IngestionQueueBackend.REDIS_STREAMS ->
-                RedisConfig.sync().xadd(spec.streamKey, streamAddArgs(spec.streamMaxLen), streamBody(pipeline, payload))
-        }
+        return RedisConfig.sync().xadd(spec.streamKey, streamAddArgs(spec.streamMaxLen), streamBody(pipeline, payload))
     }
 
     fun pushToDlq(
@@ -64,23 +57,18 @@ object IngestionQueueClient {
         }
         OperationalMetrics.recordWorkerProcessingFailure(spec.pipeline.workerName, request.workerId, request.cause)
         return runCatching {
-            when (IngestionQueueSettings.backend()) {
-                IngestionQueueBackend.REDIS_LIST -> RedisConfig.sync().rpush(spec.dlqKey, request.payload)
-                IngestionQueueBackend.REDIS_STREAMS -> {
-                    RedisConfig.sync().xadd(
-                        spec.dlqStreamKey,
-                        streamAddArgs(spec.dlqStreamMaxLen),
-                        streamDlqBody(spec.pipeline, request.payload, request.cause, request.streamId)
-                    )
-                    1L
-                }
-            }
+            RedisConfig.sync().xadd(
+                spec.dlqStreamKey,
+                streamAddArgs(spec.dlqStreamMaxLen),
+                streamDlqBody(spec.pipeline, request.payload, request.cause, request.streamId)
+            )
+            1L
         }.onSuccess {
-            OperationalMetrics.recordDlqPush(spec.pipeline.workerName, dlqMetricKey(spec), "success")
+            OperationalMetrics.recordDlqPush(spec.pipeline.workerName, spec.dlqStreamKey, "success")
         }.onFailure { dlqErr ->
-            OperationalMetrics.recordDlqPush(spec.pipeline.workerName, dlqMetricKey(spec), "failure")
+            OperationalMetrics.recordDlqPush(spec.pipeline.workerName, spec.dlqStreamKey, "failure")
             logger.error(dlqErr) {
-                "Failed to write to DLQ for worker ${request.workerId}, dlqKey=${dlqMetricKey(spec)}"
+                "Failed to write to DLQ for worker ${request.workerId}, dlqKey=${spec.dlqStreamKey}"
             }
         }.isSuccess
     }
@@ -115,12 +103,5 @@ object IngestionQueueClient {
             if (streamId != null) {
                 put(FIELD_ORIGINAL_STREAM_ID, streamId)
             }
-        }
-
-    private fun dlqMetricKey(spec: IngestionQueueSpec): String =
-        if (IngestionQueueSettings.backend() == IngestionQueueBackend.REDIS_STREAMS) {
-            spec.dlqStreamKey
-        } else {
-            spec.dlqKey
         }
 }

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueSettings.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueSettings.kt
@@ -27,39 +27,8 @@ private const val DEFAULT_STREAM_MAX_LEN = 250_000L
 private const val DEFAULT_DLQ_STREAM_MAX_LEN = 10_000L
 private const val MIN_STREAM_BATCH_SIZE = 1
 
-enum class IngestionQueueBackend {
-    REDIS_LIST,
-    REDIS_STREAMS;
-
-    companion object {
-        fun from(raw: String?): IngestionQueueBackend =
-            when (raw?.trim()?.lowercase()) {
-                "redis-streams", "redis_streams", "streams", "stream" -> REDIS_STREAMS
-                else -> REDIS_LIST
-            }
-    }
-}
-
-enum class IngestionQueueReadMode {
-    LIST,
-    STREAMS,
-    DUAL;
-
-    companion object {
-        fun from(raw: String?, backend: IngestionQueueBackend): IngestionQueueReadMode =
-            when (raw?.trim()?.lowercase()) {
-                "streams", "stream", "redis-streams", "redis_streams" -> STREAMS
-                "dual" -> DUAL
-                "list", "redis-list", "redis_list" -> LIST
-                else -> if (backend == IngestionQueueBackend.REDIS_STREAMS) STREAMS else LIST
-            }
-    }
-}
-
 data class IngestionQueueSpec(
     val pipeline: IngestionPipeline,
-    val queueKey: String,
-    val dlqKey: String,
     val workerCount: Int,
     val streamKey: String,
     val dlqStreamKey: String,
@@ -73,15 +42,6 @@ data class IngestionQueueSpec(
 )
 
 object IngestionQueueSettings {
-    fun backend(): IngestionQueueBackend =
-        IngestionQueueBackend.from(
-            EnvConfig.get("INGESTION_QUEUE_BACKEND")
-                ?: EnvConfig.get("QUEUE_BACKEND")
-        )
-
-    fun readMode(): IngestionQueueReadMode =
-        IngestionQueueReadMode.from(EnvConfig.get("INGESTION_QUEUE_READ_MODE"), backend())
-
     fun spec(
         pipeline: IngestionPipeline,
         queueKey: String,
@@ -91,8 +51,6 @@ object IngestionQueueSettings {
         val prefix = pipeline.envKey
         return IngestionQueueSpec(
             pipeline = pipeline,
-            queueKey = queueKey,
-            dlqKey = dlqKey,
             workerCount = max(workerCount, 1),
             streamKey = EnvConfig.get("INGESTION_${prefix}_STREAM_KEY") ?: "$queueKey:stream",
             dlqStreamKey = EnvConfig.get("INGESTION_${prefix}_DLQ_STREAM_KEY") ?: "$dlqKey:stream",

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.ingestion.queue
 
-import com.moneat.config.BRPOP_TIMEOUT_SECONDS
 import com.moneat.config.ClickHouseInsertDeduplication
 import com.moneat.config.RedisConfig
 import com.moneat.monitoring.OperationalMetrics
@@ -157,7 +156,7 @@ class RedisQueueWorker(
         registerQueues()
         logger.info {
             "Starting ${spec.pipeline.workerName} queue worker with " +
-                "${spec.workerCount} workers, queue=${spec.queueKey}, stream=${spec.streamKey}"
+                "${spec.workerCount} workers, stream=${spec.streamKey}"
         }
         jobs = (1..spec.workerCount).map { workerId ->
             scope.launch { runWorker(workerId) }
@@ -173,12 +172,10 @@ class RedisQueueWorker(
     private suspend fun runWorker(workerId: Int) {
         val conn = RedisConfig.newBlockingConnection()
         try {
-            if (usesStreams()) {
-                ensureConsumerGroup(conn)
-            }
+            ensureConsumerGroup(conn)
             while (scope.isActive) {
                 try {
-                    runQueueIteration(workerId, conn)
+                    consumeStreams(workerId, conn)
                 } catch (e: CancellationException) {
                     break
                 } catch (e: RedisException) {
@@ -192,39 +189,6 @@ class RedisQueueWorker(
         } finally {
             RedisConfig.closeBlockingConnection(conn)
         }
-    }
-
-    private suspend fun runQueueIteration(
-        workerId: Int,
-        conn: StatefulRedisConnection<String, String>,
-    ) {
-        when (IngestionQueueSettings.readMode()) {
-            IngestionQueueReadMode.LIST -> consumeListBlocking(workerId, conn)
-            IngestionQueueReadMode.STREAMS -> consumeStreams(workerId, conn)
-            IngestionQueueReadMode.DUAL -> {
-                if (!consumeListNonBlocking(workerId, conn)) {
-                    consumeStreams(workerId, conn)
-                }
-            }
-        }
-    }
-
-    private suspend fun consumeListBlocking(
-        workerId: Int,
-        conn: StatefulRedisConnection<String, String>,
-    ) {
-        val result = conn.sync().brpop(BRPOP_TIMEOUT_SECONDS, spec.queueKey)
-        val payload = result?.value ?: return
-        processMessage(workerId, payload)
-    }
-
-    private suspend fun consumeListNonBlocking(
-        workerId: Int,
-        conn: StatefulRedisConnection<String, String>,
-    ): Boolean {
-        val payload = conn.sync().rpop(spec.queueKey) ?: return false
-        processMessage(workerId, payload)
-        return true
     }
 
     private suspend fun consumeStreams(
@@ -336,7 +300,7 @@ class RedisQueueWorker(
         e: Throwable,
     ) {
         logger.error(e) { "${spec.pipeline.workerName} worker $workerId error in queue loop" }
-        OperationalMetrics.recordWorkerBrpopFailure(spec.pipeline.workerName, workerId, e)
+        OperationalMetrics.recordWorkerQueueLoopFailure(spec.pipeline.workerName, workerId, e)
         delay(ERROR_RETRY_DELAY_MS)
     }
 
@@ -345,29 +309,19 @@ class RedisQueueWorker(
     }
 
     private fun registerQueues() {
-        OperationalMetrics.registerWorkerQueues(spec.pipeline.workerName, spec.queueKey, spec.dlqKey)
-        if (usesStreams()) {
-            OperationalMetrics.registerWorkerQueues(spec.pipeline.workerName, spec.streamKey, spec.dlqStreamKey)
-            OperationalMetrics.registerWorkerStream(
-                workerName = spec.pipeline.workerName,
-                streamKey = spec.streamKey,
-                streamType = "primary",
-                consumerGroup = spec.consumerGroup,
-            )
-            OperationalMetrics.registerWorkerStream(
-                workerName = spec.pipeline.workerName,
-                streamKey = spec.dlqStreamKey,
-                streamType = "dlq",
-            )
-        }
+        OperationalMetrics.registerWorkerQueues(spec.pipeline.workerName, spec.streamKey, spec.dlqStreamKey)
+        OperationalMetrics.registerWorkerStream(
+            workerName = spec.pipeline.workerName,
+            streamKey = spec.streamKey,
+            streamType = "primary",
+            consumerGroup = spec.consumerGroup,
+        )
+        OperationalMetrics.registerWorkerStream(
+            workerName = spec.pipeline.workerName,
+            streamKey = spec.dlqStreamKey,
+            streamType = "dlq",
+        )
     }
-
-    private fun usesStreams(): Boolean =
-        when (IngestionQueueSettings.readMode()) {
-            IngestionQueueReadMode.LIST -> false
-            IngestionQueueReadMode.STREAMS,
-            IngestionQueueReadMode.DUAL -> true
-        }
 
     private fun consumerName(workerId: Int): String =
         "${spec.pipeline.id}-${resolveHostName()}-$workerId"

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -17,7 +17,6 @@
 package com.moneat.monitoring
 
 import com.moneat.config.RedisConfig
-import com.moneat.ingestion.queue.IngestionQueueSettings
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.lettuce.core.Limit
 import io.lettuce.core.Range
@@ -105,10 +104,10 @@ object OperationalMetrics {
         workerLastSuccessGauge(workerName, workerId).set(currentEpochSeconds())
     }
 
-    fun recordWorkerBrpopFailure(workerName: String, workerId: Int, cause: Throwable) {
+    fun recordWorkerQueueLoopFailure(workerName: String, workerId: Int, cause: Throwable) {
         counter(
-            WORKER_BRPOP_FAILURES,
-            "Redis BRPOP loop failures in background ingestion workers.",
+            WORKER_QUEUE_LOOP_FAILURES,
+            "Redis queue loop failures in background ingestion workers.",
             tags(
                 "worker" to workerName.normalizedLabelValue(),
                 "worker_id" to workerId.toString(),
@@ -264,28 +263,6 @@ object OperationalMetrics {
             .record(payloadCount.coerceAtLeast(0).toDouble())
         datadogMetricInsertSummary(DD_METRIC_FALLBACK_ROWS, "rows", fallbackTags)
             .record(rowCount.coerceAtLeast(0).toDouble())
-    }
-
-    fun recordDatadogMetricPayloadAck(status: String) {
-        counter(
-            DD_METRIC_PAYLOAD_ACKS,
-            "Datadog metric processing queue acknowledgement attempts by result.",
-            tags("status" to status.normalizedLabelValue())
-        ).increment()
-    }
-
-    fun recordDatadogMetricProcessingRecovery(recoveredPayloads: Int, status: String, cause: Throwable? = null) {
-        val recoveryTags = tags(
-            "status" to status.normalizedLabelValue(),
-            "exception" to (cause?.metricExceptionName() ?: "none")
-        )
-        counter(
-            DD_METRIC_PROCESSING_RECOVERIES,
-            "Datadog metric processing queue recovery attempts by result.",
-            recoveryTags
-        ).increment()
-        datadogMetricInsertSummary(DD_METRIC_PROCESSING_RECOVERED_PAYLOADS, "payloads", recoveryTags)
-            .record(recoveredPayloads.coerceAtLeast(0).toDouble())
     }
 
     fun recordClickHouseRequest(operation: String, status: String, durationSeconds: Double) {
@@ -662,11 +639,9 @@ object OperationalMetrics {
 
     private fun bindIngestionQueueModeMetrics() {
         if (!queueModeMetricsBound.compareAndSet(false, true)) return
-        val backend = IngestionQueueSettings.backend().name.lowercase()
-        val readMode = IngestionQueueSettings.readMode().name.lowercase()
         Gauge.builder(INGESTION_QUEUE_MODE, Unit) { 1.0 }
-            .description("Current ingestion queue backend and worker read mode for this process.")
-            .tags(tags("backend" to backend, "read_mode" to readMode))
+            .description("Current ingestion queue mode for this process.")
+            .tags(tags("backend" to "redis_streams"))
             .register(registry)
     }
 
@@ -739,7 +714,7 @@ object OperationalMetrics {
     private const val WORKER_MESSAGES_PROCESSED = "moneat_worker_messages_processed"
     private const val WORKER_LAST_SUCCESS_TIMESTAMP_SECONDS = "moneat_worker_last_success_timestamp_seconds"
     private const val WORKER_PROCESSING_FAILURES = "moneat_worker_processing_failures"
-    private const val WORKER_BRPOP_FAILURES = "moneat_worker_brpop_failures"
+    private const val WORKER_QUEUE_LOOP_FAILURES = "moneat_worker_queue_loop_failures"
     private const val WORKER_DLQ_PUSHES = "moneat_worker_dlq_pushes"
     private const val WORKER_DLQ_DEPTH = "moneat_worker_dlq_depth"
     private const val WORKER_QUEUE_DEPTH = "moneat_worker_queue_depth"
@@ -756,10 +731,6 @@ object OperationalMetrics {
     private const val DD_METRIC_INSERT_FALLBACKS = "moneat_datadog_metric_insert_fallbacks"
     private const val DD_METRIC_FALLBACK_PAYLOADS = "moneat_datadog_metric_fallback_payloads"
     private const val DD_METRIC_FALLBACK_ROWS = "moneat_datadog_metric_fallback_rows"
-    private const val DD_METRIC_PAYLOAD_ACKS = "moneat_datadog_metric_payload_acks"
-    private const val DD_METRIC_PROCESSING_RECOVERIES = "moneat_datadog_metric_processing_recoveries"
-    private const val DD_METRIC_PROCESSING_RECOVERED_PAYLOADS =
-        "moneat_datadog_metric_processing_recovered_payloads"
     private const val CLICKHOUSE_REQUESTS = "moneat_clickhouse_requests"
     private const val CLICKHOUSE_REQUEST_TIMEOUTS = "moneat_clickhouse_request_timeouts"
     private const val CLICKHOUSE_REQUEST_DURATION = "moneat_clickhouse_request_duration"

--- a/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
+++ b/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
@@ -16,10 +16,8 @@
 
 package com.moneat.utils
 
-import com.moneat.config.RedisConfig
 import com.moneat.ingestion.queue.IngestionDlqRequest
 import com.moneat.ingestion.queue.IngestionPipeline
-import com.moneat.ingestion.queue.IngestionQueueBackend
 import com.moneat.ingestion.queue.IngestionQueueClient
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.monitoring.OperationalMetrics
@@ -45,18 +43,18 @@ private val WORKER_PIPELINES =
     )
 
 /**
- * Logs a Redis BRPOP loop failure and backs off. Use after [catch] for
+ * Logs a Redis queue loop failure and backs off. Use after [catch] for
  * [io.lettuce.core.RedisException] or [java.io.IOException].
  */
-suspend fun brpopLoopBackoff(
+suspend fun queueLoopBackoff(
     logger: KLogger,
     workerId: Int,
     scopeLabel: String,
     errorDelayMs: Long,
     e: Throwable,
 ) {
-    logger.error(e) { "$scopeLabel worker $workerId error in BRPOP loop" }
-    OperationalMetrics.recordWorkerBrpopFailure(scopeLabel, workerId, e)
+    logger.error(e) { "$scopeLabel worker $workerId error in queue loop" }
+    OperationalMetrics.recordWorkerQueueLoopFailure(scopeLabel, workerId, e)
     delay(errorDelayMs)
 }
 
@@ -73,40 +71,27 @@ fun pushToDlq(
     workerName: String,
     cause: Throwable,
 ): Boolean {
-    if (IngestionQueueSettings.backend() == IngestionQueueBackend.REDIS_STREAMS) {
-        val pipeline = workerName.toIngestionPipeline()
-        if (pipeline != null) {
-            val spec = IngestionQueueSettings.spec(
-                pipeline = pipeline,
-                queueKey = queueKeyForDlq(dlqKey),
-                dlqKey = dlqKey,
-                workerCount = 1,
-            )
-            return IngestionQueueClient.pushToDlq(
-                logger = logger,
-                request = IngestionDlqRequest(
-                    spec = spec,
-                    payload = payload,
-                    workerId = workerId,
-                    cause = cause,
-                ),
-            )
-        }
+    val pipeline = workerName.toIngestionPipeline()
+    if (pipeline == null) {
+        logger.error(cause) { "Unknown ingestion pipeline for $workerName worker $workerId" }
+        OperationalMetrics.recordWorkerProcessingFailure(workerName, workerId, cause)
+        return false
     }
-    logger.error(cause) {
-        "$workerName worker $workerId failed, pushing to DLQ"
-    }
-    OperationalMetrics.recordWorkerProcessingFailure(workerName, workerId, cause)
-    return runCatching {
-        RedisConfig.sync().rpush(dlqKey, payload)
-    }.onSuccess {
-        OperationalMetrics.recordDlqPush(workerName, dlqKey, "success")
-    }.onFailure { dlqErr ->
-        OperationalMetrics.recordDlqPush(workerName, dlqKey, "failure")
-        logger.error(dlqErr) {
-            "Failed to write to DLQ for worker $workerId, dlqKey=$dlqKey"
-        }
-    }.isSuccess
+    val spec = IngestionQueueSettings.spec(
+        pipeline = pipeline,
+        queueKey = queueKeyForDlq(dlqKey),
+        dlqKey = dlqKey,
+        workerCount = 1,
+    )
+    return IngestionQueueClient.pushToDlq(
+        logger = logger,
+        request = IngestionDlqRequest(
+            spec = spec,
+            payload = payload,
+            workerId = workerId,
+            cause = cause,
+        ),
+    )
 }
 
 private fun String.toIngestionPipeline(): IngestionPipeline? =

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
@@ -27,7 +27,6 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkObject
-import io.mockk.verify
 import mu.KLogger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -59,18 +58,7 @@ class IngestionQueueClientTest {
     }
 
     @Test
-    fun `enqueue writes to redis list by default`() {
-        every { redis.lpush("logs:queue", "payload") } returns 1L
-
-        val streamId = IngestionQueueClient.enqueue(IngestionPipeline.LOGS, "logs:queue", "payload")
-
-        assertNull(streamId)
-        verify(exactly = 1) { redis.lpush("logs:queue", "payload") }
-    }
-
-    @Test
     fun `enqueue writes structured body to redis stream`() {
-        every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns "redis-streams"
         val bodySlot = slot<Map<String, String>>()
         val argsSlot = slot<XAddArgs>()
         every { redis.xadd("logs:queue:stream", capture(argsSlot), capture(bodySlot)) } returns "1-0"
@@ -86,23 +74,7 @@ class IngestionQueueClientTest {
     }
 
     @Test
-    fun `pushToDlq writes list payload and records success`() {
-        every { redis.rpush("logs:dlq", "payload") } returns 1L
-        val spec = IngestionQueueSettings.spec(IngestionPipeline.LOGS, "logs:queue", "logs:dlq", workerCount = 1)
-
-        val pushed =
-            IngestionQueueClient.pushToDlq(
-                logger,
-                IngestionDlqRequest(spec, "payload", workerId = 3, cause = IllegalStateException("boom")),
-            )
-
-        assertTrue(pushed)
-        verify(exactly = 1) { redis.rpush("logs:dlq", "payload") }
-    }
-
-    @Test
     fun `pushToDlq writes stream metadata for redelivery failures`() {
-        every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns "redis-streams"
         val spec = IngestionQueueSettings.spec(IngestionPipeline.LOGS, "logs:queue", "logs:dlq", workerCount = 1)
         val bodySlot = slot<Map<String, String>>()
         val argsSlot = slot<XAddArgs>()
@@ -132,7 +104,8 @@ class IngestionQueueClientTest {
 
     @Test
     fun `pushToDlq returns false when redis write fails`() {
-        every { redis.rpush("logs:dlq", "payload") } throws RedisException("redis down")
+        every { redis.xadd("logs:dlq:stream", any<XAddArgs>(), any<Map<String, String>>()) } throws
+            RedisException("redis down")
         val spec = IngestionQueueSettings.spec(IngestionPipeline.LOGS, "logs:queue", "logs:dlq", workerCount = 1)
 
         val pushed =

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueSettingsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueSettingsTest.kt
@@ -33,48 +33,6 @@ class IngestionQueueSettingsTest {
     }
 
     @Test
-    fun `queue backend defaults to redis lists`() {
-        assertEquals(IngestionQueueBackend.REDIS_LIST, IngestionQueueBackend.from(null))
-        assertEquals(IngestionQueueBackend.REDIS_LIST, IngestionQueueBackend.from(""))
-        assertEquals(IngestionQueueBackend.REDIS_LIST, IngestionQueueBackend.from("redis-list"))
-    }
-
-    @Test
-    fun `queue backend accepts redis stream aliases`() {
-        assertEquals(IngestionQueueBackend.REDIS_STREAMS, IngestionQueueBackend.from("redis-streams"))
-        assertEquals(IngestionQueueBackend.REDIS_STREAMS, IngestionQueueBackend.from("redis_streams"))
-        assertEquals(IngestionQueueBackend.REDIS_STREAMS, IngestionQueueBackend.from(" stream "))
-    }
-
-    @Test
-    fun `read mode follows backend when unset`() {
-        assertEquals(
-            IngestionQueueReadMode.LIST,
-            IngestionQueueReadMode.from(null, IngestionQueueBackend.REDIS_LIST)
-        )
-        assertEquals(
-            IngestionQueueReadMode.STREAMS,
-            IngestionQueueReadMode.from(null, IngestionQueueBackend.REDIS_STREAMS)
-        )
-    }
-
-    @Test
-    fun `read mode accepts explicit transition values`() {
-        assertEquals(
-            IngestionQueueReadMode.DUAL,
-            IngestionQueueReadMode.from("dual", IngestionQueueBackend.REDIS_LIST)
-        )
-        assertEquals(
-            IngestionQueueReadMode.STREAMS,
-            IngestionQueueReadMode.from("redis-streams", IngestionQueueBackend.REDIS_LIST)
-        )
-        assertEquals(
-            IngestionQueueReadMode.LIST,
-            IngestionQueueReadMode.from("redis-list", IngestionQueueBackend.REDIS_STREAMS)
-        )
-    }
-
-    @Test
     fun `pipeline parser accepts ids and enum names`() {
         assertEquals(IngestionPipeline.LOGS, IngestionPipeline.parse("logs"))
         assertEquals(IngestionPipeline.OTLP_TRACES, IngestionPipeline.parse("otlp-traces"))
@@ -82,39 +40,6 @@ class IngestionQueueSettingsTest {
         assertNull(IngestionPipeline.parse("unknown"))
     }
 
-    @Test
-    fun `backend reads primary backend env before legacy fallback`() {
-        mockkObject(EnvConfig)
-        every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns "redis-streams"
-        every { EnvConfig.get("QUEUE_BACKEND") } returns "redis-list"
-
-        assertEquals(IngestionQueueBackend.REDIS_STREAMS, IngestionQueueSettings.backend())
-    }
-
-    @Test
-    fun `backend reads legacy queue backend when primary env is absent`() {
-        mockkObject(EnvConfig)
-        every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns null
-        every { EnvConfig.get("QUEUE_BACKEND") } returns "streams"
-
-        assertEquals(IngestionQueueBackend.REDIS_STREAMS, IngestionQueueSettings.backend())
-    }
-
-    @Test
-    fun `read mode follows configured value and backend default`() {
-        mockkObject(EnvConfig)
-        every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns "redis-streams"
-        every { EnvConfig.get("INGESTION_QUEUE_READ_MODE") } returns null
-        every { EnvConfig.get("QUEUE_BACKEND") } returns null
-
-        assertEquals(IngestionQueueReadMode.STREAMS, IngestionQueueSettings.readMode())
-
-        every { EnvConfig.get("INGESTION_QUEUE_READ_MODE") } returns "dual"
-
-        assertEquals(IngestionQueueReadMode.DUAL, IngestionQueueSettings.readMode())
-    }
-
-    @Test
     fun `spec applies env overrides and clamps worker count`() {
         mockkObject(EnvConfig)
         every { EnvConfig.get(any()) } returns null

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/RedisStreamQueueOperationsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/RedisStreamQueueOperationsTest.kt
@@ -134,8 +134,6 @@ class RedisStreamQueueOperationsTest {
     private fun logQueueSpec(): IngestionQueueSpec =
         IngestionQueueSpec(
             pipeline = IngestionPipeline.LOGS,
-            queueKey = "moneat:logs:queue",
-            dlqKey = "moneat:logs:dlq",
             workerCount = 1,
             streamKey = "moneat:logs:queue:stream",
             dlqStreamKey = "moneat:logs:dlq:stream",

--- a/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.monitoring
 
-import com.moneat.config.EnvConfig
 import com.moneat.config.RedisConfig
 import io.lettuce.core.Range
 import io.lettuce.core.StreamMessage
@@ -41,7 +40,6 @@ class OperationalMetricsTest {
 
     @AfterTest
     fun resetAfter() {
-        unmockkObject(EnvConfig)
         unmockkObject(RedisConfig)
         OperationalMetrics.resetForTest()
     }
@@ -137,18 +135,12 @@ class OperationalMetricsTest {
 
     @Test
     fun `renders ingestion queue mode defaults`() {
-        mockkObject(EnvConfig)
-        every { EnvConfig.get("INGESTION_QUEUE_BACKEND") } returns null
-        every { EnvConfig.get("QUEUE_BACKEND") } returns null
-        every { EnvConfig.get("INGESTION_QUEUE_READ_MODE") } returns null
-
         OperationalMetrics.bindSystemMetrics()
 
         val rendered = OperationalMetrics.scrape()
 
         assertContains(rendered, "moneat_ingestion_queue_mode")
-        assertContains(rendered, "backend=\"redis_list\"")
-        assertContains(rendered, "read_mode=\"list\"")
+        assertContains(rendered, "backend=\"redis_streams\"")
         assertHasApplicationTag(rendered)
     }
 
@@ -190,9 +182,7 @@ class OperationalMetricsTest {
     @Test
     fun `renders datadog metric ingest health metrics`() {
         // ──── Arrange ────
-        OperationalMetrics.registerQueue("DD metric", "moneat:metrics:queue", "primary")
-        OperationalMetrics.registerQueue("DD metric", "moneat:metrics:queue:processing", "processing")
-        OperationalMetrics.registerDlq("DD metric", "moneat:metrics:dlq")
+        OperationalMetrics.registerWorkerQueues("DD metric", "moneat:metrics:queue:stream", "moneat:metrics:dlq:stream")
         OperationalMetrics.recordDatadogMetricPayloadQueued(metricRows = 10)
         OperationalMetrics.recordDatadogMetricInsert(
             mode = "combined",
@@ -214,18 +204,6 @@ class OperationalMetricsTest {
             rowCount = 10,
             cause = IllegalArgumentException("fallback"),
         )
-        OperationalMetrics.recordDatadogMetricPayloadAck("success")
-        OperationalMetrics.recordDatadogMetricPayloadAck("failure")
-        OperationalMetrics.recordDatadogMetricProcessingRecovery(
-            recoveredPayloads = 3,
-            status = "success",
-        )
-        OperationalMetrics.recordDatadogMetricProcessingRecovery(
-            recoveredPayloads = 0,
-            status = "failure",
-            cause = IllegalStateException("recovery failed"),
-        )
-
         // ──── Act ────
         val rendered = OperationalMetrics.scrape()
 
@@ -239,10 +217,8 @@ class OperationalMetricsTest {
         assertContains(rendered, "moneat_datadog_metric_insert_fallbacks_total")
         assertContains(rendered, "moneat_datadog_metric_fallback_payloads_count")
         assertContains(rendered, "moneat_datadog_metric_fallback_rows_count")
-        assertContains(rendered, "moneat_datadog_metric_payload_acks_total")
-        assertContains(rendered, "moneat_datadog_metric_processing_recoveries_total")
-        assertContains(rendered, "moneat_datadog_metric_processing_recovered_payloads_count")
-        assertContains(rendered, "queue_type=\"processing\"")
+        assertContains(rendered, "queue_key=\"moneat:metrics:queue:stream\"")
+        assertContains(rendered, "queue_key=\"moneat:metrics:dlq:stream\"")
         assertContains(rendered, "mode=\"combined\"")
         assertContains(rendered, "mode=\"single\"")
         assertContains(rendered, "status=\"failure\"")

--- a/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServicesExtendedTest.kt
@@ -18,6 +18,7 @@
 
 package com.moneat.services
 
+import com.moneat.config.RedisConfig
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.services.AlertEpisodeContext
 import com.moneat.alerts.services.AlertEpisodeService
@@ -41,10 +42,14 @@ import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.testsupport.TestDatabaseHelper
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.NotFoundException
+import io.lettuce.core.XAddArgs
+import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
@@ -1043,15 +1048,28 @@ class EventServicesExtendedTest {
     }
 
     @Test
-    fun `worker DLQ callback invoked on parse failure`() = runBlocking {
+    fun `worker writes DLQ stream on parse failure`() = runBlocking {
         val worker = IngestionWorker("q:test", "q:test:dlq", 1)
-        val dlq = mutableListOf<String>()
+        val redis = mockDlqStream()
         val badPayload = IngestionWorker.encodeMessage(1L, "not-an-envelope".toByteArray())
 
-        worker.processMessageForTest(workerId = 1, value = badPayload) { dlq.add(it) }
+        try {
+            worker.processMessageForTest(workerId = 1, value = badPayload)
 
-        assertEquals(1, dlq.size)
-        assertEquals(badPayload, dlq[0])
+            verify(exactly = 1) {
+                redis.xadd("q:test:dlq:stream", any<XAddArgs>(), any<Map<String, String>>())
+            }
+        } finally {
+            unmockkObject(RedisConfig)
+        }
+    }
+
+    private fun mockDlqStream(): RedisCommands<String, String> {
+        val redis = mockk<RedisCommands<String, String>>()
+        mockkObject(RedisConfig)
+        every { RedisConfig.sync() } returns redis
+        every { redis.xadd("q:test:dlq:stream", any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
+        return redis
     }
 
     // ================================================================

--- a/backend/src/test/kotlin/com/moneat/services/IngestionWorkerTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/IngestionWorkerTest.kt
@@ -16,7 +16,15 @@
 
 package com.moneat.services
 
+import com.moneat.config.RedisConfig
 import com.moneat.events.services.IngestionWorker
+import io.lettuce.core.XAddArgs
+import io.lettuce.core.api.sync.RedisCommands
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -51,23 +59,43 @@ class IngestionWorkerTest {
     fun `worker sends message to DLQ when base64 decode fails`() =
         runBlocking {
             val worker = IngestionWorker("q:test", "q:test:dlq", 1)
-            val dlq = mutableListOf<String>()
+            val redis = mockDlqStream()
             val badMessage = "!!!not-base64!!!"
 
-            worker.processMessageForTest(workerId = 1, value = badMessage) { dlq.add(it) }
+            try {
+                worker.processMessageForTest(workerId = 1, value = badMessage)
 
-            assertEquals(listOf(badMessage), dlq)
+                verify(exactly = 1) {
+                    redis.xadd("q:test:dlq:stream", any<XAddArgs>(), any<Map<String, String>>())
+                }
+            } finally {
+                unmockkObject(RedisConfig)
+            }
         }
 
     @Test
     fun `worker sends message to DLQ when envelope parse fails`() =
         runBlocking {
             val worker = IngestionWorker("q:test", "q:test:dlq", 1)
-            val dlq = mutableListOf<String>()
+            val redis = mockDlqStream()
             val badEnvelopeMessage = IngestionWorker.encodeMessage(42L, "invalid-envelope".toByteArray())
 
-            worker.processMessageForTest(workerId = 2, value = badEnvelopeMessage) { dlq.add(it) }
+            try {
+                worker.processMessageForTest(workerId = 2, value = badEnvelopeMessage)
 
-            assertEquals(listOf(badEnvelopeMessage), dlq)
+                verify(exactly = 1) {
+                    redis.xadd("q:test:dlq:stream", any<XAddArgs>(), any<Map<String, String>>())
+                }
+            } finally {
+                unmockkObject(RedisConfig)
+            }
         }
+
+    private fun mockDlqStream(): RedisCommands<String, String> {
+        val redis = mockk<RedisCommands<String, String>>()
+        mockkObject(RedisConfig)
+        every { RedisConfig.sync() } returns redis
+        every { redis.xadd("q:test:dlq:stream", any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
+        return redis
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/services/LogServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/LogServiceCoverageTest.kt
@@ -26,6 +26,7 @@ import com.moneat.logs.models.QueuedLogBatch
 import com.moneat.logs.models.QueuedLogEntry
 import com.moneat.logs.repositories.LogRepository
 import com.moneat.logs.services.LogService
+import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.every
@@ -52,7 +53,7 @@ class LogServiceCoverageTest {
             mockkObject(RedisConfig)
             val redis = mockk<RedisCommands<String, String>>()
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(any(), any()) } returns 1L
+            every { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
 
             mockkObject(ClickHouseClient)
             every { ClickHouseClient.getDatabase() } returns "test"
@@ -75,7 +76,7 @@ class LogServiceCoverageTest {
             mockkObject(RedisConfig)
             val redis = mockk<RedisCommands<String, String>>()
             every { RedisConfig.sync() } returns redis
-            every { redis.lpush(any(), any()) } returns 1L
+            every { redis.xadd(any<String>(), any<XAddArgs>(), any<Map<String, String>>()) } returns "1-0"
             mockkObject(ClickHouseClient)
             every { ClickHouseClient.getDatabase() } returns "test"
 


### PR DESCRIPTION
## Summary
- Remove legacy queue modes
- Keep ingestion stream-backed
- Update queue tests

## Tests
- ./gradlew detekt
- ./gradlew :test -x :ee:test --tests com.moneat.ingestion.queue.IngestionQueueClientTest --tests com.moneat.ingestion.queue.IngestionQueueSettingsTest --tests com.moneat.ingestion.queue.RedisStreamQueueOperationsTest --tests com.moneat.monitoring.OperationalMetricsTest --tests com.moneat.services.LogServiceCoverageTest --tests com.moneat.services.IngestionWorkerTest --tests com.moneat.services.EventServicesExtendedTest
- ./gradlew :features:analytics:test --tests com.moneat.analytics.AnalyticsIngestionWorkerTest --tests com.moneat.analytics.AnalyticsServerIngestRoutesTest :features:datadog:test --tests com.moneat.datadog.workers.DatadogMetricIngestionWorkerTest --tests com.moneat.services.MiscIngestionServiceCoverageTest --tests com.moneat.datadog.services.DbmIngestionServiceTest --tests com.moneat.datadog.services.DatadogMetricServiceTest --tests com.moneat.services.NetworkDevicesTest --tests com.moneat.services.SecurityServiceTest :features:logs:test --tests com.moneat.services.LogIngestionWorkerTest :features:llm:test --tests com.moneat.services.LlmIngestionWorkerTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redis Streams is now the primary ingestion queue mechanism with improved reliability and durability for message processing.

* **Improvements**
  * Streamlined queue worker architecture across all ingestion pipelines for better maintainability and consistent behavior.
  * Unified dead letter queue (DLQ) handling for improved failure tracking and observability.

* **Configuration Changes**
  * Removed legacy queue backend selection options; Redis Streams is now always used for ingestion queues.
  * New environment variables for configuring stream size limits per pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->