### PR TITLE
test: move incident extended tests into feature module

### DIFF
--- a/backend/features/incident/build.gradle.kts
+++ b/backend/features/incident/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.h2)
+    testImplementation(libs.mockk)
     testImplementation(kotlin("reflect"))
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/backend/features/incident/src/test/kotlin/com/moneat/services/IncidentServiceExtendedTest.kt
+++ b/backend/features/incident/src/test/kotlin/com/moneat/services/IncidentServiceExtendedTest.kt
@@ -364,12 +364,42 @@ class IncidentServiceExtendedTest {
     }
 
     @Test
-    fun `autoResolve source allowlist only includes deterministic recovery sources`() {
-        assertTrue(service.isAutoResolvableSource(AlertSource.HOST_ALERT))
-        assertTrue(service.isAutoResolvableSource(AlertSource.HOST_DOWN))
-        assertTrue(service.isAutoResolvableSource(AlertSource.UPTIME_MONITOR))
-        assertTrue(service.isAutoResolvableSource(AlertSource.DASHBOARD_ALERT))
-        assertFalse(service.isAutoResolvableSource(AlertSource.ERROR_ALERT))
+    fun `autoResolve source allowlist only includes deterministic recovery sources`() = runBlocking {
+        val allowedSources = listOf(
+            AlertSource.HOST_ALERT,
+            AlertSource.HOST_DOWN,
+            AlertSource.UPTIME_MONITOR,
+            AlertSource.DASHBOARD_ALERT
+        )
+        val blockedSource = AlertSource.ERROR_ALERT
+
+        transaction {
+            (allowedSources + blockedSource).forEach { source ->
+                IncidentRoutingRules.insert {
+                    it[providerConfigId] = this@IncidentServiceExtendedTest.providerConfigId
+                    it[alertSource] = source.name
+                    it[alertType] = null
+                    it[alertPriority] = "high"
+                    it[createdAt] = Clock.System.now()
+                    it[updatedAt] = Clock.System.now()
+                }
+            }
+        }
+
+        IncidentTestHelper.registerMockProvider(
+            testProviderType,
+            resolveAlertResult = Result.success("auto-resolved")
+        )
+
+        allowedSources.forEach { source ->
+            service.autoResolveAlert(orgId, source, "dedup-${source.name.lowercase()}")
+        }
+        service.autoResolveAlert(orgId, blockedSource, "dedup-blocked")
+
+        val logs = IncidentTestHelper.getEventLogs(orgId)
+        assertEquals(allowedSources.size, logs.size)
+        assertTrue(logs.all { it[IncidentEventLog.success] })
+        assertFalse(logs.any { it[IncidentEventLog.alertSource] == blockedSource.name })
     }
 
     // ──── resolveAlertPriority edge cases ────


### PR DESCRIPTION
## Summary
- move incident extended service coverage into the incident feature module
- add the feature test dependency needed for the moved coverage

## Validation
- cd backend && ./gradlew :features:incident:compileTestKotlin :features:incident:test :features:incident:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated incident service tests to validate auto-resolve behavior through database routing rules and log verification.

* **Chores**
  * Added testing library dependency to the incident service module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->