### PR TITLE
refactor: move uptime DI into feature module

### DIFF
--- a/backend/features/uptime/src/main/kotlin/com/moneat/uptime/UptimeModule.kt
+++ b/backend/features/uptime/src/main/kotlin/com/moneat/uptime/UptimeModule.kt
@@ -16,19 +16,73 @@
 
 package com.moneat.uptime
 
+import com.moneat.billing.services.BillingQuotaService
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.incident.services.IncidentService
+import com.moneat.uptime.repositories.UptimeMonitorRepository
+import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
 import com.moneat.uptime.routes.uptimeRoutes
+import com.moneat.uptime.services.UptimeCheckExecutor
+import com.moneat.uptime.services.UptimeScheduler
+import com.moneat.uptime.services.UptimeService
+import com.moneat.workflows.services.WorkflowService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
+import org.koin.core.context.GlobalContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.util.concurrent.atomic.AtomicReference
 
 class UptimeModule : EnterpriseModule {
     override val name: String = "Uptime"
+    private val uptimeScheduler = AtomicReference<UptimeScheduler?>(null)
+    private val lifecycleLock = Any()
 
     override fun registerRoutes(route: Route) {
         route.uptimeRoutes()
     }
 
-    override fun startBackgroundJobs(application: Application) = Unit
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single<UptimeMonitorRepository> { UptimeMonitorRepositoryImpl() }
+                single { UptimeService(get(), get()) }
+                single { UptimeCheckExecutor() }
+            }
+        )
 
-    override fun stopBackgroundJobs() = Unit
+    override fun startBackgroundJobs(application: Application) {
+        synchronized(lifecycleLock) {
+            if (uptimeScheduler.get() != null) return
+
+            val koin = GlobalContext.get()
+            val scheduler = UptimeScheduler(
+                uptimeService = koin.get<UptimeService>(),
+                checkExecutor = koin.get<UptimeCheckExecutor>(),
+                incidentService = koin.get<IncidentService>(),
+                billingQuotaService = koin.get<BillingQuotaService>(),
+                workflowService = koin.get<WorkflowService>(),
+                frontendBaseUrl = application.frontendBaseUrl(),
+            )
+            uptimeScheduler.set(scheduler)
+            scheduler.start()
+        }
+    }
+
+    override fun stopBackgroundJobs() {
+        synchronized(lifecycleLock) {
+            uptimeScheduler.getAndSet(null)?.stop()
+        }
+    }
+
+    private fun Application.frontendBaseUrl(): String =
+        environment.config
+            .propertyOrNull(FRONTEND_BASE_URL_CONFIG)
+            ?.getString()
+            ?: DEFAULT_FRONTEND_BASE_URL
+
+    private companion object {
+        private const val FRONTEND_BASE_URL_CONFIG = "email.frontendUrl"
+        private const val DEFAULT_FRONTEND_BASE_URL = "https://moneat.io"
+    }
 }

--- a/backend/features/uptime/src/test/kotlin/com/moneat/uptime/UptimeFeatureRegistryTest.kt
+++ b/backend/features/uptime/src/test/kotlin/com/moneat/uptime/UptimeFeatureRegistryTest.kt
@@ -16,10 +16,13 @@
 
 package com.moneat.uptime
 
+import com.moneat.billing.services.BillingQuotaService
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
+import com.moneat.uptime.services.UptimeCheckExecutor
+import com.moneat.uptime.services.UptimeService
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
@@ -29,10 +32,13 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import org.koin.core.KoinApplication
+import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class UptimeFeatureRegistryTest {
@@ -52,6 +58,24 @@ class UptimeFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Uptime" in moduleNames)
+    }
+
+    @Test
+    fun `Uptime module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(
+                module {
+                    single { BillingQuotaService() }
+                },
+                *UptimeModule().koinModules().toTypedArray(),
+            )
+
+        try {
+            assertIs<UptimeService>(koinApplication.koin.get<UptimeService>())
+            assertIs<UptimeCheckExecutor>(koinApplication.koin.get<UptimeCheckExecutor>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/src/main/kotlin/com/moneat/Application.kt
+++ b/backend/src/main/kotlin/com/moneat/Application.kt
@@ -88,8 +88,7 @@ fun Application.module() {
 
     install(Koin) {
         slf4jLogger()
-        val frontendBaseUrl = environment.config.property("email.frontendUrl").getString()
-        modules(buildAppModules(frontendBaseUrl = frontendBaseUrl) + FeatureRegistry.koinModules())
+        modules(buildAppModules() + FeatureRegistry.koinModules())
     }
     val processRole = RuntimeMode.role()
     if (processRole == MoneatProcessRole.WORKFLOW_EGRESS || workflowWorkerMode() == WorkflowWorkerMode.EGRESS) {

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -102,11 +102,6 @@ import com.moneat.shared.services.RetentionBackgroundService
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.shared.services.TraceFinalizerBackgroundService
 import com.moneat.synthetics.routes.SyntheticsService
-import com.moneat.uptime.repositories.UptimeMonitorRepository
-import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
-import com.moneat.uptime.services.UptimeCheckExecutor
-import com.moneat.uptime.services.UptimeScheduler
-import com.moneat.uptime.services.UptimeService
 import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
 import com.moneat.workflows.engine.temporal.ExecuteEgressActionActivityImpl
 import com.moneat.workflows.engine.temporal.PersistRunActivityImpl
@@ -263,24 +258,6 @@ val logsModule = module {
     single { LogManagementService() }
 }
 
-/** Uptime monitoring and status pages. */
-fun uptimeModule(frontendBaseUrl: String) = module {
-    single<UptimeMonitorRepository> { UptimeMonitorRepositoryImpl() }
-
-    single { UptimeService(get(), get()) }
-    single { UptimeCheckExecutor() }
-    single {
-        UptimeScheduler(
-            uptimeService = get(),
-            checkExecutor = get(),
-            incidentService = get(),
-            billingQuotaService = get(),
-            workflowService = get(),
-            frontendBaseUrl = frontendBaseUrl
-        )
-    }
-}
-
 /** Custom dashboards, alert evaluation, and external data sources. */
 val dashboardsModule = module {
     single<DashboardFolderRepository> { DashboardFolderRepositoryImpl() }
@@ -316,9 +293,7 @@ val dashboardsModule = module {
 val aiModule = module {}
 
 /** All application modules combined in load order. */
-private const val DEFAULT_FRONTEND_BASE_URL = "https://moneat.io"
-
-fun buildAppModules(frontendBaseUrl: String = DEFAULT_FRONTEND_BASE_URL) =
+fun buildAppModules() =
     listOf(
         sharedModule,
         authModule,
@@ -327,7 +302,6 @@ fun buildAppModules(frontendBaseUrl: String = DEFAULT_FRONTEND_BASE_URL) =
         eventsModule,
         monitorModule,
         logsModule,
-        uptimeModule(frontendBaseUrl),
         dashboardsModule,
         aiModule,
     )

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -33,7 +33,6 @@ import com.moneat.shared.services.RetentionBackgroundService
 import com.moneat.shared.services.TaskLock
 import com.moneat.shared.services.TraceFinalizerBackgroundService
 import com.moneat.shared.services.UsageTrackingService
-import com.moneat.uptime.services.UptimeScheduler
 import com.moneat.utils.suspendRunCatching
 import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
 import com.moneat.workflows.engine.temporal.ExecuteEgressActionActivityImpl
@@ -151,7 +150,6 @@ private class SchedulerBackgroundJobs {
     private val traceFinalizerBackgroundService = koin.get<TraceFinalizerBackgroundService>()
     private val refreshTokenCleanupService = koin.get<RefreshTokenCleanupService>()
     private val artifactCleanupService = koin.get<ArtifactCleanupService>()
-    private val uptimeScheduler = koin.get<UptimeScheduler>()
     private val demoLivenessBackgroundService = koin.get<DemoLivenessBackgroundService>()
 
     fun start(jobScope: CoroutineScope) {
@@ -162,7 +160,6 @@ private class SchedulerBackgroundJobs {
         traceFinalizerBackgroundService.start(jobScope)
         refreshTokenCleanupService.start(jobScope)
         artifactCleanupService.start(jobScope)
-        uptimeScheduler.start()
         demoLivenessBackgroundService.start(jobScope)
     }
 
@@ -174,7 +171,6 @@ private class SchedulerBackgroundJobs {
         traceFinalizerBackgroundService.stop()
         refreshTokenCleanupService.stop()
         artifactCleanupService.stop()
-        uptimeScheduler.stop()
         demoLivenessBackgroundService.stop()
     }
 }


### PR DESCRIPTION
## Summary
- move uptime service bindings into the uptime feature module
- start and stop the uptime scheduler through the feature module lifecycle

## Validation
- cd backend && ./gradlew :features:uptime:compileKotlin :features:uptime:compileTestKotlin :features:uptime:test :features:uptime:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uptime monitoring background jobs are now fully initialized and scheduled automatically.
  * Uptime checks now use the configured frontend URL, defaulting to `https://moneat.io` when not set.
* **Refactor**
  * Dependency injection is now driven by feature-provided modules, so uptime wires itself and its lifecycle handling.
* **Tests**
  * Added a Koin binding test to ensure uptime services can be resolved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->