### PR TITLE
refactor: move billing DI into feature module

### DIFF
--- a/backend/features/billing/src/main/kotlin/com/moneat/billing/BillingModule.kt
+++ b/backend/features/billing/src/main/kotlin/com/moneat/billing/BillingModule.kt
@@ -16,19 +16,38 @@
 
 package com.moneat.billing
 
+import com.moneat.billing.repositories.SubscriptionRepository
+import com.moneat.billing.repositories.SubscriptionRepositoryImpl
 import com.moneat.billing.routes.billingRoutes
 import com.moneat.billing.routes.publicBillingRoutes
 import com.moneat.billing.routes.stripeWebhookRoutes
+import com.moneat.billing.services.AdminBillingService
+import com.moneat.billing.services.BillingBackgroundService
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.billing.services.EntitlementService
+import com.moneat.billing.services.PricingTierService
+import com.moneat.billing.services.StripeService
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.shared.repositories.OrganizationRepository
 import io.ktor.server.application.Application
 import io.ktor.server.auth.authenticate
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.route
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.koin.core.context.GlobalContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.util.concurrent.atomic.AtomicReference
 
 class BillingModule : EnterpriseModule {
     override val name: String = "Billing"
+    private val runningBackgroundJobs = AtomicReference<RunningBillingJobs?>(null)
+    private val lifecycleLock = Any()
 
     override fun registerRoutes(route: Route) {
         route.stripeWebhookRoutes()
@@ -44,7 +63,73 @@ class BillingModule : EnterpriseModule {
         }
     }
 
-    override fun startBackgroundJobs(application: Application) = Unit
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single<SubscriptionRepository> { SubscriptionRepositoryImpl() }
+                single { PricingTierService() }
+                single { BillingQuotaService(get()) }
+                single { EntitlementService(get()) }
+                single {
+                    StripeService(
+                        subscriptionRepository = get(),
+                        organizationRepository = get<OrganizationRepository>(),
+                        pricingTierService = get(),
+                    )
+                }
+                single {
+                    BillingBackgroundService(
+                        stripeService = get(),
+                        quotaService = get(),
+                        emailService = get(),
+                        pricingTierService = get(),
+                    )
+                }
+                single { AdminBillingService(get()) }
+            }
+        )
 
-    override fun stopBackgroundJobs() = Unit
+    override fun startBackgroundJobs(application: Application) {
+        startBackgroundJobs(application, startSchedulers = true, startIngestionWorkers = true)
+    }
+
+    override fun startBackgroundJobs(
+        application: Application,
+        startSchedulers: Boolean,
+        startIngestionWorkers: Boolean,
+    ) {
+        if (!startSchedulers) return
+
+        synchronized(lifecycleLock) {
+            if (runningBackgroundJobs.get() != null) return
+
+            val runningJobs = RunningBillingJobs(
+                service = GlobalContext.get().get(),
+                scope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+            )
+            try {
+                runningJobs.service.start(runningJobs.scope)
+                runningBackgroundJobs.set(runningJobs)
+            } catch (e: Throwable) {
+                runningJobs.stop()
+                throw e
+            }
+        }
+    }
+
+    override fun stopBackgroundJobs() {
+        synchronized(lifecycleLock) {
+            runningBackgroundJobs.getAndSet(null)?.stop()
+        }
+    }
+
+    private data class RunningBillingJobs(
+        val service: BillingBackgroundService,
+        val scope: CoroutineScope,
+    ) {
+        fun stop() {
+            service.stop()
+            scope.cancel()
+        }
+    }
 }

--- a/backend/features/billing/src/test/kotlin/com/moneat/billing/BillingFeatureRegistryTest.kt
+++ b/backend/features/billing/src/test/kotlin/com/moneat/billing/BillingFeatureRegistryTest.kt
@@ -16,10 +16,20 @@
 
 package com.moneat.billing
 
+import com.moneat.billing.repositories.SubscriptionRepository
+import com.moneat.billing.services.AdminBillingService
+import com.moneat.billing.services.BillingBackgroundService
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.billing.services.EntitlementService
+import com.moneat.billing.services.PricingTierService
+import com.moneat.billing.services.StripeService
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.notifications.services.EmailService
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
+import com.moneat.shared.repositories.OrganizationRepository
+import com.moneat.shared.repositories.OrganizationRepositoryImpl
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
@@ -29,10 +39,13 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import org.koin.core.KoinApplication
+import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class BillingFeatureRegistryTest {
@@ -52,6 +65,30 @@ class BillingFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Billing" in moduleNames)
+    }
+
+    @Test
+    fun `Billing module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(
+                module {
+                    single<OrganizationRepository> { OrganizationRepositoryImpl() }
+                    single { EmailService() }
+                },
+                *BillingModule().koinModules().toTypedArray(),
+            )
+
+        try {
+            assertIs<SubscriptionRepository>(koinApplication.koin.get<SubscriptionRepository>())
+            assertIs<PricingTierService>(koinApplication.koin.get<PricingTierService>())
+            assertIs<BillingQuotaService>(koinApplication.koin.get<BillingQuotaService>())
+            assertIs<EntitlementService>(koinApplication.koin.get<EntitlementService>())
+            assertIs<StripeService>(koinApplication.koin.get<StripeService>())
+            assertIs<BillingBackgroundService>(koinApplication.koin.get<BillingBackgroundService>())
+            assertIs<AdminBillingService>(koinApplication.koin.get<AdminBillingService>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -24,14 +24,6 @@ import com.moneat.auth.services.AuthTokenService
 import com.moneat.auth.services.OAuthService
 import com.moneat.auth.services.RefreshTokenCleanupService
 import com.moneat.auth.services.RefreshTokenService
-import com.moneat.billing.repositories.SubscriptionRepository
-import com.moneat.billing.repositories.SubscriptionRepositoryImpl
-import com.moneat.billing.services.AdminBillingService
-import com.moneat.billing.services.BillingBackgroundService
-import com.moneat.billing.services.BillingQuotaService
-import com.moneat.billing.services.EntitlementService
-import com.moneat.billing.services.PricingTierService
-import com.moneat.billing.services.StripeService
 import com.moneat.dashboards.repositories.DashboardFolderRepository
 import com.moneat.dashboards.repositories.DashboardFolderRepositoryImpl
 import com.moneat.dashboards.repositories.DashboardRepository
@@ -117,7 +109,7 @@ import com.moneat.workflows.services.WorkflowStepRenderer
 import com.moneat.workflows.services.WorkflowTrustedActionExecutor
 import org.koin.dsl.module
 
-/** Shared cross-domain singletons: notification channels, pricing, retention, shared repositories. */
+/** Shared cross-domain singletons: notification channels, retention, shared repositories. */
 val sharedModule = module {
     single<MembershipRepository> { MembershipRepositoryImpl() }
     single<OrganizationRepository> { OrganizationRepositoryImpl() }
@@ -149,9 +141,6 @@ val sharedModule = module {
     single { WorkflowGovernanceService(get()) }
     single { IncidentService(get()) }
 
-    single { PricingTierService() }
-    single { BillingQuotaService(get()) }
-    single { EntitlementService(get()) }
     single { RetentionPolicyService(get()) }
     single { RetentionBackgroundService(get()) }
     single { TraceFinalizerBackgroundService.fromConfig() }
@@ -181,28 +170,6 @@ val authModule = module {
         )
     }
     single { ArtifactCleanupService(get(), get()) }
-}
-
-/** Billing, subscriptions, and Stripe integration. */
-val billingModule = module {
-    single<SubscriptionRepository> { SubscriptionRepositoryImpl() }
-
-    single {
-        StripeService(
-            subscriptionRepository = get(),
-            organizationRepository = get(),
-            pricingTierService = get(),
-        )
-    }
-    single {
-        BillingBackgroundService(
-            stripeService = get(),
-            quotaService = get(),
-            emailService = get(),
-            pricingTierService = get(),
-        )
-    }
-    single { AdminBillingService(get()) }
 }
 
 /** Organization membership, invitations, and admin operations. */
@@ -297,7 +264,6 @@ fun buildAppModules() =
     listOf(
         sharedModule,
         authModule,
-        billingModule,
         orgModule,
         eventsModule,
         monitorModule,

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -17,7 +17,6 @@
 package com.moneat.plugins
 
 import com.moneat.auth.services.RefreshTokenCleanupService
-import com.moneat.billing.services.BillingBackgroundService
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.dashboards.services.DashboardAlertService
@@ -145,7 +144,6 @@ private class SchedulerBackgroundJobs {
     private val koin = GlobalContext.get()
     private val monitorAlertService = koin.get<MonitorAlertService>()
     private val dashboardAlertService = koin.get<DashboardAlertService>()
-    private val billingBackgroundService = koin.get<BillingBackgroundService>()
     private val retentionBackgroundService = koin.get<RetentionBackgroundService>()
     private val traceFinalizerBackgroundService = koin.get<TraceFinalizerBackgroundService>()
     private val refreshTokenCleanupService = koin.get<RefreshTokenCleanupService>()
@@ -155,7 +153,6 @@ private class SchedulerBackgroundJobs {
     fun start(jobScope: CoroutineScope) {
         monitorAlertService.start(jobScope)
         dashboardAlertService.start(jobScope)
-        billingBackgroundService.start(jobScope)
         retentionBackgroundService.start(jobScope)
         traceFinalizerBackgroundService.start(jobScope)
         refreshTokenCleanupService.start(jobScope)
@@ -166,7 +163,6 @@ private class SchedulerBackgroundJobs {
     fun stop() {
         monitorAlertService.stop()
         dashboardAlertService.stop()
-        billingBackgroundService.stop()
         retentionBackgroundService.stop()
         traceFinalizerBackgroundService.stop()
         refreshTokenCleanupService.stop()


### PR DESCRIPTION
## Summary
- move billing Koin bindings into the billing feature module
- let the billing feature own BillingBackgroundService lifecycle
- add feature-module coverage for billing DI bindings

## Validation
- cd backend && ./gradlew :features:billing:compileKotlin :features:billing:compileTestKotlin :features:billing:test :features:billing:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Billing now manages its own dependency injection wiring and background service lifecycle, ensuring billing jobs are started and stopped reliably via module lifecycle hooks.
  * Billing-related wiring was removed from the main app module graph and the background job scheduler plugin.

* **Tests**
  * Added a test to verify billing module dependency injection bindings and that key billing services can be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->