### PR TITLE
refactor: move org DI into feature module

### DIFF
--- a/backend/features/org/src/main/kotlin/com/moneat/org/OrgModule.kt
+++ b/backend/features/org/src/main/kotlin/com/moneat/org/OrgModule.kt
@@ -17,10 +17,19 @@
 package com.moneat.org
 
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.org.repositories.OrgInvitationRepository
+import com.moneat.org.repositories.OrgInvitationRepositoryImpl
+import com.moneat.org.repositories.OrgMembershipRepository
+import com.moneat.org.repositories.OrgMembershipRepositoryImpl
 import com.moneat.org.routes.adminRoutes
 import com.moneat.org.routes.orgManagementRoutes
+import com.moneat.org.services.AdminService
+import com.moneat.org.services.OrgInvitationService
+import com.moneat.org.services.OrgMembershipService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
+import org.koin.core.module.Module
+import org.koin.dsl.module
 
 class OrgModule : EnterpriseModule {
     override val name: String = "Organization"
@@ -29,6 +38,18 @@ class OrgModule : EnterpriseModule {
         route.adminRoutes()
         route.orgManagementRoutes()
     }
+
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single<OrgMembershipRepository> { OrgMembershipRepositoryImpl() }
+                single<OrgInvitationRepository> { OrgInvitationRepositoryImpl() }
+
+                single { OrgMembershipService(get()) }
+                single { OrgInvitationService(get(), get(), get()) }
+                single { AdminService(get()) }
+            }
+        )
 
     override fun startBackgroundJobs(application: Application) = Unit
 

--- a/backend/features/org/src/test/kotlin/com/moneat/org/OrgFeatureRegistryTest.kt
+++ b/backend/features/org/src/test/kotlin/com/moneat/org/OrgFeatureRegistryTest.kt
@@ -16,9 +16,16 @@
 
 package com.moneat.org
 
+import com.moneat.billing.services.PricingTierService
 import com.moneat.config.EnvConfig
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.notifications.services.EmailService
+import com.moneat.org.repositories.OrgInvitationRepository
+import com.moneat.org.repositories.OrgMembershipRepository
+import com.moneat.org.services.AdminService
+import com.moneat.org.services.OrgInvitationService
+import com.moneat.org.services.OrgMembershipService
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
 import io.ktor.client.call.body
@@ -30,10 +37,13 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import org.koin.core.KoinApplication
+import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class OrgFeatureRegistryTest {
@@ -53,6 +63,28 @@ class OrgFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Organization" in moduleNames)
+    }
+
+    @Test
+    fun `Organization module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(
+                module {
+                    single { EmailService() }
+                    single { PricingTierService() }
+                },
+                *OrgModule().koinModules().toTypedArray(),
+            )
+
+        try {
+            assertIs<OrgMembershipRepository>(koinApplication.koin.get<OrgMembershipRepository>())
+            assertIs<OrgInvitationRepository>(koinApplication.koin.get<OrgInvitationRepository>())
+            assertIs<OrgMembershipService>(koinApplication.koin.get<OrgMembershipService>())
+            assertIs<OrgInvitationService>(koinApplication.koin.get<OrgInvitationService>())
+            assertIs<AdminService>(koinApplication.koin.get<AdminService>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -72,13 +72,6 @@ import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.notifications.services.SlackService
-import com.moneat.org.repositories.OrgInvitationRepository
-import com.moneat.org.repositories.OrgInvitationRepositoryImpl
-import com.moneat.org.repositories.OrgMembershipRepository
-import com.moneat.org.repositories.OrgMembershipRepositoryImpl
-import com.moneat.org.services.AdminService
-import com.moneat.org.services.OrgInvitationService
-import com.moneat.org.services.OrgMembershipService
 import com.moneat.otlp.services.OtlpApiKeyService
 import com.moneat.otlp.services.OtlpServiceRoutingService
 import com.moneat.shared.repositories.MembershipRepository
@@ -172,16 +165,6 @@ val authModule = module {
     single { ArtifactCleanupService(get(), get()) }
 }
 
-/** Organization membership, invitations, and admin operations. */
-val orgModule = module {
-    single<OrgMembershipRepository> { OrgMembershipRepositoryImpl() }
-    single<OrgInvitationRepository> { OrgInvitationRepositoryImpl() }
-
-    single { OrgMembershipService(get()) }
-    single { OrgInvitationService(get(), get(), get()) }
-    single { AdminService(get()) }
-}
-
 /** Core error-tracking and telemetry pipeline. */
 val eventsModule = module {
     single<EventRepository> { EventRepositoryImpl() }
@@ -264,7 +247,6 @@ fun buildAppModules() =
     listOf(
         sharedModule,
         authModule,
-        orgModule,
         eventsModule,
         monitorModule,
         logsModule,


### PR DESCRIPTION
## Summary
- move organization Koin bindings into the org feature module
- remove the root org DI block from app startup modules
- add feature-module coverage for org DI bindings

## Validation
- cd backend && ./gradlew :features:org:compileKotlin :features:org:compileTestKotlin :features:org:test :features:org:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check
