### PR TITLE
refactor: move auth DI into feature modules

### DIFF
--- a/backend/features/auth-tokens/src/main/kotlin/com/moneat/auth/AuthTokensModule.kt
+++ b/backend/features/auth-tokens/src/main/kotlin/com/moneat/auth/AuthTokensModule.kt
@@ -17,18 +17,80 @@
 package com.moneat.auth
 
 import com.moneat.auth.routes.authTokenRoutes
+import com.moneat.auth.services.AuthTokenService
+import com.moneat.auth.services.RefreshTokenCleanupService
+import com.moneat.auth.services.RefreshTokenService
 import com.moneat.enterprise.EnterpriseModule
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.koin.core.context.GlobalContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.util.concurrent.atomic.AtomicReference
 
 class AuthTokensModule : EnterpriseModule {
     override val name: String = "Auth Tokens"
+    private val runningBackgroundJobs = AtomicReference<RunningAuthTokenJobs?>(null)
+    private val lifecycleLock = Any()
 
     override fun registerRoutes(route: Route) {
         route.authTokenRoutes()
     }
 
-    override fun startBackgroundJobs(application: Application) = Unit
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single { AuthTokenService() }
+                single { RefreshTokenService() }
+                single { RefreshTokenCleanupService() }
+            }
+        )
 
-    override fun stopBackgroundJobs() = Unit
+    override fun startBackgroundJobs(application: Application) {
+        startBackgroundJobs(application, startSchedulers = true, startIngestionWorkers = true)
+    }
+
+    override fun startBackgroundJobs(
+        application: Application,
+        startSchedulers: Boolean,
+        startIngestionWorkers: Boolean,
+    ) {
+        if (!startSchedulers) return
+
+        synchronized(lifecycleLock) {
+            if (runningBackgroundJobs.get() != null) return
+
+            val runningJobs = RunningAuthTokenJobs(
+                service = GlobalContext.get().get(),
+                scope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+            )
+            try {
+                runningJobs.service.start(runningJobs.scope)
+                runningBackgroundJobs.set(runningJobs)
+            } catch (e: Throwable) {
+                runningJobs.stop()
+                throw e
+            }
+        }
+    }
+
+    override fun stopBackgroundJobs() {
+        synchronized(lifecycleLock) {
+            runningBackgroundJobs.getAndSet(null)?.stop()
+        }
+    }
+
+    private data class RunningAuthTokenJobs(
+        val service: RefreshTokenCleanupService,
+        val scope: CoroutineScope,
+    ) {
+        fun stop() {
+            service.stop()
+            scope.cancel()
+        }
+    }
 }

--- a/backend/features/auth-tokens/src/test/kotlin/com/moneat/auth/AuthTokensFeatureRegistryTest.kt
+++ b/backend/features/auth-tokens/src/test/kotlin/com/moneat/auth/AuthTokensFeatureRegistryTest.kt
@@ -16,6 +16,9 @@
 
 package com.moneat.auth
 
+import com.moneat.auth.services.AuthTokenService
+import com.moneat.auth.services.RefreshTokenCleanupService
+import com.moneat.auth.services.RefreshTokenService
 import com.moneat.config.EnvConfig
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
@@ -30,10 +33,12 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import org.koin.core.KoinApplication
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class AuthTokensFeatureRegistryTest {
@@ -53,6 +58,20 @@ class AuthTokensFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Auth Tokens" in moduleNames)
+    }
+
+    @Test
+    fun `Auth Tokens module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(*AuthTokensModule().koinModules().toTypedArray())
+
+        try {
+            assertIs<AuthTokenService>(koinApplication.koin.get<AuthTokenService>())
+            assertIs<RefreshTokenService>(koinApplication.koin.get<RefreshTokenService>())
+            assertIs<RefreshTokenCleanupService>(koinApplication.koin.get<RefreshTokenCleanupService>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/features/auth/src/main/kotlin/com/moneat/auth/AuthModule.kt
+++ b/backend/features/auth/src/main/kotlin/com/moneat/auth/AuthModule.kt
@@ -16,10 +16,16 @@
 
 package com.moneat.auth
 
+import com.moneat.auth.repositories.UserRepository
+import com.moneat.auth.repositories.UserRepositoryImpl
 import com.moneat.auth.routes.authRoutes
+import com.moneat.auth.services.AuthService
+import com.moneat.auth.services.OAuthService
 import com.moneat.enterprise.EnterpriseModule
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
+import org.koin.core.module.Module
+import org.koin.dsl.module
 
 class AuthModule : EnterpriseModule {
     override val name: String = "Authentication"
@@ -27,6 +33,24 @@ class AuthModule : EnterpriseModule {
     override fun registerRoutes(route: Route) {
         route.authRoutes()
     }
+
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single<UserRepository> { UserRepositoryImpl() }
+                single { OAuthService(get()) }
+                single {
+                    AuthService(
+                        userRepository = get(),
+                        membershipRepository = get(),
+                        organizationRepository = get(),
+                        emailService = get(),
+                        refreshTokenService = get(),
+                        workflowService = get(),
+                    )
+                }
+            }
+        )
 
     override fun startBackgroundJobs(application: Application) = Unit
 

--- a/backend/features/auth/src/test/kotlin/com/moneat/auth/AuthFeatureRegistryTest.kt
+++ b/backend/features/auth/src/test/kotlin/com/moneat/auth/AuthFeatureRegistryTest.kt
@@ -16,11 +16,21 @@
 
 package com.moneat.auth
 
+import com.moneat.auth.repositories.UserRepository
+import com.moneat.auth.services.AuthService
+import com.moneat.auth.services.OAuthService
+import com.moneat.auth.services.RefreshTokenService
 import com.moneat.config.EnvConfig
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.notifications.services.EmailService
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
+import com.moneat.shared.repositories.MembershipRepository
+import com.moneat.shared.repositories.MembershipRepositoryImpl
+import com.moneat.shared.repositories.OrganizationRepository
+import com.moneat.shared.repositories.OrganizationRepositoryImpl
+import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
@@ -30,10 +40,13 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import org.koin.core.KoinApplication
+import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class AuthFeatureRegistryTest {
@@ -53,6 +66,31 @@ class AuthFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Authentication" in moduleNames)
+    }
+
+    @Test
+    fun `Authentication module provides feature Koin bindings`() {
+        withProperties(mapOf("FRONTEND_URL" to "https://dashboard.test.local")) {
+            val koinApplication = KoinApplication.init()
+                .modules(
+                    module {
+                        single<MembershipRepository> { MembershipRepositoryImpl() }
+                        single<OrganizationRepository> { OrganizationRepositoryImpl() }
+                        single { EmailService() }
+                        single { RefreshTokenService() }
+                        single { WorkflowService() }
+                    },
+                    *AuthModule().koinModules().toTypedArray(),
+                )
+
+            try {
+                assertIs<UserRepository>(koinApplication.koin.get<UserRepository>())
+                assertIs<OAuthService>(koinApplication.koin.get<OAuthService>())
+                assertIs<AuthService>(koinApplication.koin.get<AuthService>())
+            } finally {
+                koinApplication.close()
+            }
+        }
     }
 
     @Test
@@ -84,5 +122,24 @@ class AuthFeatureRegistryTest {
                 selfHost = EnvConfig.SelfHost.enabled,
             )
         )
+    }
+
+    private fun withProperties(
+        properties: Map<String, String>,
+        block: () -> Unit,
+    ) {
+        val previousValues = properties.keys.associateWith { key -> System.getProperty(key) }
+        properties.forEach { (key, value) -> System.setProperty(key, value) }
+        try {
+            block()
+        } finally {
+            previousValues.forEach { (key, value) ->
+                if (value == null) {
+                    System.clearProperty(key)
+                } else {
+                    System.setProperty(key, value)
+                }
+            }
+        }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -17,13 +17,6 @@
 package com.moneat.di
 
 import com.moneat.alerts.services.AlertEpisodeService
-import com.moneat.auth.repositories.UserRepository
-import com.moneat.auth.repositories.UserRepositoryImpl
-import com.moneat.auth.services.AuthService
-import com.moneat.auth.services.AuthTokenService
-import com.moneat.auth.services.OAuthService
-import com.moneat.auth.services.RefreshTokenCleanupService
-import com.moneat.auth.services.RefreshTokenService
 import com.moneat.dashboards.repositories.DashboardFolderRepository
 import com.moneat.dashboards.repositories.DashboardFolderRepositoryImpl
 import com.moneat.dashboards.repositories.DashboardRepository
@@ -142,26 +135,6 @@ val sharedModule = module {
     single { AttributionAnalyticsService() }
     single { DemoLivenessBackgroundService() }
     single { GeoIpService() }
-}
-
-/** Authentication, token management, and account lifecycle. */
-val authModule = module {
-    single<UserRepository> { UserRepositoryImpl() }
-
-    single { OAuthService() }
-    single { AuthTokenService() }
-    single { RefreshTokenService() }
-    single { RefreshTokenCleanupService() }
-    single {
-        AuthService(
-            userRepository = get(),
-            membershipRepository = get(),
-            organizationRepository = get(),
-            emailService = get(),
-            refreshTokenService = get(),
-            workflowService = get(),
-        )
-    }
     single { ArtifactCleanupService(get(), get()) }
 }
 
@@ -246,7 +219,6 @@ val aiModule = module {}
 fun buildAppModules() =
     listOf(
         sharedModule,
-        authModule,
         eventsModule,
         monitorModule,
         logsModule,

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -16,7 +16,6 @@
 
 package com.moneat.plugins
 
-import com.moneat.auth.services.RefreshTokenCleanupService
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
 import com.moneat.dashboards.services.DashboardAlertService
@@ -146,7 +145,6 @@ private class SchedulerBackgroundJobs {
     private val dashboardAlertService = koin.get<DashboardAlertService>()
     private val retentionBackgroundService = koin.get<RetentionBackgroundService>()
     private val traceFinalizerBackgroundService = koin.get<TraceFinalizerBackgroundService>()
-    private val refreshTokenCleanupService = koin.get<RefreshTokenCleanupService>()
     private val artifactCleanupService = koin.get<ArtifactCleanupService>()
     private val demoLivenessBackgroundService = koin.get<DemoLivenessBackgroundService>()
 
@@ -155,7 +153,6 @@ private class SchedulerBackgroundJobs {
         dashboardAlertService.start(jobScope)
         retentionBackgroundService.start(jobScope)
         traceFinalizerBackgroundService.start(jobScope)
-        refreshTokenCleanupService.start(jobScope)
         artifactCleanupService.start(jobScope)
         demoLivenessBackgroundService.start(jobScope)
     }
@@ -165,7 +162,6 @@ private class SchedulerBackgroundJobs {
         dashboardAlertService.stop()
         retentionBackgroundService.stop()
         traceFinalizerBackgroundService.stop()
-        refreshTokenCleanupService.stop()
         artifactCleanupService.stop()
         demoLivenessBackgroundService.stop()
     }


### PR DESCRIPTION
## Summary
- Move auth and auth-token Koin bindings into their feature modules
- Move refresh token cleanup lifecycle behind the auth-token feature module
- Keep root app wiring focused on shared services

## Validation
- cd backend && ./gradlew :features:auth-tokens:compileKotlin :features:auth-tokens:compileTestKotlin :features:auth-tokens:test :features:auth-tokens:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew :features:auth:compileKotlin :features:auth:compileTestKotlin :features:auth:test :features:auth:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication and token service module configurations to ensure proper service initialization.

* **Refactor**
  * Reorganized authentication service module architecture for improved dependency management and application structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->