### PR TITLE
refactor: move logs and otlp DI into feature modules

### DIFF
--- a/backend/features/logs/src/main/kotlin/com/moneat/logs/LogsModule.kt
+++ b/backend/features/logs/src/main/kotlin/com/moneat/logs/LogsModule.kt
@@ -19,14 +19,21 @@ package com.moneat.logs
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
+import com.moneat.logs.repositories.LogRepository
+import com.moneat.logs.repositories.LogRepositoryImpl
 import com.moneat.logs.routes.logIngestRoutes
 import com.moneat.logs.routes.logRoutes
+import com.moneat.logs.services.LogIndexService
 import com.moneat.logs.services.LogIngestionWorker
+import com.moneat.logs.services.LogManagementService
+import com.moneat.logs.services.LogService
 import io.ktor.server.application.Application
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.routing.Route
 import org.koin.core.context.GlobalContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
 
 private const val DEFAULT_LOG_QUEUE_KEY = "moneat:logs:queue"
 private const val DEFAULT_LOG_DLQ_KEY = "moneat:logs:dlq"
@@ -43,6 +50,16 @@ class LogsModule : EnterpriseModule {
         }
         route.logRoutes()
     }
+
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single<LogRepository> { LogRepositoryImpl() }
+                single { LogService(get()) }
+                single { LogIndexService() }
+                single { LogManagementService() }
+            }
+        )
 
     override fun startBackgroundJobs(application: Application) {
         startBackgroundJobs(application, startSchedulers = true, startIngestionWorkers = true)

--- a/backend/features/logs/src/test/kotlin/com/moneat/logs/LogsFeatureRegistryTest.kt
+++ b/backend/features/logs/src/test/kotlin/com/moneat/logs/LogsFeatureRegistryTest.kt
@@ -18,6 +18,10 @@ package com.moneat.logs
 
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.logs.repositories.LogRepository
+import com.moneat.logs.services.LogIndexService
+import com.moneat.logs.services.LogManagementService
+import com.moneat.logs.services.LogService
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
 import io.ktor.client.call.body
@@ -29,10 +33,12 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import org.koin.core.KoinApplication
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class LogsFeatureRegistryTest {
@@ -52,6 +58,21 @@ class LogsFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Logs" in moduleNames)
+    }
+
+    @Test
+    fun `Logs module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(*LogsModule().koinModules().toTypedArray())
+
+        try {
+            assertIs<LogRepository>(koinApplication.koin.get<LogRepository>())
+            assertIs<LogService>(koinApplication.koin.get<LogService>())
+            assertIs<LogIndexService>(koinApplication.koin.get<LogIndexService>())
+            assertIs<LogManagementService>(koinApplication.koin.get<LogManagementService>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/features/otlp/src/main/kotlin/com/moneat/otlp/OtlpModule.kt
+++ b/backend/features/otlp/src/main/kotlin/com/moneat/otlp/OtlpModule.kt
@@ -23,8 +23,10 @@ import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.otlp.routes.otlpFeedbackRoutes
 import com.moneat.otlp.routes.otlpMetricsRoutes
 import com.moneat.otlp.routes.otlpTraceRoutes
+import com.moneat.otlp.services.OtlpApiKeyService
 import com.moneat.otlp.services.OtlpIngestionWorkerBase
 import com.moneat.otlp.services.OtlpMetricsIngestionWorker
+import com.moneat.otlp.services.OtlpServiceRoutingService
 import com.moneat.otlp.services.OtlpTraceIngestionWorker
 import io.ktor.server.application.Application
 import io.ktor.server.config.ApplicationConfig
@@ -34,6 +36,8 @@ import io.ktor.server.routing.Route
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.koin.core.context.GlobalContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
 
 private const val DEFAULT_OTLP_TRACES_QUEUE_KEY = "moneat:otlp-traces:queue"
 private const val DEFAULT_OTLP_TRACES_DLQ_KEY = "moneat:otlp-traces:dlq"
@@ -54,6 +58,14 @@ class OtlpModule : EnterpriseModule {
             otlpFeedbackRoutes()
         }
     }
+
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single { OtlpApiKeyService() }
+                single { OtlpServiceRoutingService() }
+            }
+        )
 
     override fun startBackgroundJobs(application: Application) {
         startBackgroundJobs(application, startSchedulers = true, startIngestionWorkers = true)

--- a/backend/features/otlp/src/test/kotlin/com/moneat/otlp/OtlpFeatureRegistryTest.kt
+++ b/backend/features/otlp/src/test/kotlin/com/moneat/otlp/OtlpFeatureRegistryTest.kt
@@ -18,6 +18,8 @@ package com.moneat.otlp
 
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.otlp.services.OtlpApiKeyService
+import com.moneat.otlp.services.OtlpServiceRoutingService
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
 import io.ktor.client.call.body
@@ -29,10 +31,12 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import org.koin.core.KoinApplication
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class OtlpFeatureRegistryTest {
@@ -52,6 +56,19 @@ class OtlpFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("OTLP" in moduleNames)
+    }
+
+    @Test
+    fun `OTLP module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(*OtlpModule().koinModules().toTypedArray())
+
+        try {
+            assertIs<OtlpApiKeyService>(koinApplication.koin.get<OtlpApiKeyService>())
+            assertIs<OtlpServiceRoutingService>(koinApplication.koin.get<OtlpServiceRoutingService>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -40,11 +40,6 @@ import com.moneat.events.services.DashboardService
 import com.moneat.events.services.EventService
 import com.moneat.events.services.ReleaseService
 import com.moneat.incident.services.IncidentService
-import com.moneat.logs.repositories.LogRepository
-import com.moneat.logs.repositories.LogRepositoryImpl
-import com.moneat.logs.services.LogIndexService
-import com.moneat.logs.services.LogManagementService
-import com.moneat.logs.services.LogService
 import com.moneat.monitor.repositories.HostAlertRepository
 import com.moneat.monitor.repositories.HostAlertRepositoryImpl
 import com.moneat.monitor.repositories.HostRepository
@@ -65,8 +60,6 @@ import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.notifications.services.SlackService
-import com.moneat.otlp.services.OtlpApiKeyService
-import com.moneat.otlp.services.OtlpServiceRoutingService
 import com.moneat.shared.repositories.MembershipRepository
 import com.moneat.shared.repositories.MembershipRepositoryImpl
 import com.moneat.shared.repositories.OrganizationRepository
@@ -170,17 +163,6 @@ val monitorModule = module {
     single { SyntheticsService(get(), get()) }
 }
 
-/** Log ingestion and querying. */
-val logsModule = module {
-    single<LogRepository> { LogRepositoryImpl() }
-
-    single { LogService(get()) }
-    single { OtlpApiKeyService() }
-    single { OtlpServiceRoutingService() }
-    single { LogIndexService() }
-    single { LogManagementService() }
-}
-
 /** Custom dashboards, alert evaluation, and external data sources. */
 val dashboardsModule = module {
     single<DashboardFolderRepository> { DashboardFolderRepositoryImpl() }
@@ -221,7 +203,6 @@ fun buildAppModules() =
         sharedModule,
         eventsModule,
         monitorModule,
-        logsModule,
         dashboardsModule,
         aiModule,
     )


### PR DESCRIPTION
## Summary
- move logs Koin bindings into the logs feature module
- move OTLP Koin bindings into the OTLP feature module
- keep the root backend app host free of those service bindings

## Validation
- cd backend && ./gradlew :features:logs:compileKotlin :features:logs:compileTestKotlin :features:logs:test :features:logs:detekt :features:otlp:compileKotlin :features:otlp:compileTestKotlin :features:otlp:test :features:otlp:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests verifying that dependency injection module configurations are correctly exposed and resolvable.

* **Chores**
  * Reorganized dependency injection configuration by migrating it from centralized application module to individual feature modules for improved modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->