### PR TITLE
refactor: move monitoring DI into feature modules

### DIFF
--- a/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
+++ b/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
@@ -17,14 +17,31 @@
 package com.moneat.monitoring
 
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.monitor.repositories.HostAlertRepository
+import com.moneat.monitor.repositories.HostAlertRepositoryImpl
+import com.moneat.monitor.repositories.HostRepository
+import com.moneat.monitor.repositories.HostRepositoryImpl
+import com.moneat.monitor.repositories.ResourceOwnershipRepository
+import com.moneat.monitor.repositories.ResourceOwnershipRepositoryImpl
 import com.moneat.monitor.routes.agentApiKeyRoutes
 import com.moneat.monitor.routes.cloudSourceRoutes
 import com.moneat.monitor.routes.infraRoutes
 import com.moneat.monitor.routes.monitorRoutes
 import com.moneat.monitor.routes.resourceCatalogRoutes
+import com.moneat.monitor.services.AgentApiKeyService
+import com.moneat.monitor.services.ClickHouseCloudResourceWriter
+import com.moneat.monitor.services.CloudResourceWriter
+import com.moneat.monitor.services.CloudSourceService
+import com.moneat.monitor.services.CloudSourceVerifier
+import com.moneat.monitor.services.ManagedIdentityCloudSourceVerifier
+import com.moneat.monitor.services.MonitorAlertService
+import com.moneat.monitor.services.MonitorService
+import com.moneat.monitor.services.ResourceCatalogService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
 import mu.KotlinLogging
+import org.koin.core.module.Module
+import org.koin.dsl.module
 
 private val logger = KotlinLogging.logger {}
 
@@ -43,6 +60,23 @@ class MonitoringModule : EnterpriseModule {
             agentApiKeyRoutes()
         }
     }
+
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single<HostRepository> { HostRepositoryImpl() }
+                single<HostAlertRepository> { HostAlertRepositoryImpl() }
+
+                single { MonitorService(get(), get(), get(), get()) }
+                single { MonitorAlertService(get(), get()) }
+                single<ResourceOwnershipRepository> { ResourceOwnershipRepositoryImpl() }
+                single { ResourceCatalogService(monitorService = get(), ownershipRepository = get()) }
+                single<CloudSourceVerifier> { ManagedIdentityCloudSourceVerifier() }
+                single<CloudResourceWriter> { ClickHouseCloudResourceWriter() }
+                single { CloudSourceService(get(), get()) }
+                single { AgentApiKeyService() }
+            }
+        )
 
     override fun startBackgroundJobs(application: Application) {
         logger.info { "Starting monitoring enterprise background jobs" }

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/MonitoringFeatureRegistryTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/MonitoringFeatureRegistryTest.kt
@@ -18,8 +18,27 @@ package com.moneat.monitoring
 
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.incident.services.IncidentService
+import com.moneat.monitor.repositories.HostAlertRepository
+import com.moneat.monitor.repositories.HostAlertRepositoryImpl
+import com.moneat.monitor.repositories.HostRepository
+import com.moneat.monitor.repositories.HostRepositoryImpl
+import com.moneat.monitor.repositories.ResourceOwnershipRepository
+import com.moneat.monitor.repositories.ResourceOwnershipRepositoryImpl
+import com.moneat.monitor.services.AgentApiKeyService
+import com.moneat.monitor.services.ClickHouseCloudResourceWriter
+import com.moneat.monitor.services.CloudResourceWriter
+import com.moneat.monitor.services.CloudSourceService
+import com.moneat.monitor.services.CloudSourceVerifier
+import com.moneat.monitor.services.ManagedIdentityCloudSourceVerifier
+import com.moneat.monitor.services.MonitorAlertService
+import com.moneat.monitor.services.MonitorService
+import com.moneat.monitor.services.ResourceCatalogService
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
+import com.moneat.billing.services.PricingTierService
+import com.moneat.shared.services.RetentionPolicyService
+import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
@@ -29,10 +48,14 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import org.koin.core.KoinApplication
+import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class MonitoringFeatureRegistryTest {
@@ -52,6 +75,35 @@ class MonitoringFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Monitoring" in moduleNames)
+    }
+
+    @Test
+    fun `Monitoring module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(
+                module {
+                    single { mockk<PricingTierService>(relaxed = true) }
+                    single { mockk<RetentionPolicyService>(relaxed = true) }
+                    single { mockk<IncidentService>(relaxed = true) }
+                    single { mockk<WorkflowService>(relaxed = true) }
+                },
+                *MonitoringModule().koinModules().toTypedArray(),
+            )
+
+        try {
+            assertIs<HostRepositoryImpl>(koinApplication.koin.get<HostRepository>())
+            assertIs<HostAlertRepositoryImpl>(koinApplication.koin.get<HostAlertRepository>())
+            assertIs<MonitorService>(koinApplication.koin.get<MonitorService>())
+            assertIs<MonitorAlertService>(koinApplication.koin.get<MonitorAlertService>())
+            assertIs<ResourceOwnershipRepositoryImpl>(koinApplication.koin.get<ResourceOwnershipRepository>())
+            assertIs<ResourceCatalogService>(koinApplication.koin.get<ResourceCatalogService>())
+            assertIs<ManagedIdentityCloudSourceVerifier>(koinApplication.koin.get<CloudSourceVerifier>())
+            assertIs<ClickHouseCloudResourceWriter>(koinApplication.koin.get<CloudResourceWriter>())
+            assertIs<CloudSourceService>(koinApplication.koin.get<CloudSourceService>())
+            assertIs<AgentApiKeyService>(koinApplication.koin.get<AgentApiKeyService>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/features/synthetics/src/main/kotlin/com/moneat/synthetics/SyntheticsModule.kt
+++ b/backend/features/synthetics/src/main/kotlin/com/moneat/synthetics/SyntheticsModule.kt
@@ -18,9 +18,12 @@ package com.moneat.synthetics
 
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.synthetics.routes.SyntheticsScheduler
+import com.moneat.synthetics.routes.SyntheticsService
 import com.moneat.synthetics.routes.syntheticsRoutes
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
+import org.koin.core.module.Module
+import org.koin.dsl.module
 
 class SyntheticsModule : EnterpriseModule {
     override val name: String = "Synthetics"
@@ -30,6 +33,13 @@ class SyntheticsModule : EnterpriseModule {
     override fun registerRoutes(route: Route) {
         route.syntheticsRoutes()
     }
+
+    override fun koinModules(): List<Module> =
+        listOf(
+            module {
+                single { SyntheticsService(get(), get()) }
+            }
+        )
 
     override fun startBackgroundJobs(application: Application) {
         startBackgroundJobs(application, startSchedulers = true, startIngestionWorkers = true)

--- a/backend/features/synthetics/src/test/kotlin/com/moneat/synthetics/SyntheticsFeatureRegistryTest.kt
+++ b/backend/features/synthetics/src/test/kotlin/com/moneat/synthetics/SyntheticsFeatureRegistryTest.kt
@@ -18,8 +18,11 @@ package com.moneat.synthetics
 
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.billing.services.BillingQuotaService
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
+import com.moneat.synthetics.routes.SyntheticsService
+import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
@@ -29,10 +32,14 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.mockk
+import org.koin.core.KoinApplication
+import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class SyntheticsFeatureRegistryTest {
@@ -52,6 +59,24 @@ class SyntheticsFeatureRegistryTest {
             .map { module -> module.name }
 
         assertTrue("Synthetics" in moduleNames)
+    }
+
+    @Test
+    fun `Synthetics module provides feature Koin bindings`() {
+        val koinApplication = KoinApplication.init()
+            .modules(
+                module {
+                    single { mockk<BillingQuotaService>(relaxed = true) }
+                    single { mockk<WorkflowService>(relaxed = true) }
+                },
+                *SyntheticsModule().koinModules().toTypedArray(),
+            )
+
+        try {
+            assertIs<SyntheticsService>(koinApplication.koin.get<SyntheticsService>())
+        } finally {
+            koinApplication.close()
+        }
     }
 
     @Test

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -28,21 +28,7 @@ import com.moneat.events.services.DashboardService
 import com.moneat.events.services.EventService
 import com.moneat.events.services.ReleaseService
 import com.moneat.incident.services.IncidentService
-import com.moneat.monitor.repositories.HostAlertRepository
-import com.moneat.monitor.repositories.HostAlertRepositoryImpl
-import com.moneat.monitor.repositories.HostRepository
-import com.moneat.monitor.repositories.HostRepositoryImpl
-import com.moneat.monitor.repositories.ResourceOwnershipRepository
-import com.moneat.monitor.repositories.ResourceOwnershipRepositoryImpl
-import com.moneat.monitor.services.AgentApiKeyService
-import com.moneat.monitor.services.ClickHouseCloudResourceWriter
-import com.moneat.monitor.services.CloudResourceWriter
-import com.moneat.monitor.services.CloudSourceService
-import com.moneat.monitor.services.CloudSourceVerifier
-import com.moneat.monitor.services.ManagedIdentityCloudSourceVerifier
 import com.moneat.monitor.services.MonitorAlertService
-import com.moneat.monitor.services.MonitorService
-import com.moneat.monitor.services.ResourceCatalogService
 import com.moneat.notifications.services.AlertNotificationPreferencesService
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
@@ -60,7 +46,6 @@ import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.shared.services.RetentionBackgroundService
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.shared.services.TraceFinalizerBackgroundService
-import com.moneat.synthetics.routes.SyntheticsService
 import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
 import com.moneat.workflows.engine.temporal.ExecuteEgressActionActivityImpl
 import com.moneat.workflows.engine.temporal.PersistRunActivityImpl
@@ -135,22 +120,6 @@ val eventsModule = module {
     single { DashboardService(get(), get(), get(), get()) }
 }
 
-/** Infrastructure monitoring and alerting. */
-val monitorModule = module {
-    single<HostRepository> { HostRepositoryImpl() }
-    single<HostAlertRepository> { HostAlertRepositoryImpl() }
-
-    single { MonitorService(get(), get(), get(), get()) }
-    single { MonitorAlertService(get(), get()) }
-    single<ResourceOwnershipRepository> { ResourceOwnershipRepositoryImpl() }
-    single { ResourceCatalogService(monitorService = get(), ownershipRepository = get()) }
-    single<CloudSourceVerifier> { ManagedIdentityCloudSourceVerifier() }
-    single<CloudResourceWriter> { ClickHouseCloudResourceWriter() }
-    single { CloudSourceService(get(), get()) }
-    single { AgentApiKeyService() }
-    single { SyntheticsService(get(), get()) }
-}
-
 /** AI chat assistant. */
 val aiModule = module {}
 
@@ -159,7 +128,6 @@ fun buildAppModules() =
     listOf(
         sharedModule,
         eventsModule,
-        monitorModule,
         aiModule,
     )
 


### PR DESCRIPTION
Moves monitoring and synthetics bindings into their feature modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized dependency injection configuration by moving monitoring and synthetics module wiring from centralized application configuration to their respective feature modules, improving code modularity and maintainability.

* **Tests**
  * Added comprehensive test coverage verifying that monitoring and synthetics module dependency injection bindings are correctly wired and accessible within the dependency container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->