### PR TITLE
refactor: move workflow worker startup into feature module

### DIFF
--- a/backend/features/workflows/build.gradle.kts
+++ b/backend/features/workflows/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(libs.exposed.jdbc)
     implementation(libs.kotlin.logging)
     implementation(libs.koin.ktor)
+    implementation(libs.temporal.sdk)
 
     detektPlugins(libs.detekt.formatting)
 

--- a/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowBackgroundWorkers.kt
+++ b/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowBackgroundWorkers.kt
@@ -1,0 +1,143 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows
+
+import com.moneat.plugins.WorkflowWorkerMode
+import com.moneat.plugins.workflowWorkerMode
+import com.moneat.runtime.MoneatProcessRole
+import com.moneat.runtime.RuntimeMode
+import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
+import com.moneat.workflows.engine.temporal.ExecuteEgressActionActivityImpl
+import com.moneat.workflows.engine.temporal.PersistRunActivityImpl
+import com.moneat.workflows.engine.temporal.RequestApprovalActivityImpl
+import com.moneat.workflows.engine.temporal.TemporalClientProvider
+import com.moneat.workflows.engine.temporal.WORKFLOW_EGRESS_TASK_QUEUE
+import com.moneat.workflows.engine.temporal.WORKFLOW_TASK_QUEUE
+import com.moneat.workflows.engine.temporal.WorkflowInterpreterWorkflowImpl
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopping
+import io.temporal.worker.WorkerFactory
+import mu.KotlinLogging
+import org.koin.core.context.GlobalContext
+import java.util.concurrent.TimeUnit
+
+private val logger = KotlinLogging.logger {}
+private const val WORKFLOW_WORKER_SHUTDOWN_TIMEOUT_SECONDS = 30L
+
+internal class WorkflowBackgroundWorkers {
+    private var activeWorkers: ActiveWorkflowWorkers? = null
+
+    fun start(application: Application, startSchedulers: Boolean) {
+        if (shouldStartIsolatedEgressWorker(application)) {
+            startIsolatedEgressWorker(application)
+            return
+        }
+
+        if (startSchedulers) {
+            startScheduledWorkers(application)
+        }
+    }
+
+    fun stop() {
+        activeWorkers?.let { workers ->
+            shutdownWorkflowWorker(workers.factory, workers.provider)
+            activeWorkers = null
+        }
+    }
+
+    private fun shouldStartIsolatedEgressWorker(application: Application): Boolean =
+        RuntimeMode.role() == MoneatProcessRole.WORKFLOW_EGRESS ||
+            application.workflowWorkerMode() == WorkflowWorkerMode.EGRESS
+
+    private fun startIsolatedEgressWorker(application: Application) {
+        val koin = GlobalContext.get()
+        val temporalClientProvider = koin.get<TemporalClientProvider>()
+        val workflowWorkerFactory = temporalClientProvider.newWorkerFactory()
+        workflowWorkerFactory
+            .newWorker(WORKFLOW_EGRESS_TASK_QUEUE)
+            .registerActivitiesImplementations(koin.get<ExecuteEgressActionActivityImpl>())
+        logger.info { "Starting isolated Temporal egress worker on $WORKFLOW_EGRESS_TASK_QUEUE" }
+        activeWorkers = ActiveWorkflowWorkers(temporalClientProvider, workflowWorkerFactory)
+        workflowWorkerFactory.start()
+        application.monitor.subscribe(ApplicationStopping) {
+            stop()
+        }
+    }
+
+    private fun startScheduledWorkers(application: Application) {
+        val workers = initializeWorkflowWorkers(application) ?: return
+        activeWorkers = workers
+        workers.factory.start()
+    }
+
+    private fun initializeWorkflowWorkers(application: Application): ActiveWorkflowWorkers? {
+        val koin = GlobalContext.get()
+        val workflowWorkerMode = application.workflowWorkerMode()
+        return try {
+            val provider = koin.get<TemporalClientProvider>()
+            val factory = provider.newWorkerFactory()
+            if (workflowWorkerMode == WorkflowWorkerMode.ALL || workflowWorkerMode == WorkflowWorkerMode.TRUSTED) {
+                val workflowWorker = factory.newWorker(WORKFLOW_TASK_QUEUE)
+                workflowWorker.registerWorkflowImplementationTypes(WorkflowInterpreterWorkflowImpl::class.java)
+                workflowWorker.registerActivitiesImplementations(
+                    koin.get<ExecuteActionActivityImpl>(),
+                    koin.get<PersistRunActivityImpl>(),
+                    koin.get<RequestApprovalActivityImpl>()
+                )
+            }
+            if (workflowWorkerMode == WorkflowWorkerMode.ALL || workflowWorkerMode == WorkflowWorkerMode.EGRESS) {
+                factory
+                    .newWorker(WORKFLOW_EGRESS_TASK_QUEUE)
+                    .registerActivitiesImplementations(koin.get<ExecuteEgressActionActivityImpl>())
+            }
+            ActiveWorkflowWorkers(provider, factory)
+        } catch (e: Throwable) {
+            logger.error(e) {
+                "Temporal workflow worker initialization failed; workflow execution disabled on this instance"
+            }
+            null
+        }
+    }
+
+    private fun shutdownWorkflowWorker(
+        workflowWorkerFactory: WorkerFactory,
+        temporalClientProvider: TemporalClientProvider,
+    ) {
+        try {
+            workflowWorkerFactory.shutdown()
+            workflowWorkerFactory.awaitTermination(WORKFLOW_WORKER_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            if (!workflowWorkerFactory.isTerminated) {
+                logger.warn {
+                    "Temporal workflow worker did not stop within " +
+                        "$WORKFLOW_WORKER_SHUTDOWN_TIMEOUT_SECONDS seconds; forcing shutdown"
+                }
+                workflowWorkerFactory.shutdownNow()
+            }
+        } catch (error: InterruptedException) {
+            Thread.currentThread().interrupt()
+            logger.warn(error) { "Interrupted while stopping Temporal workflow worker; forcing shutdown" }
+            workflowWorkerFactory.shutdownNow()
+        } finally {
+            temporalClientProvider.close()
+        }
+    }
+}
+
+private data class ActiveWorkflowWorkers(
+    val provider: TemporalClientProvider,
+    val factory: WorkerFactory,
+)

--- a/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowsModule.kt
+++ b/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowsModule.kt
@@ -18,7 +18,6 @@ package com.moneat.workflows
 
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.monitor.services.MonitorAlertService
-import com.moneat.workflows.routes.workflowRoutes
 import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
 import com.moneat.workflows.engine.temporal.ExecuteEgressActionActivityImpl
 import com.moneat.workflows.engine.temporal.PersistRunActivityImpl
@@ -26,6 +25,7 @@ import com.moneat.workflows.engine.temporal.RequestApprovalActivityImpl
 import com.moneat.workflows.engine.temporal.TemporalClientProvider
 import com.moneat.workflows.engine.temporal.TemporalWorkflowExecutionEngine
 import com.moneat.workflows.engine.temporal.WorkflowExecutionEngine
+import com.moneat.workflows.routes.workflowRoutes
 import com.moneat.workflows.services.WorkflowActionExecutor
 import com.moneat.workflows.services.WorkflowEgressActionExecutor
 import com.moneat.workflows.services.WorkflowGovernanceService
@@ -40,6 +40,8 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 class WorkflowsModule : EnterpriseModule {
+    private val backgroundWorkers = WorkflowBackgroundWorkers()
+
     override val name: String = "Workflows"
 
     override fun registerRoutes(route: Route) {
@@ -74,7 +76,20 @@ class WorkflowsModule : EnterpriseModule {
             }
         )
 
-    override fun startBackgroundJobs(application: Application) = Unit
+    override fun startBackgroundJobs(application: Application) {
+        backgroundWorkers.start(application, startSchedulers = true)
+    }
 
-    override fun stopBackgroundJobs() = Unit
+    override fun startBackgroundJobs(
+        application: Application,
+        startSchedulers: Boolean,
+        startIngestionWorkers: Boolean,
+    ) {
+        if (!startSchedulers && startIngestionWorkers) return
+        backgroundWorkers.start(application, startSchedulers)
+    }
+
+    override fun stopBackgroundJobs() {
+        backgroundWorkers.stop()
+    }
 }

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowsFeatureRegistryTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowsFeatureRegistryTest.kt
@@ -136,6 +136,16 @@ class WorkflowsFeatureRegistryTest {
         assertTrue("Workflows" in response.modules)
     }
 
+    @Test
+    fun `Workflows module skips Temporal workers for ingestion worker role`() = testApplication {
+        application {
+            val workflowsModule = WorkflowsModule()
+
+            workflowsModule.startBackgroundJobs(this, startSchedulers = false, startIngestionWorkers = true)
+            workflowsModule.stopBackgroundJobs()
+        }
+    }
+
     private suspend fun ApplicationCall.respondFeatures() {
         respond(
             FeaturesResponse(

--- a/backend/src/main/kotlin/com/moneat/Application.kt
+++ b/backend/src/main/kotlin/com/moneat/Application.kt
@@ -22,10 +22,10 @@ import com.moneat.config.configureClickHouse
 import com.moneat.config.configureRedis
 import com.moneat.di.buildAppModules
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.plugins.WorkflowWorkerMode
 import com.moneat.plugins.configureBackgroundJobs
 import com.moneat.plugins.configureDatabases
 import com.moneat.plugins.configureDemoModeRestrictions
-import com.moneat.plugins.configureEgressWorkflowWorker
 import com.moneat.plugins.configureHealthRouting
 import com.moneat.plugins.configureHTTP
 import com.moneat.plugins.configureMonitoring
@@ -33,7 +33,6 @@ import com.moneat.plugins.configureRateLimiting
 import com.moneat.plugins.configureRouting
 import com.moneat.plugins.configureSecurity
 import com.moneat.plugins.configureSerialization
-import com.moneat.plugins.WorkflowWorkerMode
 import com.moneat.plugins.workflowWorkerMode
 import com.moneat.runtime.MoneatProcessRole
 import com.moneat.runtime.RuntimeMode
@@ -93,7 +92,7 @@ fun Application.module() {
     val processRole = RuntimeMode.role()
     if (processRole == MoneatProcessRole.WORKFLOW_EGRESS || workflowWorkerMode() == WorkflowWorkerMode.EGRESS) {
         configureSerialization()
-        configureEgressWorkflowWorker()
+        FeatureRegistry.startBackgroundJobs(this, startSchedulers = false, startIngestionWorkers = false)
         log.info("Workflow egress worker startup complete")
         return
     }

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -32,30 +32,19 @@ import com.moneat.shared.services.TaskLock
 import com.moneat.shared.services.TraceFinalizerBackgroundService
 import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.suspendRunCatching
-import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
-import com.moneat.workflows.engine.temporal.ExecuteEgressActionActivityImpl
-import com.moneat.workflows.engine.temporal.PersistRunActivityImpl
-import com.moneat.workflows.engine.temporal.RequestApprovalActivityImpl
-import com.moneat.workflows.engine.temporal.TemporalClientProvider
-import com.moneat.workflows.engine.temporal.WORKFLOW_EGRESS_TASK_QUEUE
-import com.moneat.workflows.engine.temporal.WORKFLOW_TASK_QUEUE
-import com.moneat.workflows.engine.temporal.WorkflowInterpreterWorkflowImpl
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopping
-import io.temporal.worker.WorkerFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import mu.KotlinLogging
 import net.javacrumbs.shedlock.provider.exposed.ExposedLockProvider
 import org.koin.core.context.GlobalContext
-import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.hours
 
 private val logger = KotlinLogging.logger {}
 private const val DEFAULT_WORKER_THREADS = 4
 private const val DEFAULT_PULSE_INTERVAL_HOURS = 4
-private const val WORKFLOW_WORKER_SHUTDOWN_TIMEOUT_SECONDS = 30L
 private const val WORKFLOW_WORKER_MODE_CONFIG = "workflows.workerMode"
 
 enum class WorkflowWorkerMode {
@@ -85,20 +74,6 @@ internal fun parseWorkflowWorkerMode(rawMode: String?): WorkflowWorkerMode {
         )
 }
 
-fun Application.configureEgressWorkflowWorker() {
-    val koin = GlobalContext.get()
-    val temporalClientProvider = koin.get<TemporalClientProvider>()
-    val workflowWorkerFactory = temporalClientProvider.newWorkerFactory()
-    workflowWorkerFactory
-        .newWorker(WORKFLOW_EGRESS_TASK_QUEUE)
-        .registerActivitiesImplementations(koin.get<ExecuteEgressActionActivityImpl>())
-    logger.info { "Starting isolated Temporal egress worker on $WORKFLOW_EGRESS_TASK_QUEUE" }
-    workflowWorkerFactory.start()
-    monitor.subscribe(ApplicationStopping) {
-        shutdownWorkflowWorker(workflowWorkerFactory, temporalClientProvider)
-    }
-}
-
 fun Application.configureBackgroundJobs(
     startSchedulers: Boolean = true,
     startIngestionWorkers: Boolean = true,
@@ -115,18 +90,16 @@ fun Application.configureBackgroundJobs(
     val jobScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     val schedulerJobs = SchedulerBackgroundJobs()
     val coreWorkers = CoreIngestionWorkers(this)
-    val workflowWorkers = if (startSchedulers) initializeWorkflowWorkers() else WorkflowWorkers()
 
     logger.info { "Starting background jobs" }
     if (startSchedulers) {
         schedulerJobs.start(jobScope)
-        workflowWorkers.factory?.start()
     }
     coreWorkers.startSelected(startIngestionWorkers)
 
     FeatureRegistry.startBackgroundJobs(this, startSchedulers, startIngestionWorkers)
     val pulseService = startPulseIfEnabled(startSchedulers, jobScope)
-    registerBackgroundShutdown(schedulerJobs, coreWorkers, workflowWorkers, pulseService)
+    registerBackgroundShutdown(schedulerJobs, coreWorkers, pulseService)
 }
 
 private fun Application.backgroundJobsEnabled(): Boolean =
@@ -188,40 +161,6 @@ private class CoreIngestionWorkers(application: Application) {
     }
 }
 
-private data class WorkflowWorkers(
-    val provider: TemporalClientProvider? = null,
-    val factory: WorkerFactory? = null,
-)
-
-private fun Application.initializeWorkflowWorkers(): WorkflowWorkers {
-    val koin = GlobalContext.get()
-    val workflowWorkerMode = workflowWorkerMode()
-    return try {
-        val provider = koin.get<TemporalClientProvider>()
-        val factory = provider.newWorkerFactory()
-        if (workflowWorkerMode == WorkflowWorkerMode.ALL || workflowWorkerMode == WorkflowWorkerMode.TRUSTED) {
-            val workflowWorker = factory.newWorker(WORKFLOW_TASK_QUEUE)
-            workflowWorker.registerWorkflowImplementationTypes(WorkflowInterpreterWorkflowImpl::class.java)
-            workflowWorker.registerActivitiesImplementations(
-                koin.get<ExecuteActionActivityImpl>(),
-                koin.get<PersistRunActivityImpl>(),
-                koin.get<RequestApprovalActivityImpl>()
-            )
-        }
-        if (workflowWorkerMode == WorkflowWorkerMode.ALL || workflowWorkerMode == WorkflowWorkerMode.EGRESS) {
-            factory
-                .newWorker(WORKFLOW_EGRESS_TASK_QUEUE)
-                .registerActivitiesImplementations(koin.get<ExecuteEgressActionActivityImpl>())
-        }
-        WorkflowWorkers(provider, factory)
-    } catch (e: Throwable) {
-        logger.error(e) {
-            "Temporal workflow worker initialization failed; workflow execution disabled on this instance"
-        }
-        WorkflowWorkers()
-    }
-}
-
 private fun Application.startPulseIfEnabled(
     startSchedulers: Boolean,
     jobScope: CoroutineScope,
@@ -242,14 +181,12 @@ private fun Application.startPulseIfEnabled(
 private fun Application.registerBackgroundShutdown(
     schedulerJobs: SchedulerBackgroundJobs,
     coreWorkers: CoreIngestionWorkers,
-    workflowWorkers: WorkflowWorkers,
     pulseService: PulseService?,
 ) {
     monitor.subscribe(ApplicationStopping) {
         flushUsageOnShutdown()
         schedulerJobs.stop()
         coreWorkers.stop()
-        stopWorkflowWorkers(workflowWorkers)
         pulseService?.stop()
         FeatureRegistry.stopBackgroundJobs()
         closeInfrastructureConnections()
@@ -265,42 +202,11 @@ private fun flushUsageOnShutdown() {
     }
 }
 
-private fun stopWorkflowWorkers(workflowWorkers: WorkflowWorkers) {
-    val factoryToStop = workflowWorkers.factory
-    val providerToStop = workflowWorkers.provider
-    if (factoryToStop != null && providerToStop != null) {
-        shutdownWorkflowWorker(factoryToStop, providerToStop)
-    }
-}
-
 private fun closeInfrastructureConnections() {
     logger.info { "Closing infrastructure connections..." }
     RedisConfig.close()
     ClickHouseClient.close()
     logger.info { "Infrastructure connections closed" }
-}
-
-private fun shutdownWorkflowWorker(
-    workflowWorkerFactory: WorkerFactory,
-    temporalClientProvider: TemporalClientProvider
-) {
-    try {
-        workflowWorkerFactory.shutdown()
-        workflowWorkerFactory.awaitTermination(WORKFLOW_WORKER_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        if (!workflowWorkerFactory.isTerminated) {
-            logger.warn {
-                "Temporal workflow worker did not stop within " +
-                    "$WORKFLOW_WORKER_SHUTDOWN_TIMEOUT_SECONDS seconds; forcing shutdown"
-            }
-            workflowWorkerFactory.shutdownNow()
-        }
-    } catch (error: InterruptedException) {
-        Thread.currentThread().interrupt()
-        logger.warn(error) { "Interrupted while stopping Temporal workflow worker; forcing shutdown" }
-        workflowWorkerFactory.shutdownNow()
-    } finally {
-        temporalClientProvider.close()
-    }
 }
 
 private fun shouldStartIngestionPipeline(


### PR DESCRIPTION
## Summary
- move workflow worker lifecycle into the workflows feature module
- keep root startup delegating through FeatureRegistry

## Validation
- `cd backend && ./gradlew :features:workflows:compileKotlin :features:workflows:compileTestKotlin :features:workflows:test :features:workflows:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false`
- `cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false`
- `python3 scripts/check-migration-versions.py --base-ref origin/develop`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced workflow processing lifecycle management with improved startup and shutdown procedures.
  * Reorganized workflow worker initialization to support flexible operational modes and configurations.
  * Refined integration of workflow processing into the application startup and shutdown sequences for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->