### PR TITLE
refactor: isolate workflow startup hook

### DIFF
--- a/backend/feature-spi/src/main/kotlin/com/moneat/enterprise/EnterpriseModule.kt
+++ b/backend/feature-spi/src/main/kotlin/com/moneat/enterprise/EnterpriseModule.kt
@@ -44,6 +44,9 @@ interface EnterpriseModule {
     /** Register module-owned Koin bindings during application startup. */
     fun koinModules(): List<Module> = emptyList()
 
+    /** Whether this module needs isolated startup before core infrastructure and routes are configured. */
+    fun shouldStartIsolatedBackgroundJobs(application: Application): Boolean = false
+
     /** Start module background jobs during application startup. */
     fun startBackgroundJobs(application: Application)
 

--- a/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowBackgroundWorkers.kt
+++ b/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowBackgroundWorkers.kt
@@ -16,8 +16,6 @@
 
 package com.moneat.workflows
 
-import com.moneat.plugins.WorkflowWorkerMode
-import com.moneat.plugins.workflowWorkerMode
 import com.moneat.runtime.MoneatProcessRole
 import com.moneat.runtime.RuntimeMode
 import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
@@ -59,7 +57,7 @@ internal class WorkflowBackgroundWorkers {
         }
     }
 
-    private fun shouldStartIsolatedEgressWorker(application: Application): Boolean =
+    fun shouldStartIsolatedEgressWorker(application: Application): Boolean =
         RuntimeMode.role() == MoneatProcessRole.WORKFLOW_EGRESS ||
             application.workflowWorkerMode() == WorkflowWorkerMode.EGRESS
 

--- a/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowWorkerMode.kt
+++ b/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowWorkerMode.kt
@@ -1,0 +1,48 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows
+
+import io.ktor.server.application.Application
+
+private const val WORKFLOW_WORKER_MODE_CONFIG = "workflows.workerMode"
+
+internal enum class WorkflowWorkerMode {
+    ALL,
+    TRUSTED,
+    EGRESS,
+    NONE
+}
+
+internal fun Application.workflowWorkerMode(): WorkflowWorkerMode {
+    return parseWorkflowWorkerMode(
+        environment.config
+            .propertyOrNull(WORKFLOW_WORKER_MODE_CONFIG)
+            ?.getString()
+    )
+}
+
+internal fun parseWorkflowWorkerMode(rawMode: String?): WorkflowWorkerMode {
+    val normalized = rawMode?.trim()?.uppercase()
+    if (normalized.isNullOrBlank()) {
+        return WorkflowWorkerMode.TRUSTED
+    }
+    return WorkflowWorkerMode.entries.firstOrNull { mode -> mode.name == normalized }
+        ?: throw IllegalArgumentException(
+            "Invalid $WORKFLOW_WORKER_MODE_CONFIG value '$normalized'. Expected one of: " +
+                WorkflowWorkerMode.entries.joinToString { mode -> mode.name.lowercase() }
+        )
+}

--- a/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowsModule.kt
+++ b/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowsModule.kt
@@ -80,6 +80,9 @@ class WorkflowsModule : EnterpriseModule {
         backgroundWorkers.start(application, startSchedulers = true)
     }
 
+    override fun shouldStartIsolatedBackgroundJobs(application: Application): Boolean =
+        backgroundWorkers.shouldStartIsolatedEgressWorker(application)
+
     override fun startBackgroundJobs(
         application: Application,
         startSchedulers: Boolean,

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowWorkerModeTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowWorkerModeTest.kt
@@ -14,30 +14,34 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-package com.moneat.plugins
+package com.moneat.workflows
 
-import com.moneat.runtime.MoneatProcessRole
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class BackgroundJobsTest {
+class WorkflowWorkerModeTest {
     @Test
-    fun `process role parser accepts deployable roles`() {
-        assertEquals(MoneatProcessRole.ALL, MoneatProcessRole.from(null))
-        assertEquals(MoneatProcessRole.API, MoneatProcessRole.from("api-only"))
-        assertEquals(MoneatProcessRole.SCHEDULER, MoneatProcessRole.from("schedulers"))
-        assertEquals(MoneatProcessRole.INGESTION_WORKER, MoneatProcessRole.from("ingestion-worker"))
-        assertEquals(MoneatProcessRole.WORKFLOW_EGRESS, MoneatProcessRole.from("egress"))
+    fun `workflow worker mode defaults to trusted when unset or blank`() {
+        assertEquals(WorkflowWorkerMode.TRUSTED, parseWorkflowWorkerMode(null))
+        assertEquals(WorkflowWorkerMode.TRUSTED, parseWorkflowWorkerMode("  "))
     }
 
     @Test
-    fun `process role parser rejects invalid values`() {
+    fun `workflow worker mode accepts configured enum names case insensitively`() {
+        assertEquals(WorkflowWorkerMode.ALL, parseWorkflowWorkerMode("all"))
+        assertEquals(WorkflowWorkerMode.EGRESS, parseWorkflowWorkerMode(" egress "))
+        assertEquals(WorkflowWorkerMode.NONE, parseWorkflowWorkerMode("NONE"))
+    }
+
+    @Test
+    fun `workflow worker mode rejects invalid values`() {
         val error = assertFailsWith<IllegalArgumentException> {
-            MoneatProcessRole.from("web")
+            parseWorkflowWorkerMode("egres")
         }
 
-        assertTrue(error.message.orEmpty().contains("MONEAT_PROCESS_ROLE"))
+        assertTrue(error.message.orEmpty().contains("EGRES"))
+        assertTrue(error.message.orEmpty().contains("trusted"))
     }
 }

--- a/backend/src/main/kotlin/com/moneat/Application.kt
+++ b/backend/src/main/kotlin/com/moneat/Application.kt
@@ -22,7 +22,6 @@ import com.moneat.config.configureClickHouse
 import com.moneat.config.configureRedis
 import com.moneat.di.buildAppModules
 import com.moneat.enterprise.FeatureRegistry
-import com.moneat.plugins.WorkflowWorkerMode
 import com.moneat.plugins.configureBackgroundJobs
 import com.moneat.plugins.configureDatabases
 import com.moneat.plugins.configureDemoModeRestrictions
@@ -33,7 +32,6 @@ import com.moneat.plugins.configureRateLimiting
 import com.moneat.plugins.configureRouting
 import com.moneat.plugins.configureSecurity
 import com.moneat.plugins.configureSerialization
-import com.moneat.plugins.workflowWorkerMode
 import com.moneat.runtime.MoneatProcessRole
 import com.moneat.runtime.RuntimeMode
 import io.ktor.server.application.Application
@@ -90,10 +88,10 @@ fun Application.module() {
         modules(buildAppModules() + FeatureRegistry.koinModules())
     }
     val processRole = RuntimeMode.role()
-    if (processRole == MoneatProcessRole.WORKFLOW_EGRESS || workflowWorkerMode() == WorkflowWorkerMode.EGRESS) {
+    if (FeatureRegistry.shouldStartIsolatedBackgroundJobs(this)) {
         configureSerialization()
         FeatureRegistry.startBackgroundJobs(this, startSchedulers = false, startIngestionWorkers = false)
-        log.info("Workflow egress worker startup complete")
+        log.info("Isolated feature worker startup complete")
         return
     }
     configureSecurity()

--- a/backend/src/main/kotlin/com/moneat/enterprise/FeatureRegistry.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/FeatureRegistry.kt
@@ -126,6 +126,16 @@ object FeatureRegistry {
             }
         }
 
+    fun shouldStartIsolatedBackgroundJobs(application: Application): Boolean =
+        modules.any { module ->
+            suspendRunCatching {
+                module.shouldStartIsolatedBackgroundJobs(application)
+            }.getOrElse { e ->
+                logger.error(e) { "Failed to resolve isolated startup state for enterprise module: ${module.name}" }
+                throw e
+            }
+        }
+
     fun startBackgroundJobs(
         application: Application,
         startSchedulers: Boolean = true,

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -45,34 +45,6 @@ import kotlin.time.Duration.Companion.hours
 private val logger = KotlinLogging.logger {}
 private const val DEFAULT_WORKER_THREADS = 4
 private const val DEFAULT_PULSE_INTERVAL_HOURS = 4
-private const val WORKFLOW_WORKER_MODE_CONFIG = "workflows.workerMode"
-
-enum class WorkflowWorkerMode {
-    ALL,
-    TRUSTED,
-    EGRESS,
-    NONE
-}
-
-fun Application.workflowWorkerMode(): WorkflowWorkerMode {
-    return parseWorkflowWorkerMode(
-        environment.config
-            .propertyOrNull(WORKFLOW_WORKER_MODE_CONFIG)
-            ?.getString()
-    )
-}
-
-internal fun parseWorkflowWorkerMode(rawMode: String?): WorkflowWorkerMode {
-    val normalized = rawMode?.trim()?.uppercase()
-    if (normalized.isNullOrBlank()) {
-        return WorkflowWorkerMode.TRUSTED
-    }
-    return WorkflowWorkerMode.entries.firstOrNull { mode -> mode.name == normalized }
-        ?: throw IllegalArgumentException(
-            "Invalid $WORKFLOW_WORKER_MODE_CONFIG value '$normalized'. Expected one of: " +
-                WorkflowWorkerMode.entries.joinToString { mode -> mode.name.lowercase() }
-        )
-}
 
 fun Application.configureBackgroundJobs(
     startSchedulers: Boolean = true,


### PR DESCRIPTION
Summary:
- add feature SPI support for isolated background startup
- move workflow worker-mode parsing into the workflows feature
- remove root workflow worker-mode startup imports

Validation:
- cd backend && ./gradlew :feature-spi:compileKotlin :features:workflows:compileKotlin :features:workflows:compileTestKotlin :features:workflows:test :features:workflows:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check