### PR TITLE
refactor: move monitoring scheduler startup

### DIFF
--- a/backend/features/monitoring/build.gradle.kts
+++ b/backend/features/monitoring/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.client.core)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlin.logging)
     implementation(libs.koin.ktor)
 

--- a/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
+++ b/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
@@ -39,7 +39,12 @@ import com.moneat.monitor.services.MonitorService
 import com.moneat.monitor.services.ResourceCatalogService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import mu.KotlinLogging
+import org.koin.core.context.GlobalContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -49,6 +54,8 @@ private val logger = KotlinLogging.logger {}
  * Enterprise monitoring module that contributes monitor and resource APIs.
  */
 class MonitoringModule : EnterpriseModule {
+    private var backgroundJobs: MonitoringBackgroundJobs? = null
+
     override val name: String = "Monitoring"
 
     override fun registerRoutes(route: Route) {
@@ -79,10 +86,30 @@ class MonitoringModule : EnterpriseModule {
         )
 
     override fun startBackgroundJobs(application: Application) {
-        logger.info { "Starting monitoring enterprise background jobs" }
+        if (backgroundJobs != null) return
+        logger.info { "Starting monitoring background jobs" }
+        backgroundJobs = MonitoringBackgroundJobs(GlobalContext.get().get<MonitorAlertService>())
+            .also { it.start() }
     }
 
     override fun stopBackgroundJobs() {
-        logger.info { "Stopping monitoring enterprise background jobs" }
+        logger.info { "Stopping monitoring background jobs" }
+        backgroundJobs?.stop()
+        backgroundJobs = null
+    }
+}
+
+private class MonitoringBackgroundJobs(
+    private val monitorAlertService: MonitorAlertService,
+) {
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    fun start() {
+        monitorAlertService.start(scope)
+    }
+
+    fun stop() {
+        monitorAlertService.stop()
+        scope.cancel()
     }
 }

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/MonitoringFeatureRegistryTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/MonitoringFeatureRegistryTest.kt
@@ -43,13 +43,18 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.mockk
+import io.mockk.verify
 import org.koin.core.KoinApplication
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
@@ -61,12 +66,14 @@ import kotlin.test.assertTrue
 class MonitoringFeatureRegistryTest {
     @BeforeTest
     fun resetBefore() {
+        stopKoinIfStarted()
         FeatureRegistry.resetForTest()
     }
 
     @AfterTest
     fun resetAfter() {
         FeatureRegistry.resetForTest()
+        stopKoinIfStarted()
     }
 
     @Test
@@ -127,6 +134,42 @@ class MonitoringFeatureRegistryTest {
         assertTrue("Monitoring" in response.modules)
     }
 
+    @Test
+    fun `Monitoring module owns alert scheduler lifecycle`() {
+        val application = mockk<Application>(relaxed = true)
+        val monitorAlertService = mockk<MonitorAlertService>(relaxUnitFun = true)
+        startKoin {
+            modules(
+                module {
+                    single { monitorAlertService }
+                }
+            )
+        }
+
+        try {
+            val monitoringModule = MonitoringModule()
+
+            monitoringModule.startBackgroundJobs(
+                application,
+                startSchedulers = false,
+                startIngestionWorkers = true,
+            )
+            verify(exactly = 0) { monitorAlertService.start(any()) }
+
+            monitoringModule.startBackgroundJobs(
+                application,
+                startSchedulers = true,
+                startIngestionWorkers = false,
+            )
+            verify(exactly = 1) { monitorAlertService.start(any()) }
+
+            monitoringModule.stopBackgroundJobs()
+            verify(exactly = 1) { monitorAlertService.stop() }
+        } finally {
+            stopKoinIfStarted()
+        }
+    }
+
     private suspend fun ApplicationCall.respondFeatures() {
         respond(
             FeaturesResponse(
@@ -135,5 +178,11 @@ class MonitoringFeatureRegistryTest {
                 selfHost = false,
             )
         )
+    }
+
+    private fun stopKoinIfStarted() {
+        if (GlobalContext.getOrNull() != null) {
+            stopKoin()
+        }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -23,7 +23,6 @@ import com.moneat.enterprise.FeatureRegistry
 import com.moneat.events.services.IngestionWorker
 import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
-import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.DemoLivenessBackgroundService
 import com.moneat.shared.services.PulseService
@@ -86,7 +85,6 @@ private fun Application.initializeTaskLock() {
 
 private class SchedulerBackgroundJobs {
     private val koin = GlobalContext.get()
-    private val monitorAlertService = koin.get<MonitorAlertService>()
     private val dashboardAlertService = koin.get<DashboardAlertService>()
     private val retentionBackgroundService = koin.get<RetentionBackgroundService>()
     private val traceFinalizerBackgroundService = koin.get<TraceFinalizerBackgroundService>()
@@ -94,7 +92,6 @@ private class SchedulerBackgroundJobs {
     private val demoLivenessBackgroundService = koin.get<DemoLivenessBackgroundService>()
 
     fun start(jobScope: CoroutineScope) {
-        monitorAlertService.start(jobScope)
         dashboardAlertService.start(jobScope)
         retentionBackgroundService.start(jobScope)
         traceFinalizerBackgroundService.start(jobScope)
@@ -103,7 +100,6 @@ private class SchedulerBackgroundJobs {
     }
 
     fun stop() {
-        monitorAlertService.stop()
         dashboardAlertService.stop()
         retentionBackgroundService.stop()
         traceFinalizerBackgroundService.stop()


### PR DESCRIPTION
## Summary
- move monitor alert scheduler lifecycle behind the monitoring feature module
- remove the root background job dependency on MonitorAlertService
- cover scheduler role behavior in the monitoring feature tests

## Tests
- cd backend && ./gradlew :features:monitoring:compileKotlin :features:monitoring:compileTestKotlin :features:monitoring:test :features:monitoring:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring background job lifecycle management to prevent duplicate starts.

* **Tests**
  * Added test coverage for monitoring module background job lifecycle ownership.

* **Chores**
  * Added coroutines dependency for monitoring module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->