### PR TITLE
refactor: move dashboard scheduler startup

### DIFF
--- a/backend/features/dashboards/build.gradle.kts
+++ b/backend/features/dashboards/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.kotlin.logging)

--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/DashboardModule.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/DashboardModule.kt
@@ -33,10 +33,20 @@ import com.moneat.enterprise.EnterpriseModule
 import com.moneat.events.repositories.ProjectRepositoryImpl
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import mu.KotlinLogging
+import org.koin.core.context.GlobalContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
+private val logger = KotlinLogging.logger {}
+
 class DashboardModule : EnterpriseModule {
+    private var backgroundJobs: DashboardBackgroundJobs? = null
+
     override val name: String = "Dashboards"
 
     override fun registerRoutes(route: Route) {
@@ -75,7 +85,31 @@ class DashboardModule : EnterpriseModule {
             }
         )
 
-    override fun startBackgroundJobs(application: Application) = Unit
+    override fun startBackgroundJobs(application: Application) {
+        if (backgroundJobs != null) return
+        logger.info { "Starting dashboard background jobs" }
+        backgroundJobs = DashboardBackgroundJobs(GlobalContext.get().get<DashboardAlertService>())
+            .also { it.start() }
+    }
 
-    override fun stopBackgroundJobs() = Unit
+    override fun stopBackgroundJobs() {
+        logger.info { "Stopping dashboard background jobs" }
+        backgroundJobs?.stop()
+        backgroundJobs = null
+    }
+}
+
+private class DashboardBackgroundJobs(
+    private val dashboardAlertService: DashboardAlertService,
+) {
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    fun start() {
+        dashboardAlertService.start(scope)
+    }
+
+    fun stop() {
+        dashboardAlertService.stop()
+        scope.cancel()
+    }
 }

--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardFeatureRegistryTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardFeatureRegistryTest.kt
@@ -39,13 +39,18 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.mockk
+import io.mockk.verify
 import org.koin.core.KoinApplication
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import java.util.ServiceLoader
 import kotlin.test.AfterTest
@@ -57,12 +62,14 @@ import kotlin.test.assertTrue
 class DashboardFeatureRegistryTest {
     @BeforeTest
     fun resetBefore() {
+        stopKoinIfStarted()
         FeatureRegistry.resetForTest()
     }
 
     @AfterTest
     fun resetAfter() {
         FeatureRegistry.resetForTest()
+        stopKoinIfStarted()
     }
 
     @Test
@@ -121,6 +128,42 @@ class DashboardFeatureRegistryTest {
         assertTrue("Dashboards" in response.modules)
     }
 
+    @Test
+    fun `Dashboards module owns alert scheduler lifecycle`() {
+        val application = mockk<Application>(relaxed = true)
+        val dashboardAlertService = mockk<DashboardAlertService>(relaxUnitFun = true)
+        startKoin {
+            modules(
+                module {
+                    single { dashboardAlertService }
+                }
+            )
+        }
+
+        try {
+            val dashboardModule = DashboardModule()
+
+            dashboardModule.startBackgroundJobs(
+                application,
+                startSchedulers = false,
+                startIngestionWorkers = true,
+            )
+            verify(exactly = 0) { dashboardAlertService.start(any()) }
+
+            dashboardModule.startBackgroundJobs(
+                application,
+                startSchedulers = true,
+                startIngestionWorkers = false,
+            )
+            verify(exactly = 1) { dashboardAlertService.start(any()) }
+
+            dashboardModule.stopBackgroundJobs()
+            verify(exactly = 1) { dashboardAlertService.stop() }
+        } finally {
+            stopKoinIfStarted()
+        }
+    }
+
     private suspend fun ApplicationCall.respondFeatures() {
         respond(
             FeaturesResponse(
@@ -129,5 +172,11 @@ class DashboardFeatureRegistryTest {
                 selfHost = false,
             )
         )
+    }
+
+    private fun stopKoinIfStarted() {
+        if (GlobalContext.getOrNull() != null) {
+            stopKoin()
+        }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -18,7 +18,6 @@ package com.moneat.plugins
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
-import com.moneat.dashboards.services.DashboardAlertService
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.events.services.IngestionWorker
 import com.moneat.ingestion.queue.IngestionPipeline
@@ -85,14 +84,12 @@ private fun Application.initializeTaskLock() {
 
 private class SchedulerBackgroundJobs {
     private val koin = GlobalContext.get()
-    private val dashboardAlertService = koin.get<DashboardAlertService>()
     private val retentionBackgroundService = koin.get<RetentionBackgroundService>()
     private val traceFinalizerBackgroundService = koin.get<TraceFinalizerBackgroundService>()
     private val artifactCleanupService = koin.get<ArtifactCleanupService>()
     private val demoLivenessBackgroundService = koin.get<DemoLivenessBackgroundService>()
 
     fun start(jobScope: CoroutineScope) {
-        dashboardAlertService.start(jobScope)
         retentionBackgroundService.start(jobScope)
         traceFinalizerBackgroundService.start(jobScope)
         artifactCleanupService.start(jobScope)
@@ -100,7 +97,6 @@ private class SchedulerBackgroundJobs {
     }
 
     fun stop() {
-        dashboardAlertService.stop()
         retentionBackgroundService.stop()
         traceFinalizerBackgroundService.stop()
         artifactCleanupService.stop()


### PR DESCRIPTION
## Summary
- move dashboard alert scheduler lifecycle behind the dashboards feature module
- remove the root background job dependency on DashboardAlertService
- cover scheduler role behavior in the dashboards feature tests

## Tests
- cd backend && ./gradlew :features:dashboards:compileKotlin :features:dashboards:compileTestKotlin :features:dashboards:test :features:dashboards:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check