### PR TITLE
refactor: move pulse scheduler startup

### DIFF
--- a/backend/features/pulse/build.gradle.kts
+++ b/backend/features/pulse/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlin.logging)
     implementation(libs.koin.ktor)
 
@@ -41,6 +42,7 @@ dependencies {
     testImplementation(libs.ktor.serialization.kotlinx.json)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.mockk)
     testImplementation(kotlin("reflect"))
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/backend/features/pulse/src/main/kotlin/com/moneat/pulse/PulseModule.kt
+++ b/backend/features/pulse/src/main/kotlin/com/moneat/pulse/PulseModule.kt
@@ -18,12 +18,32 @@ package com.moneat.pulse
 
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.events.routes.telemetryIngestRoutes
+import com.moneat.shared.services.PulseService
 import io.ktor.server.application.Application
 import io.ktor.server.plugins.ratelimit.RateLimitName
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.routing.Route
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import mu.KotlinLogging
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
+private val logger = KotlinLogging.logger {}
+private const val DEFAULT_PULSE_INTERVAL_HOURS = 4
 
 class PulseModule : EnterpriseModule {
+    private val pulseServiceFactory: (Duration) -> PulseService
+    private var backgroundJobs: PulseBackgroundJobs? = null
+
+    constructor() : this({ interval -> PulseService(interval = interval) })
+
+    internal constructor(pulseServiceFactory: (Duration) -> PulseService) {
+        this.pulseServiceFactory = pulseServiceFactory
+    }
+
     override val name: String = "Pulse"
 
     override fun registerRoutes(route: Route) {
@@ -32,7 +52,36 @@ class PulseModule : EnterpriseModule {
         }
     }
 
-    override fun startBackgroundJobs(application: Application) = Unit
+    override fun startBackgroundJobs(application: Application) {
+        if (backgroundJobs != null || !PulseService.isEnabled()) return
+        val telemetryIntervalHours =
+            application.environment.config
+                .propertyOrNull("pulse.intervalHours")
+                ?.getString()
+                ?.toIntOrNull()
+                ?.takeIf { it > 0 } ?: DEFAULT_PULSE_INTERVAL_HOURS
+        logger.info { "Telemetry pulse enabled for self-hosted deployment" }
+        backgroundJobs = PulseBackgroundJobs(pulseServiceFactory(telemetryIntervalHours.hours))
+            .also { it.start() }
+    }
 
-    override fun stopBackgroundJobs() = Unit
+    override fun stopBackgroundJobs() {
+        backgroundJobs?.stop()
+        backgroundJobs = null
+    }
+}
+
+private class PulseBackgroundJobs(
+    private val pulseService: PulseService,
+) {
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    fun start() {
+        pulseService.start(scope)
+    }
+
+    fun stop() {
+        pulseService.stop()
+        scope.cancel()
+    }
 }

--- a/backend/features/pulse/src/test/kotlin/com/moneat/pulse/PulseFeatureRegistryTest.kt
+++ b/backend/features/pulse/src/test/kotlin/com/moneat/pulse/PulseFeatureRegistryTest.kt
@@ -21,20 +21,30 @@ import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.plugins.FeaturesResponse
 import com.moneat.plugins.configureSerialization
+import com.moneat.shared.services.PulseService
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
+import io.ktor.server.config.MapApplicationConfig
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import java.util.ServiceLoader
+import kotlin.test.assertEquals
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 
 class PulseFeatureRegistryTest {
     @BeforeTest
@@ -76,6 +86,44 @@ class PulseFeatureRegistryTest {
         assertTrue("Pulse" in response.modules)
     }
 
+    @Test
+    fun `Pulse module owns telemetry pulse scheduler lifecycle`() {
+        withSelfHostedTelemetryEnabled {
+            testApplication {
+                environment {
+                    config = MapApplicationConfig("pulse.intervalHours" to "2")
+                }
+
+                val pulseService = mockk<PulseService>(relaxUnitFun = true)
+                var capturedInterval: Duration? = null
+                val pulseModule = PulseModule { interval ->
+                    capturedInterval = interval
+                    pulseService
+                }
+
+                application {
+                    pulseModule.startBackgroundJobs(
+                        this,
+                        startSchedulers = false,
+                        startIngestionWorkers = true,
+                    )
+                    verify(exactly = 0) { pulseService.start(any()) }
+
+                    pulseModule.startBackgroundJobs(
+                        this,
+                        startSchedulers = true,
+                        startIngestionWorkers = false,
+                    )
+                    assertEquals(2.hours, capturedInterval)
+                    verify(exactly = 1) { pulseService.start(any()) }
+
+                    pulseModule.stopBackgroundJobs()
+                    verify(exactly = 1) { pulseService.stop() }
+                }
+            }
+        }
+    }
+
     private suspend fun ApplicationCall.respondFeatures() {
         respond(
             FeaturesResponse(
@@ -84,5 +132,22 @@ class PulseFeatureRegistryTest {
                 selfHost = EnvConfig.SelfHost.enabled,
             )
         )
+    }
+
+    private fun withSelfHostedTelemetryEnabled(block: () -> Unit) {
+        val previousTelemetryEnabled = System.getProperty("TELEMETRY_ENABLED")
+        mockkObject(EnvConfig.SelfHost)
+        try {
+            every { EnvConfig.SelfHost.enabled } returns true
+            System.setProperty("TELEMETRY_ENABLED", "true")
+            block()
+        } finally {
+            if (previousTelemetryEnabled == null) {
+                System.clearProperty("TELEMETRY_ENABLED")
+            } else {
+                System.setProperty("TELEMETRY_ENABLED", previousTelemetryEnabled)
+            }
+            unmockkObject(EnvConfig.SelfHost)
+        }
     }
 }

--- a/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
+++ b/backend/src/main/kotlin/com/moneat/plugins/BackgroundJobs.kt
@@ -24,7 +24,6 @@ import com.moneat.ingestion.queue.IngestionPipeline
 import com.moneat.ingestion.queue.IngestionQueueSettings
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.DemoLivenessBackgroundService
-import com.moneat.shared.services.PulseService
 import com.moneat.shared.services.RetentionBackgroundService
 import com.moneat.shared.services.TaskLock
 import com.moneat.shared.services.TraceFinalizerBackgroundService
@@ -38,11 +37,9 @@ import kotlinx.coroutines.SupervisorJob
 import mu.KotlinLogging
 import net.javacrumbs.shedlock.provider.exposed.ExposedLockProvider
 import org.koin.core.context.GlobalContext
-import kotlin.time.Duration.Companion.hours
 
 private val logger = KotlinLogging.logger {}
 private const val DEFAULT_WORKER_THREADS = 4
-private const val DEFAULT_PULSE_INTERVAL_HOURS = 4
 
 fun Application.configureBackgroundJobs(
     startSchedulers: Boolean = true,
@@ -68,8 +65,7 @@ fun Application.configureBackgroundJobs(
     coreWorkers.startSelected(startIngestionWorkers)
 
     FeatureRegistry.startBackgroundJobs(this, startSchedulers, startIngestionWorkers)
-    val pulseService = startPulseIfEnabled(startSchedulers, jobScope)
-    registerBackgroundShutdown(schedulerJobs, coreWorkers, pulseService)
+    registerBackgroundShutdown(schedulerJobs, coreWorkers)
 }
 
 private fun Application.backgroundJobsEnabled(): Boolean =
@@ -125,33 +121,14 @@ private class CoreIngestionWorkers(application: Application) {
     }
 }
 
-private fun Application.startPulseIfEnabled(
-    startSchedulers: Boolean,
-    jobScope: CoroutineScope,
-): PulseService? {
-    if (!startSchedulers || !PulseService.isEnabled()) return null
-    val telemetryIntervalHours =
-        environment.config
-            .propertyOrNull("pulse.intervalHours")
-            ?.getString()
-            ?.toIntOrNull()
-            ?.takeIf { it > 0 } ?: DEFAULT_PULSE_INTERVAL_HOURS
-    return PulseService(interval = telemetryIntervalHours.hours).also {
-        logger.info { "Telemetry pulse enabled for self-hosted deployment" }
-        it.start(jobScope)
-    }
-}
-
 private fun Application.registerBackgroundShutdown(
     schedulerJobs: SchedulerBackgroundJobs,
     coreWorkers: CoreIngestionWorkers,
-    pulseService: PulseService?,
 ) {
     monitor.subscribe(ApplicationStopping) {
         flushUsageOnShutdown()
         schedulerJobs.stop()
         coreWorkers.stop()
-        pulseService?.stop()
         FeatureRegistry.stopBackgroundJobs()
         closeInfrastructureConnections()
     }


### PR DESCRIPTION
## Summary
- move telemetry pulse scheduler lifecycle behind the Pulse feature module
- remove root BackgroundJobs direct PulseService startup and shutdown
- cover scheduler role behavior in Pulse feature tests

## Tests
- cd backend && ./gradlew :features:pulse:compileKotlin :features:pulse:compileTestKotlin :features:pulse:test :features:pulse:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background telemetry jobs now support configurable scheduling intervals with a default period of 4 hours.

* **Tests**
  * Expanded test coverage for telemetry job lifecycle management and scheduler operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->