### PR TITLE
feat: add RevenueCat connector settings UI

### DIFF
--- a/dashboard/src/components/settings/ConnectorInstallationDialogs.tsx
+++ b/dashboard/src/components/settings/ConnectorInstallationDialogs.tsx
@@ -108,11 +108,17 @@ function CopyButton({
 }) {
   const {toast} = useToast()
   const [copied, setCopied] = useState(false)
-  const onCopy = () => {
-    void navigator.clipboard?.writeText(value)
-    setCopied(true)
-    toast({title: `${label} copied`})
-    globalThis.setTimeout(() => setCopied(false), 1500)
+  const onCopy = async () => {
+    try {
+      const clipboard = globalThis.navigator.clipboard
+      if (!clipboard) throw new Error('Clipboard unavailable')
+      await clipboard.writeText(value)
+      setCopied(true)
+      toast({title: `${label} copied`})
+      globalThis.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      toast({title: `Failed to copy ${label.toLowerCase()}`, variant: 'destructive'})
+    }
   }
   const Icon = copied ? Check : Copy
   if (size === 'sm') {

--- a/dashboard/src/components/settings/ConnectorInstallationDialogs.tsx
+++ b/dashboard/src/components/settings/ConnectorInstallationDialogs.tsx
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+import type {Dispatch, SetStateAction} from 'react'
 import {useMemo, useState} from 'react'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
@@ -34,9 +35,11 @@ import {
 import {api} from '@/lib/api'
 import type {
   ConnectorBindingInput,
+  ConnectorExternalResourceResponse,
   ConnectorInstallationResponse,
   ConnectorProviderDefinition,
   ConnectorProviderStateDetail,
+  Project,
 } from '@/lib/api/types'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
@@ -67,6 +70,9 @@ import {
 const REVENUECAT_APP_RESOURCE_TYPE = 'revenuecat_app'
 const PROJECT_LOCAL_RESOURCE_TYPE = 'project'
 const UNMAPPED_VALUE = '__unmapped__'
+const REVENUECAT_PROJECT_URL_RE = /projects\/([^/?#\s]+)/i
+const WHITESPACE_RE = /\s+/g
+const PROJECT_PREFIX_RE = /^proj/i
 
 const ENVIRONMENT_LABELS: Record<string, string> = {
   production_and_sandbox: 'Production & sandbox',
@@ -84,9 +90,9 @@ function ts(value: string | null | undefined): string {
 // drop stray whitespace, and strip a redundant leading `proj` so it isn't doubled.
 function normalizeProjectIdInput(raw: string): string {
   let value = raw.trim()
-  const fromUrl = value.match(/projects\/([^/?#\s]+)/i)
+  const fromUrl = REVENUECAT_PROJECT_URL_RE.exec(value)
   if (fromUrl) value = fromUrl[1]
-  return value.replace(/\s+/g, '').replace(/^proj/i, '')
+  return value.replaceAll(WHITESPACE_RE, '').replace(PROJECT_PREFIX_RE, '')
 }
 
 // ── small primitives ─────────────────────────────────────────────────────────
@@ -347,7 +353,7 @@ export function ConnectorSetupDialog({
                   >
                     Project settings → API keys ↗
                   </a>
-                  . Moneat validates it before connecting.
+                  {'. '}Moneat validates it before connecting.
                 </p>
               </div>
               <div className="rounded-md border bg-muted/40 p-3">
@@ -1023,74 +1029,13 @@ function MappingTab({installationId, active}: Readonly<{installationId: string; 
         </Button>
       </div>
 
-      {resourcesLoading ? (
-        <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" /> Loading apps…
-        </div>
-      ) : apps.length === 0 ? (
-        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
-          <Inbox className="mx-auto mb-2 h-8 w-8 opacity-50" />
-          <p className="font-medium">No RevenueCat apps yet</p>
-          <p className="mt-0.5 text-xs">Refresh apps after creating apps in your RevenueCat project.</p>
-        </div>
-      ) : (
-        <div className="divide-y rounded-md border">
-          {apps.map((app) => {
-            const mappedTo = valueFor(app.externalResourceId)
-            return (
-              <div key={app.externalResourceId} className="flex items-center gap-3 px-3 py-2">
-                <Link2 className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm font-medium">
-                    {app.displayName ?? app.externalResourceId}
-                  </div>
-                  <div className="truncate font-mono text-[11px] text-muted-foreground">
-                    {app.externalResourceId}
-                  </div>
-                </div>
-                <Select
-                  value={mappedTo || UNMAPPED_VALUE}
-                  onValueChange={(val) =>
-                    setDraft((d) => ({
-                      ...d,
-                      [app.externalResourceId]: val === UNMAPPED_VALUE ? '' : val,
-                    }))
-                  }
-                >
-                  <SelectTrigger
-                    className="h-8 w-[200px]"
-                    aria-label={`Moneat project for ${app.displayName ?? app.externalResourceId}`}
-                  >
-                    <SelectValue placeholder="Not mapped" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={UNMAPPED_VALUE}>Not mapped</SelectItem>
-                    {projects.map((project) => (
-                      <SelectItem key={project.id} value={project.id}>
-                        {project.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {mappedTo ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-muted-foreground"
-                    aria-label={`Unmap ${app.displayName ?? app.externalResourceId}`}
-                    onClick={() => setDraft((d) => ({...d, [app.externalResourceId]: ''}))}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                ) : (
-                  <span className="w-8" />
-                )}
-              </div>
-            )
-          })}
-        </div>
-      )}
+      <MappingAppsContent
+        resourcesLoading={resourcesLoading}
+        apps={apps}
+        projects={projects}
+        valueFor={valueFor}
+        setDraft={setDraft}
+      />
 
       <div className="flex items-center justify-end gap-2">
         {isDirty && (
@@ -1102,6 +1047,112 @@ function MappingTab({installationId, active}: Readonly<{installationId: string; 
           {save.isPending ? 'Saving…' : 'Save mapping'}
         </Button>
       </div>
+    </div>
+  )
+}
+
+function MappingAppsContent({
+  resourcesLoading,
+  apps,
+  projects,
+  valueFor,
+  setDraft,
+}: {
+  readonly resourcesLoading: boolean
+  readonly apps: ConnectorExternalResourceResponse[]
+  readonly projects: Project[]
+  readonly valueFor: (appId: string) => string
+  readonly setDraft: Dispatch<SetStateAction<Record<string, string>>>
+}) {
+  if (resourcesLoading) {
+    return (
+      <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading apps…
+      </div>
+    )
+  }
+
+  if (apps.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+        <Inbox className="mx-auto mb-2 h-8 w-8 opacity-50" />
+        <p className="font-medium">No RevenueCat apps yet</p>
+        <p className="mt-0.5 text-xs">Refresh apps after creating apps in your RevenueCat project.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="divide-y rounded-md border">
+      {apps.map((app) => (
+        <MappingAppRow
+          key={app.externalResourceId}
+          app={app}
+          projects={projects}
+          mappedTo={valueFor(app.externalResourceId)}
+          setDraft={setDraft}
+        />
+      ))}
+    </div>
+  )
+}
+
+function MappingAppRow({
+  app,
+  projects,
+  mappedTo,
+  setDraft,
+}: {
+  readonly app: ConnectorExternalResourceResponse
+  readonly projects: Project[]
+  readonly mappedTo: string
+  readonly setDraft: Dispatch<SetStateAction<Record<string, string>>>
+}) {
+  const appName = app.displayName ?? app.externalResourceId
+  return (
+    <div className="flex items-center gap-3 px-3 py-2">
+      <Link2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">{appName}</div>
+        <div className="truncate font-mono text-[11px] text-muted-foreground">
+          {app.externalResourceId}
+        </div>
+      </div>
+      <Select
+        value={mappedTo || UNMAPPED_VALUE}
+        onValueChange={(val) =>
+          setDraft((d) => ({
+            ...d,
+            [app.externalResourceId]: val === UNMAPPED_VALUE ? '' : val,
+          }))
+        }
+      >
+        <SelectTrigger className="h-8 w-[200px]" aria-label={`Moneat project for ${appName}`}>
+          <SelectValue placeholder="Not mapped" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={UNMAPPED_VALUE}>Not mapped</SelectItem>
+          {projects.map((project) => (
+            <SelectItem key={project.id} value={project.id}>
+              {project.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {mappedTo ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground"
+          aria-label={`Unmap ${appName}`}
+          onClick={() => setDraft((d) => ({...d, [app.externalResourceId]: ''}))}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      ) : (
+        <span className="w-8" />
+      )}
     </div>
   )
 }

--- a/dashboard/src/components/settings/ConnectorInstallationDialogs.tsx
+++ b/dashboard/src/components/settings/ConnectorInstallationDialogs.tsx
@@ -1,0 +1,1107 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useMemo, useState} from 'react'
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+import {
+  AlertTriangle,
+  Check,
+  Copy,
+  Inbox,
+  KeyRound,
+  Link2,
+  Loader2,
+  RefreshCw,
+  RotateCw,
+  ShieldCheck,
+  Trash2,
+  X,
+} from 'lucide-react'
+
+import {api} from '@/lib/api'
+import type {
+  ConnectorBindingInput,
+  ConnectorInstallationResponse,
+  ConnectorProviderDefinition,
+  ConnectorProviderStateDetail,
+} from '@/lib/api/types'
+import {Badge} from '@/components/ui/badge'
+import {Button} from '@/components/ui/button'
+import {Input} from '@/components/ui/input'
+import {Label} from '@/components/ui/label'
+import {StatusDot} from '@/components/ui/status-dot'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
+import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {cn, formatRelativeTime} from '@/lib/utils'
+import {useToast} from '@/hooks/useToast'
+import {trackEvent} from '@/lib/analytics'
+import {ConnectorLogo} from './BrandLogos'
+import {
+  describeConnectorHealth,
+  effectiveConnectorState,
+  formatProcessingLag,
+  installAuthProfileId,
+} from './connectorHealth'
+
+const REVENUECAT_APP_RESOURCE_TYPE = 'revenuecat_app'
+const PROJECT_LOCAL_RESOURCE_TYPE = 'project'
+const UNMAPPED_VALUE = '__unmapped__'
+
+const ENVIRONMENT_LABELS: Record<string, string> = {
+  production_and_sandbox: 'Production & sandbox',
+  production: 'Production',
+  sandbox: 'Sandbox',
+}
+
+function ts(value: string | null | undefined): string {
+  if (!value) return '—'
+  return formatRelativeTime(value)
+}
+
+// RevenueCat project IDs are `proj…`; the setup field renders a fixed `proj` prefix and
+// stores only the suffix. Normalize pasted input: pull the id out of a dashboard URL,
+// drop stray whitespace, and strip a redundant leading `proj` so it isn't doubled.
+function normalizeProjectIdInput(raw: string): string {
+  let value = raw.trim()
+  const fromUrl = value.match(/projects\/([^/?#\s]+)/i)
+  if (fromUrl) value = fromUrl[1]
+  return value.replace(/\s+/g, '').replace(/^proj/i, '')
+}
+
+// ── small primitives ─────────────────────────────────────────────────────────
+
+function CopyButton({
+  value,
+  label,
+  size = 'icon',
+}: {
+  readonly value: string
+  readonly label: string
+  readonly size?: 'icon' | 'sm'
+}) {
+  const {toast} = useToast()
+  const [copied, setCopied] = useState(false)
+  const onCopy = () => {
+    void navigator.clipboard?.writeText(value)
+    setCopied(true)
+    toast({title: `${label} copied`})
+    globalThis.setTimeout(() => setCopied(false), 1500)
+  }
+  const Icon = copied ? Check : Copy
+  if (size === 'sm') {
+    return (
+      <Button type="button" variant="outline" size="sm" onClick={onCopy} aria-label={`Copy ${label}`}>
+        <Icon className="mr-1.5 h-3.5 w-3.5" />
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+    )
+  }
+  return (
+    <Button type="button" variant="outline" size="icon" onClick={onCopy} aria-label={`Copy ${label}`}>
+      <Icon className="h-4 w-4" />
+    </Button>
+  )
+}
+
+function CopyField({
+  label,
+  value,
+  mono = true,
+}: {
+  readonly label: string
+  readonly value: string
+  readonly mono?: boolean
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <div className="flex gap-2">
+        <Input readOnly value={value} className={cn('text-sm', mono && 'font-mono')} />
+        <CopyButton value={value} label={label} />
+      </div>
+    </div>
+  )
+}
+
+function DetailRow({label, children}: {readonly label: string; readonly children: React.ReactNode}) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="m-0 text-right font-medium">{children}</dd>
+    </>
+  )
+}
+
+function MetricTile({
+  label,
+  value,
+  tone,
+}: {
+  readonly label: string
+  readonly value: React.ReactNode
+  readonly tone?: 'warning' | 'danger'
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border bg-card px-2.5 py-2',
+        tone === 'warning' && 'border-warning-border bg-warning-bg/40',
+        tone === 'danger' && 'border-danger-border bg-danger-bg/40'
+      )}
+    >
+      <div className="text-[11px] uppercase tracking-[0.04em] text-muted-foreground">{label}</div>
+      <div className="mt-0.5 text-sm font-semibold tabular-nums">{value}</div>
+    </div>
+  )
+}
+
+function HealthBadge({state, enabled}: {readonly state?: string; readonly enabled?: boolean}) {
+  const {badge, label, tone} = describeConnectorHealth(state, enabled)
+  return (
+    <Badge variant={badge} className="gap-1.5">
+      <StatusDot tone={tone} size="sm" />
+      {label}
+    </Badge>
+  )
+}
+
+// ── setup wizard (generic installation-backed connectors) ─────────────────────
+
+const SETUP_STEPS = ['Connect', 'Webhook', 'Map apps'] as const
+
+function WizardSteps({current}: {readonly current: number}) {
+  return (
+    <ol className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs" aria-label="Setup progress">
+      {SETUP_STEPS.map((label, i) => {
+        const n = i + 1
+        const done = n < current
+        const active = n === current
+        return (
+          <li key={label} className="flex items-center gap-1.5">
+            <span
+              className={cn(
+                'flex h-5 w-5 items-center justify-center rounded-full border text-[11px] font-semibold',
+                active && 'border-primary bg-primary text-primary-foreground',
+                done && 'border-success-border bg-success-bg text-success-fg',
+                !active && !done && 'border-border text-muted-foreground'
+              )}
+            >
+              {done ? <Check className="h-3 w-3" /> : n}
+            </span>
+            <span className={cn('font-medium', active ? 'text-foreground' : 'text-muted-foreground')}>
+              {label}
+            </span>
+            {n < SETUP_STEPS.length && <span className="mx-1 h-px w-5 bg-border" aria-hidden />}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+// Guided 3-step setup: ① connect the API key → ② surface the webhook URL + one-time
+// token to paste into RevenueCat → ③ map apps to projects. Steps 2–3 reuse the same
+// WebhookTab/MappingTab as Manage so there's one source of truth for that UI.
+export function ConnectorSetupDialog({
+  provider,
+  onClose,
+}: Readonly<{provider: ConnectorProviderDefinition; onClose: () => void}>) {
+  const queryClient = useQueryClient()
+  const {toast} = useToast()
+  const [step, setStep] = useState(1)
+  const [name, setName] = useState('')
+  const [projectId, setProjectId] = useState('')
+  const [secret, setSecret] = useState('')
+  const [created, setCreated] = useState<ConnectorInstallationResponse | null>(null)
+
+  const authProfileId = installAuthProfileId(provider) ?? 'project_api_key'
+  const invalidate = () => {
+    queryClient.invalidateQueries({queryKey: ['connectorInstallations']})
+    queryClient.invalidateQueries({queryKey: ['connectorState']})
+  }
+
+  const create = useMutation({
+    mutationFn: () =>
+      api.createConnectorInstallation({
+        providerId: provider.id,
+        authProfileId,
+        name: name.trim(),
+        externalAccount: {projectId: `proj${projectId.trim()}`},
+        secret: secret.trim(),
+      }),
+    onSuccess: (res) => {
+      trackEvent('Connector Installed', {provider: provider.id})
+      invalidate()
+      setSecret('')
+      setCreated(res)
+      setStep(2)
+    },
+    onError: (err: Error) =>
+      toast({title: 'Could not connect', description: err.message, variant: 'destructive'}),
+  })
+
+  const canSubmit = !!projectId.trim() && !!secret.trim() && !create.isPending
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-h-[86vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="space-y-3 border-b px-5 py-4">
+          <DialogTitle className="flex items-center gap-2">
+            <ConnectorLogo providerId={provider.id} className="h-7 w-7" />
+            Connect {provider.name}
+          </DialogTitle>
+          <WizardSteps current={step} />
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          {step === 1 && (
+            <div className="space-y-4">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Two connections get set up: Moneat reads your catalog with a {provider.name} API key,
+                then {provider.name} pushes events to a Moneat webhook (next step). Data is imported
+                from install onward — {provider.name} history isn’t backfilled.
+              </p>
+              <div className="space-y-1.5">
+                <Label htmlFor="connector-name">Connection name</Label>
+                <Input
+                  id="connector-name"
+                  placeholder="e.g. Production RevenueCat"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Optional — defaults to your {provider.name} project name.
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="connector-project">RevenueCat project ID</Label>
+                <div className="flex">
+                  <span className="inline-flex select-none items-center rounded-l-md border border-r-0 border-input bg-muted px-2.5 font-mono text-sm text-muted-foreground">
+                    proj
+                  </span>
+                  <Input
+                    id="connector-project"
+                    placeholder="1ab2c3d4"
+                    value={projectId}
+                    onChange={(e) => setProjectId(normalizeProjectIdInput(e.target.value))}
+                    className="rounded-l-none font-mono"
+                    required
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Paste just the ID — the <span className="font-mono">proj</span> prefix is added
+                  for you. Find it in{' '}
+                  <a
+                    href="https://app.revenuecat.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline-offset-2 hover:underline"
+                  >
+                    RevenueCat → Project settings ↗
+                  </a>{' '}
+                  or your dashboard URL (fine if it doesn’t show the{' '}
+                  <span className="font-mono">proj</span> prefix).
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="connector-secret">RevenueCat V2 secret API key</Label>
+                <Input
+                  id="connector-secret"
+                  type="password"
+                  placeholder="sk_…"
+                  value={secret}
+                  onChange={(e) => setSecret(e.target.value)}
+                  className="font-mono"
+                  autoComplete="off"
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  A <span className="font-medium text-foreground">secret</span> key (starts with{' '}
+                  <span className="font-mono">sk_</span>), not a public key. Create one in{' '}
+                  <a
+                    href="https://app.revenuecat.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline-offset-2 hover:underline"
+                  >
+                    Project settings → API keys ↗
+                  </a>
+                  . Moneat validates it before connecting.
+                </p>
+              </div>
+              <div className="rounded-md border bg-muted/40 p-3">
+                <div className="flex items-center gap-2">
+                  <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                  <p className="text-xs font-medium">What this key needs</p>
+                </div>
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Under <span className="font-medium text-foreground">Project configuration</span>,
+                  set these to <span className="font-medium text-foreground">Read only</span> — leave
+                  everything else <span className="font-medium text-foreground">No access</span>:
+                </p>
+                <ul className="mt-2 space-y-1 text-xs">
+                  <li className="flex items-baseline gap-2">
+                    <span className="font-medium text-foreground">Projects</span>
+                    <span className="text-muted-foreground">— validate the project</span>
+                  </li>
+                  <li className="flex items-baseline gap-2">
+                    <span className="font-medium text-foreground">Apps</span>
+                    <span className="text-muted-foreground">— list apps to map</span>
+                  </li>
+                  <li className="flex items-baseline gap-2">
+                    <span className="font-medium text-foreground">Integrations</span>
+                    <span className="text-muted-foreground">— optional; lets Moneat verify the webhook</span>
+                  </li>
+                </ul>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Moneat only reads — it never writes to {provider.name}. Purchases and subscriptions
+                  arrive through the webhook, so no customer-data scopes are needed.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {step === 2 && created && (
+            <WebhookTab
+              installationId={created.id}
+              active
+              initialToken={created.webhookToken ?? undefined}
+              onRotated={invalidate}
+            />
+          )}
+
+          {step === 3 && created && <MappingTab installationId={created.id} active />}
+        </div>
+
+        <DialogFooter className="flex-row items-center justify-between border-t px-5 py-3 sm:justify-between">
+          {step === 1 && (
+            <>
+              <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="button" size="sm" onClick={() => create.mutate()} disabled={!canSubmit}>
+                {create.isPending && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+                Connect
+              </Button>
+            </>
+          )}
+          {step === 2 && (
+            <>
+              <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+                Finish later
+              </Button>
+              <Button type="button" size="sm" onClick={() => setStep(3)}>
+                Next: map apps
+              </Button>
+            </>
+          )}
+          {step === 3 && (
+            <>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setStep(2)}>
+                Back
+              </Button>
+              <Button type="button" size="sm" onClick={onClose}>
+                Done
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// One-time webhook token reveal — shown on create and after a rotate. Presents the
+// ready-to-paste `Authorization` header value (RevenueCat sends `Bearer <token>`).
+function OneTimeToken({token}: {readonly token: string}) {
+  const headerValue = `Bearer ${token}`
+  return (
+    <div className="space-y-3 rounded-md border border-warning-border bg-warning-bg/40 p-3">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning-fg" />
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Copy this now.</span> The webhook token is
+          shown only once and can’t be retrieved later. Set it as the{' '}
+          <span className="font-mono">Authorization</span> header on your RevenueCat webhook.
+        </p>
+      </div>
+      <CopyField label="Authorization header value" value={headerValue} />
+    </div>
+  )
+}
+
+// ── manage dialog (RevenueCat installation) ──────────────────────────────────
+
+type ManageTab = 'overview' | 'webhook' | 'mapping'
+
+export function RevenueCatManageDialog({
+  provider,
+  installation,
+  detail,
+  onClose,
+}: Readonly<{
+  provider: ConnectorProviderDefinition
+  installation: ConnectorInstallationResponse
+  detail?: ConnectorProviderStateDetail | null
+  onClose: () => void
+}>) {
+  const queryClient = useQueryClient()
+  const {toast} = useToast()
+  const id = installation.id
+  const [tab, setTab] = useState<ManageTab>('overview')
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false)
+
+  const fail = (title: string) => (err: Error) =>
+    toast({title, description: err.message, variant: 'destructive'})
+  const invalidateInstallation = () => {
+    queryClient.invalidateQueries({queryKey: ['connectorInstallation', id]})
+    queryClient.invalidateQueries({queryKey: ['connectorInstallations']})
+    queryClient.invalidateQueries({queryKey: ['connectorState']})
+  }
+
+  // Keep the installation fresh after test / rotate without closing the dialog.
+  const {data: inst = installation} = useQuery({
+    queryKey: ['connectorInstallation', id],
+    queryFn: () => api.getConnectorInstallation(id),
+    initialData: installation,
+  })
+
+  const test = useMutation({
+    mutationFn: () => api.testConnectorInstallation(id),
+    onSuccess: (res) => {
+      invalidateInstallation()
+      toast({
+        title: res.lastTestResult === 'failed' ? 'Test failed' : 'Connection healthy',
+        description: res.lastTestResult === 'failed' ? (res.lastError ?? undefined) : undefined,
+        variant: res.lastTestResult === 'failed' ? 'destructive' : 'default',
+      })
+    },
+    onError: fail('Test failed'),
+  })
+
+  const disconnect = useMutation({
+    mutationFn: () => api.deleteConnectorInstallation(id),
+    onSuccess: () => {
+      invalidateInstallation()
+      toast({title: `${provider.name} disconnected`})
+      onClose()
+    },
+    onError: fail('Failed to disconnect'),
+  })
+
+  const displayState = effectiveConnectorState(detail, inst)
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-h-[86vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="space-y-1 border-b px-5 py-4">
+          <DialogTitle className="flex items-center gap-2">
+            <ConnectorLogo providerId={provider.id} className="h-7 w-7" />
+            Manage {provider.name}
+            <span className="ml-1">
+              <HealthBadge state={displayState} enabled={inst.enabled} />
+            </span>
+          </DialogTitle>
+          <DialogDescription className="font-mono text-xs">
+            {inst.externalProjectName ?? '—'}
+            {inst.externalProjectId ? ` · ${inst.externalProjectId}` : ''}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={tab} onValueChange={(v) => setTab(v as ManageTab)} className="flex min-h-0 flex-1 flex-col">
+          <TabsList className="mx-5 mt-3 w-fit">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="webhook">Webhook</TabsTrigger>
+            <TabsTrigger value="mapping">App mapping</TabsTrigger>
+          </TabsList>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            <TabsContent value="overview" className="mt-0">
+              <OverviewTab
+                installation={inst}
+                detail={detail}
+                displayState={displayState}
+                onRotated={invalidateInstallation}
+              />
+            </TabsContent>
+            <TabsContent value="webhook" className="mt-0">
+              <WebhookTab installationId={id} active={tab === 'webhook'} onRotated={invalidateInstallation} />
+            </TabsContent>
+            <TabsContent value="mapping" className="mt-0">
+              <MappingTab installationId={id} active={tab === 'mapping'} />
+            </TabsContent>
+          </div>
+        </Tabs>
+
+        <DialogFooter className="flex-row justify-between border-t px-5 py-3 sm:justify-between">
+          {confirmDisconnect ? (
+            <>
+              <span className="self-center text-sm text-muted-foreground">
+                Disconnect {provider.name}? Imports stop immediately.
+              </span>
+              <div className="flex gap-2">
+                <Button variant="ghost" size="sm" onClick={() => setConfirmDisconnect(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => disconnect.mutate()}
+                  disabled={disconnect.isPending}
+                >
+                  {disconnect.isPending ? 'Disconnecting…' : 'Confirm disconnect'}
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={() => setConfirmDisconnect(true)}
+              >
+                <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                Disconnect
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => test.mutate()} disabled={test.isPending}>
+                {test.isPending ? (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                )}
+                Test connection
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function OverviewTab({
+  installation,
+  detail,
+  displayState,
+  onRotated,
+}: Readonly<{
+  installation: ConnectorInstallationResponse
+  detail?: ConnectorProviderStateDetail | null
+  displayState?: string
+  onRotated: () => void
+}>) {
+  const {toast} = useToast()
+  const [rotateOpen, setRotateOpen] = useState(false)
+  const [newSecret, setNewSecret] = useState('')
+
+  const rotateKey = useMutation({
+    mutationFn: () => api.rotateConnectorApiCredential(installation.id, {secret: newSecret.trim()}),
+    onSuccess: () => {
+      onRotated()
+      setNewSecret('')
+      setRotateOpen(false)
+      toast({title: 'API key rotated'})
+    },
+    onError: (err: Error) =>
+      toast({title: 'Failed to rotate API key', description: err.message, variant: 'destructive'}),
+  })
+
+  return (
+    <div className="space-y-4">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 rounded-md border bg-card px-3.5 py-3 text-xs">
+        <DetailRow label="Status">
+          <HealthBadge state={displayState} enabled={installation.enabled} />
+        </DetailRow>
+        <DetailRow label="RevenueCat project">
+          <span className="font-mono">{installation.externalProjectName ?? installation.externalProjectId ?? '—'}</span>
+        </DetailRow>
+        <DetailRow label="API key">
+          <span className="font-mono">
+            {installation.apiSecretLastFour ? `•••• ${installation.apiSecretLastFour}` : '—'}
+          </span>
+        </DetailRow>
+        <DetailRow label="Webhook token">
+          <span className="font-mono">
+            {installation.webhookTokenPrefix ? `${installation.webhookTokenPrefix}…` : 'Not set'}
+          </span>
+        </DetailRow>
+        <DetailRow label="Last tested">{ts(installation.lastTestedAt)}</DetailRow>
+        <DetailRow label="Last provider call">{ts(installation.lastSuccessfulProviderCallAt)}</DetailRow>
+      </dl>
+
+      {installation.lastError && (
+        <div className="flex items-start gap-2 rounded-md border border-danger-border bg-danger-bg/40 p-2.5 text-xs text-danger-fg">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span className="break-words">{installation.lastError}</span>
+        </div>
+      )}
+
+      <div>
+        <div className="mb-1.5 text-[11px] font-bold uppercase tracking-[0.06em] text-muted-foreground/80">
+          Import state
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          <MetricTile label="Mapped apps" value={(detail?.mappedResources ?? 0).toLocaleString()} />
+          <MetricTile
+            label="Unmapped events"
+            value={(detail?.unmappedEvents ?? 0).toLocaleString()}
+            tone={detail && detail.unmappedEvents > 0 ? 'warning' : undefined}
+          />
+          <MetricTile
+            label="Failed receipts"
+            value={(detail?.failedReceipts ?? 0).toLocaleString()}
+            tone={detail && detail.failedReceipts > 0 ? 'danger' : undefined}
+          />
+          <MetricTile label="Production events" value={(detail?.productionEvents ?? 0).toLocaleString()} />
+          <MetricTile label="Sandbox events" value={(detail?.sandboxEvents ?? 0).toLocaleString()} />
+          <MetricTile label="Processing lag" value={formatProcessingLag(detail?.processingLagSeconds)} />
+        </div>
+        <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 px-0.5 text-xs">
+          <DetailRow label="Last accepted webhook">{ts(detail?.lastAcceptedWebhookAt)}</DetailRow>
+          <DetailRow label="Last applied event">{ts(detail?.lastAppliedAt)}</DetailRow>
+        </dl>
+        {detail?.message && (
+          <p className="mt-2 text-xs text-muted-foreground">{detail.message}</p>
+        )}
+        <p className="mt-2 text-xs text-muted-foreground">
+          Imported data is since install — RevenueCat history isn’t backfilled.
+        </p>
+      </div>
+
+      <div className="rounded-md border p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <p className="text-sm font-medium">API key</p>
+            <p className="text-xs text-muted-foreground">
+              Replace the stored V2 secret key. The current key keeps working until you save.
+            </p>
+          </div>
+          {!rotateOpen && (
+            <Button variant="outline" size="sm" onClick={() => setRotateOpen(true)}>
+              <KeyRound className="mr-1.5 h-3.5 w-3.5" />
+              Rotate
+            </Button>
+          )}
+        </div>
+        {rotateOpen && (
+          <div className="mt-3 space-y-2">
+            <Input
+              type="password"
+              placeholder="New V2 secret API key (sk_…)"
+              value={newSecret}
+              onChange={(e) => setNewSecret(e.target.value)}
+              className="font-mono"
+              autoComplete="off"
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setRotateOpen(false)
+                  setNewSecret('')
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => rotateKey.mutate()}
+                disabled={!newSecret.trim() || rotateKey.isPending}
+              >
+                {rotateKey.isPending ? 'Saving…' : 'Save key'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function WebhookTab({
+  installationId,
+  active,
+  onRotated,
+  initialToken,
+}: Readonly<{
+  installationId: string
+  active: boolean
+  onRotated: () => void
+  // One-time token from a just-created installation (setup wizard). When present
+  // the full Authorization value is revealed immediately and the rotate control is
+  // hidden — there's nothing to rotate yet.
+  initialToken?: string
+}>) {
+  const queryClient = useQueryClient()
+  const {toast} = useToast()
+  const [rotatedToken, setRotatedToken] = useState<string | null>(initialToken ?? null)
+  const [confirmRotate, setConfirmRotate] = useState(false)
+  const showRotate = !initialToken
+
+  const {data, isLoading, error} = useQuery({
+    queryKey: ['connectorWebhookSetup', installationId],
+    queryFn: () => api.getConnectorWebhookSetup(installationId),
+    enabled: active,
+    retry: false,
+  })
+
+  const rotate = useMutation({
+    mutationFn: () => api.rotateConnectorWebhookToken(installationId),
+    onSuccess: (res) => {
+      setRotatedToken(res.webhookToken ?? null)
+      setConfirmRotate(false)
+      queryClient.invalidateQueries({queryKey: ['connectorWebhookSetup', installationId]})
+      onRotated()
+      toast({title: 'Webhook token rotated'})
+    },
+    onError: (err: Error) =>
+      toast({title: 'Failed to rotate webhook token', description: err.message, variant: 'destructive'}),
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading webhook setup…
+      </div>
+    )
+  }
+  if (error || !data) {
+    return (
+      <p className="py-8 text-sm text-muted-foreground">
+        Webhook setup is unavailable. {(error as Error | undefined)?.message}
+      </p>
+    )
+  }
+
+  const envLabel = ENVIRONMENT_LABELS[data.recommendedEnvironment] ?? data.recommendedEnvironment
+  const hasFullValue = !!data.authorizationHeaderValue || !!rotatedToken
+  const effectiveHeaderValue = rotatedToken
+    ? `Bearer ${rotatedToken}`
+    : data.authorizationHeaderValue ?? null
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Add this webhook in RevenueCat → Project settings → Integrations → Webhooks. Use the{' '}
+        {envLabel.toLowerCase()} environment.
+      </p>
+
+      <CopyField label="Webhook URL" value={data.webhookUrl} />
+
+      <div className="space-y-1.5">
+        <Label className="text-xs text-muted-foreground">Authorization header</Label>
+        <div className="flex gap-2">
+          <Input readOnly value={data.authorizationHeaderName} className="max-w-[140px] font-mono text-sm" />
+          {effectiveHeaderValue ? (
+            <>
+              <Input readOnly value={effectiveHeaderValue} className="font-mono text-sm" />
+              <CopyButton value={effectiveHeaderValue} label="authorization header" />
+            </>
+          ) : (
+            <Input
+              readOnly
+              value={data.authorizationHeaderPrefix ? `Bearer ${data.authorizationHeaderPrefix}…` : 'Not set'}
+              className="font-mono text-sm"
+            />
+          )}
+        </div>
+        {!hasFullValue && (
+          <p className="text-xs text-muted-foreground">
+            Only the token prefix is stored. Rotate the webhook token below to reveal a new one-time
+            value to paste into RevenueCat.
+          </p>
+        )}
+      </div>
+
+      {rotatedToken && <OneTimeToken token={rotatedToken} />}
+
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-xs text-muted-foreground">
+            Recommended event types ({data.recommendedEventTypes.length})
+          </Label>
+          {data.recommendedEventTypes.length > 0 && (
+            <CopyButton value={data.recommendedEventTypes.join('\n')} label="event types" size="sm" />
+          )}
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {data.recommendedEventTypes.map((evt) => (
+            <span
+              key={evt}
+              className="inline-flex items-center rounded border bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+            >
+              {evt}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {data.warnings && data.warnings.length > 0 && (
+        <div className="space-y-1.5 rounded-md border border-warning-border bg-warning-bg/40 p-2.5">
+          {data.warnings.map((warning) => (
+            <div key={warning} className="flex items-start gap-2 text-xs text-warning-fg">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{warning}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {data.observedIntegrations && data.observedIntegrations.length > 0 && (
+        <div className="space-y-1.5">
+          <Label className="text-xs text-muted-foreground">Observed RevenueCat webhooks</Label>
+          <div className="space-y-1.5">
+            {data.observedIntegrations.map((obs) => (
+              <div key={obs.id} className="rounded-md border px-2.5 py-2 text-xs">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-medium">{obs.name ?? obs.id}</span>
+                  <div className="flex items-center gap-1.5">
+                    {obs.matchesExpectedUrl && <Badge variant="success">This URL</Badge>}
+                    <Badge variant={obs.enabled === false ? 'secondary' : 'neutral'}>
+                      {obs.enabled === false ? 'Disabled' : 'Enabled'}
+                    </Badge>
+                  </div>
+                </div>
+                {obs.eventTypes && obs.eventTypes.length > 0 && (
+                  <p className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
+                    {obs.eventTypes.join(', ')}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {showRotate && (
+        <div className="rounded-md border p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <p className="text-sm font-medium">Webhook token</p>
+              <p className="text-xs text-muted-foreground">
+                Rotating invalidates the current token immediately and shows a new one once.
+              </p>
+            </div>
+            {!confirmRotate && (
+              <Button variant="outline" size="sm" onClick={() => setConfirmRotate(true)}>
+                <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+                Rotate token
+              </Button>
+            )}
+          </div>
+          {confirmRotate && (
+            <div className="mt-3 flex items-center justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => setConfirmRotate(false)}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={() => rotate.mutate()} disabled={rotate.isPending}>
+                {rotate.isPending ? 'Rotating…' : 'Rotate & reveal'}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MappingTab({installationId, active}: Readonly<{installationId: string; active: boolean}>) {
+  const queryClient = useQueryClient()
+  const {toast} = useToast()
+  const [draft, setDraft] = useState<Record<string, string>>({})
+
+  const {data: resourcesData, isLoading: resourcesLoading} = useQuery({
+    queryKey: ['connectorResources', installationId],
+    queryFn: () => api.getConnectorExternalResources(installationId),
+    enabled: active,
+  })
+  const {data: bindingsData} = useQuery({
+    queryKey: ['connectorBindings', installationId],
+    queryFn: () => api.getConnectorBindings(installationId),
+    enabled: active,
+  })
+  const {data: projects = []} = useQuery({
+    queryKey: ['projects'],
+    queryFn: () => api.getProjects(),
+    enabled: active,
+  })
+
+  const apps = useMemo(
+    () =>
+      (resourcesData?.resources ?? []).filter(
+        (r) => r.externalResourceType === REVENUECAT_APP_RESOURCE_TYPE
+      ),
+    [resourcesData]
+  )
+
+  // Active app→project bindings as they exist on the server.
+  const currentMapping = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const binding of bindingsData?.bindings ?? []) {
+      if (binding.externalResourceType === REVENUECAT_APP_RESOURCE_TYPE && binding.status === 'active') {
+        map[binding.externalResourceId] = binding.localResourceId
+      }
+    }
+    return map
+  }, [bindingsData])
+
+  const valueFor = (appId: string) => draft[appId] ?? currentMapping[appId] ?? ''
+  const isDirty = Object.keys(draft).some((appId) => (draft[appId] ?? '') !== (currentMapping[appId] ?? ''))
+
+  const refresh = useMutation({
+    mutationFn: () => api.refreshConnectorExternalResources(installationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: ['connectorResources', installationId]})
+      toast({title: 'Apps refreshed'})
+    },
+    onError: (err: Error) =>
+      toast({title: 'Failed to refresh apps', description: err.message, variant: 'destructive'}),
+  })
+
+  const save = useMutation({
+    mutationFn: () => {
+      // PUT /bindings is full replacement — always send the complete desired active
+      // mapping. Apps left unmapped are simply omitted, which deactivates them.
+      const bindings: ConnectorBindingInput[] = apps
+        .map((app) => ({appId: app.externalResourceId, projectId: valueFor(app.externalResourceId)}))
+        .filter((entry) => entry.projectId)
+        .map((entry) => ({
+          externalResourceType: REVENUECAT_APP_RESOURCE_TYPE,
+          externalResourceId: entry.appId,
+          localResourceType: PROJECT_LOCAL_RESOURCE_TYPE,
+          localResourceId: entry.projectId,
+        }))
+      return api.updateConnectorBindings(installationId, {bindings})
+    },
+    onSuccess: () => {
+      setDraft({})
+      queryClient.invalidateQueries({queryKey: ['connectorBindings', installationId]})
+      queryClient.invalidateQueries({queryKey: ['connectorState']})
+      toast({title: 'App mapping saved'})
+    },
+    onError: (err: Error) =>
+      toast({title: 'Failed to save mapping', description: err.message, variant: 'destructive'}),
+  })
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          Map each RevenueCat app to one Moneat project. Each app maps to a single project; leave an
+          app unmapped to stop importing it.
+        </p>
+        <Button variant="outline" size="sm" onClick={() => refresh.mutate()} disabled={refresh.isPending}>
+          {refresh.isPending ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          Refresh apps
+        </Button>
+      </div>
+
+      {resourcesLoading ? (
+        <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading apps…
+        </div>
+      ) : apps.length === 0 ? (
+        <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+          <Inbox className="mx-auto mb-2 h-8 w-8 opacity-50" />
+          <p className="font-medium">No RevenueCat apps yet</p>
+          <p className="mt-0.5 text-xs">Refresh apps after creating apps in your RevenueCat project.</p>
+        </div>
+      ) : (
+        <div className="divide-y rounded-md border">
+          {apps.map((app) => {
+            const mappedTo = valueFor(app.externalResourceId)
+            return (
+              <div key={app.externalResourceId} className="flex items-center gap-3 px-3 py-2">
+                <Link2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">
+                    {app.displayName ?? app.externalResourceId}
+                  </div>
+                  <div className="truncate font-mono text-[11px] text-muted-foreground">
+                    {app.externalResourceId}
+                  </div>
+                </div>
+                <Select
+                  value={mappedTo || UNMAPPED_VALUE}
+                  onValueChange={(val) =>
+                    setDraft((d) => ({
+                      ...d,
+                      [app.externalResourceId]: val === UNMAPPED_VALUE ? '' : val,
+                    }))
+                  }
+                >
+                  <SelectTrigger
+                    className="h-8 w-[200px]"
+                    aria-label={`Moneat project for ${app.displayName ?? app.externalResourceId}`}
+                  >
+                    <SelectValue placeholder="Not mapped" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={UNMAPPED_VALUE}>Not mapped</SelectItem>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {mappedTo ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground"
+                    aria-label={`Unmap ${app.displayName ?? app.externalResourceId}`}
+                    onClick={() => setDraft((d) => ({...d, [app.externalResourceId]: ''}))}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                ) : (
+                  <span className="w-8" />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        {isDirty && (
+          <Button variant="ghost" size="sm" onClick={() => setDraft({})}>
+            Reset
+          </Button>
+        )}
+        <Button size="sm" onClick={() => save.mutate()} disabled={!isDirty || save.isPending}>
+          {save.isPending ? 'Saving…' : 'Save mapping'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/settings/ConnectorsSettings.tsx
+++ b/dashboard/src/components/settings/ConnectorsSettings.tsx
@@ -32,7 +32,9 @@ import type {
   ConnectorConnectionState,
   ConnectorFamily,
   ConnectorHealth,
+  ConnectorInstallationResponse,
   ConnectorProviderDefinition,
+  ConnectorProviderStateDetail,
   ConnectorStateResponse,
   OrganizationIntegration,
 } from '@/lib/api/types'
@@ -55,6 +57,13 @@ import {useToast} from '@/hooks/useToast'
 import {trackEvent} from '@/lib/analytics'
 import {ConnectorLogo} from './BrandLogos'
 import {SettingsSection} from './SettingsPrimitives'
+import {ConnectorSetupDialog, RevenueCatManageDialog} from './ConnectorInstallationDialogs'
+import {
+  type HealthDescriptor,
+  describeConnectorHealth,
+  effectiveConnectorState,
+  isInstallationBacked,
+} from './connectorHealth'
 
 // ── capability facets ───────────────────────────────────────────────────────
 type Facet = 'all' | 'notifications' | 'workflows' | 'dataimport' | 'dashboard' | 'webhooks'
@@ -93,6 +102,8 @@ interface ConnectorView {
   readonly availability: 'available' | 'planned' | 'enterprise'
   readonly integration?: OrganizationIntegration
   readonly state?: ConnectorConnectionState
+  readonly installation?: ConnectorInstallationResponse
+  readonly detail?: ConnectorProviderStateDetail | null
   readonly connected: boolean
 }
 
@@ -113,7 +124,9 @@ function getProviderHealth(connected: boolean, enabled?: boolean): ConnectorHeal
 function buildViews(
   providers: ConnectorProviderDefinition[],
   integrations: OrganizationIntegration[],
-  states: Map<string, ConnectorConnectionState>
+  states: Map<string, ConnectorConnectionState>,
+  installations: Map<string, ConnectorInstallationResponse>,
+  details: Map<string, ConnectorProviderStateDetail>
 ): ConnectorView[] {
   return providers.map((provider) => {
     const facets = [...new Set(provider.uses.map((u) => FAMILY_TO_FACET[u.family]))]
@@ -121,21 +134,36 @@ function buildViews(
     const integration = integrations.find(
       (i) => i.integrationType === provider.id && i.isConfigured
     )
-    // Connection comes from a configured integration; `state` only enriches it
-    // with live health. Setup for non-OAuth providers still gates on availability.
+    // Connection comes from a configured OAuth integration (Slack/Discord) or an
+    // installation-backed connector (RevenueCat); `state`/`detail` enrich it with
+    // live health. Setup for unconnected providers still gates on availability.
     const state = states.get(provider.id)
-    return {provider, facets, availability, integration, state, connected: !!integration}
+    const installation = installations.get(provider.id)
+    const detail = details.get(provider.id)
+    return {
+      provider,
+      facets,
+      availability,
+      integration,
+      state,
+      installation,
+      detail,
+      connected: !!integration || !!installation,
+    }
   })
 }
 
+// Notification connectors (Slack/Discord) read as "Active" when healthy. Shares
+// the {tone, badge, label} shape with describeConnectorHealth so cards can render
+// either uniformly.
 function describeHealth(
   enabled: boolean,
   health: ConnectorHealth | null | undefined
-): {tone: 'success' | 'neutral' | 'warning' | 'danger'; label: string} {
-  if (!enabled) return {tone: 'neutral', label: 'Disabled'}
-  if (health === 'error') return {tone: 'danger', label: 'Error'}
-  if (health === 'degraded') return {tone: 'warning', label: 'Degraded'}
-  return {tone: 'success', label: 'Active'}
+): HealthDescriptor {
+  if (!enabled) return {tone: 'neutral', badge: 'secondary', label: 'Disabled'}
+  if (health === 'error') return {tone: 'danger', badge: 'danger', label: 'Error'}
+  if (health === 'degraded') return {tone: 'warning', badge: 'warning', label: 'Degraded'}
+  return {tone: 'success', badge: 'success', label: 'Active'}
 }
 
 function buildStateMap(state?: ConnectorStateResponse): Map<string, ConnectorConnectionState> {
@@ -159,11 +187,25 @@ function buildStateMap(state?: ConnectorStateResponse): Map<string, ConnectorCon
   return byProvider
 }
 
+// Rich per-provider state detail (mapped/unmapped/failed counts, lag, etc.) for
+// installation-backed connectors, keyed by provider id.
+function buildDetailMap(
+  state?: ConnectorStateResponse
+): Map<string, ConnectorProviderStateDetail> {
+  const byProvider = new Map<string, ConnectorProviderStateDetail>()
+  for (const provider of state?.providers ?? []) {
+    const withDetail = provider.uses.find((use) => use.detail)
+    if (withDetail?.detail) byProvider.set(provider.providerId, withDetail.detail)
+  }
+  return byProvider
+}
+
 export function ConnectorsSettings() {
   const searchRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState('')
   const [facet, setFacet] = useState<Facet>('all')
   const [manageProviderId, setManageProviderId] = useState<string | null>(null)
+  const [setupProviderId, setSetupProviderId] = useState<string | null>(null)
 
   const {data: catalog, isLoading: catalogLoading} = useQuery({
     queryKey: ['connectorProviders'],
@@ -183,19 +225,38 @@ export function ConnectorsSettings() {
     enabled: api.isAuthenticated(),
     retry: false,
   })
+  // Installations back the generic connectors (e.g. RevenueCat); presence here
+  // marks a provider connected. Degrades to empty so OAuth connectors still work.
+  const {data: installationsData} = useQuery({
+    queryKey: ['connectorInstallations'],
+    queryFn: () => api.getConnectorInstallations(),
+    enabled: api.isAuthenticated(),
+    retry: false,
+  })
 
-  const stateMap = useMemo(
-    () => buildStateMap(connectorState),
-    [connectorState]
-  )
+  const stateMap = useMemo(() => buildStateMap(connectorState), [connectorState])
+  const detailMap = useMemo(() => buildDetailMap(connectorState), [connectorState])
+  const installationMap = useMemo(() => {
+    // listInstallations is newest-first and excludes deleted rows, so the first
+    // installation per provider is the active one to manage.
+    const map = new Map<string, ConnectorInstallationResponse>()
+    for (const installation of installationsData?.installations ?? []) {
+      if (!map.has(installation.providerId)) map.set(installation.providerId, installation)
+    }
+    return map
+  }, [installationsData])
 
   const views = useMemo(
-    () => buildViews(catalog?.providers ?? [], integrations, stateMap),
-    [catalog, integrations, stateMap]
+    () => buildViews(catalog?.providers ?? [], integrations, stateMap, installationMap, detailMap),
+    [catalog, integrations, stateMap, installationMap, detailMap]
   )
   const manage = useMemo(
     () => views.find((v) => v.provider.id === manageProviderId) ?? null,
     [views, manageProviderId]
+  )
+  const setup = useMemo(
+    () => views.find((v) => v.provider.id === setupProviderId) ?? null,
+    [views, setupProviderId]
   )
 
   const filtered = useMemo(() => {
@@ -268,14 +329,24 @@ export function ConnectorsSettings() {
           {connected.length > 0 && (
             <ConnectorGroup title="Connected" count={connected.length}>
               {connected.map((v) => (
-                <ConnectorCard key={v.provider.id} view={v} onManage={() => setManageProviderId(v.provider.id)} />
+                <ConnectorCard
+                  key={v.provider.id}
+                  view={v}
+                  onManage={() => setManageProviderId(v.provider.id)}
+                  onSetup={() => setSetupProviderId(v.provider.id)}
+                />
               ))}
             </ConnectorGroup>
           )}
           {available.length > 0 && (
             <ConnectorGroup title="Available">
               {available.map((v) => (
-                <ConnectorCard key={v.provider.id} view={v} onManage={() => setManageProviderId(v.provider.id)} />
+                <ConnectorCard
+                  key={v.provider.id}
+                  view={v}
+                  onManage={() => setManageProviderId(v.provider.id)}
+                  onSetup={() => setSetupProviderId(v.provider.id)}
+                />
               ))}
             </ConnectorGroup>
           )}
@@ -287,8 +358,19 @@ export function ConnectorsSettings() {
         </>
       )}
 
-      {manage && (
+      {manage && manage.installation ? (
+        <RevenueCatManageDialog
+          provider={manage.provider}
+          installation={manage.installation}
+          detail={manage.detail}
+          onClose={() => setManageProviderId(null)}
+        />
+      ) : manage ? (
         <ManageConnectorDialog view={manage} onClose={() => setManageProviderId(null)} />
+      ) : null}
+
+      {setup && (
+        <ConnectorSetupDialog provider={setup.provider} onClose={() => setSetupProviderId(null)} />
       )}
     </section>
   )
@@ -318,11 +400,21 @@ function ConnectorGroup({
   )
 }
 
-function ConnectorCard({view, onManage}: Readonly<{view: ConnectorView; onManage: () => void}>) {
+function ConnectorCard({
+  view,
+  onManage,
+  onSetup,
+}: Readonly<{view: ConnectorView; onManage: () => void; onSetup: () => void}>) {
   const {toast} = useToast()
-  const {provider, facets, availability, integration, connected, state} = view
-  const enabled = integration?.enabled ?? false
-  const {tone: healthTone, label: healthLabel} = describeHealth(enabled, state?.health)
+  const {provider, facets, availability, integration, installation, detail, connected, state} = view
+
+  const installationBacked = isInstallationBacked(provider)
+  const enabled = installationBacked ? (installation?.enabled ?? true) : (integration?.enabled ?? false)
+  const installState = installationBacked ? effectiveConnectorState(detail, installation) : undefined
+  const footerHealth = installationBacked
+    ? describeConnectorHealth(installState, enabled)
+    : describeHealth(enabled, state?.health)
+  const footerTitle = installationBacked ? (detail?.message ?? undefined) : (state?.detail ?? undefined)
 
   const slackOAuth = useMutation({
     mutationFn: () =>
@@ -335,7 +427,9 @@ function ConnectorCard({view, onManage}: Readonly<{view: ConnectorView; onManage
       toast({title: 'Failed to start connection', description: err.message, variant: 'destructive'}),
   })
 
-  const canConnect = OAUTH_PROVIDERS.has(provider.id) && availability === 'available'
+  const canOAuthConnect = OAUTH_PROVIDERS.has(provider.id) && availability === 'available'
+  const canInstall = installationBacked && availability === 'available'
+  const usedBy = [...new Set(facets.map((f) => FACET_META[f].usedBy))].slice(0, 2).join(', ') || '—'
 
   return (
     <div className={cn('flex flex-col overflow-hidden rounded-lg border bg-card', !connected && availability !== 'available' && 'opacity-70')}>
@@ -344,7 +438,11 @@ function ConnectorCard({view, onManage}: Readonly<{view: ConnectorView; onManage
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">
             <span className="truncate text-sm font-semibold">{provider.name}</span>
-            <StatusBadge connected={connected} enabled={enabled} availability={availability} health={state?.health} />
+            {connected && installationBacked ? (
+              <Badge variant={footerHealth.badge}>{footerHealth.label}</Badge>
+            ) : (
+              <StatusBadge connected={connected} enabled={enabled} availability={availability} health={state?.health} />
+            )}
           </div>
         </div>
       </div>
@@ -373,19 +471,34 @@ function ConnectorCard({view, onManage}: Readonly<{view: ConnectorView; onManage
       {connected && (
         <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 border-t px-3.5 py-2.5 text-xs">
           <dt className="text-muted-foreground">Used by</dt>
-          <dd className="m-0 text-right font-medium">
-            {[...new Set(facets.map((f) => FACET_META[f].usedBy))].slice(0, 2).join(', ') || '—'}
-          </dd>
-          {integration?.channelName && (
+          <dd className="m-0 text-right font-medium">{usedBy}</dd>
+          {installationBacked && installation ? (
             <>
-              <dt className="text-muted-foreground">Channel</dt>
-              <dd className="m-0 text-right font-mono">#{integration.channelName}</dd>
+              <dt className="text-muted-foreground">Project</dt>
+              <dd className="m-0 truncate text-right font-mono">
+                {installation.externalProjectName ?? installation.externalProjectId ?? '—'}
+              </dd>
+              {installation.apiSecretLastFour && (
+                <>
+                  <dt className="text-muted-foreground">API key</dt>
+                  <dd className="m-0 text-right font-mono">•••• {installation.apiSecretLastFour}</dd>
+                </>
+              )}
             </>
-          )}
-          {integration?.teamName && (
+          ) : (
             <>
-              <dt className="text-muted-foreground">Workspace</dt>
-              <dd className="m-0 truncate text-right font-medium">{integration.teamName}</dd>
+              {integration?.channelName && (
+                <>
+                  <dt className="text-muted-foreground">Channel</dt>
+                  <dd className="m-0 text-right font-mono">#{integration.channelName}</dd>
+                </>
+              )}
+              {integration?.teamName && (
+                <>
+                  <dt className="text-muted-foreground">Workspace</dt>
+                  <dd className="m-0 truncate text-right font-medium">{integration.teamName}</dd>
+                </>
+              )}
             </>
           )}
         </dl>
@@ -396,10 +509,10 @@ function ConnectorCard({view, onManage}: Readonly<{view: ConnectorView; onManage
           <>
             <span
               className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
-              title={state?.detail ?? undefined}
+              title={footerTitle}
             >
-              <StatusDot tone={healthTone} size="sm" />
-              {healthLabel}
+              <StatusDot tone={footerHealth.tone} size="sm" />
+              {footerHealth.label}
             </span>
             <Button variant="outline" size="sm" onClick={onManage}>
               Manage
@@ -408,13 +521,18 @@ function ConnectorCard({view, onManage}: Readonly<{view: ConnectorView; onManage
         ) : (
           <>
             <span />
-            {canConnect ? (
+            {canOAuthConnect ? (
               <Button size="sm" onClick={() => slackOAuth.mutate()} disabled={slackOAuth.isPending}>
                 {slackOAuth.isPending ? (
                   <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                 ) : (
                   <Plus className="mr-1.5 h-3.5 w-3.5" />
                 )}
+                Connect
+              </Button>
+            ) : canInstall ? (
+              <Button size="sm" onClick={onSetup}>
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
                 Connect
               </Button>
             ) : (

--- a/dashboard/src/components/settings/ConnectorsSettings.tsx
+++ b/dashboard/src/components/settings/ConnectorsSettings.tsx
@@ -358,16 +358,7 @@ export function ConnectorsSettings() {
         </>
       )}
 
-      {manage && manage.installation ? (
-        <RevenueCatManageDialog
-          provider={manage.provider}
-          installation={manage.installation}
-          detail={manage.detail}
-          onClose={() => setManageProviderId(null)}
-        />
-      ) : manage ? (
-        <ManageConnectorDialog view={manage} onClose={() => setManageProviderId(null)} />
-      ) : null}
+      <ConnectorManageDialogSwitch view={manage} onClose={() => setManageProviderId(null)} />
 
       {setup && (
         <ConnectorSetupDialog provider={setup.provider} onClose={() => setSetupProviderId(null)} />
@@ -398,6 +389,24 @@ function ConnectorGroup({
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">{children}</div>
     </div>
   )
+}
+
+function ConnectorManageDialogSwitch({
+  view,
+  onClose,
+}: Readonly<{view?: ConnectorView | null; onClose: () => void}>) {
+  if (!view) return null
+  if (view.installation) {
+    return (
+      <RevenueCatManageDialog
+        provider={view.provider}
+        installation={view.installation}
+        detail={view.detail}
+        onClose={onClose}
+      />
+    )
+  }
+  return <ManageConnectorDialog view={view} onClose={onClose} />
 }
 
 function ConnectorCard({
@@ -433,19 +442,15 @@ function ConnectorCard({
 
   return (
     <div className={cn('flex flex-col overflow-hidden rounded-lg border bg-card', !connected && availability !== 'available' && 'opacity-70')}>
-      <div className="flex items-start gap-3 p-3.5 pb-0">
-        <ConnectorLogo providerId={provider.id} />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-2">
-            <span className="truncate text-sm font-semibold">{provider.name}</span>
-            {connected && installationBacked ? (
-              <Badge variant={footerHealth.badge}>{footerHealth.label}</Badge>
-            ) : (
-              <StatusBadge connected={connected} enabled={enabled} availability={availability} health={state?.health} />
-            )}
-          </div>
-        </div>
-      </div>
+      <ConnectorCardHeader
+        provider={provider}
+        connected={connected}
+        installationBacked={installationBacked}
+        enabled={enabled}
+        availability={availability}
+        state={state}
+        footerHealth={footerHealth}
+      />
 
       {!connected && (
         <p className="px-3.5 pt-2 text-xs leading-relaxed text-muted-foreground">
@@ -468,82 +473,239 @@ function ConnectorCard({
         })}
       </div>
 
-      {connected && (
-        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 border-t px-3.5 py-2.5 text-xs">
-          <dt className="text-muted-foreground">Used by</dt>
-          <dd className="m-0 text-right font-medium">{usedBy}</dd>
-          {installationBacked && installation ? (
-            <>
-              <dt className="text-muted-foreground">Project</dt>
-              <dd className="m-0 truncate text-right font-mono">
-                {installation.externalProjectName ?? installation.externalProjectId ?? '—'}
-              </dd>
-              {installation.apiSecretLastFour && (
-                <>
-                  <dt className="text-muted-foreground">API key</dt>
-                  <dd className="m-0 text-right font-mono">•••• {installation.apiSecretLastFour}</dd>
-                </>
-              )}
-            </>
-          ) : (
-            <>
-              {integration?.channelName && (
-                <>
-                  <dt className="text-muted-foreground">Channel</dt>
-                  <dd className="m-0 text-right font-mono">#{integration.channelName}</dd>
-                </>
-              )}
-              {integration?.teamName && (
-                <>
-                  <dt className="text-muted-foreground">Workspace</dt>
-                  <dd className="m-0 truncate text-right font-medium">{integration.teamName}</dd>
-                </>
-              )}
-            </>
-          )}
-        </dl>
-      )}
+      <ConnectorCardDetails
+        connected={connected}
+        usedBy={usedBy}
+        installation={installationBacked ? installation : undefined}
+        integration={integration}
+      />
 
       <div className="mt-auto flex items-center justify-between gap-2 border-t px-3.5 py-2.5">
-        {connected ? (
-          <>
-            <span
-              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
-              title={footerTitle}
-            >
-              <StatusDot tone={footerHealth.tone} size="sm" />
-              {footerHealth.label}
-            </span>
-            <Button variant="outline" size="sm" onClick={onManage}>
-              Manage
-            </Button>
-          </>
-        ) : (
-          <>
-            <span />
-            {canOAuthConnect ? (
-              <Button size="sm" onClick={() => slackOAuth.mutate()} disabled={slackOAuth.isPending}>
-                {slackOAuth.isPending ? (
-                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Plus className="mr-1.5 h-3.5 w-3.5" />
-                )}
-                Connect
-              </Button>
-            ) : canInstall ? (
-              <Button size="sm" onClick={onSetup}>
-                <Plus className="mr-1.5 h-3.5 w-3.5" />
-                Connect
-              </Button>
-            ) : (
-              <Button size="sm" variant="outline" disabled title={availability === 'enterprise' ? 'Enterprise plan' : 'Coming soon'}>
-                {availability === 'enterprise' ? 'Enterprise' : 'Coming soon'}
-              </Button>
-            )}
-          </>
-        )}
+        <ConnectorCardFooter
+          connected={connected}
+          footerTitle={footerTitle}
+          footerHealth={footerHealth}
+          canOAuthConnect={canOAuthConnect}
+          canInstall={canInstall}
+          oauthPending={slackOAuth.isPending}
+          availability={availability}
+          onManage={onManage}
+          onOAuthConnect={() => slackOAuth.mutate()}
+          onSetup={onSetup}
+        />
       </div>
     </div>
+  )
+}
+
+function ConnectorCardHeader({
+  provider,
+  connected,
+  installationBacked,
+  enabled,
+  availability,
+  state,
+  footerHealth,
+}: {
+  readonly provider: ConnectorProviderDefinition
+  readonly connected: boolean
+  readonly installationBacked: boolean
+  readonly enabled: boolean
+  readonly availability: ConnectorAvailability
+  readonly state?: ConnectorConnectionState
+  readonly footerHealth: HealthDescriptor
+}) {
+  return (
+    <div className="flex items-start gap-3 p-3.5 pb-0">
+      <ConnectorLogo providerId={provider.id} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="truncate text-sm font-semibold">{provider.name}</span>
+          <ConnectorCardStatus
+            connected={connected}
+            installationBacked={installationBacked}
+            enabled={enabled}
+            availability={availability}
+            health={state?.health}
+            footerHealth={footerHealth}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ConnectorCardStatus({
+  connected,
+  installationBacked,
+  enabled,
+  availability,
+  health,
+  footerHealth,
+}: {
+  readonly connected: boolean
+  readonly installationBacked: boolean
+  readonly enabled: boolean
+  readonly availability: ConnectorAvailability
+  readonly health?: ConnectorHealth | null
+  readonly footerHealth: HealthDescriptor
+}) {
+  if (connected && installationBacked) {
+    return <Badge variant={footerHealth.badge}>{footerHealth.label}</Badge>
+  }
+  return <StatusBadge connected={connected} enabled={enabled} availability={availability} health={health} />
+}
+
+function ConnectorCardDetails({
+  connected,
+  usedBy,
+  installation,
+  integration,
+}: {
+  readonly connected: boolean
+  readonly usedBy: string
+  readonly installation?: ConnectorInstallationResponse
+  readonly integration?: OrganizationIntegration
+}) {
+  if (!connected) return null
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 border-t px-3.5 py-2.5 text-xs">
+      <dt className="text-muted-foreground">Used by</dt>
+      <dd className="m-0 text-right font-medium">{usedBy}</dd>
+      <ConnectorCardConnectionFields installation={installation} integration={integration} />
+    </dl>
+  )
+}
+
+function ConnectorCardConnectionFields({
+  installation,
+  integration,
+}: {
+  readonly installation?: ConnectorInstallationResponse
+  readonly integration?: OrganizationIntegration
+}) {
+  if (installation) {
+    return (
+      <>
+        <dt className="text-muted-foreground">Project</dt>
+        <dd className="m-0 truncate text-right font-mono">
+          {installation.externalProjectName ?? installation.externalProjectId ?? '—'}
+        </dd>
+        {installation.apiSecretLastFour && (
+          <>
+            <dt className="text-muted-foreground">API key</dt>
+            <dd className="m-0 text-right font-mono">•••• {installation.apiSecretLastFour}</dd>
+          </>
+        )}
+      </>
+    )
+  }
+  return (
+    <>
+      {integration?.channelName && (
+        <>
+          <dt className="text-muted-foreground">Channel</dt>
+          <dd className="m-0 text-right font-mono">#{integration.channelName}</dd>
+        </>
+      )}
+      {integration?.teamName && (
+        <>
+          <dt className="text-muted-foreground">Workspace</dt>
+          <dd className="m-0 truncate text-right font-medium">{integration.teamName}</dd>
+        </>
+      )}
+    </>
+  )
+}
+
+function ConnectorCardFooter({
+  connected,
+  footerTitle,
+  footerHealth,
+  canOAuthConnect,
+  canInstall,
+  oauthPending,
+  availability,
+  onManage,
+  onOAuthConnect,
+  onSetup,
+}: {
+  readonly connected: boolean
+  readonly footerTitle?: string
+  readonly footerHealth: HealthDescriptor
+  readonly canOAuthConnect: boolean
+  readonly canInstall: boolean
+  readonly oauthPending: boolean
+  readonly availability: ConnectorAvailability
+  readonly onManage: () => void
+  readonly onOAuthConnect: () => void
+  readonly onSetup: () => void
+}) {
+  if (connected) {
+    return (
+      <>
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground" title={footerTitle}>
+          <StatusDot tone={footerHealth.tone} size="sm" />
+          {footerHealth.label}
+        </span>
+        <Button variant="outline" size="sm" onClick={onManage}>
+          Manage
+        </Button>
+      </>
+    )
+  }
+
+  if (canOAuthConnect) {
+    return (
+      <>
+        <span />
+        <Button size="sm" onClick={onOAuthConnect} disabled={oauthPending}>
+          <ConnectorConnectButtonIcon pending={oauthPending} />
+          Connect
+        </Button>
+      </>
+    )
+  }
+
+  if (canInstall) {
+    return (
+      <>
+        <span />
+        <Button size="sm" onClick={onSetup}>
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          Connect
+        </Button>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <span />
+      <UnavailableConnectorButton availability={availability} />
+    </>
+  )
+}
+
+function ConnectorConnectButtonIcon({pending}: Readonly<{pending: boolean}>) {
+  if (pending) return <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+  return <Plus className="mr-1.5 h-3.5 w-3.5" />
+}
+
+function UnavailableConnectorButton({
+  availability,
+}: Readonly<{availability: ConnectorAvailability}>) {
+  if (availability === 'enterprise') {
+    return (
+      <Button size="sm" variant="outline" disabled title="Enterprise plan">
+        Enterprise
+      </Button>
+    )
+  }
+  return (
+    <Button size="sm" variant="outline" disabled title="Coming soon">
+      Coming soon
+    </Button>
   )
 }
 

--- a/dashboard/src/components/settings/__tests__/ConnectorsSettings.test.tsx
+++ b/dashboard/src/components/settings/__tests__/ConnectorsSettings.test.tsx
@@ -15,18 +15,36 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
-import {render, screen, waitFor} from '@testing-library/react'
+import {render, screen, waitFor, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {ConnectorsSettings} from '../ConnectorsSettings'
-import type {ConnectorProviderDefinition, OrganizationIntegration} from '@/lib/api/types'
+import type {
+  ConnectorInstallationResponse,
+  ConnectorProviderDefinition,
+  ConnectorProviderStateDetail,
+  OrganizationIntegration,
+} from '@/lib/api/types'
 
 const apiMock = vi.hoisted(() => ({
   isAuthenticated: vi.fn(() => true),
   getConnectorProviders: vi.fn(),
   getIntegrations: vi.fn(),
   getConnectorState: vi.fn(),
+  getConnectorInstallations: vi.fn(),
+  getConnectorInstallation: vi.fn(),
+  createConnectorInstallation: vi.fn(),
+  deleteConnectorInstallation: vi.fn(),
+  testConnectorInstallation: vi.fn(),
+  rotateConnectorApiCredential: vi.fn(),
+  rotateConnectorWebhookToken: vi.fn(),
+  getConnectorExternalResources: vi.fn(),
+  refreshConnectorExternalResources: vi.fn(),
+  getConnectorBindings: vi.fn(),
+  updateConnectorBindings: vi.fn(),
+  getConnectorWebhookSetup: vi.fn(),
+  getProjects: vi.fn(),
   getSlackChannels: vi.fn(),
   getDiscordChannels: vi.fn(),
   startSlackOAuth: vi.fn(),
@@ -75,6 +93,116 @@ function provider(
   }
 }
 
+// RevenueCat ships as an installation-backed data-import connector (stateSource
+// connector_installations), unlike the OAuth notification providers above.
+function revenueCatProvider(
+  availability: 'available' | 'planned' | 'enterprise' = 'available'
+): ConnectorProviderDefinition {
+  return {
+    id: 'revenuecat',
+    name: 'RevenueCat',
+    description: 'Connect RevenueCat for subscription lifecycle and revenue data.',
+    authProfiles: [
+      {
+        id: 'project_api_key',
+        name: 'Project API key',
+        authKind: 'api_key',
+        subjectKinds: ['service_account'],
+        tokenLifecycle: 'rotatable',
+        defaultScopes: ['projects.read'],
+        separateReconsentRequired: false,
+        secretPurpose: 'data_import',
+      },
+    ],
+    uses: [
+      {
+        id: 'subscription_import',
+        name: 'Subscription import',
+        family: 'data_import',
+        availability,
+        setupMode: 'api_key',
+        capabilities: ['subscription_lifecycle_import'],
+        stateSource: 'connector_installations',
+        secretPurpose: 'data_import',
+        statusRoute: '/v1/connectors/state',
+        description: 'Import subscription lifecycle and revenue events.',
+        direction: 'read',
+        allowedAuthProfileIds: ['project_api_key'],
+        resourceTypes: ['revenuecat_app'],
+        uiGroup: 'import_data',
+      },
+    ],
+  }
+}
+
+const rcInstallation: ConnectorInstallationResponse = {
+  id: 'inst-1',
+  providerId: 'revenuecat',
+  name: 'Prod RevenueCat',
+  credentialType: 'api_key',
+  authProfileId: 'project_api_key',
+  externalProjectId: 'proj_abc',
+  externalProjectName: 'Acme',
+  status: 'healthy',
+  statusReason: null,
+  enabled: true,
+  apiSecretLastFour: '1234',
+  webhookTokenPrefix: 'whpref123456',
+  webhookToken: null,
+  lastTestedAt: '2026-06-15T10:00:00Z',
+  lastTestResult: 'success',
+  lastSuccessfulProviderCallAt: '2026-06-15T10:00:00Z',
+  lastError: null,
+  createdAt: '2026-06-15T09:00:00Z',
+  updatedAt: '2026-06-15T10:00:00Z',
+}
+
+const rcDetail: ConnectorProviderStateDetail = {
+  installationId: 'inst-1',
+  status: 'awaiting_traffic',
+  health: 'healthy',
+  message: 'Connected, awaiting RevenueCat webhook traffic',
+  mappedResources: 2,
+  unmappedEvents: 0,
+  failedReceipts: 0,
+  sandboxEvents: 0,
+  productionEvents: 0,
+  lastAcceptedWebhookAt: null,
+  lastAppliedAt: null,
+  processingLagSeconds: null,
+}
+
+// Connects RevenueCat: installation present + connected provider state with detail,
+// and no OAuth integrations so RevenueCat is the only "Manage"-able connector.
+function connectRevenueCat() {
+  apiMock.getIntegrations.mockResolvedValue([])
+  apiMock.getConnectorInstallations.mockResolvedValue({installations: [rcInstallation]})
+  apiMock.getConnectorInstallation.mockResolvedValue(rcInstallation)
+  apiMock.getConnectorState.mockResolvedValue({
+    connections: [
+      {providerId: 'revenuecat', connected: true, health: 'healthy', detail: rcDetail.message},
+    ],
+    providers: [
+      {
+        providerId: 'revenuecat',
+        uses: [
+          {
+            useId: 'subscription_import',
+            availability: 'available',
+            stateSource: 'connector_installations',
+            state: 'connected',
+            connected: true,
+            enabled: true,
+            integrationId: 'inst-1',
+            message: rcDetail.message,
+            detail: rcDetail,
+          },
+        ],
+      },
+    ],
+  })
+}
+
 function renderWithClient(ui: React.ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: {queries: {retry: false}, mutations: {retry: false}},
@@ -83,6 +211,14 @@ function renderWithClient(ui: React.ReactElement) {
 }
 
 describe('ConnectorsSettings', () => {
+  beforeAll(() => {
+    // Radix Select/Tabs use pointer-capture + scrollIntoView, absent in jsdom.
+    if (!HTMLElement.prototype.hasPointerCapture) HTMLElement.prototype.hasPointerCapture = () => false
+    if (!HTMLElement.prototype.setPointerCapture) HTMLElement.prototype.setPointerCapture = () => {}
+    if (!HTMLElement.prototype.releasePointerCapture) HTMLElement.prototype.releasePointerCapture = () => {}
+    if (!HTMLElement.prototype.scrollIntoView) HTMLElement.prototype.scrollIntoView = () => {}
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     apiMock.getConnectorProviders.mockResolvedValue({
@@ -90,6 +226,7 @@ describe('ConnectorsSettings', () => {
         provider('slack', 'Slack', 'available'),
         provider('github', 'GitHub', 'planned', 'dashboard_query'),
         provider('pagerduty', 'PagerDuty', 'enterprise'),
+        revenueCatProvider('available'),
       ],
     })
     apiMock.getIntegrations.mockResolvedValue([
@@ -124,6 +261,25 @@ describe('ConnectorsSettings', () => {
       ],
     })
     apiMock.getSlackChannels.mockResolvedValue({channels: [{id: 'C123', name: 'alerts'}]})
+    // Installation-backed defaults: nothing connected, no apps/bindings/projects.
+    apiMock.getConnectorInstallations.mockResolvedValue({installations: []})
+    apiMock.getConnectorInstallation.mockResolvedValue(rcInstallation)
+    apiMock.getConnectorExternalResources.mockResolvedValue({resources: []})
+    apiMock.getConnectorBindings.mockResolvedValue({bindings: []})
+    apiMock.getProjects.mockResolvedValue([])
+    apiMock.getConnectorWebhookSetup.mockResolvedValue({
+      installationId: 'inst-1',
+      providerId: 'revenuecat',
+      webhookUrl: 'https://moneat.test/api/connectors/revenuecat/inst-1/webhook',
+      authorizationHeaderName: 'Authorization',
+      authorizationHeaderValue: null,
+      authorizationHeaderPrefix: 'whpref123456',
+      recommendedEventTypes: ['INITIAL_PURCHASE', 'RENEWAL'],
+      recommendedEnvironment: 'production_and_sandbox',
+      setupMode: 'manual',
+      observedIntegrations: [],
+      warnings: [],
+    })
   })
 
   it('groups connected and unavailable providers with clear state labels', async () => {
@@ -149,4 +305,157 @@ describe('ConnectorsSettings', () => {
     expect(screen.getByText(/Connected to Observability/)).toBeInTheDocument()
     await waitFor(() => expect(apiMock.getSlackChannels).toHaveBeenCalled())
   })
+
+  it('shows RevenueCat as an available data-import connector with a connect action', async () => {
+    renderWithClient(<ConnectorsSettings />)
+
+    expect(await screen.findByText('RevenueCat')).toBeInTheDocument()
+    // Only RevenueCat exposes a Connect action here (Slack is connected, GitHub is
+    // planned, PagerDuty is enterprise), and it is not gated behind Coming soon.
+    const connect = screen.getByRole('button', {name: 'Connect'})
+    expect(connect).toBeEnabled()
+    expect(screen.getAllByText('Data import').length).toBeGreaterThan(0)
+  })
+
+  it('submits the generic create payload and reveals the one-time webhook token', async () => {
+    const user = userEvent.setup()
+    apiMock.createConnectorInstallation.mockResolvedValue({
+      ...rcInstallation,
+      webhookToken: 'test-webhook-token',
+    })
+    renderWithClient(<ConnectorsSettings />)
+
+    await user.click(await screen.findByRole('button', {name: 'Connect'}))
+
+    const dialog = await screen.findByRole('dialog')
+    await user.type(within(dialog).getByLabelText('Connection name'), 'Prod RevenueCat')
+    await user.type(within(dialog).getByLabelText('RevenueCat project ID'), 'proj_abc')
+    await user.type(within(dialog).getByLabelText('RevenueCat V2 secret API key'), 'sk_secret_value')
+    await user.click(within(dialog).getByRole('button', {name: 'Connect'}))
+
+    await waitFor(() =>
+      expect(apiMock.createConnectorInstallation).toHaveBeenCalledWith({
+        providerId: 'revenuecat',
+        authProfileId: 'project_api_key',
+        name: 'Prod RevenueCat',
+        externalAccount: {projectId: 'proj_abc'},
+        secret: 'sk_secret_value',
+      })
+    )
+
+    // Wizard advances to the Webhook step: URL + one-time token revealed, with the
+    // token shown as a ready-to-paste Authorization value (and flagged one-time).
+    expect(
+      await screen.findByDisplayValue('https://moneat.test/api/connectors/revenuecat/inst-1/webhook')
+    ).toBeInTheDocument()
+    expect(screen.getByText(/shown only once/i)).toBeInTheDocument()
+    expect(screen.getAllByDisplayValue('Bearer test-webhook-token').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('sends full replacement bindings when app mapping changes', async () => {
+    const user = userEvent.setup()
+    connectRevenueCat()
+    apiMock.getConnectorExternalResources.mockResolvedValue({
+      resources: [
+        {
+          id: 'res-a',
+          installationId: 'inst-1',
+          externalProjectId: 'proj_abc',
+          externalResourceType: 'revenuecat_app',
+          externalResourceId: 'appA',
+          displayName: 'App A',
+          lastSeenAt: '2026-06-15T10:00:00Z',
+        },
+        {
+          id: 'res-b',
+          installationId: 'inst-1',
+          externalProjectId: 'proj_abc',
+          externalResourceType: 'revenuecat_app',
+          externalResourceId: 'appB',
+          displayName: 'App B',
+          lastSeenAt: '2026-06-15T10:00:00Z',
+        },
+      ],
+    })
+    apiMock.getConnectorBindings.mockResolvedValue({
+      bindings: [
+        bindingFor('appA', 'proj1'),
+        bindingFor('appB', 'proj2'),
+      ],
+    })
+    apiMock.getProjects.mockResolvedValue([
+      {id: 'proj1', name: 'Web', slug: 'web', keys: [], dsn: 'dsn1'},
+      {id: 'proj2', name: 'iOS', slug: 'ios', keys: [], dsn: 'dsn2'},
+    ])
+    apiMock.updateConnectorBindings.mockResolvedValue({bindings: []})
+
+    renderWithClient(<ConnectorsSettings />)
+
+    await user.click(await screen.findByRole('button', {name: 'Manage'}))
+    await user.click(await screen.findByRole('tab', {name: 'App mapping'}))
+
+    // Unmap App A, leave App B mapped, then save.
+    await user.click(await screen.findByRole('button', {name: 'Unmap App A'}))
+    await user.click(screen.getByRole('button', {name: 'Save mapping'}))
+
+    // Replacement semantics: the full desired list is sent (App B kept), and the
+    // unmapped App A is omitted rather than patched.
+    await waitFor(() =>
+      expect(apiMock.updateConnectorBindings).toHaveBeenCalledWith('inst-1', {
+        bindings: [
+          {
+            externalResourceType: 'revenuecat_app',
+            externalResourceId: 'appB',
+            localResourceType: 'project',
+            localResourceId: 'proj2',
+          },
+        ],
+      })
+    )
+  })
+
+  it('shows copyable webhook setup and reveals a rotated one-time token', async () => {
+    const user = userEvent.setup()
+    connectRevenueCat()
+    apiMock.rotateConnectorWebhookToken.mockResolvedValue({
+      ...rcInstallation,
+      webhookToken: 'new-one-time-token',
+    })
+
+    renderWithClient(<ConnectorsSettings />)
+
+    await user.click(await screen.findByRole('button', {name: 'Manage'}))
+    await user.click(await screen.findByRole('tab', {name: 'Webhook'}))
+
+    expect(
+      await screen.findByDisplayValue('https://moneat.test/api/connectors/revenuecat/inst-1/webhook')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Copy Webhook URL'})).toBeInTheDocument()
+    // Only a token prefix is stored, so the user is told to rotate to reveal one.
+    expect(screen.getByText(/Only the token prefix is stored/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', {name: 'Rotate token'}))
+    await user.click(screen.getByRole('button', {name: 'Rotate & reveal'}))
+
+    // The rotated token surfaces (header field + one-time reveal panel) exactly once.
+    const revealed = await screen.findAllByDisplayValue('Bearer new-one-time-token')
+    expect(revealed.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText(/shown only once/i)).toBeInTheDocument()
+  })
 })
+
+function bindingFor(externalResourceId: string, localResourceId: string) {
+  return {
+    id: `binding-${externalResourceId}`,
+    installationId: 'inst-1',
+    externalProjectId: 'proj_abc',
+    externalResourceType: 'revenuecat_app',
+    externalResourceId,
+    localResourceType: 'project',
+    localResourceId,
+    status: 'active',
+    bindingVersion: 1,
+    effectiveFrom: '2026-06-15T10:00:00Z',
+    effectiveTo: null,
+  }
+}

--- a/dashboard/src/components/settings/__tests__/ConnectorsSettings.test.tsx
+++ b/dashboard/src/components/settings/__tests__/ConnectorsSettings.test.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
-import {render, screen, waitFor, within} from '@testing-library/react'
+import {fireEvent, render, screen, waitFor, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -317,6 +317,23 @@ describe('ConnectorsSettings', () => {
     expect(screen.getAllByText('Data import').length).toBeGreaterThan(0)
   })
 
+  it('focuses and filters the connector catalog', async () => {
+    const user = userEvent.setup()
+
+    renderWithClient(<ConnectorsSettings />)
+
+    await screen.findByRole('button', {name: 'Add connector'})
+
+    await user.click(screen.getByRole('button', {name: 'Dashboard data'}))
+    expect(screen.getByText('GitHub')).toBeInTheDocument()
+    expect(screen.queryByText('Slack')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Search connectors…'), {
+      target: {value: 'missing-provider'},
+    })
+    expect(screen.getByText('No connectors match your filters.')).toBeInTheDocument()
+  })
+
   it('submits the generic create payload and reveals the one-time webhook token', async () => {
     const user = userEvent.setup()
     apiMock.createConnectorInstallation.mockResolvedValue({
@@ -394,7 +411,11 @@ describe('ConnectorsSettings', () => {
     await user.click(await screen.findByRole('button', {name: 'Manage'}))
     await user.click(await screen.findByRole('tab', {name: 'App mapping'}))
 
-    // Unmap App A, leave App B mapped, then save.
+    // Unmap App A, confirm the reset control restores the server mapping, then
+    // unmap again and save.
+    await user.click(await screen.findByRole('button', {name: 'Unmap App A'}))
+    await user.click(screen.getByRole('button', {name: 'Reset'}))
+    expect(screen.getByRole('button', {name: 'Save mapping'})).toBeDisabled()
     await user.click(await screen.findByRole('button', {name: 'Unmap App A'}))
     await user.click(screen.getByRole('button', {name: 'Save mapping'}))
 
@@ -414,6 +435,93 @@ describe('ConnectorsSettings', () => {
     )
   })
 
+  it('refreshes an empty RevenueCat app mapping state', async () => {
+    const user = userEvent.setup()
+    connectRevenueCat()
+    apiMock.refreshConnectorExternalResources
+      .mockRejectedValueOnce(new Error('RevenueCat unavailable'))
+      .mockResolvedValueOnce({resources: []})
+
+    renderWithClient(<ConnectorsSettings />)
+
+    await user.click(await screen.findByRole('button', {name: 'Manage'}))
+    await user.click(await screen.findByRole('tab', {name: 'App mapping'}))
+
+    expect(await screen.findByText('No RevenueCat apps yet')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', {name: 'Refresh apps'}))
+
+    await waitFor(() => expect(apiMock.refreshConnectorExternalResources).toHaveBeenCalledWith('inst-1'))
+    await user.click(screen.getByRole('button', {name: 'Refresh apps'}))
+    await waitFor(() => expect(apiMock.refreshConnectorExternalResources).toHaveBeenCalledTimes(2))
+  })
+
+  it('keeps the mapping dialog open when saving bindings fails', async () => {
+    const user = userEvent.setup()
+    connectRevenueCat()
+    apiMock.getConnectorExternalResources.mockResolvedValue({
+      resources: [
+        {
+          id: 'res-a',
+          installationId: 'inst-1',
+          externalProjectId: 'proj_abc',
+          externalResourceType: 'revenuecat_app',
+          externalResourceId: 'appA',
+          displayName: 'App A',
+          lastSeenAt: '2026-06-15T10:00:00Z',
+        },
+      ],
+    })
+    apiMock.getConnectorBindings.mockResolvedValue({
+      bindings: [bindingFor('appA', 'proj1')],
+    })
+    apiMock.getProjects.mockResolvedValue([
+      {id: 'proj1', name: 'Web', slug: 'web', keys: [], dsn: 'dsn1'},
+    ])
+    apiMock.updateConnectorBindings.mockRejectedValue(new Error('save failed'))
+
+    renderWithClient(<ConnectorsSettings />)
+
+    await user.click(await screen.findByRole('button', {name: 'Manage'}))
+    await user.click(await screen.findByRole('tab', {name: 'App mapping'}))
+    await user.click(await screen.findByRole('button', {name: 'Unmap App A'}))
+    await user.click(screen.getByRole('button', {name: 'Save mapping'}))
+
+    await waitFor(() => expect(apiMock.updateConnectorBindings).toHaveBeenCalled())
+    expect(screen.getByRole('button', {name: 'Save mapping'})).toBeInTheDocument()
+  })
+
+  it('shows an unmapped RevenueCat app row without enabling save', async () => {
+    const user = userEvent.setup()
+    connectRevenueCat()
+    apiMock.getConnectorExternalResources.mockResolvedValue({
+      resources: [
+        {
+          id: 'res-c',
+          installationId: 'inst-1',
+          externalProjectId: 'proj_abc',
+          externalResourceType: 'revenuecat_app',
+          externalResourceId: 'appC',
+          displayName: null,
+          lastSeenAt: '2026-06-15T10:00:00Z',
+        },
+      ],
+    })
+    apiMock.getProjects.mockResolvedValue([
+      {id: 'proj1', name: 'Web', slug: 'web', keys: [], dsn: 'dsn1'},
+    ])
+    apiMock.updateConnectorBindings.mockResolvedValue({bindings: []})
+
+    renderWithClient(<ConnectorsSettings />)
+
+    await user.click(await screen.findByRole('button', {name: 'Manage'}))
+    await user.click(await screen.findByRole('tab', {name: 'App mapping'}))
+
+    expect(await screen.findAllByText('appC')).toHaveLength(2)
+    expect(screen.getByLabelText('Moneat project for appC')).toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: 'Unmap appC'})).not.toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Save mapping'})).toBeDisabled()
+  })
+
   it('shows copyable webhook setup and reveals a rotated one-time token', async () => {
     const user = userEvent.setup()
     connectRevenueCat()
@@ -431,6 +539,7 @@ describe('ConnectorsSettings', () => {
       await screen.findByDisplayValue('https://moneat.test/api/connectors/revenuecat/inst-1/webhook')
     ).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Copy Webhook URL'})).toBeInTheDocument()
+    await user.click(screen.getByRole('button', {name: 'Copy Webhook URL'}))
     // Only a token prefix is stored, so the user is told to rotate to reveal one.
     expect(screen.getByText(/Only the token prefix is stored/i)).toBeInTheDocument()
 

--- a/dashboard/src/components/settings/__tests__/ConnectorsSettings.test.tsx
+++ b/dashboard/src/components/settings/__tests__/ConnectorsSettings.test.tsx
@@ -524,6 +524,11 @@ describe('ConnectorsSettings', () => {
 
   it('shows copyable webhook setup and reveals a rotated one-time token', async () => {
     const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: {writeText},
+    })
     connectRevenueCat()
     apiMock.rotateConnectorWebhookToken.mockResolvedValue({
       ...rcInstallation,
@@ -540,6 +545,13 @@ describe('ConnectorsSettings', () => {
     ).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Copy Webhook URL'})).toBeInTheDocument()
     await user.click(screen.getByRole('button', {name: 'Copy Webhook URL'}))
+    expect(writeText).toHaveBeenCalledWith(
+      'https://moneat.test/api/connectors/revenuecat/inst-1/webhook'
+    )
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    await user.click(screen.getByRole('button', {name: 'Copy event types'}))
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(2))
+    expect(writeText).toHaveBeenLastCalledWith('INITIAL_PURCHASE\nRENEWAL')
     // Only a token prefix is stored, so the user is told to rotate to reveal one.
     expect(screen.getByText(/Only the token prefix is stored/i)).toBeInTheDocument()
 

--- a/dashboard/src/components/settings/__tests__/connectorHealth.test.ts
+++ b/dashboard/src/components/settings/__tests__/connectorHealth.test.ts
@@ -1,0 +1,156 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+
+import type {
+  ConnectorInstallationResponse,
+  ConnectorProviderDefinition,
+  ConnectorProviderStateDetail,
+} from '@/lib/api/types'
+import {
+  describeConnectorHealth,
+  effectiveConnectorState,
+  formatProcessingLag,
+  installAuthProfileId,
+  isInstallationBacked,
+} from '../connectorHealth'
+
+const provider: ConnectorProviderDefinition = {
+  id: 'revenuecat',
+  name: 'RevenueCat',
+  description: 'RevenueCat connector',
+  authProfiles: [
+    {
+      id: 'fallback_key',
+      name: 'Fallback key',
+      authKind: 'api_key',
+      subjectKinds: ['service_account'],
+      tokenLifecycle: 'rotatable',
+      defaultScopes: [],
+      separateReconsentRequired: false,
+      secretPurpose: 'data_import',
+    },
+  ],
+  uses: [
+    {
+      id: 'subscription_import',
+      name: 'Subscription import',
+      family: 'data_import',
+      availability: 'available',
+      setupMode: 'api_key',
+      capabilities: [],
+      stateSource: 'connector_installations',
+      secretPurpose: 'data_import',
+      description: 'Import subscriptions',
+      direction: 'read',
+      allowedAuthProfileIds: ['project_api_key'],
+      uiGroup: 'import_data',
+    },
+  ],
+}
+
+const installation: ConnectorInstallationResponse = {
+  id: 'inst-1',
+  providerId: 'revenuecat',
+  name: 'RevenueCat',
+  credentialType: 'api_key',
+  authProfileId: 'project_api_key',
+  externalProjectId: 'proj_abc',
+  externalProjectName: 'Project',
+  status: 'healthy',
+  statusReason: null,
+  enabled: true,
+  apiSecretLastFour: '1234',
+  webhookTokenPrefix: 'mrc_123',
+  webhookToken: null,
+  lastTestedAt: null,
+  lastTestResult: null,
+  lastSuccessfulProviderCallAt: null,
+  lastError: null,
+  createdAt: '2026-06-16T00:00:00Z',
+  updatedAt: '2026-06-16T00:00:00Z',
+}
+
+describe('connectorHealth', () => {
+  it('detects installation-backed providers and auth profiles from use metadata', () => {
+    expect(isInstallationBacked(provider)).toBe(true)
+    expect(installAuthProfileId(provider)).toBe('project_api_key')
+
+    const legacyProvider = {
+      ...provider,
+      uses: provider.uses.map((use) => ({
+        ...use,
+        stateSource: 'organization_integrations',
+        allowedAuthProfileIds: [],
+      })),
+    }
+
+    expect(isInstallationBacked(legacyProvider)).toBe(false)
+    expect(installAuthProfileId(legacyProvider)).toBe('fallback_key')
+  })
+
+  it('maps connector health states to UI descriptors', () => {
+    expect(describeConnectorHealth('healthy')).toMatchObject({tone: 'success', badge: 'success'})
+    expect(describeConnectorHealth('degraded')).toMatchObject({tone: 'warning', badge: 'warning'})
+    expect(describeConnectorHealth('error')).toMatchObject({tone: 'danger', badge: 'danger'})
+    expect(describeConnectorHealth('needs_mapping')).toMatchObject({
+      tone: 'warning',
+      label: 'Needs mapping',
+    })
+    expect(describeConnectorHealth('awaiting_traffic')).toMatchObject({
+      tone: 'info',
+      label: 'Awaiting traffic',
+    })
+    expect(describeConnectorHealth('unknown')).toMatchObject({tone: 'neutral', badge: 'neutral'})
+    expect(describeConnectorHealth('healthy', false)).toMatchObject({
+      tone: 'neutral',
+      label: 'Disabled',
+    })
+  })
+
+  it('prefers awaiting traffic status over healthy detail and falls back to installation status', () => {
+    const detail: ConnectorProviderStateDetail = {
+      installationId: 'inst-1',
+      status: 'awaiting_traffic',
+      health: 'healthy',
+      message: null,
+      mappedResources: 0,
+      unmappedEvents: 0,
+      failedReceipts: 0,
+      sandboxEvents: 0,
+      productionEvents: 0,
+      lastAcceptedWebhookAt: null,
+      lastAppliedAt: null,
+      processingLagSeconds: null,
+    }
+
+    expect(effectiveConnectorState(detail, installation)).toBe('awaiting_traffic')
+    expect(effectiveConnectorState({...detail, status: 'active', health: 'needs_mapping'}, installation)).toBe(
+      'needs_mapping'
+    )
+    expect(effectiveConnectorState(null, {...installation, status: 'degraded'})).toBe('degraded')
+  })
+
+  it('formats processing lag compactly', () => {
+    expect(formatProcessingLag(null)).toBe('Up to date')
+    expect(formatProcessingLag(1)).toBe('Up to date')
+    expect(formatProcessingLag(45)).toBe('45s behind')
+    expect(formatProcessingLag(300)).toBe('5m behind')
+    expect(formatProcessingLag(7200)).toBe('2h behind')
+    expect(formatProcessingLag(172800)).toBe('2d behind')
+  })
+})

--- a/dashboard/src/components/settings/connectorHealth.ts
+++ b/dashboard/src/components/settings/connectorHealth.ts
@@ -1,0 +1,92 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import type {BadgeProps} from '@/components/ui/badge'
+import type {StatusTone} from '@/components/ui/status-dot'
+import type {
+  ConnectorInstallationResponse,
+  ConnectorProviderDefinition,
+  ConnectorProviderStateDetail,
+} from '@/lib/api/types'
+
+// A provider is "installation-backed" when any of its uses keeps live state in
+// connector installations (the generic install/credentials/mapping APIs) rather
+// than the legacy OAuth integration tables. RevenueCat is the first such provider;
+// keeping the check capability-driven means new data-import connectors light up
+// without per-provider branching here.
+export function isInstallationBacked(provider: ConnectorProviderDefinition): boolean {
+  return provider.uses.some((use) => use.stateSource === 'connector_installations')
+}
+
+// The auth profile a setup flow should submit — the one allowed by the provider's
+// installation-backed use (e.g. RevenueCat's `project_api_key`).
+export function installAuthProfileId(provider: ConnectorProviderDefinition): string | null {
+  const use = provider.uses.find((u) => u.stateSource === 'connector_installations')
+  return use?.allowedAuthProfileIds[0] ?? provider.authProfiles[0]?.id ?? null
+}
+
+export interface HealthDescriptor {
+  readonly tone: StatusTone
+  readonly badge: NonNullable<BadgeProps['variant']>
+  readonly label: string
+}
+
+// Maps a connector health/status string to one status language. "Awaiting traffic"
+// is a healthy waiting state (connected, no webhook events yet) — it reads as
+// informational, never as an error. Unknown is neutral, not alarming.
+export function describeConnectorHealth(
+  state: string | null | undefined,
+  enabled = true,
+): HealthDescriptor {
+  if (!enabled) return {tone: 'neutral', badge: 'secondary', label: 'Disabled'}
+  switch (state) {
+    case 'healthy':
+      return {tone: 'success', badge: 'success', label: 'Healthy'}
+    case 'degraded':
+      return {tone: 'warning', badge: 'warning', label: 'Degraded'}
+    case 'error':
+      return {tone: 'danger', badge: 'danger', label: 'Error'}
+    case 'needs_mapping':
+      return {tone: 'warning', badge: 'warning', label: 'Needs mapping'}
+    case 'awaiting_traffic':
+      return {tone: 'info', badge: 'info', label: 'Awaiting traffic'}
+    default:
+      return {tone: 'neutral', badge: 'neutral', label: 'Unknown'}
+  }
+}
+
+// The backend encodes the "connected but no events yet" case in `status`
+// (`awaiting_traffic`) while `health` stays `healthy`, so surface status first to
+// keep that distinction. Falls back to the installation status when no live state
+// detail is available yet.
+export function effectiveConnectorState(
+  detail?: ConnectorProviderStateDetail | null,
+  installation?: ConnectorInstallationResponse | null,
+): string | undefined {
+  if (detail) {
+    return detail.status === 'awaiting_traffic' ? 'awaiting_traffic' : detail.health
+  }
+  return installation?.status
+}
+
+// "X processed Ns behind" — compact lag readout that stays calm for tiny values.
+export function formatProcessingLag(seconds: number | null | undefined): string {
+  if (seconds == null) return 'Up to date'
+  if (seconds < 60) return seconds <= 1 ? 'Up to date' : `${seconds}s behind`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m behind`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h behind`
+  return `${Math.floor(seconds / 86400)}d behind`
+}


### PR DESCRIPTION
## Summary
- Add RevenueCat connector setup, webhook setup, mapping, and management UI.
- Keep existing Slack and Discord connector flows intact.

## Validation
- `npm run typecheck`
- `npm run test -- src/components/settings/__tests__/ConnectorsSettings.test.tsx`
- `npm run lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-step setup wizard for connector installation and configuration
  * Connector management interface with dedicated tabs for health overview, webhook details, and app mapping
  * Webhook token rotation and management capabilities
  * Enhanced connector status display with health indicators
  * Support for data-import connectors alongside existing OAuth integrations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->