### PR TITLE
fix: support legacy Sentry ProGuard uploads

### DIFF
--- a/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
+++ b/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
@@ -662,7 +662,13 @@ private suspend fun readFileItemBytes(
 
 private fun extractProguardMappings(upload: UploadedLegacyDebugFile): List<UploadedProguardMapping> {
     return try {
-        extractProguardMappingsFromZip(upload.bytes)
+        val mappings = extractProguardMappingsFromZip(upload.bytes)
+        if (mappings.isNotEmpty() || upload.fileName.endsWith(".zip", ignoreCase = true)) {
+            mappings
+        } else {
+            logger.debug { "Legacy debug file upload was not a zip archive; storing raw file" }
+            listOf(UploadedProguardMapping(upload.fileName, upload.bytes))
+        }
     } catch (e: ZipException) {
         logger.debug(e) { "Legacy debug file upload was not a zip archive; storing raw file" }
         listOf(UploadedProguardMapping(upload.fileName, upload.bytes))

--- a/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
+++ b/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
@@ -16,9 +16,6 @@
 
 package com.moneat.events.routes
 
-import kotlinx.serialization.SerializationException
-import java.io.IOException
-
 import com.moneat.auth.services.AuthTokenService
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.billing.services.QuotaExceededResponse
@@ -38,6 +35,7 @@ import com.moneat.events.services.ReleaseService
 import com.moneat.plugins.AuthTokenPrincipal
 import com.moneat.shared.models.Users
 import com.moneat.utils.ErrorResponse
+import com.moneat.utils.suspendRunCatching
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
@@ -51,19 +49,28 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.utils.io.toByteArray
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializable
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.security.MessageDigest
 import java.util.zip.GZIPInputStream
-import com.moneat.utils.suspendRunCatching
+import java.util.zip.ZipException
+import java.util.zip.ZipInputStream
 
 private val logger = KotlinLogging.logger {}
 private const val FAILED_TO_UPLOAD_SOURCE_MAP = "Failed to upload source map"
 private const val UPLOAD_FAILED = "Upload failed"
 private const val PROJECT_NOT_FOUND = "Project not found"
+private const val LEGACY_DSYM_CPU_NAME = "any"
+private const val PROGUARD_ENTRY_PREFIX = "proguard/"
+private const val SHA_1_ALGORITHM = "SHA-1"
 
 private data class UploadedSourceMapChunk(
     val checksum: String,
@@ -75,10 +82,29 @@ private data class UploadedSourceMap(
     val bytes: ByteArray
 )
 
+private data class UploadedLegacyDebugFile(
+    val fileName: String,
+    val bytes: ByteArray
+)
+
+private data class UploadedProguardMapping(
+    val objectName: String,
+    val bytes: ByteArray
+)
+
 private data class SourceMapQuotaReservation(
     val organizationId: Int?,
     val units: Int,
     val bytes: Long
+)
+
+@Serializable
+private data class SentryDebugInfoFileResponse(
+    val uuid: String?,
+    val debugId: String?,
+    val objectName: String,
+    val cpuName: String,
+    val sha1: String
 )
 
 fun Route.releaseRoutes(
@@ -136,6 +162,17 @@ fun Route.releaseRoutes(
         // POST /api/0/organizations/{orgSlug}/artifactbundle/assemble/
         route("/api/0/organizations/{orgSlug}/artifactbundle") {
             post("/assemble/") { handleAssembleArtifactBundle(releaseService) }
+        }
+
+        // Legacy debug-file upload endpoint used by sentry-cli upload-proguard and the
+        // Sentry Android Gradle plugin's uploadSentryProguardMappings task.
+        post("/api/0/projects/{orgSlug}/{projectSlug}/files/dsyms/") {
+            handleUploadLegacyDsyms(releaseService, authTokenService, quotaService, eventService)
+        }
+
+        // sentry-cli calls this after a successful ProGuard upload unless --no-reprocessing is used.
+        post("/api/0/projects/{orgSlug}/{projectSlug}/reprocessing/") {
+            handleTriggerReprocessing(releaseService, authTokenService)
         }
 
         // Debug information files (ProGuard mappings, dSYMs) for sentry-cli upload-proguard /
@@ -553,6 +590,55 @@ private suspend fun io.ktor.server.routing.RoutingContext.receiveSourceMapUpload
     return UploadedSourceMap(finalFileName, uploadedBytes)
 }
 
+private suspend fun io.ktor.server.routing.RoutingContext.receiveLegacyDebugFileUpload(): UploadedLegacyDebugFile? {
+    val multipart = call.receiveMultipart()
+    var fileName: String? = null
+    var fileBytes: ByteArray? = null
+
+    multipart.forEachPart { part ->
+        if (part is PartData.FileItem) {
+            fileName = part.originalFileName ?: part.name ?: "unknown"
+            fileBytes = part.provider().toByteArray()
+        }
+        part.release()
+    }
+
+    val uploadedBytes = fileBytes
+    if (uploadedBytes == null) {
+        call.respond(HttpStatusCode.BadRequest, ErrorResponse("Missing debug file archive"))
+        return null
+    }
+
+    return UploadedLegacyDebugFile(fileName ?: "unknown", uploadedBytes)
+}
+
+private fun extractProguardMappings(upload: UploadedLegacyDebugFile): List<UploadedProguardMapping> {
+    return try {
+        extractProguardMappingsFromZip(upload.bytes)
+    } catch (e: ZipException) {
+        logger.debug(e) { "Legacy debug file upload was not a zip archive; storing raw file" }
+        listOf(UploadedProguardMapping(upload.fileName, upload.bytes))
+    }
+}
+
+private fun extractProguardMappingsFromZip(bytes: ByteArray): List<UploadedProguardMapping> {
+    val mappings = mutableListOf<UploadedProguardMapping>()
+
+    ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+        while (true) {
+            val entry = zip.nextEntry ?: break
+            if (!entry.isDirectory && entry.name.startsWith(PROGUARD_ENTRY_PREFIX)) {
+                val out = ByteArrayOutputStream()
+                zip.copyTo(out)
+                mappings += UploadedProguardMapping(entry.name, out.toByteArray())
+            }
+            zip.closeEntry()
+        }
+    }
+
+    return mappings
+}
+
 private suspend fun io.ktor.server.routing.RoutingContext.receiveUploadedSourceMapChunks():
     List<UploadedSourceMapChunk> {
     val chunks = mutableListOf<UploadedSourceMapChunk>()
@@ -673,6 +759,81 @@ private suspend fun io.ktor.server.routing.RoutingContext.respondChunkUploadFail
     logger.error(error) { "Failed to store chunks for org $orgSlug" }
     call.respond(HttpStatusCode.InternalServerError, ErrorResponse(UPLOAD_FAILED))
 }
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleUploadLegacyDsyms(
+    releaseService: ReleaseService,
+    authTokenService: AuthTokenService,
+    quotaService: BillingQuotaService,
+    eventService: EventService,
+) {
+    val projectId = resolveDifProject(releaseService, authTokenService, "sourcemaps:write") ?: return
+    val upload = receiveLegacyDebugFileUpload() ?: return
+    val mappings = extractProguardMappings(upload)
+
+    if (mappings.isEmpty()) {
+        call.respond(emptyList<SentryDebugInfoFileResponse>())
+        return
+    }
+
+    val quotaReservation =
+        reserveSourceMapQuotaOrRespond(
+            quotaService = quotaService,
+            organizationId = eventService.getOrganizationIdForProject(projectId),
+            units = mappings.size,
+            bytes = mappings.sumOf { it.bytes.size.toLong() }
+        ) ?: return
+
+    uploadLegacyDsymsOrRespond(releaseService, quotaService, quotaReservation, projectId, mappings)
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.uploadLegacyDsymsOrRespond(
+    releaseService: ReleaseService,
+    quotaService: BillingQuotaService,
+    quotaReservation: SourceMapQuotaReservation,
+    projectId: Long,
+    mappings: List<UploadedProguardMapping>
+) {
+    try {
+        val responses =
+            mappings.map { mapping ->
+                val checksum = sha1(mapping.bytes)
+                releaseService.storeChunk(checksum, mapping.bytes)
+                releaseService
+                    .assembleProjectDif(projectId, checksum, listOf(checksum), mapping.objectName, null)
+                    .toSentryDebugInfoFile()
+            }
+        call.respond(responses)
+    } catch (e: IOException) {
+        respondLegacyDsymUploadFailure(e, quotaService, quotaReservation)
+    } catch (e: IllegalStateException) {
+        respondLegacyDsymUploadFailure(e, quotaService, quotaReservation)
+    }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.respondLegacyDsymUploadFailure(
+    error: Exception,
+    quotaService: BillingQuotaService,
+    quotaReservation: SourceMapQuotaReservation
+) {
+    refundReservedSourceMapQuota(quotaService, quotaReservation)
+    logger.error(error) { "Failed to upload legacy debug file archive" }
+    call.respond(HttpStatusCode.InternalServerError, ErrorResponse(UPLOAD_FAILED))
+}
+
+private fun sha1(bytes: ByteArray): String =
+    MessageDigest
+        .getInstance(SHA_1_ALGORITHM)
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+
+private fun AssembledDif.toSentryDebugInfoFile(): SentryDebugInfoFileResponse =
+    SentryDebugInfoFileResponse(
+        uuid = debugId,
+        debugId = debugId,
+        objectName = objectName,
+        cpuName = LEGACY_DSYM_CPU_NAME,
+        sha1 = checksum
+    )
 
 private fun refundReservedSourceMapQuota(
     quotaService: BillingQuotaService,
@@ -834,6 +995,14 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleAssembleProjectD
         }
 
     call.respond(response)
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleTriggerReprocessing(
+    releaseService: ReleaseService,
+    authTokenService: AuthTokenService,
+) {
+    resolveDifProject(releaseService, authTokenService, "sourcemaps:write") ?: return
+    call.respond(emptyList<String>())
 }
 
 private suspend fun assembleSingleDif(

--- a/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
+++ b/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
@@ -70,6 +70,8 @@ private val logger = KotlinLogging.logger {}
 private const val FAILED_TO_UPLOAD_SOURCE_MAP = "Failed to upload source map"
 private const val UPLOAD_FAILED = "Upload failed"
 private const val PROJECT_NOT_FOUND = "Project not found"
+private const val SOURCEMAPS_READ_SCOPE = "sourcemaps:read"
+private const val SOURCEMAPS_WRITE_SCOPE = "sourcemaps:write"
 private const val LEGACY_DSYM_CPU_NAME = "any"
 private const val PROGUARD_ENTRY_PREFIX = "proguard/"
 private const val SHA_1_ALGORITHM = "SHA-1"
@@ -414,10 +416,10 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUploadSourceMap(
                 return
             }
 
-    if (!authTokenService.hasScope(principal.scopes, "sourcemaps:write")) {
+    if (!authTokenService.hasScope(principal.scopes, SOURCEMAPS_WRITE_SCOPE)) {
         call.respond(
             HttpStatusCode.Forbidden,
-            ErrorResponse("Missing required scope: sourcemaps:write")
+            ErrorResponse("Missing required scope: $SOURCEMAPS_WRITE_SCOPE")
         )
         return
     }
@@ -467,7 +469,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleListReleaseFiles
                 return
             }
 
-    if (!authTokenService.hasScope(principal.scopes, "sourcemaps:read")) {
+    if (!authTokenService.hasScope(principal.scopes, SOURCEMAPS_READ_SCOPE)) {
         call.respond(HttpStatusCode.Forbidden)
         return
     }
@@ -863,7 +865,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUploadLegacyDsym
     quotaService: BillingQuotaService,
     eventService: EventService,
 ) {
-    val projectId = resolveDifProject(releaseService, authTokenService, "sourcemaps:write") ?: return
+    val projectId = resolveDifProject(releaseService, authTokenService, SOURCEMAPS_WRITE_SCOPE) ?: return
     val upload = receiveLegacyDebugFileUpload() ?: return
     val mappings =
         try {
@@ -932,13 +934,15 @@ private suspend fun io.ktor.server.routing.RoutingContext.respondLegacyDsymUploa
     call.respond(HttpStatusCode.InternalServerError, ErrorResponse(UPLOAD_FAILED))
 }
 
-private fun sha1(bytes: ByteArray): String =
-    MessageDigest
-        // Sentry debug-file APIs require SHA-1 as a protocol checksum, not for trust or password storage.
-        // codeql[java/potentially-weak-cryptographic-algorithm]
-        .getInstance(SHA_1_ALGORITHM)
+private fun sha1(bytes: ByteArray): String {
+    // Sentry debug-file APIs require SHA-1 as a protocol checksum, not for trust or password storage.
+
+    // codeql[java/potentially-weak-cryptographic-algorithm]
+    val digest = MessageDigest.getInstance(SHA_1_ALGORITHM)
+    return digest
         .digest(bytes)
         .joinToString("") { "%02x".format(it) }
+}
 
 private fun AssembledDif.toSentryDebugInfoFile(): SentryDebugInfoFileResponse =
     SentryDebugInfoFileResponse(
@@ -1091,7 +1095,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleListProjectDifs(
     releaseService: ReleaseService,
     authTokenService: AuthTokenService,
 ) {
-    val projectId = resolveDifProject(releaseService, authTokenService, "sourcemaps:read") ?: return
+    val projectId = resolveDifProject(releaseService, authTokenService, SOURCEMAPS_READ_SCOPE) ?: return
 
     val checksums = call.request.queryParameters.getAll("checksums")?.toSet() ?: emptySet()
     val debugIds = call.request.queryParameters.getAll("debug_id")?.toSet() ?: emptySet()
@@ -1104,7 +1108,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleAssembleProjectD
     releaseService: ReleaseService,
     authTokenService: AuthTokenService,
 ) {
-    val projectId = resolveDifProject(releaseService, authTokenService, "sourcemaps:write") ?: return
+    val projectId = resolveDifProject(releaseService, authTokenService, SOURCEMAPS_WRITE_SCOPE) ?: return
 
     // Body maps each assembled file's SHA-1 checksum to its name, optional debug id, and chunks.
     val request = call.receive<Map<String, AssembleDifEntry>>()
@@ -1121,7 +1125,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleTriggerReprocess
     releaseService: ReleaseService,
     authTokenService: AuthTokenService,
 ) {
-    resolveDifProject(releaseService, authTokenService, "sourcemaps:write") ?: return
+    resolveDifProject(releaseService, authTokenService, SOURCEMAPS_WRITE_SCOPE) ?: return
     call.respond(emptyList<String>())
 }
 

--- a/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
+++ b/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
@@ -933,9 +933,9 @@ private suspend fun io.ktor.server.routing.RoutingContext.respondLegacyDsymUploa
 }
 
 private fun sha1(bytes: ByteArray): String =
-    // Sentry debug-file APIs require SHA-1 as a protocol checksum, not for trust or password storage.
-    // codeql[java/potentially-weak-cryptographic-algorithm]
     MessageDigest
+        // Sentry debug-file APIs require SHA-1 as a protocol checksum, not for trust or password storage.
+        // codeql[java/potentially-weak-cryptographic-algorithm]
         .getInstance(SHA_1_ALGORITHM)
         .digest(bytes)
         .joinToString("") { "%02x".format(it) }

--- a/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
+++ b/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
@@ -933,6 +933,8 @@ private suspend fun io.ktor.server.routing.RoutingContext.respondLegacyDsymUploa
 }
 
 private fun sha1(bytes: ByteArray): String =
+    // Sentry debug-file APIs require SHA-1 as a protocol checksum, not for trust or password storage.
+    // codeql[java/potentially-weak-cryptographic-algorithm]
     MessageDigest
         .getInstance(SHA_1_ALGORITHM)
         .digest(bytes)

--- a/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
+++ b/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
@@ -48,6 +48,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import io.ktor.utils.io.readAvailable
 import io.ktor.utils.io.toByteArray
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializable
@@ -61,6 +62,7 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.security.MessageDigest
 import java.util.zip.GZIPInputStream
+import java.util.zip.ZipEntry
 import java.util.zip.ZipException
 import java.util.zip.ZipInputStream
 
@@ -71,6 +73,11 @@ private const val PROJECT_NOT_FOUND = "Project not found"
 private const val LEGACY_DSYM_CPU_NAME = "any"
 private const val PROGUARD_ENTRY_PREFIX = "proguard/"
 private const val SHA_1_ALGORITHM = "SHA-1"
+private const val BYTES_PER_MIB = 1024L * 1024L
+private const val LEGACY_DSYM_MAX_COMPRESSED_BYTES = 32L * BYTES_PER_MIB
+private const val LEGACY_DSYM_MAX_UNCOMPRESSED_ENTRY_BYTES = 128L * BYTES_PER_MIB
+private const val LEGACY_DSYM_MAX_UNCOMPRESSED_ARCHIVE_BYTES = 256L * BYTES_PER_MIB
+private const val READ_BUFFER_SIZE = 8192
 
 private data class UploadedSourceMapChunk(
     val checksum: String,
@@ -97,6 +104,8 @@ private data class SourceMapQuotaReservation(
     val units: Int,
     val bytes: Long
 )
+
+private class UploadLimitExceededException(message: String) : IllegalArgumentException(message)
 
 @Serializable
 private data class SentryDebugInfoFileResponse(
@@ -595,12 +604,25 @@ private suspend fun io.ktor.server.routing.RoutingContext.receiveLegacyDebugFile
     var fileName: String? = null
     var fileBytes: ByteArray? = null
 
-    multipart.forEachPart { part ->
-        if (part is PartData.FileItem) {
-            fileName = part.originalFileName ?: part.name ?: "unknown"
-            fileBytes = part.provider().toByteArray()
+    try {
+        multipart.forEachPart { part ->
+            try {
+                if (part is PartData.FileItem) {
+                    fileName = part.originalFileName ?: part.name ?: "unknown"
+                    fileBytes =
+                        readFileItemBytes(
+                            part,
+                            LEGACY_DSYM_MAX_COMPRESSED_BYTES,
+                            "Debug file archive"
+                        )
+                }
+            } finally {
+                part.release()
+            }
         }
-        part.release()
+    } catch (e: UploadLimitExceededException) {
+        call.respond(HttpStatusCode.PayloadTooLarge, ErrorResponse(e.message))
+        return null
     }
 
     val uploadedBytes = fileBytes
@@ -610,6 +632,30 @@ private suspend fun io.ktor.server.routing.RoutingContext.receiveLegacyDebugFile
     }
 
     return UploadedLegacyDebugFile(fileName ?: "unknown", uploadedBytes)
+}
+
+private suspend fun readFileItemBytes(
+    part: PartData.FileItem,
+    maxBytes: Long,
+    description: String
+): ByteArray {
+    val channel = part.provider()
+    val out = ByteArrayOutputStream()
+    val buffer = ByteArray(READ_BUFFER_SIZE)
+    var totalBytes = 0L
+
+    while (true) {
+        val read = channel.readAvailable(buffer, 0, buffer.size)
+        if (read == -1) break
+
+        totalBytes += read.toLong()
+        if (totalBytes > maxBytes) {
+            throw UploadLimitExceededException("$description exceeds ${maxBytes.toMib()} MiB")
+        }
+        out.write(buffer, 0, read)
+    }
+
+    return out.toByteArray()
 }
 
 private fun extractProguardMappings(upload: UploadedLegacyDebugFile): List<UploadedProguardMapping> {
@@ -623,14 +669,16 @@ private fun extractProguardMappings(upload: UploadedLegacyDebugFile): List<Uploa
 
 private fun extractProguardMappingsFromZip(bytes: ByteArray): List<UploadedProguardMapping> {
     val mappings = mutableListOf<UploadedProguardMapping>()
+    var totalUncompressedBytes = 0L
 
     ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
         while (true) {
             val entry = zip.nextEntry ?: break
-            if (!entry.isDirectory && entry.name.startsWith(PROGUARD_ENTRY_PREFIX)) {
-                val out = ByteArrayOutputStream()
-                zip.copyTo(out)
-                mappings += UploadedProguardMapping(entry.name, out.toByteArray())
+            val mapping = readProguardMappingEntry(zip, entry)
+            if (mapping != null) {
+                totalUncompressedBytes =
+                    validateLegacyDsymArchiveSize(totalUncompressedBytes, mapping.bytes.size.toLong())
+                mappings += mapping
             }
             zip.closeEntry()
         }
@@ -638,6 +686,55 @@ private fun extractProguardMappingsFromZip(bytes: ByteArray): List<UploadedProgu
 
     return mappings
 }
+
+private fun readProguardMappingEntry(
+    zip: ZipInputStream,
+    entry: ZipEntry
+): UploadedProguardMapping? {
+    if (entry.isDirectory || !entry.name.startsWith(PROGUARD_ENTRY_PREFIX)) return null
+
+    return UploadedProguardMapping(entry.name, readZipEntryBytes(zip, entry.name))
+}
+
+private fun validateLegacyDsymArchiveSize(
+    currentBytes: Long,
+    entryBytes: Long
+): Long {
+    val totalBytes = currentBytes + entryBytes
+    if (totalBytes > LEGACY_DSYM_MAX_UNCOMPRESSED_ARCHIVE_BYTES) {
+        throw UploadLimitExceededException(
+            "Debug file archive expands beyond ${LEGACY_DSYM_MAX_UNCOMPRESSED_ARCHIVE_BYTES.toMib()} MiB"
+        )
+    }
+    return totalBytes
+}
+
+private fun readZipEntryBytes(
+    zip: ZipInputStream,
+    entryName: String
+): ByteArray {
+    val out = ByteArrayOutputStream()
+    val buffer = ByteArray(READ_BUFFER_SIZE)
+    var entryBytes = 0L
+
+    while (true) {
+        val read = zip.read(buffer)
+        if (read == -1) break
+
+        entryBytes += read.toLong()
+        if (entryBytes > LEGACY_DSYM_MAX_UNCOMPRESSED_ENTRY_BYTES) {
+            throw UploadLimitExceededException(
+                "Debug file archive entry $entryName exceeds " +
+                    "${LEGACY_DSYM_MAX_UNCOMPRESSED_ENTRY_BYTES.toMib()} MiB"
+            )
+        }
+        out.write(buffer, 0, read)
+    }
+
+    return out.toByteArray()
+}
+
+private fun Long.toMib(): Long = this / BYTES_PER_MIB
 
 private suspend fun io.ktor.server.routing.RoutingContext.receiveUploadedSourceMapChunks():
     List<UploadedSourceMapChunk> {
@@ -768,7 +865,13 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleUploadLegacyDsym
 ) {
     val projectId = resolveDifProject(releaseService, authTokenService, "sourcemaps:write") ?: return
     val upload = receiveLegacyDebugFileUpload() ?: return
-    val mappings = extractProguardMappings(upload)
+    val mappings =
+        try {
+            extractProguardMappings(upload)
+        } catch (e: UploadLimitExceededException) {
+            call.respond(HttpStatusCode.PayloadTooLarge, ErrorResponse(e.message))
+            return
+        }
 
     if (mappings.isEmpty()) {
         call.respond(emptyList<SentryDebugInfoFileResponse>())
@@ -793,29 +896,38 @@ private suspend fun io.ktor.server.routing.RoutingContext.uploadLegacyDsymsOrRes
     projectId: Long,
     mappings: List<UploadedProguardMapping>
 ) {
+    var committedUnits = 0
+    var committedBytes = 0L
+
     try {
         val responses =
             mappings.map { mapping ->
                 val checksum = sha1(mapping.bytes)
                 releaseService.storeChunk(checksum, mapping.bytes)
-                releaseService
-                    .assembleProjectDif(projectId, checksum, listOf(checksum), mapping.objectName, null)
-                    .toSentryDebugInfoFile()
+                val response =
+                    releaseService
+                        .assembleProjectDif(projectId, checksum, listOf(checksum), mapping.objectName, null)
+                        .toSentryDebugInfoFile()
+                committedUnits += 1
+                committedBytes += mapping.bytes.size.toLong()
+                response
             }
         call.respond(responses)
     } catch (e: IOException) {
-        respondLegacyDsymUploadFailure(e, quotaService, quotaReservation)
+        respondLegacyDsymUploadFailure(e, quotaService, quotaReservation, committedUnits, committedBytes)
     } catch (e: IllegalStateException) {
-        respondLegacyDsymUploadFailure(e, quotaService, quotaReservation)
+        respondLegacyDsymUploadFailure(e, quotaService, quotaReservation, committedUnits, committedBytes)
     }
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.respondLegacyDsymUploadFailure(
     error: Exception,
     quotaService: BillingQuotaService,
-    quotaReservation: SourceMapQuotaReservation
+    quotaReservation: SourceMapQuotaReservation,
+    committedUnits: Int,
+    committedBytes: Long
 ) {
-    refundReservedSourceMapQuota(quotaService, quotaReservation)
+    refundReservedSourceMapQuota(quotaService, quotaReservation, committedUnits, committedBytes)
     logger.error(error) { "Failed to upload legacy debug file archive" }
     call.respond(HttpStatusCode.InternalServerError, ErrorResponse(UPLOAD_FAILED))
 }
@@ -837,10 +949,16 @@ private fun AssembledDif.toSentryDebugInfoFile(): SentryDebugInfoFileResponse =
 
 private fun refundReservedSourceMapQuota(
     quotaService: BillingQuotaService,
-    reservation: SourceMapQuotaReservation
+    reservation: SourceMapQuotaReservation,
+    committedUnits: Int = 0,
+    committedBytes: Long = 0L
 ) {
     val organizationId = reservation.organizationId ?: return
-    quotaService.refundUnits(organizationId, reservation.units, "sourcemap", reservation.bytes)
+    val refundUnits = (reservation.units - committedUnits).coerceAtLeast(0)
+    val refundBytes = (reservation.bytes - committedBytes).coerceAtLeast(0)
+    if (refundUnits == 0 && refundBytes == 0L) return
+
+    quotaService.refundUnits(organizationId, refundUnits, "sourcemap", refundBytes)
 }
 
 private suspend fun io.ktor.server.routing.RoutingContext.handleAssembleArtifactBundle(

--- a/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
+++ b/backend/features/releases/src/main/kotlin/com/moneat/events/routes/ReleaseRoutes.kt
@@ -937,7 +937,7 @@ private suspend fun io.ktor.server.routing.RoutingContext.respondLegacyDsymUploa
 private fun sha1(bytes: ByteArray): String {
     // Sentry debug-file APIs require SHA-1 as a protocol checksum, not for trust or password storage.
 
-    // codeql[java/potentially-weak-cryptographic-algorithm]
+    // lgtm[java/potentially-weak-cryptographic-algorithm]
     val digest = MessageDigest.getInstance(SHA_1_ALGORITHM)
     return digest
         .digest(bytes)

--- a/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
+++ b/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
@@ -585,6 +585,75 @@ class ReleaseRoutesTest {
         }
 
     @Test
+    fun `POST legacy dsyms upload refunds only uncommitted mappings when later entry fails`() =
+        testApplication {
+            val releaseService = sourceMapReleaseService()
+            val firstName = "proguard/$PROGUARD_DEBUG_ID.txt"
+            val secondDebugId = "623fb246-631d-5716-8ac6-6fd116137be7"
+            val secondName = "proguard/$secondDebugId.txt"
+            val firstBytes = "first mapping".toByteArray()
+            val secondBytes = "second mapping".toByteArray()
+            val firstChecksum = sha1(firstBytes)
+            val secondChecksum = sha1(secondBytes)
+
+            every { releaseService.storeChunk(firstChecksum, any()) } just Runs
+            every {
+                releaseService.assembleProjectDif(
+                    TEST_PROJECT_ID,
+                    firstChecksum,
+                    listOf(firstChecksum),
+                    firstName,
+                    null
+                )
+            } returns AssembledDif(
+                resourceId = resourceId(102),
+                debugId = PROGUARD_DEBUG_ID,
+                objectName = firstName,
+                checksum = firstChecksum,
+                size = firstBytes.size.toLong(),
+                dateCreated = "2026-05-23T00:00:00Z"
+            )
+            every { releaseService.storeChunk(secondChecksum, any()) } throws IOException("storage failed")
+
+            val quotaService = allowingQuotaService()
+
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    releaseRoutes(releaseService, AuthTokenService(), quotaService, projectOrgEventService())
+                }
+            }
+
+            val response =
+                client.post("/api/0/projects/my-org/my-project/files/dsyms/") {
+                    header(HttpHeaders.Authorization, "Bearer $testSourceMapToken")
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                appendFile(
+                                    "file",
+                                    "proguard.zip",
+                                    zipProguardMappings(firstName to firstBytes, secondName to secondBytes)
+                                )
+                            }
+                        )
+                    )
+                }
+
+            assertEquals(HttpStatusCode.InternalServerError, response.status, response.bodyAsText())
+            verify {
+                quotaService.reserveUnits(
+                    TEST_ORG_ID,
+                    2,
+                    "sourcemap",
+                    firstBytes.size.toLong() + secondBytes.size.toLong()
+                )
+            }
+            verify { quotaService.refundUnits(TEST_ORG_ID, 1, "sourcemap", secondBytes.size.toLong()) }
+        }
+
+    @Test
     fun `POST reprocessing returns ok for sentry cli compatibility`() =
         testApplication {
             val releaseService = sourceMapReleaseService()
@@ -727,11 +796,17 @@ class ReleaseRoutesTest {
     }
 
     private fun zipProguardMapping(name: String, bytes: ByteArray): ByteArray {
+        return zipProguardMappings(name to bytes)
+    }
+
+    private fun zipProguardMappings(vararg entries: Pair<String, ByteArray>): ByteArray {
         val out = ByteArrayOutputStream()
         ZipOutputStream(out).use { zip ->
-            zip.putNextEntry(ZipEntry(name))
-            zip.write(bytes)
-            zip.closeEntry()
+            entries.forEach { (name, bytes) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(bytes)
+                zip.closeEntry()
+            }
         }
         return out.toByteArray()
     }

--- a/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
+++ b/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
@@ -65,7 +65,6 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.io.ByteArrayOutputStream
 import java.io.IOException
-import java.security.MessageDigest
 import java.util.zip.GZIPOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -530,7 +529,7 @@ class ReleaseRoutesTest {
                 com.example.Foo -> a:
                     1:1:void doThing():10:10 -> a
                 """.trimIndent().toByteArray()
-            val checksum = sha1(mappingBytes)
+            val checksum = "931c96ccfdf6418eec054cbae8fba57a3c7a8f3d"
             val storedBytes = slot<ByteArray>()
 
             every { releaseService.storeChunk(checksum, capture(storedBytes)) } just Runs
@@ -593,8 +592,8 @@ class ReleaseRoutesTest {
             val secondName = "proguard/$secondDebugId.txt"
             val firstBytes = "first mapping".toByteArray()
             val secondBytes = "second mapping".toByteArray()
-            val firstChecksum = sha1(firstBytes)
-            val secondChecksum = sha1(secondBytes)
+            val firstChecksum = "64fe3c5856063dc209a9fdef81ec63ead39bfca4"
+            val secondChecksum = "c098be88dc8bb221cb0048b31b7d313f3fd2732a"
 
             every { releaseService.storeChunk(firstChecksum, any()) } just Runs
             every {
@@ -810,12 +809,6 @@ class ReleaseRoutesTest {
         }
         return out.toByteArray()
     }
-
-    private fun sha1(bytes: ByteArray): String =
-        MessageDigest
-            .getInstance("SHA-1")
-            .digest(bytes)
-            .joinToString("") { "%02x".format(it) }
 
     @AfterTest
     fun teardownKoin() {

--- a/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
+++ b/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
@@ -649,7 +649,12 @@ class ReleaseRoutesTest {
                     firstBytes.size.toLong() + secondBytes.size.toLong()
                 )
             }
-            verify { quotaService.refundUnits(TEST_ORG_ID, 1, "sourcemap", secondBytes.size.toLong()) }
+            verify(exactly = 1) {
+                quotaService.refundUnits(TEST_ORG_ID, 1, "sourcemap", secondBytes.size.toLong())
+            }
+            verify(exactly = 0) {
+                quotaService.refundUnits(TEST_ORG_ID, 1, "sourcemap", firstBytes.size.toLong())
+            }
         }
 
     @Test

--- a/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
+++ b/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
@@ -58,13 +58,17 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.security.MessageDigest
 import java.util.zip.GZIPOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -77,6 +81,7 @@ class ReleaseRoutesTest {
     private val testSourceMapToken = "test-source-map-token-releases"
 
     companion object {
+        private const val PROGUARD_DEBUG_ID = "523fb246-631d-5716-8ac6-6fd116137be7"
         private var dbInitialized = false
         private var testUserId = -1
         private const val TEST_ORG_ID = 7
@@ -515,6 +520,98 @@ class ReleaseRoutesTest {
         }
 
     @Test
+    fun `POST legacy dsyms upload stores proguard zip entries`() =
+        testApplication {
+            val releaseService = sourceMapReleaseService()
+            val mappingName = "proguard/$PROGUARD_DEBUG_ID.txt"
+            val mappingBytes =
+                """
+                # compiler: R8
+                com.example.Foo -> a:
+                    1:1:void doThing():10:10 -> a
+                """.trimIndent().toByteArray()
+            val checksum = sha1(mappingBytes)
+            val storedBytes = slot<ByteArray>()
+
+            every { releaseService.storeChunk(checksum, capture(storedBytes)) } just Runs
+            every {
+                releaseService.assembleProjectDif(
+                    TEST_PROJECT_ID,
+                    checksum,
+                    listOf(checksum),
+                    mappingName,
+                    null
+                )
+            } returns AssembledDif(
+                resourceId = resourceId(101),
+                debugId = PROGUARD_DEBUG_ID,
+                objectName = mappingName,
+                checksum = checksum,
+                size = mappingBytes.size.toLong(),
+                dateCreated = "2026-05-23T00:00:00Z"
+            )
+
+            val quotaService = allowingQuotaService()
+            val eventService = projectOrgEventService()
+
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    releaseRoutes(releaseService, AuthTokenService(), quotaService, eventService)
+                }
+            }
+
+            val response =
+                client.post("/api/0/projects/my-org/my-project/files/dsyms/") {
+                    header(HttpHeaders.Authorization, "Bearer $testSourceMapToken")
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                appendFile("file", "proguard.zip", zipProguardMapping(mappingName, mappingBytes))
+                            }
+                        )
+                    )
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+            val body = response.bodyAsText()
+            assertTrue(body.contains(PROGUARD_DEBUG_ID), body)
+            assertTrue(body.contains("\"objectName\":\"$mappingName\""), body)
+            assertTrue(body.contains("\"cpuName\":\"any\""), body)
+            assertTrue(body.contains("\"sha1\":\"$checksum\""), body)
+            assertTrue(storedBytes.captured.contentEquals(mappingBytes))
+            verify { quotaService.reserveUnits(TEST_ORG_ID, 1, "sourcemap", mappingBytes.size.toLong()) }
+        }
+
+    @Test
+    fun `POST reprocessing returns ok for sentry cli compatibility`() =
+        testApplication {
+            val releaseService = sourceMapReleaseService()
+
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    releaseRoutes(
+                        releaseService,
+                        AuthTokenService(),
+                        allowingQuotaService(),
+                        projectOrgEventService()
+                    )
+                }
+            }
+
+            val response =
+                client.post("/api/0/projects/my-org/my-project/reprocessing/") {
+                    header(HttpHeaders.Authorization, "Bearer $testSourceMapToken")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+            assertEquals("[]", response.bodyAsText())
+        }
+
+    @Test
     fun `GET difs returns stored difs for the project`() =
         testApplication {
             val releaseService = sourceMapReleaseService()
@@ -628,6 +725,22 @@ class ReleaseRoutesTest {
         GZIPOutputStream(out).use { it.write(bytes) }
         return out.toByteArray()
     }
+
+    private fun zipProguardMapping(name: String, bytes: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            zip.putNextEntry(ZipEntry(name))
+            zip.write(bytes)
+            zip.closeEntry()
+        }
+        return out.toByteArray()
+    }
+
+    private fun sha1(bytes: ByteArray): String =
+        MessageDigest
+            .getInstance("SHA-1")
+            .digest(bytes)
+            .joinToString("") { "%02x".format(it) }
 
     @AfterTest
     fun teardownKoin() {

--- a/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
+++ b/backend/features/releases/src/test/kotlin/com/moneat/routes/ReleaseRoutesTest.kt
@@ -584,6 +584,132 @@ class ReleaseRoutesTest {
         }
 
     @Test
+    fun `POST legacy dsyms upload stores raw mapping uploads`() =
+        testApplication {
+            val releaseService = sourceMapReleaseService()
+            val mappingName = "mapping.txt"
+            val mappingBytes = "raw proguard mapping".toByteArray()
+            val checksum = "075d7fa57b20f2bbee31b0dfbbed049c8dca2c56"
+            val storedBytes = slot<ByteArray>()
+
+            every { releaseService.storeChunk(checksum, capture(storedBytes)) } just Runs
+            every {
+                releaseService.assembleProjectDif(
+                    TEST_PROJECT_ID,
+                    checksum,
+                    listOf(checksum),
+                    mappingName,
+                    null
+                )
+            } returns AssembledDif(
+                resourceId = resourceId(102),
+                debugId = PROGUARD_DEBUG_ID,
+                objectName = mappingName,
+                checksum = checksum,
+                size = mappingBytes.size.toLong(),
+                dateCreated = "2026-05-23T00:00:00Z"
+            )
+
+            val quotaService = allowingQuotaService()
+
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    releaseRoutes(releaseService, AuthTokenService(), quotaService, projectOrgEventService())
+                }
+            }
+
+            val response =
+                client.post("/api/0/projects/my-org/my-project/files/dsyms/") {
+                    header(HttpHeaders.Authorization, "Bearer $testSourceMapToken")
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                appendFile("file", mappingName, mappingBytes)
+                            }
+                        )
+                    )
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"objectName\":\"$mappingName\""), body)
+            assertTrue(body.contains("\"sha1\":\"$checksum\""), body)
+            assertTrue(storedBytes.captured.contentEquals(mappingBytes))
+            verify { quotaService.reserveUnits(TEST_ORG_ID, 1, "sourcemap", mappingBytes.size.toLong()) }
+        }
+
+    @Test
+    fun `POST legacy dsyms upload returns empty for zip without proguard entries`() =
+        testApplication {
+            val releaseService = sourceMapReleaseService()
+            val quotaService = allowingQuotaService()
+
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    releaseRoutes(releaseService, AuthTokenService(), quotaService, projectOrgEventService())
+                }
+            }
+
+            val response =
+                client.post("/api/0/projects/my-org/my-project/files/dsyms/") {
+                    header(HttpHeaders.Authorization, "Bearer $testSourceMapToken")
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                appendFile(
+                                    "file",
+                                    "proguard.zip",
+                                    zipProguardMappings("ignored/mapping.txt" to "ignored".toByteArray())
+                                )
+                            }
+                        )
+                    )
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+            assertEquals("[]", response.bodyAsText())
+            verify(exactly = 0) { quotaService.reserveUnits(any(), any(), any(), any()) }
+            verify(exactly = 0) { releaseService.storeChunk(any(), any()) }
+        }
+
+    @Test
+    fun `POST legacy dsyms upload returns 429 when quota reservation is rejected`() =
+        testApplication {
+            val releaseService = sourceMapReleaseService()
+            val mappingName = "proguard/$PROGUARD_DEBUG_ID.txt"
+            val mappingBytes = "quota mapping".toByteArray()
+            val quotaService = rejectingQuotaService()
+
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    releaseRoutes(releaseService, AuthTokenService(), quotaService, projectOrgEventService())
+                }
+            }
+
+            val response =
+                client.post("/api/0/projects/my-org/my-project/files/dsyms/") {
+                    header(HttpHeaders.Authorization, "Bearer $testSourceMapToken")
+                    setBody(
+                        MultiPartFormDataContent(
+                            formData {
+                                appendFile("file", "proguard.zip", zipProguardMapping(mappingName, mappingBytes))
+                            }
+                        )
+                    )
+                }
+
+            assertEquals(HttpStatusCode.TooManyRequests, response.status, response.bodyAsText())
+            verify { quotaService.reserveUnits(TEST_ORG_ID, 1, "sourcemap", mappingBytes.size.toLong()) }
+            verify(exactly = 0) { releaseService.storeChunk(any(), any()) }
+        }
+
+    @Test
     fun `POST legacy dsyms upload refunds only uncommitted mappings when later entry fails`() =
         testApplication {
             val releaseService = sourceMapReleaseService()


### PR DESCRIPTION
Adds compatibility for the Sentry ProGuard upload flow used by Android builds.

The legacy upload path now accepts the zipped mapping archive, stores ProGuard entries through the existing debug-file path, and handles the follow-up reprocessing request.

Validated with focused release route tests, release Detekt, backend Kotlin compilation, and diff hygiene.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a legacy Sentry CLI-compatible debug file upload endpoint that accepts multipart uploads, extracts ProGuard mappings when present, and stores processed debug information with checksum-based deduplication.
  * Added a Sentry CLI-compatible reprocessing endpoint for writing reprocessed debug information.
* **Bug Fixes**
  * Improved robustness of mapping extraction and storage so failed uploads refund only the uncommitted reserved quota.
* **Tests**
  * Added coverage for legacy upload behavior, partial refund scenarios, and the reprocessing endpoint response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->