### PR TITLE
feat: add google ads connector setup

### DIFF
--- a/ESSENTIAL_ENV_VARS.md
+++ b/ESSENTIAL_ENV_VARS.md
@@ -29,6 +29,7 @@ Workflow runtime variables are required when `WORKFLOWS_ENABLED=true` (the defau
 | `WORKFLOWS_TEMPORAL_PAYLOAD_KEY` | Workflows are enabled | Encrypts workflow payloads before they are stored in Temporal history. |
 | `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_REDIRECT_URI` | `SLACK_ENABLED=true` | Slack integration OAuth. |
 | `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `DISCORD_BOT_TOKEN` | `DISCORD_ENABLED=true` | Discord integration OAuth and bot delivery. |
+| `GOOGLE_ADS_DEVELOPER_TOKEN`, `GOOGLE_ADS_CLIENT_ID`, `GOOGLE_ADS_CLIENT_SECRET` | `GOOGLE_ADS_ENABLED=true` | Google Ads connector API access and OAuth token refresh. |
 | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | `STRIPE_ENABLED=true` | Stripe billing. |
 | `EXPO_TOKEN` | `ONCALL_ENABLED=true` | Mobile push notifications. |
 
@@ -47,6 +48,7 @@ These variables are optional. Ingestion queues use Redis Streams by default.
 | `INGESTION_<PIPELINE>_MAX_DELIVERIES` | `5` | Delivery count before a stream message is written to the DLQ stream. |
 | `INGESTION_<PIPELINE>_STREAM_MAXLEN` | `250000` | Approximate maximum length for the primary stream before Redis trims old acknowledged entries. |
 | `INGESTION_<PIPELINE>_DLQ_STREAM_MAXLEN` | `10000` | Approximate maximum length for the DLQ stream. |
+| `GOOGLE_ADS_API_VERSION` | `v24` | Google Ads API version used by the connector client. |
 
 Redis Streams are the durable ingestion buffer. Run Redis with persistence and HA appropriate for production, and
 alert on pending entries, oldest pending age, and DLQ growth.

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorCatalog.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorCatalog.kt
@@ -640,6 +640,10 @@ object ConnectorCatalog {
                             allowedAuthProfileId = "manager_oauth",
                             requiredScopes = listOf("https://www.googleapis.com/auth/adwords"),
                             resourceTypes = listOf("manager_account", "customer_account", "campaign"),
+                            availability = ConnectorAvailability.AVAILABLE,
+                            stateSource = CONNECTOR_INSTALLATIONS,
+                            setupRoute = CONNECTOR_INSTALLATIONS_SETUP_ROUTE,
+                            statusRoute = CONNECTOR_STATE_STATUS_ROUTE,
                         )
                     )
                 )

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorManagementModels.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorManagementModels.kt
@@ -21,7 +21,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ConnectorExternalAccountRequest(
-    val projectId: String,
+    val projectId: String = "",
+    val customerId: String? = null,
+    val managerCustomerId: String? = null,
 )
 
 @Serializable

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorService.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorService.kt
@@ -26,6 +26,7 @@ import com.moneat.shared.services.ProjectIdResolver
 import com.moneat.shared.services.toUuidOrNull
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -90,6 +91,7 @@ data class AcceptedConnectorWebhook(
 class ConnectorService(
     private val projectIdResolver: ProjectIdResolver = ProjectIdResolver(),
     private val revenueCatClient: RevenueCatProviderClient = RevenueCatClient(),
+    private val googleAdsClient: GoogleAdsProviderClient = GoogleAdsClient(),
     private val secretCipherFactory: () -> ConnectorSecretCipher = {
         PurposeConnectorSecretCipher(PurposeScopedSecretCipher.fromEnv(SecretVaultPurpose.DATA_IMPORT))
     },
@@ -131,6 +133,17 @@ class ConnectorService(
         }
 
     fun createInstallation(
+        organizationId: Int,
+        userId: Int,
+        request: CreateConnectorInstallationRequest,
+    ): ConnectorInstallationResponse =
+        when (request.providerId) {
+            RevenueCatClient.PROVIDER_ID -> createRevenueCatInstallation(organizationId, userId, request)
+            GoogleAdsClient.PROVIDER_ID -> createGoogleAdsInstallation(organizationId, userId, request)
+            else -> throw badRequest("Unsupported connector provider: ${request.providerId}")
+        }
+
+    private fun createRevenueCatInstallation(
         organizationId: Int,
         userId: Int,
         request: CreateConnectorInstallationRequest,
@@ -192,6 +205,70 @@ class ConnectorService(
         }
     }
 
+    private fun createGoogleAdsInstallation(
+        organizationId: Int,
+        userId: Int,
+        request: CreateConnectorInstallationRequest,
+    ): ConnectorInstallationResponse {
+        ensureGoogleAdsInstallRequest(request)
+        val credential = parseGoogleAdsCredential(request.secret)
+        val customerId = googleAdsCustomerId(request)
+        val managerCustomerId = googleAdsManagerCustomerId(request)
+        val customer = withGoogleAdsErrorMapping {
+            googleAdsClient.validateCustomer(credential, customerId, managerCustomerId)
+        }
+        val resources = withGoogleAdsErrorMapping {
+            googleAdsDiscoveredAccounts(credential, customer)
+        }
+        val cipher = secretCipherFactory()
+        val serializedCredential = json.encodeToString(credential)
+        val encryptedSecret = cipher.encrypt(serializedCredential, organizationId)
+        val now = Clock.System.now()
+
+        return transaction {
+            val installationId =
+                ConnectorInstallations.insert {
+                    it[ConnectorInstallations.organizationId] = organizationId
+                    it[provider] = GoogleAdsClient.PROVIDER_ID
+                    it[name] = request.name.trim().ifBlank {
+                        customer.descriptiveName?.let { accountName -> "Google Ads $accountName" } ?: "Google Ads"
+                    }
+                    it[credentialType] = "oauth_refresh_token"
+                    it[authProfileId] = GoogleAdsClient.AUTH_PROFILE_MANAGER_OAUTH
+                    it[externalProjectId] = customer.customerId
+                    it[externalProjectName] = customer.descriptiveName
+                    it[externalProjectDiscoveredAt] = now
+                    it[authPermissionsSummary] = stringMapJson(
+                        mapOf(
+                            "scope" to GoogleAdsClient.OAUTH_SCOPE,
+                            "loginCustomerId" to customer.loginCustomerId.orEmpty(),
+                        )
+                    )
+                    it[status] = STATUS_HEALTHY
+                    it[statusReason] = "Google Ads OAuth grant validated"
+                    it[lastTestedAt] = now
+                    it[lastTestResult] = "success"
+                    it[lastSuccessfulProviderCallAt] = now
+                    it[lastError] = null
+                    it[apiSecretCiphertext] = encryptedSecret
+                    it[apiSecretKeyId] = cipher.activeKeyId
+                    it[apiSecretLastFour] = credential.refreshToken.takeLast(API_SECRET_SUFFIX_CHARS)
+                    it[enabled] = true
+                    it[createdBy] = userId
+                    it[createdAt] = now
+                    it[updatedAt] = now
+                }[ConnectorInstallations.id]
+            upsertGoogleAdsCustomers(
+                organizationId = organizationId,
+                installationId = installationId,
+                externalProjectId = customer.customerId,
+                accounts = resources,
+                now = now,
+            )
+            installationRowById(organizationId, installationId).toInstallationResponse()
+        }
+    }
+
     fun deleteInstallation(
         organizationId: Int,
         installationResourceId: String,
@@ -213,9 +290,21 @@ class ConnectorService(
         installationResourceId: String,
         request: RotateConnectorApiCredentialRequest,
     ): ConnectorInstallationResponse {
-        val secret = normalizedSecret(request.secret)
         val row =
             transaction { installationRowByResourceId(organizationId, installationResourceId).toInstallationRecord() }
+        return when (row.provider) {
+            RevenueCatClient.PROVIDER_ID -> rotateRevenueCatCredential(organizationId, row, request)
+            GoogleAdsClient.PROVIDER_ID -> rotateGoogleAdsCredential(organizationId, row, request)
+            else -> throw badRequest("Unsupported connector provider: ${row.provider}")
+        }
+    }
+
+    private fun rotateRevenueCatCredential(
+        organizationId: Int,
+        row: ConnectorInstallationRecord,
+        request: RotateConnectorApiCredentialRequest,
+    ): ConnectorInstallationResponse {
+        val secret = normalizedSecret(request.secret)
         val projectId = row.externalProjectId ?: throw badRequest("Connector installation has no external project")
         withRevenueCatErrorMapping {
             revenueCatClient.resolveProject(secret, projectId)
@@ -245,6 +334,43 @@ class ConnectorService(
         }
     }
 
+    private fun rotateGoogleAdsCredential(
+        organizationId: Int,
+        row: ConnectorInstallationRecord,
+        request: RotateConnectorApiCredentialRequest,
+    ): ConnectorInstallationResponse {
+        val credential = parseGoogleAdsCredential(request.secret)
+        val customerId = row.externalProjectId ?: throw badRequest("Connector installation has no Google Ads customer")
+        val customer = withGoogleAdsErrorMapping {
+            googleAdsClient.validateCustomer(credential, customerId, credential.loginCustomerId)
+        }
+        val accounts = withGoogleAdsErrorMapping {
+            googleAdsDiscoveredAccounts(credential, customer)
+        }
+        val cipher = secretCipherFactory()
+        val encryptedSecret = cipher.encrypt(json.encodeToString(credential), organizationId)
+        val now = Clock.System.now()
+
+        return transaction {
+            ConnectorInstallations.update({ ConnectorInstallations.id eq row.id }) {
+                it[apiSecretCiphertext] = encryptedSecret
+                it[apiSecretKeyId] = cipher.activeKeyId
+                it[apiSecretLastFour] = credential.refreshToken.takeLast(API_SECRET_SUFFIX_CHARS)
+                it[status] = STATUS_HEALTHY
+                it[statusReason] = "Google Ads OAuth grant validated"
+                it[externalProjectName] = customer.descriptiveName
+                it[externalProjectDiscoveredAt] = now
+                it[lastTestedAt] = now
+                it[lastTestResult] = "success"
+                it[lastSuccessfulProviderCallAt] = now
+                it[lastError] = null
+                it[updatedAt] = now
+            }
+            upsertGoogleAdsCustomers(organizationId, row.id, customer.customerId, accounts, now)
+            installationRowById(organizationId, row.id).toInstallationResponse()
+        }
+    }
+
     fun rotateWebhookToken(
         organizationId: Int,
         installationResourceId: String,
@@ -253,6 +379,9 @@ class ConnectorService(
         val now = Clock.System.now()
         return transaction {
             val row = installationRowByResourceId(organizationId, installationResourceId)
+            if (row[ConnectorInstallations.provider] != RevenueCatClient.PROVIDER_ID) {
+                throw badRequest("Connector does not use webhook tokens")
+            }
             ConnectorInstallations.update({ ConnectorInstallations.id eq row[ConnectorInstallations.id] }) {
                 it[webhookTokenHash] = sha256Hex(webhookToken)
                 it[webhookTokenPrefix] = webhookToken.take(WEBHOOK_TOKEN_PREFIX_CHARS)
@@ -270,6 +399,17 @@ class ConnectorService(
     ): ConnectorInstallationResponse {
         val row =
             transaction { installationRowByResourceId(organizationId, installationResourceId).toInstallationRecord() }
+        return when (row.provider) {
+            RevenueCatClient.PROVIDER_ID -> testRevenueCatInstallation(organizationId, row)
+            GoogleAdsClient.PROVIDER_ID -> testGoogleAdsInstallation(organizationId, row)
+            else -> throw badRequest("Unsupported connector provider: ${row.provider}")
+        }
+    }
+
+    private fun testRevenueCatInstallation(
+        organizationId: Int,
+        row: ConnectorInstallationRecord,
+    ): ConnectorInstallationResponse {
         val projectId = row.externalProjectId ?: throw badRequest("Connector installation has no external project")
         val secret = decryptApiSecret(row)
         val now = Clock.System.now()
@@ -310,12 +450,67 @@ class ConnectorService(
         }
     }
 
+    private fun testGoogleAdsInstallation(
+        organizationId: Int,
+        row: ConnectorInstallationRecord,
+    ): ConnectorInstallationResponse {
+        val customerId = row.externalProjectId ?: throw badRequest("Connector installation has no Google Ads customer")
+        val credential = parseGoogleAdsCredential(decryptApiSecret(row))
+        val now = Clock.System.now()
+        return try {
+            val customer = withGoogleAdsErrorMapping {
+                googleAdsClient.validateCustomer(credential, customerId, credential.loginCustomerId)
+            }
+            val accounts = withGoogleAdsErrorMapping {
+                googleAdsDiscoveredAccounts(credential, customer)
+            }
+            transaction {
+                ConnectorInstallations.update({ ConnectorInstallations.id eq row.id }) {
+                    it[status] = STATUS_HEALTHY
+                    it[statusReason] = "Google Ads OAuth grant validated"
+                    it[externalProjectName] = customer.descriptiveName
+                    it[externalProjectDiscoveredAt] = now
+                    it[lastTestedAt] = now
+                    it[lastTestResult] = "success"
+                    it[lastSuccessfulProviderCallAt] = now
+                    it[lastError] = null
+                    it[updatedAt] = now
+                }
+                upsertGoogleAdsCustomers(organizationId, row.id, customer.customerId, accounts, now)
+                installationRowById(organizationId, row.id).toInstallationResponse()
+            }
+        } catch (error: ConnectorServiceException) {
+            transaction {
+                ConnectorInstallations.update({ ConnectorInstallations.id eq row.id }) {
+                    it[status] = STATUS_DEGRADED
+                    it[statusReason] = error.message
+                    it[lastTestedAt] = now
+                    it[lastTestResult] = "failed"
+                    it[lastError] = error.message
+                    it[updatedAt] = now
+                }
+                installationRowById(organizationId, row.id).toInstallationResponse()
+            }
+        }
+    }
+
     fun refreshExternalResources(
         organizationId: Int,
         installationResourceId: String,
     ): ConnectorExternalResourcesResponse {
         val row =
             transaction { installationRowByResourceId(organizationId, installationResourceId).toInstallationRecord() }
+        return when (row.provider) {
+            RevenueCatClient.PROVIDER_ID -> refreshRevenueCatExternalResources(organizationId, row)
+            GoogleAdsClient.PROVIDER_ID -> refreshGoogleAdsExternalResources(organizationId, row)
+            else -> throw badRequest("Unsupported connector provider: ${row.provider}")
+        }
+    }
+
+    private fun refreshRevenueCatExternalResources(
+        organizationId: Int,
+        row: ConnectorInstallationRecord,
+    ): ConnectorExternalResourcesResponse {
         val projectId = row.externalProjectId ?: throw badRequest("Connector installation has no external project")
         val apps = withRevenueCatErrorMapping {
             revenueCatClient.listApps(decryptApiSecret(row), projectId)
@@ -323,6 +518,34 @@ class ConnectorService(
         val now = Clock.System.now()
         return transaction {
             upsertRevenueCatApps(organizationId, row.id, projectId, apps, now)
+            resourcesForInstallation(organizationId, row.id)
+        }
+    }
+
+    private fun refreshGoogleAdsExternalResources(
+        organizationId: Int,
+        row: ConnectorInstallationRecord,
+    ): ConnectorExternalResourcesResponse {
+        val customerId = row.externalProjectId ?: throw badRequest("Connector installation has no Google Ads customer")
+        val credential = parseGoogleAdsCredential(decryptApiSecret(row))
+        val customer = withGoogleAdsErrorMapping {
+            googleAdsClient.validateCustomer(credential, customerId, credential.loginCustomerId)
+        }
+        val accounts = withGoogleAdsErrorMapping {
+            googleAdsDiscoveredAccounts(credential, customer)
+        }
+        val now = Clock.System.now()
+        return transaction {
+            upsertGoogleAdsCustomers(organizationId, row.id, customer.customerId, accounts, now)
+            ConnectorInstallations.update({ ConnectorInstallations.id eq row.id }) {
+                it[status] = STATUS_HEALTHY
+                it[statusReason] = "Google Ads accounts refreshed"
+                it[externalProjectName] = customer.descriptiveName
+                it[externalProjectDiscoveredAt] = now
+                it[lastSuccessfulProviderCallAt] = now
+                it[lastError] = null
+                it[updatedAt] = now
+            }
             resourcesForInstallation(organizationId, row.id)
         }
     }
@@ -371,6 +594,7 @@ class ConnectorService(
     ): ConnectorWebhookSetupResponse {
         val row =
             transaction { installationRowByResourceId(organizationId, installationResourceId).toInstallationRecord() }
+        ensureProvider(row, RevenueCatClient.PROVIDER_ID)
         val projectId = row.externalProjectId ?: throw badRequest("Connector installation has no external project")
         val webhookUrl = webhookUrl(row.resourceId)
         val observed = runCatching {
@@ -546,6 +770,26 @@ class ConnectorService(
         }
     }
 
+    fun connectorInstallationStates(
+        organizationId: Int,
+    ): Map<String, Pair<ConnectorConnectionSummary, ConnectorProviderStateDetail>> =
+        buildMap {
+            revenueCatState(organizationId).let { state ->
+                val summary = state.first
+                val detail = state.second
+                if (summary != null && detail != null) {
+                    put(RevenueCatClient.PROVIDER_ID, summary to detail)
+                }
+            }
+            googleAdsState(organizationId).let { state ->
+                val summary = state.first
+                val detail = state.second
+                if (summary != null && detail != null) {
+                    put(GoogleAdsClient.PROVIDER_ID, summary to detail)
+                }
+            }
+        }
+
     fun revenueCatState(organizationId: Int): Pair<ConnectorConnectionSummary?, ConnectorProviderStateDetail?> =
         transaction {
             val installation =
@@ -603,6 +847,52 @@ class ConnectorService(
             summary to detail
         }
 
+    fun googleAdsState(organizationId: Int): Pair<ConnectorConnectionSummary?, ConnectorProviderStateDetail?> =
+        transaction {
+            val installation =
+                ConnectorInstallations
+                    .selectAll()
+                    .where {
+                        (ConnectorInstallations.organizationId eq organizationId) and
+                            (ConnectorInstallations.provider eq GoogleAdsClient.PROVIDER_ID) and
+                            ConnectorInstallations.deletedAt.isNull()
+                    }
+                    .orderBy(ConnectorInstallations.createdAt, SortOrder.DESC)
+                    .firstOrNull()
+                    ?: return@transaction null to null
+            val record = installation.toInstallationRecord()
+            val resourceCount = externalResourceCount(record.id)
+            val health = when {
+                !record.enabled -> STATUS_DEGRADED
+                record.status == STATUS_DEGRADED -> STATUS_DEGRADED
+                record.status == STATUS_HEALTHY -> STATUS_HEALTHY
+                else -> "unknown"
+            }
+            val message = googleAdsStateMessage(record, resourceCount)
+            val detail = ConnectorProviderStateDetail(
+                installationId = record.resourceId.toString(),
+                status = record.status,
+                health = health,
+                message = message,
+                mappedResources = resourceCount,
+                unmappedEvents = 0,
+                failedReceipts = 0,
+                sandboxEvents = 0,
+                productionEvents = 0,
+                lastAcceptedWebhookAt = null,
+                lastAppliedAt = null,
+                processingLagSeconds = null,
+            )
+            val summary = ConnectorConnectionSummary(
+                providerId = GoogleAdsClient.PROVIDER_ID,
+                connected = true,
+                health = health,
+                detail = message,
+                lastCheckedAt = record.lastTestedAt?.toString(),
+            )
+            summary to detail
+        }
+
     private fun ensureRevenueCatInstallRequest(request: CreateConnectorInstallationRequest) {
         if (request.providerId != RevenueCatClient.PROVIDER_ID) {
             throw badRequest("Only RevenueCat connector installation is available in this release")
@@ -613,6 +903,53 @@ class ConnectorService(
         if (request.externalAccount.projectId.isBlank()) {
             throw badRequest("RevenueCat project ID is required")
         }
+    }
+
+    private fun ensureGoogleAdsInstallRequest(request: CreateConnectorInstallationRequest) {
+        if (request.authProfileId != GoogleAdsClient.AUTH_PROFILE_MANAGER_OAUTH) {
+            throw badRequest("Google Ads requires the manager_oauth auth profile")
+        }
+        googleAdsCustomerId(request)
+        parseGoogleAdsCredential(request.secret)
+    }
+
+    private fun googleAdsCustomerId(request: CreateConnectorInstallationRequest): String =
+        GoogleAdsClient.normalizeCustomerId(request.externalAccount.customerId ?: request.externalAccount.projectId)
+            ?: throw badRequest("Google Ads customer ID is required")
+
+    private fun googleAdsManagerCustomerId(request: CreateConnectorInstallationRequest): String? =
+        GoogleAdsClient.normalizeCustomerId(request.externalAccount.managerCustomerId)
+
+    private fun parseGoogleAdsCredential(secret: String): GoogleAdsOAuthCredential {
+        val normalized = normalizedSecret(secret)
+        val credential =
+            if (normalized.startsWith("{")) {
+                runCatching { json.decodeFromString<GoogleAdsOAuthCredential>(normalized) }
+                    .getOrElse { throw badRequest("Google Ads OAuth credential must be valid JSON") }
+            } else {
+                GoogleAdsOAuthCredential(refreshToken = normalized)
+            }
+        val refreshToken = credential.refreshToken.trim()
+        if (refreshToken.isBlank()) {
+            throw badRequest("Google Ads refresh token is required")
+        }
+        val loginCustomerId = GoogleAdsClient.normalizeCustomerId(credential.loginCustomerId)
+        return credential.copy(refreshToken = refreshToken, loginCustomerId = loginCustomerId)
+    }
+
+    private fun googleAdsDiscoveredAccounts(
+        credential: GoogleAdsOAuthCredential,
+        selectedCustomer: GoogleAdsCustomerAccount,
+    ): List<GoogleAdsCustomerAccount> {
+        val directAccounts = googleAdsClient.listAccessibleCustomers(credential)
+        val managedAccounts =
+            if (selectedCustomer.manager) {
+                googleAdsClient.listCustomerClients(credential, selectedCustomer.customerId)
+            } else {
+                emptyList()
+            }
+        return (listOf(selectedCustomer) + directAccounts + managedAccounts)
+            .distinctBy { account -> account.customerId }
     }
 
     private fun normalizedSecret(secret: String): String =
@@ -667,6 +1004,68 @@ class ConnectorService(
             }
         }
     }
+
+    private fun upsertGoogleAdsCustomers(
+        organizationId: Int,
+        installationId: Int,
+        externalProjectId: String,
+        accounts: List<GoogleAdsCustomerAccount>,
+        now: Instant,
+    ) {
+        accounts.forEach { account ->
+            val existing =
+                ConnectorExternalResources
+                    .selectAll()
+                    .where {
+                        (ConnectorExternalResources.installationId eq installationId) and
+                            (ConnectorExternalResources.externalResourceType eq googleAdsResourceType(account)) and
+                            (ConnectorExternalResources.externalResourceId eq account.customerId)
+                    }
+                    .firstOrNull()
+            val metadata = googleAdsAccountMetadata(account)
+            if (existing == null) {
+                ConnectorExternalResources.insert {
+                    it[ConnectorExternalResources.organizationId] = organizationId
+                    it[ConnectorExternalResources.installationId] = installationId
+                    it[ConnectorExternalResources.externalProjectId] = externalProjectId
+                    it[externalResourceType] = googleAdsResourceType(account)
+                    it[externalResourceId] = account.customerId
+                    it[displayName] = account.descriptiveName ?: account.customerId
+                    it[providerMetadata] = metadata
+                    it[lastSeenAt] = now
+                    it[createdAt] = now
+                    it[updatedAt] = now
+                }
+            } else {
+                ConnectorExternalResources.update({
+                    ConnectorExternalResources.id eq existing[ConnectorExternalResources.id]
+                }) {
+                    it[ConnectorExternalResources.externalProjectId] = externalProjectId
+                    it[displayName] = account.descriptiveName ?: account.customerId
+                    it[providerMetadata] = metadata
+                    it[lastSeenAt] = now
+                    it[updatedAt] = now
+                }
+            }
+        }
+    }
+
+    private fun googleAdsResourceType(account: GoogleAdsCustomerAccount): String =
+        if (account.manager) GoogleAdsClient.RESOURCE_TYPE_MANAGER else GoogleAdsClient.RESOURCE_TYPE_CUSTOMER
+
+    private fun googleAdsAccountMetadata(account: GoogleAdsCustomerAccount): String =
+        stringMapJson(
+            buildMap {
+                put("resourceName", account.resourceName)
+                put("manager", account.manager.toString())
+                account.testAccount?.let { value -> put("testAccount", value.toString()) }
+                account.status?.let { value -> put("status", value) }
+                account.currencyCode?.let { value -> put("currencyCode", value) }
+                account.timeZone?.let { value -> put("timeZone", value) }
+                account.level?.let { value -> put("level", value.toString()) }
+                account.loginCustomerId?.let { value -> put("loginCustomerId", value) }
+            }
+        )
 
     private fun resourcesForInstallation(
         organizationId: Int,
@@ -1182,6 +1581,13 @@ class ConnectorService(
             .count()
             .toInt()
 
+    private fun externalResourceCount(installationId: Int): Int =
+        ConnectorExternalResources
+            .selectAll()
+            .where { ConnectorExternalResources.installationId eq installationId }
+            .count()
+            .toInt()
+
     private fun failedReceiptCount(installationId: Int): Int =
         ConnectorEventReceipts
             .selectAll()
@@ -1283,6 +1689,19 @@ class ConnectorService(
             else -> "Connected"
         }
 
+    private fun googleAdsStateMessage(
+        record: ConnectorInstallationRecord,
+        resourceCount: Int,
+    ): String =
+        when {
+            !record.enabled -> "Google Ads connector is disabled"
+            record.lastError != null -> record.lastError
+            record.status == STATUS_DEGRADED -> "Google Ads API validation failed"
+            resourceCount == 0 -> "Connected, no Google Ads accounts discovered yet"
+            resourceCount == 1 -> "Connected to 1 Google Ads account"
+            else -> "Connected to $resourceCount Google Ads accounts"
+        }
+
     private fun ensureProvider(
         record: ConnectorInstallationRecord,
         providerId: String,
@@ -1299,12 +1718,28 @@ class ConnectorService(
             throw ConnectorServiceException(revenueCatStatus(error), error.message.orEmpty(), error)
         }
 
+    private fun <T> withGoogleAdsErrorMapping(block: () -> T): T =
+        try {
+            block()
+        } catch (error: GoogleAdsClientException) {
+            throw ConnectorServiceException(googleAdsStatus(error), error.message.orEmpty(), error)
+        }
+
     private fun revenueCatStatus(error: RevenueCatClientException): HttpStatusCode =
         when (error.code) {
             "revenuecat_unauthorized" -> HttpStatusCode.Unauthorized
             "revenuecat_forbidden" -> HttpStatusCode.Forbidden
             "revenuecat_not_found", "project_not_found" -> HttpStatusCode.NotFound
             "revenuecat_rate_limited" -> HttpStatusCode.TooManyRequests
+            else -> if (error.retryable) HttpStatusCode.BadGateway else HttpStatusCode.BadRequest
+        }
+
+    private fun googleAdsStatus(error: GoogleAdsClientException): HttpStatusCode =
+        when (error.code) {
+            "google_ads_unauthorized" -> HttpStatusCode.Unauthorized
+            "google_ads_forbidden" -> HttpStatusCode.Forbidden
+            "google_ads_not_found", "google_ads_customer_not_found" -> HttpStatusCode.NotFound
+            "google_ads_rate_limited" -> HttpStatusCode.TooManyRequests
             else -> if (error.retryable) HttpStatusCode.BadGateway else HttpStatusCode.BadRequest
         }
 

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorsModule.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorsModule.kt
@@ -43,7 +43,14 @@ class ConnectorsModule : EnterpriseModule {
         listOf(
             module {
                 single<RevenueCatProviderClient> { RevenueCatClient() }
-                single { ConnectorService(projectIdResolver = get(), revenueCatClient = get()) }
+                single<GoogleAdsProviderClient> { GoogleAdsClient() }
+                single {
+                    ConnectorService(
+                        projectIdResolver = get(),
+                        revenueCatClient = get(),
+                        googleAdsClient = get(),
+                    )
+                }
                 single { ConnectorEventWorker(connectorService = get()) }
             }
         )

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/GoogleAdsClient.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/GoogleAdsClient.kt
@@ -1,0 +1,472 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.connectors
+
+import com.moneat.config.EnvConfig
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlin.time.Clock
+
+private const val GOOGLE_ADS_BASE_URL = "https://googleads.googleapis.com"
+private const val GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+private const val GOOGLE_ADS_DEFAULT_API_VERSION = "v24"
+private const val GOOGLE_ADS_CONNECT_TIMEOUT_SECONDS = 5L
+private const val GOOGLE_ADS_REQUEST_TIMEOUT_SECONDS = 15L
+private const val PROVIDER_GOOGLE_ADS = "google_ads"
+private const val GOOGLE_ADS_REFRESH_TOKEN_GRANT = "refresh_token"
+private const val ACCESS_TOKEN_EXPIRY_SKEW_SECONDS = 60L
+
+@Serializable
+data class GoogleAdsOAuthCredential(
+    val refreshToken: String,
+    val accessToken: String? = null,
+    val expiresAtEpochSeconds: Long? = null,
+    val tokenType: String? = null,
+    val scope: String? = null,
+    val loginCustomerId: String? = null,
+)
+
+data class GoogleAdsCustomerAccount(
+    val customerId: String,
+    val resourceName: String,
+    val descriptiveName: String?,
+    val manager: Boolean,
+    val testAccount: Boolean?,
+    val status: String?,
+    val currencyCode: String?,
+    val timeZone: String?,
+    val level: Int?,
+    val loginCustomerId: String?,
+)
+
+class GoogleAdsClientException(
+    message: String,
+    val code: String,
+    val retryable: Boolean = false,
+) : RuntimeException(message)
+
+interface GoogleAdsProviderClient {
+    fun validateCustomer(
+        credential: GoogleAdsOAuthCredential,
+        customerId: String,
+        managerCustomerId: String?,
+    ): GoogleAdsCustomerAccount
+
+    fun listAccessibleCustomers(credential: GoogleAdsOAuthCredential): List<GoogleAdsCustomerAccount>
+
+    fun listCustomerClients(
+        credential: GoogleAdsOAuthCredential,
+        loginCustomerId: String,
+    ): List<GoogleAdsCustomerAccount>
+}
+
+data class GoogleAdsClientConfig(
+    val baseUrl: String = GOOGLE_ADS_BASE_URL,
+    val oauthTokenUrl: String = GOOGLE_OAUTH_TOKEN_URL,
+    val apiVersion: String = EnvConfig.get("GOOGLE_ADS_API_VERSION", GOOGLE_ADS_DEFAULT_API_VERSION),
+    val developerTokenProvider: () -> String? = { EnvConfig.get("GOOGLE_ADS_DEVELOPER_TOKEN") },
+    val clientIdProvider: () -> String? = { EnvConfig.get("GOOGLE_ADS_CLIENT_ID") },
+    val clientSecretProvider: () -> String? = { EnvConfig.get("GOOGLE_ADS_CLIENT_SECRET") },
+)
+
+class GoogleAdsClient(
+    private val config: GoogleAdsClientConfig = GoogleAdsClientConfig(),
+    private val httpClient: HttpClient = HttpClient
+        .newBuilder()
+        .connectTimeout(Duration.ofSeconds(GOOGLE_ADS_CONNECT_TIMEOUT_SECONDS))
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build(),
+) : GoogleAdsProviderClient {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun validateCustomer(
+        credential: GoogleAdsOAuthCredential,
+        customerId: String,
+        managerCustomerId: String?,
+    ): GoogleAdsCustomerAccount {
+        val normalizedCustomerId = normalizeCustomerId(customerId)
+            ?: throw GoogleAdsClientException("Google Ads customer ID is required", "missing_customer_id")
+        val normalizedManagerId = normalizeCustomerId(managerCustomerId ?: credential.loginCustomerId)
+        if (normalizedManagerId != null) {
+            val managed = listCustomerClients(credential, normalizedManagerId)
+            val match = managed.firstOrNull { account -> account.customerId == normalizedCustomerId }
+            if (match != null) return match
+        }
+        val accessible = listAccessibleCustomers(credential)
+        if (accessible.none { account -> account.customerId == normalizedCustomerId }) {
+            throw GoogleAdsClientException(
+                "Google Ads customer was not visible to this OAuth grant",
+                "google_ads_customer_not_found",
+            )
+        }
+        return getCustomer(credential, normalizedCustomerId, normalizedManagerId)
+    }
+
+    override fun listAccessibleCustomers(credential: GoogleAdsOAuthCredential): List<GoogleAdsCustomerAccount> {
+        val response = sendAdsRequest(
+            GoogleAdsRequest(
+                credential = credential,
+                method = "GET",
+                path = "/customers:listAccessibleCustomers",
+                loginCustomerId = null,
+                body = null,
+                operation = "list accessible Google Ads customers",
+            )
+        )
+        val root = json.parseToJsonElement(response.body()).jsonObject
+        return root["resourceNames"]
+            ?.jsonArray
+            ?.mapNotNull { element ->
+                val resourceName = element.jsonPrimitive.contentOrNull ?: return@mapNotNull null
+                val customerId = normalizeCustomerId(resourceName) ?: return@mapNotNull null
+                GoogleAdsCustomerAccount(
+                    customerId = customerId,
+                    resourceName = resourceName,
+                    descriptiveName = null,
+                    manager = false,
+                    testAccount = null,
+                    status = null,
+                    currencyCode = null,
+                    timeZone = null,
+                    level = null,
+                    loginCustomerId = null,
+                )
+            }
+            .orEmpty()
+    }
+
+    override fun listCustomerClients(
+        credential: GoogleAdsOAuthCredential,
+        loginCustomerId: String,
+    ): List<GoogleAdsCustomerAccount> {
+        val normalizedLoginCustomerId = normalizeCustomerId(loginCustomerId)
+            ?: throw GoogleAdsClientException("Google Ads manager customer ID is required", "missing_manager_id")
+        val response = searchStream(
+            credential = credential,
+            customerId = normalizedLoginCustomerId,
+            loginCustomerId = normalizedLoginCustomerId,
+            query = CUSTOMER_CLIENT_QUERY,
+            operation = "list Google Ads customer clients",
+        )
+        return parseSearchResults(response.body(), "customerClient").mapNotNull { obj ->
+            val resourceName = obj.string("clientCustomer") ?: obj.string("resourceName") ?: return@mapNotNull null
+            val customerId = normalizeCustomerId(resourceName) ?: return@mapNotNull null
+            GoogleAdsCustomerAccount(
+                customerId = customerId,
+                resourceName = resourceName,
+                descriptiveName = obj.string("descriptiveName"),
+                manager = obj.boolean("manager") == true,
+                testAccount = obj.boolean("testAccount"),
+                status = obj.string("status"),
+                currencyCode = obj.string("currencyCode"),
+                timeZone = obj.string("timeZone"),
+                level = obj.int("level"),
+                loginCustomerId = normalizedLoginCustomerId,
+            )
+        }
+    }
+
+    private fun getCustomer(
+        credential: GoogleAdsOAuthCredential,
+        customerId: String,
+        loginCustomerId: String?,
+    ): GoogleAdsCustomerAccount {
+        val response = searchStream(
+            credential = credential,
+            customerId = customerId,
+            loginCustomerId = loginCustomerId,
+            query = CUSTOMER_QUERY,
+            operation = "inspect Google Ads customer",
+        )
+        val customer = parseSearchResults(response.body(), "customer").firstOrNull()
+        return GoogleAdsCustomerAccount(
+            customerId = customerId,
+            resourceName = customer?.string("resourceName") ?: "customers/$customerId",
+            descriptiveName = customer?.string("descriptiveName"),
+            manager = customer?.boolean("manager") == true,
+            testAccount = customer?.boolean("testAccount"),
+            status = customer?.string("status"),
+            currencyCode = customer?.string("currencyCode"),
+            timeZone = customer?.string("timeZone"),
+            level = null,
+            loginCustomerId = loginCustomerId,
+        )
+    }
+
+    private fun searchStream(
+        credential: GoogleAdsOAuthCredential,
+        customerId: String,
+        loginCustomerId: String?,
+        query: String,
+        operation: String,
+    ): HttpResponse<String> {
+        val body = json.encodeToString(JsonObject(mapOf("query" to JsonPrimitive(query))))
+        return sendAdsRequest(
+            GoogleAdsRequest(
+                credential = credential,
+                method = "POST",
+                path = "/customers/${pathSegment(customerId)}/googleAds:searchStream",
+                loginCustomerId = loginCustomerId,
+                body = body,
+                operation = operation,
+            )
+        )
+    }
+
+    private fun sendAdsRequest(requestOptions: GoogleAdsRequest): HttpResponse<String> {
+        val uri = googleAdsUri(requestOptions.path)
+        val builder = HttpRequest
+            .newBuilder(uri)
+            .timeout(Duration.ofSeconds(GOOGLE_ADS_REQUEST_TIMEOUT_SECONDS))
+            .header("Authorization", "Bearer ${accessToken(requestOptions.credential)}")
+            .header("developer-token", developerToken())
+            .header("Accept", "application/json")
+        if (requestOptions.loginCustomerId != null) {
+            builder.header("login-customer-id", requestOptions.loginCustomerId)
+        }
+        if (requestOptions.method == "POST") {
+            builder
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestOptions.body.orEmpty()))
+        } else {
+            builder.GET()
+        }
+        val response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+        ensureSuccess(response, requestOptions.operation)
+        return response
+    }
+
+    private fun accessToken(credential: GoogleAdsOAuthCredential): String {
+        val now = Clock.System.now().epochSeconds
+        val usableAccessToken =
+            credential.accessToken?.takeIf {
+                credential.expiresAtEpochSeconds == null ||
+                    credential.expiresAtEpochSeconds > now + ACCESS_TOKEN_EXPIRY_SKEW_SECONDS
+            }
+        if (!usableAccessToken.isNullOrBlank()) return usableAccessToken
+        return refreshAccessToken(credential)
+    }
+
+    private fun refreshAccessToken(credential: GoogleAdsOAuthCredential): String {
+        val refreshToken = credential.refreshToken.trim().takeIf { it.isNotBlank() }
+            ?: throw GoogleAdsClientException("Google Ads refresh token is required", "missing_refresh_token")
+        val form = formBody(
+            mapOf(
+                "client_id" to oauthClientId(),
+                "client_secret" to oauthClientSecret(),
+                "refresh_token" to refreshToken,
+                "grant_type" to GOOGLE_ADS_REFRESH_TOKEN_GRANT,
+            )
+        )
+        val uri = URI.create(config.oauthTokenUrl)
+        if (uri.scheme != "https" || uri.host != "oauth2.googleapis.com") {
+            throw GoogleAdsClientException("Invalid Google OAuth token host", "invalid_provider_host")
+        }
+        val request = HttpRequest
+            .newBuilder(uri)
+            .timeout(Duration.ofSeconds(GOOGLE_ADS_REQUEST_TIMEOUT_SECONDS))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Accept", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(form))
+            .build()
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        ensureSuccess(response, "refresh Google Ads OAuth token")
+        return json
+            .parseToJsonElement(response.body())
+            .jsonObject
+            .string("access_token")
+            ?: throw GoogleAdsClientException("Google OAuth token response was missing an access token", "oauth_error")
+    }
+
+    private fun googleAdsUri(path: String): URI {
+        val version = config.apiVersion.trim().trim('/')
+        val normalizedPath = path.trimStart('/')
+        val uri = URI.create("${config.baseUrl.trimEnd('/')}/$version/$normalizedPath")
+        if (uri.scheme != "https" || uri.host != "googleads.googleapis.com") {
+            throw GoogleAdsClientException("Invalid Google Ads API host", "invalid_provider_host")
+        }
+        return uri
+    }
+
+    private fun developerToken(): String =
+        config.developerTokenProvider()
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: throw GoogleAdsClientException(
+                "Google Ads developer token is not configured",
+                "google_ads_not_configured",
+            )
+
+    private fun oauthClientId(): String =
+        config.clientIdProvider()
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: throw GoogleAdsClientException(
+                "Google Ads OAuth client ID is not configured",
+                "google_ads_not_configured",
+            )
+
+    private fun oauthClientSecret(): String =
+        config.clientSecretProvider()
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: throw GoogleAdsClientException(
+                "Google Ads OAuth client secret is not configured",
+                "google_ads_not_configured",
+            )
+
+    private fun ensureSuccess(
+        response: HttpResponse<String>,
+        operation: String,
+    ) {
+        when (response.statusCode()) {
+            in HTTP_SUCCESS_RANGE -> return
+            HTTP_UNAUTHORIZED -> throw GoogleAdsClientException(
+                "Google Ads rejected the OAuth credential while trying to $operation",
+                "google_ads_unauthorized",
+            )
+            HTTP_FORBIDDEN -> throw GoogleAdsClientException(
+                "Google Ads API permissions were insufficient while trying to $operation",
+                "google_ads_forbidden",
+            )
+            HTTP_NOT_FOUND -> throw GoogleAdsClientException(
+                "Google Ads resource was not found while trying to $operation",
+                "google_ads_not_found",
+            )
+            HTTP_TOO_MANY_REQUESTS -> throw GoogleAdsClientException(
+                "Google Ads rate limited the request to $operation",
+                "google_ads_rate_limited",
+                retryable = true,
+            )
+            else -> throw GoogleAdsClientException(
+                "Google Ads API request failed while trying to $operation",
+                "google_ads_api_error",
+                retryable = response.statusCode() >= HTTP_SERVER_ERROR_MIN,
+            )
+        }
+    }
+
+    private fun parseSearchResults(
+        body: String,
+        objectKey: String,
+    ): List<JsonObject> {
+        val root = json.parseToJsonElement(body)
+        val batches = if (root is JsonArray) root.toList() else listOf(root)
+        return batches.flatMap { batch ->
+            batch.jsonObjectOrNull()
+                ?.get("results")
+                ?.jsonArray
+                ?.mapNotNull { result -> result.jsonObjectOrNull()?.get(objectKey)?.jsonObjectOrNull() }
+                .orEmpty()
+        }
+    }
+
+    private fun formBody(values: Map<String, String>): String =
+        values.entries.joinToString("&") { (key, value) ->
+            "${key.urlEncode()}=${value.urlEncode()}"
+        }
+
+    private fun pathSegment(value: String): String =
+        value.trim().replace("/", "%2F")
+
+    companion object {
+        const val PROVIDER_ID: String = PROVIDER_GOOGLE_ADS
+        const val AUTH_PROFILE_MANAGER_OAUTH: String = "manager_oauth"
+        const val RESOURCE_TYPE_CUSTOMER: String = "google_ads_customer"
+        const val RESOURCE_TYPE_MANAGER: String = "google_ads_manager"
+        const val OAUTH_SCOPE: String = "https://www.googleapis.com/auth/adwords"
+
+        fun normalizeCustomerId(value: String?): String? =
+            value
+                ?.filter { char -> char.isDigit() }
+                ?.takeIf { it.isNotBlank() }
+
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_NOT_FOUND = 404
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val HTTP_SERVER_ERROR_MIN = 500
+        private val HTTP_SUCCESS_RANGE = 200..299
+        private val CUSTOMER_QUERY = """
+            SELECT
+              customer.id,
+              customer.resource_name,
+              customer.descriptive_name,
+              customer.manager,
+              customer.test_account,
+              customer.status,
+              customer.currency_code,
+              customer.time_zone
+            FROM customer
+            LIMIT 1
+        """.trimIndent()
+        private val CUSTOMER_CLIENT_QUERY = """
+            SELECT
+              customer_client.client_customer,
+              customer_client.descriptive_name,
+              customer_client.manager,
+              customer_client.test_account,
+              customer_client.status,
+              customer_client.currency_code,
+              customer_client.time_zone,
+              customer_client.level
+            FROM customer_client
+            WHERE customer_client.level <= 1
+        """.trimIndent()
+    }
+}
+
+private fun JsonElement.jsonObjectOrNull(): JsonObject? =
+    this as? JsonObject
+
+private fun JsonObject.string(key: String): String? =
+    this[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+
+private fun JsonObject.boolean(key: String): Boolean? =
+    this[key]?.jsonPrimitive?.booleanOrNull
+
+private fun JsonObject.int(key: String): Int? =
+    this[key]?.jsonPrimitive?.intOrNull
+
+private fun String.urlEncode(): String =
+    URLEncoder.encode(this, Charsets.UTF_8)
+
+private data class GoogleAdsRequest(
+    val credential: GoogleAdsOAuthCredential,
+    val method: String,
+    val path: String,
+    val loginCustomerId: String?,
+    val body: String?,
+    val operation: String,
+)

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/routes/ConnectorRoutes.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/routes/ConnectorRoutes.kt
@@ -33,7 +33,6 @@ import com.moneat.connectors.ConnectorUseDefinition
 import com.moneat.connectors.ConnectorUseState
 import com.moneat.connectors.ConnectorWebhookAcceptedResponse
 import com.moneat.connectors.CreateConnectorInstallationRequest
-import com.moneat.connectors.RevenueCatClient
 import com.moneat.connectors.RotateConnectorApiCredentialRequest
 import com.moneat.connectors.UpsertConnectorBindingRequest
 import com.moneat.shared.models.OrganizationIntegrations
@@ -80,20 +79,18 @@ private suspend fun ApplicationCall.respondConnectorState(connectorService: Conn
         principal<JWTPrincipal>()?.currentOrgIdOrNull()
             ?: return respond(HttpStatusCode.NotFound, ErrorResponse("No organization found"))
     val legacyIntegrations = legacyIntegrationStates(organizationId)
-    val revenueCatState = connectorService.revenueCatState(organizationId)
+    val connectorStates = connectorService.connectorInstallationStates(organizationId)
     val response =
         ConnectorStateResponse(
             connections = ConnectorCatalog.providers.map { provider ->
-                val connectorSummary = revenueCatState.first.takeIf {
-                    provider.id == RevenueCatClient.PROVIDER_ID
-                }
+                val connectorSummary = connectorStates[provider.id]?.first
                 provider.providerConnectionSummary(
                     integration = legacyIntegrations[provider.id],
                     connectorSummary = connectorSummary,
                 )
             },
             providers = ConnectorCatalog.providers.map { provider ->
-                val detail = revenueCatState.second.takeIf { provider.id == RevenueCatClient.PROVIDER_ID }
+                val detail = connectorStates[provider.id]?.second
                 ConnectorProviderState(
                     providerId = provider.id,
                     uses = provider.uses.map { use ->

--- a/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorCatalogTest.kt
+++ b/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorCatalogTest.kt
@@ -69,8 +69,10 @@ class ConnectorCatalogTest {
         assertEquals("/v1/connectors/installations", revenueCat.setupRoute)
         assertEquals("/v1/connectors/state", revenueCat.statusRoute)
         assertEquals(ConnectorFamily.DATA_IMPORT, googleAds.family)
-        assertEquals(ConnectorAvailability.PLANNED, googleAds.availability)
-        assertEquals("cloud_sources", googleAds.stateSource)
+        assertEquals(ConnectorAvailability.AVAILABLE, googleAds.availability)
+        assertEquals("connector_installations", googleAds.stateSource)
+        assertEquals("/v1/connectors/installations", googleAds.setupRoute)
+        assertEquals("/v1/connectors/state", googleAds.statusRoute)
     }
 
     private fun provider(id: String): ConnectorProviderDefinition {

--- a/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorServiceTest.kt
+++ b/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorServiceTest.kt
@@ -45,6 +45,9 @@ class ConnectorServiceTest {
         private const val OTHER_PROJECT_ID = 101L
         private const val REVENUECAT_PROJECT_ID = "proj_bandapella"
         private const val REVENUECAT_SECRET = "rc_sk_live_1234"
+        private const val GOOGLE_ADS_CUSTOMER_ID = "1234567890"
+        private const val GOOGLE_ADS_CHILD_CUSTOMER_ID = "2223334444"
+        private const val GOOGLE_ADS_REFRESH_TOKEN = "google_refresh_3456"
         private var db: Database? = null
     }
 
@@ -86,6 +89,39 @@ class ConnectorServiceTest {
             assertFalse(installation[ConnectorInstallations.apiSecretCiphertext].orEmpty().contains(REVENUECAT_SECRET))
             assertNotEquals(response.webhookToken, installation[ConnectorInstallations.webhookTokenHash])
             assertEquals(2L, ConnectorExternalResources.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `create installation redacts Google Ads OAuth credentials and caches accounts`() {
+        val service = connectorService()
+
+        val response = service.createInstallation(ORGANIZATION_ID, USER_ID, googleAdsRequest())
+
+        assertEquals(GoogleAdsClient.PROVIDER_ID, response.providerId)
+        assertEquals(GOOGLE_ADS_CUSTOMER_ID, response.externalProjectId)
+        assertEquals("Bandapella Google Ads", response.externalProjectName)
+        assertEquals("oauth_refresh_token", response.credentialType)
+        assertEquals("3456", response.apiSecretLastFour)
+        assertEquals("healthy", response.status)
+
+        transaction {
+            val installation = ConnectorInstallations.selectAll().single()
+            assertFalse(
+                installation[ConnectorInstallations.apiSecretCiphertext].orEmpty().contains(GOOGLE_ADS_REFRESH_TOKEN)
+            )
+            val resources = ConnectorExternalResources.selectAll().toList()
+            assertEquals(2, resources.size)
+            assertTrue(
+                resources.any { row ->
+                    row[ConnectorExternalResources.externalResourceId] == GOOGLE_ADS_CUSTOMER_ID
+                }
+            )
+            assertTrue(
+                resources.any { row ->
+                    row[ConnectorExternalResources.externalResourceId] == GOOGLE_ADS_CHILD_CUSTOMER_ID
+                }
+            )
         }
     }
 
@@ -203,11 +239,25 @@ class ConnectorServiceTest {
         assertEquals("needs_mapping", detail.health)
     }
 
+    @Test
+    fun `state reports connected Google Ads installation detail`() {
+        val service = connectorService()
+
+        service.createInstallation(ORGANIZATION_ID, USER_ID, googleAdsRequest())
+
+        val detail = assertNotNull(service.googleAdsState(ORGANIZATION_ID).second)
+
+        assertEquals(2, detail.mappedResources)
+        assertEquals("healthy", detail.health)
+        assertEquals("Connected to 2 Google Ads accounts", detail.message)
+    }
+
     private fun connectorService(
         queuedMessages: MutableList<String> = mutableListOf(),
     ): ConnectorService =
         ConnectorService(
             revenueCatClient = FakeRevenueCatProviderClient(),
+            googleAdsClient = FakeGoogleAdsProviderClient(),
             secretCipherFactory = { FakeConnectorSecretCipher },
             enqueueConnectorEvent = { payload -> queuedMessages += payload },
         )
@@ -219,6 +269,18 @@ class ConnectorServiceTest {
             name = "Bandapella RevenueCat",
             externalAccount = ConnectorExternalAccountRequest(projectId = REVENUECAT_PROJECT_ID),
             secret = REVENUECAT_SECRET,
+        )
+
+    private fun googleAdsRequest(): CreateConnectorInstallationRequest =
+        CreateConnectorInstallationRequest(
+            providerId = GoogleAdsClient.PROVIDER_ID,
+            authProfileId = GoogleAdsClient.AUTH_PROFILE_MANAGER_OAUTH,
+            name = "Bandapella Google Ads",
+            externalAccount = ConnectorExternalAccountRequest(
+                customerId = GOOGLE_ADS_CUSTOMER_ID,
+                managerCustomerId = GOOGLE_ADS_CUSTOMER_ID,
+            ),
+            secret = """{"refreshToken":"$GOOGLE_ADS_REFRESH_TOKEN"}""",
         )
 
     private fun bindingRequest(
@@ -323,6 +385,57 @@ class ConnectorServiceTest {
         ): Pair<List<ConnectorObservedWebhookIntegration>, List<String>> {
             resolveProject(apiKey, projectId)
             return emptyList<ConnectorObservedWebhookIntegration>() to emptyList()
+        }
+    }
+
+    private class FakeGoogleAdsProviderClient : GoogleAdsProviderClient {
+        override fun validateCustomer(
+            credential: GoogleAdsOAuthCredential,
+            customerId: String,
+            managerCustomerId: String?,
+        ): GoogleAdsCustomerAccount {
+            if (credential.refreshToken != GOOGLE_ADS_REFRESH_TOKEN) {
+                throw GoogleAdsClientException("Google Ads rejected the OAuth credential", "google_ads_unauthorized")
+            }
+            if (customerId != GOOGLE_ADS_CUSTOMER_ID) {
+                throw GoogleAdsClientException("Google Ads customer was not visible", "google_ads_customer_not_found")
+            }
+            return GoogleAdsCustomerAccount(
+                customerId = GOOGLE_ADS_CUSTOMER_ID,
+                resourceName = "customers/$GOOGLE_ADS_CUSTOMER_ID",
+                descriptiveName = "Bandapella Google Ads",
+                manager = true,
+                testAccount = false,
+                status = "ENABLED",
+                currencyCode = "USD",
+                timeZone = "America/New_York",
+                level = 0,
+                loginCustomerId = managerCustomerId,
+            )
+        }
+
+        override fun listAccessibleCustomers(credential: GoogleAdsOAuthCredential): List<GoogleAdsCustomerAccount> =
+            listOf(validateCustomer(credential, GOOGLE_ADS_CUSTOMER_ID, null))
+
+        override fun listCustomerClients(
+            credential: GoogleAdsOAuthCredential,
+            loginCustomerId: String,
+        ): List<GoogleAdsCustomerAccount> {
+            validateCustomer(credential, loginCustomerId, loginCustomerId)
+            return listOf(
+                GoogleAdsCustomerAccount(
+                    customerId = GOOGLE_ADS_CHILD_CUSTOMER_ID,
+                    resourceName = "customers/$GOOGLE_ADS_CHILD_CUSTOMER_ID",
+                    descriptiveName = "Bandapella iOS UA",
+                    manager = false,
+                    testAccount = false,
+                    status = "ENABLED",
+                    currencyCode = "USD",
+                    timeZone = "America/New_York",
+                    level = 1,
+                    loginCustomerId = loginCustomerId,
+                )
+            )
         }
     }
 

--- a/backend/features/connectors/src/test/kotlin/com/moneat/connectors/routes/ConnectorRoutesTest.kt
+++ b/backend/features/connectors/src/test/kotlin/com/moneat/connectors/routes/ConnectorRoutesTest.kt
@@ -209,6 +209,55 @@ class ConnectorRoutesTest {
     }
 
     @Test
+    fun `state endpoint reports Google Ads connector installation detail`() {
+        val installationId =
+            transaction {
+                Organizations.insert {
+                    it[id] = ORGANIZATION_ID
+                    it[name] = "Connector Org"
+                    it[slug] = "connector-org"
+                }
+                ConnectorInstallations.insert {
+                    it[organizationId] = ORGANIZATION_ID
+                    it[provider] = "google_ads"
+                    it[name] = "Bandapella Google Ads"
+                    it[credentialType] = "oauth_refresh_token"
+                    it[authProfileId] = "manager_oauth"
+                    it[externalProjectId] = "1234567890"
+                    it[externalProjectName] = "Bandapella Google Ads"
+                    it[status] = "healthy"
+                    it[apiSecretLastFour] = "3456"
+                    it[enabled] = true
+                    it[createdAt] = Clock.System.now()
+                    it[updatedAt] = Clock.System.now()
+                }[ConnectorInstallations.resourceId].toString()
+            }
+
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                installAuth()
+                routing {
+                    connectorRoutes()
+                }
+            }
+
+            val response =
+                client.get("/v1/connectors/state") {
+                    header(HttpHeaders.Authorization, "Bearer ${token()}")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"providerId\":\"google_ads\""))
+            assertTrue(body.contains("\"state\":\"connected\""))
+            assertTrue(body.contains("\"integrationId\":\"$installationId\""))
+            assertTrue(body.contains("Connected, no Google Ads accounts discovered yet"))
+            assertTrue(body.contains("\"status\":\"healthy\""))
+        }
+    }
+
+    @Test
     fun `installation writes require organization admin role`() {
         testApplication {
             application {

--- a/backend/src/main/kotlin/com/moneat/config/EnvironmentValidator.kt
+++ b/backend/src/main/kotlin/com/moneat/config/EnvironmentValidator.kt
@@ -22,6 +22,7 @@ import com.moneat.secrets.SecretVaultPurpose
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
+private const val GOOGLE_ADS_CONNECTOR_ENABLED_REASON = "Google Ads connector is enabled"
 
 class EnvironmentValidator {
 
@@ -112,6 +113,8 @@ class EnvironmentValidator {
             validateRequired("DISCORD_BOT_TOKEN", "Discord integration is enabled", errors)
         }
 
+        validateGoogleAdsConnectorConfig(errors)
+
         // Validate Stripe configuration when enabled
         val stripeEnabled = getConfigValue("STRIPE_ENABLED")?.toBoolean() ?: false
         if (stripeEnabled) {
@@ -151,6 +154,15 @@ class EnvironmentValidator {
 
         validateProcessRole(errors)
         validateWorkflowRuntimeConfig(errors)
+    }
+
+    private fun validateGoogleAdsConnectorConfig(errors: MutableList<String>) {
+        val googleAdsEnabled = getConfigValue("GOOGLE_ADS_ENABLED")?.toBoolean() ?: false
+        if (googleAdsEnabled) {
+            validateRequired("GOOGLE_ADS_DEVELOPER_TOKEN", GOOGLE_ADS_CONNECTOR_ENABLED_REASON, errors)
+            validateRequired("GOOGLE_ADS_CLIENT_ID", GOOGLE_ADS_CONNECTOR_ENABLED_REASON, errors)
+            validateRequired("GOOGLE_ADS_CLIENT_SECRET", GOOGLE_ADS_CONNECTOR_ENABLED_REASON, errors)
+        }
     }
 
     private fun validateProcessRole(errors: MutableList<String>) {

--- a/backend/src/test/kotlin/com/moneat/config/EnvironmentValidatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/EnvironmentValidatorTest.kt
@@ -45,7 +45,19 @@ class EnvironmentValidatorTest {
 
         assertFalse(result.errors.any { it.contains("SLACK_CLIENT_ID") })
         assertFalse(result.errors.any { it.contains("DISCORD_CLIENT_ID") })
+        assertFalse(result.errors.any { it.contains("GOOGLE_ADS_DEVELOPER_TOKEN") })
         assertFalse(result.errors.any { it.contains("STRIPE_SECRET_KEY") })
+    }
+
+    @Test
+    fun `validate requires Google Ads provider config when enabled`() {
+        withSystemProperty("GOOGLE_ADS_ENABLED", "true") {
+            val result = EnvironmentValidator().validate()
+
+            assertTrue(result.errors.any { it.contains("GOOGLE_ADS_DEVELOPER_TOKEN") })
+            assertTrue(result.errors.any { it.contains("GOOGLE_ADS_CLIENT_ID") })
+            assertTrue(result.errors.any { it.contains("GOOGLE_ADS_CLIENT_SECRET") })
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add Google Ads installation, discovery, and state support
- validate provider env config
- cover connector state and setup paths

## Tests
- ./gradlew :features:connectors:test --tests com.moneat.connectors.ConnectorServiceTest --tests com.moneat.connectors.routes.ConnectorRoutesTest --tests com.moneat.connectors.ConnectorCatalogTest --no-daemon
- ./gradlew detekt --no-daemon
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check