### PR TITLE
fix: allow portless Prometheus data sources

### DIFF
--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/CustomDataSourceServiceTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/CustomDataSourceServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.dashboards
 
+import com.moneat.dashboards.models.UpdateCustomDataSourceRequest
 import com.moneat.dashboards.services.CustomDataSourceService
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Users
@@ -27,6 +28,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
 class CustomDataSourceServiceTest {
@@ -101,6 +103,47 @@ class CustomDataSourceServiceTest {
         val source = service.listDataSources(ORG_ID).single()
 
         assertEquals(0, source.usedByDashboardCount)
+    }
+
+    @Test
+    fun `updateDataSource clears a stored port when clearPort is set`() {
+        seedDataSource(id = 20, name = "Edge Prom", sourceType = "prometheus")
+
+        val updated = service.updateDataSource(
+            id = 20,
+            orgId = ORG_ID,
+            request = UpdateCustomDataSourceRequest(clearPort = true),
+        )
+
+        assertNull(updated?.port)
+    }
+
+    @Test
+    fun `updateDataSource keeps the existing port when port is omitted`() {
+        seedDataSource(id = 21, name = "Edge Prom", sourceType = "prometheus")
+
+        val updated = service.updateDataSource(
+            id = 21,
+            orgId = ORG_ID,
+            request = UpdateCustomDataSourceRequest(name = "Renamed"),
+        )
+
+        assertEquals("Renamed", updated?.name)
+        assertEquals(9090, updated?.port)
+    }
+
+    @Test
+    fun `updateDataSource sets an explicit port and does not clear it`() {
+        seedDataSource(id = 22, name = "Edge Prom", sourceType = "prometheus")
+
+        val updated = service.updateDataSource(
+            id = 22,
+            orgId = ORG_ID,
+            request = UpdateCustomDataSourceRequest(port = 9443, clearPort = true),
+        )
+
+        // An explicit port wins over the clear flag.
+        assertEquals(9443, updated?.port)
     }
 
     private fun seedDataSource(

--- a/backend/src/main/kotlin/com/moneat/dashboards/models/CustomDataSourceModels.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/models/CustomDataSourceModels.kt
@@ -155,6 +155,9 @@ data class UpdateCustomDataSourceRequest(
     val description: String? = null,
     val host: String? = null,
     val port: Int? = null,
+    // A null `port` means "leave unchanged" (partial update); this flag is the explicit
+    // opt-in to erase a stored port, e.g. an http source moved behind a reverse proxy.
+    @SerialName("clear_port") val clearPort: Boolean = false,
     @SerialName("database_name") val databaseName: String? = null,
     val username: String? = null,
     val password: String? = null,

--- a/backend/src/main/kotlin/com/moneat/dashboards/services/CustomDataSourceService.kt
+++ b/backend/src/main/kotlin/com/moneat/dashboards/services/CustomDataSourceService.kt
@@ -207,7 +207,12 @@ class CustomDataSourceService {
                 request.name?.let { v -> it[name] = v }
                 request.description?.let { v -> it[description] = v }
                 request.host?.let { v -> it[host] = v }
-                request.port?.let { v -> it[port] = v }
+                // An explicit port wins; otherwise clearPort erases it and a plain
+                // omission leaves the stored value untouched (partial update).
+                when {
+                    request.port != null -> it[port] = request.port
+                    request.clearPort -> it[port] = null
+                }
                 request.databaseName?.let { v -> it[databaseName] = v }
                 newEncryptedCreds?.let { v -> it[encryptedCredentials] = v }
                 request.extraConfig?.let { v ->

--- a/dashboard/src/components/dashboards/DataSourceConfigureStep.tsx
+++ b/dashboard/src/components/dashboards/DataSourceConfigureStep.tsx
@@ -276,8 +276,15 @@ export function DataSourceConfigureStep({
         <Field id="ds-host" label="Host" value={state.host} onChange={onHostChange}
           placeholder={vendor.arch === 'http' || vendor.arch === 'influx' ? 'metrics.example.com' : 'db.internal.example.com'}
           hint="Hostname or IP only — no scheme, port, or path." />
-        <Field id="ds-port" label="Port" value={state.port} onChange={(v) => update({port: v})}
-          placeholder={String(vendor.port ?? '')} invalid={!portCheck.ok} />
+        <Field
+          id="ds-port"
+          label="Port"
+          optional={vendor.arch === 'http'}
+          value={state.port}
+          onChange={(v) => update({port: v})}
+          placeholder={String(vendor.port ?? '')}
+          invalid={!portCheck.ok}
+        />
       </div>
       {adjustBanner}
       {portError}

--- a/dashboard/src/components/dashboards/DataSourceConnectDialog.tsx
+++ b/dashboard/src/components/dashboards/DataSourceConnectDialog.tsx
@@ -24,7 +24,8 @@ import {Button} from '@/components/ui/button'
 import {getVendor} from './dataSourceCatalog'
 import {
   type DsFormState,
-  buildPayload, buildTestRequest, defaultFormState, hydrateFormState, isFormReady,
+  buildPayload, buildTestRequest, buildUpdatePayload,
+  defaultFormState, hydrateFormState, isFormReady,
 } from './dataSourceConnection'
 import {DataSourcePickerStep} from './DataSourcePickerStep'
 import {DataSourceConfigureStep} from './DataSourceConfigureStep'
@@ -53,12 +54,10 @@ export function DataSourceConnectDialog({mode, initial, onClose, onSaved}: DataS
   const vendor = getVendor(form?.vendor)
 
   const saveMutation = useMutation({
-    mutationFn: () => {
-      const payload = buildPayload(form!)
-      return editing && initial
-        ? api.updateCustomDataSource(initial.id, payload)
-        : api.createCustomDataSource(payload)
-    },
+    mutationFn: () =>
+      editing && initial
+        ? api.updateCustomDataSource(initial.id, buildUpdatePayload(form!))
+        : api.createCustomDataSource(buildPayload(form!)),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: ['custom-datasources']})
       queryClient.invalidateQueries({queryKey: ['datasources']})

--- a/dashboard/src/components/dashboards/__tests__/DataSourceConfigureStep.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DataSourceConfigureStep.test.tsx
@@ -135,15 +135,24 @@ describe('DataSourceConfigureStep', () => {
     })
 
     expect(screen.getByLabelText('Host')).toHaveValue('metrics.internal')
-    expect(screen.getByLabelText('Port')).toHaveValue('9443')
+    expect(screen.getByLabelText(/^Port/)).toHaveValue('9443')
     expect(screen.getByLabelText(/Base path/)).toHaveValue('/prometheus')
     expect(screen.getByText(/Split your pasted value/)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', {name: 'undo'}))
 
     expect(screen.getByLabelText('Host')).toHaveValue('')
-    expect(screen.getByLabelText('Port')).toHaveValue('9090')
+    // Prometheus has no default port, so undo restores the blank field.
+    expect(screen.getByLabelText(/^Port/)).toHaveValue('')
     expect(screen.getByLabelText(/Base path/)).toHaveValue('')
+  })
+
+  it('defaults the Prometheus port to a blank, optional field', () => {
+    renderConfigureStep('prometheus')
+
+    expect(screen.getByLabelText(/^Port/)).toHaveValue('')
+    // The Port label is flagged optional for http sources (reverse-proxy friendly).
+    expect(screen.getByText(/^Port/)).toHaveTextContent('optional')
   })
 
   it('renders HTTP authentication variants and advanced request options', () => {

--- a/dashboard/src/components/dashboards/__tests__/DataSourceConnectDialog.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DataSourceConnectDialog.test.tsx
@@ -65,7 +65,7 @@ describe('DataSourceConnectDialog', () => {
       target: {value: 'https://prom.example.com:9090/prometheus'},
     })
     expect((screen.getByLabelText('Host') as HTMLInputElement).value).toBe('prom.example.com')
-    expect((screen.getByLabelText('Port') as HTMLInputElement).value).toBe('9090')
+    expect((screen.getByLabelText(/^Port/) as HTMLInputElement).value).toBe('9090')
     expect(screen.getByText(/Split your pasted value/)).toBeInTheDocument()
   })
 
@@ -73,7 +73,7 @@ describe('DataSourceConnectDialog', () => {
     renderWithQueryClient(<DataSourceConnectDialog mode="create" onClose={vi.fn()} />)
     pickPrometheus()
     fireEvent.change(screen.getByLabelText('Host'), {target: {value: 'prom'}})
-    fireEvent.change(screen.getByLabelText('Port'), {target: {value: '80808080'}})
+    fireEvent.change(screen.getByLabelText(/^Port/), {target: {value: '80808080'}})
     expect(screen.getByText(/between 1 and 65535/)).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Add data source'})).toBeDisabled()
   })
@@ -144,5 +144,45 @@ describe('DataSourceConnectDialog', () => {
         expect.objectContaining({name: 'Renamed'})
       )
     )
+  })
+
+  it('creates a Prometheus source with no port when the field is left blank', async () => {
+    renderWithQueryClient(<DataSourceConnectDialog mode="create" onClose={vi.fn()} />)
+    pickPrometheus()
+    fireEvent.change(screen.getByLabelText('Host'), {target: {value: 'prometheus.bandapella.com'}})
+    expect((screen.getByLabelText(/^Port/) as HTMLInputElement).value).toBe('')
+    fireEvent.click(screen.getByRole('button', {name: 'Add data source'}))
+
+    await waitFor(() => expect(mockApi.createCustomDataSource).toHaveBeenCalled())
+    const payload = mockApi.createCustomDataSource.mock.calls[0][0]
+    expect(payload.host).toBe('prometheus.bandapella.com')
+    expect(payload.port).toBeUndefined()
+    expect('clear_port' in payload).toBe(false)
+  })
+
+  it('clears a stored port when the user blanks it in edit mode', async () => {
+    const initial: CustomDataSourceResponse = {
+      id: '00000000-0000-0000-0000-000000000008',
+      org_id: '11111111-1111-4111-8111-111111111111',
+      name: 'Edge Prom',
+      source_type: 'prometheus',
+      host: 'prom.example.com', port: 9090, extra_config: {scheme: 'https'},
+      enabled: true,
+      created_by: '22222222-2222-4222-8222-222222222222',
+      created_at: '',
+      updated_at: '',
+      has_credentials: true,
+    }
+    renderWithQueryClient(<DataSourceConnectDialog mode="edit" initial={initial} onClose={vi.fn()} />)
+    expect((screen.getByLabelText(/^Port/) as HTMLInputElement).value).toBe('9090')
+
+    fireEvent.change(screen.getByLabelText(/^Port/), {target: {value: ''}})
+    fireEvent.click(screen.getByRole('button', {name: 'Save changes'}))
+
+    await waitFor(() => expect(mockApi.updateCustomDataSource).toHaveBeenCalled())
+    const [id, payload] = mockApi.updateCustomDataSource.mock.calls[0]
+    expect(id).toBe('00000000-0000-0000-0000-000000000008')
+    expect(payload.clear_port).toBe(true)
+    expect(payload.port).toBeUndefined()
   })
 })

--- a/dashboard/src/components/dashboards/__tests__/dataSourceConnection.test.ts
+++ b/dashboard/src/components/dashboards/__tests__/dataSourceConnection.test.ts
@@ -18,7 +18,7 @@ import {describe, expect, it} from 'vitest'
 import type {CustomDataSourceResponse} from '@/lib/api'
 import {
   buildEndpointPreview, buildExtraConfig, buildPayload, buildTestRequest,
-  defaultFormState, effectiveName, hydrateFormState, isFormReady,
+  buildUpdatePayload, defaultFormState, effectiveName, hydrateFormState, isFormReady,
   smartSplitHost, validatePort,
 } from '../dataSourceConnection'
 
@@ -97,13 +97,19 @@ describe('buildEndpointPreview', () => {
     expect(p.sub).toContain('TLS: require')
   })
 
-  it('shows the real API path and auth for an http source', () => {
-    const s = {...defaultFormState('prometheus'), host: 'prom.example.com'}
+  it('shows the real API path and auth for an http source, omitting a blank port', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prometheus.bandapella.com'}
     const p = buildEndpointPreview(s)
-    expect(previewText(s)).toBe('https://prom.example.com:9090')
+    // Reverse-proxy case: no :9090, and no stray trailing colon either.
+    expect(previewText(s)).toBe('https://prometheus.bandapella.com')
     expect(p.sub).toContain('Moneat calls /api/v1/query')
     expect(p.sub).toContain('auth: none')
     expect(p.portOk).toBe(true)
+  })
+
+  it('shows an explicit http port when one is set', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prom.example.com', port: '9090'}
+    expect(previewText(s)).toBe('https://prom.example.com:9090')
   })
 
   it('flags an invalid port', () => {
@@ -354,9 +360,35 @@ describe('buildPayload', () => {
       extra_config: {ch_protocol: 'native'},
     })
   })
+
+  it('omits the port for a blank Prometheus form (HTTPS reverse proxy)', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prometheus.bandapella.com'}
+    const p = buildPayload(s)
+    expect(p.host).toBe('prometheus.bandapella.com')
+    expect(p.port).toBeUndefined()
+    expect('port' in p).toBe(false)
+  })
+
+  it('persists an explicit Prometheus port', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prom.internal', port: '9090'}
+    expect(buildPayload(s).port).toBe(9090)
+  })
 })
 
 describe('buildTestRequest', () => {
+  it('omits the port when testing a blank Prometheus connection', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prometheus.bandapella.com'}
+    const t = buildTestRequest(s)
+    expect(t.source_type).toBe('prometheus')
+    expect(t.host).toBe('prometheus.bandapella.com')
+    expect(t.port).toBeUndefined()
+  })
+
+  it('carries an explicit port into the test request', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prom.internal', port: '9090'}
+    expect(buildTestRequest(s).port).toBe(9090)
+  })
+
   it('mirrors the payload connection fields', () => {
     const s = {...defaultFormState('prometheus'), host: 'h', basePath: '/p'}
     const t = buildTestRequest(s)
@@ -377,6 +409,29 @@ describe('buildTestRequest', () => {
       header_value: 'tenant-a',
       extra_config: {auth_method: 'header', header_name: 'X-Scope-OrgID'},
     })
+  })
+})
+
+describe('buildUpdatePayload', () => {
+  it('signals clear_port when an http source is saved with a blank port', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prometheus.bandapella.com'}
+    const p = buildUpdatePayload(s)
+    expect(p.port).toBeUndefined()
+    expect(p.clear_port).toBe(true)
+  })
+
+  it('keeps an explicit port and leaves clear_port unset', () => {
+    const s = {...defaultFormState('prometheus'), host: 'prom.internal', port: '9090'}
+    const p = buildUpdatePayload(s)
+    expect(p.port).toBe(9090)
+    expect(p.clear_port).toBeUndefined()
+  })
+
+  it('never clears the port for a sql source that keeps its default', () => {
+    const s = {...defaultFormState('postgresql'), host: 'db.internal'}
+    const p = buildUpdatePayload(s)
+    expect(p.port).toBe(5432)
+    expect(p.clear_port).toBeUndefined()
   })
 })
 

--- a/dashboard/src/components/dashboards/dataSourceCatalog.ts
+++ b/dashboard/src/components/dashboards/dataSourceCatalog.ts
@@ -102,7 +102,10 @@ export const VENDORS: readonly VendorDef[] = [
   {key: 'cockroachdb', label: 'CockroachDB', category: 'database', arch: 'sql', port: 26257, scheme: 'postgresql', blurb: 'Distributed SQL · PG wire', dbPlaceholder: 'defaultdb', userPlaceholder: 'root', note: 'Speaks the PostgreSQL wire protocol.', supportsString: true},
   {key: 'sqlite', label: 'SQLite', category: 'database', arch: 'file', blurb: 'Embedded SQL database'},
   // Metrics & time-series
-  {key: 'prometheus', label: 'Prometheus', category: 'metrics', arch: 'http', port: 9090, apiPath: '/api/v1/query', blurb: 'Metrics & monitoring', supportsString: true},
+  // No default port: Prometheus is commonly fronted by an HTTPS reverse proxy
+  // (Thanos/Mimir/Cortex/Grafana Cloud) on the scheme's standard port, so a blank
+  // port must stay blank rather than forcing :9090 onto the endpoint.
+  {key: 'prometheus', label: 'Prometheus', category: 'metrics', arch: 'http', apiPath: '/api/v1/query', blurb: 'Metrics & monitoring', supportsString: true},
   {key: 'influxdb', label: 'InfluxDB', category: 'metrics', arch: 'influx', port: 8086, blurb: 'Time-series database'},
   {key: 'graphite', label: 'Graphite', category: 'metrics', arch: 'http', port: 80, apiPath: '/render', blurb: 'Metrics storage & graphing', supportsString: true},
   // Search & logs

--- a/dashboard/src/components/dashboards/dataSourceConnection.ts
+++ b/dashboard/src/components/dashboards/dataSourceConnection.ts
@@ -23,6 +23,7 @@ import type {
   CreateCustomDataSourceRequest,
   CustomDataSourceResponse,
   TestConnectionRequest,
+  UpdateCustomDataSourceRequest,
 } from '@/lib/api'
 import {
   type AuthMethod,
@@ -114,7 +115,9 @@ export function hydrateFormState(ds: CustomDataSourceResponse): DsFormState {
     name: ds.name,
     description: ds.description ?? '',
     host,
-    port: ds.port === undefined ? base.port : String(ds.port),
+    // `== null` also catches an explicit JSON `port: null` (the API encodes nulls),
+    // so a portless source hydrates to a blank field rather than the string "null".
+    port: ds.port == null ? base.port : String(ds.port),
     database: ds.database_name ?? '',
     scheme: x.scheme === 'http' ? 'http' : 'https',
     basePath: x.base_path ?? '',
@@ -365,14 +368,19 @@ function clickhousePreview({state, host}: PreviewContext): PreviewBody {
   }
 }
 
-function httpPreview({state, vendor, host, port}: PreviewContext): PreviewBody {
+function httpPreview({state, vendor, host}: PreviewContext): PreviewBody {
   const base = state.basePath && state.basePath !== '/' ? state.basePath.replace(/\/$/, '') : ''
   const pathSegments = base ? [{tone: 'path' as const, text: base}] : []
+  // HTTP sources can sit behind a reverse proxy on the scheme's default port, so a
+  // blank field means "no port" — show nothing rather than a vendor fallback or a
+  // stray colon (e.g. https://prometheus.example.com, not …:9090 or …:).
+  const explicitPort = state.port.trim()
+  const portSegments = explicitPort ? [{tone: 'port' as const, text: `:${explicitPort}`}] : []
   return {
     segments: [
       {tone: 'scheme', text: `${state.scheme}://`},
       {tone: 'host', text: host},
-      {tone: 'port', text: `:${port}`},
+      ...portSegments,
       ...pathSegments,
     ],
     sub: `Moneat calls ${base}${vendor.apiPath} · auth: ${authLabel(state)}`,
@@ -545,6 +553,9 @@ function payloadPort(state: DsFormState, v: VendorDef): number | undefined {
     return parseConnectionUri(state.connStr).port ?? v.port
   }
   if (state.port && /^\d+$/.test(state.port)) return Number(state.port)
+  // HTTP sources keep the port optional (reverse-proxy friendly); every other
+  // archetype falls back to its conventional wire-protocol port.
+  if (v.arch === 'http') return undefined
   return v.port
 }
 
@@ -566,6 +577,21 @@ export function buildPayload(state: DsFormState): CreateCustomDataSourceRequest 
   addCredentials(req, state, v)
   addExtraConfig(req, state)
   return req
+}
+
+/**
+ * Map the form to the update API request. Identical to {@link buildPayload}, but
+ * when a port-bearing source intentionally leaves the port blank (an http source
+ * behind a reverse proxy) it asks the backend to clear any previously stored port —
+ * a plain omitted `port` is a partial-update no-op and could not erase the old value.
+ */
+export function buildUpdatePayload(state: DsFormState): UpdateCustomDataSourceRequest & {header_value?: string} {
+  const payload: UpdateCustomDataSourceRequest & {header_value?: string} = buildPayload(state)
+  const v = getVendor(state.vendor)
+  if (v && payload.port == null && PORT_FIELD_ARCHES.has(v.arch)) {
+    payload.clear_port = true
+  }
+  return payload
 }
 
 type DataSourcePayload = CreateCustomDataSourceRequest & {header_value?: string}

--- a/dashboard/src/lib/api/types/dashboards.ts
+++ b/dashboard/src/lib/api/types/dashboards.ts
@@ -287,7 +287,7 @@ export interface CustomDataSourceResponse {
   description?: string
   source_type: string
   host: string
-  port?: number
+  port?: number | null
   database_name?: string
   extra_config: Record<string, string>
   enabled: boolean
@@ -324,6 +324,8 @@ export interface UpdateCustomDataSourceRequest {
   description?: string
   host?: string
   port?: number
+  /** Clear a previously stored port (omitting `port` is a partial-update no-op). */
+  clear_port?: boolean
   database_name?: string
   username?: string
   password?: string


### PR DESCRIPTION
## Summary
- allow Prometheus sources to keep a blank port for reverse-proxy deployments
- add explicit clear-port update handling for saved data sources
- cover create, edit, preview, test-request, and backend update behavior

## Tests
- npm test -- --run src/components/dashboards/__tests__/dataSourceConnection.test.ts src/components/dashboards/__tests__/DataSourceConfigureStep.test.tsx src/components/dashboards/__tests__/DataSourceConnectDialog.test.tsx
- npm run typecheck
- npm run lint
- ./gradlew detekt --no-daemon
- ./gradlew --no-daemon :features:dashboards:test --tests com.moneat.dashboards.CustomDataSourceServiceTest -Dkotlin.compiler.execution.strategy=in-process
- git diff --check
