### PR TITLE
feat: add google ads spend import

### DIFF
--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorImportService.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorImportService.kt
@@ -1,0 +1,880 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.connectors
+
+import com.moneat.config.ClickHouseClient
+import com.moneat.config.EnvConfig
+import com.moneat.ingestion.queue.IngestionPipeline
+import com.moneat.ingestion.queue.IngestionQueueClient
+import com.moneat.secrets.PurposeScopedSecretCipher
+import com.moneat.secrets.SecretVaultPurpose
+import com.moneat.shared.services.toUuidOrNull
+import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import io.ktor.http.HttpStatusCode
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.todayIn
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.security.MessageDigest
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import kotlin.math.max
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+private const val AD_SPEND_INSERT_BATCH_SIZE = 500
+private const val DEFAULT_GOOGLE_ADS_IMPORT_DAYS = 30
+private const val MAX_GOOGLE_ADS_IMPORT_DAYS = 92L
+private const val GOOGLE_ADS_DEFAULT_API_VERSION = "v24"
+private const val GOOGLE_ADS_SPEND_IMPORT_TYPE = "ad_spend"
+
+const val CONNECTOR_IMPORT_STATUS_QUEUED: String = "queued"
+const val CONNECTOR_IMPORT_STATUS_RUNNING: String = "running"
+const val CONNECTOR_IMPORT_STATUS_SUCCEEDED: String = "succeeded"
+const val CONNECTOR_IMPORT_STATUS_FAILED_RETRYABLE: String = "failed_retryable"
+
+class ConnectorImportService(
+    private val googleAdsClient: GoogleAdsProviderClient = GoogleAdsClient(),
+    private val secretCipherFactory: () -> ConnectorSecretCipher = {
+        PurposeConnectorSecretCipher(PurposeScopedSecretCipher.fromEnv(SecretVaultPurpose.DATA_IMPORT))
+    },
+    private val enqueueConnectorImport: (String) -> Unit = { payload ->
+        IngestionQueueClient.enqueue(
+            IngestionPipeline.CONNECTOR_IMPORTS,
+            ConnectorService.CONNECTOR_IMPORT_QUEUE_KEY,
+            payload,
+        )
+    },
+    private val insertAdSpendFacts: suspend (List<AppAdSpendFact>) -> Unit = { facts ->
+        insertAdSpendFactsIntoClickHouse(facts)
+    },
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun listImportRuns(
+        organizationId: Int,
+        installationResourceId: String,
+    ): ConnectorImportRunsResponse =
+        transaction {
+            val installation = installationRowByResourceId(organizationId, installationResourceId)
+            ConnectorImportRunsResponse(importRunsForInstallation(installation[ConnectorInstallations.id]))
+        }
+
+    fun enqueueSync(
+        organizationId: Int,
+        userId: Int,
+        installationResourceId: String,
+        request: ConnectorSyncRequest,
+    ): ConnectorImportRunResponse {
+        val dates = googleAdsImportDateRange(request)
+        val runId =
+            transaction {
+                val installation = installationRecordByResourceId(organizationId, installationResourceId)
+                ensureProvider(installation, GoogleAdsClient.PROVIDER_ID)
+                ensureGoogleAdsExternalCustomer(installation)
+                val now = Clock.System.now()
+                ConnectorImportRuns.insert {
+                    it[ConnectorImportRuns.organizationId] = organizationId
+                    it[ConnectorImportRuns.installationId] = installation.id
+                    it[provider] = GoogleAdsClient.PROVIDER_ID
+                    it[importType] = GOOGLE_ADS_SPEND_IMPORT_TYPE
+                    it[externalProjectId] = installation.externalProjectId
+                    it[externalResourceId] = installation.externalProjectId
+                    it[dateStart] = dates.start
+                    it[dateEnd] = dates.end
+                    it[status] = CONNECTOR_IMPORT_STATUS_QUEUED
+                    it[rowsImported] = 0
+                    it[requestedBy] = userId
+                    it[queuedAt] = now
+                    it[createdAt] = now
+                    it[updatedAt] = now
+                }[ConnectorImportRuns.id]
+            }
+        try {
+            enqueueConnectorImport(runId.toString())
+        } catch (error: Throwable) {
+            transaction {
+                ConnectorImportRuns.update({ ConnectorImportRuns.id eq runId }) {
+                    it[status] = CONNECTOR_IMPORT_STATUS_FAILED_RETRYABLE
+                    it[lastErrorCode] = "enqueue_failed"
+                    it[lastErrorMessage] = error.message
+                    it[updatedAt] = Clock.System.now()
+                }
+            }
+            throw ConnectorServiceException(
+                HttpStatusCode.ServiceUnavailable,
+                "Google Ads sync was created but could not be queued",
+                error,
+            )
+        }
+        return transaction { importRunRowById(runId).toImportRunResponse() }
+    }
+
+    suspend fun processImportRun(importRunId: Long) {
+        val run = transaction { importRunRecord(importRunId) }
+        if (run.status == CONNECTOR_IMPORT_STATUS_SUCCEEDED) return
+        if (run.provider != GoogleAdsClient.PROVIDER_ID || run.importType != GOOGLE_ADS_SPEND_IMPORT_TYPE) {
+            throw ConnectorServiceException(HttpStatusCode.BadRequest, "Unsupported connector import run")
+        }
+        val startedAt = Clock.System.now()
+        transaction {
+            ConnectorImportRuns.update({ ConnectorImportRuns.id eq run.id }) {
+                it[status] = CONNECTOR_IMPORT_STATUS_RUNNING
+                it[ConnectorImportRuns.startedAt] = startedAt
+                it[attemptCount] = run.attemptCount + 1
+                it[lastErrorCode] = null
+                it[lastErrorMessage] = null
+                it[updatedAt] = startedAt
+            }
+        }
+        try {
+            val facts = importGoogleAdsSpend(run, startedAt)
+            insertAdSpendFacts(facts)
+            markRunSucceeded(run, facts.size)
+        } catch (error: Throwable) {
+            markRunFailed(run, error)
+            throw error
+        }
+    }
+
+    fun latestImportRun(installationId: Int): ConnectorImportStateRecord? =
+        ConnectorImportRuns
+            .selectAll()
+            .where { ConnectorImportRuns.installationId eq installationId }
+            .orderBy(ConnectorImportRuns.createdAt, SortOrder.DESC)
+            .limit(1)
+            .firstOrNull()
+            ?.let { row ->
+                ConnectorImportStateRecord(
+                    status = row[ConnectorImportRuns.status],
+                    rowsImported = row[ConnectorImportRuns.rowsImported],
+                    startedAt = row[ConnectorImportRuns.startedAt],
+                    finishedAt = row[ConnectorImportRuns.finishedAt],
+                    lastErrorMessage = row[ConnectorImportRuns.lastErrorMessage],
+                )
+            }
+
+    fun importLagSeconds(lastImport: ConnectorImportStateRecord?): Long? {
+        if (lastImport?.status != CONNECTOR_IMPORT_STATUS_RUNNING) return null
+        val startedAt = lastImport.startedAt ?: return null
+        return max(0L, (Clock.System.now() - startedAt).inWholeSeconds)
+    }
+
+    fun googleAdsState(organizationId: Int): Pair<ConnectorConnectionSummary?, ConnectorProviderStateDetail?> =
+        transaction {
+            val installation =
+                ConnectorInstallations
+                    .selectAll()
+                    .where {
+                        (ConnectorInstallations.organizationId eq organizationId) and
+                            (ConnectorInstallations.provider eq GoogleAdsClient.PROVIDER_ID) and
+                            ConnectorInstallations.deletedAt.isNull()
+                    }
+                    .orderBy(ConnectorInstallations.createdAt, SortOrder.DESC)
+                    .firstOrNull()
+                    ?: return@transaction null to null
+            val record = installation.toImportInstallationStateRecord()
+            val resourceCount = externalResourceCount(record.id)
+            val mappedResources = activeBindingCount(organizationId, record.id)
+            val lastImport = latestImportRun(record.id)
+            val health = googleAdsHealth(record, lastImport)
+            val message = googleAdsStateMessage(record, resourceCount, lastImport)
+            val detail = ConnectorProviderStateDetail(
+                installationId = record.resourceId.toString(),
+                status = record.status,
+                health = health,
+                message = message,
+                mappedResources = mappedResources,
+                unmappedEvents = 0,
+                failedReceipts = 0,
+                sandboxEvents = 0,
+                productionEvents = 0,
+                lastAcceptedWebhookAt = null,
+                lastAppliedAt = null,
+                processingLagSeconds = null,
+                lastImportStatus = lastImport?.status,
+                lastImportFinishedAt = lastImport?.finishedAt?.toString(),
+                lastImportRows = lastImport?.rowsImported,
+                importLagSeconds = importLagSeconds(lastImport),
+            )
+            val summary = ConnectorConnectionSummary(
+                providerId = GoogleAdsClient.PROVIDER_ID,
+                connected = true,
+                health = health,
+                detail = message,
+                lastCheckedAt = record.lastTestedAt?.toString(),
+            )
+            summary to detail
+        }
+
+    private fun googleAdsHealth(
+        record: ConnectorInstallationImportStateRecord,
+        lastImport: ConnectorImportStateRecord?,
+    ): String =
+        when {
+            !record.enabled -> CONNECTOR_HEALTH_DEGRADED
+            record.status == CONNECTOR_HEALTH_DEGRADED -> CONNECTOR_HEALTH_DEGRADED
+            lastImport?.status == CONNECTOR_IMPORT_STATUS_FAILED_RETRYABLE -> CONNECTOR_HEALTH_DEGRADED
+            lastImport?.status == CONNECTOR_IMPORT_STATUS_RUNNING -> CONNECTOR_HEALTH_SYNCING
+            record.status == CONNECTOR_HEALTH_HEALTHY -> CONNECTOR_HEALTH_HEALTHY
+            else -> CONNECTOR_HEALTH_UNKNOWN
+        }
+
+    private fun googleAdsStateMessage(
+        record: ConnectorInstallationImportStateRecord,
+        resourceCount: Int,
+        lastImport: ConnectorImportStateRecord?,
+    ): String =
+        when {
+            !record.enabled -> "Google Ads connector is disabled"
+            lastImport?.status == CONNECTOR_IMPORT_STATUS_RUNNING -> "Google Ads spend sync is running"
+            lastImport?.status == CONNECTOR_IMPORT_STATUS_QUEUED -> "Google Ads spend sync is queued"
+            lastImport?.status == CONNECTOR_IMPORT_STATUS_FAILED_RETRYABLE -> {
+                lastImport.lastErrorMessage ?: "Google Ads spend sync failed"
+            }
+            record.lastError != null -> record.lastError
+            record.status == CONNECTOR_HEALTH_DEGRADED -> "Google Ads API validation failed"
+            lastImport?.status == CONNECTOR_IMPORT_STATUS_SUCCEEDED -> {
+                "Imported ${lastImport.rowsImported} Google Ads spend rows"
+            }
+            resourceCount == 0 -> "Connected, no Google Ads accounts discovered yet"
+            resourceCount == 1 -> "Connected to 1 Google Ads account"
+            else -> "Connected to $resourceCount Google Ads accounts"
+        }
+
+    private fun markRunSucceeded(
+        run: ConnectorImportRunRecord,
+        rowCount: Int,
+    ) {
+        val finishedAt = Clock.System.now()
+        transaction {
+            ConnectorImportRuns.update({ ConnectorImportRuns.id eq run.id }) {
+                it[status] = CONNECTOR_IMPORT_STATUS_SUCCEEDED
+                it[rowsImported] = rowCount
+                it[ConnectorImportRuns.finishedAt] = finishedAt
+                it[lastErrorCode] = null
+                it[lastErrorMessage] = null
+                it[updatedAt] = finishedAt
+            }
+            ConnectorInstallations.update({ ConnectorInstallations.id eq run.installationId }) {
+                it[status] = "healthy"
+                it[statusReason] = "Google Ads spend imported"
+                it[lastSuccessfulProviderCallAt] = finishedAt
+                it[lastError] = null
+                it[updatedAt] = finishedAt
+            }
+        }
+    }
+
+    private fun markRunFailed(
+        run: ConnectorImportRunRecord,
+        error: Throwable,
+    ) {
+        val failedAt = Clock.System.now()
+        transaction {
+            ConnectorImportRuns.update({ ConnectorImportRuns.id eq run.id }) {
+                it[status] = CONNECTOR_IMPORT_STATUS_FAILED_RETRYABLE
+                it[finishedAt] = failedAt
+                it[lastErrorCode] = error::class.simpleName ?: "import_failed"
+                it[lastErrorMessage] = error.message
+                it[updatedAt] = failedAt
+            }
+            ConnectorInstallations.update({ ConnectorInstallations.id eq run.installationId }) {
+                it[status] = "degraded"
+                it[statusReason] = "Google Ads spend import failed"
+                it[lastError] = error.message
+                it[updatedAt] = failedAt
+            }
+        }
+    }
+
+    private fun importGoogleAdsSpend(
+        run: ConnectorImportRunRecord,
+        pulledAt: Instant,
+    ): List<AppAdSpendFact> {
+        val installation = transaction { installationRecordById(run.organizationId, run.installationId) }
+        ensureProvider(installation, GoogleAdsClient.PROVIDER_ID)
+        val customerId = installation.externalProjectId
+            ?: throw badRequest("Connector installation has no Google Ads customer")
+        val credential = parseGoogleAdsCredential(decryptApiSecret(installation))
+        val rows = withGoogleAdsErrorMapping {
+            googleAdsClient.fetchSpendReport(
+                credential = credential,
+                customerId = customerId,
+                loginCustomerId = credential.loginCustomerId,
+                startDate = run.dateStart,
+                endDate = run.dateEnd,
+            )
+        }
+        val mappedProjectId = transaction { activeGoogleAdsProjectMapping(installation.id, customerId) }
+        return rows.map { row -> row.toFact(run, installation, mappedProjectId, pulledAt) }
+    }
+
+    private fun GoogleAdsSpendReportRow.toFact(
+        run: ConnectorImportRunRecord,
+        installation: ConnectorInstallationImportRecord,
+        mappedProjectId: Long?,
+        pulledAt: Instant,
+    ): AppAdSpendFact {
+        val rowHash = googleAdsSpendRowHash(run, this)
+        val providerApiVersion = EnvConfig.get("GOOGLE_ADS_API_VERSION", GOOGLE_ADS_DEFAULT_API_VERSION)
+        return AppAdSpendFact(
+            factId = deterministicUuid(rowHash),
+            organizationId = run.organizationId.toLong(),
+            projectId = mappedProjectId,
+            installationId = installation.id,
+            installationResourceId = installation.resourceId,
+            importRunId = run.id,
+            importRunResourceId = run.resourceId,
+            providerApiVersion = providerApiVersion,
+            googleAdsCustomerId = customerId,
+            googleAdsLoginCustomerId = loginCustomerId,
+            reportDate = reportDate,
+            device = device,
+            geoTargetCountry = geoTargetCountry,
+            campaignId = campaignId,
+            campaignName = campaignName,
+            campaignStatus = campaignStatus,
+            campaignType = campaignType,
+            campaignSubType = campaignSubType,
+            biddingStrategyType = biddingStrategyType,
+            adGroupId = adGroupId,
+            adGroupName = adGroupName,
+            adGroupStatus = adGroupStatus,
+            currencyCode = currencyCode,
+            timeZone = timeZone,
+            impressions = impressions,
+            clicks = clicks,
+            costMicros = costMicros,
+            conversions = conversions,
+            conversionsValue = conversionsValue,
+            allConversions = allConversions,
+            allConversionsValue = allConversionsValue,
+            rowIdentityHash = rowHash,
+            pulledAt = pulledAt,
+        )
+    }
+
+    private fun ensureGoogleAdsExternalCustomer(installation: ConnectorInstallationImportRecord) {
+        val customerId = installation.externalProjectId
+            ?: throw badRequest("Connector installation has no Google Ads customer")
+        val exists =
+            ConnectorExternalResources
+                .selectAll()
+                .where {
+                    (ConnectorExternalResources.installationId eq installation.id) and
+                        (ConnectorExternalResources.externalResourceId eq customerId)
+                }
+                .count() > 0
+        if (!exists) {
+            throw ConnectorServiceException(HttpStatusCode.NotFound, "External Google Ads customer was not found")
+        }
+    }
+
+    private fun googleAdsImportDateRange(request: ConnectorSyncRequest): GoogleAdsImportDateRange {
+        val today = Clock.System.todayIn(TimeZone.UTC)
+        val end = request.endDate?.let { value -> parseImportDate(value, "endDate") } ?: today
+        val start = request.startDate?.let { value ->
+            parseImportDate(value, "startDate")
+        } ?: end.minus(DatePeriod(days = DEFAULT_GOOGLE_ADS_IMPORT_DAYS - 1))
+        if (start > end) {
+            throw badRequest("startDate must be on or before endDate")
+        }
+        if (inclusiveDayCount(start, end) > MAX_GOOGLE_ADS_IMPORT_DAYS) {
+            throw badRequest("Google Ads sync range cannot exceed $MAX_GOOGLE_ADS_IMPORT_DAYS days")
+        }
+        return GoogleAdsImportDateRange(start, end)
+    }
+
+    private fun parseImportDate(
+        value: String,
+        fieldName: String,
+    ): LocalDate =
+        try {
+            LocalDate.parse(value)
+        } catch (_: IllegalArgumentException) {
+            throw badRequest("$fieldName must be an ISO date")
+        }
+
+    private fun inclusiveDayCount(
+        start: LocalDate,
+        end: LocalDate,
+    ): Long {
+        val javaStart = java.time.LocalDate.parse(start.toString())
+        val javaEnd = java.time.LocalDate.parse(end.toString())
+        return ChronoUnit.DAYS.between(javaStart, javaEnd) + 1
+    }
+
+    private fun parseGoogleAdsCredential(secret: String): GoogleAdsOAuthCredential {
+        val normalized = secret
+            .trim()
+            .takeIf { it.isNotBlank() }
+            ?: throw badRequest("Google Ads refresh token is required")
+        val credential =
+            if (normalized.startsWith("{")) {
+                runCatching { json.decodeFromString<GoogleAdsOAuthCredential>(normalized) }
+                    .getOrElse { throw badRequest("Google Ads OAuth credential must be valid JSON") }
+            } else {
+                GoogleAdsOAuthCredential(refreshToken = normalized)
+            }
+        val refreshToken = credential.refreshToken.trim()
+        if (refreshToken.isBlank()) {
+            throw badRequest("Google Ads refresh token is required")
+        }
+        val loginCustomerId = GoogleAdsClient.normalizeCustomerId(credential.loginCustomerId)
+        return credential.copy(refreshToken = refreshToken, loginCustomerId = loginCustomerId)
+    }
+
+    private fun decryptApiSecret(record: ConnectorInstallationImportRecord): String {
+        val ciphertext = record.apiSecretCiphertext ?: throw badRequest("Connector installation has no API credential")
+        return secretCipherFactory().decrypt(ciphertext, record.organizationId)
+    }
+
+    private fun importRunsForInstallation(installationId: Int): List<ConnectorImportRunResponse> =
+        ConnectorImportRuns
+            .selectAll()
+            .where { ConnectorImportRuns.installationId eq installationId }
+            .orderBy(ConnectorImportRuns.createdAt, SortOrder.DESC)
+            .limit(IMPORT_RUN_LIST_LIMIT)
+            .map { row -> row.toImportRunResponse() }
+
+    private fun externalResourceCount(installationId: Int): Int =
+        ConnectorExternalResources
+            .selectAll()
+            .where { ConnectorExternalResources.installationId eq installationId }
+            .count()
+            .toInt()
+
+    private fun activeBindingCount(
+        organizationId: Int,
+        installationId: Int,
+    ): Int =
+        ConnectorUseBindings
+            .selectAll()
+            .where {
+                (ConnectorUseBindings.organizationId eq organizationId) and
+                    (ConnectorUseBindings.installationId eq installationId) and
+                    (ConnectorUseBindings.status eq LOCAL_RESOURCE_ACTIVE) and
+                    ConnectorUseBindings.effectiveTo.isNull()
+            }
+            .count()
+            .toInt()
+
+    private fun activeGoogleAdsProjectMapping(
+        installationId: Int,
+        customerId: String,
+    ): Long? =
+        activeProjectMapping(installationId, GoogleAdsClient.RESOURCE_TYPE_CUSTOMER, customerId)
+            ?: activeProjectMapping(installationId, GoogleAdsClient.RESOURCE_TYPE_MANAGER, customerId)
+
+    private fun activeProjectMapping(
+        installationId: Int,
+        externalResourceType: String,
+        externalResourceId: String,
+    ): Long? =
+        ConnectorUseBindings
+            .selectAll()
+            .where {
+                (ConnectorUseBindings.installationId eq installationId) and
+                    (ConnectorUseBindings.externalResourceType eq externalResourceType) and
+                    (ConnectorUseBindings.externalResourceId eq externalResourceId) and
+                    (ConnectorUseBindings.status eq LOCAL_RESOURCE_ACTIVE) and
+                    ConnectorUseBindings.effectiveTo.isNull()
+            }
+            .firstOrNull()
+            ?.get(ConnectorUseBindings.localResourceNumericId)
+
+    private fun importRunRowById(importRunId: Long): ResultRow =
+        ConnectorImportRuns
+            .selectAll()
+            .where { ConnectorImportRuns.id eq importRunId }
+            .firstOrNull()
+            ?: throw ConnectorServiceException(HttpStatusCode.NotFound, "Connector import run not found")
+
+    private fun importRunRecord(importRunId: Long): ConnectorImportRunRecord {
+        val run = importRunRowById(importRunId)
+        val installation =
+            ConnectorInstallations
+                .selectAll()
+                .where { ConnectorInstallations.id eq run[ConnectorImportRuns.installationId] }
+                .firstOrNull()
+                ?: throw ConnectorServiceException(HttpStatusCode.NotFound, "Connector installation not found")
+        return ConnectorImportRunRecord(
+            id = run[ConnectorImportRuns.id],
+            resourceId = run[ConnectorImportRuns.resourceId],
+            organizationId = run[ConnectorImportRuns.organizationId],
+            installationId = run[ConnectorImportRuns.installationId],
+            installationResourceId = installation[ConnectorInstallations.resourceId],
+            provider = run[ConnectorImportRuns.provider],
+            importType = run[ConnectorImportRuns.importType],
+            externalProjectId = run[ConnectorImportRuns.externalProjectId],
+            externalResourceId = run[ConnectorImportRuns.externalResourceId],
+            dateStart = run[ConnectorImportRuns.dateStart],
+            dateEnd = run[ConnectorImportRuns.dateEnd],
+            status = run[ConnectorImportRuns.status],
+            attemptCount = run[ConnectorImportRuns.attemptCount],
+        )
+    }
+
+    private fun installationRecordByResourceId(
+        organizationId: Int,
+        installationResourceId: String,
+    ): ConnectorInstallationImportRecord =
+        installationRowByResourceId(organizationId, installationResourceId).toImportInstallationRecord()
+
+    private fun installationRowByResourceId(
+        organizationId: Int,
+        installationResourceId: String,
+    ): ResultRow {
+        val resourceId = installationResourceId.toUuidOrNull()
+            ?: throw ConnectorServiceException(HttpStatusCode.BadRequest, "installationId must be a UUID")
+        return ConnectorInstallations
+            .selectAll()
+            .where {
+                (ConnectorInstallations.organizationId eq organizationId) and
+                    (ConnectorInstallations.resourceId eq resourceId) and
+                    ConnectorInstallations.deletedAt.isNull()
+            }
+            .firstOrNull()
+            ?: throw ConnectorServiceException(HttpStatusCode.NotFound, "Connector installation not found")
+    }
+
+    private fun installationRecordById(
+        organizationId: Int,
+        installationId: Int,
+    ): ConnectorInstallationImportRecord =
+        ConnectorInstallations
+            .selectAll()
+            .where {
+                (ConnectorInstallations.organizationId eq organizationId) and
+                    (ConnectorInstallations.id eq installationId) and
+                    ConnectorInstallations.deletedAt.isNull()
+            }
+            .firstOrNull()
+            ?.toImportInstallationRecord()
+            ?: throw ConnectorServiceException(HttpStatusCode.NotFound, "Connector installation not found")
+
+    private fun ResultRow.toImportInstallationRecord(): ConnectorInstallationImportRecord =
+        ConnectorInstallationImportRecord(
+            id = this[ConnectorInstallations.id],
+            resourceId = this[ConnectorInstallations.resourceId],
+            organizationId = this[ConnectorInstallations.organizationId],
+            provider = this[ConnectorInstallations.provider],
+            externalProjectId = this[ConnectorInstallations.externalProjectId],
+            apiSecretCiphertext = this[ConnectorInstallations.apiSecretCiphertext],
+        )
+
+    private fun ResultRow.toImportInstallationStateRecord(): ConnectorInstallationImportStateRecord =
+        ConnectorInstallationImportStateRecord(
+            id = this[ConnectorInstallations.id],
+            resourceId = this[ConnectorInstallations.resourceId],
+            enabled = this[ConnectorInstallations.enabled],
+            status = this[ConnectorInstallations.status],
+            lastTestedAt = this[ConnectorInstallations.lastTestedAt],
+            lastError = this[ConnectorInstallations.lastError],
+        )
+
+    private fun ResultRow.toImportRunResponse(): ConnectorImportRunResponse =
+        ConnectorImportRunResponse(
+            id = this[ConnectorImportRuns.resourceId].toString(),
+            installationId = installationResourceId(this[ConnectorImportRuns.installationId]).toString(),
+            providerId = this[ConnectorImportRuns.provider],
+            importType = this[ConnectorImportRuns.importType],
+            externalProjectId = this[ConnectorImportRuns.externalProjectId],
+            externalResourceId = this[ConnectorImportRuns.externalResourceId],
+            startDate = this[ConnectorImportRuns.dateStart].toString(),
+            endDate = this[ConnectorImportRuns.dateEnd].toString(),
+            status = this[ConnectorImportRuns.status],
+            rowsImported = this[ConnectorImportRuns.rowsImported],
+            queuedAt = this[ConnectorImportRuns.queuedAt].toString(),
+            startedAt = this[ConnectorImportRuns.startedAt]?.toString(),
+            finishedAt = this[ConnectorImportRuns.finishedAt]?.toString(),
+            attemptCount = this[ConnectorImportRuns.attemptCount],
+            lastErrorCode = this[ConnectorImportRuns.lastErrorCode],
+            lastErrorMessage = this[ConnectorImportRuns.lastErrorMessage],
+        )
+
+    private fun installationResourceId(installationId: Int): Uuid =
+        ConnectorInstallations
+            .selectAll()
+            .where { ConnectorInstallations.id eq installationId }
+            .first()[ConnectorInstallations.resourceId]
+
+    private fun ensureProvider(
+        record: ConnectorInstallationImportRecord,
+        providerId: String,
+    ) {
+        if (record.provider != providerId) {
+            throw ConnectorServiceException(HttpStatusCode.NotFound, "Connector installation not found")
+        }
+    }
+
+    private fun <T> withGoogleAdsErrorMapping(block: () -> T): T =
+        try {
+            block()
+        } catch (error: GoogleAdsClientException) {
+            throw ConnectorServiceException(googleAdsStatus(error), error.message.orEmpty(), error)
+        }
+
+    private fun googleAdsStatus(error: GoogleAdsClientException): HttpStatusCode =
+        when (error.code) {
+            "google_ads_unauthorized" -> HttpStatusCode.Unauthorized
+            "google_ads_forbidden" -> HttpStatusCode.Forbidden
+            "google_ads_not_found", "google_ads_customer_not_found" -> HttpStatusCode.NotFound
+            "google_ads_rate_limited" -> HttpStatusCode.TooManyRequests
+            else -> if (error.retryable) HttpStatusCode.BadGateway else HttpStatusCode.BadRequest
+        }
+
+    private fun badRequest(message: String): ConnectorServiceException =
+        ConnectorServiceException(HttpStatusCode.BadRequest, message)
+
+    private companion object {
+        const val IMPORT_RUN_LIST_LIMIT = 25
+        const val LOCAL_RESOURCE_ACTIVE = "active"
+        const val CONNECTOR_HEALTH_HEALTHY = "healthy"
+        const val CONNECTOR_HEALTH_DEGRADED = "degraded"
+        const val CONNECTOR_HEALTH_SYNCING = "syncing"
+        const val CONNECTOR_HEALTH_UNKNOWN = "unknown"
+    }
+}
+
+data class ConnectorImportStateRecord(
+    val status: String,
+    val rowsImported: Int,
+    val startedAt: Instant?,
+    val finishedAt: Instant?,
+    val lastErrorMessage: String?,
+)
+
+data class AppAdSpendFact(
+    val factId: Uuid,
+    val organizationId: Long,
+    val projectId: Long?,
+    val installationId: Int,
+    val installationResourceId: Uuid,
+    val importRunId: Long,
+    val importRunResourceId: Uuid,
+    val providerApiVersion: String?,
+    val googleAdsCustomerId: String,
+    val googleAdsLoginCustomerId: String?,
+    val reportDate: LocalDate,
+    val device: String?,
+    val geoTargetCountry: String?,
+    val campaignId: String?,
+    val campaignName: String?,
+    val campaignStatus: String?,
+    val campaignType: String?,
+    val campaignSubType: String?,
+    val biddingStrategyType: String?,
+    val adGroupId: String?,
+    val adGroupName: String?,
+    val adGroupStatus: String?,
+    val currencyCode: String?,
+    val timeZone: String?,
+    val impressions: Long,
+    val clicks: Long,
+    val costMicros: Long,
+    val conversions: Double,
+    val conversionsValue: Double,
+    val allConversions: Double,
+    val allConversionsValue: Double,
+    val rowIdentityHash: String,
+    val pulledAt: Instant,
+)
+
+private data class GoogleAdsImportDateRange(
+    val start: LocalDate,
+    val end: LocalDate,
+)
+
+private data class ConnectorInstallationImportRecord(
+    val id: Int,
+    val resourceId: Uuid,
+    val organizationId: Int,
+    val provider: String,
+    val externalProjectId: String?,
+    val apiSecretCiphertext: String?,
+)
+
+private data class ConnectorInstallationImportStateRecord(
+    val id: Int,
+    val resourceId: Uuid,
+    val enabled: Boolean,
+    val status: String,
+    val lastTestedAt: Instant?,
+    val lastError: String?,
+)
+
+private data class ConnectorImportRunRecord(
+    val id: Long,
+    val resourceId: Uuid,
+    val organizationId: Int,
+    val installationId: Int,
+    val installationResourceId: Uuid,
+    val provider: String,
+    val importType: String,
+    val externalProjectId: String?,
+    val externalResourceId: String?,
+    val dateStart: LocalDate,
+    val dateEnd: LocalDate,
+    val status: String,
+    val attemptCount: Int,
+)
+
+private suspend fun insertAdSpendFactsIntoClickHouse(facts: List<AppAdSpendFact>) {
+    if (facts.isEmpty()) return
+    facts.chunked(AD_SPEND_INSERT_BATCH_SIZE).forEach { batch ->
+        val values = batch.joinToString(",\n") { fact -> fact.sqlValues() }
+        val sql = """
+            INSERT INTO `${ClickHouseClient.getDatabase()}`.app_ad_spend_facts (
+                fact_id,
+                organization_id,
+                project_id,
+                installation_id,
+                installation_resource_id,
+                import_run_id,
+                import_run_resource_id,
+                provider,
+                provider_api_version,
+                google_ads_customer_id,
+                google_ads_login_customer_id,
+                report_date,
+                device,
+                geo_target_country,
+                campaign_id,
+                campaign_name,
+                campaign_status,
+                campaign_type,
+                campaign_sub_type,
+                bidding_strategy_type,
+                ad_group_id,
+                ad_group_name,
+                ad_group_status,
+                currency_code,
+                time_zone,
+                impressions,
+                clicks,
+                cost_micros,
+                conversions,
+                conversions_value,
+                all_conversions,
+                all_conversions_value,
+                row_identity_hash,
+                pulled_at
+            ) VALUES
+            $values
+        """.trimIndent()
+        ClickHouseClient.executeWithFormat(sql, "")
+    }
+}
+
+private fun AppAdSpendFact.sqlValues(): String =
+    """
+    (
+        ${factId.sqlUuid()},
+        $organizationId,
+        ${projectId.sqlLong()},
+        $installationId,
+        ${installationResourceId.sqlUuid()},
+        $importRunId,
+        ${importRunResourceId.sqlUuid()},
+        'google_ads',
+        ${providerApiVersion.sqlString()},
+        ${googleAdsCustomerId.sqlString()},
+        ${googleAdsLoginCustomerId.sqlString()},
+        ${reportDate.sqlDate()},
+        ${device.sqlString()},
+        ${geoTargetCountry.sqlString()},
+        ${campaignId.sqlString()},
+        ${campaignName.sqlString()},
+        ${campaignStatus.sqlString()},
+        ${campaignType.sqlString()},
+        ${campaignSubType.sqlString()},
+        ${biddingStrategyType.sqlString()},
+        ${adGroupId.sqlString()},
+        ${adGroupName.sqlString()},
+        ${adGroupStatus.sqlString()},
+        ${currencyCode.sqlString()},
+        ${timeZone.sqlString()},
+        ${impressions.coerceAtLeast(0L)},
+        ${clicks.coerceAtLeast(0L)},
+        $costMicros,
+        ${conversions.sqlDouble()},
+        ${conversionsValue.sqlDouble()},
+        ${allConversions.sqlDouble()},
+        ${allConversionsValue.sqlDouble()},
+        ${rowIdentityHash.sqlString()},
+        ${pulledAt.sqlDateTime64()}
+    )
+    """.trimIndent()
+
+private fun googleAdsSpendRowHash(
+    run: ConnectorImportRunRecord,
+    row: GoogleAdsSpendReportRow,
+): String =
+    sha256Hex(
+        listOf(
+            run.organizationId.toString(),
+            run.installationId.toString(),
+            row.customerId,
+            row.reportDate.toString(),
+            row.campaignId.orEmpty(),
+            row.adGroupId.orEmpty(),
+            row.geoTargetCountry.orEmpty(),
+            row.device.orEmpty(),
+        ).joinToString("|")
+    )
+
+private fun deterministicUuid(seed: String): Uuid =
+    Uuid.parse(UUID.nameUUIDFromBytes(seed.toByteArray(Charsets.UTF_8)).toString())
+
+private fun sha256Hex(value: String): String =
+    MessageDigest
+        .getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { byte -> "%02x".format(byte) }
+
+private fun Uuid.sqlUuid(): String =
+    "'$this'"
+
+private fun LocalDate.sqlDate(): String =
+    "toDate('$this')"
+
+private fun String?.sqlString(): String =
+    this?.let { value -> "'${escapeSql(value)}'" } ?: "NULL"
+
+private fun Long?.sqlLong(): String =
+    this?.toString() ?: "NULL"
+
+private fun Double?.sqlDouble(): String =
+    this?.takeIf { value -> value.isFinite() }?.toString() ?: "NULL"
+
+private fun Instant.sqlDateTime64(): String =
+    "fromUnixTimestamp64Milli(${toEpochMilliseconds()}, 'UTC')"

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorImportWorker.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorImportWorker.kt
@@ -32,6 +32,7 @@ class ConnectorImportWorker(
     private var queueWorker: RedisQueueWorker? = null
 
     fun start() {
+        if (queueWorker != null) return
         val spec = IngestionQueueSettings.spec(
             pipeline = IngestionPipeline.CONNECTOR_IMPORTS,
             queueKey = ConnectorService.CONNECTOR_IMPORT_QUEUE_KEY,
@@ -47,6 +48,7 @@ class ConnectorImportWorker(
 
     fun stop() {
         queueWorker?.stop()
+        queueWorker = null
         connectorImportWorkerLogger.info { "ConnectorImportWorker stopped" }
     }
 

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorImportWorker.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorImportWorker.kt
@@ -1,0 +1,62 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.connectors
+
+import com.moneat.ingestion.queue.IngestionPipeline
+import com.moneat.ingestion.queue.IngestionQueueSettings
+import com.moneat.ingestion.queue.RedisQueueWorker
+import com.moneat.monitoring.OperationalMetrics
+import mu.KotlinLogging
+
+private val connectorImportWorkerLogger = KotlinLogging.logger {}
+private const val DEFAULT_CONNECTOR_IMPORT_WORKERS = 1
+
+class ConnectorImportWorker(
+    private val connectorService: ConnectorService,
+    private val workerCount: Int = DEFAULT_CONNECTOR_IMPORT_WORKERS,
+) {
+    private var queueWorker: RedisQueueWorker? = null
+
+    fun start() {
+        val spec = IngestionQueueSettings.spec(
+            pipeline = IngestionPipeline.CONNECTOR_IMPORTS,
+            queueKey = ConnectorService.CONNECTOR_IMPORT_QUEUE_KEY,
+            dlqKey = ConnectorService.CONNECTOR_IMPORT_DLQ_KEY,
+            workerCount = workerCount,
+        )
+        queueWorker = RedisQueueWorker(
+            spec = spec,
+            logger = connectorImportWorkerLogger,
+            processMessage = ::processMessageForTest,
+        ).also { worker -> worker.start() }
+    }
+
+    fun stop() {
+        queueWorker?.stop()
+        connectorImportWorkerLogger.info { "ConnectorImportWorker stopped" }
+    }
+
+    internal suspend fun processMessageForTest(
+        workerId: Int,
+        value: String,
+    ) {
+        val importRunId = value.toLongOrNull()
+            ?: throw IllegalArgumentException("Connector import payload must be an import run ID")
+        connectorService.processImportRun(importRunId)
+        OperationalMetrics.recordWorkerMessageProcessed(IngestionPipeline.CONNECTOR_IMPORTS.workerName, workerId)
+    }
+}

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorManagementModels.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorManagementModels.kt
@@ -151,6 +151,37 @@ data class ConnectorWebhookAcceptedResponse(
 )
 
 @Serializable
+data class ConnectorSyncRequest(
+    val startDate: String? = null,
+    val endDate: String? = null,
+)
+
+@Serializable
+data class ConnectorImportRunResponse(
+    val id: String,
+    val installationId: String,
+    val providerId: String,
+    val importType: String,
+    val externalProjectId: String?,
+    val externalResourceId: String?,
+    val startDate: String,
+    val endDate: String,
+    val status: String,
+    val rowsImported: Int,
+    val queuedAt: String,
+    val startedAt: String?,
+    val finishedAt: String?,
+    val attemptCount: Int,
+    val lastErrorCode: String?,
+    val lastErrorMessage: String?,
+)
+
+@Serializable
+data class ConnectorImportRunsResponse(
+    val runs: List<ConnectorImportRunResponse>,
+)
+
+@Serializable
 data class ConnectorProviderStateDetail(
     val installationId: String,
     val status: String,
@@ -164,6 +195,10 @@ data class ConnectorProviderStateDetail(
     val lastAcceptedWebhookAt: String?,
     val lastAppliedAt: String?,
     val processingLagSeconds: Long?,
+    val lastImportStatus: String? = null,
+    val lastImportFinishedAt: String? = null,
+    val lastImportRows: Int? = null,
+    val importLagSeconds: Long? = null,
 )
 
 @Serializable

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorService.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorService.kt
@@ -71,7 +71,7 @@ interface ConnectorSecretCipher {
     fun decrypt(envelope: String, organizationId: Int): String
 }
 
-private class PurposeConnectorSecretCipher(
+class PurposeConnectorSecretCipher(
     private val delegate: PurposeScopedSecretCipher,
 ) : ConnectorSecretCipher {
     override val activeKeyId: String = delegate.activeKeyId
@@ -98,6 +98,10 @@ class ConnectorService(
     private val enqueueConnectorEvent: (String) -> Unit = { payload ->
         IngestionQueueClient.enqueue(IngestionPipeline.CONNECTOR_EVENTS, CONNECTOR_EVENT_QUEUE_KEY, payload)
     },
+    private val importService: ConnectorImportService = ConnectorImportService(
+        googleAdsClient = googleAdsClient,
+        secretCipherFactory = secretCipherFactory,
+    ),
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -568,6 +572,23 @@ class ConnectorService(
             bindingsForInstallation(organizationId, row[ConnectorInstallations.id])
         }
 
+    fun listImportRuns(
+        organizationId: Int,
+        installationResourceId: String,
+    ): ConnectorImportRunsResponse =
+        importService.listImportRuns(organizationId, installationResourceId)
+
+    fun enqueueSync(
+        organizationId: Int,
+        userId: Int,
+        installationResourceId: String,
+        request: ConnectorSyncRequest,
+    ): ConnectorImportRunResponse =
+        importService.enqueueSync(organizationId, userId, installationResourceId, request)
+
+    suspend fun processImportRun(importRunId: Long) =
+        importService.processImportRun(importRunId)
+
     fun upsertBindings(
         organizationId: Int,
         userId: Int,
@@ -848,50 +869,7 @@ class ConnectorService(
         }
 
     fun googleAdsState(organizationId: Int): Pair<ConnectorConnectionSummary?, ConnectorProviderStateDetail?> =
-        transaction {
-            val installation =
-                ConnectorInstallations
-                    .selectAll()
-                    .where {
-                        (ConnectorInstallations.organizationId eq organizationId) and
-                            (ConnectorInstallations.provider eq GoogleAdsClient.PROVIDER_ID) and
-                            ConnectorInstallations.deletedAt.isNull()
-                    }
-                    .orderBy(ConnectorInstallations.createdAt, SortOrder.DESC)
-                    .firstOrNull()
-                    ?: return@transaction null to null
-            val record = installation.toInstallationRecord()
-            val resourceCount = externalResourceCount(record.id)
-            val health = when {
-                !record.enabled -> STATUS_DEGRADED
-                record.status == STATUS_DEGRADED -> STATUS_DEGRADED
-                record.status == STATUS_HEALTHY -> STATUS_HEALTHY
-                else -> "unknown"
-            }
-            val message = googleAdsStateMessage(record, resourceCount)
-            val detail = ConnectorProviderStateDetail(
-                installationId = record.resourceId.toString(),
-                status = record.status,
-                health = health,
-                message = message,
-                mappedResources = resourceCount,
-                unmappedEvents = 0,
-                failedReceipts = 0,
-                sandboxEvents = 0,
-                productionEvents = 0,
-                lastAcceptedWebhookAt = null,
-                lastAppliedAt = null,
-                processingLagSeconds = null,
-            )
-            val summary = ConnectorConnectionSummary(
-                providerId = GoogleAdsClient.PROVIDER_ID,
-                connected = true,
-                health = health,
-                detail = message,
-                lastCheckedAt = record.lastTestedAt?.toString(),
-            )
-            summary to detail
-        }
+        importService.googleAdsState(organizationId)
 
     private fun ensureRevenueCatInstallRequest(request: CreateConnectorInstallationRequest) {
         if (request.providerId != RevenueCatClient.PROVIDER_ID) {
@@ -1105,7 +1083,7 @@ class ConnectorService(
             .keys
             .firstOrNull()
         if (duplicateKey != null) {
-            throw badRequest("RevenueCat app ${duplicateKey.externalResourceId} appears more than once")
+            throw badRequest("External resource ${duplicateKey.externalResourceId} appears more than once")
         }
     }
 
@@ -1144,11 +1122,14 @@ class ConnectorService(
         input: ConnectorBindingInput,
         now: Instant,
     ) {
-        if (input.externalResourceType != RevenueCatClient.RESOURCE_TYPE_APP) {
-            throw badRequest("RevenueCat bindings must use revenuecat_app external resources")
+        val allowedExternalResourceTypes = allowedBindingExternalResourceTypes(installation.provider)
+        if (input.externalResourceType !in allowedExternalResourceTypes) {
+            throw badRequest(
+                "Connector bindings must use ${allowedExternalResourceTypes.joinToString()} external resources"
+            )
         }
-        if (input.localResourceType != RevenueCatClient.LOCAL_RESOURCE_PROJECT) {
-            throw badRequest("RevenueCat apps can only be mapped to Moneat projects")
+        if (input.localResourceType != LOCAL_RESOURCE_PROJECT) {
+            throw badRequest("Connector resources can only be mapped to Moneat projects")
         }
         val localResourceUuid =
             input.localResourceId.toUuidOrNull() ?: throw badRequest("localResourceId must be a project UUID")
@@ -1163,7 +1144,7 @@ class ConnectorService(
                         (ConnectorExternalResources.externalResourceId eq input.externalResourceId)
                 }
                 .firstOrNull()
-                ?: throw ConnectorServiceException(HttpStatusCode.NotFound, "External RevenueCat app was not found")
+                ?: throw ConnectorServiceException(HttpStatusCode.NotFound, "External connector resource was not found")
         val duplicateActive =
             ConnectorUseBindings
                 .selectAll()
@@ -1177,7 +1158,7 @@ class ConnectorService(
                 }
                 .count() > 0
         if (duplicateActive) {
-            throw badRequest("RevenueCat app is already mapped through another installation")
+            throw badRequest("External connector resource is already mapped through another installation")
         }
 
         val activeBinding =
@@ -1225,6 +1206,16 @@ class ConnectorService(
             it[updatedAt] = now
         }
     }
+
+    private fun allowedBindingExternalResourceTypes(provider: String): Set<String> =
+        when (provider) {
+            RevenueCatClient.PROVIDER_ID -> setOf(RevenueCatClient.RESOURCE_TYPE_APP)
+            GoogleAdsClient.PROVIDER_ID -> setOf(
+                GoogleAdsClient.RESOURCE_TYPE_CUSTOMER,
+                GoogleAdsClient.RESOURCE_TYPE_MANAGER,
+            )
+            else -> throw badRequest("Unsupported connector provider: $provider")
+        }
 
     private fun webhookUrl(installationResourceId: Uuid): String =
         EnvConfig.get("BACKEND_URL", "https://api.moneat.io")
@@ -1581,13 +1572,6 @@ class ConnectorService(
             .count()
             .toInt()
 
-    private fun externalResourceCount(installationId: Int): Int =
-        ConnectorExternalResources
-            .selectAll()
-            .where { ConnectorExternalResources.installationId eq installationId }
-            .count()
-            .toInt()
-
     private fun failedReceiptCount(installationId: Int): Int =
         ConnectorEventReceipts
             .selectAll()
@@ -1687,19 +1671,6 @@ class ConnectorService(
             counts.lastRaw == null && health == STATUS_HEALTHY -> "Connected, awaiting RevenueCat webhook traffic"
             record.lastError != null -> record.lastError
             else -> "Connected"
-        }
-
-    private fun googleAdsStateMessage(
-        record: ConnectorInstallationRecord,
-        resourceCount: Int,
-    ): String =
-        when {
-            !record.enabled -> "Google Ads connector is disabled"
-            record.lastError != null -> record.lastError
-            record.status == STATUS_DEGRADED -> "Google Ads API validation failed"
-            resourceCount == 0 -> "Connected, no Google Ads accounts discovered yet"
-            resourceCount == 1 -> "Connected to 1 Google Ads account"
-            else -> "Connected to $resourceCount Google Ads accounts"
         }
 
     private fun ensureProvider(
@@ -1840,8 +1811,11 @@ class ConnectorService(
     companion object {
         const val CONNECTOR_EVENT_QUEUE_KEY = "moneat:connectors:events:queue"
         const val CONNECTOR_EVENT_DLQ_KEY = "moneat:connectors:events:dlq"
+        const val CONNECTOR_IMPORT_QUEUE_KEY = "moneat:connectors:imports:queue"
+        const val CONNECTOR_IMPORT_DLQ_KEY = "moneat:connectors:imports:dlq"
         private const val API_SECRET_SUFFIX_CHARS = 4
         private const val WEBHOOK_TOKEN_PREFIX_CHARS = 12
+        private const val LOCAL_RESOURCE_PROJECT = "project"
         private const val STATUS_HEALTHY = "healthy"
         private const val STATUS_DEGRADED = "degraded"
         private const val STATUS_AWAITING_TRAFFIC = "awaiting_traffic"

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorTables.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorTables.kt
@@ -21,6 +21,7 @@ import com.moneat.shared.models.Users
 import com.moneat.shared.models.jsonb
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.date
 import org.jetbrains.exposed.v1.datetime.timestamp
 import kotlin.uuid.Uuid
 
@@ -170,6 +171,39 @@ object ConnectorEventReceipts : Table("connector_event_receipts") {
     init {
         uniqueIndex(installationId, providerEventId)
         index(false, installationId, state, updatedAt)
+    }
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object ConnectorImportRuns : Table("connector_import_runs") {
+    val id = long("id").autoIncrement()
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val installationId =
+        integer("installation_id")
+            .references(ConnectorInstallations.id, onDelete = ReferenceOption.CASCADE)
+    val provider = varchar("provider", 64)
+    val importType = varchar("import_type", 64)
+    val externalProjectId = varchar("external_project_id", 255).nullable()
+    val externalResourceId = varchar("external_resource_id", 255).nullable()
+    val dateStart = date("date_start")
+    val dateEnd = date("date_end")
+    val status = varchar("status", 32).default("queued")
+    val rowsImported = integer("rows_imported").default(0)
+    val requestedBy = integer("requested_by").references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val queuedAt = timestamp("queued_at")
+    val startedAt = timestamp("started_at").nullable()
+    val finishedAt = timestamp("finished_at").nullable()
+    val attemptCount = integer("attempt_count").default(0)
+    val lastErrorCode = varchar("last_error_code", 64).nullable()
+    val lastErrorMessage = text("last_error_message").nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        index(false, installationId, status, updatedAt)
     }
 
     override val primaryKey = PrimaryKey(id)

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorsModule.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/ConnectorsModule.kt
@@ -30,6 +30,7 @@ import org.koin.dsl.module
 class ConnectorsModule : EnterpriseModule {
     override val name: String = "Connectors"
     private var connectorEventWorker: ConnectorEventWorker? = null
+    private var connectorImportWorker: ConnectorImportWorker? = null
 
     override fun registerRoutes(route: Route) {
         route.connectorRoutes()
@@ -52,6 +53,7 @@ class ConnectorsModule : EnterpriseModule {
                     )
                 }
                 single { ConnectorEventWorker(connectorService = get()) }
+                single { ConnectorImportWorker(connectorService = get()) }
             }
         )
 
@@ -62,14 +64,21 @@ class ConnectorsModule : EnterpriseModule {
         startSchedulers: Boolean,
         startIngestionWorkers: Boolean,
     ) {
-        if (!startIngestionWorkers || !IngestionQueueSettings.isSelected(IngestionPipeline.CONNECTOR_EVENTS)) {
+        if (!startIngestionWorkers) {
             return
         }
-        connectorEventWorker = GlobalContext.get().get<ConnectorEventWorker>().also { worker -> worker.start() }
+        if (IngestionQueueSettings.isSelected(IngestionPipeline.CONNECTOR_EVENTS)) {
+            connectorEventWorker = GlobalContext.get().get<ConnectorEventWorker>().also { worker -> worker.start() }
+        }
+        if (IngestionQueueSettings.isSelected(IngestionPipeline.CONNECTOR_IMPORTS)) {
+            connectorImportWorker = GlobalContext.get().get<ConnectorImportWorker>().also { worker -> worker.start() }
+        }
     }
 
     override fun stopBackgroundJobs() {
         connectorEventWorker?.stop()
         connectorEventWorker = null
+        connectorImportWorker?.stop()
+        connectorImportWorker = null
     }
 }

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/GoogleAdsClient.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/GoogleAdsClient.kt
@@ -26,10 +26,12 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.datetime.LocalDate
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -70,6 +72,32 @@ data class GoogleAdsCustomerAccount(
     val loginCustomerId: String?,
 )
 
+data class GoogleAdsSpendReportRow(
+    val reportDate: LocalDate,
+    val customerId: String,
+    val loginCustomerId: String?,
+    val campaignId: String?,
+    val campaignName: String?,
+    val campaignStatus: String?,
+    val campaignType: String?,
+    val campaignSubType: String?,
+    val biddingStrategyType: String?,
+    val adGroupId: String?,
+    val adGroupName: String?,
+    val adGroupStatus: String?,
+    val device: String?,
+    val geoTargetCountry: String?,
+    val currencyCode: String?,
+    val timeZone: String?,
+    val impressions: Long,
+    val clicks: Long,
+    val costMicros: Long,
+    val conversions: Double,
+    val conversionsValue: Double,
+    val allConversions: Double,
+    val allConversionsValue: Double,
+)
+
 class GoogleAdsClientException(
     message: String,
     val code: String,
@@ -89,6 +117,14 @@ interface GoogleAdsProviderClient {
         credential: GoogleAdsOAuthCredential,
         loginCustomerId: String,
     ): List<GoogleAdsCustomerAccount>
+
+    fun fetchSpendReport(
+        credential: GoogleAdsOAuthCredential,
+        customerId: String,
+        loginCustomerId: String?,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<GoogleAdsSpendReportRow>
 }
 
 data class GoogleAdsClientConfig(
@@ -195,6 +231,30 @@ class GoogleAdsClient(
                 loginCustomerId = normalizedLoginCustomerId,
             )
         }
+    }
+
+    override fun fetchSpendReport(
+        credential: GoogleAdsOAuthCredential,
+        customerId: String,
+        loginCustomerId: String?,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<GoogleAdsSpendReportRow> {
+        val normalizedCustomerId = normalizeCustomerId(customerId)
+            ?: throw GoogleAdsClientException("Google Ads customer ID is required", "missing_customer_id")
+        val normalizedLoginCustomerId = normalizeCustomerId(loginCustomerId)
+        val response = searchStream(
+            credential = credential,
+            customerId = normalizedCustomerId,
+            loginCustomerId = normalizedLoginCustomerId,
+            query = spendReportQuery(startDate, endDate),
+            operation = "fetch Google Ads spend report",
+        )
+        return parseSpendReportRows(
+            body = response.body(),
+            customerId = normalizedCustomerId,
+            loginCustomerId = normalizedLoginCustomerId,
+        )
     }
 
     private fun getCustomer(
@@ -392,6 +452,22 @@ class GoogleAdsClient(
         }
     }
 
+    private fun parseSpendReportRows(
+        body: String,
+        customerId: String,
+        loginCustomerId: String?,
+    ): List<GoogleAdsSpendReportRow> {
+        val root = json.parseToJsonElement(body)
+        val batches = if (root is JsonArray) root.toList() else listOf(root)
+        return batches.flatMap { batch ->
+            batch.jsonObjectOrNull()
+                ?.get("results")
+                ?.jsonArray
+                ?.mapNotNull { result -> result.jsonObjectOrNull()?.toSpendReportRow(customerId, loginCustomerId) }
+                .orEmpty()
+        }
+    }
+
     private fun formBody(values: Map<String, String>): String =
         values.entries.joinToString("&") { (key, value) ->
             "${key.urlEncode()}=${value.urlEncode()}"
@@ -444,6 +520,36 @@ class GoogleAdsClient(
             FROM customer_client
             WHERE customer_client.level <= 1
         """.trimIndent()
+
+        private fun spendReportQuery(
+            startDate: LocalDate,
+            endDate: LocalDate,
+        ): String = """
+            SELECT
+              segments.date,
+              segments.device,
+              segments.geo_target_country,
+              customer.currency_code,
+              customer.time_zone,
+              campaign.id,
+              campaign.name,
+              campaign.status,
+              campaign.advertising_channel_type,
+              campaign.advertising_channel_sub_type,
+              campaign.bidding_strategy_type,
+              ad_group.id,
+              ad_group.name,
+              ad_group.status,
+              metrics.impressions,
+              metrics.clicks,
+              metrics.cost_micros,
+              metrics.conversions,
+              metrics.conversions_value,
+              metrics.all_conversions,
+              metrics.all_conversions_value
+            FROM geographic_view
+            WHERE segments.date BETWEEN '$startDate' AND '$endDate'
+        """.trimIndent()
     }
 }
 
@@ -453,11 +559,62 @@ private fun JsonElement.jsonObjectOrNull(): JsonObject? =
 private fun JsonObject.string(key: String): String? =
     this[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
 
+private fun JsonObject.stringAny(vararg keys: String): String? =
+    keys.firstNotNullOfOrNull { key -> string(key) }
+
 private fun JsonObject.boolean(key: String): Boolean? =
     this[key]?.jsonPrimitive?.booleanOrNull
 
 private fun JsonObject.int(key: String): Int? =
     this[key]?.jsonPrimitive?.intOrNull
+
+private fun JsonObject.longAny(vararg keys: String): Long =
+    stringAny(*keys)?.toLongOrNull() ?: 0L
+
+private fun JsonObject.doubleAny(vararg keys: String): Double =
+    stringAny(*keys)?.toDoubleOrNull()
+        ?: keys.firstNotNullOfOrNull { key -> this[key]?.jsonPrimitive?.doubleOrNull }
+        ?: 0.0
+
+private fun JsonObject.child(key: String): JsonObject =
+    this[key]?.jsonObjectOrNull() ?: JsonObject(emptyMap())
+
+private fun JsonObject.toSpendReportRow(
+    customerId: String,
+    loginCustomerId: String?,
+): GoogleAdsSpendReportRow? {
+    val segments = child("segments")
+    val metrics = child("metrics")
+    val campaign = child("campaign")
+    val adGroup = child("adGroup")
+    val customer = child("customer")
+    val date = segments.string("date")?.let { rawDate -> LocalDate.parse(rawDate) } ?: return null
+    return GoogleAdsSpendReportRow(
+        reportDate = date,
+        customerId = customerId,
+        loginCustomerId = loginCustomerId,
+        campaignId = campaign.stringAny("id"),
+        campaignName = campaign.stringAny("name"),
+        campaignStatus = campaign.stringAny("status"),
+        campaignType = campaign.stringAny("advertisingChannelType", "advertising_channel_type"),
+        campaignSubType = campaign.stringAny("advertisingChannelSubType", "advertising_channel_sub_type"),
+        biddingStrategyType = campaign.stringAny("biddingStrategyType", "bidding_strategy_type"),
+        adGroupId = adGroup.stringAny("id"),
+        adGroupName = adGroup.stringAny("name"),
+        adGroupStatus = adGroup.stringAny("status"),
+        device = segments.stringAny("device"),
+        geoTargetCountry = segments.stringAny("geoTargetCountry", "geo_target_country"),
+        currencyCode = customer.stringAny("currencyCode", "currency_code"),
+        timeZone = customer.stringAny("timeZone", "time_zone"),
+        impressions = metrics.longAny("impressions"),
+        clicks = metrics.longAny("clicks"),
+        costMicros = metrics.longAny("costMicros", "cost_micros"),
+        conversions = metrics.doubleAny("conversions"),
+        conversionsValue = metrics.doubleAny("conversionsValue", "conversions_value"),
+        allConversions = metrics.doubleAny("allConversions", "all_conversions"),
+        allConversionsValue = metrics.doubleAny("allConversionsValue", "all_conversions_value"),
+    )
+}
 
 private fun String.urlEncode(): String =
     URLEncoder.encode(this, Charsets.UTF_8)

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/routes/ConnectorRoutes.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/routes/ConnectorRoutes.kt
@@ -29,6 +29,7 @@ import com.moneat.connectors.ConnectorProvidersResponse
 import com.moneat.connectors.ConnectorService
 import com.moneat.connectors.ConnectorServiceException
 import com.moneat.connectors.ConnectorStateResponse
+import com.moneat.connectors.ConnectorSyncRequest
 import com.moneat.connectors.ConnectorUseDefinition
 import com.moneat.connectors.ConnectorUseState
 import com.moneat.connectors.ConnectorWebhookAcceptedResponse
@@ -181,6 +182,15 @@ private fun Route.connectorInstallationActionRoutes(connectorService: ConnectorS
             connectorService.webhookSetup(context.orgId, installationId)
         }
     }
+
+    post("/sync") {
+        val context = call.requireConnectorAdmin() ?: return@post
+        val installationId = call.requireInstallationId() ?: return@post
+        val request = call.receive<ConnectorSyncRequest>()
+        call.respondConnector(HttpStatusCode.Accepted) {
+            connectorService.enqueueSync(context.orgId, context.userId, installationId, request)
+        }
+    }
 }
 
 private fun Route.connectorInstallationResourceRoutes(connectorService: ConnectorService) {
@@ -205,6 +215,14 @@ private fun Route.connectorInstallationResourceRoutes(connectorService: Connecto
         val installationId = call.requireInstallationId() ?: return@get
         call.respondConnector {
             connectorService.listBindings(context.orgId, installationId)
+        }
+    }
+
+    get("/sync-runs") {
+        val context = call.requireCurrentOrg() ?: return@get
+        val installationId = call.requireInstallationId() ?: return@get
+        call.respondConnector {
+            connectorService.listImportRuns(context.orgId, installationId)
         }
     }
 

--- a/backend/features/connectors/src/main/kotlin/com/moneat/connectors/routes/ConnectorRoutes.kt
+++ b/backend/features/connectors/src/main/kotlin/com/moneat/connectors/routes/ConnectorRoutes.kt
@@ -186,11 +186,17 @@ private fun Route.connectorInstallationActionRoutes(connectorService: ConnectorS
     post("/sync") {
         val context = call.requireConnectorAdmin() ?: return@post
         val installationId = call.requireInstallationId() ?: return@post
-        val request = call.receive<ConnectorSyncRequest>()
+        val request = call.receiveConnectorSyncRequest()
         call.respondConnector(HttpStatusCode.Accepted) {
             connectorService.enqueueSync(context.orgId, context.userId, installationId, request)
         }
     }
+}
+
+private suspend fun ApplicationCall.receiveConnectorSyncRequest(): ConnectorSyncRequest {
+    val contentLength = request.header(HttpHeaders.ContentLength)?.toLongOrNull()
+    if (contentLength == 0L) return ConnectorSyncRequest()
+    return receive()
 }
 
 private fun Route.connectorInstallationResourceRoutes(connectorService: ConnectorService) {

--- a/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorH2Schema.kt
+++ b/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorH2Schema.kt
@@ -179,6 +179,33 @@ object ConnectorH2Schema {
                 )
                 """.trimIndent()
             )
+            exec(
+                """
+                CREATE TABLE connector_import_runs (
+                    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                    resource_id UUID NOT NULL,
+                    organization_id INT NOT NULL,
+                    installation_id INT NOT NULL,
+                    provider VARCHAR(64) NOT NULL,
+                    import_type VARCHAR(64) NOT NULL,
+                    external_project_id VARCHAR(255),
+                    external_resource_id VARCHAR(255),
+                    date_start DATE NOT NULL,
+                    date_end DATE NOT NULL,
+                    status VARCHAR(32) DEFAULT 'queued' NOT NULL,
+                    rows_imported INT DEFAULT 0 NOT NULL,
+                    requested_by INT,
+                    queued_at TIMESTAMP(9) NOT NULL,
+                    started_at TIMESTAMP(9),
+                    finished_at TIMESTAMP(9),
+                    attempt_count INT DEFAULT 0 NOT NULL,
+                    last_error_code VARCHAR(64),
+                    last_error_message TEXT,
+                    created_at TIMESTAMP(9) NOT NULL,
+                    updated_at TIMESTAMP(9) NOT NULL
+                )
+                """.trimIndent()
+            )
         }
     }
 
@@ -189,5 +216,6 @@ object ConnectorH2Schema {
             ConnectorUseBindings,
             ConnectorInboundEventsRaw,
             ConnectorEventReceipts,
+            ConnectorImportRuns,
         )
 }

--- a/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorServiceTest.kt
+++ b/backend/features/connectors/src/test/kotlin/com/moneat/connectors/ConnectorServiceTest.kt
@@ -20,6 +20,8 @@ import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Projects
 import com.moneat.shared.models.Users
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.LocalDate
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -247,19 +249,75 @@ class ConnectorServiceTest {
 
         val detail = assertNotNull(service.googleAdsState(ORGANIZATION_ID).second)
 
-        assertEquals(2, detail.mappedResources)
+        assertEquals(0, detail.mappedResources)
         assertEquals("healthy", detail.health)
         assertEquals("Connected to 2 Google Ads accounts", detail.message)
     }
 
+    @Test
+    fun `google ads sync run imports spend facts and updates state`() = runBlocking {
+        val queuedImports = mutableListOf<String>()
+        var importedFacts = 0
+        val service = connectorService(
+            importMessages = queuedImports,
+            insertAdSpendFacts = { facts -> importedFacts += facts.size },
+        )
+        val installation = service.createInstallation(ORGANIZATION_ID, USER_ID, googleAdsRequest())
+        service.upsertBindings(
+            organizationId = ORGANIZATION_ID,
+            userId = USER_ID,
+            installationResourceId = installation.id,
+            request = googleAdsBindingRequest(projectResourceId(PROJECT_ID)),
+        )
+
+        val queued = service.enqueueSync(
+            organizationId = ORGANIZATION_ID,
+            userId = USER_ID,
+            installationResourceId = installation.id,
+            request = ConnectorSyncRequest(startDate = "2026-06-01", endDate = "2026-06-02"),
+        )
+
+        assertEquals("queued", queued.status)
+        assertEquals(1, queuedImports.size)
+
+        service.processImportRun(queuedImports.single().toLong())
+
+        val run = service.listImportRuns(ORGANIZATION_ID, installation.id).runs.single()
+        assertEquals("succeeded", run.status)
+        assertEquals(1, run.rowsImported)
+        assertEquals(1, importedFacts)
+
+        val detail = assertNotNull(service.googleAdsState(ORGANIZATION_ID).second)
+        assertEquals("succeeded", detail.lastImportStatus)
+        assertEquals(1, detail.lastImportRows)
+        assertEquals("Imported 1 Google Ads spend rows", detail.message)
+    }
+
     private fun connectorService(
         queuedMessages: MutableList<String> = mutableListOf(),
+        importMessages: MutableList<String> = mutableListOf(),
+        insertAdSpendFacts: suspend (List<AppAdSpendFact>) -> Unit = {},
+    ): ConnectorService =
+        connectorService(
+            queuedMessages = queuedMessages,
+            importService = ConnectorImportService(
+                googleAdsClient = FakeGoogleAdsProviderClient(),
+                secretCipherFactory = { FakeConnectorSecretCipher },
+                enqueueConnectorImport = { payload -> importMessages += payload },
+                insertAdSpendFacts = insertAdSpendFacts,
+            ),
+        )
+
+    private fun connectorService(
+        queuedMessages: MutableList<String>,
+        importService: ConnectorImportService,
     ): ConnectorService =
         ConnectorService(
             revenueCatClient = FakeRevenueCatProviderClient(),
             googleAdsClient = FakeGoogleAdsProviderClient(),
             secretCipherFactory = { FakeConnectorSecretCipher },
             enqueueConnectorEvent = { payload -> queuedMessages += payload },
+            importService = importService,
         )
 
     private fun createRequest(): CreateConnectorInstallationRequest =
@@ -293,6 +351,18 @@ class ConnectorServiceTest {
                     externalResourceType = RevenueCatClient.RESOURCE_TYPE_APP,
                     externalResourceId = appId,
                     localResourceType = RevenueCatClient.LOCAL_RESOURCE_PROJECT,
+                    localResourceId = projectResourceId,
+                )
+            )
+        )
+
+    private fun googleAdsBindingRequest(projectResourceId: String): UpsertConnectorBindingRequest =
+        UpsertConnectorBindingRequest(
+            listOf(
+                ConnectorBindingInput(
+                    externalResourceType = GoogleAdsClient.RESOURCE_TYPE_MANAGER,
+                    externalResourceId = GOOGLE_ADS_CUSTOMER_ID,
+                    localResourceType = "project",
                     localResourceId = projectResourceId,
                 )
             )
@@ -434,6 +504,43 @@ class ConnectorServiceTest {
                     timeZone = "America/New_York",
                     level = 1,
                     loginCustomerId = loginCustomerId,
+                )
+            )
+        }
+
+        override fun fetchSpendReport(
+            credential: GoogleAdsOAuthCredential,
+            customerId: String,
+            loginCustomerId: String?,
+            startDate: LocalDate,
+            endDate: LocalDate,
+        ): List<GoogleAdsSpendReportRow> {
+            validateCustomer(credential, customerId, loginCustomerId)
+            return listOf(
+                GoogleAdsSpendReportRow(
+                    reportDate = startDate,
+                    customerId = customerId,
+                    loginCustomerId = loginCustomerId,
+                    campaignId = "campaign_1",
+                    campaignName = "Bandapella Search",
+                    campaignStatus = "ENABLED",
+                    campaignType = "SEARCH",
+                    campaignSubType = null,
+                    biddingStrategyType = "MAXIMIZE_CONVERSIONS",
+                    adGroupId = "ad_group_1",
+                    adGroupName = "Core",
+                    adGroupStatus = "ENABLED",
+                    device = "MOBILE",
+                    geoTargetCountry = "geoTargetConstants/2840",
+                    currencyCode = "USD",
+                    timeZone = "America/New_York",
+                    impressions = 100,
+                    clicks = 12,
+                    costMicros = 4_200_000,
+                    conversions = 2.0,
+                    conversionsValue = 12.0,
+                    allConversions = 3.0,
+                    allConversionsValue = 15.0,
                 )
             )
         }

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionPipeline.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionPipeline.kt
@@ -36,7 +36,8 @@ enum class IngestionPipeline(
     DD_MISC("dd-misc", "Misc"),
     DD_NDM("dd-ndm", "NDM"),
     DD_SECURITY("dd-security", "Security"),
-    CONNECTOR_EVENTS("connector-events", "Connector event");
+    CONNECTOR_EVENTS("connector-events", "Connector event"),
+    CONNECTOR_IMPORTS("connector-imports", "Connector import");
 
     val envKey: String = id.uppercase().replace('-', '_')
     val consumerGroup: String = "moneat:$id:workers"

--- a/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
+++ b/backend/src/main/kotlin/com/moneat/utils/WorkerQueueSupport.kt
@@ -41,6 +41,7 @@ private val WORKER_PIPELINES =
         "NDM" to IngestionPipeline.DD_NDM,
         "Security" to IngestionPipeline.DD_SECURITY,
         "Connector event" to IngestionPipeline.CONNECTOR_EVENTS,
+        "Connector import" to IngestionPipeline.CONNECTOR_IMPORTS,
     )
 
 /**

--- a/backend/src/main/resources/db/clickhouse_migration/V60__add_app_ad_spend_facts.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V60__add_app_ad_spend_facts.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS app_ad_spend_facts (
+    fact_id UUID,
+    organization_id UInt64,
+    project_id Nullable(UInt64),
+    installation_id UInt64,
+    installation_resource_id UUID,
+    import_run_id UInt64,
+    import_run_resource_id UUID,
+    provider LowCardinality(String),
+    provider_api_version Nullable(String),
+    google_ads_customer_id String,
+    google_ads_login_customer_id Nullable(String),
+    report_date Date,
+    device Nullable(String),
+    geo_target_country Nullable(String),
+    campaign_id Nullable(String),
+    campaign_name Nullable(String),
+    campaign_status Nullable(String),
+    campaign_type Nullable(String),
+    campaign_sub_type Nullable(String),
+    bidding_strategy_type Nullable(String),
+    ad_group_id Nullable(String),
+    ad_group_name Nullable(String),
+    ad_group_status Nullable(String),
+    currency_code Nullable(String),
+    time_zone Nullable(String),
+    impressions UInt64,
+    clicks UInt64,
+    cost_micros Int64,
+    conversions Float64,
+    conversions_value Float64,
+    all_conversions Float64,
+    all_conversions_value Float64,
+    row_identity_hash String,
+    pulled_at DateTime64(3, 'UTC'),
+    inserted_at DateTime64(3, 'UTC') DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree(import_run_id)
+PARTITION BY toYYYYMM(report_date)
+ORDER BY (
+    organization_id,
+    installation_id,
+    google_ads_customer_id,
+    report_date,
+    ifNull(campaign_id, ''),
+    ifNull(ad_group_id, ''),
+    ifNull(geo_target_country, ''),
+    ifNull(device, '')
+)
+TTL pulled_at + INTERVAL 730 DAY
+SETTINGS non_replicated_deduplication_window = 1000;

--- a/backend/src/main/resources/db/migration/V147__connector_import_runs.sql
+++ b/backend/src/main/resources/db/migration/V147__connector_import_runs.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS connector_import_runs (
+    id BIGSERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    installation_id INTEGER NOT NULL REFERENCES connector_installations(id) ON DELETE CASCADE,
+    provider VARCHAR(64) NOT NULL,
+    import_type VARCHAR(64) NOT NULL,
+    external_project_id VARCHAR(255),
+    external_resource_id VARCHAR(255),
+    date_start DATE NOT NULL,
+    date_end DATE NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'queued',
+    rows_imported INTEGER NOT NULL DEFAULT 0,
+    requested_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    queued_at TIMESTAMP NOT NULL,
+    started_at TIMESTAMP,
+    finished_at TIMESTAMP,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error_code VARCHAR(64),
+    last_error_message TEXT,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_connector_import_runs_org_resource
+    ON connector_import_runs(organization_id, resource_id);
+
+CREATE INDEX IF NOT EXISTS idx_connector_import_runs_installation_status
+    ON connector_import_runs(installation_id, status, updated_at);


### PR DESCRIPTION
## Summary
- add Google Ads spend sync runs and import worker
- store normalized ad spend facts for analytics
- expose sync state and run history

## Tests
- ./gradlew :features:connectors:compileKotlin :features:connectors:detekt :features:connectors:test --tests com.moneat.connectors.ConnectorServiceTest --tests com.moneat.connectors.routes.ConnectorRoutesTest --tests com.moneat.connectors.ConnectorCatalogTest --no-daemon
- ./gradlew :test --tests com.moneat.contracts.PublicSerializableResourceIdsTest --no-daemon
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Google Ads spend data import capability with status tracking
  * New endpoints to queue import syncs and view import run history
  * Enhanced provider state reporting with import metrics (status, rows, lag time)

* **Tests**
  * Added test coverage for Google Ads spend import workflows

* **Chores**
  * Database migrations and infrastructure updates for import data persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->