### PR TITLE
refactor: move pulse service into pulse feature

### DIFF
--- a/backend/features/pulse/build.gradle.kts
+++ b/backend/features/pulse/build.gradle.kts
@@ -27,9 +27,12 @@ dependencies {
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.server.rate.limit)
     implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
     implementation(libs.kotlin.logging)
     implementation(libs.koin.ktor)
 

--- a/backend/features/pulse/src/main/kotlin/com/moneat/shared/services/PulseService.kt
+++ b/backend/features/pulse/src/main/kotlin/com/moneat/shared/services/PulseService.kt
@@ -18,11 +18,11 @@ package com.moneat.shared.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
+import com.moneat.utils.suspendRunCatching
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import com.moneat.utils.suspendRunCatching
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType

--- a/backend/features/pulse/src/test/kotlin/com/moneat/services/PulseServiceTest.kt
+++ b/backend/features/pulse/src/test/kotlin/com/moneat/services/PulseServiceTest.kt
@@ -16,13 +16,20 @@
 
 package com.moneat.services
 
+import com.moneat.shared.services.PulsePayload
 import com.moneat.shared.services.PulseService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 
 /**
  * PulseService collects telemetry for self-hosted deployments.
@@ -30,6 +37,52 @@ import kotlin.test.assertTrue
  * In typical test env SELF_HOSTED is false, so enabled=false and metrics=null.
  */
 class PulseServiceTest {
+
+    @Test
+    fun `PulsePayload serializes and deserializes correctly`() {
+        val payload = PulsePayload(
+            deploymentId = "test-id-123",
+            version = "v1.2.3",
+            cpuCount = 4,
+            memTotalBytes = 8_000_000_000,
+            memUsedBytes = 4_000_000_000,
+            osName = "Linux",
+            osArch = "amd64",
+            jvmVersion = "21",
+            projectCount = 10,
+            userCount = 5,
+            eventCount = 1000,
+            issueCount = 50,
+            selfHost = true,
+            sslEnabled = true
+        )
+
+        val json = Json { encodeDefaults = true }
+        val encoded = json.encodeToString(PulsePayload.serializer(), payload)
+        val decoded = json.decodeFromString(PulsePayload.serializer(), encoded)
+
+        assertEquals(payload.deploymentId, decoded.deploymentId)
+        assertEquals(payload.version, decoded.version)
+        assertEquals(payload.cpuCount, decoded.cpuCount)
+        assertEquals(payload.memTotalBytes, decoded.memTotalBytes)
+        assertEquals(payload.memUsedBytes, decoded.memUsedBytes)
+        assertEquals(payload.osName, decoded.osName)
+        assertEquals(payload.projectCount, decoded.projectCount)
+        assertEquals(payload.sslEnabled, decoded.sslEnabled)
+    }
+
+    @Test
+    fun `PulsePayload defaults are applied`() {
+        val payload = PulsePayload(deploymentId = "minimal")
+
+        assertEquals(0, payload.cpuCount)
+        assertEquals("", payload.version)
+        assertEquals(0L, payload.memTotalBytes)
+        assertEquals("", payload.osName)
+        assertEquals(0L, payload.projectCount)
+        assertTrue(payload.selfHost)
+        assertFalse(payload.sslEnabled)
+    }
 
     @Test
     fun `getStatus returns valid PulseStatus structure`(): Unit =
@@ -64,4 +117,27 @@ class PulseServiceTest {
             // When SELF_HOSTED=false (typical in tests), enabled=false
             assertEquals(PulseService.isEnabled(), status.enabled)
         }
+
+    @Test
+    fun `getStatus has null metrics when disabled`() =
+        runBlocking {
+            val status = PulseService.getStatus()
+
+            if (!status.enabled) {
+                assertNull(status.metrics)
+            }
+        }
+
+    @Test
+    fun `start and stop does not throw`() {
+        val service = PulseService(
+            interval = 1.hours,
+            endpoint = "http://localhost:1/noop"
+        )
+        val scope = CoroutineScope(Dispatchers.Default)
+
+        service.start(scope)
+        service.stop()
+        scope.cancel()
+    }
 }

--- a/backend/src/test/kotlin/com/moneat/services/SharedServicesTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/SharedServicesTest.kt
@@ -26,8 +26,6 @@ import com.moneat.shared.models.Subscriptions
 import com.moneat.shared.models.UsageRecords
 import com.moneat.shared.services.ArtifactCleanupService
 import com.moneat.shared.services.CacheService
-import com.moneat.shared.services.PulsePayload
-import com.moneat.shared.services.PulseService
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.shared.services.TaskLock
 import com.moneat.shared.services.UsageTrackingService
@@ -45,7 +43,6 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
-import kotlinx.serialization.json.Json
 import net.javacrumbs.shedlock.core.LockConfiguration
 import net.javacrumbs.shedlock.core.LockProvider
 import net.javacrumbs.shedlock.core.SimpleLock
@@ -559,91 +556,6 @@ class SharedServicesTest {
     @Test
     fun `normalizeVersionTag returns null for two-part version`() {
         assertNull(normalizeVersionTag("1.2"))
-    }
-
-    // ──── PulsePayload serialization ────
-
-    @Test
-    fun `PulsePayload serializes and deserializes correctly`() {
-        val payload = PulsePayload(
-            deploymentId = "test-id-123",
-            version = "v1.2.3",
-            cpuCount = 4,
-            memTotalBytes = 8_000_000_000,
-            memUsedBytes = 4_000_000_000,
-            osName = "Linux",
-            osArch = "amd64",
-            jvmVersion = "21",
-            projectCount = 10,
-            userCount = 5,
-            eventCount = 1000,
-            issueCount = 50,
-            selfHost = true,
-            sslEnabled = true
-        )
-
-        val json = Json { encodeDefaults = true }
-        val encoded = json.encodeToString(PulsePayload.serializer(), payload)
-        val decoded = json.decodeFromString(PulsePayload.serializer(), encoded)
-
-        assertEquals(payload.deploymentId, decoded.deploymentId)
-        assertEquals(payload.version, decoded.version)
-        assertEquals(payload.cpuCount, decoded.cpuCount)
-        assertEquals(payload.memTotalBytes, decoded.memTotalBytes)
-        assertEquals(payload.memUsedBytes, decoded.memUsedBytes)
-        assertEquals(payload.osName, decoded.osName)
-        assertEquals(payload.projectCount, decoded.projectCount)
-        assertEquals(payload.sslEnabled, decoded.sslEnabled)
-    }
-
-    @Test
-    fun `PulsePayload defaults are applied`() {
-        val payload = PulsePayload(deploymentId = "minimal")
-
-        assertEquals(0, payload.cpuCount)
-        assertEquals("", payload.version)
-        assertEquals(0L, payload.memTotalBytes)
-        assertEquals("", payload.osName)
-        assertEquals(0L, payload.projectCount)
-        assertTrue(payload.selfHost)
-        assertFalse(payload.sslEnabled)
-    }
-
-    // ──── PulseService static methods ────
-
-    @Test
-    fun `PulseService isEnabled returns false when not self hosted`() {
-        // In test env SELF_HOSTED is typically not set
-        assertFalse(PulseService.isEnabled())
-    }
-
-    @Test
-    fun `PulseService getStatus returns consistent enabled flag`() = runBlocking {
-        val status = PulseService.getStatus()
-        assertEquals(PulseService.isEnabled(), status.enabled)
-        assertTrue(status.endpoint.isNotBlank())
-    }
-
-    @Test
-    fun `PulseService getStatus has null metrics when disabled`() = runBlocking {
-        val status = PulseService.getStatus()
-        if (!status.enabled) {
-            assertNull(status.metrics)
-        }
-    }
-
-    // ──── PulseService start and stop lifecycle ────
-
-    @Test
-    fun `PulseService start and stop does not throw`() {
-        val service = PulseService(
-            interval = kotlin.time.Duration.parse("1h"),
-            endpoint = "http://localhost:1/noop"
-        )
-        val scope = CoroutineScope(Dispatchers.Default)
-        service.start(scope)
-        service.stop()
-        scope.cancel()
     }
 
     // ──── RetentionPolicyService with PRO tier ────


### PR DESCRIPTION
## Summary
- move telemetry pulse service ownership into the pulse feature module
- keep pulse payload and status tests with the pulse feature

## Validation
- cd backend && ./gradlew :features:pulse:compileKotlin :features:pulse:compileTestKotlin :features:pulse:test :features:pulse:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check
- git diff --cached --check