### PR TITLE
fix: temporal installer startup healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
     ports:
       - "${TEMPORAL_GRPC_PORT:-7233}:7233"
     healthcheck:
-      test: ["CMD", "tctl", "--address", "127.0.0.1:7233", "cluster", "health"]
+      test: ["CMD", "temporal", "operator", "cluster", "health", "--address", "temporal:7233"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/install.sh
+++ b/install.sh
@@ -479,11 +479,11 @@ build_and_start() {
   run_cmd "Pulling Docker images..." "Images pulled" \
     docker compose pull --quiet
 
-  info "Starting databases..."
-  run_cmd "Starting PostgreSQL, ClickHouse, Redis, and Temporal..." "Databases started" \
+  info "Starting infrastructure services..."
+  run_cmd "Starting PostgreSQL, ClickHouse, Redis, and Temporal..." "Infrastructure services started" \
     docker compose up -d postgres clickhouse redis temporal-bootstrap temporal temporal-ui
 
-  info "Waiting for databases to be healthy..."
+  info "Waiting for infrastructure services to be healthy..."
   local retries=30
   while [[ $retries -gt 0 ]]; do
     local healthy=0
@@ -498,9 +498,9 @@ build_and_start() {
   done
 
   if [[ $retries -eq 0 ]]; then
-    warn "Database health check timed out — continuing anyway"
+    warn "Infrastructure health check timed out — continuing anyway"
   else
-    success "Databases healthy"
+    success "Infrastructure services healthy"
   fi
 
   info "Starting application..."


### PR DESCRIPTION
## Summary

Fix the self-hosted installer startup path after Temporal was added to the infrastructure dependency set.

- Update the Temporal healthcheck to use the supported `temporal` CLI.
- Probe Temporal via the Compose service alias `temporal:7233` instead of `127.0.0.1:7233`.
- Rename installer status output from database-only wording to infrastructure-service wording.

## Root Cause

`temporalio/auto-setup:1.27.4` starts successfully and serves health checks on the container network address / Compose service alias. The existing healthcheck probes `127.0.0.1:7233` with deprecated `tctl`, which returns connection refused inside the container. Docker Compose then marks `moneat-temporal` unhealthy and aborts the installer while starting `temporal-ui`.

## Validation

Validated on a fresh local install attempt:

- Reproduced installer failure at `docker compose up -d postgres clickhouse redis temporal-bootstrap temporal temporal-ui` with `moneat-temporal` unhealthy.
- Confirmed `temporal operator cluster health --address temporal:7233` returns `SERVING` inside the Temporal container.
- Recreated Temporal with the updated healthcheck; `moneat-temporal` became healthy and `moneat-temporal-ui` started.
- Started backend/frontend successfully; backend `/health` returned OK and frontend returned HTTP 200.
- Ran `bash -n install.sh`.
- Ran `docker compose config --quiet`.