### PR TITLE
refactor: move custom dashboard service into dashboards feature

### DIFF
--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/CustomDashboardService.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/CustomDashboardService.kt
@@ -202,9 +202,10 @@ class CustomDashboardService(
         val folderId = resolveOptionalFolderId(request.folderId, orgId)
         val updated = dashboardRepository.update(id, orgId, request, folderId)
         if (!updated) return null
-        if (request.widgets != null) {
+        val widgets = request.widgets
+        if (widgets != null) {
             val now = Clock.System.now()
-            val keptIds = dashboardWidgetRepository.bulkUpsert(id, request.widgets, now)
+            val keptIds = dashboardWidgetRepository.bulkUpsert(id, widgets, now)
             dashboardWidgetRepository.deleteNotIn(id, keptIds)
         }
         return getDashboard(id, orgId, null)

--- a/backend/features/logs/build.gradle.kts
+++ b/backend/features/logs/build.gradle.kts
@@ -21,6 +21,7 @@ val rootBackendTestOutput = rootBackendSourceSets.named("test").get().output
 
 dependencies {
     compileOnly(project(":"))
+    compileOnly(project(":features:dashboards"))
     implementation(project(":feature-spi"))
     implementation(project(":ingest-common"))
     implementation(project(":features:otlp"))
@@ -41,6 +42,7 @@ dependencies {
     detektPlugins(libs.detekt.formatting)
 
     testImplementation(project(":"))
+    testImplementation(project(":features:dashboards"))
     testImplementation(project(":features:otlp"))
     testImplementation(rootBackendTestOutput)
     testImplementation(libs.ktor.server.test.host)


### PR DESCRIPTION
Moves custom dashboard service ownership into the dashboards feature module and declares the logs feature dependency that consumes it.

Validation:
- cd backend && ./gradlew :features:dashboards:compileKotlin :features:dashboards:compileTestKotlin :features:dashboards:test :features:dashboards:detekt :features:logs:compileKotlin :features:logs:compileTestKotlin :features:logs:test :features:logs:detekt :features:mcp:compileKotlin :features:mcp:compileTestKotlin :features:mcp:test :features:mcp:detekt --no-daemon --no-build-cache -Dkotlin.incremental=false
- cd backend && ./gradlew build -x integrationTest --no-daemon --no-build-cache -Dkotlin.incremental=false
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal dashboard widget update logic.

* **Chores**
  * Updated module dependencies to support expanded dashboard functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->