### PR TITLE
[codex] Fix stream queue backlog metric

### DIFF
--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class OperationalMetricsTest {
     @BeforeTest
@@ -131,6 +132,140 @@ class OperationalMetricsTest {
         assertContains(rendered, "moneat_worker_dlq_depth")
         assertContains(rendered, "dlq_key=\"moneat:events:dlq\"")
         assertHasApplicationTag(rendered)
+    }
+
+    @Test
+    fun `renders stream queue depth from consumer backlog instead of retained stream length`() {
+        val streamKey = "moneat:logs:queue:stream"
+        val dlqKey = "moneat:logs:dlq:stream"
+        val consumerGroup = "moneat:logs:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every {
+            redis.xpending(streamKey, consumerGroup)
+        } returns PendingMessages(3, Range.create("1-0", "3-0"), mapOf("worker-1" to 3L))
+        every {
+            redis.xinfoGroups(streamKey)
+        } returns listOf(
+            listOf(
+                "name",
+                consumerGroup,
+                "consumers",
+                1L,
+                "pending",
+                3L,
+                "lag",
+                7L,
+            )
+        )
+        every { redis.llen(dlqKey) } returns 0L
+
+        OperationalMetrics.registerWorkerQueues("Log", streamKey, dlqKey, consumerGroup)
+
+        val rendered = OperationalMetrics.scrape()
+        val queueLine = metricLine(
+            rendered,
+            "moneat_worker_queue_depth",
+            "queue_key=\"$streamKey\"",
+            "queue_type=\"primary\"",
+            "worker=\"Log\"",
+        )
+
+        assertTrue(queueLine.endsWith(" 10.0"), queueLine)
+    }
+
+    @Test
+    fun `renders stream queue depth from map shaped consumer group info`() {
+        val streamKey = "moneat:metrics:queue:stream"
+        val dlqKey = "moneat:metrics:dlq:stream"
+        val consumerGroup = "moneat:metrics:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every {
+            redis.xpending(streamKey, consumerGroup)
+        } returns PendingMessages(4, Range.create("1-0", "4-0"), mapOf("worker-1" to 4L))
+        every {
+            redis.xinfoGroups(streamKey)
+        } returns listOf(mapOf("name" to consumerGroup, "lag" to "6"))
+        every { redis.llen(dlqKey) } returns 0L
+
+        OperationalMetrics.registerWorkerQueues("Metric", streamKey, dlqKey, consumerGroup)
+
+        val queueLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_queue_depth",
+            "queue_key=\"$streamKey\"",
+            "queue_type=\"primary\"",
+            "worker=\"Metric\"",
+        )
+
+        assertTrue(queueLine.endsWith(" 10.0"), queueLine)
+    }
+
+    @Test
+    fun `renders stream queue depth from pending messages when consumer group lag is absent`() {
+        val streamKey = "moneat:events:queue:stream"
+        val dlqKey = "moneat:events:dlq:stream"
+        val consumerGroup = "moneat:events:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every {
+            redis.xpending(streamKey, consumerGroup)
+        } returns PendingMessages(5, Range.create("1-0", "5-0"), mapOf("worker-1" to 5L))
+        every {
+            redis.xinfoGroups(streamKey)
+        } returns listOf(
+            "unexpected-shape",
+            listOf("name", "other-workers", "lag", 7L),
+        )
+        every { redis.llen(dlqKey) } returns 0L
+
+        OperationalMetrics.registerWorkerQueues("Event", streamKey, dlqKey, consumerGroup)
+
+        val queueLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_queue_depth",
+            "queue_key=\"$streamKey\"",
+            "queue_type=\"primary\"",
+            "worker=\"Event\"",
+        )
+
+        assertTrue(queueLine.endsWith(" 5.0"), queueLine)
+    }
+
+    @Test
+    fun `renders nan stream queue depth when consumer backlog read fails`() {
+        val streamKey = "moneat:errors:queue:stream"
+        val dlqKey = "moneat:errors:dlq:stream"
+        val consumerGroup = "moneat:errors:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } throws IllegalStateException("redis down")
+        every { redis.llen(dlqKey) } returns 0L
+
+        OperationalMetrics.registerWorkerQueues("Error", streamKey, dlqKey, consumerGroup)
+
+        val queueLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_queue_depth",
+            "queue_key=\"$streamKey\"",
+            "queue_type=\"primary\"",
+            "worker=\"Error\"",
+        )
+
+        assertTrue(queueLine.endsWith(" NaN"), queueLine)
     }
 
     @Test
@@ -276,4 +411,11 @@ class OperationalMetricsTest {
     private fun assertHasApplicationTag(rendered: String) {
         assertContains(rendered, "application=\"moneat-backend\"")
     }
+
+    private fun metricLine(rendered: String, metricName: String, vararg labels: String): String =
+        rendered.lineSequence()
+            .firstOrNull { line ->
+                line.startsWith(metricName) && labels.all { label -> line.contains(label) }
+            }
+            ?: error("Missing metric $metricName with labels ${labels.joinToString()}")
 }

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/RedisQueueWorker.kt
@@ -352,7 +352,12 @@ class RedisQueueWorker(
     }
 
     private fun registerQueues() {
-        OperationalMetrics.registerWorkerQueues(spec.pipeline.workerName, spec.streamKey, spec.dlqStreamKey)
+        OperationalMetrics.registerWorkerQueues(
+            spec.pipeline.workerName,
+            spec.streamKey,
+            spec.dlqStreamKey,
+            spec.consumerGroup,
+        )
         OperationalMetrics.registerWorkerStream(
             workerName = spec.pipeline.workerName,
             streamKey = spec.streamKey,

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -116,8 +116,13 @@ object OperationalMetrics {
         ).increment()
     }
 
-    fun registerWorkerQueues(workerName: String, queueKey: String, dlqKey: String) {
-        registerQueue(workerName, queueKey, "primary")
+    fun registerWorkerQueues(
+        workerName: String,
+        queueKey: String,
+        dlqKey: String,
+        consumerGroup: String? = null,
+    ) {
+        registerQueue(workerName, queueKey, "primary", consumerGroup)
         registerQueue(workerName, dlqKey, "dlq")
         registerDlq(workerName, dlqKey)
     }
@@ -174,12 +179,17 @@ object OperationalMetrics {
         }
     }
 
-    fun registerQueue(workerName: String, queueKey: String, queueType: String) {
+    fun registerQueue(
+        workerName: String,
+        queueKey: String,
+        queueType: String,
+        consumerGroup: String? = null,
+    ) {
         val normalizedWorkerName = workerName.normalizedLabelValue()
         val normalizedQueueType = queueType.normalizedLabelValue()
         val meterKey = "$normalizedWorkerName|$queueKey|$normalizedQueueType"
         registeredQueueMeters.computeIfAbsent(meterKey) {
-            Gauge.builder(WORKER_QUEUE_DEPTH, queueKey) { key -> readQueueDepth(key) }
+            Gauge.builder(WORKER_QUEUE_DEPTH, queueKey) { key -> readQueueDepth(key, consumerGroup) }
                 .description("Current Redis queue depth for registered worker queues.")
                 .tags(
                     tags(
@@ -645,12 +655,26 @@ object OperationalMetrics {
             .register(registry)
     }
 
-    private fun readQueueDepth(queueKey: String): Double {
+    private fun readQueueDepth(queueKey: String, consumerGroup: String? = null): Double {
         if (!RedisConfig.isConnected()) return Double.NaN
+        if (consumerGroup != null) return readStreamBacklogMessages(queueKey, consumerGroup)
         return runCatching { RedisConfig.sync().llen(queueKey).toDouble() }
             .recoverCatching { RedisConfig.sync().xlen(queueKey).toDouble() }
             .getOrElse { Double.NaN }
     }
+
+    private fun readStreamBacklogMessages(streamKey: String, consumerGroup: String): Double =
+        runCatching {
+            val redis = RedisConfig.sync()
+            val pendingMessages = redis.xpending(streamKey, consumerGroup).count
+            val lagMessages = redis.xinfoGroups(streamKey)
+                .asSequence()
+                .mapNotNull { parseStreamGroupInfo(it) }
+                .firstOrNull { group -> group.name == consumerGroup }
+                ?.lag
+                ?: 0L
+            (pendingMessages + lagMessages).toDouble()
+        }.getOrElse { Double.NaN }
 
     private fun readStreamPendingMessages(streamKey: String, consumerGroup: String): Double {
         if (!RedisConfig.isConnected()) return Double.NaN
@@ -674,6 +698,37 @@ object OperationalMetrics {
         val ageMs = System.currentTimeMillis() - createdAtMs
         return ageMs.coerceAtLeast(0L).toDouble() / MILLIS_PER_SECOND
     }
+
+    private fun parseStreamGroupInfo(group: Any?): StreamGroupInfo? =
+        when (group) {
+            is List<*> -> parseStreamGroupListInfo(group)
+            is Map<*, *> -> parseStreamGroupMapInfo(group)
+            else -> null
+        }
+
+    private fun parseStreamGroupListInfo(group: List<*>): StreamGroupInfo? {
+        var name: String? = null
+        var lag = 0L
+        for (index in 0 until group.lastIndex step XINFO_GROUP_FIELD_STEP) {
+            when (group[index]?.toString()) {
+                "name" -> name = group[index + XINFO_GROUP_VALUE_OFFSET]?.toString()
+                "lag" -> lag = group[index + XINFO_GROUP_VALUE_OFFSET].toLongOrZero()
+            }
+        }
+        return name?.let { StreamGroupInfo(it, lag) }
+    }
+
+    private fun parseStreamGroupMapInfo(group: Map<*, *>): StreamGroupInfo? {
+        val name = group["name"]?.toString() ?: return null
+        return StreamGroupInfo(name, group["lag"].toLongOrZero())
+    }
+
+    private fun Any?.toLongOrZero(): Long =
+        when (this) {
+            is Number -> toLong()
+            is String -> toLongOrNull() ?: 0L
+            else -> toString().toLongOrNull() ?: 0L
+        }
 
     private fun tags(vararg pairs: Pair<String, String>): Iterable<Tag> =
         pairs.map { (key, value) -> Tag.of(key.micrometerTagName(), value.normalizedLabelValue()) }
@@ -704,6 +759,11 @@ object OperationalMetrics {
     }
 
     private fun currentEpochSeconds(): Long = System.currentTimeMillis() / MILLIS_PER_SECOND
+
+    private data class StreamGroupInfo(
+        val name: String,
+        val lag: Long,
+    )
 
     private fun newRegistry(): PrometheusMeterRegistry =
         PrometheusMeterRegistry(PrometheusConfig.DEFAULT).also { registry ->
@@ -751,4 +811,6 @@ object OperationalMetrics {
     private const val MILLIS_PER_SECOND = 1_000
     private const val HEALTHY_VALUE = 1L
     private const val UNHEALTHY_VALUE = 0L
+    private const val XINFO_GROUP_FIELD_STEP = 2
+    private const val XINFO_GROUP_VALUE_OFFSET = 1
 }


### PR DESCRIPTION
## Summary
- make Redis Stream-backed `moneat_worker_queue_depth` report consumer backlog instead of retained stream length
- pass the ingestion stream consumer group into queue metric registration
- add a regression test proving stream queue depth uses `XPENDING + XINFO GROUPS lag`

## Root cause
The production alert `Primary queue backlog high` used `moneat_worker_queue_depth`, but for Redis Streams that metric fell back to `XLEN`. `XLEN` counts retained stream entries, not unprocessed backlog, so old delivered entries could keep the P2 alert firing even when consumer `pending=0` and `lag=0`.

## Validation
- `GRADLE_OPTS='-Xmx2g -XX:MaxMetaspaceSize=768m' ./gradlew --no-daemon :features:monitoring:test --tests com.moneat.monitoring.OperationalMetricsTest -Dkotlin.compiler.execution.strategy=in-process`
- `./gradlew detekt --no-daemon`
- `python3 scripts/check-migration-versions.py --base-ref origin/develop`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced operational queue depth metrics to calculate depth from consumer group backlog instead of stream length, improving measurement accuracy for monitoring.

* **Tests**
  * Added unit test to verify queue depth calculations are computed correctly from consumer backlog data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->