### PR TITLE
fix: serialize explorer facets in readable urls

### DIFF
--- a/dashboard/src/components/logs/LogExplorer.tsx
+++ b/dashboard/src/components/logs/LogExplorer.tsx
@@ -1096,7 +1096,11 @@ export function LogExplorer({
   
   // Sync state to URL with debounce
   useEffect(() => {
-    if (!enableUrlSync || isHydratingRef.current) return
+    const shouldNormalizeLegacyFacetUrl =
+      enableUrlSync &&
+      typeof globalThis.window !== 'undefined' &&
+      new URLSearchParams(globalThis.window.location.search).has('facets')
+    if (!enableUrlSync || (isHydratingRef.current && !shouldNormalizeLegacyFacetUrl)) return
     
     if (syncTimeoutRef.current) {
       clearTimeout(syncTimeoutRef.current)
@@ -1120,7 +1124,12 @@ export function LogExplorer({
       // Prevent our own navigate() from triggering the hydration effect and resetting state
       isHydratingRef.current = true
       navigate({
-        search: newSearch as never,
+        search: ((prev: Record<string, unknown>) => {
+          const clearedSearch = Object.fromEntries(
+            Object.keys(prev).map((key) => [key, undefined])
+          )
+          return {...clearedSearch, ...newSearch}
+        }) as never,
         replace: true,
       })
       setTimeout(() => {

--- a/dashboard/src/components/logs/LogExplorer.tsx
+++ b/dashboard/src/components/logs/LogExplorer.tsx
@@ -984,6 +984,14 @@ function InfiniteScrollFooter({
   )
 }
 
+function clearExistingRouteSearch(prev: Record<string, unknown>): Record<string, undefined> {
+  const clearedSearch: Record<string, undefined> = {}
+  for (const key of Object.keys(prev)) {
+    clearedSearch[key] = undefined
+  }
+  return clearedSearch
+}
+
 export function LogExplorer({
   systemId,
   initialQuery = '',
@@ -1098,7 +1106,7 @@ export function LogExplorer({
   useEffect(() => {
     const shouldNormalizeLegacyFacetUrl =
       enableUrlSync &&
-      typeof globalThis.window !== 'undefined' &&
+      globalThis.window !== undefined &&
       new URLSearchParams(globalThis.window.location.search).has('facets')
     if (!enableUrlSync || (isHydratingRef.current && !shouldNormalizeLegacyFacetUrl)) return
     
@@ -1125,9 +1133,7 @@ export function LogExplorer({
       isHydratingRef.current = true
       navigate({
         search: ((prev: Record<string, unknown>) => {
-          const clearedSearch = Object.fromEntries(
-            Object.keys(prev).map((key) => [key, undefined])
-          )
+          const clearedSearch = clearExistingRouteSearch(prev)
           return {...clearedSearch, ...newSearch}
         }) as never,
         replace: true,

--- a/dashboard/src/components/logs/__tests__/LogExplorer.facets.test.tsx
+++ b/dashboard/src/components/logs/__tests__/LogExplorer.facets.test.tsx
@@ -499,7 +499,7 @@ describe('LogExplorer facets', () => {
       urlSearch: {
         q: 'timeout',
         levels: 'error,warn',
-        facets: JSON.stringify(facetFilters),
+        facets: facetFilters,
         timePreset: 'custom',
         from: '2026-06-03T11:00:00.000Z',
         to: '2026-06-03T12:00:00.000Z',

--- a/dashboard/src/components/logs/logViewUrlState.test.ts
+++ b/dashboard/src/components/logs/logViewUrlState.test.ts
@@ -17,6 +17,7 @@
 import {describe, it, expect} from 'vitest'
 import {
   NO_LOG_GROUP_BY_URL_VALUE,
+  parseLogViewFacetFilters,
   parseLogViewSearch,
   parseFacetFiltersFromUrl,
   parseLevelsFromUrl,
@@ -47,10 +48,22 @@ describe('logViewUrlState', () => {
       expect(result.levels).toBe('error,warn,fatal')
     })
 
-    it('should parse valid facet filters JSON', () => {
-      const filters = [{key: 'service', value: 'api'}, {key: 'env', value: 'prod', exclude: true}]
+    it('should parse legacy facet filters JSON', () => {
+      const filters = [{key: 'service', value: 'api'}, {key: 'environment', value: 'prod', exclude: true}]
       const result = parseLogViewSearch({facets: JSON.stringify(filters)})
-      expect(result.facets).toBe(JSON.stringify(filters))
+      expect(result.service).toBe('api')
+      expect(result.exclude_environment).toBe('prod')
+      expect(parseLogViewFacetFilters(result)).toEqual(filters)
+    })
+
+    it('should parse readable facet params', () => {
+      const result = parseLogViewSearch({service: 'api', exclude_environment: 'dev'})
+      expect(result.service).toBe('api')
+      expect(result.exclude_environment).toBe('dev')
+      expect(parseLogViewFacetFilters(result)).toEqual([
+        {key: 'service', value: 'api'},
+        {key: 'environment', value: 'dev', exclude: true},
+      ])
     })
 
     it('should ignore malformed facet JSON', () => {
@@ -129,7 +142,7 @@ describe('logViewUrlState', () => {
       const search = {
         q: 'error',
         levels: 'error,warn',
-        facets: JSON.stringify(facets),
+        service: 'api',
         timePreset: '1h',
         from: '2024-01-15T10:00:00Z',
         to: '2024-01-15T11:00:00Z',
@@ -142,7 +155,8 @@ describe('logViewUrlState', () => {
       const result = parseLogViewSearch(search)
       expect(result.q).toBe('error')
       expect(result.levels).toBe('error,warn')
-      expect(result.facets).toBe(JSON.stringify(facets))
+      expect(result.service).toBe('api')
+      expect(parseLogViewFacetFilters(result)).toEqual(facets)
       expect(result.timePreset).toBe('1h')
       expect(result.viz).toBe('table')
       expect(result.cursor).toBe('abc')
@@ -178,7 +192,15 @@ describe('logViewUrlState', () => {
     it('should include non-empty facet filters', () => {
       const filters: FacetFilter[] = [{key: 'service', value: 'api'}]
       const result = serializeLogViewState({facetFilters: filters})
-      expect(result.facets).toBe(JSON.stringify(filters))
+      expect(result.service).toBe('api')
+      expect(result.facets).toBeUndefined()
+    })
+
+    it('should include excluded readable facet filters', () => {
+      const filters: FacetFilter[] = [{key: 'environment', value: 'dev', exclude: true}]
+      const result = serializeLogViewState({facetFilters: filters})
+      expect(result.exclude_environment).toBe('dev')
+      expect(result.facets).toBeUndefined()
     })
 
     it('should omit default time preset (15m)', () => {
@@ -348,7 +370,8 @@ describe('logViewUrlState', () => {
 
       expect(parsed.q).toBe(state.query)
       expect(parsed.levels).toBe(state.levels.join(','))
-      expect(parsed.facets).toBe(JSON.stringify(state.facetFilters))
+      expect(parsed.service).toBe('api')
+      expect(parseLogViewFacetFilters(parsed)).toEqual(state.facetFilters)
       expect(parsed.timePreset).toBe(state.timePreset)
       expect(parsed.viz).toBe(state.vizMode)
       expect(parsed.groupBy).toBe(state.groupBy)

--- a/dashboard/src/components/logs/logViewUrlState.test.ts
+++ b/dashboard/src/components/logs/logViewUrlState.test.ts
@@ -66,6 +66,16 @@ describe('logViewUrlState', () => {
       ])
     })
 
+    it('should parse dynamic readable tag facet params', () => {
+      const result = parseLogViewSearch({region: 'us-east-1', exclude_http_status: '500'})
+      expect(result.region).toBe('us-east-1')
+      expect(result.exclude_http_status).toBe('500')
+      expect(parseLogViewFacetFilters(result)).toEqual([
+        {key: 'region', value: 'us-east-1'},
+        {key: 'http_status', value: '500', exclude: true},
+      ])
+    })
+
     it('should ignore malformed facet JSON', () => {
       const result = parseLogViewSearch({facets: 'not-json'})
       expect(result.facets).toBeUndefined()
@@ -201,6 +211,26 @@ describe('logViewUrlState', () => {
       const result = serializeLogViewState({facetFilters: filters})
       expect(result.exclude_environment).toBe('dev')
       expect(result.facets).toBeUndefined()
+    })
+
+    it('should include dynamic tag facet filters as readable params', () => {
+      const filters: FacetFilter[] = [
+        {key: 'region', value: 'us-east-1'},
+        {key: 'http_status', value: '500', exclude: true},
+      ]
+      const result = serializeLogViewState({facetFilters: filters})
+      expect(result.region).toBe('us-east-1')
+      expect(result.exclude_http_status).toBe('500')
+      expect(result.facets).toBeUndefined()
+      expect(parseLogViewFacetFilters(result)).toEqual(filters)
+    })
+
+    it('should preserve facet keys that collide with log URL params', () => {
+      const filters: FacetFilter[] = [{key: 'timePreset', value: 'custom-tag'}]
+      const result = serializeLogViewState({facetFilters: filters})
+      expect(result.timePreset).toBeUndefined()
+      expect(result.facets).toEqual(filters)
+      expect(parseLogViewFacetFilters(result)).toEqual(filters)
     })
 
     it('should omit default time preset (15m)', () => {

--- a/dashboard/src/components/logs/logViewUrlState.ts
+++ b/dashboard/src/components/logs/logViewUrlState.ts
@@ -15,6 +15,12 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {type FacetFilter} from '@/lib/filters/types'
+import {
+  parseFacetFiltersParam,
+  parseReadableFacetFilters,
+  type ReadableFacetSearchValue,
+  serializeReadableFacetFilters,
+} from '@/lib/filters/urlState'
 import {type LogVizMode} from '@/components/logs/LogVizTabs'
 
 /**
@@ -25,7 +31,29 @@ export interface LogViewSearch {
   // Search & filters
   q?: string // query
   levels?: string // comma-separated levels
-  facets?: string // JSON-encoded facet filters
+  facets?: FacetFilter[] // component-internal structured filters; omitted from canonical route search
+  service?: ReadableFacetSearchValue
+  environment?: ReadableFacetSearchValue
+  host?: ReadableFacetSearchValue
+  level?: ReadableFacetSearchValue
+  container_name?: ReadableFacetSearchValue
+  'k8s.pod.name'?: ReadableFacetSearchValue
+  team?: ReadableFacetSearchValue
+  owner?: ReadableFacetSearchValue
+  trace_id?: ReadableFacetSearchValue
+  message_pattern?: ReadableFacetSearchValue
+  source?: ReadableFacetSearchValue
+  exclude_service?: ReadableFacetSearchValue
+  exclude_environment?: ReadableFacetSearchValue
+  exclude_host?: ReadableFacetSearchValue
+  exclude_level?: ReadableFacetSearchValue
+  exclude_container_name?: ReadableFacetSearchValue
+  'exclude_k8s.pod.name'?: ReadableFacetSearchValue
+  exclude_team?: ReadableFacetSearchValue
+  exclude_owner?: ReadableFacetSearchValue
+  exclude_trace_id?: ReadableFacetSearchValue
+  exclude_message_pattern?: ReadableFacetSearchValue
+  exclude_source?: ReadableFacetSearchValue
   
   // Time range
   timePreset?: string // e.g., "15m", "1h", "custom"
@@ -50,6 +78,25 @@ export const NO_LOG_GROUP_BY_URL_VALUE = 'none'
 const VALID_VIZ_MODES: LogVizMode[] = ['timeseries', 'table', 'toplist', 'pie']
 const VALID_TIME_PRESETS = ['5m', '15m', '30m', '1h', '4h', '12h', '24h', '3d', '7d', '14d', '30d', 'custom']
 const VALID_GROUP_BY_VALUES = [DEFAULT_LOG_GROUP_BY, 'service', 'environment', NO_LOG_GROUP_BY_URL_VALUE]
+export const LOG_FACET_URL_KEYS = [
+  'service',
+  'environment',
+  'host',
+  'level',
+  'container_name',
+  'k8s.pod.name',
+  'team',
+  'owner',
+  'trace_id',
+  'message_pattern',
+  'source',
+] as const
+
+export function parseLogViewFacetFilters(
+  search: Partial<LogViewSearch> | Record<string, unknown>
+): FacetFilter[] | undefined {
+  return parseReadableFacetFilters(search as Record<string, unknown>, LOG_FACET_URL_KEYS)
+}
 
 /**
  * Parse URL search params into normalized log view state.
@@ -71,16 +118,11 @@ export function parseLogViewSearch(search: Record<string, unknown>): LogViewSear
     }
   }
   
-  // Facet filters
-  if (typeof search.facets === 'string' && search.facets) {
-    try {
-      const parsed = JSON.parse(search.facets)
-      if (Array.isArray(parsed) && parsed.every(isFacetFilter)) {
-        result.facets = JSON.stringify(parsed)
-      }
-    } catch {
-      // Invalid JSON, ignore
-    }
+  // Facet filters. Prefer readable params (`service=api`); keep legacy
+  // `facets=` JSON as input-only compatibility.
+  const facetFilters = parseLogViewFacetFilters(search)
+  if (facetFilters) {
+    Object.assign(result, serializeReadableFacetFilters(facetFilters, LOG_FACET_URL_KEYS))
   }
   
   // Time preset
@@ -151,7 +193,24 @@ export function serializeLogViewState(state: {
   cursor?: string | null
   selectedLogId?: string | null
 }): Partial<LogViewSearch> {
-  const result: Partial<LogViewSearch> = {}
+  const result: Partial<LogViewSearch> = {
+    q: undefined,
+    levels: undefined,
+    facets: undefined,
+    timePreset: undefined,
+    from: undefined,
+    to: undefined,
+    viz: undefined,
+    groupBy: undefined,
+    topField: undefined,
+    cursor: undefined,
+    logId: undefined,
+  }
+  const clearableSearch = result as Record<string, unknown>
+  for (const key of LOG_FACET_URL_KEYS) {
+    clearableSearch[key] = undefined
+    clearableSearch[`exclude_${key}`] = undefined
+  }
   
   // Query
   if (state.query && state.query.trim()) {
@@ -165,7 +224,7 @@ export function serializeLogViewState(state: {
   
   // Facet filters
   if (state.facetFilters && state.facetFilters.length > 0) {
-    result.facets = JSON.stringify(state.facetFilters)
+    Object.assign(result, serializeReadableFacetFilters(state.facetFilters, LOG_FACET_URL_KEYS))
   }
   
   // Time range
@@ -222,33 +281,11 @@ export function resolveLogGroupBy(groupBy: string | undefined): string {
 }
 
 /**
- * Type guard for FacetFilter
+ * Parse facet filters from a JSON string. Delegates to the shared explorer
+ * helper ({@link parseFacetFiltersParam}) so logs and other ExplorerShell
+ * surfaces share one facet URL encoding.
  */
-function isFacetFilter(value: unknown): value is FacetFilter {
-  if (typeof value !== 'object' || value === null) return false
-  const obj = value as Record<string, unknown>
-  return (
-    typeof obj.key === 'string' &&
-    typeof obj.value === 'string' &&
-    (obj.exclude === undefined || typeof obj.exclude === 'boolean')
-  )
-}
-
-/**
- * Parse facet filters from JSON string
- */
-export function parseFacetFiltersFromUrl(facetsJson: string | undefined): FacetFilter[] {
-  if (!facetsJson) return []
-  try {
-    const parsed = JSON.parse(facetsJson)
-    if (Array.isArray(parsed) && parsed.every(isFacetFilter)) {
-      return parsed
-    }
-  } catch {
-    // Invalid JSON
-  }
-  return []
-}
+export const parseFacetFiltersFromUrl = parseFacetFiltersParam
 
 /**
  * Parse levels from comma-separated string

--- a/dashboard/src/components/logs/logViewUrlState.ts
+++ b/dashboard/src/components/logs/logViewUrlState.ts
@@ -16,7 +16,6 @@
 
 import {type FacetFilter} from '@/lib/filters/types'
 import {
-  parseFacetFiltersParam,
   parseReadableFacetFilters,
   type ReadableFacetSearchValue,
   serializeReadableFacetFilters,
@@ -99,80 +98,139 @@ export function parseLogViewFacetFilters(
 }
 
 /**
+ * Parse facet filters from a JSON string. Delegates to the shared explorer
+ * helper so logs and other ExplorerShell surfaces share one facet URL encoding.
+ */
+export {parseFacetFiltersParam as parseFacetFiltersFromUrl} from '@/lib/filters/urlState'
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined
+}
+
+function trimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function parseLevelsSearchValue(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value) return undefined
+  const parsed = value.split(',').filter(Boolean)
+  return parsed.length > 0 ? parsed.join(',') : undefined
+}
+
+function parseDateSearchValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : value
+}
+
+function parseVizSearchValue(value: unknown): LogVizMode | undefined {
+  if (typeof value !== 'string') return undefined
+  const vizMode = value === 'list' ? 'timeseries' : value
+  return VALID_VIZ_MODES.includes(vizMode as LogVizMode) ? (vizMode as LogVizMode) : undefined
+}
+
+function parseGroupBySearchValue(value: unknown): string | undefined {
+  const groupBy = trimmedString(value)
+  return groupBy && VALID_GROUP_BY_VALUES.includes(groupBy) ? groupBy : undefined
+}
+
+function createEmptyLogViewSearch(): Partial<LogViewSearch> {
+  const result: Partial<LogViewSearch> = {
+    q: undefined,
+    levels: undefined,
+    facets: undefined,
+    timePreset: undefined,
+    from: undefined,
+    to: undefined,
+    viz: undefined,
+    groupBy: undefined,
+    topField: undefined,
+    cursor: undefined,
+    logId: undefined,
+  }
+  const clearableSearch = result as Record<string, unknown>
+  for (const key of LOG_FACET_URL_KEYS) {
+    clearableSearch[key] = undefined
+    clearableSearch[`exclude_${key}`] = undefined
+  }
+  return result
+}
+
+function serializeLevelsValue(levels: string[] | undefined): string | undefined {
+  return levels && levels.length > 0 && levels.length < 6 ? levels.join(',') : undefined
+}
+
+function serializeDateValue(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+}
+
+function serializeTimeRangeSearch(state: {
+  timePreset?: string
+  customFrom?: string
+  customTo?: string
+}): Partial<LogViewSearch> {
+  const result: Partial<LogViewSearch> = {}
+  if (state.timePreset && state.timePreset !== '15m') {
+    result.timePreset = state.timePreset
+  }
+  if (state.timePreset !== 'custom') return result
+
+  const from = serializeDateValue(state.customFrom)
+  const to = serializeDateValue(state.customTo)
+  if (from) result.from = from
+  if (to) result.to = to
+  return result
+}
+
+function serializeGroupByValue(groupBy: string | undefined): string | undefined {
+  if (groupBy === '') return NO_LOG_GROUP_BY_URL_VALUE
+  const trimmedGroupBy = groupBy?.trim()
+  return trimmedGroupBy && trimmedGroupBy !== DEFAULT_LOG_GROUP_BY ? trimmedGroupBy : undefined
+}
+
+/**
  * Parse URL search params into normalized log view state.
  * Defensively handles malformed or invalid values.
  */
 export function parseLogViewSearch(search: Record<string, unknown>): LogViewSearch {
   const result: LogViewSearch = {}
-  
-  // Query
-  if (typeof search.q === 'string' && search.q.trim()) {
-    result.q = search.q.trim()
-  }
-  
-  // Levels
-  if (typeof search.levels === 'string' && search.levels) {
-    const parsed = search.levels.split(',').filter(Boolean)
-    if (parsed.length > 0) {
-      result.levels = parsed.join(',')
-    }
-  }
-  
-  // Facet filters. Prefer readable params (`service=api`); keep legacy
-  // `facets=` JSON as input-only compatibility.
+
+  const query = trimmedString(search.q)
+  if (query) result.q = query
+
+  const levels = parseLevelsSearchValue(search.levels)
+  if (levels) result.levels = levels
+
   const facetFilters = parseLogViewFacetFilters(search)
   if (facetFilters) {
     Object.assign(result, serializeReadableFacetFilters(facetFilters, LOG_FACET_URL_KEYS))
   }
-  
-  // Time preset
+
   if (typeof search.timePreset === 'string' && VALID_TIME_PRESETS.includes(search.timePreset)) {
     result.timePreset = search.timePreset
   }
-  
-  // Custom time range
-  if (typeof search.from === 'string') {
-    const date = new Date(search.from)
-    if (!Number.isNaN(date.getTime())) {
-      result.from = search.from
-    }
-  }
-  if (typeof search.to === 'string') {
-    const date = new Date(search.to)
-    if (!Number.isNaN(date.getTime())) {
-      result.to = search.to
-    }
-  }
-  
-  // Viz mode - migrate 'list' to 'timeseries' for backwards compatibility
-  if (typeof search.viz === 'string') {
-    const vizMode = search.viz === 'list' ? 'timeseries' : search.viz
-    if (VALID_VIZ_MODES.includes(vizMode as LogVizMode)) {
-      result.viz = vizMode as LogVizMode
-    }
-  }
-  
-  // Group by / top field
-  if (typeof search.groupBy === 'string') {
-    const groupBy = search.groupBy.trim()
-    if (VALID_GROUP_BY_VALUES.includes(groupBy)) {
-      result.groupBy = groupBy
-    }
-  }
-  if (typeof search.topField === 'string' && search.topField.trim()) {
-    result.topField = search.topField.trim()
-  }
-  
-  // Cursor
-  if (typeof search.cursor === 'string' && search.cursor) {
-    result.cursor = search.cursor
-  }
-  
-  // Selected log ID
-  if (typeof search.logId === 'string' && search.logId) {
-    result.logId = search.logId
-  }
-  
+
+  const from = parseDateSearchValue(search.from)
+  const to = parseDateSearchValue(search.to)
+  if (from) result.from = from
+  if (to) result.to = to
+
+  const viz = parseVizSearchValue(search.viz)
+  const groupBy = parseGroupBySearchValue(search.groupBy)
+  const topField = trimmedString(search.topField)
+  if (viz) result.viz = viz
+  if (groupBy) result.groupBy = groupBy
+  if (topField) result.topField = topField
+
+  const cursor = nonEmptyString(search.cursor)
+  const logId = nonEmptyString(search.logId)
+  if (cursor) result.cursor = cursor
+  if (logId) result.logId = logId
+
   return result
 }
 
@@ -193,80 +251,30 @@ export function serializeLogViewState(state: {
   cursor?: string | null
   selectedLogId?: string | null
 }): Partial<LogViewSearch> {
-  const result: Partial<LogViewSearch> = {
-    q: undefined,
-    levels: undefined,
-    facets: undefined,
-    timePreset: undefined,
-    from: undefined,
-    to: undefined,
-    viz: undefined,
-    groupBy: undefined,
-    topField: undefined,
-    cursor: undefined,
-    logId: undefined,
-  }
-  const clearableSearch = result as Record<string, unknown>
-  for (const key of LOG_FACET_URL_KEYS) {
-    clearableSearch[key] = undefined
-    clearableSearch[`exclude_${key}`] = undefined
-  }
-  
-  // Query
-  if (state.query && state.query.trim()) {
-    result.q = state.query.trim()
-  }
-  
-  // Levels (only if custom selection)
-  if (state.levels && state.levels.length > 0 && state.levels.length < 6) {
-    result.levels = state.levels.join(',')
-  }
-  
-  // Facet filters
-  if (state.facetFilters && state.facetFilters.length > 0) {
+  const result = createEmptyLogViewSearch()
+
+  const query = trimmedString(state.query)
+  const levels = serializeLevelsValue(state.levels)
+  const groupBy = serializeGroupByValue(state.groupBy)
+  const topField = trimmedString(state.topField)
+  if (query) result.q = query
+  if (levels) result.levels = levels
+
+  if (state.facetFilters?.length) {
     Object.assign(result, serializeReadableFacetFilters(state.facetFilters, LOG_FACET_URL_KEYS))
   }
-  
-  // Time range
-  if (state.timePreset && state.timePreset !== '15m') {
-    result.timePreset = state.timePreset
-  }
-  if (state.timePreset === 'custom') {
-    if (state.customFrom) {
-      const date = new Date(state.customFrom)
-      if (!Number.isNaN(date.getTime())) {
-        result.from = date.toISOString()
-      }
-    }
-    if (state.customTo) {
-      const date = new Date(state.customTo)
-      if (!Number.isNaN(date.getTime())) {
-        result.to = date.toISOString()
-      }
-    }
-  }
-  
-  // Viz mode (omit default "timeseries")
+
+  Object.assign(result, serializeTimeRangeSearch(state))
+
   if (state.vizMode && state.vizMode !== 'timeseries') {
     result.viz = state.vizMode
   }
-  
-  // Group by / top field
-  if (state.groupBy === '') {
-    result.groupBy = NO_LOG_GROUP_BY_URL_VALUE
-  } else if (state.groupBy && state.groupBy.trim() && state.groupBy !== DEFAULT_LOG_GROUP_BY) {
-    result.groupBy = state.groupBy.trim()
-  }
-  if (state.topField && state.topField.trim() && state.topField !== 'service') {
-    result.topField = state.topField.trim()
-  }
-  
-  // Cursor
+  if (groupBy) result.groupBy = groupBy
+  if (topField && topField !== 'service') result.topField = topField
+
   if (state.cursor) {
     result.cursor = state.cursor
   }
-  
-  // Selected log ID
   if (state.selectedLogId) {
     result.logId = state.selectedLogId
   }
@@ -279,13 +287,6 @@ export function resolveLogGroupBy(groupBy: string | undefined): string {
   if (groupBy && VALID_GROUP_BY_VALUES.includes(groupBy)) return groupBy
   return DEFAULT_LOG_GROUP_BY
 }
-
-/**
- * Parse facet filters from a JSON string. Delegates to the shared explorer
- * helper ({@link parseFacetFiltersParam}) so logs and other ExplorerShell
- * surfaces share one facet URL encoding.
- */
-export const parseFacetFiltersFromUrl = parseFacetFiltersParam
 
 /**
  * Parse levels from comma-separated string

--- a/dashboard/src/components/logs/logViewUrlState.ts
+++ b/dashboard/src/components/logs/logViewUrlState.ts
@@ -16,8 +16,11 @@
 
 import {type FacetFilter} from '@/lib/filters/types'
 import {
+  EXCLUDE_FACET_PARAM_PREFIX,
+  parseFacetFiltersOptionalParam,
   parseReadableFacetFilters,
   type ReadableFacetSearchValue,
+  serializeFacetFiltersParam,
   serializeReadableFacetFilters,
 } from '@/lib/filters/urlState'
 import {type LogVizMode} from '@/components/logs/LogVizTabs'
@@ -27,6 +30,7 @@ import {type LogVizMode} from '@/components/logs/LogVizTabs'
  * This enables deep linking and context-based navigation.
  */
 export interface LogViewSearch {
+  [key: string]: ReadableFacetSearchValue | FacetFilter[] | string | undefined
   // Search & filters
   q?: string // query
   levels?: string // comma-separated levels
@@ -90,11 +94,92 @@ export const LOG_FACET_URL_KEYS = [
   'message_pattern',
   'source',
 ] as const
+const LOG_NON_FACET_SEARCH_KEYS = new Set([
+  'q',
+  'levels',
+  'facets',
+  'timePreset',
+  'from',
+  'to',
+  'viz',
+  'groupBy',
+  'topField',
+  'cursor',
+  'logId',
+])
+
+function isReadableLogFacetKey(key: string): boolean {
+  return key !== '' && !LOG_NON_FACET_SEARCH_KEYS.has(key) && !key.startsWith(EXCLUDE_FACET_PARAM_PREFIX)
+}
+
+function hasSearchParamValue(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasSearchParamValue)
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return false
+  return String(value).trim() !== ''
+}
+
+function logFacetUrlKeysFromSearch(search: Record<string, unknown>): string[] {
+  const keys = new Set<string>(LOG_FACET_URL_KEYS)
+  for (const rawKey of Object.keys(search)) {
+    if (rawKey.startsWith(EXCLUDE_FACET_PARAM_PREFIX)) {
+      const key = rawKey.slice(EXCLUDE_FACET_PARAM_PREFIX.length)
+      if (isReadableLogFacetKey(key)) keys.add(key)
+      continue
+    }
+    if (isReadableLogFacetKey(rawKey)) keys.add(rawKey)
+  }
+  return [...keys]
+}
+
+function hasReadableLogFacetParam(search: Record<string, unknown>, facetKeys: readonly string[]): boolean {
+  return facetKeys.some((key) => (
+    hasSearchParamValue(search[key]) ||
+    hasSearchParamValue(search[`${EXCLUDE_FACET_PARAM_PREFIX}${key}`])
+  ))
+}
+
+function logFacetFilterIdentity(filter: FacetFilter): string {
+  return `${filter.exclude ? 'exclude' : 'include'}\u0000${filter.key}\u0000${filter.value}`
+}
+
+function mergeFacetFilters(primary: readonly FacetFilter[], fallback: readonly FacetFilter[]): FacetFilter[] {
+  const seen = new Set(primary.map(logFacetFilterIdentity))
+  const merged = [...primary]
+  for (const filter of fallback) {
+    const identity = logFacetFilterIdentity(filter)
+    if (seen.has(identity)) continue
+    seen.add(identity)
+    merged.push(filter)
+  }
+  return merged
+}
+
+function serializeLogFacetFilters(filters: readonly FacetFilter[]): Partial<LogViewSearch> {
+  const readableFilters = filters.filter((filter) => isReadableLogFacetKey(filter.key))
+  const fallbackFilters = filters.filter((filter) => !isReadableLogFacetKey(filter.key))
+  const readableKeys = new Set<string>(LOG_FACET_URL_KEYS)
+  for (const filter of readableFilters) {
+    readableKeys.add(filter.key)
+  }
+
+  const search: Partial<LogViewSearch> = serializeReadableFacetFilters(readableFilters, [...readableKeys])
+  if (fallbackFilters.length > 0) {
+    search.facets = serializeFacetFiltersParam(fallbackFilters)
+  }
+  return search
+}
 
 export function parseLogViewFacetFilters(
   search: Partial<LogViewSearch> | Record<string, unknown>
 ): FacetFilter[] | undefined {
-  return parseReadableFacetFilters(search as Record<string, unknown>, LOG_FACET_URL_KEYS)
+  const searchRecord = search as Record<string, unknown>
+  const facetKeys = logFacetUrlKeysFromSearch(searchRecord)
+  const filters = parseReadableFacetFilters(searchRecord, facetKeys)
+  if (!hasReadableLogFacetParam(searchRecord, facetKeys)) return filters
+
+  const fallbackFilters = (parseFacetFiltersOptionalParam(searchRecord.facets) ?? [])
+    .filter((filter) => !isReadableLogFacetKey(filter.key))
+  return mergeFacetFilters(filters ?? [], fallbackFilters)
 }
 
 /**
@@ -207,7 +292,7 @@ export function parseLogViewSearch(search: Record<string, unknown>): LogViewSear
 
   const facetFilters = parseLogViewFacetFilters(search)
   if (facetFilters) {
-    Object.assign(result, serializeReadableFacetFilters(facetFilters, LOG_FACET_URL_KEYS))
+    Object.assign(result, serializeLogFacetFilters(facetFilters))
   }
 
   if (typeof search.timePreset === 'string' && VALID_TIME_PRESETS.includes(search.timePreset)) {
@@ -261,7 +346,7 @@ export function serializeLogViewState(state: {
   if (levels) result.levels = levels
 
   if (state.facetFilters?.length) {
-    Object.assign(result, serializeReadableFacetFilters(state.facetFilters, LOG_FACET_URL_KEYS))
+    Object.assign(result, serializeLogFacetFilters(state.facetFilters))
   }
 
   Object.assign(result, serializeTimeRangeSearch(state))

--- a/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
@@ -488,7 +488,7 @@ type ResourceCatalogProps = Readonly<{
 }>
 
 function catalogUrlStateKey(state: ResourceCatalogUrlState | undefined): string {
-  return JSON.stringify(state ?? {query: '', facetFilters: []})
+  return state ? JSON.stringify(state) : ''
 }
 
 function releaseHydrationGuard(ref: {current: boolean}): () => void {
@@ -511,19 +511,23 @@ export function ResourceCatalog({urlState, onUrlStateChange}: ResourceCatalogPro
   const didMountRef = useRef(false)
   const isHydratingRef = useRef(false)
   const urlStateKey = catalogUrlStateKey(urlState)
+  const stableUrlState = useMemo<ResourceCatalogUrlState | undefined>(
+    () => urlStateKey ? JSON.parse(urlStateKey) as ResourceCatalogUrlState : undefined,
+    [urlStateKey]
+  )
 
   useEffect(() => {
-    if (!urlState) return undefined
+    if (!stableUrlState) return undefined
     if (!didMountRef.current) {
       didMountRef.current = true
       return undefined
     }
     if (isHydratingRef.current) return undefined
     isHydratingRef.current = true
-    setQuery(urlState.query)
-    setFacetFilters(urlState.facetFilters)
+    setQuery(stableUrlState.query)
+    setFacetFilters(stableUrlState.facetFilters)
     return releaseHydrationGuard(isHydratingRef)
-  }, [urlState, urlStateKey])
+  }, [stableUrlState])
 
   useEffect(() => {
     if (!onUrlStateChange || isHydratingRef.current) return

--- a/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceCatalog.tsx
@@ -21,7 +21,7 @@
 // split into the reusable ResourceDetailPanel. Compact density throughout.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import {useMemo, useState, type ComponentType, type KeyboardEvent, type ReactNode} from 'react'
+import {useEffect, useMemo, useRef, useState, type ComponentType, type KeyboardEvent, type ReactNode} from 'react'
 import {Link} from '@tanstack/react-router'
 import {
   Activity,
@@ -477,13 +477,62 @@ function CompactList({
 
 // ── Page ─────────────────────────────────────────────────────────────────────
 
-export function ResourceCatalog() {
+export type ResourceCatalogUrlState = Readonly<{
+  query: string
+  facetFilters: FacetFilter[]
+}>
+
+type ResourceCatalogProps = Readonly<{
+  urlState?: ResourceCatalogUrlState
+  onUrlStateChange?: (state: ResourceCatalogUrlState) => void
+}>
+
+function catalogUrlStateKey(state: ResourceCatalogUrlState | undefined): string {
+  return JSON.stringify(state ?? {query: '', facetFilters: []})
+}
+
+function releaseHydrationGuard(ref: {current: boolean}): () => void {
+  const release = globalThis.setTimeout(() => {
+    ref.current = false
+  }, 0)
+  return () => {
+    globalThis.clearTimeout(release)
+    ref.current = false
+  }
+}
+
+export function ResourceCatalog({urlState, onUrlStateChange}: ResourceCatalogProps = {}) {
   const {data: resources = [], isLoading} = useResourceCatalog()
-  const [query, setQuery] = useState('')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const [query, setQuery] = useState(() => urlState?.query ?? '')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => urlState?.facetFilters ?? [])
   const [sortKey, setSortKey] = useState<SortKey>('health')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const didMountRef = useRef(false)
+  const isHydratingRef = useRef(false)
+  const urlStateKey = catalogUrlStateKey(urlState)
+
+  useEffect(() => {
+    if (!urlState) return undefined
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return undefined
+    }
+    if (isHydratingRef.current) return undefined
+    isHydratingRef.current = true
+    setQuery(urlState.query)
+    setFacetFilters(urlState.facetFilters)
+    return releaseHydrationGuard(isHydratingRef)
+  }, [urlState, urlStateKey])
+
+  useEffect(() => {
+    if (!onUrlStateChange || isHydratingRef.current) return
+    const nextState = {query, facetFilters}
+    if (catalogUrlStateKey(nextState) === urlStateKey) return
+    isHydratingRef.current = true
+    onUrlStateChange(nextState)
+    releaseHydrationGuard(isHydratingRef)
+  }, [query, facetFilters, onUrlStateChange, urlStateKey])
 
   const sections = useMemo(() => buildCatalogSections(resources), [resources])
   const filtered = useMemo(

--- a/dashboard/src/lib/__tests__/routerSearch.test.ts
+++ b/dashboard/src/lib/__tests__/routerSearch.test.ts
@@ -27,6 +27,16 @@ describe('routerSearch', () => {
     ).toBe('?kind=host&kind=pod&kind=network-device&kind=service&env=prod')
   })
 
+  it('keeps JSON-like strings as plain query values', () => {
+    expect(
+      stringifySearchWithRepeatedPrimitiveArrays({
+        enabled: ['true', 'false'],
+        count: ['123'],
+        service: ['api'],
+      })
+    ).toBe('?enabled=true&enabled=false&count=123&service=api')
+  })
+
   it('keeps object arrays JSON encoded for legacy structured search values', () => {
     expect(
       stringifySearchWithRepeatedPrimitiveArrays({

--- a/dashboard/src/lib/__tests__/routerSearch.test.ts
+++ b/dashboard/src/lib/__tests__/routerSearch.test.ts
@@ -1,0 +1,37 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {stringifySearchWithRepeatedPrimitiveArrays} from '@/lib/routerSearch'
+
+describe('routerSearch', () => {
+  it('serializes primitive arrays as repeated params', () => {
+    expect(
+      stringifySearchWithRepeatedPrimitiveArrays({
+        kind: ['host', 'pod', 'network-device', 'service'],
+        env: 'prod',
+      })
+    ).toBe('?kind=host&kind=pod&kind=network-device&kind=service&env=prod')
+  })
+
+  it('keeps object arrays JSON encoded for legacy structured search values', () => {
+    expect(
+      stringifySearchWithRepeatedPrimitiveArrays({
+        facets: [{key: 'status', value: 'unresolved'}],
+      })
+    ).toBe('?facets=%5B%7B%22key%22%3A%22status%22%2C%22value%22%3A%22unresolved%22%7D%5D')
+  })
+})

--- a/dashboard/src/lib/filters/__tests__/urlState.test.ts
+++ b/dashboard/src/lib/filters/__tests__/urlState.test.ts
@@ -1,0 +1,177 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import type {FacetFilter} from '@/lib/filters/types'
+import {
+  isFacetFilter,
+  parseExplorerSearch,
+  parseFacetFiltersParam,
+  parseReadableFacetFilters,
+  serializeReadableFacetFilters,
+  serializeExplorerSearch,
+  serializeFacetFiltersParam,
+} from '@/lib/filters/urlState'
+
+describe('filters/urlState', () => {
+  describe('isFacetFilter', () => {
+    it('accepts well-formed filters and rejects the rest', () => {
+      expect(isFacetFilter({key: 'status', value: 'unresolved'})).toBe(true)
+      expect(isFacetFilter({key: 'service', value: 'api', exclude: true})).toBe(true)
+      expect(isFacetFilter({key: 'service', value: 'api', exclude: 'yes'})).toBe(false)
+      expect(isFacetFilter({key: 'service'})).toBe(false)
+      expect(isFacetFilter(null)).toBe(false)
+      expect(isFacetFilter('status:unresolved')).toBe(false)
+    })
+  })
+
+  describe('parseFacetFiltersParam', () => {
+    it('returns an empty array for absent, malformed, or non-conforming values', () => {
+      expect(parseFacetFiltersParam(undefined)).toEqual([])
+      expect(parseFacetFiltersParam('')).toEqual([])
+      expect(parseFacetFiltersParam('not-json')).toEqual([])
+      expect(parseFacetFiltersParam('{"key":"status"}')).toEqual([])
+      expect(parseFacetFiltersParam('[{"nope":true}]')).toEqual([])
+    })
+
+    it('preserves valid structured filters as-authored', () => {
+      const filters: FacetFilter[] = [
+        {key: 'status', value: 'unresolved'},
+        {key: 'service', value: 'api', exclude: true},
+      ]
+      expect(parseFacetFiltersParam(filters)).toEqual(filters)
+    })
+
+    it('accepts legacy JSON-string and double-stringified facet params', () => {
+      const filters: FacetFilter[] = [{key: 'status', value: 'resolved'}]
+      expect(parseFacetFiltersParam(JSON.stringify(filters))).toEqual(filters)
+      expect(parseFacetFiltersParam(JSON.stringify(JSON.stringify(filters)))).toEqual(filters)
+    })
+
+    it('round-trips an explicit empty selection', () => {
+      expect(parseFacetFiltersParam('[]')).toEqual([])
+    })
+  })
+
+  describe('serializeFacetFiltersParam', () => {
+    it('drops the redundant exclude:false for compact, stable URLs', () => {
+      expect(serializeFacetFiltersParam([{key: 'status', value: 'unresolved', exclude: false}])).toEqual([
+        {key: 'status', value: 'unresolved'},
+      ])
+    })
+
+    it('keeps exclude:true', () => {
+      expect(serializeFacetFiltersParam([{key: 'service', value: 'legacy', exclude: true}])).toEqual([
+        {key: 'service', value: 'legacy', exclude: true},
+      ])
+    })
+
+    it('emits an empty array literal for no filters', () => {
+      expect(serializeFacetFiltersParam([])).toEqual([])
+    })
+  })
+
+  describe('readable facet params', () => {
+    const keys = ['service', 'environment'] as const
+
+    it('parses include and exclude params', () => {
+      expect(parseReadableFacetFilters({service: 'api', exclude_environment: 'dev'}, keys)).toEqual([
+        {key: 'service', value: 'api'},
+        {key: 'environment', value: 'dev', exclude: true},
+      ])
+    })
+
+    it('serializes filters into first-class params', () => {
+      expect(
+        serializeReadableFacetFilters(
+          [
+            {key: 'service', value: 'api'},
+            {key: 'service', value: 'worker'},
+            {key: 'environment', value: 'dev', exclude: true},
+          ],
+          keys
+        )
+      ).toEqual({service: ['api', 'worker'], exclude_environment: 'dev'})
+    })
+
+    it('uses legacy facets only when readable params are absent', () => {
+      expect(
+        parseReadableFacetFilters(
+          {
+            facets: JSON.stringify([{key: 'service', value: 'legacy'}]),
+          },
+          keys
+        )
+      ).toEqual([{key: 'service', value: 'legacy'}])
+      expect(
+        parseReadableFacetFilters(
+          {
+            service: 'api',
+            facets: JSON.stringify([{key: 'service', value: 'legacy'}]),
+          },
+          keys
+        )
+      ).toEqual([{key: 'service', value: 'api'}])
+    })
+  })
+
+  describe('parseExplorerSearch', () => {
+    it('trims the query and drops it when empty', () => {
+      expect(parseExplorerSearch({q: '  boom  '})).toEqual({q: 'boom'})
+      expect(parseExplorerSearch({q: '   '})).toEqual({})
+    })
+
+    it('canonicalises a valid facets param, including an explicit empty array', () => {
+      expect(
+        parseExplorerSearch({facets: '[{"key":"status","value":"unresolved","exclude":false}]'})
+      ).toEqual({facets: [{key: 'status', value: 'unresolved'}]})
+      expect(parseExplorerSearch({facets: '[]'})).toEqual({facets: []})
+    })
+
+    it('canonicalises structured and double-stringified facets', () => {
+      const filters: FacetFilter[] = [{key: 'status', value: 'resolved', exclude: false}]
+      expect(parseExplorerSearch({facets: filters})).toEqual({facets: [{key: 'status', value: 'resolved'}]})
+      expect(parseExplorerSearch({facets: JSON.stringify(JSON.stringify(filters))})).toEqual({
+        facets: [{key: 'status', value: 'resolved'}],
+      })
+    })
+
+    it('omits an absent or malformed facets param so the surface can apply its default', () => {
+      expect(parseExplorerSearch({})).toEqual({})
+      expect(parseExplorerSearch({facets: 'not-json'})).toEqual({})
+      expect(parseExplorerSearch({facets: '[{"bad":1}]'})).toEqual({})
+    })
+  })
+
+  describe('serializeExplorerSearch', () => {
+    it('omits an empty query but always emits facets', () => {
+      expect(serializeExplorerSearch({query: '', facetFilters: []})).toEqual({q: undefined, facets: []})
+      expect(
+        serializeExplorerSearch({query: 'boom', facetFilters: [{key: 'status', value: 'unresolved'}]})
+      ).toEqual({q: 'boom', facets: [{key: 'status', value: 'unresolved'}]})
+    })
+
+    it('round-trips through parseExplorerSearch', () => {
+      const facetFilters: FacetFilter[] = [
+        {key: 'status', value: 'unresolved'},
+        {key: 'service', value: 'legacy', exclude: true},
+      ]
+      const serialized = serializeExplorerSearch({query: 'timeout', facetFilters})
+      expect(parseExplorerSearch({q: serialized.q, facets: serialized.facets})).toEqual(serialized)
+      expect(parseFacetFiltersParam(serialized.facets)).toEqual(facetFilters)
+    })
+  })
+})

--- a/dashboard/src/lib/filters/__tests__/urlState.test.ts
+++ b/dashboard/src/lib/filters/__tests__/urlState.test.ts
@@ -94,6 +94,12 @@ describe('filters/urlState', () => {
       ])
     })
 
+    it('keeps scalar comma values atomic', () => {
+      expect(parseReadableFacetFilters({service: 'api, v2'}, keys)).toEqual([
+        {key: 'service', value: 'api, v2'},
+      ])
+    })
+
     it('serializes filters into first-class params', () => {
       expect(
         serializeReadableFacetFilters(

--- a/dashboard/src/lib/filters/urlState.ts
+++ b/dashboard/src/lib/filters/urlState.ts
@@ -1,0 +1,225 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Surface-agnostic URL serialization for the explorer shell's filter state.
+ * Mirrors the log viewer's `?q=&facets=` deep-link encoding (see
+ * `@/components/logs/logViewUrlState`) so every ExplorerShell surface — issues,
+ * APM errors, … — shares one shareable-link format instead of inventing its
+ * own. TanStack Router serializes arrays/objects into URL params, so route
+ * search state keeps facets as a real {@link FacetFilter}[] instead of a
+ * pre-stringified JSON value.
+ */
+
+import {type FacetFilter} from '@/lib/filters/types'
+
+export const LEGACY_FACETS_PARAM = 'facets'
+export const EXCLUDE_FACET_PARAM_PREFIX = 'exclude_'
+export type ReadableFacetSearchValue = string | string[]
+
+/** The portion of a route's search params that the explorer shell owns. */
+export interface ExplorerSearch {
+  /** Free-text query. */
+  q?: string
+  /** Structured facet filters. `[]` means "explicitly no facets". */
+  facets?: FacetFilter[]
+}
+
+/** Type guard for a single URL-deserialized facet filter. */
+export function isFacetFilter(value: unknown): value is FacetFilter {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  return (
+    typeof obj.key === 'string' &&
+    typeof obj.value === 'string' &&
+    (obj.exclude === undefined || typeof obj.exclude === 'boolean')
+  )
+}
+
+/** Drop the redundant `exclude: false` so URLs stay compact and round-trip stably. */
+function canonicalFacetFilter(filter: FacetFilter): FacetFilter {
+  return filter.exclude
+    ? {key: filter.key, value: filter.value, exclude: true}
+    : {key: filter.key, value: filter.value}
+}
+
+function canonicalFacetFilters(filters: readonly FacetFilter[]): FacetFilter[] {
+  return filters.map(canonicalFacetFilter)
+}
+
+function searchParamValues(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(searchParamValues)
+  }
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return []
+  return String(value)
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+}
+
+function toSearchParamValue(values: readonly string[]): ReadableFacetSearchValue | undefined {
+  if (values.length === 0) return undefined
+  return values.length === 1 ? values[0] : [...values]
+}
+
+function parseFacetFiltersValue(value: unknown): FacetFilter[] | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  if (Array.isArray(value) && value.every(isFacetFilter)) {
+    return value
+  }
+  if (typeof value !== 'string') return undefined
+
+  let parsed: unknown = value
+  for (let i = 0; i < 2; i += 1) {
+    try {
+      parsed = JSON.parse(parsed as string)
+    } catch {
+      return undefined
+    }
+    if (Array.isArray(parsed) && parsed.every(isFacetFilter)) {
+      return parsed
+    }
+    if (typeof parsed !== 'string') return undefined
+  }
+  return undefined
+}
+
+/**
+ * Parse a `facets` search value into a validated {@link FacetFilter}[].
+ * Supports TanStack's structured array value plus legacy JSON-string params,
+ * including the accidentally double-stringified shape that produced escaped
+ * quotes in shared links.
+ */
+export function parseFacetFiltersParam(facetsValue: unknown): FacetFilter[] {
+  return parseFacetFiltersValue(facetsValue) ?? []
+}
+
+/** Parse facet filters when absence/malformed input must stay distinguishable from an explicit empty list. */
+export function parseFacetFiltersOptionalParam(facetsValue: unknown): FacetFilter[] | undefined {
+  return parseFacetFiltersValue(facetsValue)
+}
+
+/**
+ * Parse readable facet params such as `service=api&exclude_environment=dev`.
+ * Legacy `facets=` JSON remains accepted as input-only compatibility when no
+ * readable facet params are present.
+ */
+export function parseReadableFacetFilters(
+  search: Record<string, unknown>,
+  facetKeys: readonly string[]
+): FacetFilter[] | undefined {
+  const filters: FacetFilter[] = []
+  let hasReadableFacetParam = false
+
+  for (const key of facetKeys) {
+    const includeValues = searchParamValues(search[key])
+    if (includeValues.length > 0) {
+      hasReadableFacetParam = true
+      filters.push(...includeValues.map((value) => ({key, value})))
+    }
+
+    const excludeValues = searchParamValues(search[`${EXCLUDE_FACET_PARAM_PREFIX}${key}`])
+    if (excludeValues.length > 0) {
+      hasReadableFacetParam = true
+      filters.push(...excludeValues.map((value) => ({key, value, exclude: true})))
+    }
+  }
+
+  if (hasReadableFacetParam) {
+    return filters
+  }
+
+  return parseFacetFiltersOptionalParam(search[LEGACY_FACETS_PARAM])
+}
+
+/** Serialize facet filters into readable route params, one param per facet key. */
+export function serializeReadableFacetFilters(
+  filters: readonly FacetFilter[],
+  facetKeys: readonly string[]
+): Record<string, ReadableFacetSearchValue> {
+  const search: Record<string, ReadableFacetSearchValue> = {}
+
+  for (const key of facetKeys) {
+    const includeValues = filters.filter((filter) => filter.key === key && !filter.exclude).map((filter) => filter.value)
+    const excludeValues = filters.filter((filter) => filter.key === key && filter.exclude).map((filter) => filter.value)
+    const includeParam = toSearchParamValue(includeValues)
+    if (includeParam) search[key] = includeParam
+    const excludeParam = toSearchParamValue(excludeValues)
+    if (excludeParam) search[`${EXCLUDE_FACET_PARAM_PREFIX}${key}`] = excludeParam
+  }
+
+  return search
+}
+
+/** Clear readable and legacy facet params from an existing route search object. */
+export function clearReadableFacetSearch(
+  search: Record<string, unknown>,
+  facetKeys: readonly string[]
+): Record<string, unknown> {
+  const next = {...search}
+  for (const key of facetKeys) {
+    if (key in next) next[key] = undefined
+    const excludeKey = `${EXCLUDE_FACET_PARAM_PREFIX}${key}`
+    if (excludeKey in next) next[excludeKey] = undefined
+  }
+  if (LEGACY_FACETS_PARAM in next) next[LEGACY_FACETS_PARAM] = undefined
+  return next
+}
+
+/** Serialize a {@link FacetFilter}[] into the route search value TanStack will encode once. */
+export function serializeFacetFiltersParam(filters: readonly FacetFilter[]): FacetFilter[] {
+  return canonicalFacetFilters(filters)
+}
+
+/**
+ * Validate raw route search into the explorer's `{q, facets}` shape (use from a
+ * route's `validateSearch`). `q` is trimmed and dropped when empty; `facets`
+ * is kept only when it is a valid facet-filter array (including `[]`),
+ * canonicalized for a stable URL. An absent/invalid `facets` stays
+ * `undefined`, which lets a surface tell "first visit" from "explicitly
+ * cleared".
+ */
+export function parseExplorerSearch(search: Record<string, unknown>): ExplorerSearch {
+  const result: ExplorerSearch = {}
+
+  if (typeof search.q === 'string' && search.q.trim()) {
+    result.q = search.q.trim()
+  }
+
+  const facets = parseFacetFiltersValue(search.facets)
+  if (facets) {
+    result.facets = serializeFacetFiltersParam(facets)
+  }
+
+  return result
+}
+
+/**
+ * Serialize live explorer state into `{q, facets}`. `q` is omitted when empty;
+ * `facets` is ALWAYS emitted (even `[]`) so a surface with a default facet can
+ * distinguish a fresh visit (param absent) from an explicit clear (`"[]"`).
+ */
+export function serializeExplorerSearch(state: {
+  query?: string
+  facetFilters?: readonly FacetFilter[]
+}): ExplorerSearch {
+  const query = state.query?.trim()
+  return {
+    q: query || undefined,
+    facets: serializeFacetFiltersParam(state.facetFilters ?? []),
+  }
+}

--- a/dashboard/src/lib/filters/urlState.ts
+++ b/dashboard/src/lib/filters/urlState.ts
@@ -65,10 +65,8 @@ function searchParamValues(value: unknown): string[] {
     return value.flatMap(searchParamValues)
   }
   if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return []
-  return String(value)
-    .split(',')
-    .map((part) => part.trim())
-    .filter(Boolean)
+  const normalized = String(value).trim()
+  return normalized ? [normalized] : []
 }
 
 function toSearchParamValue(values: readonly string[]): ReadableFacetSearchValue | undefined {

--- a/dashboard/src/lib/filters/useReadableFacetUrlState.ts
+++ b/dashboard/src/lib/filters/useReadableFacetUrlState.ts
@@ -1,0 +1,194 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useNavigate} from '@tanstack/react-router'
+import {useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction} from 'react'
+
+import type {FacetFilter} from '@/lib/filters/types'
+import {
+  EXCLUDE_FACET_PARAM_PREFIX,
+  LEGACY_FACETS_PARAM,
+  parseReadableFacetFilters,
+  serializeReadableFacetFilters,
+} from '@/lib/filters/urlState'
+
+const EMPTY_FACET_FILTERS: readonly FacetFilter[] = []
+
+export interface ReadableFacetUrlState {
+  query: string
+  setQuery: Dispatch<SetStateAction<string>>
+  facetFilters: FacetFilter[]
+  setFacetFilters: Dispatch<SetStateAction<FacetFilter[]>>
+}
+
+export interface ReadableFacetUrlStateOptions {
+  facetKeys: readonly string[]
+  defaultQuery?: string
+  defaultFacetFilters?: readonly FacetFilter[]
+  syncQuery?: boolean
+}
+
+function searchParamsToRecord(params: URLSearchParams): Record<string, unknown> {
+  const record: Record<string, string | string[]> = {}
+  for (const [key, value] of params.entries()) {
+    const current = record[key]
+    if (Array.isArray(current)) {
+      current.push(value)
+    } else if (current !== undefined) {
+      record[key] = [current, value]
+    } else {
+      record[key] = value
+    }
+  }
+  return record
+}
+
+function readUrlState({
+  facetKeys,
+  defaultQuery = '',
+  defaultFacetFilters = EMPTY_FACET_FILTERS,
+  syncQuery = true,
+}: ReadableFacetUrlStateOptions): Pick<ReadableFacetUrlState, 'query' | 'facetFilters'> {
+  if (typeof globalThis.window === 'undefined') {
+    return {query: defaultQuery, facetFilters: [...defaultFacetFilters]}
+  }
+
+  const params = new URLSearchParams(globalThis.window.location.search)
+  const search = searchParamsToRecord(params)
+  const queryValue = syncQuery ? params.get('q')?.trim() || defaultQuery : defaultQuery
+  const parsedFacets = parseReadableFacetFilters(search, facetKeys)
+
+  return {
+    query: queryValue,
+    facetFilters: parsedFacets ?? [...defaultFacetFilters],
+  }
+}
+
+function readableFacetSearch(
+  search: Record<string, unknown>,
+  query: string,
+  facetFilters: readonly FacetFilter[],
+  {facetKeys, syncQuery = true}: ReadableFacetUrlStateOptions
+): Record<string, unknown> {
+  const next = {...search}
+  for (const key of facetKeys) {
+    next[key] = undefined
+    next[`${EXCLUDE_FACET_PARAM_PREFIX}${key}`] = undefined
+  }
+  next[LEGACY_FACETS_PARAM] = undefined
+
+  if (syncQuery) {
+    const trimmedQuery = query.trim()
+    next.q = trimmedQuery || undefined
+  }
+
+  return {
+    ...next,
+    ...serializeReadableFacetFilters(facetFilters, facetKeys),
+  }
+}
+
+function readableFacetUrlMatchesCurrentSearch(
+  query: string,
+  facetFilters: readonly FacetFilter[],
+  {facetKeys, syncQuery = true}: ReadableFacetUrlStateOptions
+): boolean {
+  if (typeof globalThis.window === 'undefined') return true
+
+  const url = new URL(globalThis.window.location.href)
+  for (const key of facetKeys) {
+    url.searchParams.delete(key)
+    url.searchParams.delete(`${EXCLUDE_FACET_PARAM_PREFIX}${key}`)
+  }
+  url.searchParams.delete(LEGACY_FACETS_PARAM)
+
+  if (syncQuery) {
+    const trimmedQuery = query.trim()
+    if (trimmedQuery) {
+      url.searchParams.set('q', trimmedQuery)
+    } else {
+      url.searchParams.delete('q')
+    }
+  }
+
+  const nextFacets = serializeReadableFacetFilters(facetFilters, facetKeys)
+  for (const [key, value] of Object.entries(nextFacets)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        url.searchParams.append(key, item)
+      }
+    } else {
+      url.searchParams.set(key, value)
+    }
+  }
+
+  const nextUrl = `${url.pathname}${url.search}${url.hash}`
+  const currentUrl = [
+    globalThis.window.location.pathname,
+    globalThis.window.location.search,
+    globalThis.window.location.hash,
+  ].join('')
+
+  if (nextUrl !== currentUrl) {
+    return false
+  }
+  return true
+}
+
+export function useReadableFacetUrlState({
+  facetKeys,
+  defaultQuery = '',
+  defaultFacetFilters = EMPTY_FACET_FILTERS,
+  syncQuery = true,
+}: ReadableFacetUrlStateOptions): ReadableFacetUrlState {
+  const navigate = useNavigate()
+  const options = useMemo(
+    () => ({facetKeys, defaultQuery, defaultFacetFilters, syncQuery}),
+    [defaultFacetFilters, defaultQuery, facetKeys, syncQuery]
+  )
+  const [query, setQuery] = useState(() => readUrlState(options).query)
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => readUrlState(options).facetFilters)
+  const applyingUrlStateRef = useRef(false)
+
+  useEffect(() => {
+    if (typeof globalThis.window === 'undefined') return undefined
+
+    const handlePopState = () => {
+      const nextState = readUrlState(options)
+      applyingUrlStateRef.current = true
+      setQuery(nextState.query)
+      setFacetFilters(nextState.facetFilters)
+    }
+
+    globalThis.window.addEventListener('popstate', handlePopState)
+    return () => globalThis.window.removeEventListener('popstate', handlePopState)
+  }, [options])
+
+  useEffect(() => {
+    if (applyingUrlStateRef.current) {
+      applyingUrlStateRef.current = false
+      return
+    }
+    if (readableFacetUrlMatchesCurrentSearch(query, facetFilters, options)) return
+    navigate({
+      replace: true,
+      search: ((prev: Record<string, unknown>) =>
+        readableFacetSearch(prev, query, facetFilters, options)) as never,
+    })
+  }, [facetFilters, navigate, options, query])
+
+  return {query, setQuery, facetFilters, setFacetFilters}
+}

--- a/dashboard/src/lib/filters/useReadableFacetUrlState.ts
+++ b/dashboard/src/lib/filters/useReadableFacetUrlState.ts
@@ -44,12 +44,12 @@ function searchParamsToRecord(params: URLSearchParams): Record<string, unknown> 
   const record: Record<string, string | string[]> = {}
   for (const [key, value] of params.entries()) {
     const current = record[key]
-    if (Array.isArray(current)) {
-      current.push(value)
-    } else if (current !== undefined) {
-      record[key] = [current, value]
-    } else {
+    if (current === undefined) {
       record[key] = value
+    } else if (Array.isArray(current)) {
+      current.push(value)
+    } else {
+      record[key] = [current, value]
     }
   }
   return record
@@ -61,7 +61,7 @@ function readUrlState({
   defaultFacetFilters = EMPTY_FACET_FILTERS,
   syncQuery = true,
 }: ReadableFacetUrlStateOptions): Pick<ReadableFacetUrlState, 'query' | 'facetFilters'> {
-  if (typeof globalThis.window === 'undefined') {
+  if (globalThis.window === undefined) {
     return {query: defaultQuery, facetFilters: [...defaultFacetFilters]}
   }
 
@@ -116,7 +116,7 @@ function readableFacetUrlMatchesCurrentSearch(
   facetFilters: readonly FacetFilter[],
   options: ReadableFacetUrlStateOptions
 ): boolean {
-  if (typeof globalThis.window === 'undefined') return true
+  if (globalThis.window === undefined) return true
 
   const url = applyReadableFacetSearchToUrl(new URL(globalThis.window.location.href), query, facetFilters, options)
 
@@ -138,7 +138,7 @@ function replaceReadableFacetUrl(
   facetFilters: readonly FacetFilter[],
   options: ReadableFacetUrlStateOptions
 ): void {
-  if (typeof globalThis.window === 'undefined') return
+  if (globalThis.window === undefined) return
 
   const url = applyReadableFacetSearchToUrl(new URL(globalThis.window.location.href), query, facetFilters, options)
   globalThis.window.history.replaceState(globalThis.window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
@@ -159,7 +159,7 @@ export function useReadableFacetUrlState({
   const applyingUrlStateRef = useRef(false)
 
   useEffect(() => {
-    if (typeof globalThis.window === 'undefined') return undefined
+    if (globalThis.window === undefined) return undefined
 
     const handlePopState = () => {
       const nextState = readUrlState(options)

--- a/dashboard/src/lib/filters/useReadableFacetUrlState.ts
+++ b/dashboard/src/lib/filters/useReadableFacetUrlState.ts
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useNavigate} from '@tanstack/react-router'
 import {useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction} from 'react'
 
 import type {FacetFilter} from '@/lib/filters/types'
@@ -77,38 +76,12 @@ function readUrlState({
   }
 }
 
-function readableFacetSearch(
-  search: Record<string, unknown>,
+function applyReadableFacetSearchToUrl(
+  url: URL,
   query: string,
   facetFilters: readonly FacetFilter[],
   {facetKeys, syncQuery = true}: ReadableFacetUrlStateOptions
-): Record<string, unknown> {
-  const next = {...search}
-  for (const key of facetKeys) {
-    next[key] = undefined
-    next[`${EXCLUDE_FACET_PARAM_PREFIX}${key}`] = undefined
-  }
-  next[LEGACY_FACETS_PARAM] = undefined
-
-  if (syncQuery) {
-    const trimmedQuery = query.trim()
-    next.q = trimmedQuery || undefined
-  }
-
-  return {
-    ...next,
-    ...serializeReadableFacetFilters(facetFilters, facetKeys),
-  }
-}
-
-function readableFacetUrlMatchesCurrentSearch(
-  query: string,
-  facetFilters: readonly FacetFilter[],
-  {facetKeys, syncQuery = true}: ReadableFacetUrlStateOptions
-): boolean {
-  if (typeof globalThis.window === 'undefined') return true
-
-  const url = new URL(globalThis.window.location.href)
+): URL {
   for (const key of facetKeys) {
     url.searchParams.delete(key)
     url.searchParams.delete(`${EXCLUDE_FACET_PARAM_PREFIX}${key}`)
@@ -135,6 +108,18 @@ function readableFacetUrlMatchesCurrentSearch(
     }
   }
 
+  return url
+}
+
+function readableFacetUrlMatchesCurrentSearch(
+  query: string,
+  facetFilters: readonly FacetFilter[],
+  options: ReadableFacetUrlStateOptions
+): boolean {
+  if (typeof globalThis.window === 'undefined') return true
+
+  const url = applyReadableFacetSearchToUrl(new URL(globalThis.window.location.href), query, facetFilters, options)
+
   const nextUrl = `${url.pathname}${url.search}${url.hash}`
   const currentUrl = [
     globalThis.window.location.pathname,
@@ -148,13 +133,23 @@ function readableFacetUrlMatchesCurrentSearch(
   return true
 }
 
+function replaceReadableFacetUrl(
+  query: string,
+  facetFilters: readonly FacetFilter[],
+  options: ReadableFacetUrlStateOptions
+): void {
+  if (typeof globalThis.window === 'undefined') return
+
+  const url = applyReadableFacetSearchToUrl(new URL(globalThis.window.location.href), query, facetFilters, options)
+  globalThis.window.history.replaceState(globalThis.window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
+}
+
 export function useReadableFacetUrlState({
   facetKeys,
   defaultQuery = '',
   defaultFacetFilters = EMPTY_FACET_FILTERS,
   syncQuery = true,
 }: ReadableFacetUrlStateOptions): ReadableFacetUrlState {
-  const navigate = useNavigate()
   const options = useMemo(
     () => ({facetKeys, defaultQuery, defaultFacetFilters, syncQuery}),
     [defaultFacetFilters, defaultQuery, facetKeys, syncQuery]
@@ -183,12 +178,8 @@ export function useReadableFacetUrlState({
       return
     }
     if (readableFacetUrlMatchesCurrentSearch(query, facetFilters, options)) return
-    navigate({
-      replace: true,
-      search: ((prev: Record<string, unknown>) =>
-        readableFacetSearch(prev, query, facetFilters, options)) as never,
-    })
-  }, [facetFilters, navigate, options, query])
+    replaceReadableFacetUrl(query, facetFilters, options)
+  }, [facetFilters, options, query])
 
   return {query, setQuery, facetFilters, setFacetFilters}
 }

--- a/dashboard/src/lib/routerSearch.ts
+++ b/dashboard/src/lib/routerSearch.ts
@@ -1,0 +1,58 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+type SearchPrimitive = string | number | boolean
+
+function isSearchPrimitive(value: unknown): value is SearchPrimitive {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+}
+
+function stringifySearchValue(value: unknown): string {
+  if (typeof value === 'object' && value !== null) {
+    return JSON.stringify(value)
+  }
+
+  if (typeof value === 'string') {
+    try {
+      JSON.parse(value)
+      return JSON.stringify(value)
+    } catch {
+      return value
+    }
+  }
+
+  return String(value)
+}
+
+export function stringifySearchWithRepeatedPrimitiveArrays(search: Record<string, unknown>): string {
+  const params = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(search)) {
+    if (value === undefined) continue
+
+    if (Array.isArray(value) && value.every(isSearchPrimitive)) {
+      for (const item of value) {
+        params.append(key, stringifySearchValue(item))
+      }
+      continue
+    }
+
+    params.set(key, stringifySearchValue(value))
+  }
+
+  const searchString = params.toString()
+  return searchString ? `?${searchString}` : ''
+}

--- a/dashboard/src/lib/routerSearch.ts
+++ b/dashboard/src/lib/routerSearch.ts
@@ -25,14 +25,7 @@ function stringifySearchValue(value: unknown): string {
     return JSON.stringify(value)
   }
 
-  if (typeof value === 'string') {
-    try {
-      JSON.parse(value)
-      return JSON.stringify(value)
-    } catch {
-      return value
-    }
-  }
+  if (typeof value === 'string') return value
 
   return String(value)
 }

--- a/dashboard/src/lib/service-facet-scope.ts
+++ b/dashboard/src/lib/service-facet-scope.ts
@@ -1,6 +1,8 @@
 import type {Issue, IssueListParams, Project} from '@/lib/api'
 import type {FacetFilter, FacetRailSection} from '@/lib/filters/types'
 
+export const SERVICE_FACET_URL_KEYS = ['service'] as const
+
 type ServiceList = readonly Project[] | null | undefined
 
 export const HOME_OVERVIEW_ISSUES_QUERY = {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -24,6 +24,7 @@ import {HelmetProvider} from 'react-helmet-async'
 import * as Sentry from '@sentry/react'
 import {initAnalytics} from './lib/analytics'
 import {shouldRetryQuery} from './lib/query-retry'
+import {stringifySearchWithRepeatedPrimitiveArrays} from './lib/routerSearch'
 import './index.css'
 
 function configuredEnv(value: string | undefined): string | undefined {
@@ -108,6 +109,7 @@ const router = createRouter({
   routeTree,
   context: { queryClient },
   scrollRestoration: true,
+  stringifySearch: stringifySearchWithRepeatedPrimitiveArrays,
 })
 
 declare module '@tanstack/react-router' {

--- a/dashboard/src/routes/__tests__/-priority-routes.test.tsx
+++ b/dashboard/src/routes/__tests__/-priority-routes.test.tsx
@@ -69,6 +69,7 @@ vi.mock('@tanstack/react-router', () => ({
     options,
     useParams: () => ({ issueId: 'issue-123' }),
     useSearch: () => ({}),
+    useNavigate: () => mockNavigate,
   }),
   Link: ({ children, ...props }: { children: React.ReactNode }) => React.createElement('a', props, children),
   redirect: (opts: Record<string, unknown>) => ({ ...opts, __redirect: true }),

--- a/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
@@ -71,7 +71,7 @@ function lastNavigatedSearch(): Record<string, unknown> | undefined {
   const arg = call[0] as { search?: unknown } | undefined
   const search = arg?.search
   return typeof search === 'function'
-    ? (search as (prev: Record<string, unknown>) => Record<string, unknown>)({})
+    ? (search as (prev: Record<string, unknown>) => Record<string, unknown>)(mockSearch.value)
     : (search as Record<string, unknown> | undefined)
 }
 
@@ -408,6 +408,9 @@ describe('Issues Index - data coverage', () => {
       expect(resolveIssueFacetFilters({service: 'api'})).toEqual([
         { key: 'service', value: 'api' },
       ])
+      expect(resolveIssueFacetFilters({service: 'api, v2'})).toEqual([
+        {key: 'service', value: 'api, v2'},
+      ])
     })
 
     it('normalises legacy facets search params into readable issue params', () => {
@@ -533,6 +536,7 @@ describe('Issues Index - data coverage', () => {
 
       await waitFor(() => {
         expect(lastNavigatedSearch()).toEqual({
+          view: 'apm-errors',
           aq: undefined,
           apm_service: 'api-gateway',
         })

--- a/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/issues-index-coverage.test.tsx
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderRoute, clearAuthStorage } from '@/test/utils'
 
-const { mockNavigate, mockToast, mockApi } = vi.hoisted(() => ({
+const { mockNavigate, mockToast, mockApi, mockSearch } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockToast: vi.fn(),
+  // Mutable container so each test can drive what the route's `useSearch` returns.
+  mockSearch: { value: {} as Record<string, unknown> },
   mockApi: {
     isAuthenticated: vi.fn(),
     checkAuth: vi.fn(),
@@ -37,6 +39,8 @@ vi.mock('@tanstack/react-router', () => ({
     ...options,
     options,
     useParams: () => ({}),
+    useSearch: () => mockSearch.value,
+    useNavigate: () => mockNavigate,
   }),
   Link: ({
     children,
@@ -55,7 +59,21 @@ vi.mock('@tanstack/react-router', () => ({
   Outlet: () => null,
 }))
 
-import { Route as IssuesIndexRoute } from '../issues.index'
+import { Route as IssuesIndexRoute, resolveIssueFacetFilters } from '../issues.index'
+
+const UNRESOLVED_FACETS = [{ key: 'status', value: 'unresolved' }]
+const STATUS_ALL_SEARCH = { status: 'all' }
+
+/** Pull the last search payload navigate() was called with, resolved to an object. */
+function lastNavigatedSearch(): Record<string, unknown> | undefined {
+  const call = mockNavigate.mock.calls.at(-1)
+  if (!call) return undefined
+  const arg = call[0] as { search?: unknown } | undefined
+  const search = arg?.search
+  return typeof search === 'function'
+    ? (search as (prev: Record<string, unknown>) => Record<string, unknown>)({})
+    : (search as Record<string, unknown> | undefined)
+}
 
 const mockProject = {
   id: 'proj-1',
@@ -136,6 +154,8 @@ describe('Issues Index - data coverage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     clearAuthStorage()
+    // Default to a fresh visit (no facets param) so the unresolved default applies.
+    mockSearch.value = {}
     mockApi.isAuthenticated.mockReturnValue(true)
     mockApi.checkAuth.mockResolvedValue(true)
     mockApi.getProjects.mockResolvedValue([mockProject])
@@ -147,6 +167,8 @@ describe('Issues Index - data coverage', () => {
   })
 
   it('renders issues list with projects and issues data', async () => {
+    // Explicitly-empty facets = the user cleared the default, so all statuses show.
+    mockSearch.value = STATUS_ALL_SEARCH
     renderRoute(IssuesIndexRoute)
 
     // Should show the search bar
@@ -201,6 +223,7 @@ describe('Issues Index - data coverage', () => {
   })
 
   it('filters by status from the rail and clears it again (removable, multi-select capable)', async () => {
+    mockSearch.value = STATUS_ALL_SEARCH
     renderRoute(IssuesIndexRoute)
 
     await screen.findByText(/app.main: TypeError: null ref/)
@@ -272,7 +295,8 @@ describe('Issues Index - data coverage', () => {
     expect(screen.getByText('No issues match your filters')).toBeInTheDocument()
   })
 
-  it('shows empty state when issues list is empty for default filter', async () => {
+  it('shows the no-issues-yet empty state when there are no issues and no active filters', async () => {
+    mockSearch.value = STATUS_ALL_SEARCH
     mockApi.getOrganizationIssues.mockResolvedValue([])
 
     renderRoute(IssuesIndexRoute)
@@ -288,6 +312,7 @@ describe('Issues Index - data coverage', () => {
       slug: 'worker-service',
     }
     mockApi.getProjects.mockResolvedValue([mockProject, workerProject])
+    mockSearch.value = STATUS_ALL_SEARCH
 
     renderRoute(IssuesIndexRoute)
 
@@ -350,18 +375,20 @@ describe('Issues Index - data coverage', () => {
       ],
     })
 
-    localStorage.clear()
-    localStorage.setItem('apmErrors.facetFilters', JSON.stringify([{ key: 'service', value: 'api-gateway' }]))
+    // Seed the active tab + APM service facet straight from the URL (APM now
+    // persists in readable aq/apm_* params, not localStorage).
+    mockSearch.value = {
+      view: 'apm-errors',
+      apm_service: 'api-gateway',
+    }
     renderRoute(IssuesIndexRoute)
 
-    await screen.findByRole('textbox')
-    fireEvent.click(screen.getByText('APM Errors'))
-
-    // Seed the selected service via its persisted slice (the rail/bar selection),
-    // which loads its errors.
     expect(await screen.findByText('Connection refused')).toBeInTheDocument()
     expect(screen.getByText('NetworkError')).toBeInTheDocument()
     expect(screen.getByText('View trace')).toBeInTheDocument()
+    expect(mockApi.getApmErrors).toHaveBeenCalledWith(
+      expect.objectContaining({ services: ['api-gateway'] })
+    )
   })
 
   it('does not show create or settings affordances in the header', async () => {
@@ -372,5 +399,157 @@ describe('Issues Index - data coverage', () => {
     expect(screen.queryByText('New Service')).not.toBeInTheDocument()
     expect(screen.queryByText('New Project')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Service settings')).not.toBeInTheDocument()
+  })
+
+  describe('facet URL state', () => {
+    it('resolveIssueFacetFilters defaults a fresh visit to unresolved but honours an explicit clear', () => {
+      expect(resolveIssueFacetFilters(undefined)).toEqual([{ key: 'status', value: 'unresolved' }])
+      expect(resolveIssueFacetFilters(STATUS_ALL_SEARCH)).toEqual([])
+      expect(resolveIssueFacetFilters({service: 'api'})).toEqual([
+        { key: 'service', value: 'api' },
+      ])
+    })
+
+    it('normalises legacy facets search params into readable issue params', () => {
+      const validateSearch = IssuesIndexRoute.options.validateSearch as (search: Record<string, unknown>) => unknown
+      expect(validateSearch({facets: '[{"key":"status","value":"resolved"}]'})).toEqual({status: 'resolved'})
+      expect(validateSearch({facets: '[]'})).toEqual({status: 'all'})
+      expect(validateSearch({facets: JSON.stringify(JSON.stringify(UNRESOLVED_FACETS))})).toEqual({
+        status: 'unresolved',
+      })
+    })
+
+    it('applies the unresolved default and normalises a fresh URL to carry it', async () => {
+      // mockSearch.value defaults to {} (no facets param) in beforeEach.
+      renderRoute(IssuesIndexRoute)
+
+      // Only the two unresolved issues survive the default client-side filter.
+      expect(await screen.findByText(/app.main: TypeError: null ref/)).toBeInTheDocument()
+      expect(screen.queryByText(/api.handler: ValueError: invalid input/)).not.toBeInTheDocument()
+      expect(screen.getByText('2 results')).toBeInTheDocument()
+
+      // The unresolved status drives the org issue request...
+      expect(mockApi.getOrganizationIssues).toHaveBeenCalledWith({
+        page: 1,
+        limit: 500,
+        status: 'unresolved',
+        services: undefined,
+      })
+
+      // ...and the URL is normalised so the default is shareable.
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalled()
+      })
+      expect(lastNavigatedSearch()).toEqual({ q: undefined, status: 'unresolved' })
+    })
+
+    it('restores facet state from the URL without re-normalising', async () => {
+      mockSearch.value = { status: 'resolved' }
+      renderRoute(IssuesIndexRoute)
+
+      expect(await screen.findByText(/api.handler: ValueError: invalid input/)).toBeInTheDocument()
+      expect(screen.queryByText(/app.main: TypeError: null ref/)).not.toBeInTheDocument()
+      expect(screen.getByText('1 result')).toBeInTheDocument()
+      expect(mockApi.getOrganizationIssues).toHaveBeenCalledWith({
+        page: 1,
+        limit: 500,
+        status: 'resolved',
+        services: undefined,
+      })
+
+      // Already in sync with the URL → no redundant navigation.
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('writes facet selections back to the URL', async () => {
+      mockSearch.value = STATUS_ALL_SEARCH
+      renderRoute(IssuesIndexRoute)
+
+      await screen.findByText(/app.main: TypeError: null ref/)
+      fireEvent.click(screen.getByRole('button', { name: 'Resolved' }))
+
+      await waitFor(() => {
+        expect(lastNavigatedSearch()).toEqual({
+          q: undefined,
+          status: 'resolved',
+        })
+      })
+    })
+
+    it('records an explicit empty facets param when the default is cleared', async () => {
+      // Fresh visit → unresolved default; toggling it off must not silently
+      // resurrect on reload, so the URL gets an explicit "[]".
+      renderRoute(IssuesIndexRoute)
+
+      await screen.findByText(/app.main: TypeError: null ref/)
+      fireEvent.click(screen.getByRole('button', { name: 'Unresolved' }))
+
+      await waitFor(() => {
+        expect(mockApi.getOrganizationIssues).toHaveBeenLastCalledWith({
+          page: 1,
+          limit: 500,
+          status: undefined,
+          services: undefined,
+        })
+      })
+      expect(await screen.findByText('5 results')).toBeInTheDocument()
+      expect(lastNavigatedSearch()).toEqual({ q: undefined, status: 'all' })
+    })
+  })
+
+  describe('tab URL state', () => {
+    it('persists the active tab in the URL', async () => {
+      renderRoute(IssuesIndexRoute)
+
+      await screen.findByRole('textbox')
+      fireEvent.click(screen.getByText('APM Errors'))
+
+      expect(await screen.findByText('No APM errors found')).toBeInTheDocument()
+      expect(lastNavigatedSearch()).toEqual({ view: 'apm-errors' })
+    })
+
+    it('restores the active tab from the URL', async () => {
+      mockSearch.value = { view: 'apm-errors' }
+      renderRoute(IssuesIndexRoute)
+
+      // Lands on APM Errors without a click, and never queries the issues list.
+      expect(await screen.findByText('No APM errors found')).toBeInTheDocument()
+      expect(mockApi.getOrganizationIssues).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('APM facet URL state', () => {
+    it('writes APM facet selections to its own namespaced URL params', async () => {
+      mockApi.getApmErrors.mockResolvedValue({
+        errors: [],
+        totalCount: 0,
+        serviceFacets: [{ service: 'api-gateway', count: 35 }],
+      })
+      mockSearch.value = { view: 'apm-errors' }
+      renderRoute(IssuesIndexRoute)
+
+      // The rail offers services from the facet counts; selecting one writes apm_service.
+      fireEvent.click(await screen.findByLabelText('api-gateway'))
+
+      await waitFor(() => {
+        expect(lastNavigatedSearch()).toEqual({
+          aq: undefined,
+          apm_service: 'api-gateway',
+        })
+      })
+    })
+
+    it('keeps Issues and APM facets separate — no cross-tab leakage', async () => {
+      mockApi.getApmErrors.mockResolvedValue({ errors: [], totalCount: 0, serviceFacets: [] })
+      // Issues default (unresolved) lives in q/facets; APM must ignore it.
+      mockSearch.value = { view: 'apm-errors', status: 'unresolved' }
+      renderRoute(IssuesIndexRoute)
+
+      await screen.findByText('No APM errors found')
+      expect(screen.queryByText('status:unresolved')).not.toBeInTheDocument()
+      expect(mockApi.getApmErrors).toHaveBeenCalledWith(
+        expect.objectContaining({ services: undefined })
+      )
+    })
   })
 })

--- a/dashboard/src/routes/ai.generations.tsx
+++ b/dashboard/src/routes/ai.generations.tsx
@@ -33,12 +33,14 @@ import {ProviderLogo} from '@/components/icons/AiProviders'
 import {useTimezone} from '@/hooks/useTimezone'
 import {formatDateTime} from '@/lib/date-format'
 import {
+  SERVICE_FACET_URL_KEYS,
   facetValues,
   serviceNamesForQuery,
   serviceRailSections,
   serviceScopeKey,
 } from '@/lib/service-facet-scope'
 import type {FacetFilter} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 
 export const Route = createFileRoute('/ai/generations')({
   component: GenerationsPage,
@@ -63,7 +65,10 @@ function GenerationsPage() {
   const [statusFilter, setStatusFilter] = useState<string>('')
   const [typeFilter, setTypeFilter] = useState<string>('')
   const [selectedGenId, setSelectedGenId] = useState<string | null>(null)
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {facetFilters, setFacetFilters} = useReadableFacetUrlState({
+    facetKeys: SERVICE_FACET_URL_KEYS,
+    syncQuery: false,
+  })
 
   const {data: projects, isLoading: projectsLoading, error: projectsError} = useQuery({
     queryKey: ['projects'],
@@ -116,7 +121,7 @@ function GenerationsPage() {
     setFacetFilters(nextFilters)
     setPage(1)
     setSelectedGenId(null)
-  }, [])
+  }, [setFacetFilters])
 
   if (projectsLoading) {
     return <div className="p-8 text-sm text-muted-foreground">Loading generations...</div>

--- a/dashboard/src/routes/ai.index.tsx
+++ b/dashboard/src/routes/ai.index.tsx
@@ -32,12 +32,13 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { Brain, Coins, Clock, AlertTriangle, Hash, Zap, BookOpen, ArrowRight, TrendingUp } from 'lucide-react'
 import { ProviderLogo } from '@/components/icons/AiProviders'
 import {
+  SERVICE_FACET_URL_KEYS,
   facetValues,
   serviceNamesForQuery,
   serviceRailSections,
   serviceScopeKey,
 } from '@/lib/service-facet-scope'
-import type {FacetFilter} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 
 export const Route = createFileRoute('/ai/')({
   component: AiOverviewPage,
@@ -76,7 +77,10 @@ function llmBreakdowns(overview: LlmOverview | undefined) {
 
 function AiOverviewPage() {
   const [range, setRange] = useState('24h')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {facetFilters, setFacetFilters} = useReadableFacetUrlState({
+    facetKeys: SERVICE_FACET_URL_KEYS,
+    syncQuery: false,
+  })
 
   const {data: projects, isLoading: projectsLoading, error: projectsError} = useQuery({
     queryKey: ['projects'],

--- a/dashboard/src/routes/analytics.index.tsx
+++ b/dashboard/src/routes/analytics.index.tsx
@@ -3,7 +3,7 @@ import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {useAnalyticsParams} from '@/contexts/UseAnalyticsParams'
-import {serviceNamesForQuery} from '@/lib/service-facet-scope'
+import {SERVICE_FACET_URL_KEYS, serviceNamesForQuery} from '@/lib/service-facet-scope'
 import {AnalyticsFilterBar} from '@/components/analytics/AnalyticsFilterBar'
 import {AnalyticsKpiCards, AnalyticsKpiCardsSkeleton} from '@/components/analytics/AnalyticsKpiCards'
 import {AnalyticsChart} from '@/components/analytics/AnalyticsChart'
@@ -29,6 +29,7 @@ import type {
   Project,
 } from '@/lib/api'
 import type {FacetFilter, FacetRailSection} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 
 export const Route = createFileRoute('/analytics/')({
   component: AnalyticsOverview,
@@ -204,7 +205,10 @@ function useAnalyticsQueries({
 function AnalyticsOverview() {
   const {period, customFrom, customTo} = useAnalyticsParams()
   const [filters, setFilters] = useState<AnalyticsFilter[]>([])
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {facetFilters, setFacetFilters} = useReadableFacetUrlState({
+    facetKeys: SERVICE_FACET_URL_KEYS,
+    syncQuery: false,
+  })
   const [breakdownTab, setBreakdownTab] = useState('pages')
   const [analyticsTab, setAnalyticsTab] = useState<AnalyticsView>('web')
 

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -46,6 +46,7 @@ import {
 import {useMemo, useState, type ReactNode} from 'react'
 import {useToast} from '@/hooks/useToast'
 import {
+  SERVICE_FACET_URL_KEYS,
   facetValues,
   serviceNamesForQuery,
   serviceRailSections,
@@ -53,6 +54,7 @@ import {
 } from '@/lib/service-facet-scope'
 import {feedbackSourceLabel} from '@/lib/telemetry-sources'
 import type {FacetFilter} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import type {Feedback} from '@/lib/api/types/replays'
 
 export const Route = createFileRoute('/feedback')({
@@ -584,10 +586,14 @@ function FeedbackMainContent(props: FeedbackMainContentProps) {
 }
 
 function FeedbackPage() {
-  const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>('unresolved')
   const [selectedFeedback, setSelectedFeedback] = useState<Set<string>>(new Set())
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {
+    query: searchQuery,
+    setQuery: setSearchQuery,
+    facetFilters,
+    setFacetFilters,
+  } = useReadableFacetUrlState({facetKeys: SERVICE_FACET_URL_KEYS})
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const navigate = useNavigate()

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -32,6 +32,11 @@ import {SegmentedTabs, type SegmentedOption} from '@/components/filters/Segmente
 import {TimeRangePicker} from '@/components/filters/TimeRangePicker'
 import type {TimeRangePreset} from '@/lib/filters/time'
 import type {FacetFilter, FacetSchema, FacetRailSection} from '@/lib/filters/types'
+import {
+  parseExplorerSearch,
+  parseFacetFiltersOptionalParam,
+  type ReadableFacetSearchValue,
+} from '@/lib/filters/urlState'
 import {levelBadgeVariant, levelBorderClass} from '@/lib/severity'
 import {Checkbox} from '@/components/ui/checkbox'
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu'
@@ -49,7 +54,7 @@ import {
   Server,
   Timer,
 } from 'lucide-react'
-import {useEffect, useMemo, useState} from 'react'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import type {ReactNode} from 'react'
 import {useToast} from '@/hooks/useToast'
 import {getNow} from '@/lib/demo'
@@ -409,11 +414,389 @@ function EventSparkline({ eventCount, eventSeries }: { eventCount: number; event
   )
 }
 
+/** Issues default to the unresolved status facet (also mirrored into the URL). */
+export const DEFAULT_ISSUE_FACET_FILTERS: readonly FacetFilter[] = [
+  {key: 'status', value: 'unresolved'},
+]
+
+const ISSUE_STATUS_ALL_URL_VALUE = 'all'
+const ISSUE_FACET_KEYS = ['service', 'status', 'level'] as const
+const APM_FACET_KEYS = ['service'] as const
+const APM_FACET_PARAM_PREFIX = 'apm_'
+type IssueFacetKey = (typeof ISSUE_FACET_KEYS)[number]
+type IssueExcludeFacetKey = `exclude_${IssueFacetKey}`
+const ISSUE_EXCLUDE_FACET_KEYS = ISSUE_FACET_KEYS.map((key) => `exclude_${key}` as const)
+type ApmFacetKey = (typeof APM_FACET_KEYS)[number]
+type ApmFacetParamKey = `${typeof APM_FACET_PARAM_PREFIX}${ApmFacetKey}`
+type ApmExcludeFacetParamKey = `exclude_${ApmFacetParamKey}`
+
+type IssueFacetSearch = Partial<Record<IssueFacetKey | IssueExcludeFacetKey, ReadableFacetSearchValue>>
+type ApmFacetSearch = Partial<Record<ApmFacetParamKey | ApmExcludeFacetParamKey, ReadableFacetSearchValue>>
+
+function apmFacetParamKey(key: ApmFacetKey): ApmFacetParamKey {
+  return `${APM_FACET_PARAM_PREFIX}${key}` as ApmFacetParamKey
+}
+
+function apmExcludeFacetParamKey(key: ApmFacetKey): ApmExcludeFacetParamKey {
+  return `exclude_${apmFacetParamKey(key)}` as ApmExcludeFacetParamKey
+}
+
+function searchParamValues(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(searchParamValues)
+  }
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return []
+  return String(value)
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+}
+
+function toSearchParamValue(values: readonly string[]): ReadableFacetSearchValue | undefined {
+  if (values.length === 0) return undefined
+  return values.length === 1 ? values[0] : [...values]
+}
+
+function issueFacetFiltersFromSearch(search: Partial<IssuesSearch> | Record<string, unknown>): FacetFilter[] | undefined {
+  const filters: FacetFilter[] = []
+  let hasCleanFacetParam = false
+
+  for (const key of ISSUE_FACET_KEYS) {
+    const includeValues = searchParamValues(search[key])
+    if (includeValues.length > 0) {
+      hasCleanFacetParam = true
+      for (const value of includeValues) {
+        if (key === 'status' && value === ISSUE_STATUS_ALL_URL_VALUE) continue
+        filters.push({key, value})
+      }
+    }
+
+    const excludeKey = `exclude_${key}` as const
+    const excludeValues = searchParamValues(search[excludeKey])
+    if (excludeValues.length > 0) {
+      hasCleanFacetParam = true
+      filters.push(...excludeValues.map((value) => ({key, value, exclude: true})))
+    }
+  }
+
+  if (hasCleanFacetParam) {
+    return filters
+  }
+
+  return parseFacetFiltersOptionalParam('facets' in search ? search.facets : undefined)
+}
+
+function serializeIssueFacetSearch(filters: readonly FacetFilter[], forceStatusParam: boolean): IssueFacetSearch {
+  const search: IssueFacetSearch = {}
+
+  for (const key of ISSUE_FACET_KEYS) {
+    const includeValues = filters.filter((filter) => filter.key === key && !filter.exclude).map((filter) => filter.value)
+    const excludeValues = filters.filter((filter) => filter.key === key && filter.exclude).map((filter) => filter.value)
+
+    const includeParam = toSearchParamValue(includeValues)
+    if (includeParam) {
+      search[key] = includeParam
+    }
+
+    const excludeParam = toSearchParamValue(excludeValues)
+    if (excludeParam) {
+      search[`exclude_${key}` as const] = excludeParam
+    }
+  }
+
+  if (forceStatusParam && !search.status && !search.exclude_status) {
+    search.status = ISSUE_STATUS_ALL_URL_VALUE
+  }
+
+  return search
+}
+
+function issueFacetSearchKey(search: Partial<IssuesSearch>): string | undefined {
+  const filters = issueFacetFiltersFromSearch(search)
+  if (filters === undefined) return undefined
+  return JSON.stringify(serializeIssueFacetSearch(filters, true))
+}
+
+function apmFacetFiltersFromSearch(search: Record<string, unknown>): FacetFilter[] | undefined {
+  const filters: FacetFilter[] = []
+  let hasCleanFacetParam = false
+
+  for (const key of APM_FACET_KEYS) {
+    const includeParamKey = apmFacetParamKey(key)
+    const includeValues = searchParamValues(search[includeParamKey])
+    if (includeValues.length > 0) {
+      hasCleanFacetParam = true
+      filters.push(...includeValues.map((value) => ({key, value})))
+    }
+
+    const excludeParamKey = apmExcludeFacetParamKey(key)
+    const excludeValues = searchParamValues(search[excludeParamKey])
+    if (excludeValues.length > 0) {
+      hasCleanFacetParam = true
+      filters.push(...excludeValues.map((value) => ({key, value, exclude: true})))
+    }
+  }
+
+  if (hasCleanFacetParam) {
+    return filters
+  }
+
+  return parseFacetFiltersOptionalParam('afacets' in search ? search.afacets : undefined)
+}
+
+function serializeApmFacetSearch(filters: readonly FacetFilter[]): ApmFacetSearch {
+  const search: ApmFacetSearch = {}
+
+  for (const key of APM_FACET_KEYS) {
+    const includeValues = filters.filter((filter) => filter.key === key && !filter.exclude).map((filter) => filter.value)
+    const excludeValues = filters.filter((filter) => filter.key === key && filter.exclude).map((filter) => filter.value)
+
+    const includeParam = toSearchParamValue(includeValues)
+    if (includeParam) {
+      search[apmFacetParamKey(key)] = includeParam
+    }
+
+    const excludeParam = toSearchParamValue(excludeValues)
+    if (excludeParam) {
+      search[apmExcludeFacetParamKey(key)] = excludeParam
+    }
+  }
+
+  return search
+}
+
+function apmFacetSearchKey(search: Record<string, unknown>): string | undefined {
+  const filters = apmFacetFiltersFromSearch(search)
+  if (filters === undefined) return undefined
+  return JSON.stringify(serializeApmFacetSearch(filters))
+}
+
+function clearIssueFacetSearch(prev: Record<string, unknown>): Record<string, unknown> {
+  const next = {...prev}
+  for (const key of ISSUE_FACET_KEYS) {
+    if (key in next) next[key] = undefined
+  }
+  for (const key of ISSUE_EXCLUDE_FACET_KEYS) {
+    if (key in next) next[key] = undefined
+  }
+  if ('facets' in next) next.facets = undefined
+  return next
+}
+
+function clearApmFacetSearch(prev: Record<string, unknown>): Record<string, unknown> {
+  const next = {...prev}
+  for (const key of APM_FACET_KEYS) {
+    const includeKey = apmFacetParamKey(key)
+    if (includeKey in next) next[includeKey] = undefined
+    const excludeKey = apmExcludeFacetParamKey(key)
+    if (excludeKey in next) next[excludeKey] = undefined
+  }
+  if ('afacets' in next) next.afacets = undefined
+  return next
+}
+
+function hasLegacyIssueFacetParam(): boolean {
+  if (typeof globalThis.window === 'undefined') return false
+  return new URLSearchParams(globalThis.window.location.search).has('facets')
+}
+
+function hasLegacyApmFacetParam(): boolean {
+  if (typeof globalThis.window === 'undefined') return false
+  return new URLSearchParams(globalThis.window.location.search).has('afacets')
+}
+
+function releaseHydrationGuard(ref: {current: boolean}): () => void {
+  const release = globalThis.setTimeout(() => {
+    ref.current = false
+  }, 0)
+  return () => {
+    globalThis.clearTimeout(release)
+    ref.current = false
+  }
+}
+
+/**
+ * Resolve issue-explorer facet state from clean URL params. An absent facet
+ * state falls back to the unresolved default; `status=all` means the user
+ * explicitly cleared every status facet.
+ */
+export function resolveIssueFacetFilters(search: Partial<IssuesSearch> | undefined): FacetFilter[] {
+  const filters = search ? issueFacetFiltersFromSearch(search) : undefined
+  if (filters === undefined) {
+    return DEFAULT_ISSUE_FACET_FILTERS.map((filter) => ({...filter}))
+  }
+  return filters
+}
+
+/** Issue explorer sub-views (tabs), persisted in the URL as `?view=`. */
+export type IssuesView = 'issues' | 'apm-errors'
+const ISSUES_VIEWS: readonly IssuesView[] = ['issues', 'apm-errors']
+
+function parseIssuesView(value: unknown): IssuesView | undefined {
+  return typeof value === 'string' && (ISSUES_VIEWS as readonly string[]).includes(value)
+    ? (value as IssuesView)
+    : undefined
+}
+
+/**
+ * Issue explorer route search: the Issues tab's readable filters, the active
+ * tab (`view`), and the APM Errors tab's own readable `apm_*` filters so each
+ * tab's view persists independently without one tab's facets leaking into the
+ * other. Legacy `facets`/`afacets` JSON is accepted by validateSearch only.
+ */
+export interface IssuesSearch {
+  q?: string
+  view?: IssuesView
+  service?: ReadableFacetSearchValue
+  status?: ReadableFacetSearchValue
+  level?: ReadableFacetSearchValue
+  exclude_service?: ReadableFacetSearchValue
+  exclude_status?: ReadableFacetSearchValue
+  exclude_level?: ReadableFacetSearchValue
+  aq?: string
+  apm_service?: ReadableFacetSearchValue
+  exclude_apm_service?: ReadableFacetSearchValue
+  afacets?: FacetFilter[]
+}
+
 export const Route = createFileRoute('/issues/')({
+  validateSearch: (search: Record<string, unknown>): IssuesSearch => {
+    const issueFacets = issueFacetFiltersFromSearch(search)
+    const issueSearch = issueFacets ? serializeIssueFacetSearch(issueFacets, true) : {}
+    const parsedExplorer = parseExplorerSearch(search)
+    const apmFacets = apmFacetFiltersFromSearch(search)
+    const apmSearch = apmFacets ? serializeApmFacetSearch(apmFacets) : {}
+    const apmQuery = parseExplorerSearch({q: search.aq})
+    const result: IssuesSearch = {
+      ...issueSearch,
+      ...apmSearch,
+    }
+    if (parsedExplorer.q) result.q = parsedExplorer.q
+    const view = parseIssuesView(search.view)
+    if (view) result.view = view
+    if (apmQuery.q) result.aq = apmQuery.q
+    return result
+  },
   component: IndexPage,
 })
 
-type IssuesView = 'issues' | 'apm-errors'
+function useIssueFacetUrlState() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const urlQuery = search.q
+  const urlFacetsKey = issueFacetSearchKey(search)
+  const shouldNormalizeFacetsUrl = hasLegacyIssueFacetParam()
+  const resolvedFacetFilters = useMemo(() => resolveIssueFacetFilters(search), [search])
+
+  const [searchQuery, setSearchQuery] = useState(() => urlQuery ?? '')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => resolvedFacetFilters)
+  const didMountRef = useRef(false)
+  const isHydratingRef = useRef(false)
+
+  // URL -> state: adopt external changes only (shared-link nav, back/forward).
+  // The first run is skipped because state is already seeded from the URL above.
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return undefined
+    }
+    if (isHydratingRef.current) return undefined
+    isHydratingRef.current = true
+    setSearchQuery(urlQuery ?? '')
+    setFacetFilters(resolvedFacetFilters)
+    return releaseHydrationGuard(isHydratingRef)
+  }, [urlQuery, urlFacetsKey, resolvedFacetFilters])
+
+  // state -> URL: reflect active filters in human-readable params such as
+  // `status=unresolved&service=api`. Unrelated params persist.
+  useEffect(() => {
+    if (isHydratingRef.current) return undefined
+    const nextQuery = searchQuery.trim() || undefined
+    const nextFacetSearch = serializeIssueFacetSearch(facetFilters, true)
+    const nextFacetsKey = JSON.stringify(nextFacetSearch)
+    if (nextQuery === urlQuery && nextFacetsKey === urlFacetsKey && !shouldNormalizeFacetsUrl) return undefined
+    isHydratingRef.current = true
+    navigate({
+      replace: true,
+      search: (prev) => ({
+        ...clearIssueFacetSearch(prev),
+        q: nextQuery,
+        ...nextFacetSearch,
+      }),
+    })
+    return releaseHydrationGuard(isHydratingRef)
+  }, [searchQuery, facetFilters, navigate, urlQuery, urlFacetsKey, shouldNormalizeFacetsUrl])
+
+  return {searchQuery, setSearchQuery, facetFilters, setFacetFilters}
+}
+
+function isDoubleStringifiedFacetSearchParam(name: string): boolean {
+  if (typeof globalThis.window === 'undefined') return false
+  return new URLSearchParams(globalThis.window.location.search).get(name)?.startsWith('"') ?? false
+}
+
+/**
+ * Two-way bind an explorer's free-text query + facet filters to the route URL.
+ * State stays the source of truth for the UI; the URL mirrors it in APM's
+ * namespaced `aq`/`apm_*` params and seeds it on load / back-forward.
+ * `isHydratingRef` keeps the two effects from echoing each other (same approach
+ * as LogExplorer).
+ */
+function useApmFacetUrlState() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const urlQuery = search.aq
+  const urlFacetsKey = apmFacetSearchKey(search)
+  const shouldNormalizeFacetsUrl =
+    hasLegacyApmFacetParam() || isDoubleStringifiedFacetSearchParam('afacets')
+
+  const [searchQuery, setSearchQuery] = useState(() => urlQuery ?? '')
+  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => apmFacetFiltersFromSearch(search) ?? [])
+  const didMountRef = useRef(false)
+  const isHydratingRef = useRef(false)
+
+  // URL -> state: adopt external changes only (shared-link nav, back/forward).
+  // The first run is skipped because state is already seeded from the URL above.
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return undefined
+    }
+    if (isHydratingRef.current) return undefined
+    isHydratingRef.current = true
+    setSearchQuery(urlQuery ?? '')
+    setFacetFilters(apmFacetFiltersFromSearch(search) ?? [])
+    return releaseHydrationGuard(isHydratingRef)
+  }, [urlQuery, urlFacetsKey, search])
+
+  // state -> URL: reflect active APM filters. Unrelated params persist.
+  useEffect(() => {
+    if (isHydratingRef.current) return undefined
+    const nextQuery = searchQuery.trim() || undefined
+    const nextFacetSearch = serializeApmFacetSearch(facetFilters)
+    const nextFacetsKey = Object.keys(nextFacetSearch).length > 0 ? JSON.stringify(nextFacetSearch) : undefined
+    if (nextQuery === urlQuery && nextFacetsKey === urlFacetsKey && !shouldNormalizeFacetsUrl) return undefined
+    isHydratingRef.current = true
+    navigate({
+      replace: true,
+      search: (prev) => ({
+        ...clearApmFacetSearch(prev),
+        aq: nextQuery,
+        ...nextFacetSearch,
+      }),
+    })
+    return releaseHydrationGuard(isHydratingRef)
+  }, [
+    searchQuery,
+    facetFilters,
+    navigate,
+    urlQuery,
+    urlFacetsKey,
+    shouldNormalizeFacetsUrl,
+  ])
+
+  return {searchQuery, setSearchQuery, facetFilters, setFacetFilters}
+}
 
 const ISSUES_VIEW_TABS = [
   {value: 'issues', label: 'Issues', icon: AlertCircle},
@@ -421,13 +804,32 @@ const ISSUES_VIEW_TABS = [
 ] as const satisfies ReadonlyArray<SegmentedOption<IssuesView>>
 
 function IndexPage() {
-  const [activeTab, setActiveTab] = useState<IssuesView>('issues')
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  // State stays the source of truth for the tab; the URL mirrors it (shareable
+  // links) and seeds it on load. The default tab stays out of the URL to keep
+  // links clean. Adopt external URL changes (back/forward) by adjusting state
+  // during render — React's sanctioned alternative to a state-syncing effect.
+  const [activeTab, setActiveTab] = useState<IssuesView>(() => search.view ?? 'issues')
+  const [syncedView, setSyncedView] = useState(search.view)
+  if (syncedView !== search.view) {
+    setSyncedView(search.view)
+    setActiveTab(search.view ?? 'issues')
+  }
+
+  const handleTabChange = (view: IssuesView) => {
+    setActiveTab(view)
+    navigate({
+      replace: true,
+      search: (prev) => ({...prev, view: view === 'issues' ? undefined : view}),
+    })
+  }
 
   const viewTabs = (
     <SegmentedTabs
       ariaLabel="Issues view"
       value={activeTab}
-      onChange={setActiveTab}
+      onChange={handleTabChange}
       options={ISSUES_VIEW_TABS}
     />
   )
@@ -448,8 +850,9 @@ type DashboardPageProps = Readonly<{
 }>
 
 function DashboardPage({tabs}: DashboardPageProps) {
-  const [searchQuery, setSearchQuery] = useState('')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  // Issues filters round-trip through readable URL params such as
+  // `status=unresolved`, defaulting a fresh visit to unresolved.
+  const {searchQuery, setSearchQuery, facetFilters, setFacetFilters} = useIssueFacetUrlState()
   const [selectedIssueKeys, setSelectedIssueKeys] = useState<Set<string>>(new Set())
   const [page, setPage] = useState(1)
   const pageSize = 25
@@ -1072,21 +1475,6 @@ const APM_TIME_PRESETS: TimeRangePreset[] = [
   {label: '90d', value: '90d', minutes: 129600},
 ]
 
-function loadApmErrorFacetFilters(): FacetFilter[] {
-  try {
-    const raw = globalThis.localStorage?.getItem('apmErrors.facetFilters')
-    const parsed = raw ? JSON.parse(raw) : null
-    return Array.isArray(parsed)
-      ? parsed.filter(
-          (filter): filter is FacetFilter =>
-            !!filter && typeof filter.key === 'string' && typeof filter.value === 'string'
-        )
-      : []
-  } catch {
-    return []
-  }
-}
-
 function visibleApmErrors(errors: readonly ApmErrorGroup[], normalizedQuery: string): readonly ApmErrorGroup[] {
   if (!normalizedQuery) return errors
   return errors.filter((error) =>
@@ -1100,20 +1488,13 @@ type ApmErrorsTabProps = Readonly<{
 }>
 
 function ApmErrorsTab({ isActive, tabs }: ApmErrorsTabProps) {
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(loadApmErrorFacetFilters)
-  const [query, setQuery] = useState('')
+  // APM filters live in the URL under their own namespace (aq/apm_*) so the
+  // Issues and APM tab views stay shareable and persist independently across tab
+  // switches (replaces the old localStorage facet slice). No default facet.
+  const {searchQuery: query, setSearchQuery: setQuery, facetFilters, setFacetFilters} =
+    useApmFacetUrlState()
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('24h')
   const [offset, setOffset] = useState(0)
-
-  // Persist the selected facets so the slice survives reloads (service-first
-  // navigation — replaces the old global "active project" mode).
-  useEffect(() => {
-    try {
-      globalThis.localStorage?.setItem('apmErrors.facetFilters', JSON.stringify(facetFilters))
-    } catch {
-      /* ignore persistence errors */
-    }
-  }, [facetFilters])
 
   // The trace API filters by an explicit service list (no excludes), so only
   // include-mode service facets reach the query.

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -596,12 +596,12 @@ function clearApmFacetSearch(prev: Record<string, unknown>): Record<string, unkn
 }
 
 function hasLegacyIssueFacetParam(): boolean {
-  if (typeof globalThis.window === 'undefined') return false
+  if (globalThis.window === undefined) return false
   return new URLSearchParams(globalThis.window.location.search).has('facets')
 }
 
 function hasLegacyApmFacetParam(): boolean {
-  if (typeof globalThis.window === 'undefined') return false
+  if (globalThis.window === undefined) return false
   return new URLSearchParams(globalThis.window.location.search).has('afacets')
 }
 
@@ -731,7 +731,7 @@ function useIssueFacetUrlState() {
 }
 
 function isDoubleStringifiedFacetSearchParam(name: string): boolean {
-  if (typeof globalThis.window === 'undefined') return false
+  if (globalThis.window === undefined) return false
   return new URLSearchParams(globalThis.window.location.search).get(name)?.startsWith('"') ?? false
 }
 

--- a/dashboard/src/routes/issues.index.tsx
+++ b/dashboard/src/routes/issues.index.tsx
@@ -54,8 +54,7 @@ import {
   Server,
   Timer,
 } from 'lucide-react'
-import {useEffect, useMemo, useRef, useState} from 'react'
-import type {ReactNode} from 'react'
+import {useEffect, useMemo, useRef, useState, type ReactNode} from 'react'
 import {useToast} from '@/hooks/useToast'
 import {getNow} from '@/lib/demo'
 import {parseDate} from '@/lib/date-format'
@@ -446,10 +445,8 @@ function searchParamValues(value: unknown): string[] {
     return value.flatMap(searchParamValues)
   }
   if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return []
-  return String(value)
-    .split(',')
-    .map((part) => part.trim())
-    .filter(Boolean)
+  const normalized = String(value).trim()
+  return normalized ? [normalized] : []
 }
 
 function toSearchParamValue(values: readonly string[]): ReadableFacetSearchValue | undefined {

--- a/dashboard/src/routes/logs.tsx
+++ b/dashboard/src/routes/logs.tsx
@@ -16,9 +16,14 @@
 
 import {createFileRoute, redirect} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
+import {useMemo} from 'react'
 import {api} from '@/lib/api'
 import {LogExplorer} from '@/components/logs/LogExplorer'
-import {parseLogViewSearch, type LogViewSearch} from '@/components/logs/logViewUrlState'
+import {
+  parseLogViewFacetFilters,
+  parseLogViewSearch,
+  type LogViewSearch,
+} from '@/components/logs/logViewUrlState'
 
 export const Route = createFileRoute('/logs')({
   validateSearch: (search: Record<string, unknown>): LogViewSearch => {
@@ -34,6 +39,10 @@ export const Route = createFileRoute('/logs')({
 
 function LogsPage() {
   const search = Route.useSearch()
+  const urlSearch = useMemo<LogViewSearch>(
+    () => ({...search, facets: parseLogViewFacetFilters(search)}),
+    [search]
+  )
   const {data: sdkVersionsResponse} = useQuery({
     queryKey: ['sdk-versions'],
     queryFn: () => api.getSdkVersions(),
@@ -54,7 +63,7 @@ function LogsPage() {
         sdkVersions={sdkVersionsResponse?.versions}
         className="h-full"
         enableUrlSync={true}
-        urlSearch={search}
+        urlSearch={urlSearch}
       />
     </div>
   )

--- a/dashboard/src/routes/performance.traces.index.tsx
+++ b/dashboard/src/routes/performance.traces.index.tsx
@@ -64,6 +64,7 @@ import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
 import type {FacetFilter, FacetRailSection, FacetSchema} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/performance/traces/')({
@@ -76,6 +77,7 @@ const DURATION_BAR_MAX_NS = 1_000_000_000
 const SEARCH_DEBOUNCE_MS = 300
 const KPI_CARD_COUNT = 6
 const SKELETON_TABLE_ROWS = 4
+const TRACE_FACET_URL_KEYS = ['service', 'operation', 'env', 'status', 'source'] as const
 
 const TIME_RANGE_OPTIONS: Array<{value: ApmTimeRange; label: string}> = [
   {value: '1h', label: 'Last hour'},
@@ -217,8 +219,12 @@ function PerformanceTracesPage() {
   const queryClient = useQueryClient()
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('24h')
   const [refresh, setRefresh] = useState<RefreshValue>('15s')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
-  const [search, setSearch] = useState('')
+  const {
+    query: search,
+    setQuery: setSearch,
+    facetFilters,
+    setFacetFilters,
+  } = useReadableFacetUrlState({facetKeys: TRACE_FACET_URL_KEYS})
   const [page, setPage] = useState(0)
   const [showErroringResources, setShowErroringResources] = useState(false)
   const [erroringResourcesScrollKey, setErroringResourcesScrollKey] = useState(0)

--- a/dashboard/src/routes/profiles.index.tsx
+++ b/dashboard/src/routes/profiles.index.tsx
@@ -17,6 +17,7 @@ import {FacetRail} from '@/components/filters/FacetRail'
 import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
 import {api, type ProfileServiceSummary} from '@/lib/api'
 import type {FacetFilter, FacetRailSection, FacetSchema} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/profiles/')({
@@ -24,6 +25,7 @@ export const Route = createFileRoute('/profiles/')({
 })
 
 type ProfilesView = 'services' | 'all'
+const PROFILE_FACET_URL_KEYS = ['service', 'type'] as const
 
 const PROFILE_FACET_SCHEMA = [
   {
@@ -45,8 +47,9 @@ const PROFILE_FACET_SCHEMA = [
 
 function ProfilesIndexPage() {
   const [view, setView] = useState<ProfilesView>('services')
-  const [query, setQuery] = useState('')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {query, setQuery, facetFilters, setFacetFilters} = useReadableFacetUrlState({
+    facetKeys: PROFILE_FACET_URL_KEYS,
+  })
 
   const {data: servicesData} = useQuery({
     queryKey: ['profileServices'],

--- a/dashboard/src/routes/profiles.service.$service.tsx
+++ b/dashboard/src/routes/profiles.service.$service.tsx
@@ -8,7 +8,7 @@
 
 import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
-import {useCallback, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useState} from 'react'
 import {Flame} from 'lucide-react'
 import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
@@ -17,6 +17,7 @@ import {TimeRangePicker} from '@/components/filters/TimeRangePicker'
 import {ServiceExplorer} from '@/components/profiling/ServiceExplorer'
 import {api, type ProfileServiceSummary} from '@/lib/api'
 import type {FacetFilter, FacetRailSection, FacetSchema} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 
 export const Route = createFileRoute('/profiles/service/$service')({
   component: ServiceExplorerPage,
@@ -25,6 +26,7 @@ export const Route = createFileRoute('/profiles/service/$service')({
 type ProfileRangeKey = '1h' | '6h' | '24h' | '7d'
 
 const DEFAULT_PROFILE_RANGE: ProfileRangeKey = '24h'
+const PROFILE_SERVICE_FACET_URL_KEYS = ['service', 'env', 'type'] as const
 const PROFILE_TIME_PRESETS: Array<{
   label: string
   value: ProfileRangeKey
@@ -43,17 +45,25 @@ function ServiceExplorerPage() {
 }
 
 function SeededServiceExplorerPage({routeService}: Readonly<{routeService: string}>) {
-  const [query, setQuery] = useState('')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>(() => [
-    serviceFacet(routeService),
-  ])
+  const defaultFacetFilters = useMemo(() => [serviceFacet(routeService)], [routeService])
+  const {query, setQuery, facetFilters, setFacetFilters} = useReadableFacetUrlState({
+    facetKeys: PROFILE_SERVICE_FACET_URL_KEYS,
+    defaultFacetFilters,
+  })
   const [timeRange, setTimeRange] = useState<ProfileRangeKey>(DEFAULT_PROFILE_RANGE)
   const handleFacetFiltersChange = useCallback(
     (filters: FacetFilter[]) => {
       setFacetFilters(lockServiceFacet(filters, routeService))
     },
-    [routeService],
+    [routeService, setFacetFilters],
   )
+
+  useEffect(() => {
+    const lockedFilters = lockServiceFacet(facetFilters, routeService)
+    if (JSON.stringify(lockedFilters) !== JSON.stringify(facetFilters)) {
+      setFacetFilters(lockedFilters)
+    }
+  }, [facetFilters, routeService, setFacetFilters])
 
   const {data: servicesData} = useQuery({
     queryKey: ['profileServices'],

--- a/dashboard/src/routes/releases.tsx
+++ b/dashboard/src/routes/releases.tsx
@@ -29,12 +29,13 @@ import {EmptyState} from '@/components/ui/empty-state'
 import {StatusDot} from '@/components/ui/status-dot'
 import {Activity, AlertCircle, Flame, Package, Search, ShieldCheck, Users} from 'lucide-react'
 import {
+  SERVICE_FACET_URL_KEYS,
   facetValues,
   serviceNamesForQuery,
   serviceRailSections,
   serviceScopeKey,
 } from '@/lib/service-facet-scope'
-import type {FacetFilter} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {parseDate} from '@/lib/date-format'
 
 export const Route = createFileRoute('/releases')({
@@ -73,9 +74,13 @@ function crashFreeTextClass(tone: CrashFreeTone): string {
 }
 
 function ReleasesPage() {
-  const [searchQuery, setSearchQuery] = useState('')
   const [sortBy, setSortBy] = useState<SortBy>('latest')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {
+    query: searchQuery,
+    setQuery: setSearchQuery,
+    facetFilters,
+    setFacetFilters,
+  } = useReadableFacetUrlState({facetKeys: SERVICE_FACET_URL_KEYS})
 
   const { data: projects, isLoading: projectsLoading, error: projectsError } = useQuery({
     queryKey: ['projects'],

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -25,6 +25,7 @@ import {type KeyboardEvent, useCallback, useMemo, useState} from 'react'
 import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {Badge} from '@/components/ui/badge'
 import {EmptyState} from '@/components/ui/empty-state'
 import {Avatar, AvatarFallback} from '@/components/ui/avatar'
@@ -51,6 +52,7 @@ import {
   Video,
 } from 'lucide-react'
 import {
+  SERVICE_FACET_URL_KEYS,
   facetValues,
   serviceNamesForQuery,
   serviceRailSections,
@@ -100,6 +102,7 @@ function formatDate(isoString: string, timezone: string) {
 
 type ReplayPeriod = '24h' | '7d' | '30d' | '90d'
 type ReplayView = 'all' | 'errors' | 'mobile'
+const REPLAY_FACET_URL_KEYS = [...SERVICE_FACET_URL_KEYS, 'environment'] as const
 
 export const replaysHelperTestHooks = {
   ReplaysLayout,
@@ -374,8 +377,12 @@ function ReplaysPage() {
   const { timezone } = useTimezone()
   const [period, setPeriod] = useState<ReplayPeriod>('7d')
   const [page, setPage] = useState(1)
-  const [searchQuery, setSearchQuery] = useState('')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {
+    query: searchQuery,
+    setQuery: setSearchQuery,
+    facetFilters,
+    setFacetFilters,
+  } = useReadableFacetUrlState({facetKeys: REPLAY_FACET_URL_KEYS})
   const [view, setView] = useState<ReplayView>('all')
 
   const { data: projects, isLoading: projectsLoading, error: projectsError } = useQuery({

--- a/dashboard/src/routes/resources.tsx
+++ b/dashboard/src/routes/resources.tsx
@@ -17,21 +17,66 @@
 import {createFileRoute, redirect} from '@tanstack/react-router'
 import {api} from '@/lib/api'
 import {MonitoringTabBar} from '@/components/monitoring/MonitoringTabBar'
-import {ResourceCatalog} from '@/components/monitoring/catalog/ResourceCatalog'
+import {ResourceCatalog, type ResourceCatalogUrlState} from '@/components/monitoring/catalog/ResourceCatalog'
+import {
+  clearReadableFacetSearch,
+  parseReadableFacetFilters,
+  type ReadableFacetSearchValue,
+  serializeReadableFacetFilters,
+} from '@/lib/filters/urlState'
+
+const RESOURCE_FACET_URL_KEYS = ['kind', 'env', 'health', 'team', 'cloud', 'tag'] as const
+
+type ResourceFacetUrlKey = (typeof RESOURCE_FACET_URL_KEYS)[number]
+type ResourceExcludeFacetUrlKey = `exclude_${ResourceFacetUrlKey}`
+
+type ResourcesSearch = {
+  q?: string
+} & Partial<Record<ResourceFacetUrlKey | ResourceExcludeFacetUrlKey, ReadableFacetSearchValue>>
+
+function parseResourcesSearch(search: Record<string, unknown>): ResourcesSearch {
+  const result: ResourcesSearch = {}
+  if (typeof search.q === 'string' && search.q.trim()) {
+    result.q = search.q.trim()
+  }
+  const facetFilters = parseReadableFacetFilters(search, RESOURCE_FACET_URL_KEYS)
+  if (facetFilters) {
+    Object.assign(result, serializeReadableFacetFilters(facetFilters, RESOURCE_FACET_URL_KEYS))
+  }
+  return result
+}
 
 // /resources sits outside the /monitoring layout, so it renders the shared
 // Infrastructure tab strip itself to stay in step with Map, Processes, etc.
 // The catalog already reserves the bar's 43px in its viewport height calc.
 function ResourcesPage() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const urlState: ResourceCatalogUrlState = {
+    query: search.q ?? '',
+    facetFilters: parseReadableFacetFilters(search, RESOURCE_FACET_URL_KEYS) ?? [],
+  }
+  const handleUrlStateChange = (next: ResourceCatalogUrlState) => {
+    navigate({
+      replace: true,
+      search: (prev) => ({
+        ...clearReadableFacetSearch(prev, RESOURCE_FACET_URL_KEYS),
+        q: next.query.trim() || undefined,
+        ...serializeReadableFacetFilters(next.facetFilters, RESOURCE_FACET_URL_KEYS),
+      }),
+    })
+  }
+
   return (
     <>
       <MonitoringTabBar />
-      <ResourceCatalog />
+      <ResourceCatalog urlState={urlState} onUrlStateChange={handleUrlStateChange} />
     </>
   )
 }
 
 export const Route = createFileRoute('/resources')({
+  validateSearch: parseResourcesSearch,
   beforeLoad: async () => {
     if (!api.isAuthenticated()) {
       const hasSession = await api.checkAuth()

--- a/dashboard/src/routes/resources.tsx
+++ b/dashboard/src/routes/resources.tsx
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {createFileRoute, redirect} from '@tanstack/react-router'
+import {useMemo} from 'react'
 import {api} from '@/lib/api'
 import {MonitoringTabBar} from '@/components/monitoring/MonitoringTabBar'
 import {ResourceCatalog, type ResourceCatalogUrlState} from '@/components/monitoring/catalog/ResourceCatalog'
@@ -34,6 +35,13 @@ type ResourcesSearch = {
   q?: string
 } & Partial<Record<ResourceFacetUrlKey | ResourceExcludeFacetUrlKey, ReadableFacetSearchValue>>
 
+function resourceCatalogUrlStateFromSearch(search: ResourcesSearch): ResourceCatalogUrlState {
+  return {
+    query: search.q ?? '',
+    facetFilters: parseReadableFacetFilters(search, RESOURCE_FACET_URL_KEYS) ?? [],
+  }
+}
+
 function parseResourcesSearch(search: Record<string, unknown>): ResourcesSearch {
   const result: ResourcesSearch = {}
   if (typeof search.q === 'string' && search.q.trim()) {
@@ -52,10 +60,11 @@ function parseResourcesSearch(search: Record<string, unknown>): ResourcesSearch 
 function ResourcesPage() {
   const search = Route.useSearch()
   const navigate = Route.useNavigate()
-  const urlState: ResourceCatalogUrlState = {
-    query: search.q ?? '',
-    facetFilters: parseReadableFacetFilters(search, RESOURCE_FACET_URL_KEYS) ?? [],
-  }
+  const urlStateKey = JSON.stringify(resourceCatalogUrlStateFromSearch(search))
+  const urlState = useMemo(
+    () => JSON.parse(urlStateKey) as ResourceCatalogUrlState,
+    [urlStateKey]
+  )
   const handleUrlStateChange = (next: ResourceCatalogUrlState) => {
     navigate({
       replace: true,

--- a/dashboard/src/routes/services.index.tsx
+++ b/dashboard/src/routes/services.index.tsx
@@ -44,6 +44,7 @@ import {
   statusTone,
 } from '@/lib/apm-view'
 import type {FacetFilter, FacetRailSection, FacetValue} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/services/')({
@@ -66,11 +67,13 @@ const SORT_OPTIONS: ReadonlyArray<{value: SortKey; label: string}> = [
   {value: 'apdex', label: 'Apdex'},
   {value: 'name', label: 'Name'},
 ]
+const SERVICES_FACET_URL_KEYS = ['env', 'type', 'source'] as const
 
 function ServicesCatalogPage() {
   const navigate = useNavigate()
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
-  const [query, setQuery] = useState('')
+  const {query, setQuery, facetFilters, setFacetFilters} = useReadableFacetUrlState({
+    facetKeys: SERVICES_FACET_URL_KEYS,
+  })
   const [sort, setSort] = useState<SortState>({key: 'error', dir: 'desc'})
   const [view, setView] = useState<'list' | 'map'>('list')
   const [timeRange, setTimeRange] = useState<ApmTimeRange>('1h')

--- a/dashboard/src/routes/synthetics.index.tsx
+++ b/dashboard/src/routes/synthetics.index.tsx
@@ -41,6 +41,7 @@ import {ExplorerShell} from '@/components/filters/ExplorerShell'
 import {FacetRail} from '@/components/filters/FacetRail'
 import {SearchFilterBar} from '@/components/filters/SearchFilterBar'
 import type {FacetFilter, FacetRailSection, FacetSchema} from '@/lib/filters/types'
+import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
 import {Checkbox} from '@/components/ui/checkbox'
@@ -54,6 +55,7 @@ export const Route = createFileRoute('/synthetics/')({
 })
 
 type DerivedStatus = 'passing' | 'failing' | 'degraded' | 'paused'
+const SYNTHETICS_FACET_URL_KEYS = ['service', 'type', 'location', 'tag'] as const
 
 const TYPE_ICON: Record<string, React.ComponentType<{className?: string}>> = {
   api: FlaskConical,
@@ -285,8 +287,12 @@ function SyntheticsOverview() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const {toast} = useToast()
-  const [searchQuery, setSearchQuery] = useState('')
-  const [facetFilters, setFacetFilters] = useState<FacetFilter[]>([])
+  const {
+    query: searchQuery,
+    setQuery: setSearchQuery,
+    facetFilters,
+    setFacetFilters,
+  } = useReadableFacetUrlState({facetKeys: SYNTHETICS_FACET_URL_KEYS})
   const [statusTab, setStatusTab] = useState<DerivedStatus | 'all'>('all')
   const [selected, setSelected] = useState<Set<string>>(new Set())
 

--- a/dashboard/src/test/setup.ts
+++ b/dashboard/src/test/setup.ts
@@ -29,7 +29,7 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   server.resetHandlers()
   cleanup()
-  window.history.replaceState(window.history.state, '', '/')
+  globalThis.window.history.replaceState(globalThis.window.history.state, '', '/')
 })
 
 // Cleanup MSW server after all tests

--- a/dashboard/src/test/setup.ts
+++ b/dashboard/src/test/setup.ts
@@ -29,6 +29,7 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   server.resetHandlers()
   cleanup()
+  window.history.replaceState(window.history.state, '', '/')
 })
 
 // Cleanup MSW server after all tests


### PR DESCRIPTION
## Summary
- normalize explorer facet filters into readable URL params
- use repeated params for multi-select facets
- preserve legacy facet links as input compatibility

## Verification\n- npm run test -- src/lib/__tests__/routerSearch.test.ts src/lib/filters/__tests__/urlState.test.ts src/components/logs/logViewUrlState.test.ts src/routes/__tests__/issues-index-coverage.test.tsx src/components/logs/__tests__/LogExplorer.facets.test.tsx src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx
- npm run typecheck
- npm run lint
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search queries and facet filters now synchronize with the URL across Logs, Issues, Analytics, Feedback, Traces, Profiles, Services, Releases, Replays, Resources, and Synthetics pages.
  * URLs now include readable filter parameters (e.g., `service=api`) alongside support for legacy filter formats.

* **Improvements**
  * Filter selections persist across page navigation and reloads.
  * URLs are now shareable with current search and filter state intact.
  * Enhanced backward compatibility for existing filter URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->