### PR TITLE
fix: make the dashboard usable on mobile viewports

### DIFF
--- a/dashboard/src/components/AiFloatingPanel.tsx
+++ b/dashboard/src/components/AiFloatingPanel.tsx
@@ -27,8 +27,15 @@ const RESIZE_HANDLE = 8
 
 export function AiFloatingPanel() {
   const palette = useCommandPalette()
-  const [pos, setPos] = useState({x: window.innerWidth - DEFAULT_WIDTH - 24, y: 80})
-  const [size, setSize] = useState({w: DEFAULT_WIDTH, h: DEFAULT_HEIGHT})
+  // Clamp the initial window to the viewport so it stays usable on small/mobile screens.
+  const [size, setSize] = useState(() => ({
+    w: Math.min(DEFAULT_WIDTH, window.innerWidth - 16),
+    h: Math.min(DEFAULT_HEIGHT, window.innerHeight - 96),
+  }))
+  const [pos, setPos] = useState(() => {
+    const w = Math.min(DEFAULT_WIDTH, window.innerWidth - 16)
+    return {x: Math.max(8, window.innerWidth - w - 24), y: 80}
+  })
   const dragOffset = useRef<{x: number; y: number} | null>(null)
   const resizeStart = useRef<{mx: number; my: number; w: number; h: number} | null>(null)
   const panelRef = useRef<HTMLDivElement>(null)

--- a/dashboard/src/components/AiFloatingPanel.tsx
+++ b/dashboard/src/components/AiFloatingPanel.tsx
@@ -25,31 +25,48 @@ const MIN_WIDTH = 300
 const MIN_HEIGHT = 360
 const RESIZE_HANDLE = 8
 
+function getViewportSize() {
+  const browserWindow = globalThis.window
+  return {
+    width: browserWindow?.innerWidth ?? DEFAULT_WIDTH + 16,
+    height: browserWindow?.innerHeight ?? DEFAULT_HEIGHT + 96,
+  }
+}
+
+function getInitialPanelSize() {
+  const {width, height} = getViewportSize()
+  return {
+    w: Math.min(DEFAULT_WIDTH, width - 16),
+    h: Math.min(DEFAULT_HEIGHT, height - 96),
+  }
+}
+
+function getInitialPanelPosition() {
+  const {width} = getViewportSize()
+  const w = Math.min(DEFAULT_WIDTH, width - 16)
+  return {x: Math.max(8, width - w - 24), y: 80}
+}
+
 export function AiFloatingPanel() {
   const palette = useCommandPalette()
   // Clamp the initial window to the viewport so it stays usable on small/mobile screens.
-  const [size, setSize] = useState(() => ({
-    w: Math.min(DEFAULT_WIDTH, window.innerWidth - 16),
-    h: Math.min(DEFAULT_HEIGHT, window.innerHeight - 96),
-  }))
-  const [pos, setPos] = useState(() => {
-    const w = Math.min(DEFAULT_WIDTH, window.innerWidth - 16)
-    return {x: Math.max(8, window.innerWidth - w - 24), y: 80}
-  })
+  const [size, setSize] = useState(getInitialPanelSize)
+  const [pos, setPos] = useState(getInitialPanelPosition)
   const dragOffset = useRef<{x: number; y: number} | null>(null)
   const resizeStart = useRef<{mx: number; my: number; w: number; h: number} | null>(null)
   const panelRef = useRef<HTMLDivElement>(null)
 
   // Keep panel within viewport on resize
   useEffect(() => {
+    const browserWindow = globalThis.window
     const onResize = () => {
       setPos((p) => ({
-        x: Math.min(p.x, window.innerWidth - size.w - 8),
-        y: Math.min(p.y, window.innerHeight - size.h - 8),
+        x: Math.min(p.x, browserWindow.innerWidth - size.w - 8),
+        y: Math.min(p.y, browserWindow.innerHeight - size.h - 8),
       }))
     }
-    window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
+    browserWindow.addEventListener('resize', onResize)
+    return () => browserWindow.removeEventListener('resize', onResize)
   }, [size])
 
   const startDrag = useCallback((e: React.MouseEvent) => {
@@ -59,17 +76,17 @@ export function AiFloatingPanel() {
     const onMove = (ev: MouseEvent) => {
       if (!dragOffset.current) return
       setPos({
-        x: Math.max(0, Math.min(ev.clientX - dragOffset.current.x, window.innerWidth - size.w)),
-        y: Math.max(0, Math.min(ev.clientY - dragOffset.current.y, window.innerHeight - size.h)),
+        x: Math.max(0, Math.min(ev.clientX - dragOffset.current.x, globalThis.window.innerWidth - size.w)),
+        y: Math.max(0, Math.min(ev.clientY - dragOffset.current.y, globalThis.window.innerHeight - size.h)),
       })
     }
     const onUp = () => {
       dragOffset.current = null
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
+      globalThis.window.removeEventListener('mousemove', onMove)
+      globalThis.window.removeEventListener('mouseup', onUp)
     }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
+    globalThis.window.addEventListener('mousemove', onMove)
+    globalThis.window.addEventListener('mouseup', onUp)
   }, [pos, size])
 
   const startResize = useCallback((e: React.MouseEvent) => {
@@ -87,11 +104,11 @@ export function AiFloatingPanel() {
     }
     const onUp = () => {
       resizeStart.current = null
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
+      globalThis.window.removeEventListener('mousemove', onMove)
+      globalThis.window.removeEventListener('mouseup', onUp)
     }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
+    globalThis.window.addEventListener('mousemove', onMove)
+    globalThis.window.addEventListener('mouseup', onUp)
   }, [size])
 
   if (!palette || palette.aiPanelMode !== 'float') return null

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useEffect, useState} from 'react'
+import {type ComponentType, useEffect, useState} from 'react'
 import {Link, useNavigate, useRouterState} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
@@ -95,9 +95,54 @@ interface SidebarProps {
   readonly onMobileOpenChange?: (open: boolean) => void
 }
 
+type NavGroupId = 'core' | 'infrastructure' | 'insights' | 'operations' | 'analytics' | 'management'
+
+interface NavItem {
+  key: string
+  icon: ComponentType<{className?: string}>
+  label: string
+  href: string
+  requiresProject: boolean
+  badge?: string
+  group: NavGroupId
+}
+
 function getInitials(name?: string) {
   if (!name) return 'U'
   return name.split(' ').map((n) => n[0]).join('').toUpperCase().slice(0, 2)
+}
+
+function isMoreSpecificActivePath(currentPath: string, item: NavItem, other: NavItem) {
+  if (other.href === item.href) return false
+  if (!other.href.startsWith(item.href + '/')) return false
+  return currentPath === other.href || currentPath.startsWith(other.href + '/')
+}
+
+function isNavItemActive(
+  currentPath: string,
+  currentSearch: unknown,
+  item: NavItem,
+  navItems: NavItem[],
+) {
+  if (item.href === APP_OVERVIEW_HREF) {
+    return currentPath === '/' && isAppOverviewSearch(currentSearch)
+  }
+
+  if (currentPath === item.href) return true
+  if (!currentPath.startsWith(item.href + '/')) return false
+  return !navItems.some((other) => isMoreSpecificActivePath(currentPath, item, other))
+}
+
+function FadingDivider() {
+  return (
+    <div
+      className="h-px my-1 bg-border shrink-0"
+      style={{
+        maskImage: 'linear-gradient(to right, transparent, black 15%, black 85%, transparent)',
+        WebkitMaskImage: 'linear-gradient(to right, transparent, black 15%, black 85%, transparent)',
+      }}
+    />
+  )
 }
 
 export function Sidebar({
@@ -187,18 +232,6 @@ export function Sidebar({
   const resetCreateForm = () => {
     setShowCreateDialog(false)
     createServiceMutation.reset()
-  }
-
-  type NavGroupId = 'core' | 'infrastructure' | 'insights' | 'operations' | 'analytics' | 'management'
-
-  interface NavItem {
-    key: string
-    icon: React.ComponentType<{className?: string}>
-    label: string
-    href: string
-    requiresProject: boolean
-    badge?: string
-    group: NavGroupId
   }
 
   const datadogCoreNavItems: NavItem[] = hasEnterpriseModule(features, 'datadog')
@@ -297,16 +330,10 @@ export function Sidebar({
     items: navItems.filter(item => item.group === groupId),
   })).filter(g => g.items.length > 0)
 
-
-  const FadingDivider = () => (
-    <div
-      className="h-px my-1 bg-border shrink-0"
-      style={{
-        maskImage: 'linear-gradient(to right, transparent, black 15%, black 85%, transparent)',
-        WebkitMaskImage: 'linear-gradient(to right, transparent, black 15%, black 85%, transparent)',
-      }}
-    />
-  )
+  const desktopSidebarWidthClassName = isExpanded ? 'w-44' : 'w-14'
+  const sidebarModeClassName = isMobile
+    ? cn('z-50 w-[min(82vw,288px)] shadow-2xl', !isMobileOpen && '-translate-x-full')
+    : cn('z-40 transition-all', desktopSidebarWidthClassName)
 
   const renderSidebarContent = () => (
     <>
@@ -387,16 +414,7 @@ export function Sidebar({
               )}
               <div className={cn('space-y-1')}>
                 {group.items.map((item) => {
-                  const isActive = item.href === APP_OVERVIEW_HREF
-                    ? currentPath === '/' && isAppOverviewSearch(router.location.search)
-                    : currentPath === item.href ||
-                      (currentPath.startsWith(item.href + '/') &&
-                        !navItems.some(
-                          (other) =>
-                            other.href !== item.href &&
-                            (currentPath === other.href || currentPath.startsWith(other.href + '/')) &&
-                            other.href.startsWith(item.href + '/')
-                        ))
+                  const isActive = isNavItemActive(currentPath, router.location.search, item, navItems)
                   const Icon = item.icon
 
                   const linkContent = (
@@ -579,7 +597,7 @@ export function Sidebar({
                   Settings
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={async () => { await api.logout(); window.location.href = '/login' }}>
+                <DropdownMenuItem onClick={async () => { await api.logout(); globalThis.window.location.href = '/login' }}>
                   <LogOut className="h-4 w-4 mr-2" />
                   Logout
                 </DropdownMenuItem>
@@ -611,9 +629,7 @@ export function Sidebar({
       <div
         className={cn(
           'sidebar fixed left-0 bg-card border-r flex flex-col transition-transform duration-300',
-          isMobile
-            ? cn('z-50 w-[min(82vw,288px)] shadow-2xl', !isMobileOpen && '-translate-x-full')
-            : cn('z-40 transition-all', isExpanded ? 'w-44' : 'w-14')
+          sidebarModeClassName
         )}
         style={{top: headerHeight, height: `calc(100dvh - ${headerHeight}px)`}}
         inert={isMobile && !isMobileOpen ? true : undefined}

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -54,6 +54,7 @@ import {
     Sparkles,
     Timer,
     Workflow,
+    X,
 } from 'lucide-react'
 import {cn} from '@/lib/utils'
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip'
@@ -86,6 +87,12 @@ interface SidebarProps {
   readonly isExpanded: boolean
   readonly onExpandedChange: (expanded: boolean) => void
   readonly headerHeight: number
+  /** Render as an off-canvas drawer (viewport below the `md` breakpoint). */
+  readonly isMobile?: boolean
+  /** Whether the mobile drawer is currently open. */
+  readonly isMobileOpen?: boolean
+  /** Toggle the mobile drawer open/closed. */
+  readonly onMobileOpenChange?: (open: boolean) => void
 }
 
 function getInitials(name?: string) {
@@ -93,10 +100,21 @@ function getInitials(name?: string) {
   return name.split(' ').map((n) => n[0]).join('').toUpperCase().slice(0, 2)
 }
 
-export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarProps) {
+export function Sidebar({
+  isExpanded,
+  onExpandedChange,
+  headerHeight,
+  isMobile = false,
+  isMobileOpen = false,
+  onMobileOpenChange,
+}: SidebarProps) {
   const router = useRouterState()
   const currentPath = router.location.pathname
   const navigate = useNavigate()
+  // In the mobile drawer the rail is always full-width with labels; the
+  // collapsed icon-only rail is a desktop-only affordance.
+  const expanded = isMobile ? true : isExpanded
+  const closeMobileDrawer = () => onMobileOpenChange?.(false)
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const { data: features } = useEnterpriseFeatures()
@@ -293,18 +311,29 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
   const renderSidebarContent = () => (
     <>
       {/* Logo at top */}
-      <div className={cn('shrink-0 border-b flex items-center justify-center h-[var(--app-header-h)]', isExpanded ? 'px-2.5' : 'px-1.5')}>
+      <div className={cn('shrink-0 border-b flex items-center h-[var(--app-header-h)]', expanded ? 'px-2.5' : 'px-1.5', expanded && isMobile ? 'justify-between' : 'justify-center')}>
         <Link
           to="/"
           search={APP_OVERVIEW_SEARCH}
+          onClick={closeMobileDrawer}
           className="flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-ring rounded"
         >
-          {isExpanded ? <Logo className="h-6" /> : <Logo markOnly className="h-6 w-8" />}
+          {expanded ? <Logo className="h-6" /> : <Logo markOnly className="h-6 w-8" />}
         </Link>
+        {isMobile && (
+          <button
+            type="button"
+            onClick={closeMobileDrawer}
+            aria-label="Close navigation"
+            className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        )}
       </div>
       {/* Search bar */}
       <div className="shrink-0 border-b flex items-center h-[var(--app-subheader-h)] px-1.5">
-        {isExpanded ? (
+        {expanded ? (
           <button
             type="button"
             onClick={() => openPalette?.()}
@@ -339,17 +368,17 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
       {/* Navigation Items */}
       <nav
         className={cn(
-          'flex-1 overflow-y-auto overscroll-contain',
-          isExpanded
+          'min-h-0 flex-1 overflow-y-auto overscroll-contain',
+          expanded
             ? 'p-1.5'
             : 'py-1.5 [&::-webkit-scrollbar]:hidden [scrollbar-width:none] [-ms-overflow-style:none]'
         )}
       >
-        <div className={cn(!isExpanded && 'px-1.5')}>
+        <div className={cn(!expanded && 'px-1.5')}>
           {navGroups.map((group, groupIndex) => (
             <div key={group.id}>
               {groupIndex > 0 && <FadingDivider />}
-              {isExpanded && (
+              {expanded && (
                 <div className="px-2.5 pt-0.5 pb-0.5">
                   <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
                     {group.label}
@@ -374,19 +403,21 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                     <Link
                       key={item.href}
                       to={item.href}
+                      onClick={closeMobileDrawer}
                       className={cn(
-                        'flex items-center gap-2 py-1.5 rounded-md transition-colors',
-                        isExpanded ? 'px-2.5' : 'px-1.5',
+                        'flex items-center gap-2 rounded-md transition-colors',
+                        isMobile ? 'py-2.5' : 'py-1.5',
+                        expanded ? 'px-2.5' : 'px-1.5',
                         isActive
                           ? 'bg-[hsl(var(--sidebar-active))] text-[hsl(var(--sidebar-active-foreground))]'
                           : 'hover:bg-accent text-muted-foreground hover:text-foreground',
-                        !isExpanded && 'justify-center'
+                        !expanded && 'justify-center'
                       )}
                     >
-                      <Icon className="h-4 w-4 flex-shrink-0" />
-                      {isExpanded && (
+                      <Icon className={cn('flex-shrink-0', isMobile ? 'h-[18px] w-[18px]' : 'h-4 w-4')} />
+                      {expanded && (
                         <div className="flex items-center gap-1.5 flex-1">
-                          <span className="text-xs font-medium">{item.label}</span>
+                          <span className={cn('font-medium', isMobile ? 'text-sm' : 'text-xs')}>{item.label}</span>
                           {item.badge && (
                             <Badge variant="secondary" className="h-3 px-1 text-[9px] font-medium">
                               {item.badge}
@@ -397,7 +428,7 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                     </Link>
                   )
 
-                  if (!isExpanded) {
+                  if (!expanded) {
                     return (
                       <Tooltip key={item.href}>
                         <TooltipTrigger asChild>
@@ -419,8 +450,8 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
       </nav>
 
       {/* Bottom Section - compact single row when expanded */}
-      <div className={cn('border-t p-1.5', isExpanded ? 'py-1' : 'space-y-0.5')}>
-        {isExpanded ? (
+      <div className={cn('shrink-0 border-t p-1.5', expanded ? 'py-1' : 'space-y-0.5')}>
+        {expanded ? (
           <div className="flex items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -448,21 +479,23 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
                 <p>Docs</p>
               </TooltipContent>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-                  onClick={() => onExpandedChange(false)}
-                >
-                  <ChevronLeft className="h-3.5 w-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                <p>Collapse</p>
-              </TooltipContent>
-            </Tooltip>
+            {!isMobile && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={() => onExpandedChange(false)}
+                  >
+                    <ChevronLeft className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  <p>Collapse</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
             <div className="ml-auto shrink-0">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -560,13 +593,30 @@ export function Sidebar({ isExpanded, onExpandedChange, headerHeight }: SidebarP
 
   return (
     <>
-      {/* Fixed Sidebar */}
+      {/* Mobile drawer backdrop */}
+      {isMobile && (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-hidden={!isMobileOpen}
+          onClick={closeMobileDrawer}
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-40 bg-black/50 transition-opacity duration-300',
+            isMobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+          )}
+          style={{top: headerHeight}}
+        />
+      )}
+      {/* Fixed sidebar (desktop rail) / off-canvas drawer (mobile) */}
       <div
         className={cn(
-          'sidebar fixed left-0 bg-card border-r flex flex-col transition-all duration-300 z-40',
-          isExpanded ? 'w-44' : 'w-14'
+          'sidebar fixed left-0 bg-card border-r flex flex-col transition-transform duration-300',
+          isMobile
+            ? cn('z-50 w-[min(82vw,288px)] shadow-2xl', !isMobileOpen && '-translate-x-full')
+            : cn('z-40 transition-all', isExpanded ? 'w-44' : 'w-14')
         )}
-        style={{top: headerHeight, height: `calc(100vh - ${headerHeight}px)`}}
+        style={{top: headerHeight, height: `calc(100dvh - ${headerHeight}px)`}}
+        inert={isMobile && !isMobileOpen ? true : undefined}
       >
         {renderSidebarContent()}
       </div>

--- a/dashboard/src/components/__tests__/AiFloatingPanel.test.tsx
+++ b/dashboard/src/components/__tests__/AiFloatingPanel.test.tsx
@@ -1,0 +1,43 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {render} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+
+import {AiFloatingPanel} from '@/components/AiFloatingPanel'
+
+describe('AiFloatingPanel', () => {
+  it('renders nothing when no floating panel is active', () => {
+    // With no command-palette provider the panel bails out, but its size/position
+    // state initializers (clamped to the viewport for small screens) still run.
+    const {container} = render(<AiFloatingPanel />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('clamps its initial geometry to a narrow viewport without throwing', () => {
+    const originalWidth = window.innerWidth
+    const originalHeight = window.innerHeight
+    try {
+      Object.defineProperty(window, 'innerWidth', {configurable: true, value: 360})
+      Object.defineProperty(window, 'innerHeight', {configurable: true, value: 640})
+      const {container} = render(<AiFloatingPanel />)
+      expect(container).toBeEmptyDOMElement()
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {configurable: true, value: originalWidth})
+      Object.defineProperty(window, 'innerHeight', {configurable: true, value: originalHeight})
+    }
+  })
+})

--- a/dashboard/src/components/__tests__/AiFloatingPanel.test.tsx
+++ b/dashboard/src/components/__tests__/AiFloatingPanel.test.tsx
@@ -19,6 +19,15 @@ import {describe, expect, it} from 'vitest'
 
 import {AiFloatingPanel} from '@/components/AiFloatingPanel'
 
+function restoreWindowProperty(property: keyof Window, descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(globalThis.window, property, descriptor)
+    return
+  }
+
+  delete (globalThis.window as Partial<Window>)[property]
+}
+
 describe('AiFloatingPanel', () => {
   it('renders nothing when no floating panel is active', () => {
     // With no command-palette provider the panel bails out, but its size/position
@@ -28,16 +37,16 @@ describe('AiFloatingPanel', () => {
   })
 
   it('clamps its initial geometry to a narrow viewport without throwing', () => {
-    const originalWidth = window.innerWidth
-    const originalHeight = window.innerHeight
+    const originalWidth = Object.getOwnPropertyDescriptor(globalThis.window, 'innerWidth')
+    const originalHeight = Object.getOwnPropertyDescriptor(globalThis.window, 'innerHeight')
     try {
-      Object.defineProperty(window, 'innerWidth', {configurable: true, value: 360})
-      Object.defineProperty(window, 'innerHeight', {configurable: true, value: 640})
+      Object.defineProperty(globalThis.window, 'innerWidth', {configurable: true, value: 360})
+      Object.defineProperty(globalThis.window, 'innerHeight', {configurable: true, value: 640})
       const {container} = render(<AiFloatingPanel />)
       expect(container).toBeEmptyDOMElement()
     } finally {
-      Object.defineProperty(window, 'innerWidth', {configurable: true, value: originalWidth})
-      Object.defineProperty(window, 'innerHeight', {configurable: true, value: originalHeight})
+      restoreWindowProperty('innerWidth', originalWidth)
+      restoreWindowProperty('innerHeight', originalHeight)
     }
   })
 })

--- a/dashboard/src/components/__tests__/Sidebar.test.tsx
+++ b/dashboard/src/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,128 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {fireEvent, screen} from '@testing-library/react'
+import type {ReactNode} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {Sidebar} from '@/components/Sidebar'
+import {TooltipProvider} from '@/components/ui/tooltip'
+import {renderWithQueryClient} from '@/test/utils'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const React = await import('react')
+  return {
+    ...actual,
+    Link: ({
+      to,
+      onClick,
+      className,
+      children,
+    }: {
+      to?: string
+      onClick?: () => void
+      className?: string
+      children: ReactNode
+    }) => React.createElement('a', {href: typeof to === 'string' ? to : '#', onClick, className}, children),
+    useNavigate: () => mockNavigate,
+    useRouterState: () => ({location: {pathname: '/', search: {}}}),
+  }
+})
+
+// The sidebar fetches enterprise features through react-query; stub the hook so
+// the component renders offline and the enterprise-gated items stay hidden.
+vi.mock('@/hooks/useEnterpriseFeatures', () => ({
+  useEnterpriseFeatures: () => ({data: undefined}),
+  hasEnterpriseModule: () => false,
+}))
+
+vi.mock('@/components/ThemeSwitcher', async () => {
+  const React = await import('react')
+  return {ThemeSwitcher: () => React.createElement('button', {type: 'button'}, 'theme')}
+})
+
+type SidebarProps = Parameters<typeof Sidebar>[0]
+
+function renderSidebar(props: Partial<SidebarProps> = {}) {
+  const merged: SidebarProps = {
+    isExpanded: true,
+    onExpandedChange: vi.fn(),
+    headerHeight: 48,
+    ...props,
+  }
+  return renderWithQueryClient(
+    <TooltipProvider>
+      <Sidebar {...merged} />
+    </TooltipProvider>,
+  )
+}
+
+function sidebarEl(container: HTMLElement) {
+  return container.querySelector('.sidebar') as HTMLElement
+}
+
+describe('Sidebar', () => {
+  it('renders the full-width drawer on mobile and closes it on navigation', () => {
+    const onMobileOpenChange = vi.fn()
+    renderSidebar({isMobile: true, isMobileOpen: true, onMobileOpenChange, isExpanded: false})
+
+    // Mobile forces the expanded layout, so group labels are visible.
+    expect(screen.getByText('Observability')).toBeInTheDocument()
+    expect(screen.getByText('Management')).toBeInTheDocument()
+
+    // The dedicated close affordance only exists in the mobile drawer.
+    fireEvent.click(screen.getByRole('button', {name: /close navigation/i}))
+    expect(onMobileOpenChange).toHaveBeenCalledWith(false)
+
+    // Tapping a nav link also dismisses the drawer.
+    fireEvent.click(screen.getByRole('link', {name: /Overview/i}))
+    expect(onMobileOpenChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('translates the drawer off-canvas when closed on mobile', () => {
+    const {container} = renderSidebar({
+      isMobile: true,
+      isMobileOpen: false,
+      onMobileOpenChange: vi.fn(),
+      isExpanded: false,
+    })
+
+    const el = sidebarEl(container)
+    expect(el.className).toContain('-translate-x-full')
+    // Height tracks the dynamic viewport so the Management group never falls
+    // behind a mobile browser's bottom toolbar.
+    expect(el.style.height).toContain('100dvh')
+  })
+
+  it('renders the expanded desktop rail with the collapse control', () => {
+    renderSidebar({isMobile: false, isExpanded: true, onExpandedChange: vi.fn()})
+
+    expect(screen.getByText('Management')).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /Setup/i})).toBeInTheDocument()
+  })
+
+  it('renders the collapsed icon rail without group labels', () => {
+    const {container} = renderSidebar({isMobile: false, isExpanded: false, onExpandedChange: vi.fn()})
+
+    const el = sidebarEl(container)
+    expect(el.className).toContain('w-14')
+    // Group labels are hidden in the collapsed rail.
+    expect(screen.queryByText('Management')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/analytics/product/ProductAnalyticsView.tsx
+++ b/dashboard/src/components/analytics/product/ProductAnalyticsView.tsx
@@ -77,12 +77,12 @@ export function ProductAnalyticsView({
     <div className="space-y-3">
       <ProductKpiBand data={summary.data} isLoading={summary.isLoading} />
 
-      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.85fr)_minmax(0,1fr)]">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1.85fr)_minmax(0,1fr)]">
         <ProductActivityChart data={activity.data} isLoading={activity.isLoading} />
         <ProductMovers data={movers.data} isLoading={movers.isLoading} />
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
         <ProductActivationFunnel scopeId={scopeId} params={params} />
         <ProductEventTrends data={eventTrends.data} isLoading={eventTrends.isLoading} />
       </div>

--- a/dashboard/src/components/dashboards/DashboardGrid.tsx
+++ b/dashboard/src/components/dashboards/DashboardGrid.tsx
@@ -31,6 +31,19 @@ const GRID_COLS = {lg: 12, md: 12, sm: 12, xs: 6}
 const GRID_MARGIN: [number, number] = [12, 12]
 const LEGACY_SMALL_WIDGET_TYPES = new Set(['stat', 'gauge', 'bargauge'])
 
+// Below this container width the drag-grid is replaced by a simple stacked layout:
+// small KPI/stat tiles sit two-up, everything else spans the full width.
+const MOBILE_STACK_MAX_WIDTH = 640
+const SMALL_MOBILE_WIDGET_TYPES = new Set(['stat', 'gauge', 'bargauge', 'kpi'])
+
+function mobileWidgetHeightPx(widget: DashboardWidget): number | undefined {
+  if (widget.widget_type === 'section') return 36
+  // Banner / text size to their own content so wrapped lines aren't clipped.
+  if (widget.widget_type === 'system_status' || widget.widget_type === 'text') return undefined
+  const rows = widget.grid_h
+  return Math.max(rows * 40 + (rows - 1) * 12, 100)
+}
+
 interface DashboardGridProps {
   widgets: DashboardWidget[]
   isEditing: boolean
@@ -258,6 +271,51 @@ export function DashboardGrid({
     return (
       <div className="flex items-center justify-center py-16 text-muted-foreground text-sm">
         This dashboard has no widgets yet. Click Edit to add some.
+      </div>
+    )
+  }
+
+  // Mobile: drop the drag-grid and stack widgets. Small KPI/stat tiles share a
+  // two-column row; charts, tables and sections take the full width.
+  if (width > 0 && width < MOBILE_STACK_MAX_WIDTH) {
+    return (
+      <div ref={containerRef} className="relative z-0 w-full">
+        <div className="grid grid-cols-2 items-start gap-3">
+          {visibleWidgets.map((widget) => {
+            const isSmall = SMALL_MOBILE_WIDGET_TYPES.has(widget.widget_type)
+            const widgetHeight = mobileWidgetHeightPx(widget)
+            return (
+              <div
+                key={String(widget.id)}
+                className={isSmall ? 'min-w-0' : 'col-span-2 min-w-0'}
+                style={widgetHeight === undefined ? undefined : {height: widgetHeight}}
+              >
+                {widget.widget_type === 'section' ? (
+                  <SectionHeader
+                    widget={widget}
+                    isEditing={false}
+                    isCollapsed={collapsedSections.has(widget.id)}
+                    onToggle={() => toggleSection(widget.id)}
+                    onDelete={() => onWidgetDelete(widget.id)}
+                  />
+                ) : (
+                  <WidgetCard
+                    widget={widget}
+                    isEditing={false}
+                    dashboardId={dashboardId}
+                    projectId={projectId}
+                    timeRange={timeRange}
+                    autoRefresh={autoRefresh}
+                    variableValues={variableValues}
+                    alerts={alerts}
+                    onWidgetClick={onWidgetClick}
+                    onWidgetDelete={onWidgetDelete}
+                  />
+                )}
+              </div>
+            )
+          })}
+        </div>
       </div>
     )
   }

--- a/dashboard/src/components/dashboards/DashboardGrid.tsx
+++ b/dashboard/src/components/dashboards/DashboardGrid.tsx
@@ -79,6 +79,15 @@ type WidgetCardProps = Readonly<{
   onWidgetDelete: (widgetId: string) => void
 }>
 
+type SectionHeaderProps = Readonly<{
+  widget: DashboardWidget
+  isEditing: boolean
+  showDragHandle: boolean
+  isCollapsed: boolean
+  onToggle: () => void
+  onDelete: () => void
+}>
+
 function widgetMinHeight(widgetType: DashboardWidget['widget_type']): number {
   if (widgetType === 'section') return 1
   if (isOverviewWidgetType(widgetType)) return overviewWidgetDef(widgetType)?.minH ?? 4
@@ -386,14 +395,7 @@ function SectionHeader({
   isCollapsed,
   onToggle,
   onDelete,
-}: {
-  widget: DashboardWidget
-  isEditing: boolean
-  showDragHandle: boolean
-  isCollapsed: boolean
-  onToggle: () => void
-  onDelete: () => void
-}) {
+}: SectionHeaderProps) {
   return (
     <div className="h-full flex items-center gap-2 px-1">
       {showDragHandle && (

--- a/dashboard/src/components/dashboards/DashboardGrid.tsx
+++ b/dashboard/src/components/dashboards/DashboardGrid.tsx
@@ -68,6 +68,7 @@ type WidgetCardAlert = {
 type WidgetCardProps = Readonly<{
   widget: DashboardWidget
   isEditing: boolean
+  showDragHandle: boolean
   dashboardId: string
   projectId?: string
   timeRange: TimeRangeDef
@@ -287,13 +288,14 @@ export function DashboardGrid({
             return (
               <div
                 key={String(widget.id)}
-                className={isSmall ? 'min-w-0' : 'col-span-2 min-w-0'}
+                className={`group ${isSmall ? 'min-w-0' : 'col-span-2 min-w-0'}`}
                 style={widgetHeight === undefined ? undefined : {height: widgetHeight}}
               >
                 {widget.widget_type === 'section' ? (
                   <SectionHeader
                     widget={widget}
-                    isEditing={false}
+                    isEditing={isEditing}
+                    showDragHandle={false}
                     isCollapsed={collapsedSections.has(widget.id)}
                     onToggle={() => toggleSection(widget.id)}
                     onDelete={() => onWidgetDelete(widget.id)}
@@ -301,7 +303,8 @@ export function DashboardGrid({
                 ) : (
                   <WidgetCard
                     widget={widget}
-                    isEditing={false}
+                    isEditing={isEditing}
+                    showDragHandle={false}
                     dashboardId={dashboardId}
                     projectId={projectId}
                     timeRange={timeRange}
@@ -349,6 +352,7 @@ export function DashboardGrid({
             <SectionHeader
               widget={widget}
               isEditing={isEditing}
+              showDragHandle={isEditing}
               isCollapsed={collapsedSections.has(widget.id)}
               onToggle={() => toggleSection(widget.id)}
               onDelete={() => onWidgetDelete(widget.id)}
@@ -357,6 +361,7 @@ export function DashboardGrid({
             <WidgetCard
               widget={widget}
               isEditing={isEditing}
+              showDragHandle={isEditing}
               dashboardId={dashboardId}
               projectId={projectId}
               timeRange={timeRange}
@@ -377,19 +382,21 @@ export function DashboardGrid({
 function SectionHeader({
   widget,
   isEditing,
+  showDragHandle,
   isCollapsed,
   onToggle,
   onDelete,
 }: {
   widget: DashboardWidget
   isEditing: boolean
+  showDragHandle: boolean
   isCollapsed: boolean
   onToggle: () => void
   onDelete: () => void
 }) {
   return (
     <div className="h-full flex items-center gap-2 px-1">
-      {isEditing && (
+      {showDragHandle && (
         <div className="drag-handle cursor-grab active:cursor-grabbing shrink-0">
           <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
         </div>
@@ -411,7 +418,7 @@ function SectionHeader({
             e.stopPropagation()
             onDelete()
           }}
-          className="p-1 rounded text-destructive hover:bg-destructive/10 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+          className="p-1 rounded text-destructive hover:bg-destructive/10 opacity-100 transition-opacity shrink-0 md:opacity-0 md:group-hover:opacity-100"
         >
           <Trash2 className="h-3 w-3" />
         </button>
@@ -423,6 +430,7 @@ function SectionHeader({
 function WidgetCard({
   widget,
   isEditing,
+  showDragHandle,
   dashboardId,
   projectId,
   timeRange,
@@ -438,10 +446,12 @@ function WidgetCard({
     return (
       <div className="relative h-full" style={{contain: 'style'}}>
         {isEditing && (
-          <div className="absolute right-1 top-1 z-10 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-            <div className="drag-handle cursor-grab rounded border bg-background/90 p-1 shadow-sm active:cursor-grabbing">
-              <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
-            </div>
+          <div className="absolute right-1 top-1 z-10 flex items-center gap-1 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
+            {showDragHandle && (
+              <div className="drag-handle cursor-grab rounded border bg-background/90 p-1 shadow-sm active:cursor-grabbing">
+                <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+              </div>
+            )}
             <button
               type="button"
               aria-label={`Delete ${widget.title ?? 'widget'}`}
@@ -476,7 +486,7 @@ function WidgetCard({
     >
       <div className="flex items-center justify-between px-3 py-2 border-b bg-muted/30 min-h-[36px]">
         <div className="flex items-center gap-1.5 min-w-0 flex-1">
-          {isEditing && (
+          {showDragHandle && (
             <div className="drag-handle cursor-grab active:cursor-grabbing">
               <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
             </div>
@@ -512,7 +522,7 @@ function WidgetCard({
           })()}
         </div>
         {isEditing && (
-          <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <div className="flex items-center gap-1 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
             <button
               onClick={(e) => {
                 e.stopPropagation()

--- a/dashboard/src/components/dashboards/DashboardsBoardsPanel.tsx
+++ b/dashboard/src/components/dashboards/DashboardsBoardsPanel.tsx
@@ -66,7 +66,9 @@ const SORT_LABELS: Record<SortKey, string> = {
   created: 'Recently created',
 }
 
-const LIST_GRID = 'grid-cols-[26px_56px_1fr_78px_104px_44px_30px]'
+// Mobile collapses to star · name · actions; the metadata columns return at `sm`.
+const LIST_GRID =
+  'grid-cols-[26px_minmax(0,1fr)_30px] sm:grid-cols-[26px_56px_1fr_78px_104px_44px_30px]'
 
 // Categorical palette for folder swatches / owner avatars (identity, not status).
 const SWATCHES = [
@@ -533,11 +535,11 @@ function ListView({dashboards, folders, now, ...actions}: BoardViewProps) {
         )}
       >
         <span />
-        <span />
+        <span className="hidden sm:block" />
         <span>Name</span>
-        <span className="text-right">Widgets</span>
-        <span className="text-right">Updated</span>
-        <span className="text-right">Owner</span>
+        <span className="hidden text-right sm:block">Widgets</span>
+        <span className="hidden text-right sm:block">Updated</span>
+        <span className="hidden text-right sm:block">Owner</span>
         <span />
       </div>
       <div className="overflow-hidden rounded-lg border bg-card">
@@ -582,7 +584,7 @@ const DashboardListRow = memo(function DashboardListRow({
       <Link
         to="/dashboards/$dashboardId"
         params={{dashboardId: String(dashboard.id)}}
-        className="col-span-5 grid grid-cols-[56px_1fr_78px_104px_44px] items-center gap-2 text-foreground no-underline"
+        className="col-span-1 grid grid-cols-[56px_minmax(0,1fr)] items-center gap-2 text-foreground no-underline sm:col-span-5 sm:grid-cols-[56px_1fr_78px_104px_44px]"
       >
         <span className="block h-9 w-14 overflow-hidden rounded-sm border border-border/60 bg-[hsl(var(--viz-surface))]">
           <SparkThumb kind={thumb} />
@@ -615,11 +617,11 @@ const DashboardListRow = memo(function DashboardListRow({
             ))}
           </span>
         </span>
-        <span className="text-right font-mono text-xs text-foreground">{dashboard.widgets.length}</span>
-        <span className="text-right text-xs tabular-nums text-muted-foreground">
+        <span className="hidden text-right font-mono text-xs text-foreground sm:block">{dashboard.widgets.length}</span>
+        <span className="hidden text-right text-xs tabular-nums text-muted-foreground sm:block">
           {formatRelative(now, dashboard.updated_at)}
         </span>
-        <span className="flex justify-end">
+        <span className="hidden justify-end sm:flex">
           <OwnerAvatar owner={owner} />
         </span>
       </Link>

--- a/dashboard/src/components/dashboards/__tests__/DashboardGrid.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DashboardGrid.test.tsx
@@ -253,4 +253,40 @@ describe('DashboardGrid', () => {
       expect.objectContaining({id: WIDGET_ID, grid_x: 1, grid_y: 2, grid_w: 5, grid_h: 4}),
     ])
   })
+
+  it('stacks widgets instead of the drag-grid at mobile container widths', () => {
+    // Force a narrow container so the grid drops the drag layout and stacks.
+    const proto = HTMLElement.prototype
+    const original = Object.getOwnPropertyDescriptor(proto, 'offsetWidth')
+    Object.defineProperty(proto, 'offsetWidth', {configurable: true, get: () => 400})
+
+    try {
+      const {container} = render(
+        <DashboardGrid
+          widgets={[
+            {...widget, id: 'w-stat', widget_type: 'stat', title: 'Error rate'},
+            widget,
+          ]}
+          isEditing={false}
+          dashboardId={DASHBOARD_ID}
+          timeRange={{from: 'now-24h', to: 'now'}}
+          autoRefresh={false}
+          onLayoutChange={vi.fn()}
+          onWidgetClick={vi.fn()}
+          onWidgetDelete={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByTestId('responsive-grid-layout')).not.toBeInTheDocument()
+      expect(container.querySelector('.grid-cols-2')).toBeInTheDocument()
+      expect(screen.getByText('Dependency p95 check latency')).toBeInTheDocument()
+      expect(screen.getByText('Error rate')).toBeInTheDocument()
+    } finally {
+      if (original) {
+        Object.defineProperty(proto, 'offsetWidth', original)
+      } else {
+        delete (proto as {offsetWidth?: number}).offsetWidth
+      }
+    }
+  })
 })

--- a/dashboard/src/components/dashboards/__tests__/DashboardGrid.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/DashboardGrid.test.tsx
@@ -115,6 +115,22 @@ beforeEach(() => {
   queryState.alerts = []
 })
 
+function withContainerWidth(width: number, run: () => void) {
+  const proto = HTMLElement.prototype
+  const original = Object.getOwnPropertyDescriptor(proto, 'offsetWidth')
+  Object.defineProperty(proto, 'offsetWidth', {configurable: true, get: () => width})
+
+  try {
+    run()
+  } finally {
+    if (original) {
+      Object.defineProperty(proto, 'offsetWidth', original)
+    } else {
+      delete (proto as {offsetWidth?: number}).offsetWidth
+    }
+  }
+}
+
 describe('DashboardGrid', () => {
   it('keeps widget stacking inside the grid container', () => {
     const onLayoutChange = vi.fn()
@@ -255,12 +271,7 @@ describe('DashboardGrid', () => {
   })
 
   it('stacks widgets instead of the drag-grid at mobile container widths', () => {
-    // Force a narrow container so the grid drops the drag layout and stacks.
-    const proto = HTMLElement.prototype
-    const original = Object.getOwnPropertyDescriptor(proto, 'offsetWidth')
-    Object.defineProperty(proto, 'offsetWidth', {configurable: true, get: () => 400})
-
-    try {
+    withContainerWidth(400, () => {
       const {container} = render(
         <DashboardGrid
           widgets={[
@@ -281,12 +292,37 @@ describe('DashboardGrid', () => {
       expect(container.querySelector('.grid-cols-2')).toBeInTheDocument()
       expect(screen.getByText('Dependency p95 check latency')).toBeInTheDocument()
       expect(screen.getByText('Error rate')).toBeInTheDocument()
-    } finally {
-      if (original) {
-        Object.defineProperty(proto, 'offsetWidth', original)
-      } else {
-        delete (proto as {offsetWidth?: number}).offsetWidth
-      }
-    }
+    })
+  })
+
+  it('keeps edit controls available in the mobile stack', () => {
+    const onWidgetClick = vi.fn()
+    const onWidgetDelete = vi.fn()
+
+    withContainerWidth(400, () => {
+      render(
+        <DashboardGrid
+          widgets={[widget]}
+          isEditing={true}
+          dashboardId={DASHBOARD_ID}
+          timeRange={{from: 'now-24h', to: 'now'}}
+          autoRefresh={false}
+          onLayoutChange={vi.fn()}
+          onWidgetClick={onWidgetClick}
+          onWidgetDelete={onWidgetDelete}
+        />
+      )
+
+      expect(screen.queryByTestId('responsive-grid-layout')).not.toBeInTheDocument()
+      const editButton = screen.getByText('Edit')
+      expect(editButton.parentElement).toHaveClass('opacity-100')
+
+      fireEvent.click(editButton)
+      expect(onWidgetClick).toHaveBeenCalledWith(expect.objectContaining({id: WIDGET_ID}))
+
+      const buttons = screen.getAllByRole('button')
+      fireEvent.click(buttons[buttons.length - 1])
+      expect(onWidgetDelete).toHaveBeenCalledWith(WIDGET_ID)
+    })
   })
 })

--- a/dashboard/src/components/filters/ExplorerShell.tsx
+++ b/dashboard/src/components/filters/ExplorerShell.tsx
@@ -19,6 +19,7 @@ import type {ReactNode} from 'react'
 import {PanelLeftClose, PanelLeftOpen} from 'lucide-react'
 
 import {cn} from '@/lib/utils'
+import {useIsMobile} from '@/hooks/useIsMobile'
 
 export interface ExplorerShellProps {
   /** The search/filter bar (typically a <SearchFilterBar/>), stretched to fill. */
@@ -63,10 +64,16 @@ export function ExplorerShell({
   children,
   className,
 }: Readonly<ExplorerShellProps>) {
+  const isMobile = useIsMobile()
   const [railOpen, setRailOpen] = useState(defaultRailOpen)
+  // On mobile the rail is an overlay drawer that defaults closed, so it never
+  // squeezes the result list; on desktop it stays inline and pushes content.
+  const [mobileRailOpen, setMobileRailOpen] = useState(false)
+  const open = isMobile ? mobileRailOpen : railOpen
+  const toggleRail = () => (isMobile ? setMobileRailOpen((v) => !v) : setRailOpen((v) => !v))
 
   return (
-    <div className={cn('flex h-[calc(100dvh-var(--header-height,0px))] flex-col', className)}>
+    <div className={cn('flex h-[calc(100dvh-var(--header-height,0px))] flex-col overflow-x-clip', className)}>
       {/* Header bar */}
       <div className="@container/header flex min-h-[var(--app-header-h)] items-center gap-2 border-b px-2 py-1 sm:px-3">
         {(icon || title) && (
@@ -75,14 +82,14 @@ export function ExplorerShell({
             {title && <h2 className="hidden text-xs font-semibold leading-tight sm:block">{title}</h2>}
           </div>
         )}
-        {tabs && <div className="flex shrink-0 items-center">{tabs}</div>}
+        {tabs && <div className="flex min-w-0 shrink items-center">{tabs}</div>}
         <div className="min-w-0 flex-1">{searchBar}</div>
         {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
       </div>
 
       {/* Body: rail + content */}
-      <div className="flex min-h-0 flex-1">
-        {rail && (
+      <div className="relative flex min-h-0 flex-1">
+        {rail && !isMobile && (
           <div
             className={cn(
               'shrink-0 self-stretch overflow-y-auto border-r transition-all duration-200',
@@ -93,18 +100,43 @@ export function ExplorerShell({
           </div>
         )}
 
+        {/* Mobile facet overlay */}
+        {rail && isMobile && (
+          <>
+            <button
+              type="button"
+              tabIndex={-1}
+              aria-hidden={!open}
+              onClick={() => setMobileRailOpen(false)}
+              className={cn(
+                'absolute inset-0 z-20 bg-black/50 transition-opacity duration-200',
+                open ? 'opacity-100' : 'pointer-events-none opacity-0'
+              )}
+            />
+            <div
+              className={cn(
+                'absolute inset-y-0 left-0 z-30 w-[min(80%,280px)] overflow-y-auto border-r bg-card shadow-xl transition-transform duration-200',
+                open ? 'translate-x-0' : '-translate-x-full'
+              )}
+              inert={open ? undefined : true}
+            >
+              {rail}
+            </div>
+          </>
+        )}
+
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {(rail || toolbar) && (
             <div className="flex h-[var(--app-subheader-h)] shrink-0 items-center gap-1.5 border-b bg-card/30 px-2">
               {rail && (
                 <button
                   type="button"
-                  onClick={() => setRailOpen((v) => !v)}
+                  onClick={toggleRail}
                   className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  title={railOpen ? 'Hide facets' : 'Show facets'}
-                  aria-label={railOpen ? 'Hide facets' : 'Show facets'}
+                  title={open ? 'Hide facets' : 'Show facets'}
+                  aria-label={open ? 'Hide facets' : 'Show facets'}
                 >
-                  {railOpen ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}
+                  {open ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}
                 </button>
               )}
               {toolbar}

--- a/dashboard/src/components/filters/__tests__/ExplorerShell.test.tsx
+++ b/dashboard/src/components/filters/__tests__/ExplorerShell.test.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {render, screen, fireEvent} from '@testing-library/react'
-import {describe, it, expect} from 'vitest'
+import {afterEach, beforeEach, describe, it, expect} from 'vitest'
 
 import {ExplorerShell} from '@/components/filters/ExplorerShell'
 
@@ -99,5 +99,42 @@ describe('ExplorerShell', () => {
     )
 
     expect(screen.getByRole('button', {name: 'APM Errors'})).toBeTruthy()
+  })
+})
+
+describe('ExplorerShell (mobile)', () => {
+  const realMatchMedia = window.matchMedia
+
+  beforeEach(() => {
+    // Force the `md`-breakpoint media query to match so useIsMobile() is true and
+    // the facet rail renders as an off-canvas overlay instead of an inline column.
+    const noop = () => undefined
+    window.matchMedia = ((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: noop,
+      removeListener: noop,
+      addEventListener: noop,
+      removeEventListener: noop,
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia
+  })
+
+  afterEach(() => {
+    window.matchMedia = realMatchMedia
+  })
+
+  it('renders the rail as a closed overlay drawer that toggles open', () => {
+    render(
+      <ExplorerShell searchBar={<input aria-label="Search" />} rail={<div>Facet rail</div>}>
+        <div>Rows</div>
+      </ExplorerShell>
+    )
+
+    // On mobile the rail stays mounted inside the drawer but defaults closed.
+    expect(screen.getByText('Facet rail')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', {name: 'Show facets'}))
+    expect(screen.getByRole('button', {name: 'Hide facets'})).toBeTruthy()
   })
 })

--- a/dashboard/src/components/monitoring/ContainerList.tsx
+++ b/dashboard/src/components/monitoring/ContainerList.tsx
@@ -267,7 +267,7 @@ export function ContainerList() {
             className="pl-9"
           />
         </div>
-        <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+        <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
           {(['all', 'running', 'stopped'] as const).map((f) => (
             <button
               key={f}

--- a/dashboard/src/components/monitoring/EventStream.tsx
+++ b/dashboard/src/components/monitoring/EventStream.tsx
@@ -406,7 +406,7 @@ export function EventStream() {
             className="pl-9"
           />
         </div>
-        <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+        <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
           {(['all', 'error', 'warning', 'info', 'success'] as const).map((f) => (
             <button
               key={f}

--- a/dashboard/src/components/monitoring/HostList.tsx
+++ b/dashboard/src/components/monitoring/HostList.tsx
@@ -164,7 +164,7 @@ export function HostList() {
             className="pl-9"
           />
         </div>
-        <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+        <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
           {([
             {key: 'all' as const, tone: 'neutral' as const, count: hosts.length},
             {key: 'online' as const, tone: 'success' as const, count: onlineCount},

--- a/dashboard/src/components/monitoring/NetworkConnections.tsx
+++ b/dashboard/src/components/monitoring/NetworkConnections.tsx
@@ -174,7 +174,7 @@ export function NetworkConnections() {
           />
         </div>
 
-        <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+        <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
           {(['all', 'tcp', 'udp'] as const).map((f) => (
             <button
               key={f}
@@ -197,7 +197,7 @@ export function NetworkConnections() {
           ))}
         </div>
 
-        <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+        <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
           {(['all', 'incoming', 'outgoing'] as const).map((f) => (
             <button
               key={f}

--- a/dashboard/src/components/monitoring/ProcessExplorer.tsx
+++ b/dashboard/src/components/monitoring/ProcessExplorer.tsx
@@ -267,7 +267,7 @@ export function ProcessExplorer() {
             className="pl-9"
           />
         </div>
-        <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+        <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
           {([
             {key: 'all' as const, tone: 'neutral' as const, count: processes.length},
             {key: 'running' as const, tone: 'success' as const, count: runningCount},

--- a/dashboard/src/components/monitoring/ServiceCheckList.tsx
+++ b/dashboard/src/components/monitoring/ServiceCheckList.tsx
@@ -187,7 +187,7 @@ export function ServiceCheckList() {
             className="pl-9"
           />
         </div>
-        <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+        <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
           {filters.map((f) => (
             <button
               key={f}

--- a/dashboard/src/components/overview/OverviewDashboard.tsx
+++ b/dashboard/src/components/overview/OverviewDashboard.tsx
@@ -136,7 +136,7 @@ export function OverviewDashboard() {
   return (
     <OverviewDataProvider>
       <div className="min-h-screen">
-        <div className="px-6 py-3">
+        <div className="px-3 py-3 sm:px-6">
           <OverviewHeader
             isEditing={isEditing}
             onToggleEdit={handleToggleEdit}

--- a/dashboard/src/components/overview/widgets/ServiceHealthWidget.tsx
+++ b/dashboard/src/components/overview/widgets/ServiceHealthWidget.tsx
@@ -156,7 +156,8 @@ export function ServiceHealthWidget() {
       }
       flush
     >
-      <table className="w-full border-collapse text-sm">
+      <div className="overflow-x-auto">
+      <table className="w-full min-w-[680px] border-collapse text-sm">
         <thead>
           <tr className="border-b bg-muted/40">
             <th className={TH}>Service</th>
@@ -175,6 +176,7 @@ export function ServiceHealthWidget() {
           ))}
         </tbody>
       </table>
+      </div>
     </OverviewPanel>
   )
 }

--- a/dashboard/src/components/settings/RbacSettings.tsx
+++ b/dashboard/src/components/settings/RbacSettings.tsx
@@ -431,7 +431,7 @@ function PermissionChecklist({
           </Badge>
         </div>
 
-        <div className="grid min-h-[320px] md:grid-cols-[260px_1fr]">
+        <div className="grid grid-cols-1 min-h-[320px] md:grid-cols-[260px_1fr]">
           <div className="border-b bg-muted/30 p-2 md:border-b-0 md:border-r">
             <div className="flex max-h-52 flex-col gap-1 overflow-y-auto md:max-h-[360px]">
               {visibleGroups.map((group) => {
@@ -975,7 +975,7 @@ export function RbacSettings() {
       ) : roles.length === 0 ? (
         <EmptyRolesState onCreate={() => setCreateOpen(true)} />
       ) : (
-        <div className="grid gap-6 lg:grid-cols-[minmax(260px,360px),1fr]">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(260px,360px),1fr]">
           <RoleList roles={roles} selectedRoleId={effectiveSelectedRoleId} onSelectRole={setSelectedRoleId} />
           {selectedRole && (
             <RoleDetails

--- a/dashboard/src/components/settings/RbacSettings.tsx
+++ b/dashboard/src/components/settings/RbacSettings.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {useMemo, useState} from 'react'
+import {type ReactNode, useMemo, useState} from 'react'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {AlertCircle, Loader2, Pencil, Plus, Search, Trash2, UserPlus, X} from 'lucide-react'
 import {api, type OrgMember, type RbacRole} from '@/lib/api'
@@ -946,6 +946,27 @@ export function RbacSettings() {
 
   const pageError = rolesQuery.error ?? membersQuery.error
   const isLoading = rolesQuery.isLoading || membersQuery.isLoading
+  let rolesContent: ReactNode
+
+  if (isLoading) {
+    rolesContent = <RoleLoadingState />
+  } else if (roles.length === 0) {
+    rolesContent = <EmptyRolesState onCreate={() => setCreateOpen(true)} />
+  } else {
+    rolesContent = (
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(260px,360px)_1fr]">
+        <RoleList roles={roles} selectedRoleId={effectiveSelectedRoleId} onSelectRole={setSelectedRoleId} />
+        {selectedRole && (
+          <RoleDetails
+            role={selectedRole}
+            members={members}
+            onEdit={setRoleToEdit}
+            onDelete={setRoleToDelete}
+          />
+        )}
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -970,23 +991,7 @@ export function RbacSettings() {
         </Alert>
       )}
 
-      {isLoading ? (
-        <RoleLoadingState />
-      ) : roles.length === 0 ? (
-        <EmptyRolesState onCreate={() => setCreateOpen(true)} />
-      ) : (
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(260px,360px),1fr]">
-          <RoleList roles={roles} selectedRoleId={effectiveSelectedRoleId} onSelectRole={setSelectedRoleId} />
-          {selectedRole && (
-            <RoleDetails
-              role={selectedRole}
-              members={members}
-              onEdit={setRoleToEdit}
-              onDelete={setRoleToDelete}
-            />
-          )}
-        </div>
-      )}
+      {rolesContent}
 
       <RbacRoleFormDialog
         open={createOpen}

--- a/dashboard/src/components/setup/CloudAccountSetup.tsx
+++ b/dashboard/src/components/setup/CloudAccountSetup.tsx
@@ -237,7 +237,7 @@ export function CloudAccountSetup() {
   }
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[340px_minmax(0,1fr)]">
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-[340px_minmax(0,1fr)]">
       <SectionCard title="Cloud account" icon={CloudCog} bodyClassName="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Provider</p>

--- a/dashboard/src/components/setup/InfrastructureAgentSetup.tsx
+++ b/dashboard/src/components/setup/InfrastructureAgentSetup.tsx
@@ -281,7 +281,7 @@ export function InfrastructureAgentSetup() {
   ]
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[340px_minmax(0,1fr)]">
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-[340px_minmax(0,1fr)]">
       <SectionCard title="Agent" icon={ServerCog} bodyClassName="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Platform</p>

--- a/dashboard/src/hooks/useIsMobile.ts
+++ b/dashboard/src/hooks/useIsMobile.ts
@@ -23,8 +23,9 @@ const MOBILE_BREAKPOINT = 768
 const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
 function getMatches(): boolean {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
-  return window.matchMedia(MOBILE_QUERY).matches
+  const browserWindow = globalThis.window
+  if (typeof browserWindow === 'undefined' || typeof browserWindow.matchMedia !== 'function') return false
+  return browserWindow.matchMedia(MOBILE_QUERY).matches
 }
 
 /** True when the viewport is narrower than the `md` breakpoint. Updates on resize. */
@@ -32,7 +33,12 @@ export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(getMatches)
 
   useEffect(() => {
-    const mql = window.matchMedia(MOBILE_QUERY)
+    const browserWindow = globalThis.window
+    if (typeof browserWindow === 'undefined' || typeof browserWindow.matchMedia !== 'function') {
+      return
+    }
+
+    const mql = browserWindow.matchMedia(MOBILE_QUERY)
     const onChange = () => setIsMobile(mql.matches)
     onChange()
     mql.addEventListener('change', onChange)

--- a/dashboard/src/hooks/useIsMobile.ts
+++ b/dashboard/src/hooks/useIsMobile.ts
@@ -31,9 +31,7 @@ function getBrowserWindow(): MobileBrowserWindow | undefined {
 }
 
 function getMatches(): boolean {
-  const browserWindow = getBrowserWindow()
-  if (browserWindow === undefined || browserWindow.matchMedia === undefined) return false
-  return browserWindow.matchMedia(MOBILE_QUERY).matches
+  return getBrowserWindow()?.matchMedia?.(MOBILE_QUERY).matches ?? false
 }
 
 /** True when the viewport is narrower than the `md` breakpoint. Updates on resize. */
@@ -41,12 +39,11 @@ export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(getMatches)
 
   useEffect(() => {
-    const browserWindow = getBrowserWindow()
-    if (browserWindow === undefined || browserWindow.matchMedia === undefined) {
+    const mql = getBrowserWindow()?.matchMedia?.(MOBILE_QUERY)
+    if (mql === undefined) {
       return
     }
 
-    const mql = browserWindow.matchMedia(MOBILE_QUERY)
     const onChange = () => setIsMobile(mql.matches)
     onChange()
     mql.addEventListener('change', onChange)

--- a/dashboard/src/hooks/useIsMobile.ts
+++ b/dashboard/src/hooks/useIsMobile.ts
@@ -22,9 +22,17 @@ const MOBILE_BREAKPOINT = 768
 
 const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
+type MobileBrowserWindow = Omit<Window, 'matchMedia'> & {
+  readonly matchMedia?: Window['matchMedia']
+}
+
+function getBrowserWindow(): MobileBrowserWindow | undefined {
+  return globalThis.window as MobileBrowserWindow | undefined
+}
+
 function getMatches(): boolean {
-  const browserWindow = globalThis.window
-  if (typeof browserWindow === 'undefined' || typeof browserWindow.matchMedia !== 'function') return false
+  const browserWindow = getBrowserWindow()
+  if (browserWindow === undefined || browserWindow.matchMedia === undefined) return false
   return browserWindow.matchMedia(MOBILE_QUERY).matches
 }
 
@@ -33,8 +41,8 @@ export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(getMatches)
 
   useEffect(() => {
-    const browserWindow = globalThis.window
-    if (typeof browserWindow === 'undefined' || typeof browserWindow.matchMedia !== 'function') {
+    const browserWindow = getBrowserWindow()
+    if (browserWindow === undefined || browserWindow.matchMedia === undefined) {
       return
     }
 

--- a/dashboard/src/hooks/useIsMobile.ts
+++ b/dashboard/src/hooks/useIsMobile.ts
@@ -1,0 +1,43 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useEffect, useState} from 'react'
+
+// Matches Tailwind's `md` breakpoint: anything below 768px is treated as mobile,
+// driving the off-canvas navigation drawer and full-width content shell.
+const MOBILE_BREAKPOINT = 768
+
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function getMatches(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(MOBILE_QUERY).matches
+}
+
+/** True when the viewport is narrower than the `md` breakpoint. Updates on resize. */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(getMatches)
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_QUERY)
+    const onChange = () => setIsMobile(mql.matches)
+    onChange()
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return isMobile
+}

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -17,7 +17,10 @@
 import {createRootRoute, Outlet, Link, useRouterState, useNavigate} from '@tanstack/react-router'
 import {useCallback, useEffect, useState} from 'react'
 import {useQuery} from '@tanstack/react-query'
+import {Menu} from 'lucide-react'
 import {Sidebar, SIDEBAR_COLLAPSED_WIDTH, SIDEBAR_EXPANDED_WIDTH} from '../components/Sidebar'
+import {Logo} from '../components/Logo'
+import {useIsMobile} from '../hooks/useIsMobile'
 import {CommandPalette} from '../components/CommandPalette'
 import {CommandPaletteProvider} from '../contexts/CommandPaletteProvider'
 import {Toaster} from '../components/ui/toaster'
@@ -286,6 +289,8 @@ function RootComponent() {
     setIsSidebarExpanded(expanded)
     localStorage.setItem('moneat:sidebar-expanded', String(expanded))
   }, [])
+  const isMobile = useIsMobile()
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
   const [onboardingChecked, setOnboardingChecked] = useState(false)
   const [authCheckComplete, setAuthCheckComplete] = useState(false)
   const [headerHeight, setHeaderHeight] = useState(0)
@@ -365,7 +370,9 @@ function RootComponent() {
     pathname: currentPath,
     search: router.location.search,
   })
-  const sidebarWidth = isSidebarExpanded ? SIDEBAR_EXPANDED_WIDTH : SIDEBAR_COLLAPSED_WIDTH
+  // On mobile the sidebar is an overlay drawer, so content spans the full width.
+  const desktopSidebarWidth = isSidebarExpanded ? SIDEBAR_EXPANDED_WIDTH : SIDEBAR_COLLAPSED_WIDTH
+  const sidebarWidth = isMobile ? 0 : desktopSidebarWidth
 
   // Show loading state while checking auth and onboarding
   if (!authCheckComplete && !isPublicRoute) {
@@ -380,14 +387,38 @@ function RootComponent() {
     <div className="min-h-screen bg-background">
       {showSidebar && (
         <CommandPaletteProvider>
-          {/* Fixed header: optional demo banner */}
+          {/* Fixed header: optional demo banner + mobile top bar with nav toggle */}
           <div ref={headerRef} className="fixed top-0 left-0 right-0 z-50 w-full">
             <DemoBanner isDemoMode={showDemoBanner} />
+            {isMobile && (
+              <div className="flex items-center gap-2 h-[var(--app-header-h)] border-b bg-card px-2">
+                <button
+                  type="button"
+                  onClick={() => setIsMobileNavOpen(true)}
+                  aria-label="Open navigation"
+                  aria-expanded={isMobileNavOpen}
+                  className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <Menu className="h-5 w-5" />
+                </button>
+                <Link
+                  to="/"
+                  search={APP_OVERVIEW_SEARCH}
+                  onClick={() => setIsMobileNavOpen(false)}
+                  className="flex items-center focus:outline-none focus:ring-2 focus:ring-ring rounded"
+                >
+                  <Logo className="h-6" />
+                </Link>
+              </div>
+            )}
           </div>
           <Sidebar
             isExpanded={isSidebarExpanded}
             onExpandedChange={handleSidebarExpandedChange}
             headerHeight={headerHeight}
+            isMobile={isMobile}
+            isMobileOpen={isMobileNavOpen}
+            onMobileOpenChange={setIsMobileNavOpen}
           />
           <AuthenticatedContent sidebarWidth={sidebarWidth} headerHeight={headerHeight} />
           <CommandPalette />

--- a/dashboard/src/routes/admin.organizations.$orgId.tsx
+++ b/dashboard/src/routes/admin.organizations.$orgId.tsx
@@ -374,7 +374,7 @@ function AdminOrgDetailPage() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid gap-4 lg:grid-cols-[1.4fr_1fr_1fr_auto] lg:items-end">
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.4fr_1fr_1fr_auto] lg:items-end">
             <div className="space-y-2">
               <Label htmlFor="quota-type">Type</Label>
               <Select value={quotaType} onValueChange={(value) => setQuotaType(value as AdminQuotaType)}>

--- a/dashboard/src/routes/feature-flags.tsx
+++ b/dashboard/src/routes/feature-flags.tsx
@@ -553,7 +553,7 @@ val enabled = client.getBooleanValue("checkout.enabled", false, evaluationContex
           />
         </div>
 
-        <div className="grid gap-3 lg:grid-cols-[minmax(260px,320px)_1fr]">
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(260px,320px)_1fr]">
         <Card>
           <CardHeader className="space-y-2 p-3 pb-2">
             <div className="flex items-center justify-between gap-2">
@@ -946,7 +946,7 @@ function FlagDetail(props: Readonly<{
         </TabsContent>
 
       <TabsContent value="segments">
-        <div className="grid gap-3 lg:grid-cols-[300px_1fr]">
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-[300px_1fr]">
           <Card>
             <CardHeader className="p-3 pb-2">
               <CardTitle className="flex items-center gap-1.5 text-base">
@@ -1093,7 +1093,7 @@ function FlagDetail(props: Readonly<{
       </TabsContent>
 
       <TabsContent value="setup">
-        <div className="grid gap-3 lg:grid-cols-[300px_1fr]">
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-[300px_1fr]">
           <Card>
             <CardHeader className="p-3 pb-2">
               <CardTitle className="flex items-center gap-1.5 text-base">

--- a/dashboard/src/routes/monitoring.hosts.$hostId.tsx
+++ b/dashboard/src/routes/monitoring.hosts.$hostId.tsx
@@ -542,7 +542,7 @@ function HostDetailPage() {
             </TabsList>
 
             {activeTab === 'containers' && containers.length > 0 && (
-              <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+              <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
                 <Button
                   variant={containerViewMode === 'cards' ? 'secondary' : 'ghost'}
                   size="sm"

--- a/dashboard/src/routes/monitoring.hosts.index.tsx
+++ b/dashboard/src/routes/monitoring.hosts.index.tsx
@@ -1195,7 +1195,7 @@ function MonitoringHostsPage() {
               />
             </div>
             <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+              <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
                 {([
                   {key: 'all' as const, tone: 'neutral' as const, count: hosts.length},
                   {key: 'online' as const, tone: 'success' as const, count: onlineCount},
@@ -1217,7 +1217,7 @@ function MonitoringHostsPage() {
                   </button>
                 ))}
               </div>
-              <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+              <div className="flex items-center gap-1 rounded-lg border bg-background p-1 max-w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>button]:shrink-0">
                 <button
                   onClick={() => setViewMode('grid')}
                   className={cn(

--- a/dashboard/src/routes/monitoring.network-devices.tsx
+++ b/dashboard/src/routes/monitoring.network-devices.tsx
@@ -69,7 +69,7 @@ function NetworkDevicesLayout() {
   return (
     <div className="container mx-auto px-4 py-4 space-y-4">
       <div className="border-b">
-        <nav className="flex gap-1">
+        <nav className="flex gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {tabs.map((tab) => {
             const isActive = tab.href === '/monitoring/network-devices'
               ? isIndexPage

--- a/dashboard/src/routes/on-call.tsx
+++ b/dashboard/src/routes/on-call.tsx
@@ -46,7 +46,7 @@ function OnCallLayout() {
 
       {/* Tab Navigation */}
       <div className="border-b">
-        <nav className="flex gap-1">
+        <nav className="flex gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {tabs.map((tab) => {
             const isActive = tab.href === '/on-call'
               ? currentPath === '/on-call'

--- a/dashboard/src/routes/security.tsx
+++ b/dashboard/src/routes/security.tsx
@@ -47,7 +47,7 @@ function SecurityLayout() {
         </div>
       </div>
       <div className="border-b">
-        <nav className="flex gap-1">
+        <nav className="flex gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {tabs.map((tab) => {
             const isActive = currentPath.startsWith(tab.href)
             const Icon = tab.icon

--- a/dashboard/src/routes/services.$service.resources.$resource.tsx
+++ b/dashboard/src/routes/services.$service.resources.$resource.tsx
@@ -118,7 +118,7 @@ function ResourceDetailPage() {
 
       <ApmKpiRow kpis={detail.kpis} />
 
-      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[3fr_2fr]">
         <SectionCard
           title="Latency percentiles"
           actions={<Badge variant="neutral" shape="pill" size="sm">{rangeLabel}</Badge>}
@@ -145,7 +145,7 @@ function ResourceDetailPage() {
         </SectionCard>
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[3fr_2fr]">
         <SectionCard title="Latency distribution">
           <LatencyDistribution bars={detail.distribution} markers={detail.distMarkers} axis={detail.distAxis} />
         </SectionCard>

--- a/dashboard/src/routes/services.$service.tsx
+++ b/dashboard/src/routes/services.$service.tsx
@@ -138,7 +138,7 @@ function ServiceDetailContent({service}: Readonly<{service: string}>) {
 
       <ApmKpiRow kpis={detail.kpis} />
 
-      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[3fr_2fr]">
         <SectionCard
           title="Latency percentiles"
           actions={<Badge variant="neutral" shape="pill" size="sm">{rangeLabel}</Badge>}
@@ -166,7 +166,7 @@ function ServiceDetailContent({service}: Readonly<{service: string}>) {
         </SectionCard>
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-[3fr_2fr]">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[3fr_2fr]">
         <SectionCard
           title="Errors over time"
           actions={

--- a/dashboard/src/routes/usage-insights.tsx
+++ b/dashboard/src/routes/usage-insights.tsx
@@ -162,7 +162,7 @@ function UsageInsightsPage() {
         ))}
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(360px,0.8fr)]">
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(360px,0.8fr)]">
         <SectionCard title="Forecast Timeline" icon={LineChart} flushBody>
             <div className="w-full overflow-x-auto">
               <Table className="min-w-[640px]">

--- a/dashboard/src/routes/workflows.insights.tsx
+++ b/dashboard/src/routes/workflows.insights.tsx
@@ -96,7 +96,7 @@ function InsightsSection() {
 
   return (
     <SectionCard title="Overview" icon={Gauge} iconTone="accent">
-      <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_320px]">
+      <div className="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,1fr)_320px]">
         <OverviewBlock query={overviewQuery} />
         <UsageBlock query={usageQuery} />
       </div>

--- a/dashboard/src/routes/workflows.tsx
+++ b/dashboard/src/routes/workflows.tsx
@@ -226,7 +226,7 @@ function WorkflowsPage() {
   return (
     <div className="workflows-page">
       <WorkflowsHeader onCreate={openCreate} />
-      <div className="grid gap-4 px-6 py-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+      <div className="grid grid-cols-1 gap-4 px-3 py-4 sm:px-6 lg:grid-cols-[320px_minmax(0,1fr)]">
         <WorkflowList
           workflows={workflows}
           catalog={catalog}
@@ -459,7 +459,7 @@ function WorkflowDetail({
             )}
           </div>
         </div>
-        <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="grid grid-cols-1 gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_360px]">
           <WorkflowCanvas
             graph={workflow.graph}
             catalog={catalog}
@@ -585,7 +585,7 @@ function WorkflowEditorDialog({
             Configure a workflow automation graph with triggers, conditions, controls, and actions.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 xl:grid-cols-[240px_minmax(0,1fr)_360px]">
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-[240px_minmax(0,1fr)_360px]">
           <div className="space-y-3">
             <WorkflowDraftFields draft={draft} catalog={catalog} onDraftChange={onDraftChange} onTriggerChange={changeTrigger} />
             <NodePalette catalog={catalog} onAddNode={addNode} />


### PR DESCRIPTION
## What

Adds a responsive layer to the authenticated dashboard so it's usable on phones, without changing the desktop experience.

## Changes
- **Sidebar → off-canvas drawer** below the `md` breakpoint: backdrop, a mobile top bar with a hamburger in the app shell, and full-width content. The rail uses `100dvh` with a pinned footer so the nav scrolls all the way to the **Management** group on short/mobile viewports (fixes the bottom group being unreachable).
- **Grids reflow:** dashboard/overview grids stack under 640px; added a `grid-cols-1` mobile base to grids that previously collapsed to a single max-content column.
- **ExplorerShell** facet rail becomes an overlay drawer on mobile.
- Scrollable tab and filter-pill rows across the monitoring views.
- Clamp the AI floating panel to the viewport on small screens.

## Tests
New unit tests cover the new mobile branches (Sidebar drawer open/closed + desktop rail, ExplorerShell overlay, DashboardGrid stacking, AiFloatingPanel geometry). Full suite green; frontend line coverage ~80.8%.

## Risk
Desktop layout is unchanged — all mobile behavior is gated on the `md` breakpoint / `useIsMobile`. Verified across ~25 pages at 375px in a preview browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-friendly navigation with an off-canvas sidebar and backdrop.
  * Improved responsive layouts across dashboards, analytics, setup, workflows, and settings screens.
  * Enabled horizontal scrolling for filter and tab bars on narrow screens.

* **Bug Fixes**
  * Prevented floating panels from opening off-screen on smaller viewports.
  * Made dashboard widgets and tables usable on mobile by stacking or scrolling content.

* **Tests**
  * Added coverage for mobile navigation, responsive dashboard layouts, and floating panel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->