### PR TITLE
fix: resolve native on-call alerts

### DIFF
--- a/backend/src/main/kotlin/com/moneat/enterprise/OnCallBridge.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/OnCallBridge.kt
@@ -64,6 +64,13 @@ interface OnCallBridge {
         metadata: String?
     ): String?
 
+    /** Resolve open on-call alerts for the source/deduplication key. */
+    suspend fun resolveEscalation(
+        organizationId: Int,
+        alertSource: String,
+        deduplicationKey: String
+    ): Boolean
+
     /** Declare an operational incident and return the declared incident resource ID. */
     suspend fun declareIncident(
         organizationId: Int,

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
@@ -160,6 +160,15 @@ class IncidentService(
         moneatUrl: String = "",
         publishWorkflow: Boolean = true
     ) {
+        val onCallEnabled = EnvConfig.get("ONCALL_ENABLED", "false").toBoolean()
+        if (onCallEnabled) {
+            suspendRunCatching {
+                resolveNativeEscalation(organizationId, source, deduplicationKey)
+            }.getOrElse { e ->
+                logger.error("Error resolving native escalation", e)
+            }
+        }
+
         if (publishWorkflow) {
             suspendRunCatching {
                 workflowService.publishAlertResolved(
@@ -421,6 +430,16 @@ class IncidentService(
             }
 
             // Trigger escalation
+            val serializedMetadata =
+                if (event.metadata.isNotEmpty()) {
+                    kotlinx.serialization.json.Json.encodeToString(
+                        kotlinx.serialization.serializer(),
+                        event.metadata,
+                    )
+                } else {
+                    null
+                }
+
             val incidentId =
                 bridge.triggerEscalation(
                     organizationId = event.organizationId,
@@ -430,15 +449,7 @@ class IncidentService(
                     priority = priority.priority,
                     alertSource = event.source.name,
                     deduplicationKey = event.deduplicationKey,
-                    metadata =
-                    if (event.metadata.isNotEmpty()) {
-                        kotlinx.serialization.json.Json.encodeToString(
-                            kotlinx.serialization.serializer(),
-                            event.metadata
-                        )
-                    } else {
-                        null
-                    }
+                    metadata = serializedMetadata,
                 )
 
             if (incidentId != null) {
@@ -446,6 +457,40 @@ class IncidentService(
             }
         }.getOrElse { e ->
             logger.error("Error triggering native escalation", e)
+        }
+    }
+
+    /**
+     * Resolve native on-call alerts that were created from the same source and deduplication key.
+     */
+    private suspend fun resolveNativeEscalation(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String,
+    ) {
+        val bridge = FeatureRegistry.getOnCallBridge()
+        if (bridge == null) {
+            logger.debug("On-call enterprise module not loaded — skipping native escalation resolve")
+            return
+        }
+
+        val resolved =
+            bridge.resolveEscalation(
+                organizationId = organizationId,
+                alertSource = source.name,
+                deduplicationKey = deduplicationKey,
+            )
+
+        if (resolved) {
+            logger.info(
+                "Native escalation resolved for org $organizationId, source ${source.name}, " +
+                    "deduplication key $deduplicationKey",
+            )
+        } else {
+            logger.debug(
+                "No open native escalation found for org $organizationId, source ${source.name}, " +
+                    "deduplication key $deduplicationKey",
+            )
         }
     }
 

--- a/backend/src/test/kotlin/com/moneat/enterprise/IncidentServiceOnCallBridgeTest.kt
+++ b/backend/src/test/kotlin/com/moneat/enterprise/IncidentServiceOnCallBridgeTest.kt
@@ -1,0 +1,199 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.enterprise
+
+import com.moneat.alerts.models.AlertSource
+import com.moneat.config.EnvConfig
+import com.moneat.incident.services.IncidentService
+import com.moneat.workflows.services.WorkflowService
+import io.ktor.server.application.Application
+import io.ktor.server.routing.Route
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val ORGANIZATION_ID = 42
+private const val UPTIME_DEDUPLICATION_KEY = "uptime-monitor:payments-api"
+private const val DASHBOARD_DEDUPLICATION_KEY = "dashboard-alert:error-rate"
+
+class IncidentServiceOnCallBridgeTest {
+    private lateinit var bridge: RecordingOnCallBridgeModule
+    private lateinit var service: IncidentService
+
+    @BeforeTest
+    fun setUp() {
+        FeatureRegistry.resetForTest()
+        bridge = RecordingOnCallBridgeModule()
+        FeatureRegistry.registerForTest(bridge)
+        mockkObject(EnvConfig)
+        every { EnvConfig.get("ONCALL_ENABLED", "false") } returns "true"
+        service = IncidentService(workflowService = mockk<WorkflowService>(relaxed = true))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(EnvConfig)
+        FeatureRegistry.resetForTest()
+    }
+
+    @Test
+    fun `resolveAlert resolves native on-call alert by source and deduplication key`() = runBlocking {
+        service.resolveAlert(
+            organizationId = ORGANIZATION_ID,
+            source = AlertSource.UPTIME_MONITOR,
+            deduplicationKey = UPTIME_DEDUPLICATION_KEY,
+            publishWorkflow = false,
+        )
+
+        assertEquals(
+            listOf(
+                ResolvedEscalation(
+                    organizationId = ORGANIZATION_ID,
+                    alertSource = AlertSource.UPTIME_MONITOR.name,
+                    deduplicationKey = UPTIME_DEDUPLICATION_KEY,
+                ),
+            ),
+            bridge.resolvedEscalations,
+        )
+    }
+
+    @Test
+    fun `autoResolveAlert resolves native on-call alert through common resolve path`() = runBlocking {
+        service.autoResolveAlert(
+            organizationId = ORGANIZATION_ID,
+            source = AlertSource.DASHBOARD_ALERT,
+            deduplicationKey = DASHBOARD_DEDUPLICATION_KEY,
+            publishWorkflow = false,
+        )
+
+        assertEquals(
+            listOf(
+                ResolvedEscalation(
+                    organizationId = ORGANIZATION_ID,
+                    alertSource = AlertSource.DASHBOARD_ALERT.name,
+                    deduplicationKey = DASHBOARD_DEDUPLICATION_KEY,
+                ),
+            ),
+            bridge.resolvedEscalations,
+        )
+    }
+}
+
+private data class ResolvedEscalation(
+    val organizationId: Int,
+    val alertSource: String,
+    val deduplicationKey: String,
+)
+
+private class RecordingOnCallBridgeModule :
+    EnterpriseModule,
+    OnCallBridge {
+    val resolvedEscalations = mutableListOf<ResolvedEscalation>()
+
+    override val name: String = "Recording On-Call"
+
+    override fun registerRoutes(route: Route) = Unit
+
+    override fun startBackgroundJobs(application: Application) = Unit
+
+    override fun stopBackgroundJobs() = Unit
+
+    override fun resolvePriority(
+        organizationId: Int,
+        priority: String,
+    ): PriorityInfo? = null
+
+    override fun shouldEscalate(
+        organizationId: Int,
+        priority: String,
+    ): Boolean = false
+
+    override fun resolveEscalationPolicyId(
+        organizationId: Int,
+        escalationPolicyResourceId: String,
+    ): Int? = null
+
+    override fun resolveAlertId(
+        organizationId: Int,
+        alertResourceId: String,
+    ): Int? = null
+
+    override fun getCurrentOnCall(
+        organizationId: Int,
+        scheduleId: Int,
+    ): OnCallUserInfo? = null
+
+    override suspend fun triggerEscalation(
+        organizationId: Int,
+        escalationPolicyId: Int,
+        title: String,
+        description: String?,
+        priority: String,
+        alertSource: String,
+        deduplicationKey: String?,
+        metadata: String?,
+    ): String? = null
+
+    override suspend fun resolveEscalation(
+        organizationId: Int,
+        alertSource: String,
+        deduplicationKey: String,
+    ): Boolean {
+        resolvedEscalations +=
+            ResolvedEscalation(
+                organizationId = organizationId,
+                alertSource = alertSource,
+                deduplicationKey = deduplicationKey,
+            )
+        return true
+    }
+
+    override suspend fun declareIncident(
+        organizationId: Int,
+        userId: Int,
+        alertId: Int?,
+        title: String,
+        description: String?,
+        severity: String,
+    ): String? = null
+
+    override fun getIncident(
+        incidentId: Int,
+        userId: Int,
+    ): IncidentInfo? = null
+
+    override fun acknowledgeIncident(
+        incidentId: Int,
+        userId: Int,
+    ): Boolean = false
+
+    override fun getAlert(
+        alertId: Int,
+        userId: Int,
+    ): IncidentInfo? = null
+
+    override fun acknowledgeAlert(
+        alertId: Int,
+        userId: Int,
+    ): Boolean = false
+}

--- a/dashboard/src/lib/api/modules/__tests__/on-call.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/on-call.test.ts
@@ -289,19 +289,19 @@ describe('onCallMethods', () => {
     })
   })
 
-  // ──── Incidents ────
+  // ──── Alerts ────
 
-  describe('getIncidents', () => {
-    it('fetches incidents without filters', async () => {
+  describe('getAlerts', () => {
+    it('fetches alerts without filters', async () => {
       const mock = [{ id: ALERT_ID_PRIMARY, title: 'Server Down', status: 'TRIGGERED' }]
       server.use(
         http.get(`${API_BASE}/on-call/alerts`, () => HttpResponse.json(mock))
       )
-      const result = await api.getIncidents()
+      const result = await api.getAlerts()
       expect(result).toEqual(mock)
     })
 
-    it('fetches incidents with filters', async () => {
+    it('fetches alerts with filters', async () => {
       const mock = [{ id: ALERT_ID_SECONDARY, title: 'High CPU', status: 'ACKNOWLEDGED' }]
       server.use(
         http.get(`${API_BASE}/on-call/alerts`, ({ request }) => {
@@ -313,7 +313,7 @@ describe('onCallMethods', () => {
           return HttpResponse.json(mock)
         })
       )
-      const result = await api.getIncidents({
+      const result = await api.getAlerts({
         status: 'ACKNOWLEDGED',
         priority: 'P1',
         fromDate: '2025-01-01',
@@ -322,7 +322,7 @@ describe('onCallMethods', () => {
       expect(result).toEqual(mock)
     })
 
-    it('fetches incidents with multiple statuses', async () => {
+    it('fetches alerts with multiple statuses', async () => {
       const mock = [
         { id: ALERT_ID_PRIMARY, title: 'Server Down', status: 'TRIGGERED' },
         { id: ALERT_ID_SECONDARY, title: 'High CPU', status: 'ACKNOWLEDGED' },
@@ -335,7 +335,7 @@ describe('onCallMethods', () => {
           return HttpResponse.json(mock)
         })
       )
-      const result = await api.getIncidents({
+      const result = await api.getAlerts({
         status: ['TRIGGERED', 'ACKNOWLEDGED'],
         priority: 'P0',
       })
@@ -343,55 +343,60 @@ describe('onCallMethods', () => {
     })
   })
 
-  describe('getIncident', () => {
-    it('fetches single incident', async () => {
+  describe('getAlert', () => {
+    it('fetches single alert', async () => {
       const mock = { id: ALERT_ID_PRIMARY, title: 'Server Down', status: 'TRIGGERED', timeline: [] }
       server.use(
         http.get(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}`, () => HttpResponse.json(mock))
       )
-      const result = await api.getIncident(ALERT_ID_PRIMARY)
+      const result = await api.getAlert(ALERT_ID_PRIMARY)
       expect(result).toEqual(mock)
     })
   })
 
-  describe('getIncidentTimeline', () => {
-    it('fetches incident timeline', async () => {
-      const mock = [{ type: 'TRIGGERED', timestamp: '2025-01-01T00:00:00Z' }]
+  describe('getAlertTimeline', () => {
+    it('fetches alert timeline', async () => {
+      const mock = [{
+        id: 'timeline-event-1',
+        targetId: ALERT_ID_PRIMARY,
+        eventType: 'TRIGGERED',
+        createdAt: '2025-01-01T00:00:00Z',
+      }]
       server.use(
         http.get(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}/timeline`, () => HttpResponse.json(mock))
       )
-      const result = await api.getIncidentTimeline(ALERT_ID_PRIMARY)
+      const result = await api.getAlertTimeline(ALERT_ID_PRIMARY)
       expect(result).toEqual(mock)
     })
   })
 
-  describe('acknowledgeIncident', () => {
+  describe('acknowledgeAlert', () => {
     it('sends POST to acknowledge', async () => {
-      const mock = { id: ALERT_ID_PRIMARY, status: 'ACKNOWLEDGED' }
+      const mock = { message: 'Alert acknowledged' }
       server.use(
         http.post(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}/acknowledge`, () =>
           HttpResponse.json(mock)
         )
       )
-      const result = await api.acknowledgeIncident(ALERT_ID_PRIMARY)
+      const result = await api.acknowledgeAlert(ALERT_ID_PRIMARY)
       expect(result).toEqual(mock)
     })
   })
 
-  describe('resolveIncident', () => {
+  describe('resolveAlert', () => {
     it('sends POST to resolve', async () => {
-      const mock = { id: ALERT_ID_PRIMARY, status: 'RESOLVED' }
+      const mock = { message: 'Alert resolved' }
       server.use(
         http.post(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}/resolve`, () =>
           HttpResponse.json(mock)
         )
       )
-      const result = await api.resolveIncident(ALERT_ID_PRIMARY)
+      const result = await api.resolveAlert(ALERT_ID_PRIMARY)
       expect(result).toEqual(mock)
     })
   })
 
-  describe('reassignIncident', () => {
+  describe('reassignAlert', () => {
     it('sends POST with toUserId', async () => {
       const mock = { id: ALERT_ID_PRIMARY, assignedTo: USER_ID_REASSIGN }
       server.use(
@@ -401,12 +406,12 @@ describe('onCallMethods', () => {
           return HttpResponse.json(mock)
         })
       )
-      const result = await api.reassignIncident(ALERT_ID_PRIMARY, USER_ID_REASSIGN)
+      const result = await api.reassignAlert(ALERT_ID_PRIMARY, USER_ID_REASSIGN)
       expect(result).toEqual(mock)
     })
   })
 
-  describe('addIncidentNote', () => {
+  describe('addAlertNote', () => {
     it('sends POST with note body', async () => {
       const mock = { type: 'NOTE', content: 'Investigating' }
       server.use(
@@ -416,30 +421,36 @@ describe('onCallMethods', () => {
           return HttpResponse.json(mock)
         })
       )
-      const result = await api.addIncidentNote(ALERT_ID_PRIMARY, 'Investigating')
+      const result = await api.addAlertNote(ALERT_ID_PRIMARY, 'Investigating')
       expect(result).toEqual(mock)
     })
   })
 
-  describe('viewIncident', () => {
-    it('sends POST to mark incident as viewed', async () => {
+  describe('viewAlert', () => {
+    it('sends POST to mark alert as viewed', async () => {
+      let requested = false
       server.use(
-        http.post(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}/view`, () =>
-          new HttpResponse(null, { status: 204 })
-        )
+        http.post(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}/view`, () => {
+          requested = true
+          return new HttpResponse(null, { status: 204 })
+        })
       )
-      await api.viewIncident(ALERT_ID_PRIMARY)
+      await api.viewAlert(ALERT_ID_PRIMARY)
+      expect(requested).toBe(true)
     })
   })
 
-  describe('markUnavailable', () => {
+  describe('markAlertUnavailable', () => {
     it('sends POST to mark unavailable', async () => {
+      let requested = false
       server.use(
-        http.post(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}/unavailable`, () =>
-          new HttpResponse(null, { status: 204 })
-        )
+        http.post(`${API_BASE}/on-call/alerts/${ALERT_ID_PRIMARY}/unavailable`, () => {
+          requested = true
+          return new HttpResponse(null, { status: 204 })
+        })
       )
-      await api.markUnavailable(ALERT_ID_PRIMARY)
+      await api.markAlertUnavailable(ALERT_ID_PRIMARY)
+      expect(requested).toBe(true)
     })
   })
 
@@ -475,7 +486,7 @@ describe('onCallMethods', () => {
 
   // ──── Declare Incident ────
 
-  describe('declareIncident', () => {
+  describe('declareIncidentFromAlert', () => {
     it('sends POST to declare incident from alert', async () => {
       const data = { title: 'Outage', description: 'Full outage', severity: 'SEV-1' }
       const mock = { id: DECLARED_INCIDENT_ID }
@@ -487,7 +498,7 @@ describe('onCallMethods', () => {
           return HttpResponse.json(mock)
         })
       )
-      const result = await api.declareIncident(ALERT_ID_PRIMARY, data)
+      const result = await api.declareIncidentFromAlert(ALERT_ID_PRIMARY, data)
       expect(result).toEqual(mock)
     })
   })

--- a/dashboard/src/lib/api/modules/on-call.ts
+++ b/dashboard/src/lib/api/modules/on-call.ts
@@ -22,9 +22,9 @@ import type {
   OnCallSchedule,
   OnCallOverride,
   EscalationPolicy,
-  Incident,
-  IncidentDetail,
-  IncidentTimeline,
+  OnCallAlert,
+  OnCallAlertDetail,
+  OnCallTimelineEvent,
   OnCallIncident,
   OnCallIncidentDetail,
   DeviceToken,
@@ -37,17 +37,21 @@ import type {
   UpdatePrioritiesRequest,
   UpdateBusinessHoursRequest,
   RegisterDeviceRequest,
-  IncidentListFilters,
+  OnCallAlertListFilters,
 } from '../types'
 
-function appendIncidentStatusFilters(
+function appendAlertStatusFilters(
   params: URLSearchParams,
-  status?: IncidentListFilters['status']
+  status?: OnCallAlertListFilters['status']
 ) {
   if (!status) return
 
   const statuses = Array.isArray(status) ? status : [status]
   statuses.forEach((value) => params.append('status', value))
+}
+
+type MessageResponse = {
+  message: string
 }
 
 export function onCallMethods(core: ApiClientCore) {
@@ -148,54 +152,54 @@ export function onCallMethods(core: ApiClientCore) {
         method: 'DELETE',
       }),
 
-    getIncidents: (filters?: IncidentListFilters) => {
+    getAlerts: (filters?: OnCallAlertListFilters) => {
       const params = new URLSearchParams()
-      appendIncidentStatusFilters(params, filters?.status)
+      appendAlertStatusFilters(params, filters?.status)
       if (filters?.priority) params.append('priority', filters.priority)
       if (filters?.fromDate) params.append('fromDate', filters.fromDate)
       if (filters?.toDate) params.append('toDate', filters.toDate)
       const query = params.toString()
-      return core.request<Incident[]>(
+      return core.request<OnCallAlert[]>(
         urlWithQuery(`${base}/on-call/alerts`, query)
       )
     },
 
-    getIncident: (id: string) =>
-      core.request<IncidentDetail>(`${base}/on-call/alerts/${encodeURIComponent(id)}`),
+    getAlert: (id: string) =>
+      core.request<OnCallAlertDetail>(`${base}/on-call/alerts/${encodeURIComponent(id)}`),
 
-    getIncidentTimeline: (id: string) =>
-      core.request<IncidentTimeline[]>(
+    getAlertTimeline: (id: string) =>
+      core.request<OnCallTimelineEvent[]>(
         `${base}/on-call/alerts/${encodeURIComponent(id)}/timeline`
       ),
 
-    acknowledgeIncident: (id: string) =>
-      core.request<Incident>(`${base}/on-call/alerts/${encodeURIComponent(id)}/acknowledge`, {
+    acknowledgeAlert: (id: string) =>
+      core.request<MessageResponse>(`${base}/on-call/alerts/${encodeURIComponent(id)}/acknowledge`, {
         method: 'POST',
       }),
 
-    resolveIncident: (id: string) =>
-      core.request<Incident>(`${base}/on-call/alerts/${encodeURIComponent(id)}/resolve`, {
+    resolveAlert: (id: string) =>
+      core.request<MessageResponse>(`${base}/on-call/alerts/${encodeURIComponent(id)}/resolve`, {
         method: 'POST',
       }),
 
-    reassignIncident: (id: string, toUserId: string) =>
-      core.request<Incident>(`${base}/on-call/alerts/${encodeURIComponent(id)}/reassign`, {
+    reassignAlert: (id: string, toUserId: string) =>
+      core.request<OnCallAlert>(`${base}/on-call/alerts/${encodeURIComponent(id)}/reassign`, {
         method: 'POST',
         body: JSON.stringify({ toUserId }),
       }),
 
-    addIncidentNote: (id: string, note: string) =>
-      core.request<IncidentTimeline>(`${base}/on-call/alerts/${encodeURIComponent(id)}/notes`, {
+    addAlertNote: (id: string, note: string) =>
+      core.request<OnCallTimelineEvent>(`${base}/on-call/alerts/${encodeURIComponent(id)}/notes`, {
         method: 'POST',
         body: JSON.stringify({ note }),
       }),
 
-    viewIncident: (id: string) =>
+    viewAlert: (id: string) =>
       core.request<void>(`${base}/on-call/alerts/${encodeURIComponent(id)}/view`, {
         method: 'POST',
       }),
 
-    markUnavailable: (id: string) =>
+    markAlertUnavailable: (id: string) =>
       core.request<void>(`${base}/on-call/alerts/${encodeURIComponent(id)}/unavailable`, {
         method: 'POST',
       }),
@@ -211,7 +215,7 @@ export function onCallMethods(core: ApiClientCore) {
         method: 'DELETE',
       }),
 
-    declareIncident: (
+    declareIncidentFromAlert: (
       alertId: string,
       data: { title: string; description: string; severity: string }
     ) =>
@@ -244,7 +248,7 @@ export function onCallMethods(core: ApiClientCore) {
       }),
 
     getOnCallIncidentTimeline: (id: string) =>
-      core.request<IncidentTimeline[]>(
+      core.request<OnCallTimelineEvent[]>(
         `${base}/on-call/incidents/${encodeURIComponent(id)}/timeline`
       ),
 

--- a/dashboard/src/lib/api/types/on-call.ts
+++ b/dashboard/src/lib/api/types/on-call.ts
@@ -107,16 +107,16 @@ export interface EscalationPolicy {
   steps: EscalationStep[]
 }
 
-export type IncidentStatus = 'TRIGGERED' | 'ACKNOWLEDGED' | 'RESOLVED'
+export type OnCallAlertStatus = 'TRIGGERED' | 'ACKNOWLEDGED' | 'RESOLVED'
 
-export interface Incident {
+export interface OnCallAlert {
   id: string
   organizationId: string
   escalationPolicyId: string
   title: string
   description?: string
   priority: string
-  status: IncidentStatus
+  status: OnCallAlertStatus
   alertSource: string
   deduplicationKey?: string
   triggeredAt: string
@@ -131,27 +131,22 @@ export interface Incident {
   viewedByCurrentUser?: boolean
 }
 
-export interface IncidentTimeline {
+export interface OnCallTimelineEvent {
   id: string
-  incidentId: string
-  eventType:
-    | 'TRIGGERED'
-    | 'ESCALATED'
-    | 'ACKNOWLEDGED'
-    | 'RESOLVED'
-    | 'REASSIGNED'
-    | 'NOTE_ADDED'
-    | 'STEP_TIMEOUT'
-    | 'NOTIFICATION_SENT'
-    | 'VIEWED'
+  targetId: string
+  eventType: string
   actorUserId?: string
+  actorName?: string
   actorUserName?: string
   details?: Record<string, unknown>
   createdAt: string
+  source?: string
+  alertId?: string
+  alertTitle?: string
 }
 
-export interface IncidentDetail extends Incident {
-  timeline?: IncidentTimeline[]
+export interface OnCallAlertDetail extends OnCallAlert {
+  timeline?: OnCallTimelineEvent[]
 }
 
 export interface OnCallIncident {
@@ -174,7 +169,7 @@ export interface OnCallIncident {
 }
 
 export interface OnCallIncidentDetail extends OnCallIncident {
-  timeline?: IncidentTimeline[]
+  timeline?: OnCallTimelineEvent[]
 }
 
 export interface DeviceToken {
@@ -264,8 +259,8 @@ export interface RegisterDeviceRequest {
   deviceName?: string
 }
 
-export interface IncidentListFilters {
-  status?: IncidentStatus | IncidentStatus[]
+export interface OnCallAlertListFilters {
+  status?: OnCallAlertStatus | OnCallAlertStatus[]
   priority?: string
   fromDate?: string
   toDate?: string

--- a/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
@@ -24,21 +24,21 @@ const {
     getUptimeMonitors: vi.fn(),
     getUptimeHeartbeats: vi.fn(),
     getMonitorHosts: vi.fn(),
-    getIncidents: vi.fn(),
+    getAlerts: vi.fn(),
     getOnCallSchedules: vi.fn(),
     getEscalationPolicies: vi.fn(),
     getPriorities: vi.fn(),
     getBusinessHours: vi.fn(),
     getStatusPages: vi.fn(),
     getStatusPage: vi.fn(),
-    getIncident: vi.fn(),
-    getIncidentTimeline: vi.fn(),
-    viewIncident: vi.fn(),
-    acknowledgeIncident: vi.fn(),
-    resolveIncident: vi.fn(),
-    markUnavailable: vi.fn(),
-    addIncidentNote: vi.fn(),
-    declareIncident: vi.fn(),
+    getAlert: vi.fn(),
+    getAlertTimeline: vi.fn(),
+    viewAlert: vi.fn(),
+    acknowledgeAlert: vi.fn(),
+    resolveAlert: vi.fn(),
+    markAlertUnavailable: vi.fn(),
+    addAlertNote: vi.fn(),
+    declareIncidentFromAlert: vi.fn(),
     getOnCallIncidents: vi.fn(),
     getOnCallIncident: vi.fn(),
     getOnCallIncidentTimeline: vi.fn(),
@@ -417,7 +417,7 @@ describe('overview alert and incident dashboard', () => {
       {timestamp: Date.now(), status: 1, responseTimeMs: 123, statusCode: 200, message: 'ok'},
     ])
     mockApi.getMonitorHosts.mockResolvedValue([host])
-    mockApi.getIncidents.mockResolvedValue([alert])
+    mockApi.getAlerts.mockResolvedValue([alert])
     mockApi.getOnCallSchedules.mockResolvedValue([schedule])
     mockApi.getEscalationPolicies.mockResolvedValue([
       {
@@ -459,14 +459,14 @@ describe('overview alert and incident dashboard', () => {
       ],
       customDomains: [],
     })
-    mockApi.getIncident.mockResolvedValue({...alert, description: 'Payments API is down'})
-    mockApi.getIncidentTimeline.mockResolvedValue(alertTimeline)
-    mockApi.viewIncident.mockResolvedValue(undefined)
-    mockApi.acknowledgeIncident.mockResolvedValue({...alert, status: 'ACKNOWLEDGED'})
-    mockApi.resolveIncident.mockResolvedValue({...alert, status: 'RESOLVED'})
-    mockApi.markUnavailable.mockResolvedValue(undefined)
-    mockApi.addIncidentNote.mockResolvedValue(alertTimeline[1])
-    mockApi.declareIncident.mockResolvedValue(declaredIncident)
+    mockApi.getAlert.mockResolvedValue({...alert, description: 'Payments API is down'})
+    mockApi.getAlertTimeline.mockResolvedValue(alertTimeline)
+    mockApi.viewAlert.mockResolvedValue(undefined)
+    mockApi.acknowledgeAlert.mockResolvedValue({message: 'Alert acknowledged'})
+    mockApi.resolveAlert.mockResolvedValue({message: 'Alert resolved'})
+    mockApi.markAlertUnavailable.mockResolvedValue(undefined)
+    mockApi.addAlertNote.mockResolvedValue(alertTimeline[1])
+    mockApi.declareIncidentFromAlert.mockResolvedValue(declaredIncident)
     mockApi.getOnCallIncidents.mockResolvedValue([declaredIncident])
     mockApi.getOnCallIncident.mockResolvedValue(declaredIncident)
     mockApi.getOnCallIncidentTimeline.mockResolvedValue(declaredIncidentTimeline)
@@ -518,7 +518,7 @@ describe('overview alert and incident dashboard', () => {
     mockApi.getOnCallSchedules.mockResolvedValue([
       {...schedule, id: resourceId(702), name: 'Backup Rotation', currentOnCall: null},
     ])
-    mockApi.getIncidents.mockResolvedValue([
+    mockApi.getAlerts.mockResolvedValue([
       makeAlert({id: resourceId(201), title: 'Primary P0', priority: 'P0', status: 'TRIGGERED'}),
       makeAlert({id: resourceId(202), title: 'Primary P1', priority: 'P1', status: 'ACKNOWLEDGED'}),
       makeAlert({id: resourceId(203), title: 'Primary P2', priority: 'P2', status: 'TRIGGERED'}),
@@ -558,7 +558,7 @@ describe('overview alert and incident dashboard', () => {
     expect((await screen.findAllByText('+1 more')).length).toBeGreaterThan(0)
 
     mockApi.getOnCallSchedules.mockResolvedValue([])
-    mockApi.getIncidents.mockResolvedValue([])
+    mockApi.getAlerts.mockResolvedValue([])
     mockApi.getBusinessHours.mockResolvedValue({
       id: resourceId(135),
       organizationId: ORGANIZATION_RESOURCE_ID,
@@ -599,7 +599,7 @@ describe('overview alert and incident dashboard', () => {
       },
       {...schedule, id: resourceId(713), name: 'Fallback Rotation', currentOnCall: {userName: 'Fallback User'}},
     ])
-    mockApi.getIncidents.mockResolvedValue([])
+    mockApi.getAlerts.mockResolvedValue([])
     mockApi.getBusinessHours.mockResolvedValue({
       id: resourceId(136),
       organizationId: ORGANIZATION_RESOURCE_ID,
@@ -639,7 +639,7 @@ describe('overview alert and incident dashboard', () => {
 
   it('renders the alert list route with P-priority alerts', async () => {
     mockRoutePathname.current = '/on-call/alerts'
-    mockApi.getIncidents.mockResolvedValue([
+    mockApi.getAlerts.mockResolvedValue([
       makeAlert({
         id: resourceId(401),
         title: 'Escalating payment alert',
@@ -689,17 +689,17 @@ describe('overview alert and incident dashboard', () => {
     expect(await screen.findByText('to Ada Lovelace via email')).toBeInTheDocument()
     expect(await screen.findByText('"Investigating payment failures"')).toBeInTheDocument()
     expect(await screen.findByText('Declare Incident')).toBeInTheDocument()
-    expect(mockApi.viewIncident).toHaveBeenCalledWith(ALERT_RESOURCE_ID)
+    expect(mockApi.viewAlert).toHaveBeenCalledWith(ALERT_RESOURCE_ID)
 
     fireEvent.click(await screen.findByText('Acknowledge'))
-    await waitFor(() => expect(mockApi.acknowledgeIncident).toHaveBeenCalledWith(ALERT_RESOURCE_ID))
+    await waitFor(() => expect(mockApi.acknowledgeAlert).toHaveBeenCalledWith(ALERT_RESOURCE_ID))
     fireEvent.click(await screen.findByText('Resolve'))
-    await waitFor(() => expect(mockApi.resolveIncident).toHaveBeenCalledWith(ALERT_RESOURCE_ID))
+    await waitFor(() => expect(mockApi.resolveAlert).toHaveBeenCalledWith(ALERT_RESOURCE_ID))
     fireEvent.click(await screen.findByText("I'm not available"))
-    await waitFor(() => expect(mockApi.markUnavailable).toHaveBeenCalledWith(ALERT_RESOURCE_ID))
+    await waitFor(() => expect(mockApi.markAlertUnavailable).toHaveBeenCalledWith(ALERT_RESOURCE_ID))
     fireEvent.change(screen.getByPlaceholderText('Enter your note...'), {target: {value: 'Adding context'}})
     clickLastText('Add note')
-    await waitFor(() => expect(mockApi.addIncidentNote).toHaveBeenCalledWith(ALERT_RESOURCE_ID, 'Adding context'))
+    await waitFor(() => expect(mockApi.addAlertNote).toHaveBeenCalledWith(ALERT_RESOURCE_ID, 'Adding context'))
   })
 
   it('rejects numeric alert identifiers without fetching alert data', async () => {
@@ -708,7 +708,7 @@ describe('overview alert and incident dashboard', () => {
     renderRoute(AlertDetailRoute)
 
     expect(await screen.findByText('Invalid alert ID')).toBeInTheDocument()
-    expect(mockApi.getIncident).not.toHaveBeenCalled()
+    expect(mockApi.getAlert).not.toHaveBeenCalled()
   })
 
   it('renders declared incident list route with SEV severity', async () => {
@@ -773,7 +773,7 @@ describe('overview alert and incident dashboard', () => {
 
   it('renders empty alert and declared incident list states', async () => {
     mockRoutePathname.current = '/on-call/alerts'
-    mockApi.getIncidents.mockResolvedValue([])
+    mockApi.getAlerts.mockResolvedValue([])
     renderRoute(AlertsRoute)
     expect(await screen.findByText('No alerts found')).toBeInTheDocument()
     expect(await screen.findByText('No alerts match your current filters. Try adjusting or clearing filters.'))
@@ -789,12 +789,12 @@ describe('overview alert and incident dashboard', () => {
 
   it('renders alert detail not-found, acknowledged, and resolved states', async () => {
     mockRouteParams.current = {alertId: UNKNOWN_RESOURCE_ID}
-    mockApi.getIncident.mockResolvedValueOnce(null)
+    mockApi.getAlert.mockResolvedValueOnce(null)
     renderRoute(AlertDetailRoute)
     expect(await screen.findByText('Alert not found')).toBeInTheDocument()
 
     mockRouteParams.current = {alertId: ACKNOWLEDGED_ALERT_RESOURCE_ID}
-    mockApi.getIncident.mockResolvedValueOnce({
+    mockApi.getAlert.mockResolvedValueOnce({
       ...alert,
       id: ACKNOWLEDGED_ALERT_RESOURCE_ID,
       status: 'ACKNOWLEDGED',
@@ -804,7 +804,7 @@ describe('overview alert and incident dashboard', () => {
       acknowledgedAt: '2026-06-05T12:05:00.000Z',
       description: '',
     })
-    mockApi.getIncidentTimeline.mockResolvedValueOnce([
+    mockApi.getAlertTimeline.mockResolvedValueOnce([
       {
         id: resourceId(141),
         incidentId: ACKNOWLEDGED_ALERT_RESOURCE_ID,
@@ -835,7 +835,7 @@ describe('overview alert and incident dashboard', () => {
     expect(await screen.findByText('UNKNOWN EVENT')).toBeInTheDocument()
 
     mockRouteParams.current = {alertId: RESOLVED_ALERT_RESOURCE_ID}
-    mockApi.getIncident.mockResolvedValueOnce({
+    mockApi.getAlert.mockResolvedValueOnce({
       ...alert,
       id: RESOLVED_ALERT_RESOURCE_ID,
       status: 'RESOLVED',
@@ -844,7 +844,7 @@ describe('overview alert and incident dashboard', () => {
       resolvedByName: 'Grace Hopper',
       resolvedAt: '2026-06-05T12:09:00.000Z',
     })
-    mockApi.getIncidentTimeline.mockResolvedValueOnce([])
+    mockApi.getAlertTimeline.mockResolvedValueOnce([])
     renderRoute(AlertDetailRoute)
     expect(await screen.findByText('Resolved By')).toBeInTheDocument()
     expect(await screen.findByText('Grace Hopper')).toBeInTheDocument()

--- a/dashboard/src/routes/on-call.alerts.$alertId.tsx
+++ b/dashboard/src/routes/on-call.alerts.$alertId.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useQuery, useMutation, useQueryClient} from '@tanstack/react-query'
-import {api, type IncidentTimeline} from '@/lib/api'
+import {api, type OnCallTimelineEvent} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {SectionCard} from '@/components/ui/section-card'
@@ -35,12 +35,12 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import {useToast} from '@/hooks/useToast'
 import {AlertTriangle, CheckCircle, Clock, MessageSquare, ArrowLeft, Zap, UserPlus, Bell, CheckCircle2, Eye, Send} from 'lucide-react'
-import {useState, useEffect, useRef} from 'react'
+import {useState, useEffect} from 'react'
 import {cn} from '@/lib/utils'
 import {isUuidResourceId} from '@/lib/api/utils'
 
 export const Route = createFileRoute('/on-call/alerts/$alertId')({
-  component: IncidentDetailPage,
+  component: AlertDetailPage,
 })
 
 // Priority / status mapped onto the shared status language.
@@ -51,11 +51,11 @@ function priorityBadgeVariant(priority: string): BadgeProps['variant'] {
   return 'neutral'
 }
 
-type IncidentStatusKind = 'danger' | 'warning' | 'success'
+type AlertStatusKind = 'danger' | 'warning' | 'success'
 
 const getStatusConfig = (
   status: string,
-): {variant: BadgeProps['variant']; icon: typeof Zap; label: string; kind: IncidentStatusKind} => {
+): {variant: BadgeProps['variant']; icon: typeof Zap; label: string; kind: AlertStatusKind} => {
   if (status === 'TRIGGERED') return {variant: 'danger', icon: Zap, label: 'Triggered', kind: 'danger'}
   if (status === 'ACKNOWLEDGED') return {variant: 'warning', icon: Clock, label: 'Acknowledged', kind: 'warning'}
   return {variant: 'success', icon: CheckCircle2, label: 'Resolved', kind: 'success'}
@@ -93,9 +93,9 @@ function detailString(value: unknown): string | null {
   return null
 }
 
-function getTimelineDescription(event: IncidentTimeline): string | null {
+function getTimelineDescription(event: OnCallTimelineEvent): string | null {
   if (event.eventType === 'NOTIFICATION_SENT' && event.details) {
-    const toName = detailString(event.details.toUserName) ?? event.actorUserName
+    const toName = detailString(event.details.toUserName) ?? event.actorName ?? event.actorUserName
     const channel = detailString(event.details.channel)
     if (toName && channel) return `to ${toName} via ${channel}`
     if (toName) return `to ${toName}`
@@ -114,7 +114,7 @@ function getTimelineDescription(event: IncidentTimeline): string | null {
   return null
 }
 
-function IncidentDetailPage() {
+function AlertDetailPage() {
   const {alertId} = Route.useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -126,29 +126,27 @@ function IncidentDetailPage() {
   const [declareSeverity, setDeclareSeverity] = useState('SEV-2')
   const normalizedAlertId = alertId.trim()
   const hasValidAlertId = isUuidResourceId(normalizedAlertId)
-  const alertQueryKey = ['incident', normalizedAlertId] as const
-  const alertTimelineQueryKey = ['incident-timeline', normalizedAlertId] as const
+  const alertQueryKey = ['alert', normalizedAlertId] as const
+  const alertTimelineQueryKey = ['alert-timeline', normalizedAlertId] as const
 
-  const {data: incident, isLoading} = useQuery({
+  const {data: alert, isLoading} = useQuery({
     queryKey: alertQueryKey,
-    queryFn: () => api.getIncident(normalizedAlertId),
+    queryFn: () => api.getAlert(normalizedAlertId),
     enabled: hasValidAlertId,
   })
 
-  // Initialize declare form when dialog opens
-  const lastInitializedRef = useRef<string | null>(null)
-  useEffect(() => {
-    if (declareOpen && incident && lastInitializedRef.current !== incident.id) {
-      lastInitializedRef.current = incident.id
-      setDeclareTitle(incident.title)
-      setDeclareDesc(incident.description || '')
+  const handleDeclareOpenChange = (open: boolean) => {
+    if (open && alert) {
+      setDeclareTitle(alert.title)
+      setDeclareDesc(alert.description || '')
       setDeclareSeverity('SEV-2')
     }
-  }, [declareOpen, incident])
+    setDeclareOpen(open)
+  }
 
   const declareMutation = useMutation({
     mutationFn: () =>
-      api.declareIncident(normalizedAlertId, {
+      api.declareIncidentFromAlert(normalizedAlertId, {
         title: declareTitle,
         description: declareDesc,
         severity: declareSeverity,
@@ -169,20 +167,20 @@ function IncidentDetailPage() {
 
   const {data: timeline = [], isLoading: timelineLoading} = useQuery({
     queryKey: alertTimelineQueryKey,
-    queryFn: () => api.getIncidentTimeline(normalizedAlertId),
+    queryFn: () => api.getAlertTimeline(normalizedAlertId),
     enabled: hasValidAlertId,
   })
 
   // Mark as viewed (deduplicated on backend)
-  const incidentLoaded = !!incident
+  const alertLoaded = !!alert
   useEffect(() => {
-    if (hasValidAlertId && incidentLoaded) {
-      api.viewIncident(normalizedAlertId).catch(() => {})
+    if (hasValidAlertId && alertLoaded) {
+      api.viewAlert(normalizedAlertId).catch(() => {})
     }
-  }, [normalizedAlertId, hasValidAlertId, incidentLoaded])
+  }, [normalizedAlertId, hasValidAlertId, alertLoaded])
 
   const acknowledgeMutation = useMutation({
-    mutationFn: () => api.acknowledgeIncident(normalizedAlertId),
+    mutationFn: () => api.acknowledgeAlert(normalizedAlertId),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: alertQueryKey})
       queryClient.invalidateQueries({queryKey: alertTimelineQueryKey})
@@ -198,7 +196,7 @@ function IncidentDetailPage() {
   })
 
   const resolveMutation = useMutation({
-    mutationFn: () => api.resolveIncident(normalizedAlertId),
+    mutationFn: () => api.resolveAlert(normalizedAlertId),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: alertQueryKey})
       queryClient.invalidateQueries({queryKey: alertTimelineQueryKey})
@@ -214,7 +212,7 @@ function IncidentDetailPage() {
   })
 
   const markUnavailableMutation = useMutation({
-    mutationFn: () => api.markUnavailable(normalizedAlertId),
+    mutationFn: () => api.markAlertUnavailable(normalizedAlertId),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: alertQueryKey})
       queryClient.invalidateQueries({queryKey: alertTimelineQueryKey})
@@ -230,7 +228,7 @@ function IncidentDetailPage() {
   })
 
   const addNoteMutation = useMutation({
-    mutationFn: (note: string) => api.addIncidentNote(normalizedAlertId, note),
+    mutationFn: (note: string) => api.addAlertNote(normalizedAlertId, note),
     onSuccess: () => {
       queryClient.invalidateQueries({queryKey: alertQueryKey})
       queryClient.invalidateQueries({queryKey: alertTimelineQueryKey})
@@ -260,7 +258,7 @@ function IncidentDetailPage() {
     )
   }
 
-  if (!incident) {
+  if (!alert) {
     return (
       <EmptyState
         icon={AlertTriangle}
@@ -270,8 +268,8 @@ function IncidentDetailPage() {
     )
   }
 
-  const incidentTimeline = incident.timeline ?? timeline
-  const statusCfg = getStatusConfig(incident.status)
+  const alertTimeline = alert.timeline ?? timeline
+  const statusCfg = getStatusConfig(alert.status)
   const StatusIcon = statusCfg.icon
 
   return (
@@ -287,47 +285,47 @@ function IncidentDetailPage() {
               <StatusIcon className="h-3 w-3" />
               {statusCfg.label}
             </Badge>
-            <Badge variant={priorityBadgeVariant(incident.priority)} size="sm">
-              {incident.priority}
+            <Badge variant={priorityBadgeVariant(alert.priority)} size="sm">
+              {alert.priority}
             </Badge>
-            <span className="text-xs text-muted-foreground font-mono">#{incident.id}</span>
+            <span className="text-xs text-muted-foreground font-mono">#{alert.id}</span>
           </div>
-          <h2 className="text-2xl font-bold tracking-tight">{incident.title}</h2>
+          <h2 className="text-2xl font-bold tracking-tight">{alert.title}</h2>
           <p className="text-sm text-muted-foreground mt-1">
-            Triggered {timeAgo(incident.triggeredAt)} · {new Date(incident.triggeredAt).toLocaleString()}
+            Triggered {timeAgo(alert.triggeredAt)} · {new Date(alert.triggeredAt).toLocaleString()}
           </p>
         </div>
       </div>
 
       {/* Action Banner */}
-      {incident.status !== 'RESOLVED' && (
+      {alert.status !== 'RESOLVED' && (
         <div className={cn(
           'flex items-center justify-between p-4 rounded-xl border',
-          incident.status === 'TRIGGERED'
+          alert.status === 'TRIGGERED'
             ? 'bg-danger-bg border-danger-border'
             : 'bg-warning-bg border-warning-border'
         )}>
           <div className="flex items-center gap-3">
             <div className={cn(
               'flex items-center justify-center h-10 w-10 rounded-full',
-              incident.status === 'TRIGGERED' ? 'bg-danger-bg' : 'bg-warning-bg'
+              alert.status === 'TRIGGERED' ? 'bg-danger-bg' : 'bg-warning-bg'
             )}>
-              <StatusIcon className={cn('h-5 w-5', incident.status === 'TRIGGERED' ? 'text-danger-fg' : 'text-warning-fg')} />
+              <StatusIcon className={cn('h-5 w-5', alert.status === 'TRIGGERED' ? 'text-danger-fg' : 'text-warning-fg')} />
             </div>
             <div>
               <p className="font-medium text-sm">
-                {incident.status === 'TRIGGERED' ? 'This alert needs attention' : 'Alert acknowledged'}
+                {alert.status === 'TRIGGERED' ? 'This alert needs attention' : 'Alert acknowledged'}
               </p>
               <p className="text-xs text-muted-foreground">
-                {incident.status === 'TRIGGERED'
+                {alert.status === 'TRIGGERED'
                   ? 'Acknowledge to assign yourself, or resolve directly'
-                  : `Acknowledged by ${incident.acknowledgedByName || 'you'}`}
+                  : `Acknowledged by ${alert.acknowledgedByName || 'you'}`}
               </p>
             </div>
           </div>
           <div className="flex flex-col items-end gap-1">
             <div className="flex gap-2">
-              {incident.status === 'TRIGGERED' && (
+              {alert.status === 'TRIGGERED' && (
                 <>
                   <Button
                     onClick={() => acknowledgeMutation.mutate()}
@@ -349,7 +347,7 @@ function IncidentDetailPage() {
                   </Button>
                 </>
               )}
-              {incident.status === 'ACKNOWLEDGED' && (
+              {alert.status === 'ACKNOWLEDGED' && (
                 <Button
                   onClick={() => resolveMutation.mutate()}
                   disabled={resolveMutation.isPending}
@@ -370,7 +368,7 @@ function IncidentDetailPage() {
               I'm not available
             </Button>
 
-            <Dialog open={declareOpen} onOpenChange={setDeclareOpen}>
+            <Dialog open={declareOpen} onOpenChange={handleDeclareOpenChange}>
               <DialogTrigger asChild>
                 <Button variant="link" size="sm" className="h-auto p-0 text-muted-foreground hover:text-foreground text-xs">
                   Declare Incident
@@ -380,7 +378,7 @@ function IncidentDetailPage() {
                 <DialogHeader>
                   <DialogTitle>Declare Incident</DialogTitle>
                   <DialogDescription>
-                    Escalate this alert to a formal incident.
+                    Declare an incident from this alert.
                   </DialogDescription>
                 </DialogHeader>
                 <div className="grid gap-4 py-4">
@@ -425,9 +423,9 @@ function IncidentDetailPage() {
         {/* Main Column */}
         <div className="lg:col-span-2 space-y-6">
           {/* Description */}
-          {incident.description && (
+          {alert.description && (
             <SectionCard title="Description" icon={MessageSquare} iconTone="muted">
-              <p className="text-sm text-muted-foreground leading-relaxed">{incident.description}</p>
+              <p className="text-sm text-muted-foreground leading-relaxed">{alert.description}</p>
             </SectionCard>
           )}
 
@@ -435,7 +433,7 @@ function IncidentDetailPage() {
           <SectionCard title="Timeline" icon={Clock} iconTone="muted">
             <p className="-mt-1 mb-3 text-xs text-muted-foreground">Alert history and updates</p>
             <div className="relative">
-                {incidentTimeline.map((event: IncidentTimeline, idx: number) => {
+                {alertTimeline.map((event: OnCallTimelineEvent, idx: number) => {
                   const config = EVENT_CONFIG[event.eventType] || {
                     icon: Clock,
                     color: 'text-muted-foreground',
@@ -444,6 +442,7 @@ function IncidentDetailPage() {
                   }
                   const Icon = config.icon
                   const description = getTimelineDescription(event)
+                  const actorName = event.actorName ?? event.actorUserName
                   const note =
                     event.eventType === 'NOTE_ADDED' && event.details
                       ? detailString(event.details.note)
@@ -451,7 +450,7 @@ function IncidentDetailPage() {
 
                   return (
                     <div key={event.id} className="flex gap-3 pb-6 last:pb-0 relative">
-                      {idx < incidentTimeline.length - 1 && (
+                      {idx < alertTimeline.length - 1 && (
                         <div className="absolute left-[15px] top-8 bottom-0 w-px bg-border" />
                       )}
                       <div className={cn(
@@ -469,9 +468,9 @@ function IncidentDetailPage() {
                             {timeAgo(event.createdAt)}
                           </span>
                         </div>
-                        {event.actorUserName && event.eventType !== 'NOTIFICATION_SENT' && (
+                        {actorName && event.eventType !== 'NOTIFICATION_SENT' && (
                           <p className="text-xs text-muted-foreground mt-0.5">
-                            by {event.actorUserName}
+                            by {actorName}
                           </p>
                         )}
                         {description && (
@@ -519,36 +518,36 @@ function IncidentDetailPage() {
               </div>
               <div>
                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">Priority</p>
-                <Badge variant={priorityBadgeVariant(incident.priority)}>
-                  {incident.priority}
+                <Badge variant={priorityBadgeVariant(alert.priority)}>
+                  {alert.priority}
                 </Badge>
               </div>
               <div>
                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">Alert Source</p>
-                <p className="text-sm">{incident.alertSource || 'Unknown'}</p>
+                <p className="text-sm">{alert.alertSource || 'Unknown'}</p>
               </div>
               <div>
                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">Triggered At</p>
-                <p className="text-sm">{new Date(incident.triggeredAt).toLocaleString()}</p>
+                <p className="text-sm">{new Date(alert.triggeredAt).toLocaleString()}</p>
               </div>
-              {incident.acknowledgedBy && (
+              {alert.acknowledgedBy && (
                 <div>
                   <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">Acknowledged By</p>
                   <p className="text-sm">
-                    {incident.acknowledgedByName}
+                    {alert.acknowledgedByName}
                     <span className="text-xs text-muted-foreground block mt-0.5">
-                      {new Date(incident.acknowledgedAt!).toLocaleString()}
+                      {new Date(alert.acknowledgedAt!).toLocaleString()}
                     </span>
                   </p>
                 </div>
               )}
-              {incident.resolvedBy && (
+              {alert.resolvedBy && (
                 <div>
                   <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">Resolved By</p>
                   <p className="text-sm">
-                    {incident.resolvedByName}
+                    {alert.resolvedByName}
                     <span className="text-xs text-muted-foreground block mt-0.5">
-                      {new Date(incident.resolvedAt!).toLocaleString()}
+                      {new Date(alert.resolvedAt!).toLocaleString()}
                     </span>
                   </p>
                 </div>

--- a/dashboard/src/routes/on-call.alerts.tsx
+++ b/dashboard/src/routes/on-call.alerts.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute, Link, Outlet, useRouterState} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
-import {api, type IncidentListFilters, type IncidentStatus} from '@/lib/api'
+import {api, type OnCallAlertListFilters, type OnCallAlertStatus} from '@/lib/api'
 import {Card, CardContent} from '@/components/ui/card'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {EmptyState} from '@/components/ui/empty-state'
@@ -37,10 +37,10 @@ export const Route = createFileRoute('/on-call/alerts')({
   component: Alerts,
 })
 
-type AlertStatusFilter = IncidentStatus | 'active' | 'all'
+type AlertStatusFilter = OnCallAlertStatus | 'active' | 'all'
 
 const DEFAULT_ALERT_STATUS_FILTER: AlertStatusFilter = 'active'
-const ACTIVE_ALERT_STATUSES: IncidentStatus[] = ['TRIGGERED', 'ACKNOWLEDGED']
+const ACTIVE_ALERT_STATUSES: OnCallAlertStatus[] = ['TRIGGERED', 'ACKNOWLEDGED']
 
 // Priority / status mapped onto the shared status language.
 function priorityTone(priority: string): StatusTone {
@@ -86,7 +86,7 @@ function isEscalatingSoon(nextEscalationAt?: string): boolean {
   return diff > 0 && diff <= 2 * 60 * 1000
 }
 
-function toIncidentStatusFilter(statusFilter: AlertStatusFilter): IncidentListFilters['status'] | undefined {
+function toAlertStatusFilterValue(statusFilter: AlertStatusFilter): OnCallAlertListFilters['status'] | undefined {
   if (statusFilter === 'active') return ACTIVE_ALERT_STATUSES
   if (statusFilter === 'all') return undefined
   return statusFilter
@@ -105,11 +105,11 @@ function toAlertStatusFilter(value: string): AlertStatusFilter {
   return DEFAULT_ALERT_STATUS_FILTER
 }
 
-function nextAlertStatusFilter(current: AlertStatusFilter, status: IncidentStatus): AlertStatusFilter {
+function nextAlertStatusFilter(current: AlertStatusFilter, status: OnCallAlertStatus): AlertStatusFilter {
   return current === status ? DEFAULT_ALERT_STATUS_FILTER : status
 }
 
-function isAlertStatusActive(current: AlertStatusFilter, status: IncidentStatus): boolean {
+function isAlertStatusActive(current: AlertStatusFilter, status: OnCallAlertStatus): boolean {
   return current === status || (current === 'active' && ACTIVE_ALERT_STATUSES.includes(status))
 }
 
@@ -129,11 +129,11 @@ function Alerts() {
   const {data: alerts, isLoading} = useQuery({
     queryKey: ['alerts', statusFilter, priorityFilter],
     queryFn: () => {
-      const filters: IncidentListFilters = {}
-      const status = toIncidentStatusFilter(statusFilter)
+      const filters: OnCallAlertListFilters = {}
+      const status = toAlertStatusFilterValue(statusFilter)
       if (status) filters.status = status
       if (priorityFilter !== 'all') filters.priority = priorityFilter
-      return api.getIncidents(filters)
+      return api.getAlerts(filters)
     },
     refetchInterval: 30000,
   })

--- a/dashboard/src/routes/on-call.incidents.$incidentId.tsx
+++ b/dashboard/src/routes/on-call.incidents.$incidentId.tsx
@@ -16,7 +16,7 @@
 
 import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useQuery, useMutation, useQueryClient} from '@tanstack/react-query'
-import {api, type IncidentTimeline} from '@/lib/api'
+import {api, type OnCallTimelineEvent} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {Badge, type BadgeProps} from '@/components/ui/badge'
 import {SectionCard} from '@/components/ui/section-card'
@@ -68,7 +68,7 @@ interface DeclaredIncidentDetail {
   [key: string]: unknown
 }
 
-interface DeclaredIncidentTimelineEvent extends Omit<IncidentTimeline, 'eventType'> {
+interface DeclaredIncidentTimelineEvent extends Omit<OnCallTimelineEvent, 'eventType'> {
   eventType: string
   source?: string
   alertTitle?: string
@@ -149,7 +149,7 @@ function getTimelineDescription(event: DeclaredIncidentTimelineEvent): string | 
 
 function notificationDescription(event: DeclaredIncidentTimelineEvent): string | null {
   if (!event.details) return null
-  const toName = detailString(event.details.toUserName) ?? event.actorUserName
+  const toName = detailString(event.details.toUserName) ?? event.actorName ?? event.actorUserName
   const channel = detailString(event.details.channel)
   if (toName && channel) return `to ${toName} via ${channel}`
   if (toName) return `to ${toName}`

--- a/dashboard/src/routes/on-call.index.tsx
+++ b/dashboard/src/routes/on-call.index.tsx
@@ -17,7 +17,7 @@
 import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {type ComponentType, type ReactNode} from 'react'
-import {api, type BusinessHours, type Incident, type OnCallSchedule} from '@/lib/api'
+import {api, type BusinessHours, type OnCallAlert, type OnCallSchedule} from '@/lib/api'
 import {SectionCard} from '@/components/ui/section-card'
 import {StatCard} from '@/components/ui/stat-card'
 import {EmptyState} from '@/components/ui/empty-state'
@@ -192,7 +192,7 @@ function PriorityAlertList({
   emptyMessage,
   compact = false,
 }: Readonly<{
-  alerts: Incident[]
+  alerts: OnCallAlert[]
   limit: number
   emptyMessage: string
   compact?: boolean
@@ -267,8 +267,8 @@ function YourAlertSummaryCard({
   businessHours?: BusinessHours
   isWithinBusinessHours: boolean | null
   currentUserOnCallSchedules: OnCallSchedule[]
-  pageableAlerts: Incident[]
-  lowPriorityAlerts: Incident[]
+  pageableAlerts: OnCallAlert[]
+  lowPriorityAlerts: OnCallAlert[]
 }>) {
   return (
     <SectionCard
@@ -412,7 +412,7 @@ function CurrentOnCallAssignee({schedule}: Readonly<{ schedule: OnCallSchedule }
   )
 }
 
-function ActiveAlertsCard({activeAlerts}: Readonly<{ activeAlerts: Incident[] }>) {
+function ActiveAlertsCard({activeAlerts}: Readonly<{ activeAlerts: OnCallAlert[] }>) {
   if (activeAlerts.length === 0) return null
 
   return (
@@ -439,7 +439,7 @@ function ActiveAlertsCard({activeAlerts}: Readonly<{ activeAlerts: Incident[] }>
   )
 }
 
-function ActiveAlertRow({alert}: Readonly<{ alert: Incident }>) {
+function ActiveAlertRow({alert}: Readonly<{ alert: OnCallAlert }>) {
   const statusCfg = getStatusConfig(alert.status)
   const StatusIcon = statusCfg.icon
 
@@ -524,7 +524,7 @@ function OnCallOverview() {
 
   const {data: alerts, isLoading: alertsLoading} = useQuery({
     queryKey: ['alerts', {active: true}],
-    queryFn: () => api.getIncidents(),
+    queryFn: () => api.getAlerts(),
   })
 
   const {data: policies, isLoading: policiesLoading} = useQuery({

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -209,6 +209,17 @@ class OnCallModule :
         return alert?.id
     }
 
+    override suspend fun resolveEscalation(
+        organizationId: Int,
+        alertSource: String,
+        deduplicationKey: String,
+    ): Boolean =
+        escalationEngine.resolveAlertByDeduplicationKey(
+            organizationId = organizationId,
+            alertSource = alertSource,
+            deduplicationKey = deduplicationKey,
+        )
+
     override suspend fun declareIncident(
         organizationId: Int,
         userId: Int,

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationEngine.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/EscalationEngine.kt
@@ -67,6 +67,10 @@ class EscalationEngine(
         private const val TIMEOUT_KEY_PREFIX = "escalation:timeout:"
         private const val ACTIVE_INCIDENTS_KEY = "escalation:active"
         private const val SMS_FALLBACK_KEY = "escalation:sms_fallback"
+        private const val TRIGGERED_STATUS = "TRIGGERED"
+        private const val ACKNOWLEDGED_STATUS = "ACKNOWLEDGED"
+        private const val RESOLVED_STATUS = "RESOLVED"
+        private val OPEN_ALERT_STATUSES = listOf(TRIGGERED_STATUS, ACKNOWLEDGED_STATUS)
     }
 
     private data class AlertEscalationState(
@@ -150,7 +154,7 @@ class EscalationEngine(
                             .where {
                                 (OnCallAlerts.organizationId eq organizationId) and
                                     (OnCallAlerts.deduplicationKey eq deduplicationKey) and
-                                    (OnCallAlerts.status inList listOf("TRIGGERED", "ACKNOWLEDGED"))
+                                    (OnCallAlerts.status inList OPEN_ALERT_STATUSES)
                             }.singleOrNull()
 
                     if (existing != null) {
@@ -167,7 +171,7 @@ class EscalationEngine(
                             it[OnCallAlerts.title] = title
                             it[OnCallAlerts.description] = description
                             it[OnCallAlerts.priority] = priority
-                            it[OnCallAlerts.status] = "TRIGGERED"
+                            it[OnCallAlerts.status] = TRIGGERED_STATUS
                             it[OnCallAlerts.alertSource] = alertSource
                             it[OnCallAlerts.deduplicationKey] = deduplicationKey
                             it[currentStep] = 0
@@ -178,7 +182,7 @@ class EscalationEngine(
                             it[updatedAt] = now
                         }.value
 
-                insertTimelineEvent(alertId, "TRIGGERED", null, mapOf("priority" to JsonPrimitive(priority)))
+                insertTimelineEvent(alertId, TRIGGERED_STATUS, null, mapOf("priority" to JsonPrimitive(priority)))
 
                 alertId
             } ?: return null
@@ -186,6 +190,61 @@ class EscalationEngine(
         processEscalationStep(alertId, 0, 0)
         return getAlert(alertId)
     }
+
+    fun resolveAlertByDeduplicationKey(
+        organizationId: Int,
+        alertSource: String,
+        deduplicationKey: String,
+    ): Boolean =
+        transaction {
+            val now = Clock.System.now()
+            val alertIds =
+                OnCallAlerts
+                    .selectAll()
+                    .where {
+                        (OnCallAlerts.organizationId eq organizationId) and
+                            (OnCallAlerts.alertSource eq alertSource) and
+                            (OnCallAlerts.deduplicationKey eq deduplicationKey) and
+                            (OnCallAlerts.status inList OPEN_ALERT_STATUSES)
+                    }.map { row -> row[OnCallAlerts.id].value }
+
+            if (alertIds.isEmpty()) {
+                return@transaction false
+            }
+
+            val updated =
+                OnCallAlerts.update({ OnCallAlerts.id inList alertIds }) {
+                    it[status] = RESOLVED_STATUS
+                    it[resolvedAt] = now
+                    it[resolvedBy] = null
+                    it[updatedAt] = now
+                }
+
+            if (updated <= 0) {
+                return@transaction false
+            }
+
+            alertIds.forEach { alertId ->
+                removeTimeout(alertId)
+                removeSmsFallback(alertId)
+                insertTimelineEvent(
+                    alertId,
+                    RESOLVED_STATUS,
+                    null,
+                    mapOf(
+                        "source" to JsonPrimitive(alertSource),
+                        "deduplicationKey" to JsonPrimitive(deduplicationKey),
+                        "resolvedBy" to JsonPrimitive("system"),
+                    ),
+                )
+            }
+
+            logger.info(
+                "Resolved $updated on-call alert(s) for org $organizationId, source $alertSource, " +
+                    "deduplication key $deduplicationKey",
+            )
+            true
+        }
 
     private fun processEscalationStep(
         incidentId: Int,


### PR DESCRIPTION
## Summary
- Resolve native on-call alerts when source alerts clear.
- Keep alert and declared-incident API names distinct in the dashboard client.

## Testing
- `cd backend && ./gradlew :test --tests com.moneat.enterprise.IncidentServiceOnCallBridgeTest --no-daemon`
- `cd backend && ./gradlew detekt --no-daemon`
- `cd dashboard && npm run test -- src/lib/api/modules/__tests__/on-call.test.ts src/routes/__tests__/overview-alert-incident-coverage.test.tsx`
- `cd dashboard && npm run typecheck`
- `cd dashboard && npm run lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On-call pages now use **alerts** terminology across the list, detail, and overview views.
  * Added support for resolving open on-call alerts by source and deduplication key.

* **Bug Fixes**
  * Alert resolution now correctly clears matching open on-call escalations when an incident is resolved.
  * Timeline and status details in alert views are more consistent and accurate.

* **Tests**
  * Expanded automated coverage for alert listing, detail actions, and on-call resolution flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->