### PR TITLE
fix: update feedback status mutation

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/FeedbackService.kt
@@ -255,7 +255,7 @@ class FeedbackService(private val queryHelper: DashboardQueryHelper) {
             val query =
                 """
                 ALTER TABLE `$clickhouseDb`.user_feedback
-                UPDATE status = '$escapedStatus', updated_at = now64(3)
+                UPDATE status = '$escapedStatus'
                 WHERE toString(feedback_id) = '$normalizedFeedbackId'
                 """.trimIndent()
             queryHelper.executeMutation(query, "Feedback update")

--- a/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/events/services/FeedbackServiceTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.events.services
 
+import com.moneat.events.models.FeedbackUpdateRequest
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -26,6 +27,7 @@ import kotlinx.serialization.json.put
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 private const val FEEDBACK_UUID = "4f01ede1-5802-4ff1-81b7-f2fe9add31e5"
@@ -170,5 +172,17 @@ class FeedbackServiceTest {
         assertEquals("00000000000000000000000000000001", result.single().traceId)
         assertEquals("0000000000000001", result.single().spanId)
         assertEquals(mapOf("service.name" to "checkout-api"), result.single().resourceAttributes)
+    }
+
+    @Test
+    fun `updateFeedback does not mutate replacing tree version column`() = runBlocking {
+        val querySlot = slot<String>()
+        coEvery { queryHelper.executeMutation(capture(querySlot), "Feedback update") } returns Unit
+
+        service.updateFeedback(FEEDBACK_UUID, FeedbackUpdateRequest(status = "resolved"))
+
+        val query = querySlot.captured
+        assertEquals(true, query.contains("UPDATE status = 'resolved'"))
+        assertFalse(query.contains("updated_at"))
     }
 }


### PR DESCRIPTION
## Summary
- update feedback status without mutating the ClickHouse version column
- add a regression test for the generated mutation

## Tests
- ./gradlew :test --tests com.moneat.events.services.FeedbackServiceTest -x jacocoTestReport --rerun-tasks --no-daemon
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback status updates now change only the status value, avoiding unintended changes to the timestamp field.
  * Improved handling of feedback updates so the generated database update is more targeted.
* **Tests**
  * Added coverage to confirm feedback updates no longer include the timestamp field in the update request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->