### PR TITLE
fix: sort releases by version precedence

### DIFF
--- a/dashboard/src/lib/__tests__/release-version.test.ts
+++ b/dashboard/src/lib/__tests__/release-version.test.ts
@@ -1,0 +1,40 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {compareReleaseVersionPrecedence} from '../release-version'
+
+describe('compareReleaseVersionPrecedence', () => {
+  it('compares package-prefixed semantic releases with build numbers', () => {
+    expect(
+      compareReleaseVersionPrecedence('com.bandapella@4.5.1+16', 'com.bandapella@4.4.2+15')
+    ).toBeGreaterThan(0)
+  })
+
+  it('uses numeric build metadata as a same-version tie breaker', () => {
+    expect(
+      compareReleaseVersionPrecedence('com.bandapella@4.5.1+16', 'com.bandapella@4.5.1+15')
+    ).toBeGreaterThan(0)
+  })
+
+  it('keeps stable releases ahead of prereleases', () => {
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0', 'frontend@1.2.0-beta.1')).toBeGreaterThan(0)
+  })
+
+  it('does not compare versions from different release families', () => {
+    expect(compareReleaseVersionPrecedence('api@9.0.0', 'worker@1.0.0')).toBe(0)
+  })
+})

--- a/dashboard/src/lib/__tests__/release-version.test.ts
+++ b/dashboard/src/lib/__tests__/release-version.test.ts
@@ -34,6 +34,33 @@ describe('compareReleaseVersionPrecedence', () => {
     expect(compareReleaseVersionPrecedence('frontend@1.2.0', 'frontend@1.2.0-beta.1')).toBeGreaterThan(0)
   })
 
+  it('orders prerelease identifiers using semantic version precedence', () => {
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0-beta.2', 'frontend@1.2.0-beta.1')).toBeGreaterThan(0)
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0-1', 'frontend@1.2.0-alpha')).toBeLessThan(0)
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0-alpha', 'frontend@1.2.0-1')).toBeGreaterThan(0)
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0-alpha', 'frontend@1.2.0-beta')).toBeLessThan(0)
+  })
+
+  it('keeps longer prerelease and build metadata ahead when the shared prefix matches', () => {
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0-beta.1', 'frontend@1.2.0-beta')).toBeGreaterThan(0)
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0+build.2', 'frontend@1.2.0+build')).toBeGreaterThan(0)
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0+build', 'frontend@1.2.0+build.2')).toBeLessThan(0)
+  })
+
+  it('falls back to the last version-like token when no package separator is present', () => {
+    expect(compareReleaseVersionPrecedence('web build v2.4.0', 'web build v2.3.9')).toBeGreaterThan(0)
+  })
+
+  it('ignores unparsable release labels', () => {
+    expect(compareReleaseVersionPrecedence('frontend@release', 'frontend@1.0.0')).toBe(0)
+    expect(compareReleaseVersionPrecedence('frontend@1', 'frontend@1.0.0')).toBe(0)
+  })
+
+  it('treats equivalent version precedence as equal', () => {
+    expect(compareReleaseVersionPrecedence('frontend@1.2.0-beta', 'frontend@1.2.0-beta')).toBe(0)
+    expect(compareReleaseVersionPrecedence('frontend@1.2', 'frontend@1.2.0')).toBe(0)
+  })
+
   it('does not compare versions from different release families', () => {
     expect(compareReleaseVersionPrecedence('api@9.0.0', 'worker@1.0.0')).toBe(0)
   })

--- a/dashboard/src/lib/release-version.ts
+++ b/dashboard/src/lib/release-version.ts
@@ -1,0 +1,141 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+type ParsedReleaseVersion = {
+  family: string
+  core: number[]
+  prerelease: string[]
+  build: string[]
+}
+
+const VERSION_CANDIDATE_PATTERN = /v?\d+(?:\.\d+)+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/g
+
+export function compareReleaseVersionPrecedence(left: string, right: string): number {
+  const leftVersion = parseReleaseVersion(left)
+  const rightVersion = parseReleaseVersion(right)
+
+  if (!leftVersion || !rightVersion || leftVersion.family !== rightVersion.family) return 0
+
+  const coreOrder = compareNumberList(leftVersion.core, rightVersion.core)
+  if (coreOrder !== 0) return coreOrder
+
+  const prereleaseOrder = comparePrerelease(leftVersion.prerelease, rightVersion.prerelease)
+  if (prereleaseOrder !== 0) return prereleaseOrder
+
+  return compareBuild(leftVersion.build, rightVersion.build)
+}
+
+function parseReleaseVersion(value: string): ParsedReleaseVersion | null {
+  const trimmed = value.trim()
+  const atIndex = trimmed.lastIndexOf('@')
+  if (atIndex >= 0) {
+    const atVersion = parseCandidateAt(trimmed, atIndex + 1)
+    if (atVersion) return atVersion
+  }
+
+  const matches = Array.from(trimmed.matchAll(VERSION_CANDIDATE_PATTERN))
+  const match = matches.at(-1)
+  if (!match || match.index == null) return null
+
+  return parseCandidate(trimmed, match.index, match[0])
+}
+
+function parseCandidateAt(value: string, index: number): ParsedReleaseVersion | null {
+  const match = /^v?\d+(?:\.\d+)+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/.exec(value.slice(index))
+  if (!match) return null
+
+  return parseCandidate(value, index, match[0])
+}
+
+function parseCandidate(source: string, index: number, candidate: string): ParsedReleaseVersion | null {
+  const normalized = candidate.replace(/^v/i, '')
+  const buildIndex = normalized.indexOf('+')
+  const withoutBuild = buildIndex >= 0 ? normalized.slice(0, buildIndex) : normalized
+  const build = buildIndex >= 0 ? normalized.slice(buildIndex + 1).split('.') : []
+  const prereleaseIndex = withoutBuild.indexOf('-')
+  const coreText = prereleaseIndex >= 0 ? withoutBuild.slice(0, prereleaseIndex) : withoutBuild
+  const prerelease = prereleaseIndex >= 0 ? withoutBuild.slice(prereleaseIndex + 1).split('.') : []
+  const core = coreText.split('.').map((segment) => Number.parseInt(segment, 10))
+
+  if (core.some((segment) => !Number.isSafeInteger(segment))) return null
+
+  return {
+    family: source.slice(0, index).toLowerCase(),
+    core,
+    prerelease,
+    build,
+  }
+}
+
+function compareNumberList(left: number[], right: number[]): number {
+  const segmentCount = Math.max(left.length, right.length)
+  for (let index = 0; index < segmentCount; index += 1) {
+    const leftSegment = left[index] ?? 0
+    const rightSegment = right[index] ?? 0
+    if (leftSegment !== rightSegment) return leftSegment - rightSegment
+  }
+
+  return 0
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 0
+  if (left.length === 0) return 1
+  if (right.length === 0) return -1
+
+  return compareIdentifierList(left, right)
+}
+
+function compareBuild(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 0
+  if (left.length === 0) return -1
+  if (right.length === 0) return 1
+
+  return compareIdentifierList(left, right)
+}
+
+function compareIdentifierList(left: string[], right: string[]): number {
+  const segmentCount = Math.max(left.length, right.length)
+  for (let index = 0; index < segmentCount; index += 1) {
+    const leftSegment = left[index]
+    const rightSegment = right[index]
+    if (leftSegment == null) return -1
+    if (rightSegment == null) return 1
+
+    const segmentOrder = compareIdentifier(leftSegment, rightSegment)
+    if (segmentOrder !== 0) return segmentOrder
+  }
+
+  return 0
+}
+
+function compareIdentifier(left: string, right: string): number {
+  const leftNumber = parseNumericIdentifier(left)
+  const rightNumber = parseNumericIdentifier(right)
+
+  if (leftNumber != null && rightNumber != null) return leftNumber - rightNumber
+  if (leftNumber != null) return -1
+  if (rightNumber != null) return 1
+
+  return left.localeCompare(right)
+}
+
+function parseNumericIdentifier(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}

--- a/dashboard/src/lib/release-version.ts
+++ b/dashboard/src/lib/release-version.ts
@@ -21,7 +21,10 @@ type ParsedReleaseVersion = {
   build: string[]
 }
 
-const VERSION_CANDIDATE_PATTERN = /v?\d+(?:\.\d+)+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/g
+type CandidateRange = {
+  start: number
+  end: number
+}
 
 export function compareReleaseVersionPrecedence(left: string, right: string): number {
   const leftVersion = parseReleaseVersion(left)
@@ -43,26 +46,38 @@ function parseReleaseVersion(value: string): ParsedReleaseVersion | null {
   const trimmed = value.trim()
   const atIndex = trimmed.lastIndexOf('@')
   if (atIndex >= 0) {
-    const atVersion = parseCandidateAt(trimmed, atIndex + 1)
+    const atVersion = parseCandidate(trimmed, atIndex + 1)
     if (atVersion) return atVersion
   }
 
-  const matches = Array.from(trimmed.matchAll(VERSION_CANDIDATE_PATTERN))
-  const match = matches.at(-1)
-  if (match?.index == null) return null
+  const range = findLastCandidateRange(trimmed)
+  if (range == null) return null
 
-  return parseCandidate(trimmed, match.index, match[0])
+  return parseCandidate(trimmed, range.start)
 }
 
-function parseCandidateAt(value: string, index: number): ParsedReleaseVersion | null {
-  const match = /^v?\d+(?:\.\d+)+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/.exec(value.slice(index))
-  if (!match) return null
+function findLastCandidateRange(value: string): CandidateRange | null {
+  let lastRange: CandidateRange | null = null
+  let index = 0
+  while (index < value.length) {
+    const range = readCandidateRange(value, index)
+    if (range == null) {
+      index += 1
+    } else {
+      lastRange = range
+      index = range.end
+    }
+  }
 
-  return parseCandidate(value, index, match[0])
+  return lastRange
 }
 
-function parseCandidate(source: string, index: number, candidate: string): ParsedReleaseVersion | null {
-  const normalized = candidate.replace(/^v/i, '')
+function parseCandidate(source: string, index: number): ParsedReleaseVersion | null {
+  const range = readCandidateRange(source, index)
+  if (range == null) return null
+
+  const candidate = source.slice(range.start, range.end)
+  const normalized = isVersionPrefix(candidate.charAt(0)) ? candidate.slice(1) : candidate
   const buildIndex = normalized.indexOf('+')
   const withoutBuild = buildIndex >= 0 ? normalized.slice(0, buildIndex) : normalized
   const build = buildIndex >= 0 ? normalized.slice(buildIndex + 1).split('.') : []
@@ -79,6 +94,73 @@ function parseCandidate(source: string, index: number, candidate: string): Parse
     prerelease,
     build,
   }
+}
+
+function readCandidateRange(value: string, start: number): CandidateRange | null {
+  let index = isVersionPrefix(value.charAt(start)) ? start + 1 : start
+  const firstSegmentEnd = readDigits(value, index)
+  if (firstSegmentEnd === index) return null
+
+  index = firstSegmentEnd
+  let coreSegmentCount = 1
+  while (value.charAt(index) === '.') {
+    const nextSegmentStart = index + 1
+    const nextSegmentEnd = readDigits(value, nextSegmentStart)
+    if (nextSegmentEnd === nextSegmentStart) break
+
+    coreSegmentCount += 1
+    index = nextSegmentEnd
+  }
+
+  if (coreSegmentCount < 2) return null
+
+  if (value.charAt(index) === '-') {
+    const prereleaseStart = index + 1
+    const prereleaseEnd = readVersionSuffix(value, prereleaseStart)
+    if (prereleaseEnd > prereleaseStart) index = prereleaseEnd
+  }
+
+  if (value.charAt(index) === '+') {
+    const buildStart = index + 1
+    const buildEnd = readVersionSuffix(value, buildStart)
+    if (buildEnd > buildStart) index = buildEnd
+  }
+
+  return {start, end: index}
+}
+
+function readDigits(value: string, start: number): number {
+  let index = start
+  while (isDigit(value.charAt(index))) index += 1
+
+  return index
+}
+
+function readVersionSuffix(value: string, start: number): number {
+  let index = start
+  while (isVersionSuffixChar(value.charAt(index))) index += 1
+
+  return index
+}
+
+function isVersionPrefix(value: string): boolean {
+  return value === 'v' || value === 'V'
+}
+
+function isVersionSuffixChar(value: string): boolean {
+  return isDigit(value) || isUppercaseLetter(value) || isLowercaseLetter(value) || value === '.' || value === '-'
+}
+
+function isDigit(value: string): boolean {
+  return value >= '0' && value <= '9'
+}
+
+function isUppercaseLetter(value: string): boolean {
+  return value >= 'A' && value <= 'Z'
+}
+
+function isLowercaseLetter(value: string): boolean {
+  return value >= 'a' && value <= 'z'
 }
 
 function compareNumberList(left: number[], right: number[]): number {
@@ -135,8 +217,18 @@ function compareIdentifier(left: string, right: string): number {
 }
 
 function parseNumericIdentifier(value: string): number | null {
-  if (!/^\d+$/.test(value)) return null
+  if (!hasOnlyDigits(value)) return null
 
   const parsed = Number.parseInt(value, 10)
   return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+function hasOnlyDigits(value: string): boolean {
+  if (value.length === 0) return false
+
+  for (const character of value) {
+    if (!isDigit(character)) return false
+  }
+
+  return true
 }

--- a/dashboard/src/lib/release-version.ts
+++ b/dashboard/src/lib/release-version.ts
@@ -27,7 +27,8 @@ export function compareReleaseVersionPrecedence(left: string, right: string): nu
   const leftVersion = parseReleaseVersion(left)
   const rightVersion = parseReleaseVersion(right)
 
-  if (!leftVersion || !rightVersion || leftVersion.family !== rightVersion.family) return 0
+  if (leftVersion == null || rightVersion == null) return 0
+  if (leftVersion.family !== rightVersion.family) return 0
 
   const coreOrder = compareNumberList(leftVersion.core, rightVersion.core)
   if (coreOrder !== 0) return coreOrder
@@ -48,7 +49,7 @@ function parseReleaseVersion(value: string): ParsedReleaseVersion | null {
 
   const matches = Array.from(trimmed.matchAll(VERSION_CANDIDATE_PATTERN))
   const match = matches.at(-1)
-  if (!match || match.index == null) return null
+  if (match?.index == null) return null
 
   return parseCandidate(trimmed, match.index, match[0])
 }

--- a/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
+++ b/dashboard/src/routes/__tests__/release-replay-feedback-service-facets.test.tsx
@@ -251,6 +251,30 @@ describe('release, replay, and feedback service facets', () => {
     expect(mockApi.getOrganizationReleases).toHaveBeenCalledWith({})
   })
 
+  it('marks the highest release version as latest when older releases report later signals', async () => {
+    mockApi.getOrganizationReleases.mockResolvedValue([
+      {
+        ...release,
+        version: 'com.bandapella@4.4.2+15',
+        firstSeen: '2026-06-26T21:08:00.000Z',
+        lastSeen: '2026-07-02T20:02:00.000Z',
+      },
+      {
+        ...healthyRelease,
+        version: 'com.bandapella@4.5.1+16',
+        firstSeen: '2026-07-01T15:54:00.000Z',
+        lastSeen: '2026-07-01T15:54:00.000Z',
+      },
+    ])
+
+    renderRoute(ReleasesRoute)
+
+    const latestBadge = await screen.findByText('Latest')
+    const latestRow = latestBadge.closest('a')
+    expect(latestRow).toHaveTextContent('com.bandapella@4.5.1+16')
+    expect(latestRow).not.toHaveTextContent('com.bandapella@4.4.2+15')
+  })
+
   it('adds selected services to release calls', async () => {
     renderRoute(ReleasesRoute)
 

--- a/dashboard/src/routes/releases.tsx
+++ b/dashboard/src/routes/releases.tsx
@@ -37,6 +37,8 @@ import {
 } from '@/lib/service-facet-scope'
 import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {parseDate} from '@/lib/date-format'
+import {compareReleaseVersionPrecedence} from '@/lib/release-version'
+import type {Release} from '@/lib/api/types'
 
 export const Route = createFileRoute('/releases')({
   beforeLoad: async ({ location }) => {
@@ -71,6 +73,17 @@ function crashFreeTextClass(tone: CrashFreeTone): string {
   if (tone === 'success') return 'text-success-fg'
   if (tone === 'warning') return 'text-warning-fg'
   return 'text-danger-fg'
+}
+
+function compareReleasesByLastSeen(left: Release, right: Release): number {
+  return parseDate(right.lastSeen).getTime() - parseDate(left.lastSeen).getTime()
+}
+
+function compareReleasesByLatest(left: Release, right: Release): number {
+  const versionOrder = compareReleaseVersionPrecedence(right.version, left.version)
+  if (versionOrder !== 0) return versionOrder
+
+  return compareReleasesByLastSeen(left, right)
 }
 
 function ReleasesPage() {
@@ -145,9 +158,7 @@ function ReleasesPage() {
         : null
 
     const mostActive = [...releaseList].sort((a, b) => b.eventCount - a.eventCount)[0]
-    const latest = [...releaseList].sort(
-      (a, b) => parseDate(b.lastSeen).getTime() - parseDate(a.lastSeen).getTime()
-    )[0]
+    const latest = [...releaseList].sort(compareReleasesByLatest)[0]
 
     return {
       healthyCount,
@@ -172,7 +183,7 @@ function ReleasesPage() {
         return bRate - aRate
       }
 
-      return parseDate(b.lastSeen).getTime() - parseDate(a.lastSeen).getTime()
+      return compareReleasesByLatest(a, b)
     })
   }, [releaseList, searchQuery, sortBy])
 
@@ -282,7 +293,7 @@ function ReleasesPage() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="latest">Sort: Latest seen</SelectItem>
+                    <SelectItem value="latest">Sort: Latest release</SelectItem>
                     <SelectItem value="events">Sort: Most signals</SelectItem>
                     <SelectItem value="issues">Sort: Most new issues</SelectItem>
                     <SelectItem value="stability">Sort: Most stable</SelectItem>


### PR DESCRIPTION
## Summary
- sort release lists by parsed release version before falling back to telemetry recency
- add release-version comparator coverage and route-level regression coverage

## Validation
- `cd dashboard && npm run test -- --run src/lib/__tests__/release-version.test.ts src/routes/__tests__/release-replay-feedback-service-facets.test.tsx`
- `cd dashboard && npm run lint`
- `cd dashboard && npm run typecheck`
- `git diff --check`