### PR TITLE
fix: avoid replay context project id collision

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
@@ -526,7 +526,7 @@ class ReplayService(
         val query =
             """
             SELECT
-                toInt64(project_id) as project_id,
+                toInt64(project_id) as $REPLAY_CONTEXT_PROJECT_ID_FIELD,
                 toUnixTimestamp64Milli(timestamp) as ts_ms,
                 user_id,
                 contexts,
@@ -544,7 +544,7 @@ class ReplayService(
             val enrichments = validWindows.associateWith { ReplayContextEnrichment() }.toMutableMap()
 
             rows.forEach { row ->
-                val projectId = row["project_id"]?.jsonPrimitive?.long ?: return@forEach
+                val projectId = row[REPLAY_CONTEXT_PROJECT_ID_FIELD]?.jsonPrimitive?.long ?: return@forEach
                 val timestampMs = row["ts_ms"]?.jsonPrimitive?.contentOrNull?.toLongOrNull() ?: return@forEach
                 val rowUserId = row["user_id"]?.jsonPrimitive?.contentOrNull
                 val contexts = parseStoredJsonObject(stringValue(row, "contexts"))
@@ -1787,6 +1787,7 @@ class ReplayService(
         private const val PERIOD_7D_MS = 7 * MILLIS_PER_DAY
         private const val PERIOD_30D_MS = 30 * MILLIS_PER_DAY
         private const val PERIOD_90D_MS = 90 * MILLIS_PER_DAY
+        private const val REPLAY_CONTEXT_PROJECT_ID_FIELD = "context_project_id"
         private const val REPLAY_CONTEXT_EVENT_LIMIT = 100
         private const val REPLAY_BREADCRUMB_EVENT_LIMIT = 100
         private val HTTP_STATUS_REGEX = Regex("""\b([1-5]\d{2})\b""")

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
@@ -209,14 +209,16 @@ class ReplayServiceTest {
 
     @Test
     fun `getReplays returns paginated replay list`() = runBlocking {
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
         val replayRow = """
 {"replay_id":"$REPLAY_UUID","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","started_ms":"1767225600000","finished_ms":"1767225900000","duration_ms":"300000","urls":["https://app.example.com"],"error_count":2,"user_id":"u-1","user_email":"test@test.com","user_username":"tester","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":8}
         """.trimIndent()
         val contextRow = """
-{"project_id":1,"ts_ms":"1767225660000","user_id":"u-1","contexts":"{}","breadcrumbs":"[{\"timestamp\":\"2026-01-01T00:01:00.000Z\",\"category\":\"ui.click\",\"message\":\"rage click x3\"}]"}
+{"context_project_id":1,"ts_ms":"1767225660000","user_id":"u-1","contexts":"{}","breadcrumbs":"[{\"timestamp\":\"2026-01-01T00:01:00.000Z\",\"category\":\"ui.click\",\"message\":\"rage click x3\"}]"}
         """.trimIndent()
         withClickHouseMockServer({ exchange ->
             val query = exchange.requestBodyText()
+            queries += query
             if (query.contains("toUnixTimestamp64Milli(timestamp) as ts_ms")) {
                 exchange.respond(200, contextRow, TEXT_PLAIN)
             } else {
@@ -235,6 +237,9 @@ class ReplayServiceTest {
             assertEquals("https://app.example.com", result[0].entryUrl)
             assertTrue("error" in result[0].signals)
             assertTrue("rage_click" in result[0].signals)
+            val contextQueries = queries.filter { it.contains("toUnixTimestamp64Milli(timestamp) as ts_ms") }
+            assertTrue(contextQueries.any { it.contains("toInt64(project_id) as context_project_id") })
+            assertTrue(contextQueries.none { it.contains("toInt64(project_id) as project_id") })
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid aliasing replay enrichment project IDs over the source column
- add regression coverage for the generated query shape

## Validation
- git diff --check
- ./gradlew :test --tests com.moneat.services.ReplayServiceTest --no-daemon