### PR TITLE
fix: route overview alerts to attention panel

### DIFF
--- a/dashboard/src/components/overview/OverviewPanel.tsx
+++ b/dashboard/src/components/overview/OverviewPanel.tsx
@@ -22,6 +22,7 @@ import type {Tone} from './overviewData'
 import {toneBgSolid} from './overviewTone'
 
 type OverviewPanelProps = Readonly<{
+  id?: string
   title: string
   icon?: LucideIcon | ComponentType<{className?: string}>
   count?: ReactNode
@@ -54,6 +55,7 @@ type MiniBarProps = Readonly<{
 
 /** Shared panel chrome for overview widgets — mirrors SectionCard at compact density. */
 export function OverviewPanel({
+  id,
   title,
   icon: Icon,
   count,
@@ -65,6 +67,7 @@ export function OverviewPanel({
 }: OverviewPanelProps) {
   return (
     <div
+      id={id}
       data-testid={testId}
       className="flex h-full flex-col overflow-hidden rounded-lg border border-border/60 bg-card"
     >

--- a/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
+++ b/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
@@ -135,6 +135,26 @@ describe('TriageWidget', () => {
     expect(screen.getByText('Alerts firing')).toBeInTheDocument()
     expect(screen.queryByRole('link', {name: 'View all'})).not.toBeInTheDocument()
   })
+
+  it('links to security signals when alerts and security signals both need attention', () => {
+    renderWithOverview(<TriageWidget />, {
+      triage: {
+        incidents: [],
+        alerts: overviewTestData.triage.alerts,
+        issues: [],
+        security: [{
+          level: 'warn',
+          title: 'Suspicious login volume',
+          detail: '12 flagged sessions',
+          ageLabel: '4m',
+        }],
+      },
+    })
+
+    expect(screen.getByText('Security signals')).toBeInTheDocument()
+    const action = screen.getByRole('link', {name: 'View all'})
+    expect(action).toHaveAttribute('href', '/security/signals')
+  })
 })
 
 describe('InfraSummaryWidget', () => {

--- a/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
+++ b/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
@@ -49,8 +49,8 @@ describe('SystemStatusWidget', () => {
     renderWithOverview(<SystemStatusWidget />)
     expect(screen.getByTestId('widget-system_status')).toBeInTheDocument()
     expect(screen.getByText('Action needed')).toBeInTheDocument()
-    const action = screen.getByRole('link', {name: 'View alerts'})
-    expect(action).toHaveAttribute('href', '/on-call/alerts')
+    const action = screen.getByRole('link', {name: 'Review firing alerts in needs attention'})
+    expect(action).toHaveAttribute('href', '#overview-needs-attention')
   })
 })
 
@@ -119,7 +119,21 @@ describe('TriageWidget', () => {
     expect(screen.getByText('Alerts firing')).toBeInTheDocument()
     expect(screen.getByText('Elevated 5xx on checkout-api')).toBeInTheDocument()
     const action = screen.getByRole('link', {name: 'View all'})
-    expect(action).toHaveAttribute('href', '/on-call/alerts')
+    expect(action).toHaveAttribute('href', '/issues')
+  })
+
+  it('does not link broad alert episodes to native on-call alerts', () => {
+    renderWithOverview(<TriageWidget />, {
+      triage: {
+        incidents: [],
+        alerts: overviewTestData.triage.alerts,
+        issues: [],
+        security: [],
+      },
+    })
+
+    expect(screen.getByText('Alerts firing')).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'View all'})).not.toBeInTheDocument()
   })
 })
 

--- a/dashboard/src/components/overview/widgets/SystemStatusWidget.tsx
+++ b/dashboard/src/components/overview/widgets/SystemStatusWidget.tsx
@@ -23,10 +23,13 @@ import {useSystemStatus} from '../overviewData'
 import {toneBgSolid, toneBorder, toneSoftBg, toneText} from '../overviewTone'
 
 type StatusAction = Readonly<{
-  to: string
+  to?: string
+  href?: string
   label: string
   ariaLabel: string
 }>
+
+const NEEDS_ATTENTION_ANCHOR = '#overview-needs-attention'
 
 function nounLabel(count: number, singular: string, plural = `${singular}s`) {
   return count === 1 ? singular : plural
@@ -37,7 +40,11 @@ function statusAction(counts: OverviewCounts): StatusAction | null {
     return {to: '/on-call/incidents', label: 'View incidents', ariaLabel: 'View active incidents'}
   }
   if (counts.alerts > 0) {
-    return {to: '/on-call/alerts', label: 'View alerts', ariaLabel: 'View firing alerts'}
+    return {
+      href: NEEDS_ATTENTION_ANCHOR,
+      label: 'Review attention',
+      ariaLabel: 'Review firing alerts in needs attention',
+    }
   }
   if (counts.hostsOffline > 0) {
     return {to: '/monitoring/hosts', label: 'View hosts', ariaLabel: 'View offline hosts'}
@@ -99,9 +106,15 @@ export function SystemStatusWidget() {
         {action && (
           <div className="flex shrink-0 items-center gap-1.5">
             <Button asChild size="sm" className="h-6 px-2 text-[11px]">
-              <Link to={action.to} aria-label={action.ariaLabel}>
-                {action.label}
-              </Link>
+              {action.href ? (
+                <a href={action.href} aria-label={action.ariaLabel}>
+                  {action.label}
+                </a>
+              ) : (
+                <Link to={action.to ?? '/'} aria-label={action.ariaLabel}>
+                  {action.label}
+                </Link>
+              )}
             </Button>
           </div>
         )}

--- a/dashboard/src/components/overview/widgets/TriageWidget.tsx
+++ b/dashboard/src/components/overview/widgets/TriageWidget.tsx
@@ -43,13 +43,17 @@ type AttentionRouteInput = Readonly<{
   incidents: readonly unknown[]
   alerts: readonly unknown[]
   issues: readonly unknown[]
+  security: readonly unknown[]
 }>
 
-function attentionRouteFor(triage: AttentionRouteInput): string {
+const NEEDS_ATTENTION_ID = 'overview-needs-attention'
+
+function attentionRouteFor(triage: AttentionRouteInput): string | null {
   if (triage.incidents.length > 0) return '/on-call/incidents'
-  if (triage.alerts.length > 0) return '/on-call/alerts'
   if (triage.issues.length > 0) return '/issues'
-  return '/security/signals'
+  if (triage.alerts.length > 0) return null
+  if (triage.security.length > 0) return '/security/signals'
+  return null
 }
 
 function borderForLevel(level: TriageLevel): string {
@@ -112,10 +116,11 @@ export function TriageWidget() {
   return (
     <OverviewPanel
       testId="widget-triage"
+      id={NEEDS_ATTENTION_ID}
       title="Needs attention"
       icon={ListChecks}
       count={total}
-      actions={total > 0 ? <PanelLink to={attentionRoute}>View all</PanelLink> : undefined}
+      actions={attentionRoute ? <PanelLink to={attentionRoute}>View all</PanelLink> : undefined}
       flush
     >
       {t.incidents.length > 0 && (

--- a/dashboard/src/components/overview/widgets/TriageWidget.tsx
+++ b/dashboard/src/components/overview/widgets/TriageWidget.tsx
@@ -51,7 +51,6 @@ const NEEDS_ATTENTION_ID = 'overview-needs-attention'
 function attentionRouteFor(triage: AttentionRouteInput): string | null {
   if (triage.incidents.length > 0) return '/on-call/incidents'
   if (triage.issues.length > 0) return '/issues'
-  if (triage.alerts.length > 0) return null
   if (triage.security.length > 0) return '/security/signals'
   return null
 }


### PR DESCRIPTION
Fixes overview alert navigation so broad alert counts stay on the attention surface instead of opening the native on-call alert list.

Validated with focused dashboard tests, lint, typecheck, and diff hygiene.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overview panels now support in-page anchors, enabling “needs attention” actions to jump directly to the relevant section on the page.

* **Bug Fixes**
  * Updated “Review firing alerts” and “View all” links to point to the correct destinations.
  * Alerts-only states no longer show a misleading “View all” link when no matching drill-down is available.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->