### PR TITLE
fix: preserve auth redirects for private routes

### DIFF
--- a/dashboard/src/components/logs/context-viewer/LogContextViewer.tsx
+++ b/dashboard/src/components/logs/context-viewer/LogContextViewer.tsx
@@ -39,7 +39,7 @@ import {
   X,
   Zap,
 } from 'lucide-react'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {AttributesPanel} from './AttributesPanel'
 import {ContentPanel} from './ContentPanel'
 import {ContextPanel} from './ContextPanel'
@@ -263,6 +263,7 @@ export function LogContextViewer({
   const {timezone} = useTimezone()
   const [activeTab, setActiveTab] = useState<TabId>('content')
   const [linkCopied, setLinkCopied] = useState(false)
+  const linkCopiedResetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   const level = normalizeLevel(log.level)
   const message = stripAnsi(log.message || log.body || '')
@@ -286,6 +287,14 @@ export function LogContextViewer({
   // Keyboard: J/K to move between events, Esc to close. Ignore while typing.
   useLogContextKeyboard({canPrev, canNext, onNavigate, onClose})
 
+  useEffect(() => {
+    return () => {
+      if (linkCopiedResetTimer.current !== undefined) {
+        clearTimeout(linkCopiedResetTimer.current)
+      }
+    }
+  }, [])
+
   const handleCopyLink = useCallback(async () => {
     const url = globalThis.window?.location?.href
     const clipboard = globalThis.navigator?.clipboard
@@ -293,7 +302,10 @@ export function LogContextViewer({
     try {
       await clipboard.writeText(url)
       setLinkCopied(true)
-      setTimeout(() => setLinkCopied(false), 1100)
+      if (linkCopiedResetTimer.current !== undefined) {
+        clearTimeout(linkCopiedResetTimer.current)
+      }
+      linkCopiedResetTimer.current = setTimeout(() => setLinkCopied(false), 1100)
     } catch {
       // no-op in insecure contexts
     }

--- a/dashboard/src/lib/__tests__/api.test.ts
+++ b/dashboard/src/lib/__tests__/api.test.ts
@@ -21,6 +21,22 @@ import { api, resetAuthRedirectForTesting } from '../api'
 
 const API_BASE = 'http://localhost:8080'
 
+function mockWindowLocation(location: Partial<Location> & Pick<Location, 'pathname'>): () => void {
+  const originalLocation = window.location
+  Object.defineProperty(window, 'location', {
+    value: {...originalLocation, ...location} as Location,
+    writable: true,
+    configurable: true,
+  })
+  return () => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+  }
+}
+
 describe('ApiClient', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -117,13 +133,14 @@ describe('ApiClient', () => {
   })
 
   describe('401 logout and redirect behavior', () => {
-    it('clears session and redirects to /login on 401', async () => {
+    it('clears session and redirects to login on 401', async () => {
       const mockAssign = vi.fn()
-      const originalLocation = window.location
-      // @ts-expect-error - Mocking window.location for tests
-      delete window.location
-      // @ts-expect-error - Mocking window.location for tests
-      window.location = { ...originalLocation, pathname: '/dashboard', assign: mockAssign }
+      const restoreLocation = mockWindowLocation({
+        pathname: '/issues/issue-123',
+        search: '?projectId=service-1&status=unresolved',
+        hash: '#events',
+        assign: mockAssign,
+      })
 
       sessionStorage.setItem('authenticated', 'true')
       server.use(
@@ -137,17 +154,17 @@ describe('ApiClient', () => {
       expect(sessionStorage.getItem('authenticated')).toBeNull()
       expect(mockAssign).toHaveBeenCalledWith('/login')
 
-      // @ts-expect-error - Restoring window.location
-      window.location = originalLocation
+      restoreLocation()
     })
 
     it('attempts token refresh at most once for persistent 401 responses', async () => {
       const mockAssign = vi.fn()
-      const originalLocation = window.location
-      // @ts-expect-error - Mocking window.location for tests
-      delete window.location
-      // @ts-expect-error - Mocking window.location for tests
-      window.location = { ...originalLocation, pathname: '/admin/infrastructure', assign: mockAssign }
+      const restoreLocation = mockWindowLocation({
+        pathname: '/admin/infrastructure',
+        search: '',
+        hash: '',
+        assign: mockAssign,
+      })
 
       sessionStorage.setItem('authenticated', 'true')
       localStorage.setItem('refresh_token', 'refresh-token-1')
@@ -175,17 +192,12 @@ describe('ApiClient', () => {
       expect(refreshCalls).toBe(1)
       expect(mockAssign).toHaveBeenCalledWith('/login')
 
-      // @ts-expect-error - Restoring window.location
-      window.location = originalLocation
+      restoreLocation()
     })
 
     it('does not redirect if already on auth page', async () => {
       const mockAssign = vi.fn()
-      const originalLocation = window.location
-      // @ts-expect-error - Mocking window.location for tests
-      delete window.location
-      // @ts-expect-error - Mocking window.location for tests
-      window.location = { ...originalLocation, pathname: '/login', assign: mockAssign }
+      const restoreLocation = mockWindowLocation({pathname: '/login', assign: mockAssign})
 
       sessionStorage.setItem('authenticated', 'true')
       server.use(
@@ -198,17 +210,34 @@ describe('ApiClient', () => {
 
       expect(mockAssign).not.toHaveBeenCalled()
 
-      // @ts-expect-error - Restoring window.location
-      window.location = originalLocation
+      restoreLocation()
     })
 
-    it('redirects on 401 even without session flag', async () => {
+    it('does not redirect from the public landing page on 401', async () => {
       const mockAssign = vi.fn()
-      const originalLocation = window.location
-      // @ts-expect-error - Mocking window.location for tests
-      delete window.location
-      // @ts-expect-error - Mocking window.location for tests
-      window.location = { ...originalLocation, pathname: '/dashboard', assign: mockAssign }
+      const restoreLocation = mockWindowLocation({pathname: '/', search: '', hash: '', assign: mockAssign})
+
+      server.use(
+        http.get(`${API_BASE}/v1/projects`, () => {
+          return new HttpResponse(null, { status: 401 })
+        })
+      )
+
+      await expect(api.getProjects()).rejects.toThrow('Unauthorized')
+
+      expect(mockAssign).not.toHaveBeenCalled()
+
+      restoreLocation()
+    })
+
+    it('redirects from the authenticated overview on 401', async () => {
+      const mockAssign = vi.fn()
+      const restoreLocation = mockWindowLocation({
+        pathname: '/',
+        search: '?view=overview',
+        hash: '',
+        assign: mockAssign,
+      })
 
       server.use(
         http.get(`${API_BASE}/v1/projects`, () => {
@@ -220,8 +249,29 @@ describe('ApiClient', () => {
 
       expect(mockAssign).toHaveBeenCalledWith('/login')
 
-      // @ts-expect-error - Restoring window.location
-      window.location = originalLocation
+      restoreLocation()
+    })
+
+    it('redirects on 401 even without session flag', async () => {
+      const mockAssign = vi.fn()
+      const restoreLocation = mockWindowLocation({
+        pathname: '/dashboard',
+        search: '',
+        hash: '',
+        assign: mockAssign,
+      })
+
+      server.use(
+        http.get(`${API_BASE}/v1/projects`, () => {
+          return new HttpResponse(null, { status: 401 })
+        })
+      )
+
+      await expect(api.getProjects()).rejects.toThrow('Unauthorized')
+
+      expect(mockAssign).toHaveBeenCalledWith('/login')
+
+      restoreLocation()
     })
 
     it('clears sessionStorage on logout', () => {

--- a/dashboard/src/lib/__tests__/auth-redirect.test.ts
+++ b/dashboard/src/lib/__tests__/auth-redirect.test.ts
@@ -1,0 +1,65 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, expect, it} from 'vitest'
+import {
+  currentRouteFromLocation,
+  isAuthPagePath,
+  isPublicLandingLocation,
+  normalizeInternalRedirectPath,
+  consumePendingAuthRedirect,
+  storePendingAuthRedirect,
+} from '@/lib/auth-redirect'
+
+describe('auth redirect helpers', () => {
+  it('detects auth page paths', () => {
+    expect(isAuthPagePath('/reset-password')).toBe(true)
+    expect(isAuthPagePath('/login/')).toBe(true)
+    expect(isAuthPagePath('/issues')).toBe(false)
+  })
+
+  it('preserves the authenticated overview but not the public landing page', () => {
+    expect(isPublicLandingLocation({pathname: '/'})).toBe(true)
+    expect(isPublicLandingLocation({pathname: '/', search: '?view=overview'})).toBe(false)
+  })
+
+  it('handles locations without search or hash values', () => {
+    expect(currentRouteFromLocation({pathname: '/logs'})).toBe('/logs')
+  })
+
+  it('normalizes post-login redirects to same-origin internal paths', () => {
+    expect(normalizeInternalRedirectPath('/replays/replay-1?tab=errors#event')).toBe(
+      '/replays/replay-1?tab=errors#event'
+    )
+    expect(normalizeInternalRedirectPath('https://moneat.io/issues/issue-1')).toBeUndefined()
+    expect(normalizeInternalRedirectPath('https://www.moneat.io/logs?query=error')).toBeUndefined()
+    expect(normalizeInternalRedirectPath('https://example.com/issues/issue-1')).toBeUndefined()
+    expect(normalizeInternalRedirectPath('//example.com/issues/issue-1')).toBeUndefined()
+    expect(normalizeInternalRedirectPath('')).toBeUndefined()
+    expect(normalizeInternalRedirectPath(null)).toBeUndefined()
+  })
+
+  it('stores and consumes a pending auth redirect path', () => {
+    storePendingAuthRedirect({
+      pathname: '/issues/issue-123',
+      search: '?projectId=service-1&status=unresolved',
+      hash: '#events',
+    })
+
+    expect(consumePendingAuthRedirect()).toBe('/issues/issue-123?projectId=service-1&status=unresolved#events')
+    expect(consumePendingAuthRedirect()).toBeUndefined()
+  })
+})

--- a/dashboard/src/lib/__tests__/auth-redirect.test.ts
+++ b/dashboard/src/lib/__tests__/auth-redirect.test.ts
@@ -48,6 +48,7 @@ describe('auth redirect helpers', () => {
     expect(normalizeInternalRedirectPath('https://www.moneat.io/logs?query=error')).toBeUndefined()
     expect(normalizeInternalRedirectPath('https://example.com/issues/issue-1')).toBeUndefined()
     expect(normalizeInternalRedirectPath('//example.com/issues/issue-1')).toBeUndefined()
+    expect(normalizeInternalRedirectPath('/\\example.com/issues/issue-1')).toBeUndefined()
     expect(normalizeInternalRedirectPath('')).toBeUndefined()
     expect(normalizeInternalRedirectPath(null)).toBeUndefined()
   })

--- a/dashboard/src/lib/api/__tests__/client-branches.test.ts
+++ b/dashboard/src/lib/api/__tests__/client-branches.test.ts
@@ -64,7 +64,12 @@ describe('client – branch coverage', () => {
     it('redirects to login when refresh fails', async () => {
       const assignSpy = vi.fn()
       Object.defineProperty(globalThis.window, 'location', {
-        value: { pathname: '/dashboard', assign: assignSpy },
+        value: {
+          pathname: '/issues/issue-123',
+          search: '?projectId=service-1&status=unresolved',
+          hash: '#events',
+          assign: assignSpy,
+        },
         writable: true,
         configurable: true,
       })

--- a/dashboard/src/lib/api/client.ts
+++ b/dashboard/src/lib/api/client.ts
@@ -15,16 +15,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import { isDemo, setDemoEpoch, syncDemoEpochFromUser } from '../demo'
+import { isAuthPagePath, isPublicLandingLocation } from '../auth-redirect'
 
 export const API_BASE = `${import.meta.env.VITE_BACKEND_URL || ''}/v1`
-const AUTH_PAGE_PATHS = new Set([
-  '/',
-  '/login',
-  '/signup',
-  '/verify-email',
-  '/forgot-password',
-  '/reset-password',
-])
 const AUTH_CHECK_TIMEOUT_MS = 4000
 const API_REQUEST_TIMEOUT_MS = 15000
 
@@ -163,7 +156,8 @@ export function createApiClientCore(): ApiClientCore {
     if (
       !authRedirectInProgress &&
       globalThis.window !== undefined &&
-      !AUTH_PAGE_PATHS.has(globalThis.window.location.pathname)
+      !isAuthPagePath(globalThis.window.location.pathname) &&
+      !isPublicLandingLocation(globalThis.window.location)
     ) {
       authRedirectInProgress = true
       globalThis.window.location.assign('/login')

--- a/dashboard/src/lib/auth-redirect.ts
+++ b/dashboard/src/lib/auth-redirect.ts
@@ -40,7 +40,11 @@ export function currentRouteFromLocation(location: BrowserLocationLike): string 
 
 function normalizePath(pathname: string): string {
   if (!pathname || pathname === '/') return '/'
-  return pathname.replace(/\/+$/, '') || '/'
+  let end = pathname.length
+  while (end > 1 && pathname[end - 1] === '/') {
+    end -= 1
+  }
+  return pathname.slice(0, end) || '/'
 }
 
 export function isAuthPagePath(pathname: string): boolean {

--- a/dashboard/src/lib/auth-redirect.ts
+++ b/dashboard/src/lib/auth-redirect.ts
@@ -62,8 +62,9 @@ export function normalizeInternalRedirectPath(value: unknown): string | undefine
   const trimmed = value.trim()
   if (!trimmed) return undefined
 
-  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed
-  return undefined
+  if (!trimmed.startsWith('/')) return undefined
+  if (trimmed[1] === '/' || trimmed[1] === '\\') return undefined
+  return trimmed
 }
 
 export function storePendingAuthRedirect(location: BrowserLocationLike): void {

--- a/dashboard/src/lib/auth-redirect.ts
+++ b/dashboard/src/lib/auth-redirect.ts
@@ -1,0 +1,75 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {APP_OVERVIEW_VIEW} from './overview-route'
+
+const LOGIN_PATH = '/login'
+const AUTH_PAGE_PATHS = new Set([
+  LOGIN_PATH,
+  '/signup',
+  '/verify-email',
+  '/forgot-password',
+  '/reset-password',
+])
+const pendingAuthRedirect = {
+  path: undefined as string | undefined,
+}
+
+export interface BrowserLocationLike {
+  readonly pathname: string
+  readonly search?: string
+  readonly hash?: string
+}
+
+export function currentRouteFromLocation(location: BrowserLocationLike): string {
+  return `${location.pathname}${location.search ?? ''}${location.hash ?? ''}`
+}
+
+function normalizePath(pathname: string): string {
+  if (!pathname || pathname === '/') return '/'
+  return pathname.replace(/\/+$/, '') || '/'
+}
+
+export function isAuthPagePath(pathname: string): boolean {
+  return AUTH_PAGE_PATHS.has(normalizePath(pathname))
+}
+
+export function isPublicLandingLocation(location: BrowserLocationLike): boolean {
+  if (normalizePath(location.pathname) !== '/') return false
+  const params = new URLSearchParams(location.search ?? '')
+  return params.get('view') !== APP_OVERVIEW_VIEW
+}
+
+export function normalizeInternalRedirectPath(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed
+  return undefined
+}
+
+export function storePendingAuthRedirect(location: BrowserLocationLike): void {
+  const redirectPath = normalizeInternalRedirectPath(currentRouteFromLocation(location))
+  if (redirectPath === undefined) return
+  pendingAuthRedirect.path = redirectPath
+}
+
+export function consumePendingAuthRedirect(): string | undefined {
+  const value = pendingAuthRedirect.path
+  pendingAuthRedirect.path = undefined
+  return normalizeInternalRedirectPath(value)
+}

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createRootRoute, Outlet, Link, useRouterState, useNavigate} from '@tanstack/react-router'
+import {createRootRoute, Outlet, Link, redirect, useRouterState, useNavigate} from '@tanstack/react-router'
 import {useCallback, useEffect, useState} from 'react'
 import {useQuery} from '@tanstack/react-query'
 import {Sidebar, SIDEBAR_COLLAPSED_WIDTH, SIDEBAR_EXPANDED_WIDTH} from '../components/Sidebar'
@@ -28,11 +28,7 @@ import {DemoBanner} from '../components/demo/DemoBanner'
 import {AiFloatingPanel} from '../components/AiFloatingPanel'
 import {AiSplitPanel} from '../components/AiSplitPanel'
 import {useCommandPalette} from '../hooks/useCommandPalette'
-
-export const Route = createRootRoute({
-  component: RootComponent,
-  notFoundComponent: NotFoundPage,
-})
+import {storePendingAuthRedirect} from '../lib/auth-redirect'
 
 const STATIC_TITLES: Record<string, string> = {
   '/': 'Overview',
@@ -144,6 +140,11 @@ const PUBLIC_ROUTES: ReadonlySet<string> = new Set([
 
 const PUBLIC_ROUTE_PREFIXES = ['/s', '/auth', '/legal', '/docs', '/blog'] as const
 
+const AUTH_OPTIONAL_ROUTE_EXCLUSIONS: ReadonlySet<string> = new Set([
+  '/onboarding',
+  '/verify-email-required',
+])
+
 function normalizePath(pathname: string): string {
   if (!pathname || pathname === '/') return '/'
   return pathname.replace(/\/+$/, '')
@@ -161,6 +162,38 @@ export function isPublicAppRoute(pathname: string, search: unknown): boolean {
     PUBLIC_ROUTE_PREFIXES.some((routeRoot) => isRouteBranch(normalizedPath, routeRoot))
   )
 }
+
+export function isAuthOptionalAppRoute(pathname: string, search: unknown): boolean {
+  const normalizedPath = normalizePath(pathname)
+  return (
+    isPublicLandingRoute(normalizedPath, search) ||
+    (PUBLIC_ROUTES.has(normalizedPath) && !AUTH_OPTIONAL_ROUTE_EXCLUSIONS.has(normalizedPath)) ||
+    PUBLIC_ROUTE_PREFIXES.some((routeRoot) => isRouteBranch(normalizedPath, routeRoot))
+  )
+}
+
+interface AppRouteLocation {
+  readonly pathname: string
+  readonly search: unknown
+  readonly href: string
+}
+
+export async function ensurePrivateRouteCanLoad(location: AppRouteLocation): Promise<void> {
+  if (isAuthOptionalAppRoute(location.pathname, location.search)) return
+  if (api.isAuthenticated()) return
+
+  const hasSession = await api.checkAuth()
+  if (!hasSession) {
+    storePendingAuthRedirect({pathname: location.href})
+    throw redirect({to: '/login'})
+  }
+}
+
+export const Route = createRootRoute({
+  beforeLoad: ({location}) => ensurePrivateRouteCanLoad(location),
+  component: RootComponent,
+  notFoundComponent: NotFoundPage,
+})
 
 interface AuthenticatedSidebarVisibilityOptions {
   readonly isAuthenticated: boolean
@@ -331,9 +364,6 @@ function RootComponent() {
         setIsAuthenticated(hasSession) // Update state based on auth check
         setAuthCheckComplete(true)
         setOnboardingChecked(true)
-        if (!hasSession) {
-          return
-        }
       } else {
         setAuthCheckComplete(true)
         setOnboardingChecked(true)

--- a/dashboard/src/routes/__tests__/-auth-redirect-guards.test.ts
+++ b/dashboard/src/routes/__tests__/-auth-redirect-guards.test.ts
@@ -1,0 +1,35 @@
+import {readdirSync, readFileSync, statSync} from 'node:fs'
+import {dirname, join, relative, resolve} from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {describe, expect, it} from 'vitest'
+
+const routesDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const loginRedirectPattern = /throw\s+redirect\(\{\s*to:\s*['"]\/login['"]/g
+const allowedLoginRedirectFiles = new Set(['__root.tsx', 'demo.tsx'])
+
+function routeFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry)
+    const stats = statSync(path)
+    if (stats.isDirectory()) {
+      return entry === '__tests__' ? [] : routeFiles(path)
+    }
+    return /\.(tsx?|jsx?)$/.test(entry) ? [path] : []
+  })
+}
+
+describe('route auth redirects', () => {
+  it('keeps login redirects centralized in the root route guard', () => {
+    const offenders = routeFiles(routesDir)
+      .filter((file) => file.endsWith('.tsx') || file.endsWith('.ts'))
+      .flatMap((file) => {
+        const relativeFile = relative(routesDir, file)
+        if (allowedLoginRedirectFiles.has(relativeFile)) return []
+
+        const source = readFileSync(file, 'utf8')
+        return Array.from(source.matchAll(loginRedirectPattern)).map(() => relativeFile)
+      })
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/dashboard/src/routes/__tests__/-auth-redirect-guards.test.ts
+++ b/dashboard/src/routes/__tests__/-auth-redirect-guards.test.ts
@@ -1,3 +1,19 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 import {readdirSync, readFileSync, statSync} from 'node:fs'
 import {dirname, join, relative, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'

--- a/dashboard/src/routes/__tests__/-monitoring-route.test.tsx
+++ b/dashboard/src/routes/__tests__/-monitoring-route.test.tsx
@@ -2,21 +2,13 @@ import React from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {render, screen, waitFor} from '@testing-library/react'
 
-const {mockApi, mockRouteState, mockFeatures} = vi.hoisted(() => ({
-  mockApi: {
-    isAuthenticated: vi.fn(),
-    checkAuth: vi.fn(),
-  },
+const {mockRouteState, mockFeatures} = vi.hoisted(() => ({
   mockRouteState: {
     pathname: '/monitoring',
   },
   mockFeatures: {
     modules: [] as string[],
   },
-}))
-
-vi.mock('@/lib/api', () => ({
-  api: mockApi,
 }))
 
 vi.mock('@/hooks/useEnterpriseFeatures', () => ({
@@ -30,7 +22,6 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({children, to, ...props}: {children: React.ReactNode; to?: string}) =>
     React.createElement('a', {href: to, ...props}, children),
   Outlet: () => <div data-testid="monitoring-outlet" />,
-  redirect: (options: Record<string, unknown>) => ({...options, __redirect: true}),
   useRouterState: () => ({location: {pathname: mockRouteState.pathname}}),
 }))
 
@@ -79,8 +70,6 @@ function renderMonitoringRoute() {
 describe('monitoring route shell', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockApi.isAuthenticated.mockReturnValue(true)
-    mockApi.checkAuth.mockResolvedValue(true)
     mockRouteState.pathname = '/monitoring'
     mockFeatures.modules = []
     monitoringNavWidth = 900
@@ -102,19 +91,6 @@ describe('monitoring route shell', () => {
       unobserve(): void {}
       disconnect(): void {}
     })
-  })
-
-  it('redirects unauthenticated sessions before loading monitoring', async () => {
-    mockApi.isAuthenticated.mockReturnValue(false)
-    mockApi.checkAuth.mockResolvedValue(false)
-
-    const beforeLoad = (MonitoringRoute as unknown as {beforeLoad: () => Promise<void>}).beforeLoad
-
-    await expect(beforeLoad()).rejects.toMatchObject({
-      __redirect: true,
-      to: '/login',
-    })
-    expect(mockApi.checkAuth).toHaveBeenCalled()
   })
 
   it('renders core monitoring tabs and hides Datadog tabs without the module', () => {

--- a/dashboard/src/routes/__tests__/-replay-detail-helpers.test.ts
+++ b/dashboard/src/routes/__tests__/-replay-detail-helpers.test.ts
@@ -1,10 +1,9 @@
 import {describe, expect, it, vi} from 'vitest'
-import {api, type ReplayDetail} from '@/lib/api'
+import type {ReplayDetail} from '@/lib/api'
 
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (options: Record<string, unknown>) => options,
   Link: ({children}: {children: unknown}) => children,
-  redirect: (options: Record<string, unknown>) => options,
 }))
 
 vi.mock('@/components/ReplayPlayer', () => ({
@@ -31,7 +30,7 @@ vi.mock('@/components/replay-containers/MobileDeviceContainer', () => ({
   MobileDeviceContainer: ({children}: {children: unknown}) => children,
 }))
 
-import {Route as ReplayRoute, replayDetailHelperTestHooks as helpers} from '../replays.$replayId'
+import {replayDetailHelperTestHooks as helpers} from '../replays.$replayId'
 
 function replay(overrides: Partial<ReplayDetail> = {}): ReplayDetail {
   return {
@@ -79,26 +78,6 @@ function elementProps(value: unknown): Record<string, unknown> {
 }
 
 describe('replay detail helper coverage', () => {
-  it('redirects unauthenticated replay route loads', () => {
-    const beforeLoad = (ReplayRoute as unknown as {
-      beforeLoad: (args: {location: {href: string}}) => void
-    }).beforeLoad
-    const isAuthenticated = vi.spyOn(api, 'isAuthenticated')
-
-    isAuthenticated.mockReturnValueOnce(false)
-    let thrown: unknown
-    try {
-      beforeLoad({location: {href: '/replays/replay-1'}})
-    } catch (error) {
-      thrown = error
-    }
-    expect(thrown).toEqual({to: '/login', search: {redirect: '/replays/replay-1'}})
-
-    isAuthenticated.mockReturnValueOnce(true)
-    expect(() => beforeLoad({location: {href: '/replays/replay-1'}})).not.toThrow()
-    isAuthenticated.mockRestore()
-  })
-
   it('formats replay labels, dates, and identifiers', () => {
     expect(helpers.formatDuration(999)).toBe('999ms')
     expect(helpers.formatDuration(1500)).toBe('1.50s')

--- a/dashboard/src/routes/__tests__/-replays-route-helpers.test.ts
+++ b/dashboard/src/routes/__tests__/-replays-route-helpers.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from 'vitest'
-import {api, type Replay} from '@/lib/api'
+import type {Replay} from '@/lib/api'
 
 const routerMocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -10,12 +10,11 @@ vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (options: Record<string, unknown>) => options,
   Link: ({children}: {children: unknown}) => children,
   Outlet: () => null,
-  redirect: (options: Record<string, unknown>) => options,
   useMatches: routerMocks.useMatches,
   useNavigate: () => routerMocks.navigate,
 }))
 
-import {Route as ReplaysRoute, replaysHelperTestHooks as helpers} from '../replays'
+import {replaysHelperTestHooks as helpers} from '../replays'
 
 function replay(overrides: Partial<Replay> = {}): Replay {
   return {
@@ -39,23 +38,6 @@ function elementProps(value: unknown): Record<string, unknown> {
 }
 
 describe('replays route helper coverage', () => {
-  it('redirects unauthenticated replay list loads', async () => {
-    const beforeLoad = (ReplaysRoute as unknown as {
-      beforeLoad: (args: {location: {href: string}}) => Promise<void>
-    }).beforeLoad
-    const isAuthenticated = vi.spyOn(api, 'isAuthenticated')
-
-    isAuthenticated.mockReturnValueOnce(false)
-    await expect(beforeLoad({location: {href: '/replays'}})).rejects.toEqual({
-      to: '/login',
-      search: {redirect: '/replays'},
-    })
-
-    isAuthenticated.mockReturnValueOnce(true)
-    await expect(beforeLoad({location: {href: '/replays'}})).resolves.toBeUndefined()
-    isAuthenticated.mockRestore()
-  })
-
   it('renders the outlet when a replay detail child route is active', () => {
     routerMocks.useMatches.mockReturnValueOnce([{id: '/replays/$replayId'}])
 

--- a/dashboard/src/routes/__tests__/-root-public-route.test.ts
+++ b/dashboard/src/routes/__tests__/-root-public-route.test.ts
@@ -1,8 +1,52 @@
-import {describe, expect, it} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
-import {isPublicAppRoute, shouldShowAuthenticatedSidebar} from '../__root'
+import {consumePendingAuthRedirect} from '@/lib/auth-redirect'
+
+const {mockApi} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    checkAuth: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    options,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({}),
+    useSearch: () => ({}),
+  }),
+  createRootRoute: (options: Record<string, unknown>) => ({...options, options}),
+  Link: ({children}: {children: unknown}) => children,
+  Outlet: () => null,
+  redirect: (options: Record<string, unknown>) => ({...options, __redirect: true}),
+  useNavigate: () => vi.fn(),
+  useRouterState: () => ({location: {pathname: '/', search: {}, href: '/'}}),
+}))
+
+import {
+  ensurePrivateRouteCanLoad,
+  isAuthOptionalAppRoute,
+  isPublicAppRoute,
+  shouldShowAuthenticatedSidebar,
+} from '../__root'
+
+function routeLocation(pathname: string, href = pathname, search: unknown = {}) {
+  return {pathname, href, search}
+}
 
 describe('root public route shell visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.isAuthenticated.mockReturnValue(false)
+    mockApi.checkAuth.mockResolvedValue(false)
+  })
+
   it.each([
     ['landing page', '/', {}],
     ['docs', '/docs/getting-started', {}],
@@ -14,6 +58,15 @@ describe('root public route shell visibility', () => {
 
   it('keeps the authenticated overview in the app shell', () => {
     expect(isPublicAppRoute('/', APP_OVERVIEW_SEARCH)).toBe(false)
+    expect(isAuthOptionalAppRoute('/', APP_OVERVIEW_SEARCH)).toBe(false)
+  })
+
+  it('distinguishes shell-public authenticated routes from auth-optional routes', () => {
+    expect(isPublicAppRoute('/onboarding', {})).toBe(true)
+    expect(isAuthOptionalAppRoute('/onboarding', {})).toBe(false)
+    expect(isPublicAppRoute('/verify-email-required', {})).toBe(true)
+    expect(isAuthOptionalAppRoute('/verify-email-required', {})).toBe(false)
+    expect(isAuthOptionalAppRoute('/login', {})).toBe(true)
   })
 
   it('does not show the authenticated sidebar on public routes', () => {
@@ -34,5 +87,60 @@ describe('root public route shell visibility', () => {
         search: {},
       })
     ).toBe(true)
+  })
+
+  it('redirects unauthenticated private deep links to login with the attempted route', async () => {
+    const attemptedRoute = '/issues/issue-123?status=unresolved#events'
+
+    await expect(
+      ensurePrivateRouteCanLoad(routeLocation('/issues/issue-123', attemptedRoute, {status: 'unresolved'}))
+    ).rejects.toMatchObject({
+      __redirect: true,
+      to: '/login',
+    })
+    expect(mockApi.checkAuth).toHaveBeenCalledOnce()
+    expect(consumePendingAuthRedirect()).toBe(attemptedRoute)
+  })
+
+  it('redirects unauthenticated overview loads to login with the attempted route', async () => {
+    await expect(
+      ensurePrivateRouteCanLoad(routeLocation('/', '/?view=overview', APP_OVERVIEW_SEARCH))
+    ).rejects.toMatchObject({
+      __redirect: true,
+      to: '/login',
+    })
+    expect(mockApi.checkAuth).toHaveBeenCalledOnce()
+    expect(consumePendingAuthRedirect()).toBe('/?view=overview')
+  })
+
+  it.each([
+    ['/onboarding'],
+    ['/verify-email-required'],
+  ])('redirects unauthenticated shell-public auth-required route %s', async (pathname) => {
+    await expect(ensurePrivateRouteCanLoad(routeLocation(pathname))).rejects.toMatchObject({
+      __redirect: true,
+      to: '/login',
+    })
+    expect(mockApi.checkAuth).toHaveBeenCalledOnce()
+    expect(consumePendingAuthRedirect()).toBe(pathname)
+  })
+
+  it('allows private routes when the session flag is already present', async () => {
+    mockApi.isAuthenticated.mockReturnValue(true)
+
+    await expect(ensurePrivateRouteCanLoad(routeLocation('/replays/replay-1'))).resolves.toBeUndefined()
+    expect(mockApi.checkAuth).not.toHaveBeenCalled()
+  })
+
+  it('allows private routes when the auth cookie validates on cold load', async () => {
+    mockApi.checkAuth.mockResolvedValue(true)
+
+    await expect(ensurePrivateRouteCanLoad(routeLocation('/logs'))).resolves.toBeUndefined()
+    expect(mockApi.checkAuth).toHaveBeenCalledOnce()
+  })
+
+  it('skips auth checks for auth-optional routes', async () => {
+    await expect(ensurePrivateRouteCanLoad(routeLocation('/docs/getting-started'))).resolves.toBeUndefined()
+    expect(mockApi.checkAuth).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/routes/__tests__/login-route.test.tsx
+++ b/dashboard/src/routes/__tests__/login-route.test.tsx
@@ -1,0 +1,240 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import type {ComponentType, ReactNode} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {storePendingAuthRedirect} from '@/lib/auth-redirect'
+
+const {mockApi, mockNavigate, mockTrackEvent} = vi.hoisted(() => ({
+  mockApi: {
+    isAuthenticated: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+    initSso: vi.fn(),
+  },
+  mockNavigate: vi.fn(),
+  mockTrackEvent: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({options}),
+  Link: ({children}: {children: ReactNode}) => <>{children}</>,
+  redirect: (options: Record<string, unknown>) => ({...options, __redirect: true}),
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+}))
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: mockTrackEvent,
+}))
+
+vi.mock('@/components/auth/AuthShell', () => ({
+  AuthAlert: ({children}: {children: ReactNode}) => <div>{children}</div>,
+  AuthDivider: () => <div />,
+  AuthField: ({children, label}: {children: ReactNode; label: string}) => (
+    <label>
+      {label}
+      {children}
+    </label>
+  ),
+  AuthShell: ({children}: {children: ReactNode}) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({children, ...props}: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock('@/components/landing/Landing', () => ({
+  GRADIENT_BG: '',
+  GRADIENT_TEXT: '',
+}))
+
+import {Route} from '../login'
+
+type LoginBeforeLoadContext = Parameters<NonNullable<typeof Route.options.beforeLoad>>[0]
+
+function beforeLoadContext(search: Record<string, unknown>): LoginBeforeLoadContext {
+  return {search} as unknown as LoginBeforeLoadContext
+}
+
+async function submitEmailLogin() {
+  const LoginPage = Route.options.component as ComponentType
+
+  render(<LoginPage />)
+
+  fireEvent.change(screen.getByLabelText('Email'), {target: {value: 'test@example.com'}})
+  fireEvent.change(screen.getByPlaceholderText('Enter your password'), {target: {value: 'password'}})
+  fireEvent.click(screen.getByRole('button', {name: 'Sign in'}))
+
+  await waitFor(() => {
+    expect(mockApi.login).toHaveBeenCalledWith('test@example.com', 'password')
+  })
+}
+
+describe('login route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.isAuthenticated.mockReturnValue(false)
+    mockApi.login.mockResolvedValue({token: 'token-1'})
+    window.history.replaceState(null, '', '/login')
+  })
+
+  it('navigates to a pending private route after email login', async () => {
+    storePendingAuthRedirect({
+      pathname: '/replays/replay-1',
+      search: '?tab=errors',
+      hash: '#event',
+    })
+
+    await submitEmailLogin()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({to: '/replays/replay-1?tab=errors#event'})
+    })
+  })
+
+  it('uses an internal redirect query after email login', async () => {
+    window.history.replaceState(null, '', '/login?redirect=/issues?status=unresolved')
+
+    await submitEmailLogin()
+
+    expect(mockNavigate).toHaveBeenCalledWith({to: '/issues?status=unresolved'})
+  })
+
+  it('routes invite tokens through the accept-invite page after email login', async () => {
+    window.history.replaceState(null, '', '/login?inviteToken=invite%201')
+
+    await submitEmailLogin()
+
+    expect(mockNavigate).toHaveBeenCalledWith({to: '/accept-invite?token=invite+1'})
+  })
+
+  it('falls back to the app overview for missing or external redirects', async () => {
+    window.history.replaceState(null, '', '/login?redirect=https%3A%2F%2Fevil.example%2Fissues')
+
+    await submitEmailLogin()
+
+    expect(mockNavigate).toHaveBeenCalledWith({to: '/?view=overview'})
+  })
+
+  it('shows an invalid credentials error when email login fails', async () => {
+    mockApi.login.mockRejectedValue(new Error('UNAUTHORIZED'))
+    const LoginPage = Route.options.component as ComponentType
+
+    render(<LoginPage />)
+
+    fireEvent.change(screen.getByLabelText('Email'), {target: {value: 'test@example.com'}})
+    fireEvent.change(screen.getByPlaceholderText('Enter your password'), {target: {value: 'wrong'}})
+    fireEvent.click(screen.getByRole('button', {name: 'Sign in'}))
+
+    expect(await screen.findByText('Invalid email or password. Please try again.')).toBeTruthy()
+  })
+
+  it('redirects authenticated users with an internal redirect before loading the page', () => {
+    mockApi.isAuthenticated.mockReturnValue(true)
+
+    expect(() => {
+      Route.options.beforeLoad?.(beforeLoadContext({redirect: '/replays/replay-1'}))
+    }).toThrow(expect.objectContaining({to: '/replays/replay-1'}))
+  })
+
+  it('logs out authenticated mobile redirect sessions before loading the page', () => {
+    mockApi.isAuthenticated.mockReturnValue(true)
+
+    Route.options.beforeLoad?.(beforeLoadContext({redirect_uri: 'bandapella://auth'}))
+
+    expect(mockApi.logout).toHaveBeenCalled()
+  })
+
+  it('redirects authenticated users without special params to the app overview', () => {
+    mockApi.isAuthenticated.mockReturnValue(true)
+
+    expect(() => {
+      Route.options.beforeLoad?.(beforeLoadContext({}))
+    }).toThrow(expect.objectContaining({to: '/', search: {view: 'overview'}}))
+  })
+
+  it('starts SSO login from a work email', async () => {
+    mockApi.initSso.mockResolvedValue({redirectUrl: 'https://sso.example.test/start'})
+    const LoginPage = Route.options.component as ComponentType
+
+    render(<LoginPage />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'Sign in with SSO instead'}))
+    fireEvent.change(screen.getByLabelText('Work email'), {target: {value: 'sso@example.com'}})
+    fireEvent.click(screen.getByRole('button', {name: 'Continue with SSO'}))
+
+    await waitFor(() => {
+      expect(mockApi.initSso).toHaveBeenCalledWith('sso@example.com')
+    })
+  })
+
+  it('rejects non-HTTPS SSO redirect URLs', async () => {
+    mockApi.initSso.mockResolvedValue({redirectUrl: 'javascript:alert(1)'})
+    const LoginPage = Route.options.component as ComponentType
+
+    render(<LoginPage />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'Sign in with SSO instead'}))
+    fireEvent.change(screen.getByLabelText('Work email'), {target: {value: 'sso@example.com'}})
+    fireEvent.click(screen.getByRole('button', {name: 'Continue with SSO'}))
+
+    expect(await screen.findByText('Invalid SSO redirect URL')).toBeTruthy()
+  })
+
+
+  it('shows a network error when SSO initialization cannot reach the backend', async () => {
+    mockApi.initSso.mockRejectedValue(new Error('NETWORK_ERROR'))
+    const LoginPage = Route.options.component as ComponentType
+
+    render(<LoginPage />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'Sign in with SSO instead'}))
+    fireEvent.change(screen.getByLabelText('Work email'), {target: {value: 'sso@example.com'}})
+    fireEvent.click(screen.getByRole('button', {name: 'Continue with SSO'}))
+
+    expect(await screen.findByText('Unable to connect to the server. Please check your connection and try again.')).toBeTruthy()
+  })
+
+  it('shows the backend SSO error message when SSO initialization is rejected', async () => {
+    mockApi.initSso.mockRejectedValue(new Error('SSO is not configured'))
+    const LoginPage = Route.options.component as ComponentType
+
+    render(<LoginPage />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'Sign in with SSO instead'}))
+    fireEvent.change(screen.getByLabelText('Work email'), {target: {value: 'sso@example.com'}})
+    fireEvent.click(screen.getByRole('button', {name: 'Continue with SSO'}))
+
+    expect(await screen.findByText('SSO is not configured')).toBeTruthy()
+  })
+
+  it('can cancel the SSO form after entering an email', () => {
+    const LoginPage = Route.options.component as ComponentType
+
+    render(<LoginPage />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'Sign in with SSO instead'}))
+    fireEvent.change(screen.getByLabelText('Work email'), {target: {value: 'sso@example.com'}})
+    fireEvent.click(screen.getByRole('button', {name: 'Cancel'}))
+
+    expect(screen.queryByLabelText('Work email')).toBeNull()
+  })
+
+  it('starts GitHub OAuth through the backend', () => {
+    const LoginPage = Route.options.component as ComponentType
+
+    render(<LoginPage />)
+
+    fireEvent.click(screen.getByRole('button', {name: 'GitHub'}))
+
+    expect(screen.getByRole('button', {name: 'GitHub'})).toBeTruthy()
+  })
+})

--- a/dashboard/src/routes/__tests__/login-route.test.tsx
+++ b/dashboard/src/routes/__tests__/login-route.test.tsx
@@ -96,7 +96,11 @@ describe('login route', () => {
     await submitEmailLogin()
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith({to: '/replays/replay-1?tab=errors#event'})
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/replays/replay-1',
+        search: {tab: 'errors'},
+        hash: 'event',
+      })
     })
   })
 
@@ -105,7 +109,7 @@ describe('login route', () => {
 
     await submitEmailLogin()
 
-    expect(mockNavigate).toHaveBeenCalledWith({to: '/issues?status=unresolved'})
+    expect(mockNavigate).toHaveBeenCalledWith({to: '/issues', search: {status: 'unresolved'}})
   })
 
   it('routes invite tokens through the accept-invite page after email login', async () => {
@@ -113,7 +117,7 @@ describe('login route', () => {
 
     await submitEmailLogin()
 
-    expect(mockNavigate).toHaveBeenCalledWith({to: '/accept-invite?token=invite+1'})
+    expect(mockNavigate).toHaveBeenCalledWith({to: '/accept-invite', search: {token: 'invite 1'}})
   })
 
   it('falls back to the app overview for missing or external redirects', async () => {
@@ -121,7 +125,7 @@ describe('login route', () => {
 
     await submitEmailLogin()
 
-    expect(mockNavigate).toHaveBeenCalledWith({to: '/?view=overview'})
+    expect(mockNavigate).toHaveBeenCalledWith({to: '/', search: {view: 'overview'}})
   })
 
   it('shows an invalid credentials error when email login fails', async () => {

--- a/dashboard/src/routes/__tests__/workflows-insights.test.tsx
+++ b/dashboard/src/routes/__tests__/workflows-insights.test.tsx
@@ -22,7 +22,6 @@ import {fireEvent, render, screen, waitFor} from '@testing-library/react'
 const {mockApi, mockToast} = vi.hoisted(() => ({
   mockApi: {
     isAuthenticated: vi.fn(() => true),
-    checkAuth: vi.fn(),
     getWorkflowOverview: vi.fn(),
     getWorkflowUsage: vi.fn(),
     getWorkflowBlueprints: vi.fn(),
@@ -42,14 +41,12 @@ vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (options: Record<string, unknown>) => ({...options, options}),
   Link: ({children, ...props}: {children: React.ReactNode}) =>
     React.createElement('a', props, children),
-  redirect: (opts: Record<string, unknown>) => ({...opts, __redirect: true}),
 }))
 
 import {Route as InsightsRouteImport} from '../workflows.insights'
 
 const InsightsRoute = InsightsRouteImport as unknown as {
   component: React.ComponentType
-  beforeLoad: () => Promise<unknown>
 }
 
 const overview = {
@@ -101,20 +98,6 @@ describe('workflows insights route', () => {
     mockApi.getWorkflowBlueprints.mockResolvedValue(blueprints)
     mockApi.getWorkflowAudit.mockResolvedValue(audit)
     mockApi.instantiateBlueprint.mockResolvedValue({id: WORKFLOW_RESOURCE_ID, name: 'Error spike alert'})
-  })
-
-  it('guards the route via beforeLoad when unauthenticated', async () => {
-    mockApi.isAuthenticated.mockReturnValue(false)
-    mockApi.checkAuth.mockResolvedValue(false)
-    await expect(InsightsRoute.beforeLoad()).rejects.toMatchObject({
-      to: '/login',
-      __redirect: true,
-    })
-  })
-
-  it('passes the guard when authenticated', async () => {
-    mockApi.isAuthenticated.mockReturnValue(true)
-    await expect(InsightsRoute.beforeLoad()).resolves.toBeUndefined()
   })
 
   it('renders overview, usage, blueprints, and audit', async () => {

--- a/dashboard/src/routes/admin.tsx
+++ b/dashboard/src/routes/admin.tsx
@@ -51,7 +51,7 @@ export const Route = createFileRoute('/admin')({
       // Network errors shouldn't kick users to login — surface them instead
       if (err.message === 'NETWORK_ERROR') throw e
       console.error('[Admin] access check failed:', err.message, err.status)
-      throw redirect({to: '/login'})
+      throw e
     }
   },
   component: AdminLayout,

--- a/dashboard/src/routes/feature-flags.tsx
+++ b/dashboard/src/routes/feature-flags.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {useMemo, useState, type ReactNode} from 'react'
-import {createFileRoute, redirect} from '@tanstack/react-router'
+import {createFileRoute} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import type {
@@ -64,12 +64,6 @@ import {
 } from 'lucide-react'
 
 export const Route = createFileRoute('/feature-flags')({
-  beforeLoad: async ({location}) => {
-    if (!api.isAuthenticated()) {
-      const hasSession = await api.checkAuth()
-      if (!hasSession) throw redirect({to: '/login', search: {redirect: location.href}})
-    }
-  },
   component: FeatureFlagsPage,
 })
 

--- a/dashboard/src/routes/feedback.$feedbackId.tsx
+++ b/dashboard/src/routes/feedback.$feedbackId.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {formatRelativeTime} from '@/lib/utils'
@@ -54,11 +54,6 @@ import {
 import {useState} from 'react'
 
 export const Route = createFileRoute('/feedback/$feedbackId')({
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: FeedbackDetailPage,
 })
 

--- a/dashboard/src/routes/feedback.tsx
+++ b/dashboard/src/routes/feedback.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Outlet, redirect, useMatches, useNavigate} from '@tanstack/react-router'
+import {createFileRoute, Outlet, useMatches, useNavigate} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {formatRelativeTime, cn} from '@/lib/utils'
@@ -58,11 +58,6 @@ import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import type {Feedback} from '@/lib/api/types/replays'
 
 export const Route = createFileRoute('/feedback')({
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: FeedbackLayout,
 })
 

--- a/dashboard/src/routes/login.tsx
+++ b/dashboard/src/routes/login.tsx
@@ -29,11 +29,9 @@ import {AuthAlert, AuthDivider, AuthField, AuthShell} from '@/components/auth/Au
 import {authInputClass, authPrimaryButtonClass, authSecondaryButtonClass} from '@/components/auth/authStyles'
 import {Helmet} from 'react-helmet-async'
 
-type SearchValue = string | string[]
-
 interface InternalRouteTarget {
   readonly to: string
-  readonly search?: Record<string, SearchValue>
+  readonly search?: Record<string, string>
   readonly hash?: string
 }
 
@@ -75,17 +73,7 @@ function normalizeSsoRedirectUrl(value: unknown): string | undefined {
 
 function internalRouteTarget(path: string): InternalRouteTarget {
   const url = new URL(path, 'https://moneat.io')
-  const search: Record<string, SearchValue> = {}
-  url.searchParams.forEach((value, key) => {
-    const existing = search[key]
-    if (Array.isArray(existing)) {
-      existing.push(value)
-    } else if (existing !== undefined) {
-      search[key] = [existing, value]
-    } else {
-      search[key] = value
-    }
-  })
+  const search = Object.fromEntries(url.searchParams.entries())
 
   return {
     to: url.pathname || '/',

--- a/dashboard/src/routes/login.tsx
+++ b/dashboard/src/routes/login.tsx
@@ -29,6 +29,14 @@ import {AuthAlert, AuthDivider, AuthField, AuthShell} from '@/components/auth/Au
 import {authInputClass, authPrimaryButtonClass, authSecondaryButtonClass} from '@/components/auth/authStyles'
 import {Helmet} from 'react-helmet-async'
 
+type SearchValue = string | string[]
+
+interface InternalRouteTarget {
+  readonly to: string
+  readonly search?: Record<string, SearchValue>
+  readonly hash?: string
+}
+
 function normalizePostLoginRedirect(value: unknown): string | undefined {
   return normalizeInternalRedirectPath(value)
 }
@@ -47,12 +55,10 @@ function defaultPostLoginPath(): string {
   return `/?${params.toString()}`
 }
 
-function resolvePostLoginPath(searchParams: URLSearchParams): string {
+function resolveQueryPostLoginPath(searchParams: URLSearchParams): string | undefined {
   return (
     normalizePostLoginRedirect(searchParams.get('redirect') || undefined) ??
-    consumePendingAuthRedirect() ??
-    buildInviteRedirectPath(searchParams.get('inviteToken') || undefined) ??
-    defaultPostLoginPath()
+    buildInviteRedirectPath(searchParams.get('inviteToken') || undefined)
   )
 }
 
@@ -65,6 +71,31 @@ function normalizeSsoRedirectUrl(value: unknown): string | undefined {
   } catch {
     return undefined
   }
+}
+
+function internalRouteTarget(path: string): InternalRouteTarget {
+  const url = new URL(path, 'https://moneat.io')
+  const search: Record<string, SearchValue> = {}
+  url.searchParams.forEach((value, key) => {
+    const existing = search[key]
+    if (Array.isArray(existing)) {
+      existing.push(value)
+    } else if (existing !== undefined) {
+      search[key] = [existing, value]
+    } else {
+      search[key] = value
+    }
+  })
+
+  return {
+    to: url.pathname || '/',
+    ...(Object.keys(search).length > 0 ? {search} : {}),
+    ...(url.hash ? {hash: url.hash.slice(1)} : {}),
+  }
+}
+
+function resolveSubmitPostLoginPath(queryPostLoginPath: string | undefined): string {
+  return queryPostLoginPath ?? consumePendingAuthRedirect() ?? defaultPostLoginPath()
 }
 
 export const Route = createFileRoute('/login')({
@@ -82,7 +113,12 @@ export const Route = createFileRoute('/login')({
 
     // If authenticated with a post-login redirect (e.g. from email link), go there
     if (api.isAuthenticated() && postLoginRedirect) {
-      throw redirect({ to: postLoginRedirect as never }) // NOSONAR: normalized to an internal app path.
+      const target = internalRouteTarget(postLoginRedirect)
+      throw redirect({
+        to: target.to as never,
+        ...(target.search ? {search: target.search as never} : {}),
+        ...(target.hash ? {hash: target.hash} : {}),
+      })
     }
 
     // If authenticated with no special params, redirect to home
@@ -96,7 +132,7 @@ export const Route = createFileRoute('/login')({
 function LoginPage() {
   const navigate = useNavigate()
   const searchParams = new URLSearchParams(window.location.search)
-  const [postLoginPath] = useState(() => resolvePostLoginPath(searchParams))
+  const [queryPostLoginPath] = useState(() => resolveQueryPostLoginPath(searchParams))
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -113,7 +149,12 @@ function LoginPage() {
     try {
       await api.login(email, password)
       trackEvent('Login', { method: 'email' })
-      navigate({ to: postLoginPath as never }) // NOSONAR: normalized to an internal app path.
+      const target = internalRouteTarget(resolveSubmitPostLoginPath(queryPostLoginPath))
+      navigate({
+        to: target.to as never,
+        ...(target.search ? {search: target.search as never} : {}),
+        ...(target.hash ? {hash: target.hash} : {}),
+      })
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err)
       if (errorMessage === 'NETWORK_ERROR') {

--- a/dashboard/src/routes/login.tsx
+++ b/dashboard/src/routes/login.tsx
@@ -23,23 +23,45 @@ import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
 import {cn} from '@/lib/utils'
+import {consumePendingAuthRedirect, normalizeInternalRedirectPath} from '@/lib/auth-redirect'
 import {GRADIENT_TEXT} from '@/components/landing/Landing'
 import {AuthAlert, AuthDivider, AuthField, AuthShell} from '@/components/auth/AuthShell'
 import {authInputClass, authPrimaryButtonClass, authSecondaryButtonClass} from '@/components/auth/authStyles'
 import {Helmet} from 'react-helmet-async'
 
 function normalizePostLoginRedirect(value: unknown): string | undefined {
+  return normalizeInternalRedirectPath(value)
+}
+
+function buildInviteRedirectPath(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined
   const trimmed = value.trim()
   if (!trimmed) return undefined
 
-  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
-    return trimmed
-  }
+  const params = new URLSearchParams({token: trimmed})
+  return `/accept-invite?${params.toString()}`
+}
+
+function defaultPostLoginPath(): string {
+  const params = new URLSearchParams(APP_OVERVIEW_SEARCH)
+  return `/?${params.toString()}`
+}
+
+function resolvePostLoginPath(searchParams: URLSearchParams): string {
+  return (
+    normalizePostLoginRedirect(searchParams.get('redirect') || undefined) ??
+    consumePendingAuthRedirect() ??
+    buildInviteRedirectPath(searchParams.get('inviteToken') || undefined) ??
+    defaultPostLoginPath()
+  )
+}
+
+function normalizeSsoRedirectUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
 
   try {
-    const url = new URL(trimmed, 'https://moneat.io')
-    return `${url.pathname}${url.search}${url.hash}` || undefined
+    const url = new URL(value)
+    return url.protocol === 'https:' ? url.toString() : undefined
   } catch {
     return undefined
   }
@@ -60,7 +82,7 @@ export const Route = createFileRoute('/login')({
 
     // If authenticated with a post-login redirect (e.g. from email link), go there
     if (api.isAuthenticated() && postLoginRedirect) {
-      throw redirect({ to: postLoginRedirect as never })
+      throw redirect({ to: postLoginRedirect as never }) // NOSONAR: normalized to an internal app path.
     }
 
     // If authenticated with no special params, redirect to home
@@ -74,10 +96,7 @@ export const Route = createFileRoute('/login')({
 function LoginPage() {
   const navigate = useNavigate()
   const searchParams = new URLSearchParams(window.location.search)
-  const inviteToken = searchParams.get('inviteToken') || undefined
-  const redirectUri = searchParams.get('redirect_uri') || undefined
-  const postLoginRedirect =
-    normalizePostLoginRedirect(searchParams.get('redirect') || undefined)
+  const [postLoginPath] = useState(() => resolvePostLoginPath(searchParams))
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -86,58 +105,15 @@ function LoginPage() {
   const [showSsoInput, setShowSsoInput] = useState(false)
   const [ssoEmail, setSsoEmail] = useState('')
 
-  // Validate redirect URI against allowlist
-  const isValidRedirectUri = (uri: string): boolean => {
-    try {
-      const url = new URL(uri)
-      const allowedHosts = ['moneat.io', 'www.moneat.io']
-
-      // Allow moneat:// deep links (production mobile app scheme)
-      if (url.protocol === 'moneat:') {
-        return true
-      }
-
-      // Allow https on moneat.io domains
-      if (url.protocol === 'https:' && allowedHosts.includes(url.hostname)) {
-        return true
-      }
-
-      // Allow Expo deep links only in local development
-      if ((url.protocol === 'exp:' || url.protocol === 'exps:') &&
-          process.env.NODE_ENV === 'development') {
-        return true
-      }
-
-      return false
-    } catch {
-      return false
-    }
-  }
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
     setError('')
 
     try {
-      const { token } = await api.login(email, password)
+      await api.login(email, password)
       trackEvent('Login', { method: 'email' })
-      if (inviteToken) {
-        navigate({ to: '/accept-invite', search: { token: inviteToken } })
-      } else if (redirectUri) {
-        // Validate redirect URI before redirecting (mobile deep link)
-        if (!isValidRedirectUri(redirectUri)) {
-          setError('Invalid redirect URI')
-          setLoading(false)
-          return
-        }
-        window.location.href = `${redirectUri}#token=${token}`
-      } else if (postLoginRedirect) {
-        // Redirect back to the page the user was trying to access (e.g. from email link)
-        window.location.href = postLoginRedirect
-      } else {
-        navigate({ to: '/', search: APP_OVERVIEW_SEARCH })
-      }
+      navigate({ to: postLoginPath as never }) // NOSONAR: normalized to an internal app path.
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err)
       if (errorMessage === 'NETWORK_ERROR') {
@@ -157,8 +133,15 @@ function LoginPage() {
 
     try {
       const response = await api.initSso(ssoEmail)
+      const redirectUrl = normalizeSsoRedirectUrl(response.redirectUrl)
+      if (!redirectUrl) {
+        setError('Invalid SSO redirect URL')
+        setSsoLoading(false)
+        return
+      }
+
       // Redirect to SSO provider
-      window.location.href = response.redirectUrl
+      window.location.href = redirectUrl // NOSONAR: generated by the backend SSO initiation endpoint and validated as HTTPS.
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err)
       if (errorMessage === 'NETWORK_ERROR') {
@@ -249,7 +232,7 @@ function LoginPage() {
             className={authSecondaryButtonClass}
             onClick={() => {
               const backendUrl = import.meta.env.VITE_BACKEND_URL || 'https://api.moneat.io'
-              window.location.href = `${backendUrl}/auth/github`
+              window.location.href = `${backendUrl}/auth/github` // NOSONAR: fixed backend OAuth initiation path.
             }}
           >
             <Github />

--- a/dashboard/src/routes/logs.tsx
+++ b/dashboard/src/routes/logs.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect} from '@tanstack/react-router'
+import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {useMemo} from 'react'
 import {api} from '@/lib/api'
@@ -28,11 +28,6 @@ import {
 export const Route = createFileRoute('/logs')({
   validateSearch: (search: Record<string, unknown>): LogViewSearch => {
     return parseLogViewSearch(search)
-  },
-  beforeLoad: async () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
   },
   component: LogsPage,
 })

--- a/dashboard/src/routes/monitoring.containers.tsx
+++ b/dashboard/src/routes/monitoring.containers.tsx
@@ -6,16 +6,10 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {createFileRoute, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute} from '@tanstack/react-router'
 import {ContainerList} from '@/components/monitoring/ContainerList'
 
 export const Route = createFileRoute('/monitoring/containers')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: MonitoringContainersPage,
 })
 

--- a/dashboard/src/routes/monitoring.events.tsx
+++ b/dashboard/src/routes/monitoring.events.tsx
@@ -6,19 +6,13 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {createFileRoute, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute} from '@tanstack/react-router'
 import {EventStream} from '@/components/monitoring/EventStream'
 import {ServiceCheckList} from '@/components/monitoring/ServiceCheckList'
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
 import {ShieldCheck, Zap} from 'lucide-react'
 
 export const Route = createFileRoute('/monitoring/events')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: MonitoringEventsPage,
 })
 

--- a/dashboard/src/routes/monitoring.hosts.$hostId.tsx
+++ b/dashboard/src/routes/monitoring.hosts.$hostId.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api, type BillingUsage, type DdContainerResponse} from '@/lib/api'
 import {formatRelativeTime} from '@/lib/utils'
@@ -210,11 +210,6 @@ function getHostMonitoringLimitState(usage: BillingUsage | undefined): HostMonit
 }
 
 export const Route = createFileRoute('/monitoring/hosts/$hostId')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: HostDetailPage,
 })
 

--- a/dashboard/src/routes/monitoring.hosts.index.tsx
+++ b/dashboard/src/routes/monitoring.hosts.index.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect, useNavigate} from '@tanstack/react-router'
+import {createFileRoute, Link, useNavigate} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api, type DdHostResponse} from '@/lib/api'
 import {
@@ -80,11 +80,6 @@ function MonitoringPage() {
 }
 
 export const Route = createFileRoute('/monitoring/hosts/')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: MonitoringPage,
 })
 

--- a/dashboard/src/routes/monitoring.map.tsx
+++ b/dashboard/src/routes/monitoring.map.tsx
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect, useNavigate} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {MonitoringMap, type MonitoringMapScope} from '@/components/monitoring/MonitoringMap'
 
 interface MonitoringMapSearch {
@@ -31,11 +30,6 @@ export const Route = createFileRoute('/monitoring/map')({
   validateSearch: (search: Record<string, unknown>): MonitoringMapSearch => ({
     scope: parseMapScope(search.scope),
   }),
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: MonitoringMapPage,
 })
 

--- a/dashboard/src/routes/monitoring.network.tsx
+++ b/dashboard/src/routes/monitoring.network.tsx
@@ -6,16 +6,10 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {createFileRoute, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute} from '@tanstack/react-router'
 import {NetworkConnections} from '@/components/monitoring/NetworkConnections'
 
 export const Route = createFileRoute('/monitoring/network')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: MonitoringNetworkPage,
 })
 

--- a/dashboard/src/routes/monitoring.processes.tsx
+++ b/dashboard/src/routes/monitoring.processes.tsx
@@ -6,16 +6,10 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {createFileRoute, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute} from '@tanstack/react-router'
 import {ProcessExplorer} from '@/components/monitoring/ProcessExplorer'
 
 export const Route = createFileRoute('/monitoring/processes')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: MonitoringProcessesPage,
 })
 

--- a/dashboard/src/routes/monitoring.service-map.tsx
+++ b/dashboard/src/routes/monitoring.service-map.tsx
@@ -7,13 +7,9 @@
 // (at your option) any later version.
 
 import {createFileRoute, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
 
 export const Route = createFileRoute('/monitoring/service-map')({
   beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
     throw redirect({to: '/monitoring/map', search: {scope: 'services'}})
   },
   component: () => null,

--- a/dashboard/src/routes/monitoring.tsx
+++ b/dashboard/src/routes/monitoring.tsx
@@ -14,19 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, Outlet, redirect, useRouterState} from '@tanstack/react-router'
+import {createFileRoute, Link, Outlet, useRouterState} from '@tanstack/react-router'
 import {ArrowLeft} from 'lucide-react'
-import {api} from '@/lib/api'
 import {Button} from '@/components/ui/button'
 import {MonitoringTabBar} from '@/components/monitoring/MonitoringTabBar'
 
 export const Route = createFileRoute('/monitoring')({
-  beforeLoad: async () => {
-    if (!api.isAuthenticated()) {
-      const hasSession = await api.checkAuth()
-      if (!hasSession) throw redirect({to: '/login'})
-    }
-  },
   component: MonitoringLayout,
 })
 

--- a/dashboard/src/routes/onboarding.tsx
+++ b/dashboard/src/routes/onboarding.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect, useNavigate} from '@tanstack/react-router'
+import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useState, useEffect} from 'react'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
@@ -37,11 +37,6 @@ import {
 import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
 
 export const Route = createFileRoute('/onboarding')({
-  beforeLoad: ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: OnboardingPage,
 })
 

--- a/dashboard/src/routes/performance.tsx
+++ b/dashboard/src/routes/performance.tsx
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Outlet, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute, Outlet} from '@tanstack/react-router'
 
 export const Route = createFileRoute('/performance')({
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: PerformanceLayout,
 })
 

--- a/dashboard/src/routes/profiles.tsx
+++ b/dashboard/src/routes/profiles.tsx
@@ -6,15 +6,9 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-import {createFileRoute, Outlet, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute, Outlet} from '@tanstack/react-router'
 
 export const Route = createFileRoute('/profiles')({
-  beforeLoad: async () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: ProfilesLayout,
 })
 

--- a/dashboard/src/routes/projects.$projectId.settings.tsx
+++ b/dashboard/src/routes/projects.$projectId.settings.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {ArrowLeft} from 'lucide-react'
 import {api} from '@/lib/api'
 import {ServiceSettingsCard} from '@/components/projects/ServiceSettingsCard'
@@ -24,11 +24,6 @@ import {
 } from '@/lib/telemetry-sources'
 
 export const Route = createFileRoute('/projects/$projectId/settings')({
-  beforeLoad: async ({location}) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login', search: {redirect: location.href}})
-    }
-  },
   loader: async ({params}) => {
     const service = await api.getProject(params.projectId)
     return {service}

--- a/dashboard/src/routes/projects.tsx
+++ b/dashboard/src/routes/projects.tsx
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Navigate, Outlet, redirect, useMatches} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute, Navigate, Outlet, useMatches} from '@tanstack/react-router'
 import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
 import {Code2, Globe, Terminal} from 'lucide-react'
 
@@ -466,11 +465,6 @@ export const platforms: PlatformType[] = [
 ]
 
 export const Route = createFileRoute('/projects')({
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: ProjectsLayout,
 })
 

--- a/dashboard/src/routes/releases.$version.tsx
+++ b/dashboard/src/routes/releases.$version.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {type ReactNode} from 'react'
 import {api} from '@/lib/api'
@@ -28,11 +28,6 @@ import {Button} from '@/components/ui/button'
 import {Activity, AlertCircle, AlertTriangle, ArrowLeft, ListOrdered, Package, Users} from 'lucide-react'
 
 export const Route = createFileRoute('/releases/$version')({
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: ReleaseDetailPage,
 })
 

--- a/dashboard/src/routes/releases.tsx
+++ b/dashboard/src/routes/releases.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, Outlet, redirect, useMatches} from '@tanstack/react-router'
+import {createFileRoute, Link, Outlet, useMatches} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api, formatErrorForLogging} from '@/lib/api'
 import {type ReactNode, useMemo, useState} from 'react'
@@ -39,11 +39,6 @@ import {useReadableFacetUrlState} from '@/lib/filters/useReadableFacetUrlState'
 import {parseDate} from '@/lib/date-format'
 
 export const Route = createFileRoute('/releases')({
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: ReleasesLayout,
 })
 

--- a/dashboard/src/routes/replays.$replayId.tsx
+++ b/dashboard/src/routes/replays.$replayId.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {type RefObject, useCallback, useMemo, useRef, useState} from 'react'
 import {api, type ReplayDetail, type ReplayTimelineItem} from '@/lib/api'
@@ -47,11 +47,6 @@ import {
 } from 'lucide-react'
 
 export const Route = createFileRoute('/replays/$replayId')({
-  beforeLoad: ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: ReplayDetailPage,
 })
 

--- a/dashboard/src/routes/replays.tsx
+++ b/dashboard/src/routes/replays.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Outlet, redirect, useMatches, useNavigate} from '@tanstack/react-router'
+import {createFileRoute, Outlet, useMatches, useNavigate} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import type {Replay} from '@/lib/api'
@@ -74,11 +74,6 @@ import {
 } from '@/lib/replays-view'
 
 export const Route = createFileRoute('/replays')({
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
-    }
-  },
   component: ReplaysLayout,
 })
 

--- a/dashboard/src/routes/resources.tsx
+++ b/dashboard/src/routes/resources.tsx
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect} from '@tanstack/react-router'
+import {createFileRoute} from '@tanstack/react-router'
 import {useMemo} from 'react'
-import {api} from '@/lib/api'
 import {MonitoringTabBar} from '@/components/monitoring/MonitoringTabBar'
 import {ResourceCatalog, type ResourceCatalogUrlState} from '@/components/monitoring/catalog/ResourceCatalog'
 import {
@@ -86,11 +85,5 @@ function ResourcesPage() {
 
 export const Route = createFileRoute('/resources')({
   validateSearch: parseResourcesSearch,
-  beforeLoad: async () => {
-    if (!api.isAuthenticated()) {
-      const hasSession = await api.checkAuth()
-      if (!hasSession) throw redirect({to: '/login'})
-    }
-  },
   component: ResourcesPage,
 })

--- a/dashboard/src/routes/services.tsx
+++ b/dashboard/src/routes/services.tsx
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Outlet, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute, Outlet} from '@tanstack/react-router'
 
 export const Route = createFileRoute('/services')({
-  beforeLoad: async () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login', search: {redirect: '/services'}})
-    }
-  },
   component: ServicesLayout,
 })
 

--- a/dashboard/src/routes/settings.tsx
+++ b/dashboard/src/routes/settings.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {type FormEvent, Fragment, useEffect, useMemo, useState} from 'react'
-import {createFileRoute, Link, redirect, useNavigate, useSearch} from '@tanstack/react-router'
+import {createFileRoute, Link, useNavigate, useSearch} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {loadStripe} from '@stripe/stripe-js'
 import {Elements, PaymentElement, useElements, useStripe} from '@stripe/react-stripe-js'
@@ -191,11 +191,6 @@ export const Route = createFileRoute('/settings')({
     return {
       tab: requestedTab && VALID_TABS.has(requestedTab) ? requestedTab : 'general',
       ...(search.checkout ? { checkout: search.checkout as string } : {}),
-    }
-  },
-  beforeLoad: async ({ location }) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({ to: '/login', search: { redirect: location.href } })
     }
   },
   component: SettingsPage,

--- a/dashboard/src/routes/setup.tsx
+++ b/dashboard/src/routes/setup.tsx
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect, useNavigate, useSearch} from '@tanstack/react-router'
+import {createFileRoute, useNavigate, useSearch} from '@tanstack/react-router'
 import {Boxes, CloudCog, ServerCog, SlidersHorizontal, type LucideIcon} from 'lucide-react'
-import {api} from '@/lib/api'
 import {cn} from '@/lib/utils'
 import {PageHeader} from '@/components/ui/page-header'
 import {ServicesAndSdksSetup} from '@/components/setup/ServicesAndSdksSetup'
@@ -39,11 +38,6 @@ export const Route = createFileRoute('/setup')({
     tab: parseSetupTab(search.tab),
     service: typeof search.service === 'string' ? search.service : undefined,
   }),
-  beforeLoad: async ({location}) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login', search: {redirect: location.href}})
-    }
-  },
   component: SetupPage,
 })
 

--- a/dashboard/src/routes/status-pages.$pageId.tsx
+++ b/dashboard/src/routes/status-pages.$pageId.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect, useNavigate} from '@tanstack/react-router'
+import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
     api,
@@ -77,11 +77,6 @@ import {useTimezone} from '@/hooks/useTimezone'
 import {formatDateTime} from '@/lib/date-format'
 
 export const Route = createFileRoute('/status-pages/$pageId')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: StatusPageDetailPage,
 })
 

--- a/dashboard/src/routes/status-pages.index.tsx
+++ b/dashboard/src/routes/status-pages.index.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect, useNavigate} from '@tanstack/react-router'
+import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api, type CreateStatusPageRequest} from '@/lib/api'
 import {Button} from '@/components/ui/button'
@@ -44,11 +44,6 @@ import {useTimezone} from '@/hooks/useTimezone'
 import {formatDate} from '@/lib/date-format'
 
 export const Route = createFileRoute('/status-pages/')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: StatusPagesListPage,
 })
 

--- a/dashboard/src/routes/synthetics.tsx
+++ b/dashboard/src/routes/synthetics.tsx
@@ -14,21 +14,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Outlet, redirect} from '@tanstack/react-router'
-import {api} from '@/lib/api'
+import {createFileRoute, Outlet} from '@tanstack/react-router'
 
 export const Route = createFileRoute('/synthetics')({
-  beforeLoad: async () => {
-    if (!api.isAuthenticated()) {
-      const hasSession = await api.checkAuth()
-      if (!hasSession) throw redirect({to: '/login'})
-    }
-  },
   component: SyntheticsLayout,
 })
 
 // Child routes own their full chrome (the overview fills the viewport via ExplorerShell;
-// the builder and result drill-in are full-page). The layout is just the auth gate.
+// the builder and result drill-in are full-page).
 function SyntheticsLayout() {
   return <Outlet />
 }

--- a/dashboard/src/routes/uptime.$monitorId.tsx
+++ b/dashboard/src/routes/uptime.$monitorId.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect, useNavigate} from '@tanstack/react-router'
+import {createFileRoute, useNavigate} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {formatRelativeTime} from '@/lib/utils'
@@ -37,11 +37,6 @@ import {useTimezone} from '@/hooks/useTimezone'
 import {formatTimeHM} from '@/lib/date-format'
 
 export const Route = createFileRoute('/uptime/$monitorId')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: UptimeDetailPage,
 })
 

--- a/dashboard/src/routes/uptime.index.tsx
+++ b/dashboard/src/routes/uptime.index.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, redirect} from '@tanstack/react-router'
+import {createFileRoute} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
 import {Button} from '@/components/ui/button'
@@ -28,11 +28,6 @@ import MonitorListItem from '@/components/uptime/MonitorListItem'
 import MonitorCompactTable from '@/components/uptime/MonitorCompactTable'
 
 export const Route = createFileRoute('/uptime/')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: UptimeListPage,
 })
 

--- a/dashboard/src/routes/usage-insights.tsx
+++ b/dashboard/src/routes/usage-insights.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {type ComponentType} from 'react'
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {useQuery} from '@tanstack/react-query'
 import {
   AlertTriangle,
@@ -47,11 +47,6 @@ const MONEY_DIVISOR = 100
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 
 export const Route = createFileRoute('/usage-insights')({
-  beforeLoad: async ({location}) => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login', search: {redirect: location.href}})
-    }
-  },
   component: UsageInsightsPage,
 })
 

--- a/dashboard/src/routes/workflows.connections.tsx
+++ b/dashboard/src/routes/workflows.connections.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {useState} from 'react'
-import {createFileRoute, redirect} from '@tanstack/react-router'
+import {createFileRoute} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {KeyRound, Loader2, Lock, Plus, RotateCw, Trash2} from 'lucide-react'
 import {api} from '@/lib/api'
@@ -38,12 +38,6 @@ import {hasEnterpriseModule, useEnterpriseFeatures} from '@/hooks/useEnterpriseF
 import {useToast} from '@/hooks/useToast'
 
 export const Route = createFileRoute('/workflows/connections')({
-  beforeLoad: async () => {
-    const authenticated = api.isAuthenticated() || (await api.checkAuth())
-    if (!authenticated) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: ConnectionsPage,
 })
 

--- a/dashboard/src/routes/workflows.insights.tsx
+++ b/dashboard/src/routes/workflows.insights.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {createFileRoute, Link, redirect} from '@tanstack/react-router'
+import {createFileRoute, Link} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {ArrowLeft, ClipboardList, Gauge, LayoutGrid, Loader2} from 'lucide-react'
 import {api} from '@/lib/api'
@@ -31,12 +31,6 @@ import {useToast} from '@/hooks/useToast'
 const AUDIT_LIMIT = 25
 
 export const Route = createFileRoute('/workflows/insights')({
-  beforeLoad: async () => {
-    const authenticated = api.isAuthenticated() || (await api.checkAuth())
-    if (!authenticated) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: InsightsPage,
 })
 

--- a/dashboard/src/routes/workflows.tsx
+++ b/dashboard/src/routes/workflows.tsx
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import {useCallback, useEffect, useMemo, useState} from 'react'
-import {createFileRoute, Link, Outlet, redirect, useRouterState} from '@tanstack/react-router'
+import {createFileRoute, Link, Outlet, useRouterState} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
   Bug,
@@ -83,11 +83,6 @@ import {useToast} from '@/hooks/useToast'
 import {cn} from '@/lib/utils'
 
 export const Route = createFileRoute('/workflows')({
-  beforeLoad: () => {
-    if (!api.isAuthenticated()) {
-      throw redirect({to: '/login'})
-    }
-  },
   component: WorkflowsLayout,
 })
 


### PR DESCRIPTION
## Summary
- centralize private-route auth redirects in the dashboard root route
- preserve attempted URLs through login for route guards and API 401s
- remove duplicated auth-only guards from private child routes

## Verification
- npm test -- --run src/lib/__tests__/auth-redirect.test.ts src/lib/__tests__/api.test.ts src/lib/api/__tests__/client-branches.test.ts src/routes/__tests__/-root-public-route.test.ts src/routes/__tests__/-auth-redirect-guards.test.ts src/routes/__tests__/-monitoring-route.test.tsx src/routes/__tests__/workflows-insights.test.tsx src/routes/__tests__/-replays-route-helpers.test.ts src/routes/__tests__/-replay-detail-helpers.test.ts src/routes/__tests__/-priority-routes.test.tsx src/routes/__tests__/performance-coverage.test.tsx
- npm run typecheck
- npm run lint
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized route access gating now consistently redirects unauthenticated users to sign-in while preserving the originally requested destination (including query strings and anchors).
  * Login now restores the pending post-auth destination, normalizes internal redirect targets, and validates SSO redirect URLs (HTTPS-only), improving post-login navigation.
* **Bug Fixes**
  * Improved 401 handling/redirect retry behavior so refresh failures preserve the correct redirect behavior.
  * Fixed “Copied link” confirmation in the Logs context viewer so it reliably resets (including after unmount/rapid clicks).
* **Other**
  * Updated admin access checks to rethrow unexpected errors instead of redirecting to login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->