### PR TITLE
fix: SSO missing orgId claim

### DIFF
--- a/backend/features/sso/src/main/kotlin/com/moneat/sso/services/SsoService.kt
+++ b/backend/features/sso/src/main/kotlin/com/moneat/sso/services/SsoService.kt
@@ -648,9 +648,17 @@ open class SsoService {
                             (UserSsoLinks.externalId eq externalId)
                     }.firstOrNull()
 
-            val userId =
+            val (userId, orgRole) =
                 if (existingLink != null) {
-                    existingLink[UserSsoLinks.userId]
+                    val membership =
+                        Memberships
+                            .selectAll()
+                            .where { Memberships.user_id eq existingLink[UserSsoLinks.userId] }
+                            .firstOrNull()
+                    Pair(
+                        existingLink[UserSsoLinks.userId],
+                        membership?.get(Memberships.role) ?: "member",
+                    )
                 } else {
                     linkOrCreateUser(
                         normalizedEmail,
@@ -667,7 +675,7 @@ open class SsoService {
                     .where { Users.id eq userId }
                     .first()
 
-            val token = generateToken(userId, user[Users.email])
+            val token = generateToken(userId, user[Users.email], organizationId, orgRole)
             Triple(token, user[Users.email], user[Users.name] ?: email)
         }
     }
@@ -868,12 +876,16 @@ open class SsoService {
     private fun generateToken(
         userId: Int,
         email: String,
+        orgId: Int,
+        orgRole: String,
     ): String =
         JWT
             .create()
             .withAudience(jwtAudience)
             .withIssuer(jwtIssuer)
             .withClaim("userId", userId)
+            .withClaim("orgId", orgId)
+            .withClaim("orgRole", orgRole)
             .withClaim("email", email)
             .withExpiresAt(Date(System.currentTimeMillis() + TOKEN_TTL_MS))
             .sign(Algorithm.HMAC256(jwtSecret))
@@ -884,7 +896,7 @@ open class SsoService {
         externalId: String,
         ssoConfigId: Int,
         organizationId: Int,
-    ): Int {
+    ): Pair<Int, String> {
         ensureSsoEmailDomainAllowsNewLink(normalizedEmail, ssoConfigId)
         val existingUser =
             Users
@@ -905,7 +917,7 @@ open class SsoService {
             }
             addToOrgIfNeeded(uid, organizationId, invitationRole)
             acceptPendingInvitation(normalizedEmail, organizationId)
-            uid
+            Pair(uid, invitationRole ?: "member")
         } else {
             val invitationRole = pendingInvitationRole(normalizedEmail, organizationId)
             val uid =
@@ -927,7 +939,7 @@ open class SsoService {
                 it[role] = invitationRole ?: "member"
             }
             acceptPendingInvitation(normalizedEmail, organizationId)
-            uid
+            Pair(uid, invitationRole ?: "member")
         }
     }
 

--- a/backend/features/sso/src/main/kotlin/com/moneat/sso/services/SsoService.kt
+++ b/backend/features/sso/src/main/kotlin/com/moneat/sso/services/SsoService.kt
@@ -650,15 +650,17 @@ open class SsoService {
 
             val (userId, orgRole) =
                 if (existingLink != null) {
+                    val userId = existingLink[UserSsoLinks.userId]
                     val membership =
                         Memberships
                             .selectAll()
-                            .where { Memberships.user_id eq existingLink[UserSsoLinks.userId] }
+                            .where {
+                                (Memberships.user_id eq userId) and
+                                    (Memberships.organization_id eq organizationId)
+                            }
                             .firstOrNull()
-                    Pair(
-                        existingLink[UserSsoLinks.userId],
-                        membership?.get(Memberships.role) ?: "member",
-                    )
+                            ?: throw SsoForbiddenException("SSO user is not a member of this organization")
+                    Pair(userId, membership[Memberships.role])
                 } else {
                     linkOrCreateUser(
                         normalizedEmail,
@@ -906,8 +908,16 @@ open class SsoService {
 
         return if (existingUser != null) {
             val uid = existingUser[Users.id]
+            val membership =
+                Memberships
+                    .selectAll()
+                    .where {
+                        (Memberships.user_id eq uid) and
+                            (Memberships.organization_id eq organizationId)
+                    }
+                    .firstOrNull()
             val invitationRole = pendingInvitationRole(normalizedEmail, organizationId)
-            require(isOrganizationMember(uid, organizationId) || invitationRole != null) {
+            require(membership != null || invitationRole != null) {
                 "SSO account linking requires an existing membership or invitation"
             }
             UserSsoLinks.insert {
@@ -917,7 +927,7 @@ open class SsoService {
             }
             addToOrgIfNeeded(uid, organizationId, invitationRole)
             acceptPendingInvitation(normalizedEmail, organizationId)
-            Pair(uid, invitationRole ?: "member")
+            Pair(uid, membership?.get(Memberships.role) ?: invitationRole ?: "member")
         } else {
             val invitationRole = pendingInvitationRole(normalizedEmail, organizationId)
             val uid =


### PR DESCRIPTION
## Description

So I was trying to setup moneat with sso and it kept returning 401 with "Invalid Token" error message. It seems that "requireCurrentOrg" wants `orgId` to be present on the token claims which they are not being set on the SSO flow.

## Related Issue

I can create it :)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have signed the [CLA](../CLA.md)
- [x] My code follows the project's coding conventions
- [ ] I have added tests that cover my changes (if applicable)
- [x] All new and existing tests pass
- [ ] I have addressed all code review feedback
- [ ] I have joined [Discord](https://discord.com/invite/dTsahnJeyH) and notified the team that this PR is ready for review
- [ ] I have updated documentation (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSO sign-in tokens now include organization details, helping apps recognize the user’s organization and role.
  * Organization role information is now carried through sign-in, with a sensible default when no role is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->