### PR TITLE
fix: surface datasource query errors

### DIFF
--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/handlers/JdbcHandler.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/handlers/JdbcHandler.kt
@@ -291,7 +291,7 @@ abstract class JdbcHandler(
         return rows
     }
 
-    private fun hasSemicolonOutsideQuotes(query: String): Boolean {
+    private fun hasNonTrailingSemicolonOutsideQuotes(query: String): Boolean {
         var i = 0
         var inSingle = false
         var inDouble = false
@@ -310,7 +310,7 @@ abstract class JdbcHandler(
                 }
                 c == '\'' -> inSingle = true
                 c == '"' -> inDouble = true
-                c == ';' -> return true
+                c == ';' -> return query.drop(i + 1).any { !it.isWhitespace() }
             }
             i++
         }
@@ -335,7 +335,7 @@ abstract class JdbcHandler(
         require(trimmed.startsWith("SELECT") || trimmed.startsWith("WITH")) {
             "Only SELECT or WITH queries are allowed"
         }
-        require(!hasSemicolonOutsideQuotes(normalized)) { "Multiple statements are not allowed" }
+        require(!hasNonTrailingSemicolonOutsideQuotes(normalized)) { "Multiple statements are not allowed" }
         for ((pattern, name) in forbiddenKeywords()) {
             require(!pattern.containsMatchIn(normalized)) { "$name statements are not allowed" }
         }

--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/CustomDataSourceExecutorTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/CustomDataSourceExecutorTest.kt
@@ -141,6 +141,11 @@ class CustomDataSourceExecutorTest {
     }
 
     @Test
+    fun `validateSqlQuery allows trailing semicolon`() {
+        postgresHandler.validateSqlQuery("WITH users AS (SELECT 1 AS id) SELECT id FROM users;")
+    }
+
+    @Test
     fun `validateSqlQuery allows comment as column name`() {
         postgresHandler.validateSqlQuery("SELECT comment FROM posts")
     }

--- a/dashboard/src/components/dashboards/QueryBuilderForm.tsx
+++ b/dashboard/src/components/dashboards/QueryBuilderForm.tsx
@@ -148,7 +148,7 @@ export function QueryBuilderForm({value, onChange}: QueryBuilderFormProps) {
           <p className="text-xs text-muted-foreground mt-1">
             {selectedSource?.label?.includes('prometheus')
               ? 'Enter a PromQL query expression'
-              : 'Only SELECT queries are allowed. Read-only access is enforced.'}
+              : 'Only SELECT or WITH queries are allowed. Read-only access is enforced.'}
           </p>
           {/* Limit */}
           <div className="mt-3">

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -249,8 +249,10 @@ function QueryErrorState({error}: {error: unknown}) {
 }
 
 function queryErrorDetail(error: unknown): string | null {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message === 'NETWORK_ERROR' ? 'Network error' : error.message
+  if (error instanceof Error) {
+    const message = error.message.trim()
+    if (!message) return null
+    return message === 'NETWORK_ERROR' ? 'Network error' : message
   }
   return null
 }

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -238,7 +238,7 @@ function isTimeKey(key: string): boolean {
   return TIME_KEYS.has(key)
 }
 
-function QueryErrorState({error}: {error: unknown}) {
+function QueryErrorState({error}: Readonly<{error: unknown}>) {
   const detail = queryErrorDetail(error)
   return (
     <div className="max-w-full px-4 text-center">

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -172,7 +172,7 @@ export const WidgetRenderer = memo(function WidgetRenderer({
   if (error || (!isExtendedWidget && (!data || data.length === 0))) {
     return (
       <div className="h-full flex items-center justify-center text-xs text-muted-foreground">
-        {error ? 'Query error' : 'No data'}
+        {error ? <QueryErrorState error={error} /> : 'No data'}
       </div>
     )
   }
@@ -236,6 +236,23 @@ export const WidgetRenderer = memo(function WidgetRenderer({
 
 function isTimeKey(key: string): boolean {
   return TIME_KEYS.has(key)
+}
+
+function QueryErrorState({error}: {error: unknown}) {
+  const detail = queryErrorDetail(error)
+  return (
+    <div className="max-w-full px-4 text-center">
+      <div>Query error</div>
+      {detail ? <div className="mt-1 break-words">{detail}</div> : null}
+    </div>
+  )
+}
+
+function queryErrorDetail(error: unknown): string | null {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message === 'NETWORK_ERROR' ? 'Network error' : error.message
+  }
+  return null
 }
 
 function isQueryDrivenWidget(widgetType: string): boolean {

--- a/dashboard/src/components/dashboards/__tests__/QueryBuilderForm-extended.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/QueryBuilderForm-extended.test.tsx
@@ -89,7 +89,7 @@ describe('QueryBuilderForm – extended branch coverage', () => {
       await waitFor(() => {
         expect(screen.getByText('SQL Query')).toBeInTheDocument()
       })
-      expect(screen.getByText(/Only SELECT queries are allowed/)).toBeInTheDocument()
+      expect(screen.getByText(/Only SELECT or WITH queries are allowed/)).toBeInTheDocument()
     })
 
     it('renders PromQL editor for prometheus custom source', async () => {

--- a/dashboard/src/components/dashboards/__tests__/WidgetRendererError.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/WidgetRendererError.test.tsx
@@ -1,0 +1,87 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {screen} from '@testing-library/react'
+import {renderWithQueryClient} from '@/test/utils'
+import type {DashboardWidget, QueryDsl, TimeRangeDef} from '@/lib/api'
+import {WidgetRenderer} from '../WidgetRenderer'
+import {fetchWidgetRows} from '../widgetRows'
+
+vi.mock('../widgetRows', async () => {
+  const actual = await vi.importActual<typeof import('../widgetRows')>('../widgetRows')
+  return {
+    ...actual,
+    fetchWidgetRows: vi.fn(),
+  }
+})
+
+const fetchWidgetRowsMock = vi.mocked(fetchWidgetRows)
+
+const timeRange: TimeRangeDef = {from: 'now-24h', to: 'now'}
+
+beforeEach(() => {
+  fetchWidgetRowsMock.mockReset()
+})
+
+function query(): QueryDsl {
+  return {
+    dataSource: 'custom:218f4ce4-3f2a-7a67-a32b-0c1848f62b9d',
+    metrics: [],
+    groupBy: [],
+    filters: [],
+    limit: 5000,
+    timeRange,
+    rawQuery: 'select * from missing_table',
+  }
+}
+
+function widget(): DashboardWidget {
+  return {
+    id: 'widget-1',
+    dashboard_id: 'dashboard-1',
+    title: 'Broken query',
+    widget_type: 'timeseries',
+    grid_x: 0,
+    grid_y: 0,
+    grid_w: 8,
+    grid_h: 6,
+    query_configs: [query()],
+    display_config: {},
+    sort_order: 0,
+  }
+}
+
+describe('WidgetRenderer query errors', () => {
+  it('shows backend query error detail when a widget query fails', async () => {
+    fetchWidgetRowsMock.mockRejectedValue(
+      new Error('Data source query failed: ERROR: relation "missing_table" does not exist Position: 15')
+    )
+
+    renderWithQueryClient(
+      <WidgetRenderer
+        widget={widget()}
+        dashboardId="dashboard-1"
+        projectId="018f4ce4-3f2a-7a67-a32b-0c1848f62b9d"
+        timeRange={timeRange}
+        autoRefresh={false}
+      />,
+    )
+
+    expect(await screen.findByText('Query error')).toBeInTheDocument()
+    expect(screen.getByText(/relation "missing_table" does not exist/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Show datasource query failure details in widget previews
- Allow a single trailing semicolon for read-only SQL queries
- Align query editor guidance with SELECT and WITH support

## Validation
- npm run test -- WidgetRendererError.test.tsx --run
- ./gradlew :features:dashboards:test --tests com.moneat.dashboards.CustomDataSourceExecutorTest --no-daemon
- npx eslint src/components/dashboards/WidgetRenderer.tsx src/components/dashboards/QueryBuilderForm.tsx src/components/dashboards/__tests__/WidgetRendererError.test.tsx --report-unused-disable-directives --max-warnings 0
- npm run typecheck
- ./gradlew :features:dashboards:detekt --no-daemon
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widget query failures now display a richer error state, including a clearer “Network error” when applicable.
* **Bug Fixes**
  * Read-only query validation now allows trailing semicolons when they don’t introduce additional statements (e.g., `WITH ... SELECT ...;`).
  * Widget error views now show more useful details, such as missing-relation text, when available.
* **Documentation**
  * Raw query help text now clarifies that read-only sources allow `SELECT` or `WITH` queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->