### PR TITLE
fix: place overview release marker by timestamp

### DIFF
--- a/backend/features/overview/src/main/kotlin/com/moneat/overview/services/OverviewService.kt
+++ b/backend/features/overview/src/main/kotlin/com/moneat/overview/services/OverviewService.kt
@@ -103,6 +103,7 @@ private const val NANOS_PER_MILLI = 1_000_000
 private const val MILLIS_PER_SECOND = 1_000L
 private const val SECONDS_PER_MINUTE = 60L
 private const val MINUTES_PER_HOUR = 60L
+private const val MILLIS_PER_HOUR = MILLIS_PER_SECOND * SECONDS_PER_MINUTE * MINUTES_PER_HOUR
 private const val HOURS_PER_DAY = 24L
 private const val DAYS_PER_MONTH = 30L
 private const val WARN_RESOURCE_PCT = 70
@@ -175,7 +176,8 @@ class OverviewService(
         val traceMetrics = traceMetricsDeferred.await()
         val logMetrics = logMetricsDeferred.await()
         val issueItems = issueItemsDeferred.await()
-        val deploys = deploysDeferred.await()
+        val deploySnapshots = deploysDeferred.await()
+        val deploys = deploySnapshots.map { snapshot -> snapshot.row }
         val alertItems = alertsDeferred.await()
         val incidents = emptyList<OverviewIncidentItem>()
         val serviceRows = serviceRowsDeferred.await()
@@ -191,7 +193,7 @@ class OverviewService(
             systemStatus = systemStatus(counts),
             kpis = kpis(eventMetrics, traceMetrics, logMetrics, issueItems.size, monitors),
             serviceHealth = serviceRows,
-            telemetry = telemetry(eventMetrics, traceMetrics, logMetrics, deploys),
+            telemetry = telemetry(eventMetrics, traceMetrics, logMetrics, deploySnapshots, demoEpochMs),
             triage = OverviewTriageData(
                 incidents = incidents,
                 alerts = alertItems,
@@ -338,18 +340,34 @@ class OverviewService(
         eventMetrics: EventMetrics,
         traceMetrics: TraceMetrics,
         logMetrics: LogMetrics,
-        deploys: List<OverviewDeployRow>,
+        deploys: List<OverviewDeploySnapshot>,
+        demoEpochMs: Long?,
     ): OverviewTelemetryData {
-        val deployAtPct = if (deploys.isEmpty()) 0 else PERCENT.roundToInt()
-        val deployLabel = deploys.firstOrNull()?.version ?: DEFAULT_DEPLOY_LABEL
+        val deployMarker = deployMarker(deploys, demoEpochMs)
         return OverviewTelemetryData(
             errors = filledSeries(sumSeries(eventMetrics.errorSpark, logMetrics.errorSpark)),
             latency = filledSeries(traceMetrics.latencySpark),
             throughput = filledSeries(traceMetrics.throughputSpark),
             logs = filledSeries(logMetrics.volumeSpark),
-            deployAtPct = deployAtPct,
-            deployLabel = deployLabel,
+            deployAtPct = deployMarker?.pct ?: 0,
+            deployLabel = deployMarker?.label ?: DEFAULT_DEPLOY_LABEL,
         )
+    }
+
+    private fun deployMarker(
+        deploys: List<OverviewDeploySnapshot>,
+        demoEpochMs: Long?,
+    ): TelemetryDeployMarker? {
+        val nowMs = demoEpochMs ?: Clock.System.now().toEpochMilliseconds()
+        val windowStartMs = nowMs - CURRENT_WINDOW_HOURS * MILLIS_PER_HOUR
+        val deploy = deploys
+            .filter { snapshot -> snapshot.markerAtMs in windowStartMs..nowMs }
+            .maxByOrNull { snapshot -> snapshot.markerAtMs }
+            ?: return null
+        val pct = ((deploy.markerAtMs - windowStartMs).toDouble() / (nowMs - windowStartMs) * PERCENT)
+            .roundToInt()
+            .coerceIn(MIN_PERCENT_INT, MAX_PERCENT_INT)
+        return TelemetryDeployMarker(pct = pct, label = deploy.row.version)
     }
 
     private fun infra(
@@ -433,7 +451,7 @@ class OverviewService(
                 .map { row -> ProjectRef(row[Projects.id], row[Projects.name]) }
         }
 
-    private fun loadDeploys(organizationId: Int): List<OverviewDeployRow> =
+    private fun loadDeploys(organizationId: Int): List<OverviewDeploySnapshot> =
         transaction {
             Releases
                 .innerJoin(Projects)
@@ -442,13 +460,16 @@ class OverviewService(
                 .orderBy(Releases.created_at to SortOrder.DESC)
                 .limit(MAX_DEPLOY_ROWS)
                 .map { row ->
-                    val age = ageLabel(row[Releases.created_at])
-                    OverviewDeployRow(
-                        version = row[Releases.version],
-                        service = row[Projects.name],
-                        status = "neutral",
-                        label = "released",
-                        ageLabel = age,
+                    val createdAt = row[Releases.created_at]
+                    OverviewDeploySnapshot(
+                        row = OverviewDeployRow(
+                            version = row[Releases.version],
+                            service = row[Projects.name],
+                            status = "neutral",
+                            label = "released",
+                            ageLabel = ageLabel(createdAt),
+                        ),
+                        markerAtMs = row[Releases.first_seen] ?: createdAt,
                     )
                 }
         }
@@ -1213,6 +1234,16 @@ class OverviewService(
 private data class ProjectRef(
     val id: Long,
     val name: String,
+)
+
+private data class OverviewDeploySnapshot(
+    val row: OverviewDeployRow,
+    val markerAtMs: Long,
+)
+
+private data class TelemetryDeployMarker(
+    val pct: Int,
+    val label: String,
 )
 
 private data class MetricKpiSpec(

--- a/backend/features/overview/src/test/kotlin/com/moneat/overview/OverviewServiceTest.kt
+++ b/backend/features/overview/src/test/kotlin/com/moneat/overview/OverviewServiceTest.kt
@@ -84,7 +84,7 @@ class OverviewServiceTest {
         assertEquals("v1.2.3", overview.deploys.single().version)
         assertEquals("Backend API", overview.deploys.single().service)
         assertEquals("v1.2.3", overview.telemetry.deployLabel)
-        assertEquals(100, overview.telemetry.deployAtPct)
+        assertEquals(75, overview.telemetry.deployAtPct)
 
         assertTrue(overview.triage.incidents.isEmpty())
         assertEquals("error", overview.triage.alerts.single().level)
@@ -155,6 +155,49 @@ class OverviewServiceTest {
         } finally {
             unmockkObject(ClickHouseClient)
         }
+    }
+
+    @Test
+    fun `overview positions telemetry deploy marker from first seen timestamp`() = runBlocking {
+        val orgId = seedOverviewData()
+
+        transaction {
+            TransactionManager.current().exec(
+                """
+                UPDATE releases
+                SET created_at = ${DEMO_EPOCH_MS - HOUR_MILLIS},
+                    first_seen = ${DEMO_EPOCH_MS - 12 * HOUR_MILLIS}
+                WHERE version = 'v1.2.3'
+                """.trimIndent(),
+            )
+        }
+
+        val overview = OverviewService().getOverview(orgId, demoEpochMs = DEMO_EPOCH_MS)
+
+        assertEquals("v1.2.3", overview.telemetry.deployLabel)
+        assertEquals(50, overview.telemetry.deployAtPct)
+    }
+
+    @Test
+    fun `overview omits telemetry deploy marker outside current window`() = runBlocking {
+        val orgId = seedOverviewData()
+
+        transaction {
+            TransactionManager.current().exec(
+                """
+                UPDATE releases
+                SET created_at = ${DEMO_EPOCH_MS - 25 * HOUR_MILLIS},
+                    first_seen = ${DEMO_EPOCH_MS - 25 * HOUR_MILLIS}
+                WHERE version = 'v1.2.3'
+                """.trimIndent(),
+            )
+        }
+
+        val overview = OverviewService().getOverview(orgId, demoEpochMs = DEMO_EPOCH_MS)
+
+        assertEquals("No deploys", overview.telemetry.deployLabel)
+        assertEquals(0, overview.telemetry.deployAtPct)
+        assertEquals("v1.2.3", overview.deploys.single().version)
     }
 
     @Test
@@ -297,7 +340,8 @@ class OverviewServiceTest {
             Releases.insert {
                 it[project_id] = projectId
                 it[version] = "v1.2.3"
-                it[created_at] = Clock.System.now().toEpochMilliseconds() - HOUR_MILLIS
+                it[created_at] = DEMO_EPOCH_MS - 6 * HOUR_MILLIS
+                it[first_seen] = DEMO_EPOCH_MS - 6 * HOUR_MILLIS
             }
             seedDashboardAlertTablesForFallbackTest()
             AlertEpisodes.insert {

--- a/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
+++ b/dashboard/src/components/overview/__tests__/overviewWidgets.test.tsx
@@ -86,6 +86,18 @@ describe('TelemetryWidget', () => {
     expect(screen.getByText('log volume')).toBeInTheDocument()
   })
 
+  it('does not render a deploy marker when no deploy is in the telemetry window', () => {
+    renderWithOverview(<TelemetryWidget />, {
+      telemetry: {
+        ...overviewTestData.telemetry,
+        deployAtPct: 0,
+        deployLabel: 'No deploys',
+      },
+    })
+
+    expect(screen.queryByText('No deploys')).not.toBeInTheDocument()
+  })
+
   it('keeps deploy labels inside chart edges', () => {
     const {rerender} = render(
       <svg>

--- a/dashboard/src/components/overview/widgets/TelemetryWidget.tsx
+++ b/dashboard/src/components/overview/widgets/TelemetryWidget.tsx
@@ -44,6 +44,10 @@ const TABS: TabDef[] = [
 ]
 
 const X_LABELS = ['00:00', '04:00', '08:00', '12:00', '16:00', '20:00', 'now']
+const DEFAULT_DEPLOY_LABEL = 'No deploys'
+const MIN_DEPLOY_PCT = 0
+const MAX_DEPLOY_PCT = 100
+const DEPLOY_MARKER_ALIGN_RIGHT_PCT = 60
 
 interface DeployLabelProps {
   // Injected by recharts when used as a ReferenceLine label.
@@ -83,8 +87,18 @@ export function TelemetryWidget() {
 
   const series = telem[activeKey]
   const data = series.map((value, i) => ({i, value}))
-  const deployIndex = Math.round((telem.deployAtPct / 100) * (series.length - 1))
-  const deployLabelRight = telem.deployAtPct > 60
+  const deployAtPct = Math.min(MAX_DEPLOY_PCT, Math.max(MIN_DEPLOY_PCT, telem.deployAtPct))
+  const deployIndex = Math.round((deployAtPct / MAX_DEPLOY_PCT) * Math.max(series.length - 1, 0))
+  const deployLabelRight = deployAtPct > DEPLOY_MARKER_ALIGN_RIGHT_PCT
+  const hasDeployMarker = telem.deployLabel.trim() !== '' && telem.deployLabel !== DEFAULT_DEPLOY_LABEL
+  const deployMarker = hasDeployMarker ? (
+    <ReferenceLine
+      x={deployIndex}
+      stroke="hsl(var(--primary))"
+      strokeDasharray="4 3"
+      label={<DeployLabel text={telem.deployLabel} alignRight={deployLabelRight} />}
+    />
+  ) : null
 
   return (
     <OverviewPanel
@@ -125,12 +139,7 @@ export function TelemetryWidget() {
           {activeKey === 'logs' ? (
             <BarChart data={data} margin={{top: 6, right: 6, left: 0, bottom: 0}}>
               <CartesianGrid vertical={false} stroke="hsl(var(--border))" strokeOpacity={0.6} />
-              <ReferenceLine
-                x={deployIndex}
-                stroke="hsl(var(--primary))"
-                strokeDasharray="4 3"
-                label={<DeployLabel text={telem.deployLabel} alignRight={deployLabelRight} />}
-              />
+              {deployMarker}
               <Bar dataKey="value" fill={tab.color} radius={[1, 1, 0, 0]} />
             </BarChart>
           ) : (
@@ -151,12 +160,7 @@ export function TelemetryWidget() {
                   label={{value: 'alert: 5xx > 2%', position: 'insideTopRight', fontSize: 10, fill: 'hsl(var(--danger-fg))'}}
                 />
               )}
-              <ReferenceLine
-                x={deployIndex}
-                stroke="hsl(var(--primary))"
-                strokeDasharray="4 3"
-                label={<DeployLabel text={telem.deployLabel} alignRight={deployLabelRight} />}
-              />
+              {deployMarker}
               <Area
                 type="monotone"
                 dataKey="value"


### PR DESCRIPTION
## Summary
- place the overview telemetry release marker from release timing
- hide the marker when no release falls in the chart window

## Validation
- ./gradlew :features:overview:test --tests com.moneat.overview.OverviewServiceTest --no-daemon
- ./gradlew :features:overview:detekt --no-daemon
- npm run test -- overviewWidgets.test.tsx
- npm run lint
- npm run typecheck
- git diff --check HEAD~1 HEAD