### PR TITLE
ci: write CLA signatures via GITHUB_TOKEN (drop expired PAT dependency)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,12 +23,9 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/${{ github.repository }}/blob/main/CLA.md'
-          remote-organization-name: ${{ github.repository_owner }}
-          remote-repository-name: ${{ github.event.repository.name }}
           branch: 'develop'
           allowlist: 'dependabot[bot],github-actions[bot],Copilot,renovate[bot]'
           custom-notsigned-prcomment: |


### PR DESCRIPTION
## What
Have the CLA Assistant write signatures via the built-in `GITHUB_TOKEN` instead of a Personal Access Token.

- Remove `remote-organization-name` / `remote-repository-name` — they pointed at **this same** repo, which is the only reason the action reached for `PERSONAL_ACCESS_TOKEN`.
- Remove the now-unused `PERSONAL_ACCESS_TOKEN` env line.

The workflow already grants `contents: write` to `GITHUB_TOKEN`, and signatures live in this repo (`signatures/cla.json` on `develop`), so no PAT is needed.

## Why
The `PERSONAL_ACCESS_TOKEN` secret (last set 2026-02-22) expired. Since the last successful signature write (2026-03-27), every external-contributor sign attempt has silently failed to persist: the bot updates its PR comment but can't commit to `signatures/cla.json`, so `cla-check` reports "must sign" forever.

Seen on #839 — @Tvalerio1 posted the sign phrase (two `issue_comment` runs at 22:07/22:08 on 07-03) but both failed to record, and the file's commit history has no entry for them.

Using `GITHUB_TOKEN` removes the recurring-expiry failure mode entirely — nothing to rotate.

## After merge
- Existing signatures are untouched (same file, branch, and repo).
- Re-trigger #839 by having the contributor re-comment the sign phrase (or push a commit); the signature will now persist.
- The `PERSONAL_ACCESS_TOKEN` repo secret can be deleted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)