### PR TITLE
fix: preserve disk metric identity

### DIFF
--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogMetricServiceTest.kt
@@ -520,7 +520,7 @@ class DatadogMetricServiceTest {
                             timestampMs = 1_700_000_000_000L,
                             value = 0.42,
                             host = "web-01",
-                            tags = mapOf("host_id" to "7"),
+                            tags = mapOf("host_id" to "7", "device" to "/dev/vda1", "mountpoint" to "/"),
                         ),
                         QueuedMetricEntry(
                             name = "system.net.bytes_rcvd",
@@ -559,6 +559,8 @@ class DatadogMetricServiceTest {
             val latestRollup = queries.single { it.contains("metrics_latest_by_host") }
             assertTrue(latestRollup.contains("'system.disk.percent'"))
             assertTrue(latestRollup.contains("42.0"))
+            assertTrue(latestRollup.contains("metric_identity"))
+            assertTrue(latestRollup.contains("'device=/dev/vda1|mountpoint=/'"))
             assertTrue(latestRollup.contains("'system.net.recv_bytes'"))
             assertTrue(latestRollup.contains("'system.mem.available'"))
             assertTrue(latestRollup.contains("928.0"))
@@ -566,6 +568,9 @@ class DatadogMetricServiceTest {
             assertFalse(latestRollup.contains("system.net.bytes_rcvd"))
             assertFalse(latestRollup.contains("system.mem.pct_usable"))
             assertFalse(latestRollup.contains("system.mem.usable"))
+
+            val minuteRollup = queries.single { it.contains("metrics_rollup_1m") }
+            assertTrue(minuteRollup.contains("'device=/dev/vda1|mountpoint=/'"))
         } finally {
             unmockkObject(ClickHouseClient)
         }

--- a/backend/features/monitoring/src/main/kotlin/com/moneat/monitor/services/InfraTelemetryRollups.kt
+++ b/backend/features/monitoring/src/main/kotlin/com/moneat/monitor/services/InfraTelemetryRollups.kt
@@ -84,6 +84,7 @@ object InfraTelemetryRollups {
 
         val db = ClickHouseClient.getDatabase()
         val latestRows = resolvedRows.joinToString(",\n") { (row, hostId) ->
+            val metricIdentity = metricIdentity(row.metricName, row.tags)
             """(
                 ${row.organizationId},
                 $hostId,
@@ -93,10 +94,12 @@ object InfraTelemetryRollups {
                 '${escapeSql(row.host)}',
                 '${escapeSql(row.unit)}',
                 '${escapeSql(row.source)}',
+                '${escapeSql(metricIdentity)}',
                 ${mapToSqlMap(row.tags)}
             )"""
         }
         val rollupRows = resolvedRows.joinToString(",\n") { (row, hostId) ->
+            val metricIdentity = metricIdentity(row.metricName, row.tags)
             """(
                 ${row.organizationId},
                 $hostId,
@@ -105,6 +108,8 @@ object InfraTelemetryRollups {
                 '${escapeSql(row.host)}',
                 '${escapeSql(row.unit)}',
                 '${escapeSql(row.source)}',
+                '${escapeSql(metricIdentity)}',
+                ${mapToSqlMap(row.tags)},
                 ${row.value},
                 1
             )"""
@@ -114,7 +119,7 @@ object InfraTelemetryRollups {
             """
             INSERT INTO `$db`.metrics_latest_by_host (
                 organization_id, host_id, metric_name, timestamp, value,
-                host, unit, source, tags
+                host, unit, source, metric_identity, tags
             ) VALUES
             $latestRows
             """.trimIndent(),
@@ -124,7 +129,7 @@ object InfraTelemetryRollups {
             """
             INSERT INTO `$db`.metrics_rollup_1m (
                 organization_id, host_id, bucket_start, metric_name, host,
-                unit, source, value_sum, value_count
+                unit, source, metric_identity, tags, value_sum, value_count
             ) VALUES
             $rollupRows
             """.trimIndent(),
@@ -216,6 +221,16 @@ object InfraTelemetryRollups {
             ?.toLongOrNull()
             ?.takeIf { it > 0L }
 
+    private fun metricIdentity(metricName: String, tags: Map<String, String>): String =
+        if (metricName in diskMetricNames) diskIdentity(tags) else ""
+
+    private fun diskIdentity(tags: Map<String, String>): String {
+        val parts = diskIdentityTagKeys.mapNotNull { key ->
+            tags[key]?.takeIf { it.isNotBlank() }?.let { value -> "$key=$value" }
+        }
+        return parts.ifEmpty { listOf(DEFAULT_DISK_IDENTITY) }.joinToString("|")
+    }
+
     private fun mapToSqlMap(map: Map<String, String>): String {
         if (map.isEmpty()) return "map()"
         val entries = map.entries.joinToString(", ") { (key, value) ->
@@ -235,4 +250,21 @@ object InfraTelemetryRollups {
     )
 
     private const val ERROR_BODY_PREVIEW_CHARS = 600
+    private const val DEFAULT_DISK_IDENTITY = "default"
+    private val diskMetricNames = setOf(
+        "system.disk.percent",
+        "system.disk.total",
+        "system.disk.used",
+    )
+    private val diskIdentityTagKeys = listOf(
+        "device_name",
+        "device",
+        "system.filesystem.device",
+        "mount_point",
+        "mountpoint",
+        "system.filesystem.mountpoint",
+        "filesystem",
+        "system.filesystem.type",
+        "type",
+    )
 }

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitor/services/InfraTelemetryRollupsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitor/services/InfraTelemetryRollupsTest.kt
@@ -1,0 +1,137 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.monitor.services
+
+import com.moneat.config.ClickHouseClient
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InfraTelemetryRollupsTest {
+    @BeforeTest
+    fun setUp() {
+        mockkObject(ClickHouseClient)
+        every { ClickHouseClient.getDatabase() } returns "testdb"
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(ClickHouseClient)
+    }
+
+    @Test
+    fun `insertMetricRollups writes disk metric identity and preserves tags`() = runBlocking {
+        val queries = mutableListOf<String>()
+        val response = mockk<HttpResponse>()
+        every { response.status } returns HttpStatusCode.OK
+        coEvery { ClickHouseClient.execute(capture(queries)) } returns response
+
+        InfraTelemetryRollups.insertMetricRollups(
+            listOf(
+                InfraMetricRollupRow(
+                    organizationId = 7,
+                    metricName = "system.disk.percent",
+                    timestampMs = 1_720_000_000_000,
+                    value = 94.2,
+                    host = "ubuntu1",
+                    tags = mapOf(
+                        "host_id" to "42",
+                        "device_name" to "/dev/nvme0n1p1",
+                        "mount_point" to "/",
+                        "filesystem" to "ext4",
+                    ),
+                    unit = "%",
+                    source = "otel",
+                ),
+                InfraMetricRollupRow(
+                    organizationId = 7,
+                    metricName = "system.cpu.user",
+                    timestampMs = 1_720_000_000_000,
+                    value = 12.5,
+                    host = "ubuntu1",
+                    tags = mapOf("host_id" to "42"),
+                    unit = "%",
+                    source = "otel",
+                ),
+            )
+        )
+
+        assertEquals(2, queries.size)
+        assertTrue(queries[0].contains("metrics_latest_by_host"))
+        assertTrue(queries[1].contains("metrics_rollup_1m"))
+
+        queries.forEach { query ->
+            assertTrue(query.contains("'system.disk.percent'"))
+            assertTrue(query.contains("'system.cpu.user'"))
+            assertTrue(query.contains("'device_name=/dev/nvme0n1p1|mount_point=/|filesystem=ext4'"))
+            assertTrue(query.contains("'system.cpu.user',"))
+            assertTrue(query.contains("'',"))
+            assertTrue(query.contains("'device_name', '/dev/nvme0n1p1'"))
+            assertTrue(query.contains("'mount_point', '/'"))
+            assertTrue(query.contains("'filesystem', 'ext4'"))
+        }
+
+        coVerify(exactly = 2) { ClickHouseClient.execute(any()) }
+    }
+
+    @Test
+    fun `insertMetricRollups skips unsupported metrics and rows without host identity`() = runBlocking {
+        val querySlot = slot<String>()
+        val response = mockk<HttpResponse>()
+        every { response.status } returns HttpStatusCode.OK
+        coEvery { ClickHouseClient.execute(capture(querySlot)) } returns response
+
+        InfraTelemetryRollups.insertMetricRollups(
+            listOf(
+                InfraMetricRollupRow(
+                    organizationId = 7,
+                    metricName = "custom.metric",
+                    timestampMs = 1_720_000_000_000,
+                    value = 1.0,
+                    host = "ubuntu1",
+                    tags = mapOf("host_id" to "42"),
+                    unit = "count",
+                    source = "otel",
+                ),
+                InfraMetricRollupRow(
+                    organizationId = 7,
+                    metricName = "system.disk.used",
+                    timestampMs = 1_720_000_000_000,
+                    value = 1.0,
+                    host = "ubuntu1",
+                    tags = emptyMap(),
+                    unit = "bytes",
+                    source = "otel",
+                ),
+            )
+        )
+
+        coVerify(exactly = 0) { ClickHouseClient.execute(any()) }
+    }
+}

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/services/MonitorServiceTest.kt
@@ -233,30 +233,41 @@ class MonitorServiceTest {
     fun `getLatestMetricsForHosts derives normalized host metric percentages`() = runBlocking {
         val hostRepository = mockk<HostRepository>()
         val hostAlertRepository = mockk<HostAlertRepository>(relaxed = true)
-        val querySlot = slot<String>()
-        coEvery { hostRepository.executeClickHouseQuery(capture(querySlot)) } returns
-            """
-            {
-              "data": [
-                [7, 23.5, 16000000, 12000000, 0, 100, 40, 123, 456, 1.2, null, null, null, 40.0]
-              ]
+        val queries = mutableListOf<String>()
+        coEvery { hostRepository.executeClickHouseQuery(any()) } coAnswers {
+            val query = firstArg<String>()
+            queries.add(query)
+            if (query.contains("GROUP BY host_id, metric_identity")) {
+                """{"data": [[7, 100.0, 45.0, 45.0]]}"""
+            } else {
+                """
+                {
+                  "data": [
+                    [7, 23.5, 16000000, 12000000, 0, 100, 40, 123, 456, 1.2, null, null, null, 40.0]
+                  ]
+                }
+                """.trimIndent()
             }
-            """.trimIndent()
+        }
 
         val result = MonitorService(hostRepository, hostAlertRepository)
             .getLatestMetricsForHosts(listOf(7), 42)
             .getValue(7)
 
         assertNotNull(result)
-        assertTrue(querySlot.captured.contains("system.cpu.user"))
-        assertFalse(querySlot.captured.contains("system.mem.pct_usable"))
-        assertTrue(querySlot.captured.contains("system.mem.used"))
-        assertTrue(querySlot.captured.contains("system.mem.total"))
-        assertFalse(querySlot.captured.contains("system.disk.in_use"))
-        assertTrue(querySlot.captured.contains("system.disk.percent"))
+        val latestQuery = queries.first()
+        val diskQuery = queries.last()
+        assertTrue(latestQuery.contains("system.cpu.user"))
+        assertFalse(latestQuery.contains("system.mem.pct_usable"))
+        assertTrue(latestQuery.contains("system.mem.used"))
+        assertTrue(latestQuery.contains("system.mem.total"))
+        assertFalse(latestQuery.contains("system.disk.in_use"))
+        assertTrue(latestQuery.contains("system.disk.percent"))
+        assertTrue(diskQuery.contains("GROUP BY host_id, metric_identity"))
+        assertTrue(diskQuery.contains("max(pct) as disk_percent"))
         assertEquals(23.5f, result.cpuPercent)
         assertEquals(75.0f, result.memPercent)
-        assertEquals(40.0f, result.diskPercent)
+        assertEquals(45.0f, result.diskPercent)
         assertEquals(123L, result.netRecvBytes)
         assertEquals(456L, result.netSentBytes)
     }

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -84,12 +84,17 @@ private const val DISK_PERCENT_METRIC = "system.disk.percent"
 private const val DISK_USED_METRIC = "system.disk.used"
 private const val DISK_TOTAL_METRIC = "system.disk.total"
 private const val DISK_ID_EXPRESSION = """
-    multiIf(
-        tags['device_name'] != '', tags['device_name'],
-        tags['device'] != '', tags['device'],
-        tags['mount_point'] != '', tags['mount_point'],
-        tags['filesystem'] != '', tags['filesystem'],
-        'default'
+    if(
+        metric_identity != '',
+        metric_identity,
+        multiIf(
+            tags['device_name'] != '', tags['device_name'],
+            tags['device'] != '', tags['device'],
+            tags['mount_point'] != '', tags['mount_point'],
+            tags['mountpoint'] != '', tags['mountpoint'],
+            tags['filesystem'] != '', tags['filesystem'],
+            'default'
+        )
     )
 """
 
@@ -770,14 +775,30 @@ class MonitorAlertService(
                 percentExpression = rollupMemoryPercentExpr(),
                 metricFilter = memoryPercentMetricFilter(),
             )
-            "disk_percent" -> derivedSustainedConditionQuery(
-                alert = alert,
-                baseFilter = baseFilter,
-                percentExpression = rollupDiskPercentExpr(),
-                metricFilter = diskPercentMetricFilter(),
-            )
+            "disk_percent" -> diskSustainedConditionQuery(alert, baseFilter)
             else -> scalarSustainedConditionQuery(alert, baseFilter)
         }
+
+    private fun diskSustainedConditionQuery(alert: AlertData, baseFilter: String): String? {
+        val havingClause = conditionSql("pct", alert.condition, alert.threshold) ?: return null
+        return """
+            SELECT count(*) as cnt FROM (
+                SELECT bucket_start, max(pct) as pct
+                FROM (
+                    SELECT bucket_start,
+                        metric_identity,
+                        ${rollupDiskPercentExpr()} as pct
+                    FROM `$clickhouseDb`.metrics_rollup_1m
+                    WHERE $baseFilter AND ${diskPercentMetricFilter()}
+                    GROUP BY bucket_start, metric_identity
+                    HAVING pct IS NOT NULL
+                )
+                GROUP BY bucket_start
+                HAVING $havingClause
+            )
+            FORMAT JSONCompact
+        """.trimIndent()
+    }
 
     private fun derivedSustainedConditionQuery(
         alert: AlertData,

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
@@ -107,6 +107,14 @@ class MonitorService(
                 "'system.disk.percent','system.disk.total','system.disk.used'," +
                 "'system.net.recv_bytes','system.net.sent_bytes'," +
                 "'system.load.1','system.temp.max','system.gpu.percent','system.battery.percent'"
+        private const val DISK_PERCENT_METRIC = "system.disk.percent"
+        private const val DISK_USED_METRIC = "system.disk.used"
+        private const val DISK_TOTAL_METRIC = "system.disk.total"
+        private const val DISK_METRIC_NAMES_SQL = "'system.disk.percent','system.disk.used','system.disk.total'"
+        private const val DISK_QUERY_COL_HOST_ID = 0
+        private const val DISK_QUERY_COL_TOTAL = 1
+        private const val DISK_QUERY_COL_USED = 2
+        private const val DISK_QUERY_COL_PERCENT = 3
 
         // Time-range thresholds for historical downsampling (in seconds)
         private const val ONE_HOUR_SECONDS = 3600L
@@ -202,6 +210,12 @@ class MonitorService(
         private const val PERCENT_MULTIPLIER = 100
         private const val DATETIME64_MILLIS_PRECISION = 3
     }
+
+    private data class DiskMetrics(
+        val total: Long,
+        val used: Long,
+        val percent: Float,
+    )
 
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
     private val defaultAlertTemplates =
@@ -350,6 +364,7 @@ class MonitorService(
             val json = Json { ignoreUnknownKeys = true }
             val result = json.parseToJsonElement(body).jsonObject
             val data = result["data"]?.jsonArray?.firstOrNull()?.jsonArray ?: return null
+            val diskMetrics = getLatestDiskMetricsForHosts(listOf(hostId), host.organizationId)[hostId]
 
             val cpuPercent = data.getOrNull(0)?.toString()?.toFloatOrNull() ?: 0f
             val memTotal =
@@ -402,14 +417,16 @@ class MonitorService(
 
             val effectiveMemUsed = if (memAvailable > 0) memTotal - memAvailable else memUsed
             val memPercent = percent(effectiveMemUsed, memTotal)
-            val diskPercent = diskPercent(diskPercentMetric, diskUsed, diskTotal)
+            val resolvedDiskTotal = diskMetrics?.total ?: diskTotal
+            val resolvedDiskUsed = diskMetrics?.used ?: diskUsed
+            val diskPercent = diskMetrics?.percent ?: diskPercent(diskPercentMetric, diskUsed, diskTotal)
             return LatestMetrics(
                 cpuPercent = cpuPercent,
                 memTotal = memTotal,
                 memUsed = effectiveMemUsed,
                 memPercent = memPercent,
-                diskTotal = diskTotal,
-                diskUsed = diskUsed,
+                diskTotal = resolvedDiskTotal,
+                diskUsed = resolvedDiskUsed,
                 diskPercent = diskPercent,
                 netRecvBytes = netRecvBytes,
                 netSentBytes = netSentBytes,
@@ -491,10 +508,67 @@ class MonitorService(
                     result[hostId] = metrics
                 }
             }
-            hostIds.associateWith { result[it] }
+            val diskMetricsByHost = getLatestDiskMetricsForHosts(hostIds, organizationId, demoEpochMs)
+            hostIds.associateWith { hostId -> result[hostId]?.withDiskMetrics(diskMetricsByHost[hostId]) }
         }.getOrElse { e ->
             logger.warn(e) { "Failed to parse batch latest metrics response" }
             hostIds.associateWith { null }
+        }
+    }
+
+    private suspend fun getLatestDiskMetricsForHosts(
+        hostIds: List<Int>,
+        organizationId: Int,
+        demoEpochMs: Long? = null,
+    ): Map<Int, DiskMetrics> {
+        if (hostIds.isEmpty()) return emptyMap()
+        val hostIdList = hostIds.joinToString(",")
+        val freshnessNow = latestMetricsNowClause(demoEpochMs)
+        val query =
+            """
+            SELECT
+                toInt32(host_id) as host_id,
+                argMax(total, pct) as disk_total,
+                argMax(used, pct) as disk_used,
+                max(pct) as disk_percent
+            FROM (
+                SELECT
+                    host_id,
+                    metric_identity,
+                    argMaxIf(value, timestamp, metric_name = '$DISK_TOTAL_METRIC') as total,
+                    argMaxIf(value, timestamp, metric_name = '$DISK_USED_METRIC') as used,
+                    ${latestDiskPercentExpr()} as pct
+                FROM `$clickhouseDb`.metrics_latest_by_host
+                WHERE ${clickHouseOrgClause(organizationId)}
+                  AND host_id IN ($hostIdList)
+                  AND metric_name IN ($DISK_METRIC_NAMES_SQL)
+                  AND timestamp >= $freshnessNow - INTERVAL $LATEST_METRICS_LOOKBACK_HOURS HOUR
+                GROUP BY host_id, metric_identity
+                HAVING pct IS NOT NULL
+            )
+            GROUP BY host_id
+            FORMAT JSONCompact
+            """.trimIndent()
+
+        val body = hostRepository.executeClickHouseQuery(query)
+        if (body.isBlank()) return emptyMap()
+
+        return suspendRunCatching {
+            val json = Json { ignoreUnknownKeys = true }
+            val rows = json.parseToJsonElement(body).jsonObject["data"]?.jsonArray ?: return emptyMap()
+            rows.mapNotNull { row ->
+                val arr = row.jsonArray
+                val rowHostId = arr.stringAt(DISK_QUERY_COL_HOST_ID).toIntOrNull() ?: return@mapNotNull null
+                val diskPercent = arr.floatAt(DISK_QUERY_COL_PERCENT) ?: return@mapNotNull null
+                rowHostId to DiskMetrics(
+                    total = arr.longAt(DISK_QUERY_COL_TOTAL),
+                    used = arr.longAt(DISK_QUERY_COL_USED),
+                    percent = diskPercent,
+                )
+            }.toMap()
+        }.getOrElse { e ->
+            logger.warn(e) { "Failed to parse latest disk metrics response" }
+            emptyMap()
         }
     }
 
@@ -530,7 +604,7 @@ class MonitorService(
         getOrNull(index)?.toString()?.replace("\"", "") ?: ""
 
     private fun JsonArray.longAt(index: Int): Long =
-        stringAt(index).toLongOrNull() ?: 0L
+        stringAt(index).let { value -> value.toLongOrNull() ?: value.toDoubleOrNull()?.toLong() } ?: 0L
 
     private fun JsonArray.floatAt(index: Int): Float? =
         stringAt(index).toFloatOrNull()
@@ -540,6 +614,60 @@ class MonitorService(
 
     private fun diskPercent(diskPercent: Float?, used: Long, total: Long): Float =
         diskPercent ?: percent(used, total)
+
+    private fun LatestMetrics.withDiskMetrics(diskMetrics: DiskMetrics?): LatestMetrics =
+        if (diskMetrics == null) {
+            this
+        } else {
+            copy(
+                diskTotal = diskMetrics.total,
+                diskUsed = diskMetrics.used,
+                diskPercent = diskMetrics.percent,
+            )
+        }
+
+    private fun latestDiskPercentExpr(): String =
+        """
+        coalesce(
+            if(
+                countIf(metric_name = '$DISK_PERCENT_METRIC') > 0,
+                argMaxIf(value, timestamp, metric_name = '$DISK_PERCENT_METRIC'),
+                NULL
+            ),
+            if(
+                countIf(metric_name = '$DISK_USED_METRIC') > 0 AND
+                    countIf(metric_name = '$DISK_TOTAL_METRIC') > 0,
+                argMaxIf(value, timestamp, metric_name = '$DISK_USED_METRIC') /
+                    nullIf(argMaxIf(value, timestamp, metric_name = '$DISK_TOTAL_METRIC'), 0) * 100,
+                NULL
+            )
+        )
+        """.trimIndent()
+
+    private fun rollupDiskPercentExpr(): String =
+        """
+        coalesce(
+            if(
+                sumIf(value_count, metric_name = '$DISK_PERCENT_METRIC') > 0,
+                sumIf(value_sum, metric_name = '$DISK_PERCENT_METRIC') /
+                    nullIf(sumIf(value_count, metric_name = '$DISK_PERCENT_METRIC'), 0),
+                NULL
+            ),
+            if(
+                sumIf(value_count, metric_name = '$DISK_USED_METRIC') > 0 AND
+                    sumIf(value_count, metric_name = '$DISK_TOTAL_METRIC') > 0,
+                (
+                    sumIf(value_sum, metric_name = '$DISK_USED_METRIC') /
+                    nullIf(sumIf(value_count, metric_name = '$DISK_USED_METRIC'), 0)
+                ) / nullIf(
+                    sumIf(value_sum, metric_name = '$DISK_TOTAL_METRIC') /
+                    nullIf(sumIf(value_count, metric_name = '$DISK_TOTAL_METRIC'), 0),
+                    0
+                ) * 100,
+                NULL
+            )
+        )
+        """.trimIndent()
 
     private fun latestMetricsNowClause(demoEpochMs: Long?): String =
         if (demoEpochMs != null) {
@@ -603,80 +731,82 @@ class MonitorService(
             val query =
                 """
             SELECT
-                toUnixTimestamp(toStartOfInterval(bucket_start, INTERVAL $rollupInterval second)) as ts,
-                coalesce(
-                    sumIf(value_sum, metric_name='system.cpu.percent') /
-                        nullIf(sumIf(value_count, metric_name='system.cpu.percent'), 0),
-                    if(
-                        sumIf(value_count, metric_name IN ('system.cpu.user', 'system.cpu.system')) > 0,
-                        least(
-                            coalesce(
-                                sumIf(value_sum, metric_name='system.cpu.user') /
-                                    nullIf(sumIf(value_count, metric_name='system.cpu.user'), 0),
-                                0
-                            ) +
+                ts,
+                max(cpu) as cpu,
+                max(mem) as mem,
+                max(disk) as disk,
+                sum(net_recv) as net_recv,
+                sum(net_sent) as net_sent,
+                max(load1) as load1,
+                max(load5) as load5,
+                max(load15) as load15,
+                max(temp) as temp,
+                max(gpu) as gpu,
+                max(battery) as battery
+            FROM (
+                SELECT
+                    toUnixTimestamp(toStartOfInterval(bucket_start, INTERVAL $rollupInterval second)) as ts,
+                    metric_identity,
+                    coalesce(
+                        sumIf(value_sum, metric_name='system.cpu.percent') /
+                            nullIf(sumIf(value_count, metric_name='system.cpu.percent'), 0),
+                        if(
+                            sumIf(value_count, metric_name IN ('system.cpu.user', 'system.cpu.system')) > 0,
+                            least(
                                 coalesce(
-                                    sumIf(value_sum, metric_name='system.cpu.system') /
-                                        nullIf(sumIf(value_count, metric_name='system.cpu.system'), 0),
+                                    sumIf(value_sum, metric_name='system.cpu.user') /
+                                        nullIf(sumIf(value_count, metric_name='system.cpu.user'), 0),
                                     0
-                                ),
-                            100
-                        ),
-                        NULL
-                    )
-                ) as cpu,
-                coalesce(
-                    (1 - (
-                        sumIf(value_sum, metric_name='system.mem.available') /
-                        nullIf(sumIf(value_count, metric_name='system.mem.available'), 0)
-                    ) / nullIf(
-                        sumIf(value_sum, metric_name='system.mem.total') /
-                        nullIf(sumIf(value_count, metric_name='system.mem.total'), 0),
-                        0
-                    )) * 100,
-                    (
-                        sumIf(value_sum, metric_name='system.mem.used') /
-                        nullIf(sumIf(value_count, metric_name='system.mem.used'), 0)
-                    ) / nullIf(
-                        sumIf(value_sum, metric_name='system.mem.total') /
-                        nullIf(sumIf(value_count, metric_name='system.mem.total'), 0),
-                        0
-                    ) * 100
-                ) as mem,
-                coalesce(
-                    if(
-                        sumIf(value_count, metric_name='system.disk.percent') > 0,
-                        sumIf(value_sum, metric_name='system.disk.percent') /
-                            nullIf(sumIf(value_count, metric_name='system.disk.percent'), 0),
-                        NULL
-                    ),
-                    (
-                        sumIf(value_sum, metric_name='system.disk.used') /
-                        nullIf(sumIf(value_count, metric_name='system.disk.used'), 0)
-                    ) / nullIf(
-                        sumIf(value_sum, metric_name='system.disk.total') /
-                        nullIf(sumIf(value_count, metric_name='system.disk.total'), 0),
-                        0
-                    ) * 100
-                ) as disk,
-                sumIf(value_sum, metric_name='system.net.recv_bytes') as net_recv,
-                sumIf(value_sum, metric_name='system.net.sent_bytes') as net_sent,
-                sumIf(value_sum, metric_name='system.load.1') /
-                    nullIf(sumIf(value_count, metric_name='system.load.1'), 0) as load1,
-                sumIf(value_sum, metric_name='system.load.5') /
-                    nullIf(sumIf(value_count, metric_name='system.load.5'), 0) as load5,
-                sumIf(value_sum, metric_name='system.load.15') /
-                    nullIf(sumIf(value_count, metric_name='system.load.15'), 0) as load15,
-                maxIf(value_sum / value_count, metric_name='system.temp.max') as temp,
-                sumIf(value_sum, metric_name='system.gpu.percent') /
-                    nullIf(sumIf(value_count, metric_name='system.gpu.percent'), 0) as gpu,
-                sumIf(value_sum, metric_name='system.battery.percent') /
-                    nullIf(sumIf(value_count, metric_name='system.battery.percent'), 0) as battery
-            FROM `$clickhouseDb`.metrics_rollup_1m
-            WHERE ${clickHouseOrgClause(host.organizationId)}
-              AND host_id = $hostId
-              AND bucket_start >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
-              AND bucket_start <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
+                                ) +
+                                    coalesce(
+                                        sumIf(value_sum, metric_name='system.cpu.system') /
+                                            nullIf(sumIf(value_count, metric_name='system.cpu.system'), 0),
+                                        0
+                                    ),
+                                100
+                            ),
+                            NULL
+                        )
+                    ) as cpu,
+                    coalesce(
+                        (1 - (
+                            sumIf(value_sum, metric_name='system.mem.available') /
+                            nullIf(sumIf(value_count, metric_name='system.mem.available'), 0)
+                        ) / nullIf(
+                            sumIf(value_sum, metric_name='system.mem.total') /
+                            nullIf(sumIf(value_count, metric_name='system.mem.total'), 0),
+                            0
+                        )) * 100,
+                        (
+                            sumIf(value_sum, metric_name='system.mem.used') /
+                            nullIf(sumIf(value_count, metric_name='system.mem.used'), 0)
+                        ) / nullIf(
+                            sumIf(value_sum, metric_name='system.mem.total') /
+                            nullIf(sumIf(value_count, metric_name='system.mem.total'), 0),
+                            0
+                        ) * 100
+                    ) as mem,
+                    ${rollupDiskPercentExpr()} as disk,
+                    sumIf(value_sum, metric_name='system.net.recv_bytes') as net_recv,
+                    sumIf(value_sum, metric_name='system.net.sent_bytes') as net_sent,
+                    sumIf(value_sum, metric_name='system.load.1') /
+                        nullIf(sumIf(value_count, metric_name='system.load.1'), 0) as load1,
+                    sumIf(value_sum, metric_name='system.load.5') /
+                        nullIf(sumIf(value_count, metric_name='system.load.5'), 0) as load5,
+                    sumIf(value_sum, metric_name='system.load.15') /
+                        nullIf(sumIf(value_count, metric_name='system.load.15'), 0) as load15,
+                    maxIf(value_sum / value_count, metric_name='system.temp.max') as temp,
+                    sumIf(value_sum, metric_name='system.gpu.percent') /
+                        nullIf(sumIf(value_count, metric_name='system.gpu.percent'), 0) as gpu,
+                    sumIf(value_sum, metric_name='system.battery.percent') /
+                        nullIf(sumIf(value_count, metric_name='system.battery.percent'), 0) as battery
+                FROM `$clickhouseDb`.metrics_rollup_1m
+                WHERE ${clickHouseOrgClause(host.organizationId)}
+                  AND host_id = $hostId
+                  AND bucket_start >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
+                  AND bucket_start <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
+                GROUP BY ts, metric_identity
+            )
             GROUP BY ts
             ORDER BY ts
             FORMAT JSONCompact

--- a/backend/src/main/resources/db/clickhouse_migration/V61__preserve_infra_metric_identity.sql
+++ b/backend/src/main/resources/db/clickhouse_migration/V61__preserve_infra_metric_identity.sql
@@ -1,0 +1,111 @@
+-- Preserve per-resource metric identity for host infrastructure rollups.
+-- Disk metrics can emit one row per filesystem, so host-level latest and
+-- rollup tables must keep those identities distinct before dashboard and
+-- alert queries collapse them to a host-level "worst filesystem" value.
+--
+-- Existing rows were already collapsed without filesystem identity. Preserve
+-- them with an empty identity so historical views keep their current values;
+-- new ingestion writes per-filesystem identities for correct future data.
+
+DROP TABLE IF EXISTS metrics_latest_by_host_rekey_v61;
+
+CREATE TABLE metrics_latest_by_host_rekey_v61 (
+    organization_id UInt64,
+    host_id UInt64,
+    metric_name LowCardinality(String),
+    timestamp DateTime64(3, 'UTC'),
+    value Float64,
+    host String DEFAULT '',
+    unit String DEFAULT '',
+    source LowCardinality(String) DEFAULT '',
+    metric_identity String DEFAULT '',
+    tags Map(String, String)
+) ENGINE = ReplacingMergeTree(timestamp)
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (organization_id, host_id, metric_name, metric_identity)
+TTL toDateTime(timestamp) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+INSERT INTO metrics_latest_by_host_rekey_v61 (
+    organization_id,
+    host_id,
+    metric_name,
+    timestamp,
+    value,
+    host,
+    unit,
+    source,
+    metric_identity,
+    tags
+)
+SELECT
+    organization_id,
+    host_id,
+    metric_name,
+    timestamp,
+    value,
+    host,
+    unit,
+    source,
+    '',
+    tags
+FROM metrics_latest_by_host;
+
+DROP TABLE IF EXISTS metrics_latest_by_host_before_v61;
+
+RENAME TABLE
+    metrics_latest_by_host TO metrics_latest_by_host_before_v61,
+    metrics_latest_by_host_rekey_v61 TO metrics_latest_by_host;
+
+DROP TABLE IF EXISTS metrics_rollup_1m_rekey_v61;
+
+CREATE TABLE metrics_rollup_1m_rekey_v61 (
+    organization_id UInt64,
+    host_id UInt64,
+    bucket_start DateTime64(3, 'UTC'),
+    metric_name LowCardinality(String),
+    host String DEFAULT '',
+    unit String DEFAULT '',
+    source LowCardinality(String) DEFAULT '',
+    metric_identity String DEFAULT '',
+    tags Map(String, String) DEFAULT map(),
+    value_sum Float64,
+    value_count UInt64
+) ENGINE = SummingMergeTree((value_sum, value_count))
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (organization_id, host_id, bucket_start, metric_name, metric_identity)
+TTL toDateTime(bucket_start) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+INSERT INTO metrics_rollup_1m_rekey_v61 (
+    organization_id,
+    host_id,
+    bucket_start,
+    metric_name,
+    host,
+    unit,
+    source,
+    metric_identity,
+    tags,
+    value_sum,
+    value_count
+)
+SELECT
+    organization_id,
+    host_id,
+    bucket_start,
+    metric_name,
+    host,
+    unit,
+    source,
+    '',
+    map(),
+    value_sum,
+    value_count
+FROM metrics_rollup_1m;
+
+DROP TABLE IF EXISTS metrics_rollup_1m_before_v61;
+
+RENAME TABLE
+    metrics_rollup_1m TO metrics_rollup_1m_before_v61,
+    metrics_rollup_1m_rekey_v61 TO metrics_rollup_1m;

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -261,8 +261,10 @@ class MonitorAlertServiceCoverageTest {
 
         assertNotNull(query)
         assertTrue(query.contains("metric_name IN ('system.disk.percent','system.disk.used','system.disk.total')"))
+        assertTrue(query.contains("metric_identity != ''"))
         assertTrue(query.contains("GROUP BY disk_identity"))
         assertTrue(query.contains("tags['device_name']"))
+        assertTrue(query.contains("tags['mountpoint']"))
         assertTrue(query.contains("max(pct)"))
         assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.percent')"))
         assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.used')"))
@@ -360,6 +362,8 @@ class MonitorAlertServiceCoverageTest {
             assertTrue(query.contains("metric_name = 'system.disk.percent'"))
             assertTrue(query.contains("metric_name = 'system.disk.used'"))
             assertTrue(query.contains("metric_name = 'system.disk.total'"))
+            assertTrue(query.contains("GROUP BY bucket_start, metric_identity"))
+            assertTrue(query.contains("SELECT bucket_start, max(pct) as pct"))
             assertTrue(query.contains("HAVING pct <= 90.0"))
             assertFalse(query.contains("system.disk.in_use"))
         }

--- a/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
@@ -465,6 +465,8 @@ class MonitorServiceExtendedTest {
         assertTrue(query.contains("system.mem.used"))
         assertFalse(query.contains("system.disk.in_use"))
         assertTrue(query.indexOf("system.disk.percent") < query.indexOf("system.disk.used"))
+        assertTrue(query.contains("GROUP BY ts, metric_identity"))
+        assertTrue(query.contains("max(disk) as disk"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- preserve per-filesystem disk metric identity in host metric rollups
- report latest, historical, and alert disk usage using worst-filesystem semantics
- preserve existing collapsed history while future samples write identity-aware rows

## Validation
- ./gradlew detekt --no-daemon
- ./gradlew :features:monitoring:test --tests com.moneat.services.MonitorServiceTest --no-daemon
- ./gradlew :test --tests com.moneat.services.MonitorServiceExtendedTest --tests com.moneat.services.MonitorAlertServiceCoverageTest -x jacocoTestReport --no-daemon
- python3 scripts/check-migration-versions.py --base-ref origin/develop
- git diff --check origin/develop...HEAD