### PR TITLE
fix: add organization integration resource IDs

### DIFF
--- a/backend/src/main/resources/db/migration/V150__add_organization_integration_resource_ids.sql
+++ b/backend/src/main/resources/db/migration/V150__add_organization_integration_resource_ids.sql
@@ -1,0 +1,13 @@
+ALTER TABLE organization_integrations
+    ADD COLUMN IF NOT EXISTS resource_id UUID;
+
+UPDATE organization_integrations
+SET resource_id = gen_random_uuid()
+WHERE resource_id IS NULL;
+
+ALTER TABLE organization_integrations
+    ALTER COLUMN resource_id SET DEFAULT gen_random_uuid(),
+    ALTER COLUMN resource_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_organization_integrations_org_resource_id
+    ON organization_integrations(organization_id, resource_id);


### PR DESCRIPTION
## Summary

Adds the missing `resource_id` column and organization-scoped unique index for `organization_integrations`.

## Why

The Exposed table model now includes `OrganizationIntegrations.resource_id`, but the legacy table migration never added the column. Runtime queries that select organization integrations can fail with `column organization_integrations.resource_id does not exist`.

## Validation

- `python3 scripts/check-migration-versions.py --base-ref origin/develop`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of organization integration records by ensuring each entry has a stable unique identifier.
  * Added safeguards to prevent duplicate integration associations within the same organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->