### PR TITLE
fix: enable dashboard self-monitoring logs

### DIFF
--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogLogRoutes.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogLogRoutes.kt
@@ -101,13 +101,24 @@ private suspend fun RoutingContext.handleDatadogLogs(
 private fun parseLogEntries(bodyStr: String): List<DatadogLogEntry>? {
     return suspendRunCatching {
         val trimmed = bodyStr.trimStart()
-        if (trimmed.startsWith("[")) {
-            json.decodeFromString<List<DatadogLogEntry>>(trimmed)
-        } else {
-            listOf(json.decodeFromString<DatadogLogEntry>(trimmed))
+        when {
+            trimmed.startsWith("[") -> json.decodeFromString<List<DatadogLogEntry>>(trimmed)
+            else -> parseSingleOrLineDelimitedLogEntries(trimmed)
         }
     }.getOrElse { e ->
         logger.warn(e) { "Failed to parse DD log payload" }
         null
     }
 }
+
+private fun parseSingleOrLineDelimitedLogEntries(trimmed: String): List<DatadogLogEntry> =
+    runCatching {
+        listOf(json.decodeFromString<DatadogLogEntry>(trimmed))
+    }.getOrElse {
+        trimmed
+            .lineSequence()
+            .map { line -> line.trim() }
+            .filter { line -> line.isNotEmpty() }
+            .map { line -> json.decodeFromString<DatadogLogEntry>(line) }
+            .toList()
+    }

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogLogRoutes.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogLogRoutes.kt
@@ -111,14 +111,28 @@ private fun parseLogEntries(bodyStr: String): List<DatadogLogEntry>? {
     }
 }
 
-private fun parseSingleOrLineDelimitedLogEntries(trimmed: String): List<DatadogLogEntry> =
+private fun parseSingleOrLineDelimitedLogEntries(trimmed: String): List<DatadogLogEntry>? =
     runCatching {
         listOf(json.decodeFromString<DatadogLogEntry>(trimmed))
     }.getOrElse {
-        trimmed
-            .lineSequence()
-            .map { line -> line.trim() }
-            .filter { line -> line.isNotEmpty() }
-            .map { line -> json.decodeFromString<DatadogLogEntry>(line) }
-            .toList()
+        parseLineDelimitedLogEntries(trimmed)
     }
+
+private fun parseLineDelimitedLogEntries(trimmed: String): List<DatadogLogEntry>? {
+    var skippedMalformedLine = false
+    val entries = trimmed
+        .lineSequence()
+        .map { line -> line.trim() }
+        .filter { line -> line.isNotEmpty() }
+        .mapNotNull { line ->
+            runCatching {
+                json.decodeFromString<DatadogLogEntry>(line)
+            }.getOrElse { error ->
+                skippedMalformedLine = true
+                logger.warn(error) { "Skipping malformed DD log line" }
+                null
+            }
+        }
+        .toList()
+    return entries.ifEmpty { if (skippedMalformedLine) null else emptyList() }
+}

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -485,6 +485,32 @@ class DatadogIngestRoutesTest {
         assertEquals(HttpStatusCode.OK, response.status)
     }
 
+    @Test
+    fun `v2 logs accepts newline-delimited browser log batches`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val body = """
+            {"message":"first console error","ddsource":"browser","ddtags":"env:production","hostname":"moneat.io"}
+            {"message":"second console error","ddsource":"browser","ddtags":"env:production","hostname":"moneat.io"}
+        """.trimIndent()
+        val response = client.post("/dd/api/v2/logs") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Text.Plain)
+            setBody(body)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify {
+            DatadogLogService.enqueueLogs(
+                ORG_ID.toLong(),
+                match {
+                    it.size == 2 &&
+                        it[0].message == "first console error" &&
+                        it[1].message == "second console error"
+                },
+            )
+        }
+    }
+
     // ──── Events ────
 
     @Test

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogIngestRoutesTest.kt
@@ -511,6 +511,33 @@ class DatadogIngestRoutesTest {
         }
     }
 
+    @Test
+    fun `v2 logs skips malformed lines in newline-delimited browser batches`() = testApplication {
+        every { DatadogService.validateApiKey(VALID_KEY) } returns ORG_ID
+        installRoutes()()
+        val body = """
+            {"message":"first console error","ddsource":"browser","ddtags":"env:production","hostname":"moneat.io"}
+            {not json}
+            {"message":"second console error","ddsource":"browser","ddtags":"env:production","hostname":"moneat.io"}
+        """.trimIndent()
+        val response = client.post("/dd/api/v2/logs") {
+            header(DD_API_KEY_HEADER, VALID_KEY)
+            contentType(ContentType.Text.Plain)
+            setBody(body)
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify {
+            DatadogLogService.enqueueLogs(
+                ORG_ID.toLong(),
+                match {
+                    it.size == 2 &&
+                        it[0].message == "first console error" &&
+                        it[1].message == "second console error"
+                },
+            )
+        }
+    }
+
     // ──── Events ────
 
     @Test

--- a/dashboard/src/__tests__/main-telemetry.test.tsx
+++ b/dashboard/src/__tests__/main-telemetry.test.tsx
@@ -121,4 +121,18 @@ describe('main telemetry setup', () => {
     expect(mocks.initDatadog).not.toHaveBeenCalled()
     expect(mocks.render).toHaveBeenCalledTimes(1)
   })
+
+  it('enables browser logging when only the Datadog-compatible client token is configured', async () => {
+    vi.stubEnv('VITE_BACKEND_URL', 'https://api.moneat.io')
+    vi.stubEnv('VITE_DD_CLIENT_TOKEN', 'magt_browser_logs')
+
+    await importMainEntrypoint()
+
+    expect(mocks.initDatadog).toHaveBeenCalledWith(expect.objectContaining({
+      applicationId: undefined,
+      backendUrl: 'https://api.moneat.io',
+      clientToken: 'magt_browser_logs',
+    }))
+    expect(mocks.render).toHaveBeenCalledTimes(1)
+  })
 })

--- a/dashboard/src/lib/__tests__/datadog.test.ts
+++ b/dashboard/src/lib/__tests__/datadog.test.ts
@@ -29,9 +29,33 @@ describe('initDatadog', () => {
     vi.clearAllMocks()
   })
 
-  it('initializes RUM and Logs with proxy pointing to Moneat', async () => {
+  it('initializes browser logs with proxy pointing to Moneat', async () => {
     const {datadogRum} = await import('@datadog/browser-rum')
     const {datadogLogs} = await import('@datadog/browser-logs')
+
+    initDatadog({
+      clientToken: 'tok-456',
+      backendUrl: 'https://api.moneat.io',
+    })
+
+    expect(datadogRum.init).not.toHaveBeenCalled()
+    expect(datadogLogs.init).toHaveBeenCalledOnce()
+
+    const logsCall = vi.mocked(datadogLogs.init).mock.calls[0][0]
+    expect(logsCall.clientToken).toBe('tok-456')
+    expect(logsCall.service).toBe('moneat-dashboard')
+    expect(logsCall.env).toBe('production')
+    expect(logsCall.forwardErrorsToLogs).toBe(true)
+    expect(logsCall.forwardConsoleLogs).toEqual(['error'])
+
+    // Verify proxy function routes to Moneat
+    const proxyFn = logsCall.proxy as ({path, parameters}: {path: string; parameters: string}) => string
+    expect(proxyFn({path: '/api/v2/logs', parameters: 'ddsource=browser'}))
+      .toBe('https://api.moneat.io/dd/api/v2/logs?ddsource=browser')
+  })
+
+  it('initializes RUM when an application id is provided', async () => {
+    const {datadogRum} = await import('@datadog/browser-rum')
 
     initDatadog({
       applicationId: 'app-123',
@@ -40,18 +64,12 @@ describe('initDatadog', () => {
     })
 
     expect(datadogRum.init).toHaveBeenCalledOnce()
-    expect(datadogLogs.init).toHaveBeenCalledOnce()
 
     const rumCall = vi.mocked(datadogRum.init).mock.calls[0][0]
     expect(rumCall.applicationId).toBe('app-123')
     expect(rumCall.clientToken).toBe('tok-456')
     expect(rumCall.service).toBe('moneat-dashboard')
     expect(rumCall.env).toBe('production')
-
-    // Verify proxy function routes to Moneat
-    const proxyFn = rumCall.proxy as ({path, parameters}: {path: string; parameters: string}) => string
-    expect(proxyFn({path: '/api/v2/rum', parameters: 'ddsource=browser'}))
-      .toBe('https://api.moneat.io/dd/api/v2/rum?ddsource=browser')
   })
 
   it('uses custom service and env when provided', async () => {
@@ -87,9 +105,8 @@ describe('initDatadog', () => {
   })
 
   it.each([
-    {desc: 'applicationId is empty', applicationId: '', clientToken: 'tok-456'},
     {desc: 'clientToken is empty', applicationId: 'app-123', clientToken: ''},
-    {desc: 'values are unreplaced placeholders', applicationId: '__MONEAT_DD_APPLICATION_ID__', clientToken: '__MONEAT_DD_CLIENT_TOKEN__'},
+    {desc: 'clientToken is an unreplaced placeholder', applicationId: 'app-123', clientToken: '__MONEAT_DD_CLIENT_TOKEN__'},
   ])('skips init when $desc', async ({applicationId, clientToken}) => {
     const {datadogRum} = await import('@datadog/browser-rum')
     const {datadogLogs} = await import('@datadog/browser-logs')

--- a/dashboard/src/lib/datadog.ts
+++ b/dashboard/src/lib/datadog.ts
@@ -2,7 +2,7 @@ import {datadogRum} from '@datadog/browser-rum'
 import {datadogLogs} from '@datadog/browser-logs'
 
 export interface DatadogInitOptions {
-  applicationId: string
+  applicationId?: string
   clientToken: string
   proxyUrl?: string
   backendUrl?: string
@@ -27,7 +27,7 @@ function isConfigured(value: string | undefined): value is string {
 }
 
 export function initDatadog(options: DatadogInitOptions): void {
-  if (!isConfigured(options.applicationId) || !isConfigured(options.clientToken)) {
+  if (!isConfigured(options.clientToken)) {
     return
   }
 
@@ -38,21 +38,23 @@ export function initDatadog(options: DatadogInitOptions): void {
   const proxyFn = ({path, parameters}: {path: string; parameters: string}) =>
     joinUrl(ddProxyUrl, path) + (parameters ? `?${parameters}` : '')
 
-  datadogRum.init({
-    applicationId: options.applicationId,
-    clientToken: options.clientToken,
-    site: 'datadoghq.com',
-    proxy: proxyFn,
-    service,
-    env,
-    version,
-    sessionSampleRate: 100,
-    sessionReplaySampleRate: 100,
-    trackUserInteractions: true,
-    trackResources: true,
-    trackLongTasks: true,
-    defaultPrivacyLevel: 'mask-user-input',
-  })
+  if (isConfigured(options.applicationId)) {
+    datadogRum.init({
+      applicationId: options.applicationId,
+      clientToken: options.clientToken,
+      site: 'datadoghq.com',
+      proxy: proxyFn,
+      service,
+      env,
+      version,
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 100,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: 'mask-user-input',
+    })
+  }
 
   datadogLogs.init({
     clientToken: options.clientToken,
@@ -62,6 +64,7 @@ export function initDatadog(options: DatadogInitOptions): void {
     env,
     version,
     forwardErrorsToLogs: true,
+    forwardConsoleLogs: ['error'],
     sessionSampleRate: 100,
   })
 }

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -86,7 +86,7 @@ if (analyticsKey) {
 // Data is sent to Moneat's DD-compatible intake via the proxy parameter.
 const datadogApplicationId = configuredEnv(import.meta.env.VITE_DD_APPLICATION_ID)
 const datadogClientToken = configuredEnv(import.meta.env.VITE_DD_CLIENT_TOKEN)
-if (datadogApplicationId && datadogClientToken) {
+if (datadogClientToken) {
   const {initDatadog} = await import('./lib/datadog')
   initDatadog({
     applicationId: datadogApplicationId,


### PR DESCRIPTION
Adds dashboard self-monitoring log support and compatible intake parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser logging now initializes with only the Datadog-compatible client token (no application ID required for basic logging).
  * Log ingest now supports newline-delimited “browser” log batches in addition to standard JSON payloads.

* **Bug Fixes**
  * Improved log parsing for mixed payload formats, including single-entry JSON and line-delimited JSON.
  * Malformed lines in newline-delimited batches are skipped while valid entries are still ingested.
  * Telemetry initialization now follows the updated configuration rules for enabling/disabling components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->