### PR TITLE
feat: add Datadog RUM replay ingestion

### DIFF
--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/DatadogModule.kt
@@ -29,6 +29,7 @@ import com.moneat.datadog.routes.datadogInfraQueryRoutes
 import com.moneat.datadog.routes.datadogInfraRoutes
 import com.moneat.datadog.routes.datadogLogRoutes
 import com.moneat.datadog.routes.datadogMetricRoutes
+import com.moneat.datadog.routes.datadogReplayRoutes
 import com.moneat.datadog.routes.datadogValidateRoutes
 import com.moneat.datadog.routes.dbmIngestRoutes
 import com.moneat.datadog.routes.debuggerIngestRoutes
@@ -106,6 +107,7 @@ class DatadogModule : EnterpriseModule, IngestionRateLimitKeyResolver {
             rateLimit(RateLimitName("datadog-ingestion")) {
                 datadogLogRoutes()
                 datadogMetricRoutes()
+                datadogReplayRoutes()
                 datadogDogStatsDRoutes()
                 traceIngestRoutes()
                 profileIngestRoutes()

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/auth/DatadogAuthMiddleware.kt
@@ -171,4 +171,5 @@ object DatadogAuthMiddleware {
         API_KEY_HEADER_NAMES.firstNotNullOfOrNull { call.request.headers[it] }
             ?: call.request.queryParameters["api_key"]
             ?: call.request.queryParameters["api-key"]
+            ?: call.request.queryParameters["dd-api-key"]
 }

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/models/DatadogReplayModels.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/models/DatadogReplayModels.kt
@@ -1,0 +1,41 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DdReplayIdRef(
+    val id: String = "",
+)
+
+@Serializable
+data class DdReplaySegmentEvent(
+    val source: String = "",
+    @SerialName("creation_reason") val creationReason: String = "",
+    val start: Long? = null,
+    val end: Long? = null,
+    @SerialName("records_count") val recordsCount: Int = 0,
+    @SerialName("index_in_view") val indexInView: Int? = null,
+    @SerialName("has_full_snapshot") val hasFullSnapshot: Boolean? = null,
+    @SerialName("raw_segment_size") val rawSegmentSize: Long? = null,
+    @SerialName("compressed_segment_size") val compressedSegmentSize: Long? = null,
+    val application: DdReplayIdRef? = null,
+    val session: DdReplayIdRef? = null,
+    val view: DdReplayIdRef? = null,
+)

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogReplayRoutes.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogReplayRoutes.kt
@@ -1,0 +1,208 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.routes
+
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.datadog.auth.DatadogAuthMiddleware
+import com.moneat.datadog.models.DdReplaySegmentEvent
+import com.moneat.datadog.reserveDatadogQuota
+import com.moneat.datadog.services.DatadogReplayIngestRequest
+import com.moneat.datadog.services.DatadogReplayIngestionService
+import com.moneat.utils.suspendRunCatching
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.PartData
+import io.ktor.http.content.forEachPart
+import io.ktor.server.application.call
+import io.ktor.server.request.contentType
+import io.ktor.server.request.receiveMultipart
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.utils.io.toByteArray
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import mu.KotlinLogging
+
+private const val REPLAY_EVENT_TYPE = "replay"
+private const val DD_TAGS_QUERY_PARAM = "ddtags"
+private const val DD_ENCODING_QUERY_PARAM = "dd-evp-encoding"
+private const val DD_ORIGIN_VERSION_QUERY_PARAM = "dd-evp-origin-version"
+
+private val logger = KotlinLogging.logger {}
+private val replayRouteJson = Json {
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+}
+
+internal data class DatadogReplayUpload(
+    val event: DdReplaySegmentEvent?,
+    val eventBytes: Int,
+    val segmentBytes: ByteArray?,
+    val segmentEncoding: String?,
+)
+
+fun Route.datadogReplayRoutes(
+    quotaService: BillingQuotaService = BillingQuotaService(),
+) {
+    route("/api/v2") {
+        post("/replay") { handleDatadogReplayUpload(quotaService) }
+    }
+
+    route("/dd/api/v2") {
+        post("/replay") { handleDatadogReplayUpload(quotaService) }
+    }
+}
+
+private suspend fun RoutingContext.handleDatadogReplayUpload(
+    quotaService: BillingQuotaService,
+) {
+    val context = DatadogAuthMiddleware.authenticateContext(call) ?: return
+    val projectId = context.projectId?.toLong()
+    if (projectId == null) {
+        call.respond(
+            HttpStatusCode.BadRequest,
+            mapOf("error" to "Project-scoped Datadog API key required for replay ingestion")
+        )
+        return
+    }
+
+    if (call.request.contentType().withoutParameters() != ContentType.MultiPart.FormData) {
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Multipart replay payload required"))
+        return
+    }
+
+    val upload = suspendRunCatching {
+        receiveDatadogReplayUpload()
+    }.getOrElse { error ->
+        logger.warn(error) { "Failed to parse Datadog replay multipart upload" }
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to (error.message ?: "Invalid replay upload")))
+        return
+    }
+    val event = upload.event
+    val segmentBytes = upload.segmentBytes
+    if (event == null || segmentBytes == null) {
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Replay event and segment parts are required"))
+        return
+    }
+
+    val totalBytes = upload.eventBytes.toLong() + segmentBytes.size
+    if (!reserveDatadogQuota(call, quotaService, context.organizationId, 1, REPLAY_EVENT_TYPE, totalBytes)) {
+        return
+    }
+
+    val tags = parseDdTags(call.request.queryParameters[DD_TAGS_QUERY_PARAM]) +
+        sdkTag(call.request.queryParameters[DD_ORIGIN_VERSION_QUERY_PARAM])
+    val request = DatadogReplayIngestRequest(
+        organizationId = context.organizationId,
+        projectId = projectId,
+        event = event,
+        segmentBytes = segmentBytes,
+        declaredEncoding = call.request.queryParameters[DD_ENCODING_QUERY_PARAM] ?: upload.segmentEncoding,
+        tags = tags,
+    )
+
+    val result = suspendRunCatching {
+        DatadogReplayIngestionService.ingestReplaySegment(request)
+    }.getOrElse { error ->
+        if (error is IllegalArgumentException) {
+            logger.warn(error) { "Datadog replay upload rejected" }
+            call.respond(HttpStatusCode.BadRequest, mapOf("error" to (error.message ?: "Invalid replay payload")))
+        } else {
+            logger.error(error) { "Failed to ingest Datadog replay upload" }
+            call.respond(HttpStatusCode.InternalServerError, mapOf("error" to "Failed to ingest replay payload"))
+        }
+        return
+    }
+
+    call.respond(
+        HttpStatusCode.Accepted,
+        mapOf(
+            "status" to "ok",
+            "replay_id" to result.replayId,
+            "segment_id" to result.segmentId.toString(),
+            "records" to result.recordCount.toString(),
+        )
+    )
+}
+
+private suspend fun RoutingContext.receiveDatadogReplayUpload(): DatadogReplayUpload {
+    var event: DdReplaySegmentEvent? = null
+    var eventBytes = 0
+    var segmentBytes: ByteArray? = null
+    var segmentEncoding: String? = null
+
+    call.receiveMultipart().forEachPart { part ->
+        try {
+            when {
+                part.name == "event" && part is PartData.FormItem -> {
+                    val bytes = part.value.toByteArray()
+                    eventBytes = bytes.size
+                    event = parseReplayEvent(part.value)
+                }
+                part.name == "event" && part is PartData.FileItem -> {
+                    val bytes = part.provider().toByteArray()
+                    eventBytes = bytes.size
+                    event = parseReplayEvent(bytes.decodeToString())
+                }
+                part.name == "segment" && part is PartData.FileItem -> {
+                    segmentBytes = part.provider().toByteArray()
+                    segmentEncoding = part.headers[HttpHeaders.ContentEncoding]
+                }
+            }
+        } finally {
+            part.release()
+        }
+    }
+
+    return DatadogReplayUpload(
+        event = event,
+        eventBytes = eventBytes,
+        segmentBytes = segmentBytes,
+        segmentEncoding = segmentEncoding,
+    )
+}
+
+private fun parseReplayEvent(value: String): DdReplaySegmentEvent =
+    try {
+        replayRouteJson.decodeFromString<DdReplaySegmentEvent>(value)
+    } catch (error: SerializationException) {
+        logger.warn { "Failed to parse Datadog replay event JSON: ${error.message}" }
+        throw IllegalArgumentException("Invalid replay event JSON", error)
+    }
+
+internal fun parseDdTags(value: String?): Map<String, String> {
+    if (value.isNullOrBlank()) return emptyMap()
+    return value.split(",")
+        .mapNotNull { part ->
+            val colonIdx = part.indexOf(':')
+            if (colonIdx <= 0) return@mapNotNull null
+            val key = part.substring(0, colonIdx).trim()
+            val tagValue = part.substring(colonIdx + 1).trim()
+            if (key.isEmpty()) null else key to tagValue
+        }
+        .toMap()
+}
+
+private fun sdkTag(value: String?): Map<String, String> =
+    value
+        ?.takeIf { it.isNotBlank() }
+        ?.let { mapOf("sdk_version" to it) }
+        ?: emptyMap()

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogReplayRoutes.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/routes/DatadogReplayRoutes.kt
@@ -45,6 +45,10 @@ private const val REPLAY_EVENT_TYPE = "replay"
 private const val DD_TAGS_QUERY_PARAM = "ddtags"
 private const val DD_ENCODING_QUERY_PARAM = "dd-evp-encoding"
 private const val DD_ORIGIN_VERSION_QUERY_PARAM = "dd-evp-origin-version"
+private const val BYTES_PER_MEBIBYTE = 1024 * 1024
+private const val MAX_REPLAY_MULTIPART_PART_MEBIBYTES = 50
+internal const val MAX_REPLAY_MULTIPART_PART_BYTES =
+    MAX_REPLAY_MULTIPART_PART_MEBIBYTES * BYTES_PER_MEBIBYTE
 
 private val logger = KotlinLogging.logger {}
 private val replayRouteJson = Json {
@@ -93,7 +97,7 @@ private suspend fun RoutingContext.handleDatadogReplayUpload(
         receiveDatadogReplayUpload()
     }.getOrElse { error ->
         logger.warn(error) { "Failed to parse Datadog replay multipart upload" }
-        call.respond(HttpStatusCode.BadRequest, mapOf("error" to (error.message ?: "Invalid replay upload")))
+        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid replay upload"))
         return
     }
     val event = upload.event
@@ -149,21 +153,28 @@ private suspend fun RoutingContext.receiveDatadogReplayUpload(): DatadogReplayUp
     var segmentBytes: ByteArray? = null
     var segmentEncoding: String? = null
 
-    call.receiveMultipart().forEachPart { part ->
+    call.receiveMultipart(MAX_REPLAY_MULTIPART_PART_BYTES.toLong()).forEachPart { part ->
         try {
             when {
                 part.name == "event" && part is PartData.FormItem -> {
+                    part.requireContentLengthWithinLimit()
                     val bytes = part.value.toByteArray()
+                    requirePartWithinLimit("event", bytes.size.toLong())
                     eventBytes = bytes.size
                     event = parseReplayEvent(part.value)
                 }
                 part.name == "event" && part is PartData.FileItem -> {
+                    part.requireContentLengthWithinLimit()
                     val bytes = part.provider().toByteArray()
+                    requirePartWithinLimit("event", bytes.size.toLong())
                     eventBytes = bytes.size
                     event = parseReplayEvent(bytes.decodeToString())
                 }
                 part.name == "segment" && part is PartData.FileItem -> {
-                    segmentBytes = part.provider().toByteArray()
+                    part.requireContentLengthWithinLimit()
+                    val bytes = part.provider().toByteArray()
+                    requirePartWithinLimit("segment", bytes.size.toLong())
+                    segmentBytes = bytes
                     segmentEncoding = part.headers[HttpHeaders.ContentEncoding]
                 }
             }
@@ -178,6 +189,17 @@ private suspend fun RoutingContext.receiveDatadogReplayUpload(): DatadogReplayUp
         segmentBytes = segmentBytes,
         segmentEncoding = segmentEncoding,
     )
+}
+
+private fun PartData.requireContentLengthWithinLimit() {
+    val declaredLength = headers[HttpHeaders.ContentLength]?.toLongOrNull() ?: return
+    requirePartWithinLimit(name ?: "multipart", declaredLength)
+}
+
+internal fun requirePartWithinLimit(partName: String, bytes: Long) {
+    require(bytes <= MAX_REPLAY_MULTIPART_PART_BYTES) {
+        "Replay $partName part exceeds $MAX_REPLAY_MULTIPART_PART_BYTES byte limit"
+    }
 }
 
 private fun parseReplayEvent(value: String): DdReplaySegmentEvent =

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/services/DatadogReplayIngestionService.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/services/DatadogReplayIngestionService.kt
@@ -133,9 +133,8 @@ object DatadogReplayIngestionService {
         )
 
         suspendRunCatching {
-            val replayStored = eventRepository.insertReplayEvent(replayEvent)
-            check(replayStored) { "Failed to insert replay event" }
-            eventRepository.insertReplayRecording(recording)
+            val replayStored = eventRepository.insertReplayEventWithRecording(replayEvent, recording)
+            check(replayStored) { "Failed to insert replay event and recording" }
         }.getOrElse { error ->
             logger.error(error) { "Failed to ingest Datadog replay segment" }
             throw error

--- a/backend/features/datadog/src/main/kotlin/com/moneat/datadog/services/DatadogReplayIngestionService.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/datadog/services/DatadogReplayIngestionService.kt
@@ -1,0 +1,267 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.services
+
+import com.moneat.datadog.models.DdReplaySegmentEvent
+import com.moneat.events.repositories.EventRepository
+import com.moneat.events.repositories.EventRepositoryImpl
+import com.moneat.events.repositories.models.ReplayEventInsertData
+import com.moneat.events.repositories.models.ReplayRecordingInsertData
+import com.moneat.ingest.DecompressionService
+import com.moneat.utils.suspendRunCatching
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import mu.KotlinLogging
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+private const val MAX_REPLAY_URLS = 100
+private const val RRWEB_META_EVENT_TYPE = 4
+private const val UUID_SEG1 = 8
+private const val UUID_SEG2 = 12
+private const val UUID_SEG3 = 16
+private const val UUID_SEG4 = 20
+private const val DATADOG_SDK_NAME = "@datadog/browser-rum"
+private const val DATADOG_SOURCE_TYPE = "datadog"
+private const val DATADOG_SOURCE_NAME = "Datadog RUM SDK"
+private const val DEFAULT_REPLAY_PLATFORM = "browser"
+
+private val uuidRegex = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+private val hexUuidRegex = Regex("^[0-9a-f]{32}$")
+private val logger = KotlinLogging.logger {}
+private val replayJson = Json {
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+}
+
+data class DatadogReplayIngestRequest(
+    val organizationId: Int,
+    val projectId: Long,
+    val event: DdReplaySegmentEvent,
+    val segmentBytes: ByteArray,
+    val declaredEncoding: String?,
+    val tags: Map<String, String> = emptyMap(),
+)
+
+data class DatadogReplayIngestResult(
+    val replayId: String,
+    val segmentId: Int,
+    val recordCount: Int,
+    val bytesStored: Int,
+)
+
+object DatadogReplayIngestionService {
+
+    suspend fun ingestReplaySegment(
+        request: DatadogReplayIngestRequest,
+    ): DatadogReplayIngestResult = ingestReplaySegment(request, EventRepositoryImpl())
+
+    internal suspend fun ingestReplaySegment(
+        request: DatadogReplayIngestRequest,
+        eventRepository: EventRepository,
+    ): DatadogReplayIngestResult {
+        require(request.projectId != 0L) { "Project-scoped Datadog API key required for replay ingestion" }
+        val rawSessionId = request.event.session?.id?.trim().orEmpty()
+        require(rawSessionId.isNotEmpty()) { "Datadog replay event missing session.id" }
+
+        val decoded = decodeReplaySegment(request.segmentBytes, request.declaredEncoding)
+        require(decoded.records.isNotEmpty()) { "Datadog replay segment contains no records" }
+
+        val replayId = normalizeReplayId(rawSessionId)
+        val segmentId = request.event.indexInView ?: 0
+        val timestampMs = positiveTimestamp(request.event.start)
+        val urls = extractUrls(decoded.records)
+        val tagsJson = replayTagsJson(request.event, request.tags)
+        val platform = request.event.source.ifBlank { DEFAULT_REPLAY_PLATFORM }
+        val sdkVersion = request.tags["sdk_version"].orEmpty()
+
+        val replayEvent = ReplayEventInsertData(
+            replayId = replayId,
+            projectId = request.projectId,
+            organizationId = request.organizationId,
+            segmentId = segmentId,
+            timestampMs = timestampMs,
+            replayStartTimestampMs = timestampMs,
+            urls = urls,
+            errorIds = emptyList(),
+            traceIds = emptyList(),
+            environment = request.tags["env"].orEmpty(),
+            release = request.tags["version"].orEmpty(),
+            platform = platform,
+            userId = "",
+            userEmail = "",
+            userUsername = "",
+            userIpAddress = "",
+            sdkName = DATADOG_SDK_NAME,
+            sdkVersion = sdkVersion,
+            browserName = "",
+            browserVersion = "",
+            osName = "",
+            osVersion = "",
+            deviceName = "",
+            deviceFamily = "",
+            activity = request.event.recordsCount.coerceAtLeast(decoded.records.size),
+            tags = tagsJson,
+        )
+        val recording = ReplayRecordingInsertData(
+            replayId = replayId,
+            projectId = request.projectId,
+            organizationId = request.organizationId,
+            segmentId = segmentId,
+            timestampMs = timestampMs,
+            recordingData = decoded.recordingData,
+        )
+
+        suspendRunCatching {
+            val replayStored = eventRepository.insertReplayEvent(replayEvent)
+            check(replayStored) { "Failed to insert replay event" }
+            eventRepository.insertReplayRecording(recording)
+        }.getOrElse { error ->
+            logger.error(error) { "Failed to ingest Datadog replay segment" }
+            throw error
+        }
+
+        return DatadogReplayIngestResult(
+            replayId = replayId,
+            segmentId = segmentId,
+            recordCount = decoded.records.size,
+            bytesStored = decoded.recordingData.toByteArray(StandardCharsets.UTF_8).size,
+        )
+    }
+
+    internal fun decodeReplaySegment(
+        data: ByteArray,
+        declaredEncoding: String?,
+    ): DecodedReplaySegment {
+        val candidateBytes = buildDecodeCandidates(data, declaredEncoding)
+        val parseErrors = mutableListOf<Throwable>()
+        candidateBytes.forEach { candidate ->
+            try {
+                return parseReplaySegment(candidate.decodeToString())
+            } catch (error: SerializationException) {
+                parseErrors += error
+            } catch (error: IllegalArgumentException) {
+                parseErrors += error
+            }
+        }
+        val firstError = parseErrors.firstOrNull()
+        throw IllegalArgumentException("Invalid Datadog replay segment payload", firstError)
+    }
+
+    internal fun normalizeReplayId(rawId: String): String {
+        val trimmed = rawId.trim().lowercase()
+        require(trimmed.isNotEmpty()) { "Replay ID cannot be empty" }
+        if (uuidRegex.matches(trimmed)) return trimmed
+        if (hexUuidRegex.matches(trimmed)) {
+            return "${trimmed.substring(0, UUID_SEG1)}-${trimmed.substring(UUID_SEG1, UUID_SEG2)}" +
+                "-${trimmed.substring(UUID_SEG2, UUID_SEG3)}-${trimmed.substring(UUID_SEG3, UUID_SEG4)}" +
+                "-${trimmed.substring(UUID_SEG4)}"
+        }
+        return UUID.nameUUIDFromBytes("datadog-replay:$trimmed".toByteArray(StandardCharsets.UTF_8)).toString()
+    }
+
+    private fun buildDecodeCandidates(
+        data: ByteArray,
+        declaredEncoding: String?,
+    ): List<ByteArray> {
+        val candidates = mutableListOf<ByteArray>()
+        val encoding = declaredEncoding?.trim()?.takeUnless { it.isBlank() || it.equals("identity", true) }
+        if (encoding != null) {
+            val decompressed = runCatching { DecompressionService.decompress(data, encoding) }
+                .onFailure { logger.warn { "Failed to decompress Datadog replay segment as $encoding: ${it.message}" } }
+                .getOrNull()
+            if (decompressed != null) {
+                candidates += decompressed
+            }
+        }
+        candidates += data
+        return candidates.distinctBy { it.contentHashCode() }
+    }
+
+    private fun parseReplaySegment(payload: String): DecodedReplaySegment {
+        val element = replayJson.parseToJsonElement(payload)
+        val records = when (element) {
+            is JsonArray -> element
+            is JsonObject -> element["records"] as? JsonArray
+                ?: throw IllegalArgumentException("Datadog replay segment missing records array")
+            else -> throw IllegalArgumentException("Datadog replay segment must be a JSON object or array")
+        }
+        return DecodedReplaySegment(
+            records = records,
+            recordingData = records.toString(),
+        )
+    }
+
+    private fun positiveTimestamp(timestampMs: Long?): Long =
+        timestampMs?.takeIf { it > 0 } ?: System.currentTimeMillis()
+
+    private fun extractUrls(records: JsonArray): List<String> =
+        records.asSequence()
+            .mapNotNull { record ->
+                val obj = record as? JsonObject ?: return@mapNotNull null
+                val type = obj["type"]?.jsonPrimitive?.intOrNull
+                if (type != RRWEB_META_EVENT_TYPE) return@mapNotNull null
+                (obj["data"] as? JsonObject)
+                    ?.get("href")
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+            }
+            .distinct()
+            .take(MAX_REPLAY_URLS)
+            .toList()
+
+    private fun replayTagsJson(
+        event: DdReplaySegmentEvent,
+        tags: Map<String, String>,
+    ): String {
+        val merged = linkedMapOf(
+            "source_type" to DATADOG_SOURCE_TYPE,
+            "source_name" to DATADOG_SOURCE_NAME,
+            "dd_source" to event.source,
+            "dd_creation_reason" to event.creationReason,
+            "dd_application_id" to event.application?.id.orEmpty(),
+            "dd_session_id" to event.session?.id.orEmpty(),
+            "dd_view_id" to event.view?.id.orEmpty(),
+            "dd_records_count" to event.recordsCount.toString(),
+            "dd_has_full_snapshot" to event.hasFullSnapshot?.toString().orEmpty(),
+            "dd_raw_segment_size" to event.rawSegmentSize?.toString().orEmpty(),
+            "dd_compressed_segment_size" to event.compressedSegmentSize?.toString().orEmpty(),
+        )
+        tags.forEach { (key, value) ->
+            if (key.isNotBlank()) {
+                merged[key] = value
+            }
+        }
+        return JsonObject(
+            merged
+                .filterValues { it.isNotBlank() }
+                .mapValues { (_, value) -> JsonPrimitive(value) }
+        ).toString()
+    }
+}
+
+internal data class DecodedReplaySegment(
+    val records: JsonArray,
+    val recordingData: String,
+)

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/DatadogModuleTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/DatadogModuleTest.kt
@@ -1,0 +1,313 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog
+
+import com.moneat.datadog.auth.DatadogAuthMiddleware
+import com.moneat.datadog.networkdevices.NdmIngestionWorker
+import com.moneat.datadog.security.SecurityIngestionWorker
+import com.moneat.datadog.services.ProfileStorageService
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.datadog.workers.DatadogEventIngestionWorker
+import com.moneat.datadog.workers.DatadogInfraIngestionWorker
+import com.moneat.datadog.workers.DatadogMetricIngestionWorker
+import com.moneat.datadog.workers.DbmIngestionWorker
+import com.moneat.datadog.workers.DebuggerIngestionWorker
+import com.moneat.datadog.workers.MiscIngestionWorker
+import com.moneat.datadog.workers.OrchestratorIngestionWorker
+import com.moneat.datadog.workers.TraceIngestionWorker
+import com.moneat.runtime.RuntimeMode
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.install
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+import com.moneat.testsupport.RouteTestSupport.installJwtAuth
+import org.koin.core.Koin
+import org.koin.core.context.GlobalContext
+
+class DatadogModuleTest {
+    @AfterTest
+    fun cleanup() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `registerRoutes wires datadog module routes`() = testApplication {
+        val mockKoin = mockk<Koin>(relaxed = true)
+        val mockQuotaService = mockk<BillingQuotaService>(relaxed = true)
+        mockkObject(GlobalContext)
+        every { GlobalContext.get() } returns mockKoin
+        every { mockKoin.get<BillingQuotaService>() } returns mockQuotaService
+
+        application {
+            installJwtAuth()
+            installDatadogRateLimits()
+            routing {
+                DatadogModule().registerRoutes(this)
+            }
+        }
+
+        val validateResponse = client.get("/api/v1/validate")
+        assertEquals(HttpStatusCode.Forbidden, validateResponse.status)
+
+        val ddValidateResponse = client.get("/dd/api/v1/validate/")
+        assertEquals(HttpStatusCode.Forbidden, ddValidateResponse.status)
+    }
+
+    @Test
+    fun `resolveRateLimitKey uses datadog api key extractor`() {
+        mockkObject(DatadogAuthMiddleware)
+        every { DatadogAuthMiddleware.extractApiKey(any()) } returns "abc"
+        every { DatadogAuthMiddleware.resolveOrgId("abc") } returns 77
+
+        val module = DatadogModule()
+        val call = mockk<ApplicationCall>()
+
+        val key = module.resolveRateLimitKey(call)
+        assertEquals("org:77", key)
+    }
+
+    @Test
+    fun `resolveRateLimitKey returns null when api key missing`() {
+        mockkObject(DatadogAuthMiddleware)
+        every { DatadogAuthMiddleware.extractApiKey(any()) } returns null
+
+        val module = DatadogModule()
+        val call = mockk<ApplicationCall>()
+
+        val key = module.resolveRateLimitKey(call)
+        assertNull(key)
+    }
+
+    @Test
+    fun `resolveRateLimitKey exposes configured rate limit name`() {
+        val module = DatadogModule()
+        assertEquals("datadog-ingestion", module.rateLimitName)
+    }
+
+    @Test
+    fun `startBackgroundJobs starts all ingestion workers when enabled`() {
+        withMockedRuntimeAndWorkers {
+            val module = DatadogModule()
+            val application = mockk<Application>(relaxed = true)
+
+            module.startBackgroundJobs(
+                application,
+                startSchedulers = false,
+                startIngestionWorkers = true,
+            )
+
+            verify(exactly = 1) {
+                ProfileStorageService.init()
+            }
+            verify(exactly = 1) { anyConstructed<TraceIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DatadogMetricIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DatadogEventIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DatadogInfraIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<MiscIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<OrchestratorIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DbmIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DebuggerIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<NdmIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<SecurityIngestionWorker>().start() }
+        }
+    }
+
+    @Test
+    fun `startBackgroundJobs default overload starts all ingestion workers when enabled`() {
+        withMockedRuntimeAndWorkers {
+            val module = DatadogModule()
+            val application = mockk<Application>(relaxed = true)
+
+            module.startBackgroundJobs(application)
+
+            verify(exactly = 1) { anyConstructed<TraceIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DatadogMetricIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DatadogEventIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DatadogInfraIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<OrchestratorIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DbmIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<DebuggerIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<NdmIngestionWorker>().start() }
+            verify(exactly = 1) { anyConstructed<SecurityIngestionWorker>().start() }
+        }
+    }
+
+    @Test
+    fun `stopBackgroundJobs is safe with no initialized workers`() {
+        val module = DatadogModule()
+        module.stopBackgroundJobs()
+    }
+
+    @Test
+    fun `startBackgroundJobs skips ingestion when disabled`() {
+        val module = DatadogModule()
+        val application = mockk<Application>(relaxed = true)
+
+        module.startBackgroundJobs(
+            application,
+            startSchedulers = true,
+            startIngestionWorkers = false,
+        )
+
+        assertEquals("Datadog", module.name)
+    }
+
+    @Test
+    fun `stopBackgroundJobs stops initialized workers`() {
+        withMockedRuntimeAndWorkers {
+            val module = DatadogModule()
+            val application = mockk<Application>(relaxed = true)
+
+            module.startBackgroundJobs(
+                application,
+                startSchedulers = false,
+                startIngestionWorkers = true,
+            )
+            module.stopBackgroundJobs()
+
+            verify(exactly = 1) { anyConstructed<TraceIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<DatadogMetricIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<DatadogEventIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<DatadogInfraIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<MiscIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<OrchestratorIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<DbmIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<DebuggerIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<NdmIngestionWorker>().stop() }
+            verify(exactly = 1) { anyConstructed<SecurityIngestionWorker>().stop() }
+        }
+    }
+
+    private fun withMockedRuntimeAndWorkers(action: () -> Unit) {
+        mockkObject(RuntimeMode)
+        every { RuntimeMode.shouldStartPipeline(any()) } returns true
+
+        mockkObject(ProfileStorageService)
+        every { ProfileStorageService.init() } answers {}
+
+        mockkConstructor(
+            TraceIngestionWorker::class,
+            OrchestratorIngestionWorker::class,
+            DbmIngestionWorker::class,
+            DebuggerIngestionWorker::class,
+            DatadogMetricIngestionWorker::class,
+            DatadogEventIngestionWorker::class,
+            DatadogInfraIngestionWorker::class,
+            MiscIngestionWorker::class,
+            NdmIngestionWorker::class,
+            SecurityIngestionWorker::class,
+        )
+
+        every {
+            anyConstructed<TraceIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<OrchestratorIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<DbmIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<DebuggerIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<DatadogMetricIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<DatadogEventIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<DatadogInfraIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<MiscIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<NdmIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<SecurityIngestionWorker>().start()
+        } answers {}
+        every {
+            anyConstructed<TraceIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<OrchestratorIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<DbmIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<DebuggerIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<DatadogMetricIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<DatadogEventIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<DatadogInfraIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<MiscIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<NdmIngestionWorker>().stop()
+        } answers {}
+        every {
+            anyConstructed<SecurityIngestionWorker>().stop()
+        } answers {}
+
+        action()
+    }
+
+    private fun io.ktor.server.application.Application.installDatadogRateLimits() {
+        install(RateLimit) {
+            register(RateLimitName("datadog-ingestion")) {
+                requestKey { call -> call.toString() }
+                rateLimiter(
+                    limit = 1000,
+                    refillPeriod = 1.seconds,
+                )
+            }
+            register(RateLimitName("api")) {
+                requestKey { call -> call.toString() }
+                rateLimiter(
+                    limit = 1000,
+                    refillPeriod = 1.seconds,
+                )
+            }
+        }
+    }
+}

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
@@ -160,5 +160,6 @@ class DatadogAuthMiddlewareTest {
 
         assertEquals("query-value", client.get("/probe?api_key=query-value").bodyAsText())
         assertEquals("dash-query-value", client.get("/probe?api-key=dash-query-value").bodyAsText())
+        assertEquals("dd-query-value", client.get("/probe?dd-api-key=dd-query-value").bodyAsText())
     }
 }

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
@@ -63,8 +63,8 @@ class DatadogAuthMiddlewareTest {
         val ctor = entryClass.declaredConstructors.single().apply { isAccessible = true }
         repeat(count) { index ->
             cache["cached-$fieldName-$index"] = when (fieldName) {
-                "cache" -> ctor.newInstance(index, 0L)
-                else -> ctor.newInstance(DatadogAuthContext(index, index), 0L)
+                "cache" -> ctor.newInstance(index, Long.MAX_VALUE)
+                else -> ctor.newInstance(DatadogAuthContext(index, index), Long.MAX_VALUE)
             }
         }
     }

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/auth/DatadogAuthMiddlewareTest.kt
@@ -23,20 +23,71 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.application.install
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.verify
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import io.ktor.serialization.kotlinx.json.json
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertNotEquals
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 
 class DatadogAuthMiddlewareTest {
+
+    private fun fillCache(fieldName: String, count: Int) {
+        val field = DatadogAuthMiddleware::class.java.getDeclaredField(fieldName).apply {
+            isAccessible = true
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val cache = field.get(DatadogAuthMiddleware) as MutableMap<String, Any>
+        cache.clear()
+        val entryClass = DatadogAuthMiddleware::class.nestedClasses.single {
+            it.simpleName == when (fieldName) {
+                "cache" -> "CachedKey"
+                else -> "CachedContext"
+            }
+        }.java
+        val ctor = entryClass.declaredConstructors.single().apply { isAccessible = true }
+        repeat(count) { index ->
+            cache["cached-$fieldName-$index"] = when (fieldName) {
+                "cache" -> ctor.newInstance(index, 0L)
+                else -> ctor.newInstance(DatadogAuthContext(index, index), 0L)
+            }
+        }
+    }
+
+    private fun putExpiredCacheEntry(fieldName: String, key: String, organizationId: Int = 7) {
+        val field = DatadogAuthMiddleware::class.java.getDeclaredField(fieldName).apply {
+            isAccessible = true
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val cache = field.get(DatadogAuthMiddleware) as MutableMap<String, Any>
+        val entryClass = DatadogAuthMiddleware::class.nestedClasses.single {
+            it.simpleName == when (fieldName) {
+                "cache" -> "CachedKey"
+                else -> "CachedContext"
+            }
+        }.java
+        val ctor = entryClass.declaredConstructors.single().apply { isAccessible = true }
+        cache[key] = when (fieldName) {
+            "cache" -> ctor.newInstance(organizationId, 0L)
+            else -> ctor.newInstance(DatadogAuthContext(organizationId, 12), 0L)
+        }
+    }
 
     @BeforeEach
     fun setup() {
@@ -62,12 +113,11 @@ class DatadogAuthMiddlewareTest {
         // First validation hits DB
         val orgId1 = DatadogService.validateApiKey(created.key)
         assertNotNull(orgId1)
-        assertEquals(1, orgId1)
 
         // Second should also work (verifies key is still valid)
         val orgId2 = DatadogService.validateApiKey(created.key)
         assertNotNull(orgId2)
-        assertEquals(1, orgId2)
+        assertEquals(orgId1, orgId2)
     }
 
     @Test
@@ -106,6 +156,81 @@ class DatadogAuthMiddlewareTest {
         // Should still work (re-validates from DB)
         val orgId = DatadogService.validateApiKey(created.key)
         assertNotNull(orgId)
+    }
+
+    @Test
+    fun `authenticate returns organization id when key is valid`() = testApplication {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKey("valid-key") } returns 11
+
+        application {
+            routing {
+                get("/probe") {
+                    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return@get
+                    call.respondText(orgId.toString())
+                }
+            }
+        }
+
+        val response = client.get("/probe") { header("api-key", "valid-key") }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("11", response.bodyAsText())
+
+        val secondResponse = client.get("/probe") { header("api-key", "valid-key") }
+        assertEquals(HttpStatusCode.OK, secondResponse.status)
+        assertEquals("11", secondResponse.bodyAsText())
+        verify(exactly = 1) { DatadogService.validateApiKey("valid-key") }
+    }
+
+    @Test
+    fun `authenticateContext returns cached context after first validation`() = testApplication {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKeyContext("valid-context-key") } returns
+            DatadogService.ApiKeyValidation(organizationId = 1, projectId = 2)
+
+        application {
+            routing {
+                get("/probe") {
+                    val context = DatadogAuthMiddleware.authenticateContext(call) ?: return@get
+                    call.respondText(context.projectId.toString())
+                }
+            }
+        }
+
+        val first = client.get("/probe") { header("api-key", "valid-context-key") }
+        assertEquals(HttpStatusCode.OK, first.status)
+        assertEquals("2", first.bodyAsText())
+
+        val second = client.get("/probe") { header("api-key", "valid-context-key") }
+        assertEquals(HttpStatusCode.OK, second.status)
+        assertEquals("2", second.bodyAsText())
+        verify(exactly = 1) { DatadogService.validateApiKeyContext("valid-context-key") }
+    }
+
+    @Test
+    fun `resolveOrgId uses cache and skips duplicate validation`() {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKey("cache-hit") } returns 77
+
+        val first = DatadogAuthMiddleware.resolveOrgId("cache-hit")
+        val second = DatadogAuthMiddleware.resolveOrgId("cache-hit")
+
+        assertEquals(77, first)
+        assertEquals(77, second)
+        verify(exactly = 1) { DatadogService.validateApiKey("cache-hit") }
+    }
+
+    @Test
+    fun `resolveOrgId still resolves when cache is full`() {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKey(any()) } returns 7
+
+        repeat(10_001) { index ->
+            val resolved = DatadogAuthMiddleware.resolveOrgId("key-$index")
+            assertEquals(7, resolved)
+        }
+        val resolved = DatadogAuthMiddleware.resolveOrgId("key-1")
+        assertEquals(7, resolved)
     }
 
     @Test
@@ -161,5 +286,129 @@ class DatadogAuthMiddlewareTest {
         assertEquals("query-value", client.get("/probe?api_key=query-value").bodyAsText())
         assertEquals("dash-query-value", client.get("/probe?api-key=dash-query-value").bodyAsText())
         assertEquals("dd-query-value", client.get("/probe?dd-api-key=dd-query-value").bodyAsText())
+    }
+
+    @Test
+    fun `authenticate rejects missing api key`() = testApplication {
+        application {
+            install(ContentNegotiation) {
+                json()
+            }
+            routing {
+                get("/probe") {
+                    val orgId = DatadogAuthMiddleware.authenticate(call)
+                    if (orgId != null) {
+                        call.respondText(orgId.toString())
+                    } else {
+                        return@get
+                    }
+                }
+            }
+        }
+
+        val response = client.get("/probe")
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertTrue(response.bodyAsText().contains("API key is missing or empty"))
+    }
+
+    @Test
+    fun `authenticate evicts expired cache entries before validation`() = testApplication {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKey("expired-key") } returns 77
+
+        putExpiredCacheEntry("cache", "expired-key")
+
+        application {
+            routing {
+                get("/probe") {
+                    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return@get
+                    call.respondText(orgId.toString())
+                }
+            }
+        }
+
+        val response = client.get("/probe") { header("api-key", "expired-key") }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("77", response.bodyAsText())
+        verify(exactly = 1) { DatadogService.validateApiKey("expired-key") }
+    }
+
+    @Test
+    fun `authenticate skips cache insert when cache is full`() = testApplication {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKey(any()) } returns 88
+
+        fillCache("cache", 10_000)
+
+        application {
+            routing {
+                get("/probe") {
+                    val orgId = DatadogAuthMiddleware.authenticate(call) ?: return@get
+                    call.respondText(orgId.toString())
+                }
+            }
+        }
+
+        val response = client.get("/probe") { header("api-key", "full-cache-key") }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("88", response.bodyAsText())
+        verify(exactly = 1) { DatadogService.validateApiKey("full-cache-key") }
+    }
+
+    @Test
+    fun `authenticateContext evicts expired context cache entries`() = testApplication {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKeyContext("expired-context") } returns
+            DatadogService.ApiKeyValidation(11, 22)
+
+        putExpiredCacheEntry("contextCache", "expired-context")
+
+        application {
+            routing {
+                get("/probe") {
+                    val context = DatadogAuthMiddleware.authenticateContext(call) ?: return@get
+                    call.respondText("${context.organizationId}-${context.projectId}")
+                }
+            }
+        }
+
+        val response = client.get("/probe") { header("api-key", "expired-context") }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("11-22", response.bodyAsText())
+    }
+
+    @Test
+    fun `authenticateContext skips context cache insert when context cache is full`() = testApplication {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKeyContext("full-context-key") } returns
+            DatadogService.ApiKeyValidation(33, 44)
+
+        fillCache("contextCache", 10_000)
+
+        application {
+            routing {
+                get("/probe") {
+                    val context = DatadogAuthMiddleware.authenticateContext(call) ?: return@get
+                    call.respondText("${context.organizationId}-${context.projectId}")
+                }
+            }
+        }
+
+        val response = client.get("/probe") { header("api-key", "full-context-key") }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("33-44", response.bodyAsText())
+    }
+
+    @Test
+    fun `resolveOrgId evicts expired cached entries before lookup`() {
+        mockkObject(DatadogService)
+        every { DatadogService.validateApiKey("resolve-expired") } returns 55
+
+        putExpiredCacheEntry("cache", "resolve-expired")
+
+        val resolved = DatadogAuthMiddleware.resolveOrgId("resolve-expired")
+        assertEquals(55, resolved)
+        verify(exactly = 1) { DatadogService.validateApiKey("resolve-expired") }
+        assertNotEquals(0, resolved)
     }
 }

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogReplayRoutesTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogReplayRoutesTest.kt
@@ -16,6 +16,8 @@
 
 package com.moneat.datadog.routes
 
+import com.moneat.billing.models.BillingUsageResponse
+import com.moneat.billing.services.QuotaReservationResult
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.datadog.auth.DatadogAuthMiddleware
 import com.moneat.datadog.services.DatadogReplayIngestRequest
@@ -54,6 +56,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DatadogReplayRoutesTest {
@@ -64,6 +67,33 @@ class DatadogReplayRoutesTest {
         private const val PROJECT_ID = 42
         private const val REPLAY_SEGMENT_JSON =
             """{"records":[{"type":4,"timestamp":1700000000000,"data":{"href":"https://example.com/cart"}}]}"""
+        private val quotaExceededUsage = BillingUsageResponse(
+            organizationId = "123",
+            periodStart = "2026-01-01T00:00:00Z",
+            periodEnd = "2026-02-01T00:00:00Z",
+            retentionDays = 30,
+            apmTraceRetentionDays = 30,
+            usedUnits = 0,
+            usedErrors = 0,
+            errorLimit = 1000,
+            usedTransactions = 0,
+            transactionLimit = 1000,
+            usedReplays = 0,
+            replayLimit = 1000,
+            usedFeedback = 0,
+            feedbackLimit = 1000,
+            usedBytes = 0,
+            bytesLimit = 1024,
+            baseLimitUnits = 1000,
+            paygLimitUnits = 1000,
+            totalLimitUnits = 2000,
+            paygBudgetCents = 0,
+            paygUsedUnits = 0,
+            paygUsedCentsEstimate = 0,
+            plan = "pro",
+            status = "active",
+            withinQuota = true,
+        )
 
         @JvmStatic
         @BeforeAll
@@ -156,12 +186,149 @@ class DatadogReplayRoutesTest {
     }
 
     @Test
+    fun `post replay rejects invalid replay event JSON`() = testApplication {
+        installRoutes()
+
+        val response = client.post("/dd/api/v2/replay?dd-api-key=$VALID_KEY") {
+            setBody(
+                replayEventOnlyBody("{not json".toByteArray()),
+            )
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid replay event JSON"))
+        coVerify(exactly = 0) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay rejects malformed replay payload lacking segment`() = testApplication {
+        val eventBytes = replayEventJson().toByteArray()
+        coEvery { DatadogReplayIngestionService.ingestReplaySegment(any()) } returns
+            DatadogReplayIngestResult(
+                replayId = "11111111-2222-3333-4444-555555555555",
+                segmentId = 3,
+                recordCount = 2,
+                bytesStored = 128,
+            )
+        installRoutes()
+
+        val response = client.post("/dd/api/v2/replay?dd-api-key=$VALID_KEY") {
+            setBody(replayEventOnlyBody(eventBytes))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("Replay event and segment parts are required"))
+        coVerify(exactly = 0) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay rejects multipart payload missing event`() = testApplication {
+        installRoutes()
+
+        val response = client.post("/dd/api/v2/replay?dd-api-key=$VALID_KEY") {
+            setBody(replaySegmentOnlyBody(deflate(REPLAY_SEGMENT_JSON.toByteArray())))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("Replay event and segment parts are required"))
+        coVerify(exactly = 0) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay accepts event form item without filename`() = testApplication {
+        val requestSlot = slot<DatadogReplayIngestRequest>()
+        coEvery { DatadogReplayIngestionService.ingestReplaySegment(capture(requestSlot)) } returns
+            DatadogReplayIngestResult(
+                replayId = "11111111-2222-3333-4444-555555555555",
+                segmentId = 3,
+                recordCount = 2,
+                bytesStored = 128,
+            )
+        installRoutes()
+
+        val response = client.post(
+            "/dd/api/v2/replay?dd-api-key=$VALID_KEY&dd-evp-encoding=deflate"
+        ) {
+            setBody(replayFormFieldMultipartBody(deflate(REPLAY_SEGMENT_JSON.toByteArray())))
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        assertEquals(3, requestSlot.captured.event.indexInView)
+        assertEquals("11111111-2222-3333-4444-555555555555", requestSlot.captured.event.session?.id)
+        coVerify(exactly = 1) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay returns 429 when quota is exceeded`() = testApplication {
+        coEvery { quotaService.reserveUnits(any(), any(), any(), any()) } returns
+            QuotaReservationResult(
+                allowed = false,
+                reason = "replay quota exceeded",
+                usage = quotaExceededUsage,
+            )
+        every { quotaService.isEnforcementEnabled() } returns true
+        installRoutes()
+
+        val response = client.post("/dd/api/v2/replay?dd-api-key=$VALID_KEY") {
+            setBody(replayMultipartBody(deflate(REPLAY_SEGMENT_JSON.toByteArray())))
+        }
+
+        assertEquals(HttpStatusCode.TooManyRequests, response.status)
+        assertFalse(response.bodyAsText().contains("replay_id"))
+        coVerify(exactly = 0) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay returns 400 when replay ingestion request is invalid`() = testApplication {
+        coEvery { DatadogReplayIngestionService.ingestReplaySegment(any()) } throws
+            IllegalArgumentException("Invalid replay payload")
+        installRoutes()
+
+        val response = client.post("/dd/api/v2/replay?dd-api-key=$VALID_KEY") {
+            setBody(replayMultipartBody(deflate(REPLAY_SEGMENT_JSON.toByteArray())))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid replay payload"))
+        coVerify(exactly = 1) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay returns 500 when replay ingestion fails for non-validation reason`() = testApplication {
+        coEvery { DatadogReplayIngestionService.ingestReplaySegment(any()) } throws
+            IllegalStateException("backend failure")
+        installRoutes()
+
+        val response = client.post("/dd/api/v2/replay?dd-api-key=$VALID_KEY") {
+            setBody(replayMultipartBody(deflate(REPLAY_SEGMENT_JSON.toByteArray())))
+        }
+
+        assertEquals(HttpStatusCode.InternalServerError, response.status)
+        assertTrue(response.bodyAsText().contains("Failed to ingest replay payload"))
+        coVerify(exactly = 1) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
     fun `parseDdTags parses browser SDK ddtags query`() {
         val tags = parseDdTags("env:prod,version:1.2.3,url:http://localhost:8080")
 
         assertEquals("prod", tags["env"])
         assertEquals("1.2.3", tags["version"])
         assertEquals("http://localhost:8080", tags["url"])
+    }
+
+    @Test
+    fun `parseDdTags ignores malformed entries`() {
+        val tags = parseDdTags("env:prod,malformed,service:backend,:,url:http://localhost:8080")
+
+        assertEquals(
+            mapOf(
+                "env" to "prod",
+                "service" to "backend",
+                "url" to "http://localhost:8080",
+            ),
+            tags,
+        )
     }
 
     private fun io.ktor.server.testing.ApplicationTestBuilder.installRoutes() {
@@ -182,6 +349,60 @@ class DatadogReplayRoutesTest {
                     bytes = replayEventJson().toByteArray(),
                     contentType = ContentType.Application.Json,
                 )
+                appendFile("segment", "segment.bin", segmentBytes)
+            }
+        )
+
+    private fun replayMultipartBody(
+        eventJson: String,
+        segmentBytes: ByteArray,
+    ): MultiPartFormDataContent =
+        MultiPartFormDataContent(
+            formData {
+                appendFile(
+                    name = "event",
+                    fileName = "event.json",
+                    bytes = eventJson.toByteArray(),
+                    contentType = ContentType.Application.Json,
+                )
+                appendFile("segment", "segment.bin", segmentBytes)
+            }
+        )
+
+    private fun replayFormFieldMultipartBody(segmentBytes: ByteArray): MultiPartFormDataContent =
+        MultiPartFormDataContent(
+            formData {
+                append(
+                    "event",
+                    replayEventJson(),
+                    Headers.build {
+                        append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    }
+                )
+                appendFile("segment", "segment.bin", segmentBytes)
+            }
+        )
+
+    private fun replayEventOnlyBody(eventBytes: ByteArray): MultiPartFormDataContent =
+        MultiPartFormDataContent(
+            formData {
+                append(
+                    "event",
+                    eventBytes.toString(Charsets.UTF_8),
+                    Headers.build {
+                        append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                        append(
+                            HttpHeaders.ContentDisposition,
+                            "form-data; name=\"event\"; filename=\"event.json\"",
+                        )
+                    },
+                )
+            }
+        )
+
+    private fun replaySegmentOnlyBody(segmentBytes: ByteArray): MultiPartFormDataContent =
+        MultiPartFormDataContent(
+            formData {
                 appendFile("segment", "segment.bin", segmentBytes)
             }
         )

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogReplayRoutesTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogReplayRoutesTest.kt
@@ -56,6 +56,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -196,8 +197,19 @@ class DatadogReplayRoutesTest {
         }
 
         assertEquals(HttpStatusCode.BadRequest, response.status)
-        assertTrue(response.bodyAsText().contains("Invalid replay event JSON"))
+        val body = response.bodyAsText()
+        assertTrue(body.contains("Invalid replay upload"))
+        assertFalse(body.contains("Invalid replay event JSON"))
         coVerify(exactly = 0) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `replay multipart size limit rejects oversized parts`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            requirePartWithinLimit("segment", MAX_REPLAY_MULTIPART_PART_BYTES + 1L)
+        }
+
+        assertTrue(error.message.orEmpty().contains("Replay segment part exceeds"))
     }
 
     @Test
@@ -347,22 +359,6 @@ class DatadogReplayRoutesTest {
                     name = "event",
                     fileName = "event.json",
                     bytes = replayEventJson().toByteArray(),
-                    contentType = ContentType.Application.Json,
-                )
-                appendFile("segment", "segment.bin", segmentBytes)
-            }
-        )
-
-    private fun replayMultipartBody(
-        eventJson: String,
-        segmentBytes: ByteArray,
-    ): MultiPartFormDataContent =
-        MultiPartFormDataContent(
-            formData {
-                appendFile(
-                    name = "event",
-                    fileName = "event.json",
-                    bytes = eventJson.toByteArray(),
                     contentType = ContentType.Application.Json,
                 )
                 appendFile("segment", "segment.bin", segmentBytes)

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogReplayRoutesTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/routes/DatadogReplayRoutesTest.kt
@@ -1,0 +1,225 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.routes
+
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.datadog.auth.DatadogAuthMiddleware
+import com.moneat.datadog.services.DatadogReplayIngestRequest
+import com.moneat.datadog.services.DatadogReplayIngestResult
+import com.moneat.datadog.services.DatadogReplayIngestionService
+import com.moneat.datadog.services.DatadogService
+import io.ktor.client.request.forms.FormBuilder
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import java.io.ByteArrayOutputStream
+import java.util.zip.DeflaterOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DatadogReplayRoutesTest {
+
+    companion object {
+        private const val VALID_KEY = "dd-replay-test-key"
+        private const val ORG_ID = 5
+        private const val PROJECT_ID = 42
+        private const val REPLAY_SEGMENT_JSON =
+            """{"records":[{"type":4,"timestamp":1700000000000,"data":{"href":"https://example.com/cart"}}]}"""
+
+        @JvmStatic
+        @BeforeAll
+        fun installObjectMocks() {
+            mockkObject(DatadogService, DatadogReplayIngestionService)
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun removeObjectMocks() {
+            unmockkAll()
+        }
+    }
+
+    private val quotaService = mockk<BillingQuotaService> {
+        every { isEnforcementEnabled() } returns false
+    }
+
+    @BeforeTest
+    fun setup() {
+        DatadogAuthMiddleware.clearCache()
+        clearMocks(DatadogService, DatadogReplayIngestionService, quotaService)
+        every { quotaService.isEnforcementEnabled() } returns false
+        every { DatadogService.validateApiKeyContext(VALID_KEY) } returns
+            DatadogService.ApiKeyValidation(ORG_ID, PROJECT_ID)
+    }
+
+    @AfterTest
+    fun teardown() {
+        DatadogAuthMiddleware.clearCache()
+    }
+
+    @Test
+    fun `post replay accepts browser sdk multipart payload with query api key`() = testApplication {
+        val requestSlot = slot<DatadogReplayIngestRequest>()
+        coEvery { DatadogReplayIngestionService.ingestReplaySegment(capture(requestSlot)) } returns
+            DatadogReplayIngestResult(
+                replayId = "11111111-2222-3333-4444-555555555555",
+                segmentId = 3,
+                recordCount = 2,
+                bytesStored = 128,
+            )
+        installRoutes()
+
+        val response = client.post(
+            "/dd/api/v2/replay?dd-api-key=$VALID_KEY&dd-evp-encoding=deflate" +
+                "&ddtags=env:prod,version:1.2.3&dd-evp-origin-version=6.33.0"
+        ) {
+            setBody(replayMultipartBody(deflate(REPLAY_SEGMENT_JSON.toByteArray())))
+        }
+
+        assertEquals(HttpStatusCode.Accepted, response.status)
+        assertTrue(response.bodyAsText().contains("11111111-2222-3333-4444-555555555555"))
+        val captured = requestSlot.captured
+        assertEquals(ORG_ID, captured.organizationId)
+        assertEquals(PROJECT_ID.toLong(), captured.projectId)
+        assertEquals("deflate", captured.declaredEncoding)
+        assertEquals("prod", captured.tags["env"])
+        assertEquals("1.2.3", captured.tags["version"])
+        assertEquals("6.33.0", captured.tags["sdk_version"])
+
+        coVerify(exactly = 1) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay rejects org-wide Datadog API keys`() = testApplication {
+        every { DatadogService.validateApiKeyContext(VALID_KEY) } returns
+            DatadogService.ApiKeyValidation(ORG_ID, null)
+        installRoutes()
+
+        val response = client.post("/dd/api/v2/replay?dd-api-key=$VALID_KEY") {
+            setBody(replayMultipartBody(REPLAY_SEGMENT_JSON.toByteArray()))
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `post replay rejects non-multipart bodies`() = testApplication {
+        installRoutes()
+
+        val response = client.post("/api/v2/replay?dd-api-key=$VALID_KEY") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"records":[]}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        coVerify(exactly = 0) { DatadogReplayIngestionService.ingestReplaySegment(any()) }
+    }
+
+    @Test
+    fun `parseDdTags parses browser SDK ddtags query`() {
+        val tags = parseDdTags("env:prod,version:1.2.3,url:http://localhost:8080")
+
+        assertEquals("prod", tags["env"])
+        assertEquals("1.2.3", tags["version"])
+        assertEquals("http://localhost:8080", tags["url"])
+    }
+
+    private fun io.ktor.server.testing.ApplicationTestBuilder.installRoutes() {
+        application {
+            install(ContentNegotiation) { json() }
+            routing {
+                datadogReplayRoutes(quotaService)
+            }
+        }
+    }
+
+    private fun replayMultipartBody(segmentBytes: ByteArray): MultiPartFormDataContent =
+        MultiPartFormDataContent(
+            formData {
+                appendFile(
+                    name = "event",
+                    fileName = "event.json",
+                    bytes = replayEventJson().toByteArray(),
+                    contentType = ContentType.Application.Json,
+                )
+                appendFile("segment", "segment.bin", segmentBytes)
+            }
+        )
+
+    private fun FormBuilder.appendFile(
+        name: String,
+        fileName: String,
+        bytes: ByteArray,
+        contentType: ContentType = ContentType.Application.OctetStream,
+    ) {
+        append(
+            name,
+            bytes,
+            Headers.build {
+                append(HttpHeaders.ContentDisposition, "form-data; name=\"$name\"; filename=\"$fileName\"")
+                append(HttpHeaders.ContentType, contentType.toString())
+            }
+        )
+    }
+
+    private fun replayEventJson(): String =
+        """
+        {
+          "source":"browser",
+          "creation_reason":"segment_duration_limit",
+          "start":1700000000000,
+          "end":1700000005000,
+          "records_count":2,
+          "index_in_view":3,
+          "application":{"id":"application-id"},
+          "session":{"id":"11111111-2222-3333-4444-555555555555"},
+          "view":{"id":"view-id"}
+        }
+        """.trimIndent()
+
+    private fun deflate(data: ByteArray): ByteArray {
+        val output = ByteArrayOutputStream()
+        DeflaterOutputStream(output).use { it.write(data) }
+        return output.toByteArray()
+    }
+}

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogReplayIngestionServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogReplayIngestionServiceTest.kt
@@ -48,8 +48,9 @@ class DatadogReplayIngestionServiceTest {
         val repository = mockk<EventRepository>()
         val replaySlot = slot<ReplayEventInsertData>()
         val recordingSlot = slot<ReplayRecordingInsertData>()
-        coEvery { repository.insertReplayEvent(capture(replaySlot)) } returns true
-        coEvery { repository.insertReplayRecording(capture(recordingSlot)) } returns Unit
+        coEvery {
+            repository.insertReplayEventWithRecording(capture(replaySlot), capture(recordingSlot))
+        } returns true
 
         val result = DatadogReplayIngestionService.ingestReplaySegment(
             request = DatadogReplayIngestRequest(
@@ -90,8 +91,7 @@ class DatadogReplayIngestionServiceTest {
         assertTrue(recording.recordingData.startsWith("["))
         assertContains(recording.recordingData, "https://example.com/cart")
 
-        coVerify(exactly = 1) { repository.insertReplayEvent(any()) }
-        coVerify(exactly = 1) { repository.insertReplayRecording(any()) }
+        coVerify(exactly = 1) { repository.insertReplayEventWithRecording(any(), any()) }
     }
 
     @Test
@@ -125,8 +125,6 @@ class DatadogReplayIngestionServiceTest {
     @Test
     fun `ingestReplaySegment requires project-scoped api key`() = runBlocking {
         val repository = mockk<EventRepository>()
-        coEvery { repository.insertReplayEvent(any()) } returns true
-        coEvery { repository.insertReplayRecording(any()) } returns Unit
 
         val error = assertFailsWith<IllegalArgumentException> {
             DatadogReplayIngestionService.ingestReplaySegment(
@@ -147,8 +145,6 @@ class DatadogReplayIngestionServiceTest {
     @Test
     fun `ingestReplaySegment requires replay session id`() = runBlocking {
         val repository = mockk<EventRepository>()
-        coEvery { repository.insertReplayEvent(any()) } returns true
-        coEvery { repository.insertReplayRecording(any()) } returns Unit
 
         val error = assertFailsWith<IllegalArgumentException> {
             DatadogReplayIngestionService.ingestReplaySegment(
@@ -169,8 +165,6 @@ class DatadogReplayIngestionServiceTest {
     @Test
     fun `ingestReplaySegment rejects segments with no records`() = runBlocking {
         val repository = mockk<EventRepository>()
-        coEvery { repository.insertReplayEvent(any()) } returns true
-        coEvery { repository.insertReplayRecording(any()) } returns Unit
 
         val error = assertFailsWith<IllegalArgumentException> {
             DatadogReplayIngestionService.ingestReplaySegment(
@@ -193,8 +187,9 @@ class DatadogReplayIngestionServiceTest {
     fun `ingestReplaySegment defaults missing source to browser`() = runBlocking {
         val repository = mockk<EventRepository>()
         val replaySlot = slot<ReplayEventInsertData>()
-        coEvery { repository.insertReplayEvent(capture(replaySlot)) } returns true
-        coEvery { repository.insertReplayRecording(any()) } returns Unit
+        coEvery {
+            repository.insertReplayEventWithRecording(capture(replaySlot), any())
+        } returns true
 
         DatadogReplayIngestionService.ingestReplaySegment(
             request = DatadogReplayIngestRequest(
@@ -215,8 +210,9 @@ class DatadogReplayIngestionServiceTest {
     fun `ingestReplaySegment ignores blank source tags`() = runBlocking {
         val repository = mockk<EventRepository>()
         val replaySlot = slot<ReplayEventInsertData>()
-        coEvery { repository.insertReplayEvent(capture(replaySlot)) } returns true
-        coEvery { repository.insertReplayRecording(any()) } returns Unit
+        coEvery {
+            repository.insertReplayEventWithRecording(capture(replaySlot), any())
+        } returns true
 
         DatadogReplayIngestionService.ingestReplaySegment(
             request = DatadogReplayIngestRequest(
@@ -239,8 +235,7 @@ class DatadogReplayIngestionServiceTest {
     @Test
     fun `ingestReplaySegment throws when inserting replay fails`() = runBlocking {
         val repository = mockk<EventRepository>()
-        coEvery { repository.insertReplayEvent(any()) } returns false
-        coEvery { repository.insertReplayRecording(any()) } returns Unit
+        coEvery { repository.insertReplayEventWithRecording(any(), any()) } returns false
 
         val error = assertFailsWith<IllegalStateException> {
             DatadogReplayIngestionService.ingestReplaySegment(
@@ -255,7 +250,7 @@ class DatadogReplayIngestionServiceTest {
             )
         }
 
-        assertEquals("Failed to insert replay event", error.message)
+        assertEquals("Failed to insert replay event and recording", error.message)
     }
 
     private fun replayEvent(

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogReplayIngestionServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogReplayIngestionServiceTest.kt
@@ -27,14 +27,18 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
+import java.util.UUID
 import java.util.zip.Deflater
 import java.util.zip.DeflaterOutputStream
+import kotlin.test.assertFailsWith
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class DatadogReplayIngestionServiceTest {
@@ -118,8 +122,148 @@ class DatadogReplayIngestionServiceTest {
         assertEquals("11111111-2222-3333-4444-555555555555", normalized)
     }
 
-    private fun replayEvent(recordsCount: Int) = DdReplaySegmentEvent(
-        source = "browser",
+    @Test
+    fun `ingestReplaySegment requires project-scoped api key`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        coEvery { repository.insertReplayEvent(any()) } returns true
+        coEvery { repository.insertReplayRecording(any()) } returns Unit
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            DatadogReplayIngestionService.ingestReplaySegment(
+                request = DatadogReplayIngestRequest(
+                    organizationId = 7,
+                    projectId = 0L,
+                    event = replayEvent(recordsCount = 1),
+                    segmentBytes = replaySegmentJson().toByteArray(),
+                    declaredEncoding = null,
+                ),
+                eventRepository = repository,
+            )
+        }
+
+        assertEquals("Project-scoped Datadog API key required for replay ingestion", error.message)
+    }
+
+    @Test
+    fun `ingestReplaySegment requires replay session id`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        coEvery { repository.insertReplayEvent(any()) } returns true
+        coEvery { repository.insertReplayRecording(any()) } returns Unit
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            DatadogReplayIngestionService.ingestReplaySegment(
+                request = DatadogReplayIngestRequest(
+                    organizationId = 7,
+                    projectId = 11,
+                    event = replayEvent(recordsCount = 1, sessionId = ""),
+                    segmentBytes = replaySegmentJson().toByteArray(),
+                    declaredEncoding = null,
+                ),
+                eventRepository = repository,
+            )
+        }
+
+        assertEquals("Datadog replay event missing session.id", error.message)
+    }
+
+    @Test
+    fun `ingestReplaySegment rejects segments with no records`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        coEvery { repository.insertReplayEvent(any()) } returns true
+        coEvery { repository.insertReplayRecording(any()) } returns Unit
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            DatadogReplayIngestionService.ingestReplaySegment(
+                request = DatadogReplayIngestRequest(
+                    organizationId = 7,
+                    projectId = 11,
+                    event = replayEvent(recordsCount = 0),
+                    segmentBytes = replayEmptySegmentJson().toByteArray(),
+                    declaredEncoding = null,
+                    tags = mapOf("env" to "prod"),
+                ),
+                eventRepository = repository,
+            )
+        }
+
+        assertEquals("Datadog replay segment contains no records", error.message)
+    }
+
+    @Test
+    fun `ingestReplaySegment defaults missing source to browser`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        val replaySlot = slot<ReplayEventInsertData>()
+        coEvery { repository.insertReplayEvent(capture(replaySlot)) } returns true
+        coEvery { repository.insertReplayRecording(any()) } returns Unit
+
+        DatadogReplayIngestionService.ingestReplaySegment(
+            request = DatadogReplayIngestRequest(
+                organizationId = 7,
+                projectId = 11,
+                event = replayEvent(recordsCount = 1, source = ""),
+                segmentBytes = replaySegmentJson().toByteArray(),
+                declaredEncoding = null,
+                tags = mapOf("env" to "prod"),
+            ),
+            eventRepository = repository,
+        )
+
+        assertEquals("browser", replaySlot.captured.platform)
+    }
+
+    @Test
+    fun `ingestReplaySegment ignores blank source tags`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        val replaySlot = slot<ReplayEventInsertData>()
+        coEvery { repository.insertReplayEvent(capture(replaySlot)) } returns true
+        coEvery { repository.insertReplayRecording(any()) } returns Unit
+
+        DatadogReplayIngestionService.ingestReplaySegment(
+            request = DatadogReplayIngestRequest(
+                organizationId = 7,
+                projectId = 11,
+                event = replayEvent(recordsCount = 2),
+                segmentBytes = replaySegmentJson().toByteArray(),
+                declaredEncoding = null,
+                tags = mapOf("custom" to "value", "" to "skip"),
+            ),
+            eventRepository = repository,
+        )
+
+        val tags = Json.parseToJsonElement(replaySlot.captured.tags).jsonObject
+        assertEquals("value", tags["custom"]?.jsonPrimitive?.content)
+        assertNotNull(tags["dd_application_id"])
+        assertEquals("datadog", tags["source_type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `ingestReplaySegment throws when inserting replay fails`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        coEvery { repository.insertReplayEvent(any()) } returns false
+        coEvery { repository.insertReplayRecording(any()) } returns Unit
+
+        val error = assertFailsWith<IllegalStateException> {
+            DatadogReplayIngestionService.ingestReplaySegment(
+                request = DatadogReplayIngestRequest(
+                    organizationId = 7,
+                    projectId = 11,
+                    event = replayEvent(recordsCount = 1),
+                    segmentBytes = replaySegmentJson().toByteArray(),
+                    declaredEncoding = null,
+                ),
+                eventRepository = repository,
+            )
+        }
+
+        assertEquals("Failed to insert replay event", error.message)
+    }
+
+    private fun replayEvent(
+        recordsCount: Int,
+        source: String = "browser",
+        sessionId: String = "11111111-2222-3333-4444-555555555555",
+    ) = DdReplaySegmentEvent(
+        source = source,
         creationReason = "segment_duration_limit",
         start = 1700000000000,
         end = 1700000005000,
@@ -129,9 +273,79 @@ class DatadogReplayIngestionServiceTest {
         rawSegmentSize = 512,
         compressedSegmentSize = 128,
         application = DdReplayIdRef("application-id"),
-        session = DdReplayIdRef("11111111-2222-3333-4444-555555555555"),
+        session = DdReplayIdRef(sessionId),
         view = DdReplayIdRef("view-id"),
     )
+
+    @Test
+    fun `decodeReplaySegment supports json array payloads`() {
+        val encoded = Json.encodeToString(
+            JsonArray.serializer(),
+            JsonArray(
+                List(1) {
+                    Json.parseToJsonElement("""{"type":4,"data":{"href":"https://array.example.com"}}""")
+                }
+            )
+        )
+
+        val decoded = DatadogReplayIngestionService.decodeReplaySegment(
+            encoded.toByteArray(),
+            null,
+        )
+
+        assertEquals(1, decoded.records.size)
+        assertContains(decoded.recordingData, "https://array.example.com")
+    }
+
+    @Test
+    fun `decodeReplaySegment rejects object without records`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            DatadogReplayIngestionService.decodeReplaySegment("""{"type":4}""".toByteArray(), null)
+        }
+
+        assertEquals("Invalid Datadog replay segment payload", error.message)
+    }
+
+    @Test
+    fun `decodeReplaySegment rejects invalid payload shape`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            DatadogReplayIngestionService.decodeReplaySegment("not-json".toByteArray(), null)
+        }
+
+        assertEquals("Invalid Datadog replay segment payload", error.message)
+    }
+
+    @Test
+    fun `decodeReplaySegment falls back to raw data when encoding is invalid`() {
+        val decoded = DatadogReplayIngestionService.decodeReplaySegment(replaySegmentJson().toByteArray(), "deflate")
+
+        assertEquals(2, decoded.records.size)
+        assertContains(decoded.recordingData, "https://example.com/cart")
+    }
+
+    @Test
+    fun `normalizeReplayId falls back to deterministic hash`() {
+        val normalized = DatadogReplayIngestionService.normalizeReplayId("custom-session")
+        assertEquals(36, normalized.length)
+        assertNotNull(UUID.fromString(normalized))
+    }
+
+    @Test
+    fun `normalizeReplayId rejects empty session id`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            DatadogReplayIngestionService.normalizeReplayId("   ")
+        }
+
+        assertEquals("Replay ID cannot be empty", error.message)
+    }
+
+    private fun replayEmptySegmentJson(): String =
+        """
+        {
+          "records": [],
+          "records_count": 0
+        }
+        """.trimIndent()
 
     private fun replaySegmentJson(): String =
         """

--- a/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogReplayIngestionServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/datadog/services/DatadogReplayIngestionServiceTest.kt
@@ -1,0 +1,177 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.datadog.services
+
+import com.moneat.datadog.models.DdReplayIdRef
+import com.moneat.datadog.models.DdReplaySegmentEvent
+import com.moneat.events.repositories.EventRepository
+import com.moneat.events.repositories.models.ReplayEventInsertData
+import com.moneat.events.repositories.models.ReplayRecordingInsertData
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.Deflater
+import java.util.zip.DeflaterOutputStream
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DatadogReplayIngestionServiceTest {
+
+    @Test
+    fun `ingestReplaySegment stores canonical replay event and recording`() = runBlocking {
+        val repository = mockk<EventRepository>()
+        val replaySlot = slot<ReplayEventInsertData>()
+        val recordingSlot = slot<ReplayRecordingInsertData>()
+        coEvery { repository.insertReplayEvent(capture(replaySlot)) } returns true
+        coEvery { repository.insertReplayRecording(capture(recordingSlot)) } returns Unit
+
+        val result = DatadogReplayIngestionService.ingestReplaySegment(
+            request = DatadogReplayIngestRequest(
+                organizationId = 7,
+                projectId = 11,
+                event = replayEvent(recordsCount = 1),
+                segmentBytes = replaySegmentJson().toByteArray(),
+                declaredEncoding = null,
+                tags = mapOf("env" to "prod", "version" to "1.2.3", "sdk_version" to "6.33.0"),
+            ),
+            eventRepository = repository,
+        )
+
+        assertEquals("11111111-2222-3333-4444-555555555555", result.replayId)
+        assertEquals(2, result.recordCount)
+
+        val replay = replaySlot.captured
+        assertEquals(7, replay.organizationId)
+        assertEquals(11, replay.projectId)
+        assertEquals(3, replay.segmentId)
+        assertEquals(1700000000000L, replay.timestampMs)
+        assertEquals(listOf("https://example.com/cart"), replay.urls)
+        assertEquals("prod", replay.environment)
+        assertEquals("1.2.3", replay.release)
+        assertEquals("@datadog/browser-rum", replay.sdkName)
+        assertEquals("6.33.0", replay.sdkVersion)
+        assertEquals(2, replay.activity)
+
+        val tags = Json.parseToJsonElement(replay.tags).jsonObject
+        assertEquals("datadog", tags["source_type"]?.jsonPrimitive?.content)
+        assertEquals("Datadog RUM SDK", tags["source_name"]?.jsonPrimitive?.content)
+        assertEquals("application-id", tags["dd_application_id"]?.jsonPrimitive?.content)
+        assertEquals("view-id", tags["dd_view_id"]?.jsonPrimitive?.content)
+
+        val recording = recordingSlot.captured
+        assertEquals(replay.replayId, recording.replayId)
+        assertEquals(replay.segmentId, recording.segmentId)
+        assertTrue(recording.recordingData.startsWith("["))
+        assertContains(recording.recordingData, "https://example.com/cart")
+
+        coVerify(exactly = 1) { repository.insertReplayEvent(any()) }
+        coVerify(exactly = 1) { repository.insertReplayRecording(any()) }
+    }
+
+    @Test
+    fun `decodeReplaySegment inflates Datadog deflate payload and stores records array`() {
+        val compressed = deflate(replaySegmentJson().toByteArray())
+
+        val decoded = DatadogReplayIngestionService.decodeReplaySegment(compressed, "deflate")
+
+        assertEquals(2, decoded.records.size)
+        assertTrue(decoded.recordingData.startsWith("["))
+        assertContains(decoded.recordingData, "https://example.com/cart")
+    }
+
+    @Test
+    fun `decodeReplaySegment inflates browser SDK streaming deflate payload`() {
+        val compressed = datadogStreamingDeflate(replaySegmentJson().toByteArray())
+
+        val decoded = DatadogReplayIngestionService.decodeReplaySegment(compressed, "deflate")
+
+        assertEquals(2, decoded.records.size)
+        assertContains(decoded.recordingData, "https://example.com/cart")
+    }
+
+    @Test
+    fun `normalizeReplayId converts hex session ids to UUIDs`() {
+        val normalized = DatadogReplayIngestionService.normalizeReplayId("11111111222233334444555555555555")
+
+        assertEquals("11111111-2222-3333-4444-555555555555", normalized)
+    }
+
+    private fun replayEvent(recordsCount: Int) = DdReplaySegmentEvent(
+        source = "browser",
+        creationReason = "segment_duration_limit",
+        start = 1700000000000,
+        end = 1700000005000,
+        recordsCount = recordsCount,
+        indexInView = 3,
+        hasFullSnapshot = true,
+        rawSegmentSize = 512,
+        compressedSegmentSize = 128,
+        application = DdReplayIdRef("application-id"),
+        session = DdReplayIdRef("11111111-2222-3333-4444-555555555555"),
+        view = DdReplayIdRef("view-id"),
+    )
+
+    private fun replaySegmentJson(): String =
+        """
+        {
+          "records": [
+            {"type":4,"timestamp":1700000000000,"data":{"href":"https://example.com/cart"}},
+            {"type":6,"timestamp":1700000000100,"data":{"has_focus":true}}
+          ],
+          "start":1700000000000,
+          "end":1700000005000,
+          "records_count":2
+        }
+        """.trimIndent()
+
+    private fun deflate(data: ByteArray): ByteArray {
+        val output = ByteArrayOutputStream()
+        DeflaterOutputStream(output).use { it.write(data) }
+        return output.toByteArray()
+    }
+
+    private fun datadogStreamingDeflate(data: ByteArray): ByteArray {
+        val deflater = Deflater()
+        deflater.setInput(data)
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(4096)
+        while (true) {
+            val bytesWritten = deflater.deflate(buffer, 0, buffer.size, Deflater.SYNC_FLUSH)
+            if (bytesWritten == 0) break
+            output.write(buffer, 0, bytesWritten)
+        }
+        val adler = deflater.adler
+        output.write(byteArrayOf(3, 0))
+        output.write(
+            byteArrayOf(
+                ((adler ushr 24) and 255).toByte(),
+                ((adler ushr 16) and 255).toByte(),
+                ((adler ushr 8) and 255).toByte(),
+                (adler and 255).toByte(),
+            )
+        )
+        return output.toByteArray()
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/events/repositories/EventRepository.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/EventRepository.kt
@@ -44,6 +44,10 @@ interface EventRepository {
     suspend fun insertFeedback(data: FeedbackInsertData): Boolean
     suspend fun insertReplayEvent(data: ReplayEventInsertData): Boolean
     suspend fun insertReplayRecording(data: ReplayRecordingInsertData)
+    suspend fun insertReplayEventWithRecording(
+        event: ReplayEventInsertData,
+        recording: ReplayRecordingInsertData,
+    ): Boolean
     suspend fun insertLlmGenerations(rows: List<LlmGenerationInsertData>): Boolean
     suspend fun insertProfile(data: ProfileInsertData): Boolean
 }

--- a/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
+++ b/backend/src/main/kotlin/com/moneat/events/repositories/EventRepositoryImpl.kt
@@ -351,6 +351,18 @@ class EventRepositoryImpl(
     }
 
     override suspend fun insertReplayRecording(data: ReplayRecordingInsertData) {
+        insertReplayRecordingResult(data)
+    }
+
+    override suspend fun insertReplayEventWithRecording(
+        event: ReplayEventInsertData,
+        recording: ReplayRecordingInsertData,
+    ): Boolean {
+        if (!insertReplayRecordingResult(recording)) return false
+        return insertReplayEvent(event)
+    }
+
+    private suspend fun insertReplayRecordingResult(data: ReplayRecordingInsertData): Boolean {
         val sql = """
             INSERT INTO `$db`.replay_segments (
                 replay_id, service_id, project_id, organization_id, segment_id, timestamp, recording_data
@@ -364,7 +376,7 @@ class EventRepositoryImpl(
                 '${escapeSql(data.recordingData)}'
             )
         """.trimIndent()
-        executeInsertNoResult(sql)
+        return executeInsert(sql)
     }
 
     override suspend fun insertLlmGenerations(rows: List<LlmGenerationInsertData>): Boolean {


### PR DESCRIPTION
## Summary
- Add Datadog RUM replay multipart ingestion endpoint for Browser replay payloads.
- Add canonical mapping into replay_events and replay_segments using existing repository insertion paths.
- Normalize Datadog replay IDs and extract key metadata/tags from event payload and ddtags.
- Add project-scoped auth requirement via dd-api-key query param compatibility and multipart parsing for both event and segment parts.
- Add focused tests for decoding, route auth/validation, and model wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Datadog replay ingestion endpoints.
  * Replay uploads now accept multipart event and segment data, with tag and encoding handling.
  * Replay requests can now use `dd-api-key` as a query parameter fallback.

* **Bug Fixes**
  * Replay ingestion is now included in existing Datadog rate limiting and quota checks.
  * Improved handling for malformed replay uploads, missing parts, and invalid payloads.
  * Authentication now better handles cached API key lookups and expired entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->