### PR TITLE
Improve dashboard chart series controls

### DIFF
--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -43,20 +43,12 @@ import {isQueryDrivenExtendedWidget, isExtendedWidgetType} from './extendedWidge
 import ReactMarkdown from 'react-markdown'
 import type {ValueMapping} from './formatValue'
 import {formatValue} from './formatValue'
-import {pivotData, valueKeySeries} from './widgetSeries'
+import {pivotData, valueKeySeries, type SeriesDef} from './widgetSeries'
+import {seriesColor} from './chartColors'
+import {useSeriesVisibility, type SeriesVisibility} from './useSeriesVisibility'
 import {isWarningThresholdValid, type AlertThresholdPreview} from './alertThresholds'
 import {widgetQueryFingerprint} from './widgetQueryFingerprint'
 import {fetchWidgetRows, TIME_KEYS} from './widgetRows'
-
-const COLORS = [
-  'hsl(var(--chart-1))',
-  'hsl(var(--chart-2))',
-  'hsl(var(--chart-3))',
-  'hsl(var(--chart-4))',
-  'hsl(var(--chart-5))',
-  '#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#00C49F',
-  '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7',
-]
 
 /**
  * Parse a ClickHouse datetime string as UTC epoch ms.
@@ -323,11 +315,14 @@ interface LegendPayloadItem {
   color?: string
   inactive?: boolean
   value?: string | number
+  dataKey?: string | number
 }
 
 interface ChartLegendProps {
   payload?: LegendPayloadItem[]
   placement?: 'bottom' | 'right'
+  hiddenKeys?: ReadonlySet<string>
+  onToggle?: (key: string, additive: boolean) => void
 }
 
 const GRAFANA_COLORS: Record<string, string> = {
@@ -570,7 +565,7 @@ function renderAlertThresholdOverlay(overlay: AlertThresholdOverlay) {
   )
 }
 
-function getLegendProps(dc: DisplayConfig) {
+function getLegendProps(dc: DisplayConfig, visibility?: SeriesVisibility) {
   const mode = dc.legendMode || 'list'
   if (mode === 'hidden') return null
   const placement = dc.legendPlacement || 'bottom'
@@ -585,7 +580,13 @@ function getLegendProps(dc: DisplayConfig) {
   }
   return {
     wrapperStyle,
-    content: <ChartLegend placement={isRight ? 'right' : 'bottom'} />,
+    content: (
+      <ChartLegend
+        placement={isRight ? 'right' : 'bottom'}
+        hiddenKeys={visibility?.hidden}
+        onToggle={visibility?.toggle}
+      />
+    ),
     height: isRight ? undefined : 56,
     iconType: 'line' as const,
     iconSize: 8,
@@ -596,28 +597,48 @@ function getLegendProps(dc: DisplayConfig) {
   }
 }
 
-function ChartLegend({payload, placement = 'bottom'}: ChartLegendProps) {
+function ChartLegend({payload, placement = 'bottom', hiddenKeys, onToggle}: ChartLegendProps) {
   const items = payload ?? []
   if (items.length === 0) return null
 
   const isRight = placement === 'right'
+  const interactive = !!onToggle
   const containerClass = isRight
     ? 'flex h-full max-h-full flex-col gap-1 overflow-y-auto overflow-x-hidden pr-1'
     : 'flex max-h-14 flex-wrap gap-x-3 gap-y-1 overflow-y-auto overflow-x-hidden px-1 pt-1'
-  const itemClass = isRight
+  const baseItemClass = isRight
     ? 'flex min-w-0 max-w-44 items-center gap-1.5 text-[10px] leading-3 text-muted-foreground'
     : 'flex min-w-0 max-w-56 items-center gap-1.5 text-[10px] leading-3 text-muted-foreground'
+  const itemClass = interactive
+    ? `${baseItemClass} cursor-pointer select-none rounded transition-colors hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring`
+    : baseItemClass
 
   return (
     <div className={containerClass}>
       {items.map((item, index) => {
         const label = String(item.value ?? '')
+        const key = String(item.dataKey ?? item.value ?? index)
+        const inactive = hiddenKeys ? hiddenKeys.has(key) : item.inactive
         return (
           <div
-            key={`${label}-${index}`}
+            key={`${key}-${index}`}
             className={itemClass}
-            style={item.inactive ? {opacity: 0.45} : undefined}
-            title={label}
+            style={inactive ? {opacity: 0.45} : undefined}
+            title={interactive ? `${label} — click to isolate, ⌘/Ctrl-click to toggle` : label}
+            role={interactive ? 'button' : undefined}
+            tabIndex={interactive ? 0 : undefined}
+            aria-pressed={interactive ? !inactive : undefined}
+            onClick={interactive ? (e) => onToggle!(key, e.metaKey || e.ctrlKey || e.shiftKey) : undefined}
+            onKeyDown={
+              interactive
+                ? (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      onToggle!(key, e.metaKey || e.ctrlKey || e.shiftKey)
+                    }
+                  }
+                : undefined
+            }
           >
             <span
               className="h-0.5 w-3 shrink-0 rounded-full"
@@ -672,6 +693,12 @@ function classifyColumns(data: Record<string, unknown>[]) {
 }
 
 const CHART_MARGIN = {top: 5, right: 5, left: 20, bottom: 20}
+// Axis + grid styling. Recharts defaults render as a dim mid-gray that is hard
+// to read on the dark card, so we drive tick text, axis lines, and grid lines
+// from theme tokens: legible labels, a quiet axis frame, and a faint grid.
+const AXIS_TICK = {fontSize: 10, fill: 'hsl(var(--muted-foreground))'}
+const AXIS_LINE = {stroke: 'hsl(var(--border))'}
+const GRID_STROKE = 'hsl(var(--foreground) / 0.09)'
 const TOOLTIP_STYLE = {
   backgroundColor: 'hsl(var(--popover))',
   border: '1px solid hsl(var(--border))',
@@ -706,6 +733,7 @@ const TimeseriesChart = memo(function TimeseriesChart({
     [data, xKey, labelKeys, valueKeys, hasLabels]
   )
   const seriesKeys = useMemo(() => series.map(({key}) => key), [series])
+  const visibility = useSeriesVisibility(seriesKeys)
 
   // Recharts type="number" scale="time" requires numeric epoch ms values.
   // ClickHouse returns time_bucket as a string ("2026-02-24 19:00:00.000"), so
@@ -723,7 +751,7 @@ const TimeseriesChart = memo(function TimeseriesChart({
   )
 
   const thresholds = parseThresholds(dc)
-  const legendProps = getLegendProps(dc)
+  const legendProps = getLegendProps(dc, visibility)
   const yDomain = getAlertAwareYAxisDomain(dc, chartData, seriesKeys, alertThresholdPreview)
   const alertOverlay = buildAlertThresholdOverlay(alertThresholdPreview, yDomain)
   const lineWidth = parseFloat(dc.lineWidth || '1.5')
@@ -745,17 +773,17 @@ const TimeseriesChart = memo(function TimeseriesChart({
     <DebouncedChartContainer>
       {(w, h) => useArea ? (
         <AreaChart width={w} height={h} data={chartData} margin={CHART_MARGIN}>
-          {showGrid && <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />}
+          {showGrid && <CartesianGrid strokeDasharray="3 3" stroke={GRID_STROKE} />}
           <XAxis
             dataKey={xKey}
-            tick={{fontSize: 10}}
+            tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE}
             tickFormatter={(v) => formatXAxisTick(v, spanMs)}
             type="number"
             domain={['dataMin', 'dataMax']}
             scale="time"
           />
           <YAxis
-            tick={{fontSize: 10}}
+            tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE}
             width={50}
             domain={yDomain}
             scale={dc.yAxisScale === 'log' ? 'log' : 'auto'}
@@ -779,9 +807,10 @@ const TimeseriesChart = memo(function TimeseriesChart({
               type={interpolation}
               dataKey={s.key}
               name={s.name}
-              stroke={COLORS[i % COLORS.length]}
+              hide={visibility.hidden.has(s.key)}
+              stroke={seriesColor(i)}
               strokeWidth={lineWidth}
-              fill={COLORS[i % COLORS.length]}
+              fill={seriesColor(i)}
               fillOpacity={fillOpacity || 0.3}
               dot={dotProp}
               activeDot={{r: 3}}
@@ -792,17 +821,17 @@ const TimeseriesChart = memo(function TimeseriesChart({
         </AreaChart>
       ) : (
         <LineChart width={w} height={h} data={chartData} margin={CHART_MARGIN}>
-          {showGrid && <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />}
+          {showGrid && <CartesianGrid strokeDasharray="3 3" stroke={GRID_STROKE} />}
           <XAxis
             dataKey={xKey}
-            tick={{fontSize: 10}}
+            tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE}
             tickFormatter={(v) => formatXAxisTick(v, spanMs)}
             type="number"
             domain={['dataMin', 'dataMax']}
             scale="time"
           />
           <YAxis
-            tick={{fontSize: 10}}
+            tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE}
             width={50}
             domain={yDomain}
             scale={dc.yAxisScale === 'log' ? 'log' : 'auto'}
@@ -826,7 +855,8 @@ const TimeseriesChart = memo(function TimeseriesChart({
               type={interpolation}
               dataKey={s.key}
               name={s.name}
-              stroke={COLORS[i % COLORS.length]}
+              hide={visibility.hidden.has(s.key)}
+              stroke={seriesColor(i)}
               strokeWidth={lineWidth}
               dot={dotProp}
               activeDot={{r: 3}}
@@ -853,9 +883,39 @@ const BarChartWidget = memo(function BarChartWidget({
   const {timeKey, labelKeys, valueKeys} = useMemo(() => classifyColumns(data), [data])
   const spanMs = getTimeSpanMs(timeRange)
   const hasTime = !!timeKey
+  const isPivot = hasTime && labelKeys.length > 0 && valueKeys.length > 0
+
+  // Time-bucketed multi-series bars pivot to one row per timestamp (with the
+  // time key normalized to epoch ms); everything else is a flat category chart.
+  // Series are derived here — before any early return — so series visibility can
+  // be tracked with a hook that always runs.
+  const pivot = useMemo(() => {
+    if (!isPivot) return null
+    const {pivoted, series} = pivotData(data, timeKey!, labelKeys, valueKeys)
+    const normalized = pivoted.map((row) => {
+      const v = row[timeKey!]
+      if (typeof v === 'string') { const ms = parseUtcTimestamp(v); return isNaN(ms) ? row : {...row, [timeKey!]: ms} }
+      return row
+    })
+    return {pivoted: normalized, series}
+  }, [isPivot, data, timeKey, labelKeys, valueKeys])
+
+  const categoryKeys = useMemo(() => {
+    if (isPivot) return [] as string[]
+    return valueKeys.length > 0
+      ? valueKeys
+      : Object.keys(data[0] || {}).filter((k) => !isTimeKey(k) && typeof data[0][k] === 'number')
+  }, [isPivot, data, valueKeys])
+
+  const series = useMemo<SeriesDef[]>(
+    () => (pivot ? pivot.series : categoryKeys.map((k) => ({key: k, name: k.replace(/_/g, ' ')}))),
+    [pivot, categoryKeys],
+  )
+  const seriesKeys = useMemo(() => series.map((s) => s.key), [series])
+  const visibility = useSeriesVisibility(seriesKeys)
 
   const thresholds = parseThresholds(dc)
-  const legendProps = getLegendProps(dc)
+  const legendProps = getLegendProps(dc, visibility)
   const showGrid = dc.showGrid !== 'false'
   const barMode = dc.barMode || 'grouped'
   const unit = dc.unit
@@ -865,31 +925,25 @@ const BarChartWidget = memo(function BarChartWidget({
     : undefined
   const tooltipFormatter: TooltipFormatterFn = (value) => formatUnitTooltipValue(value, unit, decimals)
 
-  if (hasTime && labelKeys.length > 0 && valueKeys.length > 0) {
-    const {pivoted: rawPivoted, series} = pivotData(data, timeKey!, labelKeys, valueKeys)
-    const seriesKeys = series.map(({key}) => key)
-    const pivoted = rawPivoted.map(row => {
-      const v = row[timeKey!]
-      if (typeof v === 'string') { const ms = parseUtcTimestamp(v); return isNaN(ms) ? row : {...row, [timeKey!]: ms} }
-      return row
-    })
+  if (pivot) {
+    const pivoted = pivot.pivoted
     const yDomain = getAlertAwareYAxisDomain(dc, pivoted, seriesKeys, alertThresholdPreview)
     const alertOverlay = buildAlertThresholdOverlay(alertThresholdPreview, yDomain)
     return (
       <DebouncedChartContainer>
         {(w, h) => (
           <BarChart width={w} height={h} data={pivoted} margin={CHART_MARGIN}>
-            {showGrid && <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />}
+            {showGrid && <CartesianGrid strokeDasharray="3 3" stroke={GRID_STROKE} />}
             <XAxis
               dataKey={timeKey}
-              tick={{fontSize: 10}}
+              tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE}
               tickFormatter={(v) => formatXAxisTick(v, spanMs)}
               type="number"
               domain={['dataMin', 'dataMax']}
               scale="time"
             />
             <YAxis
-              tick={{fontSize: 10}}
+              tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE}
               width={50}
               domain={yDomain}
               scale={dc.yAxisScale === 'log' ? 'log' : 'auto'}
@@ -913,7 +967,8 @@ const BarChartWidget = memo(function BarChartWidget({
                 key={s.key}
                 dataKey={s.key}
                 name={s.name}
-                fill={COLORS[i % COLORS.length]}
+                hide={visibility.hidden.has(s.key)}
+                fill={seriesColor(i)}
                 stackId={barMode === 'stacked' ? 'stack' : undefined}
               />
             ))}
@@ -924,20 +979,17 @@ const BarChartWidget = memo(function BarChartWidget({
   }
 
   const xKey = labelKeys[0] || timeKey || 'category'
-  const barKeys = valueKeys.length > 0 ? valueKeys : Object.keys(data[0] || {}).filter(
-    k => !isTimeKey(k) && typeof data[0][k] === 'number'
-  )
-  const yDomain = getAlertAwareYAxisDomain(dc, data, barKeys, alertThresholdPreview)
+  const yDomain = getAlertAwareYAxisDomain(dc, data, seriesKeys, alertThresholdPreview)
   const alertOverlay = buildAlertThresholdOverlay(alertThresholdPreview, yDomain)
 
   return (
     <DebouncedChartContainer>
       {(w, h) => (
         <BarChart width={w} height={h} data={data} margin={CHART_MARGIN}>
-          {showGrid && <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />}
-          <XAxis dataKey={xKey} tick={{fontSize: 10}} />
+          {showGrid && <CartesianGrid strokeDasharray="3 3" stroke={GRID_STROKE} />}
+          <XAxis dataKey={xKey} tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE} />
           <YAxis
-            tick={{fontSize: 10}}
+            tick={AXIS_TICK} axisLine={AXIS_LINE} tickLine={AXIS_LINE}
             width={50}
             domain={yDomain}
             label={dc.yAxisLabel ? {value: dc.yAxisLabel, angle: -90, position: 'insideLeft', style: {fontSize: 10}} : undefined}
@@ -953,12 +1005,13 @@ const BarChartWidget = memo(function BarChartWidget({
           {thresholds.map((t, i) => (
             <ReferenceLine key={`t-${i}`} y={t.value} stroke={t.color} strokeDasharray="4 4" label={t.label} />
           ))}
-          {barKeys.map((key, i) => (
+          {series.map((s, i) => (
             <Bar
-              key={key}
-              dataKey={key}
-              name={key.replace(/_/g, ' ')}
-              fill={COLORS[i % COLORS.length]}
+              key={s.key}
+              dataKey={s.key}
+              name={s.name}
+              hide={visibility.hidden.has(s.key)}
+              fill={seriesColor(i)}
               radius={[2, 2, 0, 0]}
               stackId={barMode === 'stacked' ? 'stack' : undefined}
             />
@@ -994,7 +1047,7 @@ const DonutChartWidget = memo(function DonutChartWidget({data, displayConfig: dc
             labelLine={false}
           >
             {data.map((_, i) => (
-              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              <Cell key={i} fill={seriesColor(i)} />
             ))}
           </Pie>
           <Tooltip wrapperStyle={TOOLTIP_WRAPPER_STYLE} />
@@ -1098,7 +1151,7 @@ const StatWidget = memo(function StatWidget({
           const label = labelKeys.map((k) => String(row[k] ?? '')).join(' ')
           const value = Number(row[valueKey]) || 0
           const pctWidth = (value / maxValue) * 100
-          const barColor = getThresholdColor(value, thresholds) || COLORS[i % COLORS.length]
+          const barColor = getThresholdColor(value, thresholds) || seriesColor(i)
           return (
             <div key={i} className="relative">
               <div

--- a/dashboard/src/components/dashboards/WidgetRenderer.tsx
+++ b/dashboard/src/components/dashboards/WidgetRenderer.tsx
@@ -23,7 +23,6 @@ import {
     Bar,
     BarChart,
     CartesianGrid,
-    Cell,
     Legend,
     Line,
     LineChart,
@@ -597,7 +596,7 @@ function getLegendProps(dc: DisplayConfig, visibility?: SeriesVisibility) {
   }
 }
 
-function ChartLegend({payload, placement = 'bottom', hiddenKeys, onToggle}: ChartLegendProps) {
+function ChartLegend({payload, placement = 'bottom', hiddenKeys, onToggle}: Readonly<ChartLegendProps>) {
   const items = payload ?? []
   if (items.length === 0) return null
 
@@ -619,33 +618,39 @@ function ChartLegend({payload, placement = 'bottom', hiddenKeys, onToggle}: Char
         const label = String(item.value ?? '')
         const key = String(item.dataKey ?? item.value ?? index)
         const inactive = hiddenKeys ? hiddenKeys.has(key) : item.inactive
-        return (
-          <div
-            key={`${key}-${index}`}
-            className={itemClass}
-            style={inactive ? {opacity: 0.45} : undefined}
-            title={interactive ? `${label} — click to isolate, ⌘/Ctrl-click to toggle` : label}
-            role={interactive ? 'button' : undefined}
-            tabIndex={interactive ? 0 : undefined}
-            aria-pressed={interactive ? !inactive : undefined}
-            onClick={interactive ? (e) => onToggle!(key, e.metaKey || e.ctrlKey || e.shiftKey) : undefined}
-            onKeyDown={
-              interactive
-                ? (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      onToggle!(key, e.metaKey || e.ctrlKey || e.shiftKey)
-                    }
-                  }
-                : undefined
-            }
-          >
+        const content = (
+          <>
             <span
               className="h-0.5 w-3 shrink-0 rounded-full"
               style={{backgroundColor: item.color ?? 'currentColor'}}
             />
             <span className="min-w-0 truncate">{label}</span>
-          </div>
+          </>
+        )
+        if (!interactive) {
+          return (
+            <div
+              key={`${key}-${index}`}
+              className={itemClass}
+              style={inactive ? {opacity: 0.45} : undefined}
+              title={label}
+            >
+              {content}
+            </div>
+          )
+        }
+        return (
+          <button
+            key={`${key}-${index}`}
+            type="button"
+            className={itemClass}
+            style={inactive ? {opacity: 0.45} : undefined}
+            title={`${label} — click to isolate, ⌘/Ctrl-click to toggle`}
+            aria-pressed={!inactive}
+            onClick={(event) => onToggle?.(key, event.metaKey || event.ctrlKey || event.shiftKey)}
+          >
+            {content}
+          </button>
         )
       })}
     </div>
@@ -890,11 +895,14 @@ const BarChartWidget = memo(function BarChartWidget({
   // Series are derived here — before any early return — so series visibility can
   // be tracked with a hook that always runs.
   const pivot = useMemo(() => {
-    if (!isPivot) return null
-    const {pivoted, series} = pivotData(data, timeKey!, labelKeys, valueKeys)
+    if (!isPivot || timeKey == null) return null
+    const {pivoted, series} = pivotData(data, timeKey, labelKeys, valueKeys)
     const normalized = pivoted.map((row) => {
-      const v = row[timeKey!]
-      if (typeof v === 'string') { const ms = parseUtcTimestamp(v); return isNaN(ms) ? row : {...row, [timeKey!]: ms} }
+      const v = row[timeKey]
+      if (typeof v === 'string') {
+        const ms = parseUtcTimestamp(v)
+        return Number.isNaN(ms) ? row : {...row, [timeKey]: ms}
+      }
       return row
     })
     return {pivoted: normalized, series}
@@ -908,7 +916,7 @@ const BarChartWidget = memo(function BarChartWidget({
   }, [isPivot, data, valueKeys])
 
   const series = useMemo<SeriesDef[]>(
-    () => (pivot ? pivot.series : categoryKeys.map((k) => ({key: k, name: k.replace(/_/g, ' ')}))),
+    () => (pivot ? pivot.series : categoryKeys.map((k) => ({key: k, name: k.replaceAll('_', ' ')}))),
     [pivot, categoryKeys],
   )
   const seriesKeys = useMemo(() => series.map((s) => s.key), [series])
@@ -1027,6 +1035,10 @@ const DonutChartWidget = memo(function DonutChartWidget({data, displayConfig: dc
   const labelKey = labelKeys[0]
   const valueKey = valueKeys[0]
   const legendProps = getLegendProps(dc)
+  const donutData = useMemo(
+    () => data.map((row, index) => ({...row, fill: seriesColor(index)})),
+    [data],
+  )
 
   if (!labelKey || !valueKey) return <div className="text-xs text-muted-foreground">Invalid data</div>
 
@@ -1035,7 +1047,7 @@ const DonutChartWidget = memo(function DonutChartWidget({data, displayConfig: dc
       {(w, h) => (
         <PieChart width={w} height={h}>
           <Pie
-            data={data}
+            data={donutData}
             dataKey={valueKey}
             nameKey={labelKey}
             cx="50%"
@@ -1045,11 +1057,7 @@ const DonutChartWidget = memo(function DonutChartWidget({data, displayConfig: dc
             paddingAngle={2}
             label={({percent}) => `${((percent ?? 0) * 100).toFixed(0)}%`}
             labelLine={false}
-          >
-            {data.map((_, i) => (
-              <Cell key={i} fill={seriesColor(i)} />
-            ))}
-          </Pie>
+          />
           <Tooltip wrapperStyle={TOOLTIP_WRAPPER_STYLE} />
           {legendProps && (
             <Legend

--- a/dashboard/src/components/dashboards/__tests__/WidgetRendererCharts.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/WidgetRendererCharts.test.tsx
@@ -1,0 +1,232 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import React from 'react'
+import {beforeEach, beforeAll, describe, expect, it, vi} from 'vitest'
+import {fireEvent, screen} from '@testing-library/react'
+import type {DashboardWidget, QueryDsl, TimeRangeDef} from '@/lib/api'
+import {renderWithQueryClient} from '@/test/utils'
+import {WidgetRenderer} from '../WidgetRenderer'
+import {fetchWidgetRows} from '../widgetRows'
+
+vi.mock('../ExtendedWidgets', () => ({
+  ExtendedWidgetRenderer: () => null,
+}))
+
+vi.mock('../TopListWidget', () => ({
+  TopListWidget: () => null,
+}))
+
+vi.mock('../HeatmapWidget', () => ({
+  HeatmapWidget: () => null,
+}))
+
+vi.mock('recharts', () => {
+  const chartPart = ({children, ...props}: {children?: React.ReactNode; [key: string]: unknown}) => {
+    const dataKey = props.dataKey
+    const testId = typeof dataKey === 'string' ? `series-${dataKey}` : 'chart-part'
+    return (
+      <g data-testid={testId} data-hidden={String(props.hide === true)}>
+        {children}
+      </g>
+    )
+  }
+  const chartRoot = ({children}: {children?: React.ReactNode}) => <svg data-testid="chart-root">{children}</svg>
+  const legendPayload = [
+    {value: 'alpha', dataKey: 'alpha', color: '#111111'},
+    {value: 'beta', dataKey: 'beta', color: '#222222'},
+  ]
+  const Legend = ({content}: {content?: React.ReactElement<{payload?: typeof legendPayload}>}) => (
+    <div data-testid="chart-legend">
+      {content ? React.cloneElement(content, {payload: legendPayload}) : null}
+    </div>
+  )
+  const Pie = ({data}: {data?: Record<string, unknown>[]}) => (
+    <g data-testid="pie" data-fills={data?.map((row) => String(row.fill)).join(',')} />
+  )
+
+  return {
+    Area: chartPart,
+    AreaChart: chartRoot,
+    Bar: chartPart,
+    BarChart: chartRoot,
+    CartesianGrid: chartPart,
+    Cell: chartPart,
+    Legend,
+    Line: chartPart,
+    LineChart: chartRoot,
+    Pie,
+    PieChart: chartRoot,
+    ReferenceArea: chartPart,
+    ReferenceLine: chartPart,
+    Scatter: chartPart,
+    ScatterChart: chartRoot,
+    Tooltip: chartPart,
+    XAxis: chartPart,
+    YAxis: chartPart,
+    ZAxis: chartPart,
+  }
+})
+
+vi.mock('../widgetRows', async () => {
+  const actual = await vi.importActual<typeof import('../widgetRows')>('../widgetRows')
+  return {
+    ...actual,
+    fetchWidgetRows: vi.fn(),
+  }
+})
+
+const fetchWidgetRowsMock = vi.mocked(fetchWidgetRows)
+const timeRange: TimeRangeDef = {from: 'now-1h', to: 'now'}
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {configurable: true, value: 320})
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {configurable: true, value: 240})
+  globalThis.ResizeObserver = class {
+    private readonly callback: ResizeObserverCallback
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback
+    }
+
+    observe(target: Element) {
+      this.callback([], this as unknown as ResizeObserver)
+      void target
+    }
+
+    disconnect() {}
+
+    unobserve() {}
+
+    takeRecords(): ResizeObserverEntry[] {
+      return []
+    }
+  }
+})
+
+beforeEach(() => {
+  fetchWidgetRowsMock.mockReset()
+})
+
+function query(): QueryDsl {
+  return {
+    dataSource: 'custom:218f4ce4-3f2a-7a67-a32b-0c1848f62b9d',
+    metrics: [],
+    groupBy: [],
+    filters: [],
+    limit: 5000,
+    timeRange,
+  }
+}
+
+function widget(widgetType: string, displayConfig: Record<string, string> = {}): DashboardWidget {
+  return {
+    id: `${widgetType}-widget`,
+    dashboard_id: 'dashboard-1',
+    title: widgetType,
+    widget_type: widgetType,
+    grid_x: 0,
+    grid_y: 0,
+    grid_w: 8,
+    grid_h: 6,
+    query_configs: [query()],
+    display_config: displayConfig,
+    sort_order: 0,
+  }
+}
+
+function renderWidget(target: DashboardWidget) {
+  return renderWithQueryClient(
+    <WidgetRenderer
+      widget={target}
+      dashboardId="dashboard-1"
+      projectId="018f4ce4-3f2a-7a67-a32b-0c1848f62b9d"
+      timeRange={timeRange}
+      autoRefresh={false}
+    />,
+  )
+}
+
+describe('WidgetRenderer charts', () => {
+  it('renders an area chart and lets users isolate and restore series', async () => {
+    fetchWidgetRowsMock.mockResolvedValue([
+      {time_bucket: '2026-07-12 00:00:00.000', series: 'alpha', value: 1},
+      {time_bucket: '2026-07-12 00:00:00.000', series: 'beta', value: 2},
+      {time_bucket: '2026-07-12 01:00:00.000', series: 'alpha', value: 3},
+      {time_bucket: '2026-07-12 01:00:00.000', series: 'beta', value: 4},
+    ])
+
+    renderWidget(widget('timeseries', {fillOpacity: '0.25', legendPlacement: 'right'}))
+
+    const alpha = await screen.findByRole('button', {name: 'alpha'})
+    const beta = screen.getByRole('button', {name: 'beta'})
+    expect(screen.getByTestId('series-alpha')).toHaveAttribute('data-hidden', 'false')
+    expect(screen.getByTestId('series-beta')).toHaveAttribute('data-hidden', 'false')
+
+    fireEvent.click(alpha)
+    expect(screen.getByTestId('series-alpha')).toHaveAttribute('data-hidden', 'false')
+    expect(screen.getByTestId('series-beta')).toHaveAttribute('data-hidden', 'true')
+
+    fireEvent.click(beta, {ctrlKey: true})
+    expect(screen.getByTestId('series-alpha')).toHaveAttribute('data-hidden', 'false')
+    expect(screen.getByTestId('series-beta')).toHaveAttribute('data-hidden', 'false')
+  })
+
+  it('renders a pivoted time bar chart with stacked series', async () => {
+    fetchWidgetRowsMock.mockResolvedValue([
+      {time_bucket: '2026-07-12 00:00:00.000', series: 'alpha', value: 1},
+      {time_bucket: '2026-07-12 00:00:00.000', series: 'beta', value: 2},
+    ])
+
+    renderWidget(widget('bar', {barMode: 'stacked'}))
+
+    expect(await screen.findByTestId('series-alpha')).toHaveAttribute('data-hidden', 'false')
+    expect(screen.getByTestId('series-beta')).toHaveAttribute('data-hidden', 'false')
+  })
+
+  it('renders a flat bar chart and a donut chart with deterministic fills', async () => {
+    fetchWidgetRowsMock.mockResolvedValue([
+      {category: 'one', count: 1},
+      {category: 'two', count: 2},
+    ])
+    renderWidget(widget('bar', {legendMode: 'hidden'}))
+    expect(await screen.findByTestId('series-count')).toHaveAttribute('data-hidden', 'false')
+
+    fetchWidgetRowsMock.mockResolvedValue([
+      {label: 'one', value: 3},
+      {label: 'two', value: 2},
+    ])
+    renderWidget(widget('donut'))
+    expect(await screen.findByTestId('pie')).toHaveAttribute(
+      'data-fills',
+      'hsl(var(--chart-1)),hsl(var(--chart-2))',
+    )
+  })
+
+  it('uses the series palette for categorical stat bars', async () => {
+    fetchWidgetRowsMock.mockResolvedValue([
+      {label: 'one', count: 1},
+      {label: 'two', count: 2},
+      {label: 'three', count: 3},
+      {label: 'four', count: 4},
+    ])
+
+    renderWidget(widget('stat'))
+
+    expect(await screen.findByText('one')).toBeInTheDocument()
+    expect(screen.getByText('four')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/dashboards/__tests__/useSeriesVisibility.test.tsx
+++ b/dashboard/src/components/dashboards/__tests__/useSeriesVisibility.test.tsx
@@ -1,0 +1,105 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {describe, it, expect} from 'vitest'
+import {act, renderHook} from '@testing-library/react'
+import {useSeriesVisibility} from '../useSeriesVisibility'
+import {CHART_TOKENS, seriesColor} from '../chartColors'
+
+const KEYS = ['a', 'b', 'c']
+
+function hiddenArray(hidden: ReadonlySet<string>) {
+  return [...hidden].sort()
+}
+
+describe('useSeriesVisibility', () => {
+  it('starts with every series visible', () => {
+    const {result} = renderHook(() => useSeriesVisibility(KEYS))
+    expect(result.current.hidden.size).toBe(0)
+  })
+
+  it('isolates a series on a plain click (hides all others)', () => {
+    const {result} = renderHook(() => useSeriesVisibility(KEYS))
+    act(() => result.current.toggle('b', false))
+    expect(hiddenArray(result.current.hidden)).toEqual(['a', 'c'])
+  })
+
+  it('restores all when clicking the already-isolated series', () => {
+    const {result} = renderHook(() => useSeriesVisibility(KEYS))
+    act(() => result.current.toggle('b', false))
+    act(() => result.current.toggle('b', false))
+    expect(result.current.hidden.size).toBe(0)
+  })
+
+  it('isolates a different series when clicking another while isolated', () => {
+    const {result} = renderHook(() => useSeriesVisibility(KEYS))
+    act(() => result.current.toggle('b', false))
+    act(() => result.current.toggle('a', false))
+    expect(hiddenArray(result.current.hidden)).toEqual(['b', 'c'])
+  })
+
+  it('toggles a single series with a modifier (additive) click', () => {
+    const {result} = renderHook(() => useSeriesVisibility(KEYS))
+    act(() => result.current.toggle('a', true))
+    expect(hiddenArray(result.current.hidden)).toEqual(['a'])
+    act(() => result.current.toggle('a', true))
+    expect(result.current.hidden.size).toBe(0)
+  })
+
+  it('never hides the last visible series via additive clicks', () => {
+    const {result} = renderHook(() => useSeriesVisibility(['a', 'b']))
+    act(() => result.current.toggle('a', true))
+    act(() => result.current.toggle('b', true)) // would blank the chart — ignored
+    expect(hiddenArray(result.current.hidden)).toEqual(['a'])
+  })
+
+  it('resets visibility when the set of series changes', () => {
+    const {result, rerender} = renderHook(({keys}) => useSeriesVisibility(keys), {
+      initialProps: {keys: KEYS},
+    })
+    act(() => result.current.toggle('b', false))
+    expect(result.current.hidden.size).toBe(2)
+
+    rerender({keys: ['x', 'y', 'z']})
+    expect(result.current.hidden.size).toBe(0)
+  })
+
+  it('keeps visibility when the series set is unchanged (stable across refresh)', () => {
+    const {result, rerender} = renderHook(({keys}) => useSeriesVisibility(keys), {
+      initialProps: {keys: KEYS},
+    })
+    act(() => result.current.toggle('b', false))
+    rerender({keys: ['a', 'b', 'c']}) // same keys, new array identity (e.g. auto-refresh)
+    expect(hiddenArray(result.current.hidden)).toEqual(['a', 'c'])
+  })
+})
+
+describe('seriesColor', () => {
+  it('maps the first ten series to the theme palette tokens', () => {
+    CHART_TOKENS.forEach((token, i) => {
+      expect(seriesColor(i)).toBe(token)
+    })
+  })
+
+  it('generates distinct, deterministic hues beyond the palette', () => {
+    const c10 = seriesColor(10)
+    const c11 = seriesColor(11)
+    expect(c10).toMatch(/^hsl\(\d+ 72% 60%\)$/)
+    expect(c11).toMatch(/^hsl\(\d+ 72% 60%\)$/)
+    expect(c10).not.toBe(c11)
+    expect(seriesColor(10)).toBe(c10) // deterministic
+  })
+})

--- a/dashboard/src/components/dashboards/chartColors.ts
+++ b/dashboard/src/components/dashboards/chartColors.ts
@@ -1,0 +1,41 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Categorical series palette: the ten theme-tuned chart tokens (adjacent-hue
+// separated and legible on the dark viz canvas). Defined via CSS variables so
+// series colors track the active theme.
+export const CHART_TOKENS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+  'hsl(var(--chart-6))',
+  'hsl(var(--chart-7))',
+  'hsl(var(--chart-8))',
+  'hsl(var(--chart-9))',
+  'hsl(var(--chart-10))',
+]
+
+// Color for the series at a given index. The first ten come from the theme
+// palette; beyond that we rotate hues by the golden angle so overflow series
+// stay well separated and saturated enough to read on the dark canvas — rather
+// than falling back to dull, washed-out defaults.
+export function seriesColor(index: number): string {
+  if (index < CHART_TOKENS.length) return CHART_TOKENS[index]
+  const hue = Math.round((index * 137.508) % 360)
+  return `hsl(${hue} 72% 60%)`
+}

--- a/dashboard/src/components/dashboards/useSeriesVisibility.ts
+++ b/dashboard/src/components/dashboards/useSeriesVisibility.ts
@@ -1,0 +1,66 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useCallback, useState} from 'react'
+
+export interface SeriesVisibility {
+  hidden: ReadonlySet<string>
+  toggle: (key: string, additive: boolean) => void
+}
+
+const EMPTY_HIDDEN: ReadonlySet<string> = new Set()
+
+/**
+ * Tracks which chart series are hidden so a legend can filter the chart.
+ * A plain legend click isolates that series (hides every other one); clicking
+ * the already-isolated series restores all. A modifier click (Cmd/Ctrl/Shift)
+ * toggles a single series so custom subsets can be built. Visibility resets when
+ * the set of series changes (e.g. a new query result shape) so we never strand a
+ * key that is no longer rendered.
+ */
+export function useSeriesVisibility(seriesKeys: string[]): SeriesVisibility {
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(EMPTY_HIDDEN)
+  const signature = JSON.stringify(seriesKeys)
+
+  // Reset visibility when the set of series changes. Adjusting state during
+  // render is React's sanctioned way to reset on a prop change; an effect here
+  // would instead trigger a cascading render.
+  const [prevSignature, setPrevSignature] = useState(signature)
+  if (prevSignature !== signature) {
+    setPrevSignature(signature)
+    setHidden(EMPTY_HIDDEN)
+  }
+
+  const toggle = useCallback(
+    (key: string, additive: boolean) => {
+      setHidden((prev) => {
+        if (additive) {
+          const next = new Set(prev)
+          if (next.has(key)) next.delete(key)
+          else next.add(key)
+          // Never hide every series — that just blanks the chart.
+          return next.size >= seriesKeys.length ? prev : next
+        }
+        // Plain click isolates; clicking the already-isolated series restores all.
+        const alreadyIsolated = prev.size === seriesKeys.length - 1 && !prev.has(key)
+        return alreadyIsolated ? EMPTY_HIDDEN : new Set(seriesKeys.filter((k) => k !== key))
+      })
+    },
+    [seriesKeys],
+  )
+
+  return {hidden, toggle}
+}


### PR DESCRIPTION
## Summary
- use the dashboard theme palette for chart series, including deterministic overflow colors
- make time-series and bar-chart legends interactive for isolating and toggling series
- improve chart axis and grid contrast
- add focused hook and palette coverage

## Why
Dense dashboard charts are difficult to read and inspect when series share low-contrast fallback colors. Interactive legends make multi-series telemetry easier to isolate without changing dashboard data or alert behavior.

## Validation
- `npm test -- --run src/components/dashboards/__tests__/useSeriesVisibility.test.tsx src/components/dashboards/__tests__/overviewWidgetRender.test.tsx src/components/dashboards/__tests__/WidgetRendererError.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive chart legends for isolating, restoring, and multi-selecting data series.
  * Added keyboard- and accessibility-friendly legend controls with inactive styling for hidden series.
  * Improved chart colors with theme-aware palettes and distinct colors for larger datasets.
  * Enhanced chart readability in dark mode with clearer axes, gridlines, and labels.
  * Updated donut charts with consistent, deterministic slice colors.

* **Tests**
  * Added coverage for series visibility interactions and chart rendering across supported widget types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->