### PR TITLE
Fix alert signal reliability and inventory

### DIFF
--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -817,12 +817,12 @@ class DashboardAlertService(
                 moneatUrl = "$baseUrl/dashboards/${alert.dashboardResourceId}"
             )
 
-        suspendRunCatching {
+        val shouldNotifyIncidentProvider = suspendRunCatching {
             workflowService.publishAlertTriggered(event)
         }.onFailure { e ->
             logger.error(e) { "Failed to publish dashboard alert workflow" }
-        }
-        if (configuredAlertPriority != null) {
+        }.getOrElse { true }
+        if (configuredAlertPriority != null && shouldNotifyIncidentProvider) {
             suspendRunCatching {
                 incidentService.fireAlert(event.copy(priority = configuredAlertPriority), publishWorkflow = false)
             }.onFailure { e ->

--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
@@ -195,12 +195,20 @@ class PrometheusHandler : HttpApiHandler() {
         val promLimit = limit.coerceAtLeast(DEFAULT_PROMETHEUS_RESULT_LIMIT)
 
         return suspendRunCatching {
-            val response = if (timeRange != null) {
+            val rangeSeconds = timeRange?.let { range ->
                 val nowSec = System.currentTimeMillis() / MILLIS_PER_SECOND
-                val fromSec = resolveRelativeTimeSec(timeRange.from, nowSec)
-                val toSec = resolveRelativeTimeSec(timeRange.to, nowSec)
+                val fromSec = resolveRelativeTimeSec(range.from, nowSec)
+                val toSec = resolveRelativeTimeSec(range.to, nowSec)
+                fromSec to toSec
+            }
+            val effectiveQuery = expandQueryMacros(
+                query,
+                rangeSeconds?.let { (fromSec, toSec) -> toSec - fromSec }
+            )
+            val response = if (rangeSeconds != null) {
+                val fromSec = rangeSeconds.first
+                val toSec = rangeSeconds.second
                 val step = resolvePrometheusStep(toSec - fromSec)
-                val effectiveQuery = expandQueryMacros(query, toSec - fromSec)
 
                 httpClient.get("$baseUrl/api/v1/query_range") {
                     applyHttpAuth(credentials)
@@ -210,7 +218,6 @@ class PrometheusHandler : HttpApiHandler() {
                     parameter("step", step)
                 }
             } else {
-                val effectiveQuery = expandQueryMacros(query, null)
                 httpClient.get("$baseUrl/api/v1/query") {
                     applyHttpAuth(credentials)
                     parameter("query", effectiveQuery)
@@ -223,7 +230,9 @@ class PrometheusHandler : HttpApiHandler() {
                     "query",
                     httpStatusLabel(response.status.value)
                 )
-                logger.error { "Prometheus query failed: ${response.status} | query=$query" }
+                logger.error {
+                    "Prometheus query failed: ${response.status} | query=$query | effectiveQuery=$effectiveQuery"
+                }
                 return emptyList()
             }
             parsePrometheusResponse(response.bodyAsText(), promLimit)

--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/handlers/PrometheusHandler.kt
@@ -58,6 +58,8 @@ class PrometheusHandler : HttpApiHandler() {
         private const val DEFAULT_PROMETHEUS_RESULT_LIMIT =
             DEFAULT_PROMETHEUS_MAX_DATA_POINTS * PROMETHEUS_RESULT_SERIES_HEADROOM
         private const val MIN_PROMETHEUS_MAX_DATA_POINTS = 1
+        private const val DEFAULT_PROMETHEUS_INTERVAL_MS = 60_000L
+        private const val PROMETHEUS_RATE_INTERVAL_MULTIPLIER = 4L
         private const val MILLIS_PER_MINUTE_LONG = 60_000L
         private const val MILLIS_PER_HOUR_LONG = 3_600_000L
         private const val MILLIS_PER_DAY_LONG = 86_400_000L
@@ -198,18 +200,20 @@ class PrometheusHandler : HttpApiHandler() {
                 val fromSec = resolveRelativeTimeSec(timeRange.from, nowSec)
                 val toSec = resolveRelativeTimeSec(timeRange.to, nowSec)
                 val step = resolvePrometheusStep(toSec - fromSec)
+                val effectiveQuery = expandQueryMacros(query, toSec - fromSec)
 
                 httpClient.get("$baseUrl/api/v1/query_range") {
                     applyHttpAuth(credentials)
-                    parameter("query", query)
+                    parameter("query", effectiveQuery)
                     parameter("start", fromSec)
                     parameter("end", toSec)
                     parameter("step", step)
                 }
             } else {
+                val effectiveQuery = expandQueryMacros(query, null)
                 httpClient.get("$baseUrl/api/v1/query") {
                     applyHttpAuth(credentials)
-                    parameter("query", query)
+                    parameter("query", effectiveQuery)
                 }
             }
 
@@ -353,10 +357,29 @@ class PrometheusHandler : HttpApiHandler() {
         rangeSec: Long,
         maxDataPoints: Int = DEFAULT_PROMETHEUS_MAX_DATA_POINTS,
     ): String {
+        return formatPrometheusDuration(resolvePrometheusStepMs(rangeSec, maxDataPoints))
+    }
+
+    internal fun expandQueryMacros(query: String, rangeSec: Long?): String {
+        val stepMs = rangeSec?.let { resolvePrometheusStepMs(it, DEFAULT_PROMETHEUS_MAX_DATA_POINTS) }
+            ?: DEFAULT_PROMETHEUS_INTERVAL_MS
+        val step = formatPrometheusDuration(stepMs)
+        val rateInterval = formatPrometheusDuration(
+            maxOf(stepMs * PROMETHEUS_RATE_INTERVAL_MULTIPLIER, DEFAULT_PROMETHEUS_INTERVAL_MS)
+        )
+        return query
+            .replace("\$__rate_interval", rateInterval)
+            .replace("\$__interval", step)
+    }
+
+    private fun resolvePrometheusStepMs(
+        rangeSec: Long,
+        maxDataPoints: Int,
+    ): Long {
         val resolution = maxDataPoints.coerceAtLeast(MIN_PROMETHEUS_MAX_DATA_POINTS)
         val rangeMs = rangeSec.coerceAtLeast(0) * MILLIS_PER_SECOND_LONG
         val intervalMs = roundAutoStepIntervalMs(rangeMs.toDouble() / resolution)
-        return formatPrometheusDuration(intervalMs)
+        return intervalMs
     }
 
     private fun roundAutoStepIntervalMs(intervalMs: Double): Long {

--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -127,6 +127,7 @@ class DashboardAlertServiceTest {
         every { queryEngine.isTemplateDataSourceMarker(any()) } answers {
             firstArg<String>().startsWith("__")
         }
+        coEvery { workflowService.publishAlertTriggered(any()) } returns true
         transaction {
             exec(
                 """
@@ -1040,6 +1041,72 @@ class DashboardAlertServiceTest {
                             it.metadata["alert.channels.discord"]?.jsonPrimitive?.content == "false"
                     }
                 )
+            }
+        }
+
+    @Test
+    fun `evaluateAlerts does not fan out suppressed workflow episodes to incident providers`() =
+        runBlocking {
+            mockkObject(RedisConfig)
+            redisConfigMocked = true
+            every { RedisConfig.isConnected() } returns false
+            coEvery {
+                retentionPolicyService.getRetentionDaysForProject(any())
+            } returns RECOVERY_RETENTION_DAYS
+            coEvery {
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
+            } returns listOf(mapOf("total" to JsonPrimitive(125.0)))
+            coEvery { workflowService.publishAlertTriggered(any()) } returns false
+
+            val dashboardId = seedDashboard()
+            val widgetId = seedWidget(dashboardId, queryConfigs = "[{\"dataSource\":\"events\"}]")
+            service.createAlert(
+                dashboardId,
+                ORG_ID,
+                CREATED_BY,
+                buildCreateRequest(
+                    widgetId,
+                    AlertRequestOverrides(threshold = 100.0, alertPriority = "P1"),
+                ),
+            )
+
+            callPrivateSuspend("evaluateAlerts")
+
+            coVerify(exactly = 0) {
+                incidentService.fireAlert(any(), publishWorkflow = false)
+            }
+        }
+
+    @Test
+    fun `evaluateAlerts fails open to incident providers when workflow publication fails`() =
+        runBlocking {
+            mockkObject(RedisConfig)
+            redisConfigMocked = true
+            every { RedisConfig.isConnected() } returns false
+            coEvery {
+                retentionPolicyService.getRetentionDaysForProject(any())
+            } returns RECOVERY_RETENTION_DAYS
+            coEvery {
+                queryEngine.executeQuery(any(), any(), any(), any(), any())
+            } returns listOf(mapOf("total" to JsonPrimitive(125.0)))
+            coEvery { workflowService.publishAlertTriggered(any()) } throws RuntimeException("workflow unavailable")
+
+            val dashboardId = seedDashboard()
+            val widgetId = seedWidget(dashboardId, queryConfigs = "[{\"dataSource\":\"events\"}]")
+            service.createAlert(
+                dashboardId,
+                ORG_ID,
+                CREATED_BY,
+                buildCreateRequest(
+                    widgetId,
+                    AlertRequestOverrides(threshold = 100.0, alertPriority = "P1"),
+                ),
+            )
+
+            callPrivateSuspend("evaluateAlerts")
+
+            coVerify(exactly = 1) {
+                incidentService.fireAlert(any(), publishWorkflow = false)
             }
         }
 

--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardHandlersCoverageTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardHandlersCoverageTest.kt
@@ -209,6 +209,33 @@ class DashboardHandlersCoverageTest {
         assertEquals("30d", handler.resolvePrometheusStep(40L * 86_400L, 1))
     }
 
+    @Test
+    fun `expandQueryMacros resolves Grafana interval variables`() {
+        val handler = PrometheusHandler()
+
+        assertEquals(
+            "rate(http_requests_total[1m]) + histogram_quantile(0.95, rate(latency_bucket[10s]))",
+            handler.expandQueryMacros(
+                "rate(http_requests_total[\$__rate_interval]) + " +
+                    "histogram_quantile(0.95, rate(latency_bucket[\$__interval]))",
+                rangeSec = 10_800L,
+            ),
+        )
+    }
+
+    @Test
+    fun `expandQueryMacros uses safe instant defaults`() {
+        val handler = PrometheusHandler()
+
+        assertEquals(
+            "rate(requests_total[4m]) / scalar(up[1m])",
+            handler.expandQueryMacros(
+                "rate(requests_total[\$__rate_interval]) / scalar(up[\$__interval])",
+                rangeSec = null,
+            ),
+        )
+    }
+
     // ──── PrometheusHandler — parsePrometheusResponse ────
 
     @Test

--- a/backend/features/datadog/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
+++ b/backend/features/datadog/src/main/kotlin/com/moneat/apm/services/ApmServiceCatalogService.kt
@@ -709,8 +709,8 @@ object ApmServiceCatalogService {
             SELECT
                 count() as previous_span_count,
                 sum(error) as previous_error_count,
-                toUInt64(quantile(0.95)(duration)) as previous_p95_ns,
-                toUInt64(quantile(0.99)(duration)) as previous_p99_ns,
+                if(count() = 0, 0., quantile(0.95)(duration)) as previous_p95_ns,
+                if(count() = 0, 0., quantile(0.99)(duration)) as previous_p99_ns,
                 countIf(error = 0 AND duration <= $apdexTargetNs) as previous_apdex_satisfied,
                 countIf(
                     error = 0 AND duration > $apdexTargetNs
@@ -949,8 +949,8 @@ object ApmServiceCatalogService {
             """
             SELECT
                 if(trace_id_hex != '', trace_id_hex, toString(trace_id)) as trace_id_out,
-                argMax(resource, duration) as resource,
-                argMax(name, duration) as name,
+                argMax(resource, duration) as resource_out,
+                argMax(name, duration) as name_out,
                 max(status_code) as http_status,
                 toUInt64(max(duration) / $NANOSECONDS_PER_MILLISECOND) as duration_ms,
                 count() as span_count,
@@ -968,8 +968,8 @@ object ApmServiceCatalogService {
             ApmTraceRow(
                 time = row.stringValue("time"),
                 traceId = row.stringValue("trace_id_out"),
-                resource = row.stringValue("resource"),
-                method = methodFromResource(row.stringValue("resource")),
+                resource = row.stringValue("resource_out"),
+                method = methodFromResource(row.stringValue("resource_out")),
                 httpStatus = row.longValue("http_status").toInt().takeIf { it > 0 } ?: 0,
                 durationMs = row.longValue("duration_ms"),
                 spans = row.longValue("span_count").toInt(),

--- a/backend/features/datadog/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
+++ b/backend/features/datadog/src/test/kotlin/com/moneat/apm/services/ApmServiceCatalogServiceTest.kt
@@ -147,8 +147,8 @@ class ApmServiceCatalogServiceTest {
                             "\"first_seen\":\"2026-06-06T02:10:00.000Z\",\"last_seen\":\"2026-06-06T03:00:00.000Z\"}"
                     "GROUP BY trace_id_out" in query ->
                         "{" +
-                            "\"trace_id_out\":\"trace-1\",\"resource\":\"POST /checkout\"," +
-                            "\"name\":\"http.request\",\"http_status\":0,\"duration_ms\":620," +
+                            "\"trace_id_out\":\"trace-1\",\"resource_out\":\"POST /checkout\"," +
+                            "\"name_out\":\"http.request\",\"http_status\":0,\"duration_ms\":620," +
                             "\"span_count\":4,\"time\":\"03:01:00\"}"
                     "GROUP BY service" in query ->
                         "{" +
@@ -322,8 +322,8 @@ class ApmServiceCatalogServiceTest {
                             "\"avg_latency_ms\":180,\"p95_latency_ms\":700}"
                     "GROUP BY trace_id_out" in query ->
                         "{" +
-                            "\"trace_id_out\":\"trace-resource-1\",\"resource\":\"POST /checkout/pay\"," +
-                            "\"name\":\"POST\",\"http_status\":500,\"duration_ms\":1400," +
+                            "\"trace_id_out\":\"trace-resource-1\",\"resource_out\":\"POST /checkout/pay\"," +
+                            "\"name_out\":\"POST\",\"http_status\":500,\"duration_ms\":1400," +
                             "\"span_count\":8,\"time\":\"03:01:00\"}"
                     "previous_span_count" in query ->
                         "{" +
@@ -376,6 +376,9 @@ class ApmServiceCatalogServiceTest {
             assertEquals("2", detail.errors.single().users)
             assertTrue(detail.errors.single().unhandled)
             assertTrue(queries.any { query -> "uniqExactIf(user_key" in query })
+            val traceQuery = queries.single { query -> "GROUP BY trace_id_out" in query }
+            assertTrue("argMax(resource, duration) as resource," !in traceQuery)
+            assertTrue("argMax(resource, duration) as resource_out" in traceQuery)
             assertEquals("trace-resource-1", detail.exemplar.traceId)
             assertEquals(500, detail.exemplar.httpStatus)
             assertTrue(detail.exemplar.rows.any { row -> row.tone == "db" && row.indent != null })

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/McpToolRegistrar.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/McpToolRegistrar.kt
@@ -21,6 +21,7 @@ import com.moneat.mcp.tools.AddStatusPageMonitorTool
 import com.moneat.mcp.tools.AggregateLogsTool
 import com.moneat.mcp.tools.CreateAlertTool
 import com.moneat.mcp.tools.CreateDashboardAlertTool
+import com.moneat.mcp.tools.ListDashboardAlertsTool
 import com.moneat.mcp.tools.CreateDashboardTool
 import com.moneat.mcp.tools.CreateDashboardWidgetTool
 import com.moneat.mcp.tools.CreateDataSourceTool
@@ -343,6 +344,7 @@ object McpToolRegistrar {
         toolRegistry.register(ListComplianceFindingsTool())
 
         // Dashboard alert tools (Phase 1)
+        toolRegistry.register(ListDashboardAlertsTool())
         toolRegistry.register(CreateDashboardAlertTool())
         toolRegistry.register(UpdateDashboardAlertTool())
         toolRegistry.register(DeleteDashboardAlertTool())

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/auth/McpScopes.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/auth/McpScopes.kt
@@ -90,6 +90,7 @@ object McpScopes {
         "list_alerts",
         "list_containers",
         "list_dashboards",
+        "list_dashboard_alerts",
         "list_datasources",
         "list_hosts",
         "list_processes",

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/DashboardCrudTool.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/DashboardCrudTool.kt
@@ -77,6 +77,30 @@ private fun dashboardAlertPriority(input: String?): String? {
 private fun JsonObject.requiredStringArg(name: String): String? =
     this[name]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
 
+class ListDashboardAlertsTool : McpTool {
+    override val name = "list_dashboard_alerts"
+    override val description = "List alert configurations for a dashboard"
+    override val inputSchema = InputSchema(
+        properties = JsonObject(
+            mapOf(DASHBOARD_ID_ARG to schemaString(DASHBOARD_RESOURCE_ID_DESCRIPTION))
+        ),
+        required = listOf(DASHBOARD_ID_ARG)
+    )
+
+    override suspend fun execute(
+        args: JsonObject,
+        context: McpContext
+    ): ToolCallResult {
+        val dashboardResourceId = args.requiredStringArg(DASHBOARD_ID_ARG)
+            ?: return errorResult("$DASHBOARD_ID_ARG is required")
+        val dashboardId = dashCrudService.resolveDashboardId(
+            dashboardResourceId,
+            context.organizationId.toLong()
+        ) ?: return errorResult(ERR_DASHBOARD_NOT_FOUND)
+        return jsonResult(dashAlertService.listAlerts(dashboardId, context.organizationId.toLong()))
+    }
+}
+
 class UpdateDashboardTool : McpTool {
     override val name = "update_dashboard"
     override val description =

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeCrudTool.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeCrudTool.kt
@@ -31,7 +31,9 @@ import java.util.UUID
 
 private val uptimeCrudService = UptimeService(BillingQuotaService(), UptimeMonitorRepositoryImpl())
 
-class UpdateUptimeMonitorTool : McpTool {
+class UpdateUptimeMonitorTool(
+    private val service: UptimeService = uptimeCrudService,
+) : McpTool {
     override val name = "update_uptime_monitor"
     override val description = "Update an uptime monitor"
     override val readOnly = false
@@ -103,7 +105,7 @@ class UpdateUptimeMonitorTool : McpTool {
             retryIntervalSeconds = retryIntervalSeconds,
             active = active,
         )
-        val monitor = uptimeCrudService.updateMonitor(
+        val monitor = service.updateMonitor(
             uuid, context.organizationId, request
         ) ?: return errorResult("Monitor not found: $monitorId")
         return jsonResult(monitor)

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeCrudTool.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeCrudTool.kt
@@ -44,6 +44,12 @@ class UpdateUptimeMonitorTool : McpTool {
                 "interval_seconds" to schemaInteger(
                     "Check interval in seconds"
                 ),
+                "retries" to schemaInteger(
+                    "Retries after a failed check"
+                ),
+                "retry_interval_seconds" to schemaInteger(
+                    "Seconds between failed-check retries"
+                ),
                 "active" to schemaBoolean("Enable/disable")
             )
         ),
@@ -77,11 +83,25 @@ class UpdateUptimeMonitorTool : McpTool {
         } else {
             null
         }
+        val retries = if (args.containsKey("retries")) {
+            args["retries"]?.jsonPrimitive?.intOrNull
+                ?: return errorResult("retries must be a valid integer")
+        } else {
+            null
+        }
+        val retryIntervalSeconds = if (args.containsKey("retry_interval_seconds")) {
+            args["retry_interval_seconds"]?.jsonPrimitive?.intOrNull
+                ?: return errorResult("retry_interval_seconds must be a valid integer")
+        } else {
+            null
+        }
         val request = UpdateUptimeMonitorRequest(
             name = args["name"]?.jsonPrimitive?.content,
             url = args["url"]?.jsonPrimitive?.content,
             intervalSeconds = intervalSeconds,
-            active = active
+            retries = retries,
+            retryIntervalSeconds = retryIntervalSeconds,
+            active = active,
         )
         val monitor = uptimeCrudService.updateMonitor(
             uuid, context.organizationId, request

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeTool.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeTool.kt
@@ -33,6 +33,8 @@ private val uptimeService = UptimeService(BillingQuotaService(), UptimeMonitorRe
 private const val DEFAULT_HEARTBEAT_HOURS = 24
 private const val MAX_HEARTBEAT_HOURS = 168
 private const val DEFAULT_INTERVAL = 60
+private const val DEFAULT_RETRIES = 1
+private const val DEFAULT_RETRY_INTERVAL_SECONDS = 60
 private const val MILLIS_PER_HOUR = 3_600_000L
 
 class ListUptimeMonitorsTool : McpTool {
@@ -103,7 +105,13 @@ class CreateUptimeMonitorTool : McpTool {
                 ),
                 "interval_seconds" to schemaNumber(
                     "Check interval in seconds (default 60)"
-                )
+                ),
+                "retries" to schemaNumber(
+                    "Retries after a failed check (default 1)"
+                ),
+                "retry_interval_seconds" to schemaNumber(
+                    "Seconds between failed-check retries (default 60)"
+                ),
             )
         ),
         required = listOf("name", "url", "type")
@@ -121,13 +129,18 @@ class CreateUptimeMonitorTool : McpTool {
             ?: return errorResult("type is required")
         val interval = args["interval_seconds"]?.jsonPrimitive?.intOrNull
             ?: DEFAULT_INTERVAL
+        val retries = args["retries"]?.jsonPrimitive?.intOrNull ?: DEFAULT_RETRIES
+        val retryInterval = args["retry_interval_seconds"]?.jsonPrimitive?.intOrNull
+            ?: DEFAULT_RETRY_INTERVAL_SECONDS
 
         val request =
             com.moneat.uptime.models.CreateUptimeMonitorRequest(
                 name = name,
                 url = url,
                 type = type,
-                intervalSeconds = interval
+                intervalSeconds = interval,
+                retries = retries,
+                retryIntervalSeconds = retryInterval,
             )
         val monitor = uptimeService.createMonitor(
             context.organizationId,

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeTool.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeTool.kt
@@ -90,7 +90,9 @@ class GetMonitorHeartbeatsTool : McpTool {
     }
 }
 
-class CreateUptimeMonitorTool : McpTool {
+class CreateUptimeMonitorTool(
+    private val service: UptimeService = uptimeService,
+) : McpTool {
     override val name = "create_uptime_monitor"
     override val description = "Create a new uptime monitor"
     override val readOnly = false
@@ -142,7 +144,7 @@ class CreateUptimeMonitorTool : McpTool {
                 retries = retries,
                 retryIntervalSeconds = retryInterval,
             )
-        val monitor = uptimeService.createMonitor(
+        val monitor = service.createMonitor(
             context.organizationId,
             request
         )

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeTool.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/UptimeTool.kt
@@ -108,10 +108,10 @@ class CreateUptimeMonitorTool(
                 "interval_seconds" to schemaNumber(
                     "Check interval in seconds (default 60)"
                 ),
-                "retries" to schemaNumber(
+                "retries" to schemaInteger(
                     "Retries after a failed check (default 1)"
                 ),
-                "retry_interval_seconds" to schemaNumber(
+                "retry_interval_seconds" to schemaInteger(
                     "Seconds between failed-check retries (default 60)"
                 ),
             )
@@ -131,9 +131,18 @@ class CreateUptimeMonitorTool(
             ?: return errorResult("type is required")
         val interval = args["interval_seconds"]?.jsonPrimitive?.intOrNull
             ?: DEFAULT_INTERVAL
-        val retries = args["retries"]?.jsonPrimitive?.intOrNull ?: DEFAULT_RETRIES
-        val retryInterval = args["retry_interval_seconds"]?.jsonPrimitive?.intOrNull
-            ?: DEFAULT_RETRY_INTERVAL_SECONDS
+        val retries = if (args.containsKey("retries")) {
+            args["retries"]?.jsonPrimitive?.intOrNull
+                ?: return errorResult("retries must be a valid integer")
+        } else {
+            DEFAULT_RETRIES
+        }
+        val retryInterval = if (args.containsKey("retry_interval_seconds")) {
+            args["retry_interval_seconds"]?.jsonPrimitive?.intOrNull
+                ?: return errorResult("retry_interval_seconds must be a valid integer")
+        } else {
+            DEFAULT_RETRY_INTERVAL_SECONDS
+        }
 
         val request =
             com.moneat.uptime.models.CreateUptimeMonitorRequest(

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/protocol/McpToolRegistryTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/protocol/McpToolRegistryTest.kt
@@ -53,7 +53,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-private const val EXPECTED_CORE_MCP_TOOL_COUNT = 161
+private const val EXPECTED_CORE_MCP_TOOL_COUNT = 162
 
 class McpToolRegistryTest {
 

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
@@ -481,6 +481,11 @@ class DashboardCrudToolTest {
                 "Dashboard not found",
             ),
             ToolCase(
+                ListDashboardAlertsTool(),
+                JsonObject(mapOf("dashboard_id" to JsonPrimitive(MISSING_DASHBOARD_RESOURCE_ID))),
+                "Dashboard not found",
+            ),
+            ToolCase(
                 DeleteDashboardAlertTool(),
                 JsonObject(
                     mapOf(

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
@@ -315,6 +315,34 @@ class DashboardCrudToolTest {
     }
 
     @Test
+    fun `list dashboard alerts returns alert configurations`() = runBlocking {
+        val dashboardId = seedDashboard()
+        val widgetId = seedWidget(dashboardId)
+        CreateDashboardAlertTool().execute(
+            JsonObject(
+                mapOf(
+                    "dashboard_id" to JsonPrimitive(dashboardResourceId(dashboardId)),
+                    "widget_id" to JsonPrimitive(widgetResourceId(widgetId)),
+                    "name" to JsonPrimitive("CPU high"),
+                    "condition" to JsonPrimitive("gt"),
+                    "threshold" to JsonPrimitive(0.85),
+                )
+            ),
+            context
+        )
+
+        val result = ListDashboardAlertsTool().execute(
+            JsonObject(mapOf("dashboard_id" to JsonPrimitive(dashboardResourceId(dashboardId)))),
+            context
+        )
+
+        assertFalse(result.isError, result.content.first().text.orEmpty())
+        val alerts = json.parseToJsonElement(result.content.first().text.orEmpty()).jsonArray
+        assertEquals(1, alerts.size)
+        assertEquals("CPU high", alerts.single().jsonObject["name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `update dashboard alert can update duration priority and gte condition`() = runBlocking {
         val dashboardId = seedDashboard()
         val widgetId = seedWidget(dashboardId)
@@ -392,6 +420,11 @@ class DashboardCrudToolTest {
                         "threshold" to JsonPrimitive(0.85),
                     )
                 ),
+                "dashboard_id is required",
+            ),
+            ToolCase(
+                ListDashboardAlertsTool(),
+                JsonObject(emptyMap()),
                 "dashboard_id is required",
             ),
             ToolCase(

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/DashboardCrudToolTest.kt
@@ -343,6 +343,17 @@ class DashboardCrudToolTest {
     }
 
     @Test
+    fun `list dashboard alerts reports missing dashboard`() = runBlocking {
+        val result = ListDashboardAlertsTool().execute(
+            JsonObject(mapOf("dashboard_id" to JsonPrimitive(MISSING_DASHBOARD_RESOURCE_ID))),
+            context,
+        )
+
+        assertTrue(result.isError)
+        assertEquals("Dashboard not found", result.content.first().text)
+    }
+
+    @Test
     fun `update dashboard alert can update duration priority and gte condition`() = runBlocking {
         val dashboardId = seedDashboard()
         val widgetId = seedWidget(dashboardId)

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -602,6 +602,23 @@ class McpToolValidationTest {
             ),
             case("create_uptime_name", CreateUptimeMonitorTool(), obj(), "name is required"),
             case("create_uptime_url", CreateUptimeMonitorTool(), obj("name" to "API"), "url is required"),
+            case(
+                "create_uptime_retries",
+                CreateUptimeMonitorTool(),
+                obj("name" to "API", "url" to "https://example.com", "type" to "http", "retries" to "bad"),
+                "retries must be a valid integer",
+            ),
+            case(
+                "create_uptime_retry_interval",
+                CreateUptimeMonitorTool(),
+                obj(
+                    "name" to "API",
+                    "url" to "https://example.com",
+                    "type" to "http",
+                    "retry_interval_seconds" to "bad",
+                ),
+                "retry_interval_seconds must be a valid integer",
+            ),
             case("get_synthetic_id", GetSyntheticTestTool(), obj(), "synthetic_test_id is required"),
             case("update_synthetic_id", UpdateSyntheticTestTool(), obj(), "synthetic_test_id is required"),
             case("delete_synthetic_id", DeleteSyntheticTestTool(), obj(), "synthetic_test_id is required"),

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/McpToolValidationTest.kt
@@ -565,6 +565,18 @@ class McpToolValidationTest {
                 "interval_seconds must be a valid integer",
             ),
             case(
+                "update_uptime_retries",
+                UpdateUptimeMonitorTool(),
+                obj("monitor_id" to uuid, "retries" to "bad"),
+                "retries must be a valid integer",
+            ),
+            case(
+                "update_uptime_retry_interval",
+                UpdateUptimeMonitorTool(),
+                obj("monitor_id" to uuid, "retry_interval_seconds" to "bad"),
+                "retry_interval_seconds must be a valid integer",
+            ),
+            case(
                 "delete_uptime_uuid",
                 DeleteUptimeMonitorTool(),
                 obj("monitor_id" to "bad"),

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/UptimeToolTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/UptimeToolTest.kt
@@ -1,0 +1,111 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.mcp.tools
+
+import com.moneat.mcp.models.McpContext
+import com.moneat.uptime.models.CreateUptimeMonitorRequest
+import com.moneat.uptime.models.UpdateUptimeMonitorRequest
+import com.moneat.uptime.models.UptimeMonitorResponse
+import com.moneat.uptime.services.UptimeService
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UptimeToolTest {
+    private val context = McpContext(
+        organizationId = 42,
+        userId = 7,
+        tokenId = 3,
+        scopes = setOf("project:write"),
+        sessionId = "uptime-tool-test",
+    )
+
+    @Test
+    fun `create uptime monitor applies retry defaults`() = runBlocking {
+        val service = mockk<UptimeService>()
+        val response = sampleResponse()
+        every { service.createMonitor(42, any<CreateUptimeMonitorRequest>()) } answers {
+            val request = secondArg<CreateUptimeMonitorRequest>()
+            assertEquals(1, request.retries)
+            assertEquals(60, request.retryIntervalSeconds)
+            response
+        }
+
+        val result = CreateUptimeMonitorTool(service).execute(
+            JsonObject(
+                mapOf(
+                    "name" to JsonPrimitive("Checkout API"),
+                    "url" to JsonPrimitive("https://example.com/health"),
+                    "type" to JsonPrimitive("http"),
+                )
+            ),
+            context,
+        )
+
+        assertFalse(result.isError, result.content.first().text.orEmpty())
+        assertTrue(result.content.first().text?.contains(response.id) == true)
+    }
+
+    @Test
+    fun `update uptime monitor accepts omitted and explicit retry settings`() = runBlocking {
+        val service = mockk<UptimeService>()
+        val response = sampleResponse()
+        val monitorId = UUID.fromString(response.id)
+        every { service.updateMonitor(monitorId, 42, any<UpdateUptimeMonitorRequest>()) } answers {
+            val request = thirdArg<UpdateUptimeMonitorRequest>()
+            assertEquals(2, request.retries)
+            assertEquals(120, request.retryIntervalSeconds)
+            response
+        }
+
+        val result = UpdateUptimeMonitorTool(service).execute(
+            JsonObject(
+                mapOf(
+                    "monitor_id" to JsonPrimitive(response.id),
+                    "retries" to JsonPrimitive(2),
+                    "retry_interval_seconds" to JsonPrimitive(120),
+                )
+            ),
+            context,
+        )
+
+        assertFalse(result.isError, result.content.first().text.orEmpty())
+    }
+
+    private fun sampleResponse(): UptimeMonitorResponse = UptimeMonitorResponse(
+        id = "11111111-1111-1111-1111-111111111111",
+        organizationId = context.organizationId.toString(),
+        name = "Checkout API",
+        type = "http",
+        active = true,
+        url = "https://example.com/health",
+        intervalSeconds = 60,
+        timeoutSeconds = 30,
+        retries = 1,
+        retryIntervalSeconds = 60,
+        status = "pending",
+        createdAt = 1L,
+        updatedAt = 1L,
+    )
+}

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/UptimeToolTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/UptimeToolTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class UptimeToolTest {
@@ -72,10 +73,9 @@ class UptimeToolTest {
         val service = mockk<UptimeService>()
         val response = sampleResponse()
         val monitorId = UUID.fromString(response.id)
+        val requests = mutableListOf<UpdateUptimeMonitorRequest>()
         every { service.updateMonitor(monitorId, 42, any<UpdateUptimeMonitorRequest>()) } answers {
-            val request = thirdArg<UpdateUptimeMonitorRequest>()
-            assertEquals(2, request.retries)
-            assertEquals(120, request.retryIntervalSeconds)
+            requests += thirdArg<UpdateUptimeMonitorRequest>()
             response
         }
 
@@ -91,6 +91,60 @@ class UptimeToolTest {
         )
 
         assertFalse(result.isError, result.content.first().text.orEmpty())
+        val omittedResult = UpdateUptimeMonitorTool(service).execute(
+            JsonObject(mapOf("monitor_id" to JsonPrimitive(response.id))),
+            context,
+        )
+
+        assertFalse(omittedResult.isError, omittedResult.content.first().text.orEmpty())
+        assertEquals(2, requests[0].retries)
+        assertEquals(120, requests[0].retryIntervalSeconds)
+        assertNull(requests[1].retries)
+        assertNull(requests[1].retryIntervalSeconds)
+    }
+
+    @Test
+    fun `create uptime monitor forwards explicit retry settings`() = runBlocking {
+        val service = mockk<UptimeService>()
+        val response = sampleResponse()
+        every { service.createMonitor(42, any<CreateUptimeMonitorRequest>()) } answers {
+            val request = secondArg<CreateUptimeMonitorRequest>()
+            assertEquals(3, request.retries)
+            assertEquals(90, request.retryIntervalSeconds)
+            response
+        }
+
+        val result = CreateUptimeMonitorTool(service).execute(
+            JsonObject(
+                mapOf(
+                    "name" to JsonPrimitive("Checkout API"),
+                    "url" to JsonPrimitive("https://example.com/health"),
+                    "type" to JsonPrimitive("http"),
+                    "retries" to JsonPrimitive(3),
+                    "retry_interval_seconds" to JsonPrimitive(90),
+                )
+            ),
+            context,
+        )
+
+        assertFalse(result.isError, result.content.first().text.orEmpty())
+    }
+
+    @Test
+    fun `update uptime monitor reports missing monitor`() = runBlocking {
+        val service = mockk<UptimeService>()
+        val response = sampleResponse()
+        every {
+            service.updateMonitor(UUID.fromString(response.id), 42, any<UpdateUptimeMonitorRequest>())
+        } returns null
+
+        val result = UpdateUptimeMonitorTool(service).execute(
+            JsonObject(mapOf("monitor_id" to JsonPrimitive(response.id))),
+            context,
+        )
+
+        assertTrue(result.isError)
+        assertTrue(result.content.first().text?.contains("Monitor not found") == true)
     }
 
     private fun sampleResponse(): UptimeMonitorResponse = UptimeMonitorResponse(

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -367,6 +367,9 @@ class OperationalMetricsTest {
         every { RedisConfig.sync() } returns redis
         every { redis.xpending(primaryKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
+        every { redis.xinfoGroups(primaryKey) } returns listOf(
+            listOf("name", consumerGroup, "last-delivered-id", "0-0", "lag", 0L)
+        )
         every { redis.xrange(any(), any<Range<String>>(), any()) } returns emptyList()
 
         OperationalMetrics.registerWorkerStream("Log", primaryKey, "primary", consumerGroup)
@@ -377,6 +380,14 @@ class OperationalMetricsTest {
         assertContains(rendered, "stream_key=\"$primaryKey\"")
         assertContains(rendered, "stream_key=\"$dlqKey\"")
         assertContains(rendered, "consumer_group=\"unknown\"")
+
+        val primaryAge = metricLine(
+            rendered,
+            "moneat_worker_stream_oldest_message_age_seconds",
+            "stream_key=\"$primaryKey\"",
+            "stream_type=\"primary\"",
+        )
+        assertTrue(primaryAge.endsWith(" 0.0"), primaryAge)
     }
 
     @Test

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -315,6 +315,95 @@ class OperationalMetricsTest {
     }
 
     @Test
+    fun `reports zero oldest age when a consumer group has no backlog`() {
+        val streamKey = "moneat:logs:queue:stream"
+        val consumerGroup = "moneat:logs:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } returns
+            PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
+        every { redis.xinfoGroups(streamKey) } returns listOf(
+            listOf(
+                "name",
+                consumerGroup,
+                "pending",
+                0L,
+                "last-delivered-id",
+                "${System.currentTimeMillis() - 86_400_000L}-0",
+                "lag",
+                0L,
+            )
+        )
+
+        OperationalMetrics.registerWorkerStream(
+            workerName = "Log",
+            streamKey = streamKey,
+            streamType = "primary",
+            consumerGroup = consumerGroup,
+        )
+
+        val oldestLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_stream_oldest_message_age_seconds",
+            "stream_key=\"$streamKey\"",
+            "stream_type=\"primary\"",
+        )
+
+        assertTrue(oldestLine.endsWith(" 0.0"), oldestLine)
+    }
+
+    @Test
+    fun `registers grouped and ungrouped stream age gauges with stable tags`() {
+        val primaryKey = "moneat:logs:queue:stream"
+        val dlqKey = "moneat:logs:dlq:stream"
+        val consumerGroup = "moneat:logs:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(primaryKey, consumerGroup) } returns
+            PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
+        every { redis.xrange(any(), any<Range<String>>(), any()) } returns emptyList()
+
+        OperationalMetrics.registerWorkerStream("Log", primaryKey, "primary", consumerGroup)
+        OperationalMetrics.registerWorkerStream("Log", dlqKey, "dlq")
+
+        val rendered = OperationalMetrics.scrape()
+
+        assertContains(rendered, "stream_key=\"$primaryKey\"")
+        assertContains(rendered, "stream_key=\"$dlqKey\"")
+        assertContains(rendered, "consumer_group=\"unknown\"")
+    }
+
+    @Test
+    fun `reports zero oldest age when consumer group is missing`() {
+        val streamKey = "moneat:logs:queue:stream"
+        val consumerGroup = "moneat:logs:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } throws
+            IllegalStateException("NOGROUP No such key '$streamKey' or consumer group '$consumerGroup'")
+
+        OperationalMetrics.registerWorkerStream("Log", streamKey, "primary", consumerGroup)
+
+        val oldestLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_stream_oldest_message_age_seconds",
+            "stream_key=\"$streamKey\"",
+            "stream_type=\"primary\"",
+        )
+
+        assertTrue(oldestLine.endsWith(" 0.0"), oldestLine)
+    }
+
+    @Test
     fun `renders datadog metric ingest health metrics`() {
         // ──── Arrange ────
         OperationalMetrics.registerWorkerQueues("DD metric", "moneat:metrics:queue:stream", "moneat:metrics:dlq:stream")

--- a/backend/features/uptime/src/test/kotlin/com/moneat/services/UptimeServiceTest.kt
+++ b/backend/features/uptime/src/test/kotlin/com/moneat/services/UptimeServiceTest.kt
@@ -309,6 +309,35 @@ class UptimeServiceTest {
         }
 
     @Test
+    fun `createMonitor rejects unsafe retry settings`() =
+        runBlocking {
+            val orgId = seedOrg()
+
+            assertFailsWith<IllegalArgumentException> {
+                service.createMonitor(
+                    orgId,
+                    CreateUptimeMonitorRequest(
+                        name = "Too many retries",
+                        type = "http",
+                        url = EXAMPLE_COM_URL,
+                        retries = 11,
+                    )
+                )
+            }
+            assertFailsWith<IllegalArgumentException> {
+                service.createMonitor(
+                    orgId,
+                    CreateUptimeMonitorRequest(
+                        name = "Tight retry loop",
+                        type = "http",
+                        url = EXAMPLE_COM_URL,
+                        retryIntervalSeconds = 0,
+                    )
+                )
+            }
+        }
+
+    @Test
     fun `updateMonitor returns updated monitor with new name`() =
         runBlocking {
             val orgId = seedOrg()

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -738,8 +738,8 @@ class WorkflowServiceTest {
                 )
             publish(workflow.id)
 
-            service.publishAlertTriggered(alertEvent())
-            service.publishAlertTriggered(alertEvent())
+            assertTrue(service.publishAlertTriggered(alertEvent()))
+            assertFalse(service.publishAlertTriggered(alertEvent()))
             service.publishTrigger(
                 com.moneat.workflows.models.WorkflowTriggerEvent(
                     triggerName = "missing.trigger",
@@ -1496,7 +1496,7 @@ class WorkflowServiceTest {
                 )
             publish(workflow.id)
 
-            service.publishAlertTriggered(alertEvent())
+            assertTrue(service.publishAlertTriggered(alertEvent()))
 
             val run = service.listRuns(orgId, workflow.id).single()
             assertEquals("failed", run.status)

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -941,12 +941,13 @@ class MonitorAlertService(
                 moneatUrl = dashboardUrl
             )
 
-        suspendRunCatching {
+        val shouldNotifyIncidentProvider = suspendRunCatching {
             workflowService.publishAlertTriggered(alertLifecycleEvent)
         }.getOrElse { e ->
             logger.error(e) { "Failed to publish host alert workflow" }
+            true
         }
-        if (alertPriority != null) {
+        if (alertPriority != null && shouldNotifyIncidentProvider) {
             suspendRunCatching {
                 incidentService.fireAlert(alertLifecycleEvent, publishWorkflow = false)
             }.getOrElse { e ->

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -20,6 +20,7 @@ import com.moneat.config.RedisConfig
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.lettuce.core.Limit
 import io.lettuce.core.Range
+import io.lettuce.core.api.sync.RedisCommands
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Gauge
@@ -138,14 +139,15 @@ object OperationalMetrics {
         val baseKey = "$normalizedWorkerName|$streamKey|${consumerGroup.orEmpty()}|$normalizedStreamType"
         registeredStreamMeters.computeIfAbsent(baseKey) {
             Gauge.builder(WORKER_STREAM_OLDEST_MESSAGE_AGE_SECONDS, streamKey) { key ->
-                readStreamOldestMessageAgeSeconds(key)
+                readStreamOldestMessageAgeSeconds(key, consumerGroup)
             }
-                .description("Age in seconds of the oldest Redis stream entry for registered ingestion streams.")
+                .description("Age in seconds of the oldest pending or unconsumed Redis stream message.")
                 .tags(
                     tags(
                         "worker" to normalizedWorkerName,
                         "stream_key" to streamKey,
-                        "stream_type" to normalizedStreamType
+                        "stream_type" to normalizedStreamType,
+                        "consumer_group" to consumerGroup.orEmpty()
                     )
                 )
                 .register(registry)
@@ -682,15 +684,46 @@ object OperationalMetrics {
             .getOrElse { Double.NaN }
     }
 
-    private fun readStreamOldestMessageAgeSeconds(streamKey: String): Double {
+    private fun readStreamOldestMessageAgeSeconds(streamKey: String, consumerGroup: String?): Double {
         if (!RedisConfig.isConnected()) return Double.NaN
         return runCatching {
-            val first = RedisConfig.sync()
-                .xrange(streamKey, Range.create("-", "+"), Limit.from(1))
-                .firstOrNull()
+            val redis = RedisConfig.sync()
+            if (consumerGroup == null) {
+                return readOldestStreamEntryAgeSeconds(redis, streamKey)
+            }
+
+            val pending = redis.xpending(streamKey, consumerGroup)
+            if (pending.count > 0) {
+                return streamIdAgeSeconds(pending.messageIds.lower.value)
+            }
+
+            val group = redis.xinfoGroups(streamKey)
+                .asSequence()
+                .mapNotNull(::parseStreamGroupInfo)
+                .firstOrNull { info -> info.name == consumerGroup }
+            if (group == null) return 0.0
+            val lag = group.lag ?: return readOldestStreamEntryAgeSeconds(redis, streamKey)
+            if (lag <= 0 || group.lastDeliveredId == null) return 0.0
+
+            val firstUnconsumed = redis
+                .xrange(streamKey, Range.create(group.lastDeliveredId, "+"), Limit.from(2))
+                .firstOrNull { message -> message.id != group.lastDeliveredId }
                 ?: return 0.0
-            streamIdAgeSeconds(first.id)
-        }.getOrElse { Double.NaN }
+            streamIdAgeSeconds(firstUnconsumed.id)
+        }.getOrElse { error ->
+            if (error.isMissingRedisStreamError()) 0.0 else Double.NaN
+        }
+    }
+
+    private fun readOldestStreamEntryAgeSeconds(
+        redis: RedisCommands<String, String>,
+        streamKey: String
+    ): Double {
+        val first = redis
+            .xrange(streamKey, Range.create("-", "+"), Limit.from(1))
+            .firstOrNull()
+            ?: return 0.0
+        return streamIdAgeSeconds(first.id)
     }
 
     private fun streamIdAgeSeconds(id: String): Double {
@@ -708,26 +741,28 @@ object OperationalMetrics {
 
     private fun parseStreamGroupListInfo(group: List<*>): StreamGroupInfo? {
         var name: String? = null
-        var lag = 0L
+        var lag: Long? = null
+        var lastDeliveredId: String? = null
         for (index in 0 until group.lastIndex step XINFO_GROUP_FIELD_STEP) {
             when (group[index]?.toString()) {
                 "name" -> name = group[index + XINFO_GROUP_VALUE_OFFSET]?.toString()
-                "lag" -> lag = group[index + XINFO_GROUP_VALUE_OFFSET].toLongOrZero()
+                "lag" -> lag = group[index + XINFO_GROUP_VALUE_OFFSET].toLongOrNullValue()
+                "last-delivered-id" -> lastDeliveredId = group[index + XINFO_GROUP_VALUE_OFFSET]?.toString()
             }
         }
-        return name?.let { StreamGroupInfo(it, lag) }
+        return name?.let { StreamGroupInfo(it, lag, lastDeliveredId) }
     }
 
     private fun parseStreamGroupMapInfo(group: Map<*, *>): StreamGroupInfo? {
         val name = group["name"]?.toString() ?: return null
-        return StreamGroupInfo(name, group["lag"].toLongOrZero())
+        return StreamGroupInfo(name, group["lag"].toLongOrNullValue(), group["last-delivered-id"]?.toString())
     }
 
-    private fun Any?.toLongOrZero(): Long =
+    private fun Any?.toLongOrNullValue(): Long? =
         when (this) {
             is Number -> toLong()
-            is String -> toLongOrNull() ?: 0L
-            else -> toString().toLongOrNull() ?: 0L
+            is String -> toLongOrNull()
+            else -> toString().toLongOrNull()
         }
 
     private fun tags(vararg pairs: Pair<String, String>): Iterable<Tag> =
@@ -740,6 +775,12 @@ object OperationalMetrics {
             }
 
     private fun String.normalizedLabelValue(): String = trim().ifBlank { "unknown" }
+
+    private fun Throwable.isMissingRedisStreamError(): Boolean =
+        message?.let {
+            it.contains("NOGROUP", ignoreCase = true) ||
+                it.contains("no such key", ignoreCase = true)
+        } == true || cause?.isMissingRedisStreamError() == true
 
     private fun Throwable.metricExceptionName(): String =
         this::class.simpleName ?: javaClass.simpleName.ifBlank { "Throwable" }
@@ -762,7 +803,8 @@ object OperationalMetrics {
 
     private data class StreamGroupInfo(
         val name: String,
-        val lag: Long,
+        val lag: Long?,
+        val lastDeliveredId: String? = null,
     )
 
     private fun newRegistry(): PrometheusMeterRegistry =

--- a/backend/src/main/kotlin/com/moneat/uptime/models/UptimeModels.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/models/UptimeModels.kt
@@ -75,7 +75,7 @@ object UptimeMonitors : Table("uptime_monitors") {
     // Check config
     val intervalSeconds = integer("interval_seconds").default(60)
     val timeoutSeconds = integer("timeout_seconds").default(30)
-    val retries = integer("retries").default(0)
+    val retries = integer("retries").default(1)
     val retryIntervalSeconds = integer("retry_interval_seconds").default(60)
 
     // Status tracking
@@ -146,7 +146,7 @@ data class CreateUptimeMonitorRequest(
     // Check config
     val intervalSeconds: Int = 60,
     val timeoutSeconds: Int = 30,
-    val retries: Int = 0,
+    val retries: Int = 1,
     val retryIntervalSeconds: Int = 60,
     val alertPriority: String? = null,
     @SerialName("incidentSeverity") val legacyIncidentSeverity: String? = null

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeService.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeService.kt
@@ -62,6 +62,23 @@ class UptimeService(
         private const val HOURS_PER_WEEK = 168
         private const val HOURS_PER_MONTH = 720
         private const val TOKEN_BYTES_SIZE = 32
+        private const val MIN_RETRIES = 0
+        private const val MAX_RETRIES = 10
+        private const val MIN_RETRY_INTERVAL_SECONDS = 1
+        private const val MAX_RETRY_INTERVAL_SECONDS = 3600
+    }
+
+    private fun validateRetrySettings(retries: Int?, retryIntervalSeconds: Int?) {
+        require(retries == null || retries in MIN_RETRIES..MAX_RETRIES) {
+            "Retries must be between $MIN_RETRIES and $MAX_RETRIES"
+        }
+        require(
+            retryIntervalSeconds == null ||
+                retryIntervalSeconds in MIN_RETRY_INTERVAL_SECONDS..MAX_RETRY_INTERVAL_SECONDS
+        ) {
+            "Retry interval must be between $MIN_RETRY_INTERVAL_SECONDS and " +
+                "$MAX_RETRY_INTERVAL_SECONDS seconds"
+        }
     }
 
     /**
@@ -71,6 +88,7 @@ class UptimeService(
         organizationId: Int,
         request: CreateUptimeMonitorRequest
     ): UptimeMonitorResponse {
+        validateRetrySettings(request.retries, request.retryIntervalSeconds)
         // Check quota
         checkUptimeMonitorQuota(organizationId)
 
@@ -95,6 +113,7 @@ class UptimeService(
         organizationId: Int,
         request: UpdateUptimeMonitorRequest
     ): UptimeMonitorResponse? {
+        validateRetrySettings(request.retries, request.retryIntervalSeconds)
         val updated = uptimeMonitorRepository.update(monitorId, organizationId, request)
 
         return if (updated) getMonitor(monitorId, organizationId) else null

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -831,20 +831,36 @@ class WorkflowService(
             ?.let { resolvedWorkflowId -> verifyWebhookSignature(resolvedWorkflowId, payload, signatureHeader) }
             ?: false
 
-    suspend fun publishAlertTriggered(event: AlertLifecycleEvent) {
+    /**
+     * Publish an alert lifecycle event when the episode is due for notification.
+     *
+     * The return value lets callers that fan out to external incident providers
+     * share the same episode/reminder gate instead of sending a provider alert
+     * for every evaluator pass.
+     */
+    suspend fun publishAlertTriggered(event: AlertLifecycleEvent): Boolean {
         if (event.status == AlertStatus.RESOLVED) {
-            publishResolvedAlertEvent(event)
-            return
+            return publishResolvedAlertEvent(event)
         }
-        val episode = alertEpisodeService.recordFiring(event) ?: return
-        if (!episode.shouldPublish) return
-        publishAlertWorkflowTriggers(event, episode)
+        val episode = alertEpisodeService.recordFiring(event) ?: return true
+        if (!episode.shouldPublish) return false
+        suspendRunCatching {
+            publishAlertWorkflowTriggers(event, episode)
+        }.onFailure { e ->
+            logger.error(e) { "Failed to publish alert workflow triggers" }
+        }
+        return true
     }
 
-    private suspend fun publishResolvedAlertEvent(event: AlertLifecycleEvent) {
-        val episode = alertEpisodeService.recordResolved(event) ?: return
-        if (!episode.shouldPublish) return
-        publishAlertWorkflowTriggers(event, episode)
+    private suspend fun publishResolvedAlertEvent(event: AlertLifecycleEvent): Boolean {
+        val episode = alertEpisodeService.recordResolved(event) ?: return true
+        if (!episode.shouldPublish) return false
+        suspendRunCatching {
+            publishAlertWorkflowTriggers(event, episode)
+        }.onFailure { e ->
+            logger.error(e) { "Failed to publish resolved alert workflow triggers" }
+        }
+        return true
     }
 
     private suspend fun publishAlertWorkflowTriggers(

--- a/backend/src/main/resources/db/migration/V151__default_uptime_monitor_retry.sql
+++ b/backend/src/main/resources/db/migration/V151__default_uptime_monitor_retry.sql
@@ -1,0 +1,2 @@
+ALTER TABLE uptime_monitors
+    ALTER COLUMN retries SET DEFAULT 1;

--- a/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
@@ -1,0 +1,196 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.monitoring
+
+import com.moneat.config.RedisConfig
+import io.lettuce.core.Range
+import io.lettuce.core.StreamMessage
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.models.stream.PendingMessages
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class OperationalMetricsAlertCoverageTest {
+    @BeforeTest
+    fun resetBefore() {
+        OperationalMetrics.resetForTest()
+    }
+
+    @AfterTest
+    fun resetAfter() {
+        unmockkObject(RedisConfig)
+        OperationalMetrics.resetForTest()
+    }
+
+    @Test
+    fun `reports age of first unconsumed message after consumer group cursor`() {
+        val streamKey = "moneat:logs:queue:stream"
+        val consumerGroup = "moneat:logs:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+        val lastDeliveredId = "${System.currentTimeMillis() - 20_000L}-0"
+        val unconsumedId = "${System.currentTimeMillis() - 10_000L}-0"
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } returns
+            PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
+        every { redis.xinfoGroups(streamKey) } returns listOf(
+            listOf(
+                "name",
+                consumerGroup,
+                "last-delivered-id",
+                lastDeliveredId,
+                "lag",
+                1L,
+            )
+        )
+        every { redis.xrange(streamKey, any<Range<String>>(), any()) } returns listOf(
+            StreamMessage(streamKey, lastDeliveredId, emptyMap()),
+            StreamMessage(streamKey, unconsumedId, emptyMap()),
+        )
+
+        OperationalMetrics.registerWorkerStream("Log", streamKey, "primary", consumerGroup)
+
+        val age = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_stream_oldest_message_age_seconds",
+            "stream_key=\"$streamKey\"",
+            "stream_type=\"primary\"",
+        ).substringAfterLast(' ').toDouble()
+
+        assertTrue(age > 0.0)
+    }
+
+    @Test
+    fun `reports zero age when consumer group lag has no returned entry`() {
+        val streamKey = "moneat:logs:queue:stream"
+        val consumerGroup = "moneat:logs:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+        val lastDeliveredId = "${System.currentTimeMillis() - 20_000L}-0"
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } returns
+            PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
+        every { redis.xinfoGroups(streamKey) } returns listOf(
+            listOf(
+                "name",
+                consumerGroup,
+                "last-delivered-id",
+                lastDeliveredId,
+                "lag",
+                1L,
+            )
+        )
+        every { redis.xrange(streamKey, any<Range<String>>(), any()) } returns listOf(
+            StreamMessage(streamKey, lastDeliveredId, emptyMap()),
+        )
+
+        OperationalMetrics.registerWorkerStream("Log", streamKey, "primary", consumerGroup)
+
+        val ageLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_stream_oldest_message_age_seconds",
+            "stream_key=\"$streamKey\"",
+            "stream_type=\"primary\"",
+        )
+
+        assertTrue(ageLine.endsWith(" 0.0"), ageLine)
+    }
+
+    @Test
+    fun `falls back to oldest retained entry when group lag is unavailable`() {
+        val streamKey = "moneat:traces:queue:stream"
+        val consumerGroup = "moneat:traces:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+        val oldestId = "${System.currentTimeMillis() - 10_000L}-0"
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } returns
+            PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
+        every { redis.xinfoGroups(streamKey) } returns listOf(
+            mapOf(
+                "name" to consumerGroup,
+                "last-delivered-id" to oldestId,
+            )
+        )
+        every { redis.xrange(streamKey, any<Range<String>>(), any()) } returns listOf(
+            StreamMessage(streamKey, oldestId, emptyMap()),
+        )
+
+        OperationalMetrics.registerWorkerStream("Trace", streamKey, "primary", consumerGroup)
+
+        val age = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_stream_oldest_message_age_seconds",
+            "stream_key=\"$streamKey\"",
+            "stream_type=\"primary\"",
+        ).substringAfterLast(' ').toDouble()
+
+        assertTrue(age > 0.0)
+    }
+
+    @Test
+    fun `parses non numeric redis group values through their string form`() {
+        val streamKey = "moneat:metrics:queue:stream"
+        val dlqKey = "moneat:metrics:dlq:stream"
+        val consumerGroup = "moneat:metrics:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+        val redisNumber = object {
+            override fun toString(): String = "6"
+        }
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } returns
+            PendingMessages(4, Range.create("1-0", "4-0"), mapOf("worker-1" to 4L))
+        every { redis.xinfoGroups(streamKey) } returns listOf(
+            mapOf("name" to consumerGroup, "lag" to redisNumber)
+        )
+        every { redis.llen(dlqKey) } returns 0L
+
+        OperationalMetrics.registerWorkerQueues("Metric", streamKey, dlqKey, consumerGroup)
+
+        val queueLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_queue_depth",
+            "queue_key=\"$streamKey\"",
+            "queue_type=\"primary\"",
+            "worker=\"Metric\"",
+        )
+
+        assertTrue(queueLine.endsWith(" 10.0"), queueLine)
+    }
+
+    private fun metricLine(rendered: String, metricName: String, vararg labels: String): String =
+        rendered.lineSequence()
+            .firstOrNull { line ->
+                line.startsWith(metricName) && labels.all { label -> line.contains(label) }
+            }
+            ?: error("Missing metric $metricName with labels ${labels.joinToString()}")
+}

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -140,6 +140,7 @@ class MonitorAlertServiceCoverageTest {
 
         incidentService = mockk(relaxed = true)
         workflowService = mockk(relaxed = true)
+        coEvery { workflowService.publishAlertTriggered(any()) } returns true
         service =
             MonitorAlertService(
                 incidentService = incidentService,
@@ -744,6 +745,54 @@ class MonitorAlertServiceCoverageTest {
             coVerify(exactly = 1) {
                 incidentService.fireAlert(any(), false)
             }
+        }
+
+    @Test
+    fun `triggerAlert suppresses provider fanout when the episode gate declines`() =
+        runBlocking {
+            val fixture = createHostAlertFixture()
+            val alertKey = "alert_state:${fixture.hostId}:id_${fixture.alert.id}"
+            every { RedisConfig.isConnected() } returns true
+            val redis = mockk<RedisCommands<String, String>>()
+            every { RedisConfig.sync() } returns redis
+            every { redis.set(alertKey, "TRIGGERED") } returns "OK"
+            coEvery { workflowService.publishAlertTriggered(any()) } returns false
+
+            callPrivateSuspend(
+                "triggerAlert",
+                fixture.alert,
+                "host-alert-workflow",
+                fixture.orgId,
+                91.0,
+                alertKey,
+                Clock.System.now(),
+            )
+
+            coVerify(exactly = 0) { incidentService.fireAlert(any(), false) }
+        }
+
+    @Test
+    fun `triggerAlert fails open to provider fanout when workflow publication fails`() =
+        runBlocking {
+            val fixture = createHostAlertFixture()
+            val alertKey = "alert_state:${fixture.hostId}:id_${fixture.alert.id}"
+            every { RedisConfig.isConnected() } returns true
+            val redis = mockk<RedisCommands<String, String>>()
+            every { RedisConfig.sync() } returns redis
+            every { redis.set(alertKey, "TRIGGERED") } returns "OK"
+            coEvery { workflowService.publishAlertTriggered(any()) } throws RuntimeException("redis down")
+
+            callPrivateSuspend(
+                "triggerAlert",
+                fixture.alert,
+                "host-alert-workflow",
+                fixture.orgId,
+                91.0,
+                alertKey,
+                Clock.System.now(),
+            )
+
+            coVerify(exactly = 1) { incidentService.fireAlert(any(), false) }
         }
 
     // ──── Key helpers ────

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceExtendedTest.kt
@@ -32,6 +32,7 @@ import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Users
 import com.moneat.testsupport.TestDatabaseHelper
 import com.moneat.workflows.services.WorkflowService
+import io.mockk.coEvery
 import io.mockk.mockk
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -93,6 +94,7 @@ class MonitorAlertServiceExtendedTest {
 
         incidentService = mockk(relaxed = true)
         workflowService = mockk(relaxed = true)
+        coEvery { workflowService.publishAlertTriggered(any()) } returns true
 
         service = MonitorAlertService(
             incidentService = incidentService,

--- a/backend/src/test/kotlin/com/moneat/uptime/services/UptimeRetryValidationTest.kt
+++ b/backend/src/test/kotlin/com/moneat/uptime/services/UptimeRetryValidationTest.kt
@@ -1,0 +1,64 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.uptime.services
+
+import com.moneat.billing.services.BillingQuotaService
+import com.moneat.uptime.models.CreateUptimeMonitorRequest
+import com.moneat.uptime.models.UpdateUptimeMonitorRequest
+import com.moneat.uptime.repositories.UptimeMonitorRepository
+import io.mockk.mockk
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class UptimeRetryValidationTest {
+    private val service = UptimeService(BillingQuotaService(), mockk<UptimeMonitorRepository>(relaxed = true))
+
+    @Test
+    fun `rejects unsafe retry settings for create and update`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.createMonitor(
+                organizationId = 1,
+                request = CreateUptimeMonitorRequest(name = "Too many retries", type = "http", retries = 11),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.createMonitor(
+                organizationId = 1,
+                request = CreateUptimeMonitorRequest(
+                    name = "Tight retry loop",
+                    type = "http",
+                    retryIntervalSeconds = 0,
+                ),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.updateMonitor(
+                monitorId = UUID.randomUUID(),
+                organizationId = 1,
+                request = UpdateUptimeMonitorRequest(retries = -1),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.updateMonitor(
+                monitorId = UUID.randomUUID(),
+                organizationId = 1,
+                request = UpdateUptimeMonitorRequest(retryIntervalSeconds = 3601),
+            )
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowAlertPublicationCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowAlertPublicationCoverageTest.kt
@@ -1,0 +1,91 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.workflows.services
+
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertEpisodeContext
+import com.moneat.alerts.services.AlertEpisodeDecision
+import com.moneat.alerts.services.AlertEpisodeService
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+class WorkflowAlertPublicationCoverageTest {
+    @Test
+    fun `firing workflow publication failure fails open for provider fanout`() = runBlocking {
+        val episodeService = mockk<AlertEpisodeService>()
+        every { episodeService.recordFiring(any(), any()) } returns alertDecision()
+        val service = WorkflowService(alertEpisodeService = episodeService)
+
+        assertTrue(service.publishAlertTriggered(alertEvent()))
+    }
+
+    @Test
+    fun `resolved workflow publication failure fails open for provider fanout`() = runBlocking {
+        val episodeService = mockk<AlertEpisodeService>()
+        every { episodeService.recordResolved(any(), any()) } returns alertDecision()
+        val service = WorkflowService(alertEpisodeService = episodeService)
+
+        assertTrue(service.publishAlertTriggered(alertEvent().copy(status = AlertStatus.RESOLVED)))
+    }
+
+    private fun alertDecision(): AlertEpisodeDecision {
+        val now = Clock.System.now()
+        return AlertEpisodeDecision(
+            episode = AlertEpisodeContext(
+                id = 1,
+                resourceId = Uuid.random(),
+                organizationId = 1,
+                source = AlertSource.HOST_ALERT.name,
+                deduplicationKey = "coverage-alert",
+                episodeSeq = 1,
+                episodeKey = "coverage-alert:1",
+                status = "firing",
+                openedAt = now,
+                lastSeenAt = now,
+                resolvedAt = null,
+                lastNotificationAt = null,
+                notificationCount = 1,
+                suppressedAt = null,
+                suppressedByUserId = null,
+                suppressReason = null,
+            ),
+            shouldPublish = true,
+            notificationSequence = 1,
+            notificationKind = "initial",
+        )
+    }
+
+    private fun alertEvent(): AlertLifecycleEvent =
+        AlertLifecycleEvent(
+            title = "Coverage alert",
+            description = "The workflow publication path must fail open",
+            priority = AlertPriority.P1,
+            status = AlertStatus.FIRING,
+            source = AlertSource.HOST_ALERT,
+            deduplicationKey = "coverage-alert",
+            organizationId = Int.MAX_VALUE,
+            moneatUrl = "https://moneat.io/alerts/coverage",
+        )
+}

--- a/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowAlertPublicationCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/workflows/services/WorkflowAlertPublicationCoverageTest.kt
@@ -23,8 +23,14 @@ import com.moneat.alerts.models.AlertStatus
 import com.moneat.alerts.services.AlertEpisodeContext
 import com.moneat.alerts.services.AlertEpisodeDecision
 import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.shared.services.organizationResourceId
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -36,18 +42,34 @@ class WorkflowAlertPublicationCoverageTest {
     fun `firing workflow publication failure fails open for provider fanout`() = runBlocking {
         val episodeService = mockk<AlertEpisodeService>()
         every { episodeService.recordFiring(any(), any()) } returns alertDecision()
-        val service = WorkflowService(alertEpisodeService = episodeService)
+        mockkStatic("com.moneat.shared.services.PublicResourceIdsKt")
+        try {
+            every { organizationResourceId(any<Int>()) } returns "org-resource"
+            val service = spyk(WorkflowService(alertEpisodeService = episodeService))
+            coEvery { service.publishTrigger(any()) } throws IllegalStateException("workflow unavailable")
 
-        assertTrue(service.publishAlertTriggered(alertEvent()))
+            assertTrue(service.publishAlertTriggered(alertEvent()))
+            coVerify(exactly = 1) { service.publishTrigger(any()) }
+        } finally {
+            unmockkStatic("com.moneat.shared.services.PublicResourceIdsKt")
+        }
     }
 
     @Test
     fun `resolved workflow publication failure fails open for provider fanout`() = runBlocking {
         val episodeService = mockk<AlertEpisodeService>()
         every { episodeService.recordResolved(any(), any()) } returns alertDecision()
-        val service = WorkflowService(alertEpisodeService = episodeService)
+        mockkStatic("com.moneat.shared.services.PublicResourceIdsKt")
+        try {
+            every { organizationResourceId(any<Int>()) } returns "org-resource"
+            val service = spyk(WorkflowService(alertEpisodeService = episodeService))
+            coEvery { service.publishTrigger(any()) } throws IllegalStateException("workflow unavailable")
 
-        assertTrue(service.publishAlertTriggered(alertEvent().copy(status = AlertStatus.RESOLVED)))
+            assertTrue(service.publishAlertTriggered(alertEvent().copy(status = AlertStatus.RESOLVED)))
+            coVerify(exactly = 1) { service.publishTrigger(any()) }
+        } finally {
+            unmockkStatic("com.moneat.shared.services.PublicResourceIdsKt")
+        }
     }
 
     private fun alertDecision(): AlertEpisodeDecision {

--- a/dashboard/src/components/uptime/AddMonitorDialog.tsx
+++ b/dashboard/src/components/uptime/AddMonitorDialog.tsx
@@ -138,7 +138,7 @@ export default function AddMonitorDialog({open, onOpenChange}: AddMonitorDialogP
     method: 'GET',
     intervalSeconds: 60,
     timeoutSeconds: 30,
-    retries: 0,
+    retries: 1,
   })
 
   const createMutation = useMutation({
@@ -164,7 +164,7 @@ export default function AddMonitorDialog({open, onOpenChange}: AddMonitorDialogP
       method: 'GET',
       intervalSeconds: 60,
       timeoutSeconds: 30,
-      retries: 0,
+      retries: 1,
     })
     onOpenChange(false)
   }


### PR DESCRIPTION
## Summary

- Share the alert episode/reminder gate with host and dashboard incident-provider fan-out, while failing open on workflow/episode persistence errors.
- Expand Prometheus dashboard macros and harden APM empty-window quantiles and ClickHouse trace aliases.
- Report Redis stream age from pending/unconsumed backlog with stable metric tags.
- Default new uptime monitors to one retry, bound retry inputs server-side, and expose retry controls through MCP.
- Add read-only MCP dashboard-alert inventory.

## Evidence addressed

The changes are based on the Moneat alert investigation for the last two weeks: repeated dashboard/datasource episodes, stale worker/stream signals, ClickHouse query errors, and uptime 502/503 flapping.

## Validation

- Full backend test graph passed.
- Focused host, dashboard, workflow, monitoring, uptime, APM, MCP, and Prometheus tests passed.
- Detekt passed.
- Dashboard typecheck and lint passed.
- Migration version check and git diff check passed.
- Claude CLI final review: ready to publish; no blocking findings.

## Follow-ups

- Existing uptime monitors retain their current retry setting; changing them is a live configuration decision.
- Recheck production alert rules/panels that consume stream-age metrics because backlog semantics and labels changed.
- The worker-stale alert still needs a live query/configuration decision for idle workers versus actual queue health.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an MCP tool to list dashboard alert configurations.
  - Prometheus dashboard queries now expand Grafana interval and rate-interval macros.
  - Operational metrics now report oldest pending message age by consumer group; uptime monitors default retries to **1**.

- **Bug Fixes**
  - Alert incident fanout now respects workflow publication outcomes (suppressed/failed cases fail open appropriately).
  - Prometheus queries now use expanded “effective” expressions (including safe defaults) and improved error context.
  - Datadog APM queries handle empty previous windows and corrected trace field aliasing.

- **Tests**
  - Expanded coverage for alert publication fail-open behavior, macro expansion, operational metrics edge cases, and retry validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->