### PR TITLE
Fix issue session replay linkage

### DIFF
--- a/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
+++ b/backend/src/main/kotlin/com/moneat/events/routes/ApiRoutes.kt
@@ -1290,7 +1290,7 @@ fun Route.apiRoutes() {
                     }
 
                     val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: DEFAULT_REPLAYS_LIMIT
-                    val replays = dashboardService.getReplaysForIssue(issueId, limit)
+                    val replays = dashboardService.getReplaysForIssue(issueId, limit, projectId)
                     call.respond(replays)
                 }
 

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardQueryHelper.kt
@@ -27,6 +27,7 @@ import com.moneat.events.models.TopIssue
 import com.moneat.events.models.UserInfo
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
+import com.moneat.utils.normalizeUuidOrNull
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
@@ -181,22 +182,7 @@ class DashboardQueryHelper(
         return body
     }
 
-    fun normalizeUuid(value: String): String? {
-        val trimmed = value.trim().lowercase()
-        val uuidRegex = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
-        if (uuidRegex.matches(trimmed)) return trimmed
-
-        val hexRegex = Regex("^[0-9a-f]{32}$")
-        if (hexRegex.matches(trimmed)) {
-            return "${trimmed.substring(0, UUID_HEX_BLOCK1_END)}-" +
-                "${trimmed.substring(UUID_HEX_BLOCK1_END, UUID_HEX_BLOCK2_END)}-" +
-                "${trimmed.substring(UUID_HEX_BLOCK2_END, UUID_HEX_BLOCK3_END)}-" +
-                "${trimmed.substring(UUID_HEX_BLOCK3_END, UUID_HEX_BLOCK4_END)}-" +
-                trimmed.substring(UUID_HEX_BLOCK4_END)
-        }
-
-        return null
-    }
+    fun normalizeUuid(value: String): String? = normalizeUuidOrNull(value)
 
     fun extractUserInfo(obj: JsonObject): UserInfo? {
         val userId = obj["user_id"]?.jsonPrimitive?.contentOrNull
@@ -525,9 +511,5 @@ class DashboardQueryHelper(
         private const val LOG_BODY_CHARS = 400
         private const val LOG_SNIPPET_CHARS = 200
         private const val MILLIS_PER_SECOND = 1000.0
-        private const val UUID_HEX_BLOCK1_END = 8
-        private const val UUID_HEX_BLOCK2_END = 12
-        private const val UUID_HEX_BLOCK3_END = 16
-        private const val UUID_HEX_BLOCK4_END = 20
     }
 }

--- a/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/DashboardService.kt
@@ -290,8 +290,9 @@ class DashboardService(
 
     suspend fun getReplaysForIssue(
         issueId: String,
-        limit: Int = 10
-    ): List<ReplayListItem> = replayService.getReplaysForIssue(issueId, limit)
+        limit: Int = 10,
+        projectId: Long? = null
+    ): List<ReplayListItem> = replayService.getReplaysForIssue(issueId, limit, projectId)
 
     suspend fun getFeedback(
         projectId: Long,

--- a/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/EventService.kt
@@ -52,6 +52,7 @@ import com.moneat.shared.services.UsageTrackingService
 import com.moneat.utils.ClickHouseSqlUtils.doubleMapToSqlMap
 import com.moneat.utils.ClickHouseSqlUtils.escapeSql
 import com.moneat.utils.ClickHouseSqlUtils.mapToSqlMap
+import com.moneat.utils.normalizeUuidOrNull
 import com.moneat.utils.suspendRunCatching
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CoroutineScope
@@ -92,10 +93,6 @@ class EventService(
         private const val FINGERPRINT_HASH_LENGTH = 16
         private const val MS_PER_SECOND = 1000.0
         private const val NS_PER_SECOND = 1_000_000_000.0
-        private const val UUID_SEG1 = 8
-        private const val UUID_SEG2 = 12
-        private const val UUID_SEG3 = 16
-        private const val UUID_SEG4 = 20
         private val OTLP_STACK_FRAME_PATTERN = Regex("""[\w.$/<>-]+\([^)]*\)""")
         private const val SENTRY_SOURCE = "sentry"
         private const val SERVICE_TAG = "service"
@@ -963,7 +960,12 @@ class EventService(
         val startTs = replayEvent.replayStartTimestamp?.let { unixSecondsToMillis(it) } ?: ts
 
         val urls = replayEvent.urls?.take(MAX_REPLAY_URLS) ?: emptyList()
-        val errorIds = replayEvent.errorIds ?: emptyList()
+        val errorIds =
+            replayEvent.errorIds
+                .orEmpty()
+                .mapNotNull { errorId ->
+                    normalizeUuidOrNull(errorId) ?: errorId.trim().takeIf { it.isNotEmpty() }
+                }.distinct()
         val traceIds = replayEvent.traceIds ?: emptyList()
         val tags = replayEvent.tags?.let { JsonObject(it.mapValues { (_, v) -> JsonPrimitive(v) }).toString() } ?: "{}"
 
@@ -1315,20 +1317,8 @@ class EventService(
         return hash.joinToString("") { "%02x".format(it) }.take(FINGERPRINT_HASH_LENGTH)
     }
 
-    private fun normalizeUuid(value: String): String {
-        val trimmed = value.trim().lowercase()
-        val uuidRegex = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
-        if (uuidRegex.matches(trimmed)) return trimmed
-
-        val hexRegex = Regex("^[0-9a-f]{32}$")
-        if (hexRegex.matches(trimmed)) {
-            return "${trimmed.substring(0, UUID_SEG1)}-${trimmed.substring(UUID_SEG1, UUID_SEG2)}" +
-                "-${trimmed.substring(UUID_SEG2, UUID_SEG3)}-${trimmed.substring(UUID_SEG3, UUID_SEG4)}" +
-                "-${trimmed.substring(UUID_SEG4)}"
-        }
-
-        return UUID.randomUUID().toString()
-    }
+    private fun normalizeUuid(value: String): String =
+        normalizeUuidOrNull(value) ?: UUID.randomUUID().toString()
 
     private suspend fun insertAiSpansAsLlmGenerations(
         projectId: Long,

--- a/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
@@ -119,13 +119,18 @@ class ReplayService(
         return queryHelper.executeProjectIdQuery(query, "Replay", replayId)
     }
 
-    private suspend fun getProjectIdForIssue(issueId: String): Long? {
+    private suspend fun getProjectIdForIssue(
+        issueId: String,
+        projectId: Long? = null
+    ): Long? {
         val escapedIssueId = escapeSql(issueId)
+        val projectFilter = projectId?.let { "AND project_id = $it" } ?: ""
         val query =
             """
             SELECT toInt64(project_id) as project_id
             FROM `$clickhouseDb`.issues FINAL
             WHERE issue_id = '$escapedIssueId'
+                $projectFilter
             LIMIT 1
             FORMAT JSONEachRow
             """.trimIndent()
@@ -1746,20 +1751,21 @@ class ReplayService(
 
     suspend fun getReplaysForIssue(
         issueId: String,
-        limit: Int = 10
+        limit: Int = 10,
+        projectId: Long? = null
     ): List<ReplayListItem> {
-        val projectId = getProjectIdForIssue(issueId) ?: return emptyList()
-        val retentionDays = queryHelper.getProjectRetentionDays(projectId)
+        val resolvedProjectId = getProjectIdForIssue(issueId, projectId) ?: return emptyList()
+        val retentionDays = queryHelper.getProjectRetentionDays(resolvedProjectId)
         val escapedIssueId = escapeSql(issueId)
         val retentionClause = queryHelper.timestampRetentionClause(EVENT_TIMESTAMP_COLUMN, retentionDays)
         val replayEventsWhereClause =
             """
-            raw.project_id = $projectId
+            raw.project_id = $resolvedProjectId
                 AND raw.timestamp >= now64(3) - INTERVAL $retentionDays DAY
             """.trimIndent()
         val replaySegmentsWhereClause =
             """
-            project_id = $projectId
+            project_id = $resolvedProjectId
                 AND timestamp >= now64(3) - INTERVAL $retentionDays DAY
             """.trimIndent()
 
@@ -1791,9 +1797,9 @@ class ReplayService(
             ) r
             ARRAY JOIN arrayDistinct(r.error_ids) AS error_id
             INNER JOIN `$clickhouseDb`.events e
-                ON toString(e.event_id) = error_id
+                ON toUUIDOrNull(error_id) = e.event_id
                 AND e.issue_id = '$escapedIssueId'
-                AND e.project_id = $projectId
+                AND e.project_id = $resolvedProjectId
                 AND e.event_type = 'error'
                 AND $retentionClause
             LEFT JOIN (
@@ -1811,7 +1817,7 @@ class ReplayService(
                 suspendRunCatching {
                     buildReplayListItemFromJson(
                         obj,
-                        projectId,
+                        resolvedProjectId,
                         obj["error_count"]?.jsonPrimitive?.intOrNull ?: 0
                     )
                 }.getOrElse { e ->

--- a/backend/src/main/kotlin/com/moneat/utils/UuidUtils.kt
+++ b/backend/src/main/kotlin/com/moneat/utils/UuidUtils.kt
@@ -1,0 +1,36 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.utils
+
+private const val UUID_HEX_BLOCK1_END = 8
+private const val UUID_HEX_BLOCK2_END = 12
+private const val UUID_HEX_BLOCK3_END = 16
+private const val UUID_HEX_BLOCK4_END = 20
+private val CANONICAL_UUID_REGEX = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+private val COMPACT_UUID_REGEX = Regex("^[0-9a-f]{32}$")
+
+fun normalizeUuidOrNull(value: String): String? {
+    val normalized = value.trim().lowercase()
+    if (CANONICAL_UUID_REGEX.matches(normalized)) return normalized
+    if (!COMPACT_UUID_REGEX.matches(normalized)) return null
+
+    return "${normalized.substring(0, UUID_HEX_BLOCK1_END)}-" +
+        "${normalized.substring(UUID_HEX_BLOCK1_END, UUID_HEX_BLOCK2_END)}-" +
+        "${normalized.substring(UUID_HEX_BLOCK2_END, UUID_HEX_BLOCK3_END)}-" +
+        "${normalized.substring(UUID_HEX_BLOCK3_END, UUID_HEX_BLOCK4_END)}-" +
+        normalized.substring(UUID_HEX_BLOCK4_END)
+}

--- a/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/routes/EventRoutesExtendedTest.kt
@@ -774,18 +774,22 @@ class EventRoutesExtendedTest {
     }
 
     @Test
-    fun `GET issue replays returns 200`() = testApplication {
-        val (userId, _) = seedUserWithProject()
-        coEvery { mockDashboardService.hasIssueAccess(userId, "issue-rep-1") } returns true
+    fun `GET issue replays returns 200 and preserves project scope`() = testApplication {
+        val (userId, projectId) = seedUserWithProject()
+        val projectResourceId = projectResourceId(projectId)
+        coEvery { mockDashboardService.hasProjectAccess(userId, projectId) } returns true
         coEvery {
-            mockDashboardService.getReplaysForIssue("issue-rep-1", 10)
+            mockDashboardService.getReplaysForIssue("issue-rep-1", 10, projectId)
         } returns emptyList()
 
         application { installTestApp() }
-        val response = client.get("/v1/issues/issue-rep-1/replays") {
+        val response = client.get("/v1/issues/issue-rep-1/replays?projectId=$projectResourceId") {
             withAuth(token(userId))
         }
         assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            mockDashboardService.getReplaysForIssue("issue-rep-1", 10, projectId)
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/EventServiceCoverageTest.kt
@@ -1734,6 +1734,37 @@ class EventServiceCoverageTest {
         assertEquals(3, replaySlot.captured.segmentId)
     }
 
+    @Test
+    fun `storeReplayEvent normalizes compact error ids and preserves unknown ids`() = runBlocking {
+        val replaySlot = slot<ReplayEventInsertData>()
+        coEvery { eventRepository.insertReplayEvent(capture(replaySlot)) } returns true
+
+        val replayJson = Json.encodeToString(
+            SentryReplayEvent(
+                replayId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                errorIds = listOf(
+                    "550e8400e29b41d4a716446655440000",
+                    "550E8400-E29B-41D4-A716-446655440000",
+                    "unknown-error-id",
+                    "   "
+                )
+            )
+        )
+
+        eventService.processEnvelope(
+            testProjectId,
+            SentryEnvelope(
+                eventId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                items = listOf(EnvelopeItem("replay_event", replayJson))
+            )
+        )
+
+        assertEquals(
+            listOf("550e8400-e29b-41d4-a716-446655440000", "unknown-error-id"),
+            replaySlot.captured.errorIds
+        )
+    }
+
     // ===================== processStoreEvent =====================
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceExtendedTest.kt
@@ -197,6 +197,7 @@ class ReplayServiceExtendedTest {
 
     @Test
     fun `getReplaysForIssue returns replays linked to issue`() = runBlocking {
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
         val replayRow =
             """
             {"replay_id":"$REPLAY_UUID","project_id":1,"started_at":"2026-01-01T00:00:00.000Z","finished_at":"2026-01-01T00:05:00.000Z","duration_ms":"300000","urls":["https://app.example.com"],"error_count":3,"user_id":"u-1","user_email":"a@b.com","user_username":"u","browser_name":"Chrome","browser_version":"120","os_name":"macOS","os_version":"14","activity":5}
@@ -204,6 +205,7 @@ class ReplayServiceExtendedTest {
         val issueId = "ISSUE-ABC-123"
         withClickHouseMockServer({ exchange ->
             val query = exchange.requestBodyText()
+            queries += query
             when {
                 query.contains("issues") && query.contains("FINAL") ->
                     exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
@@ -213,12 +215,18 @@ class ReplayServiceExtendedTest {
                     exchange.respond(200, "", TEXT_PLAIN)
             }
         }) {
-            val result = service.getReplaysForIssue(issueId, limit = 5)
+            val result = service.getReplaysForIssue(issueId, limit = 5, projectId = 1)
             assertEquals(1, result.size)
             assertEquals(REPLAY_UUID, result[0].replayId)
             assertEquals(defaultProjectResourceId(), result[0].projectId)
             assertEquals(3, result[0].errorCount)
             assertEquals("Chrome", result[0].browserName)
+            assertTrue(
+                queries.any { query ->
+                    query.contains("issues FINAL") && query.contains("AND project_id = 1")
+                }
+            )
+            assertTrue(queries.any { it.contains("toUUIDOrNull(error_id) = e.event_id") })
         }
     }
 

--- a/emails/package-lock.json
+++ b/emails/package-lock.json
@@ -2200,9 +2200,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,8 +1,3 @@
 # Accepted OSV Scanner vulnerability exceptions.
 # Each ignored vulnerability must include a package/advisory-specific reason,
 # an owner, and a review date in the reason text.
-
-[[IgnoredVulns]]
-id = "GHSA-h67p-54hq-rp68"
-ignoreUntil = 2026-07-15
-reason = "Owner: platform. Review date: 2026-07-15. @maizzle/framework 5.5.0 depends on gray-matter 4, which calls js-yaml.safeLoad; forcing js-yaml 4 breaks production email builds."


### PR DESCRIPTION
## What changed

- canonicalize valid replay error event IDs during Sentry-compatible ingestion while preserving unknown source IDs
- match existing compact and canonical replay error IDs to stored ClickHouse UUIDs
- preserve the issue page's resolved project scope through the replay lookup
- add focused ingestion, query-generation, and route tests
- update the email build's transitive `js-yaml` dependency to the fixed 3.15.0 release and remove its expired OSV exception

## Root cause

Browser replay SDKs can send compact 32-character event IDs, while ClickHouse stores error event IDs as UUIDs rendered with hyphens. The reverse Issue → replay query compared those representations as exact strings. The route also resolved `projectId` for authorization but discarded it before querying, so identical issue fingerprints across projects could resolve against the wrong project.

During CI, OSV also identified that the temporary `js-yaml` vulnerability exception had expired. The compatible 3.x patched release is now available, so the lockfile can be updated without the previously incompatible major-version override.

## Impact

Issues can now find linked browser and mobile session replays across both compact and canonical UUID representations, including existing stored replay metadata. Project-scoped issue pages query only the intended project.

## Validation

- focused `ReplayServiceExtendedTest`, `EventServiceCoverageTest`, `EventRoutesExtendedTest`, and `DashboardQueryHelperTest`
- backend Detekt
- production email template build
- npm audit reports zero vulnerabilities for the email package
- `git diff --check origin/develop...HEAD`
