### PR TITLE
fix: harden ClickHouse log query failures

### DIFF
--- a/backend/features/logs/src/test/kotlin/com/moneat/services/LogQueryParserSqlTest.kt
+++ b/backend/features/logs/src/test/kotlin/com/moneat/services/LogQueryParserSqlTest.kt
@@ -246,6 +246,15 @@ class LogQueryParserSqlTest {
     }
 
     @Test
+    fun `free text with an underscore generates ILIKE SQL`() {
+        val result = parser.parse("query_logs")
+        val sql = parser.toClickHouseSql(result.rootNode, ::escapeSql)
+
+        assertTrue(sql.contains("ILIKE '%query_logs%'"), "Separated token should use ILIKE: $sql")
+        assertFalse(sql.contains("hasTokenCaseInsensitive"), "Separated token should not use hasToken: $sql")
+    }
+
+    @Test
     fun `all new features generate balanced parentheses`() {
         val queries =
             listOf(

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -41,6 +41,7 @@ import io.sentry.ISpan
 import io.sentry.Sentry
 import kotlinx.coroutines.CancellationException
 import mu.KotlinLogging
+import java.security.MessageDigest
 import java.util.Locale
 
 private val CLICKHOUSE_ERROR_CODE = Regex("""^Code:\s*(\d+)""")
@@ -62,6 +63,7 @@ object ClickHouseClient {
     private const val SOCKET_TIMEOUT_MS = 30_000L
     private const val MIGRATION_MAX_CONNECTIONS = 4
     private const val QUERY_LOG_MAX_LEN = 8192
+    private const val QUERY_FINGERPRINT_HEX_CHARS = 16
     private const val ERROR_BODY_MAX_LEN = 500
     private const val NANOS_PER_SECOND = 1_000_000_000.0
     private const val READ_QUERY_MAX_EXECUTION_SECONDS = 10
@@ -180,6 +182,12 @@ object ClickHouseClient {
             val elapsed = elapsedSeconds(startedAt)
             val status = if (response.status.isSuccess()) "success" else "http_${response.status.value}"
             OperationalMetrics.recordClickHouseRequest(operation, status, elapsed)
+            if (!response.status.isSuccess()) {
+                logger.error {
+                    "ClickHouse request failed: operation=$operation status=${response.status.value} " +
+                        "query_kind=${queryKind(query)} query_fp=${queryFingerprint(query)}"
+                }
+            }
             if (elapsed >= SLOW_QUERY_THRESHOLD_SECONDS) {
                 val elapsedText = String.format("%.1f", elapsed)
                 val truncatedQuery = query.take(QUERY_LOG_MAX_LEN)
@@ -199,6 +207,18 @@ object ClickHouseClient {
 
     private fun elapsedSeconds(startedAt: Long): Double =
         (System.nanoTime() - startedAt) / NANOS_PER_SECOND
+
+    private fun queryFingerprint(query: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(query.toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte) }
+            .take(QUERY_FINGERPRINT_HEX_CHARS)
+
+    private fun queryKind(query: String): String =
+        query.trimStart()
+            .takeWhile { it.isLetter() }
+            .lowercase(Locale.ROOT)
+            .ifBlank { "unknown" }
 
     private fun isClickHouseParameterName(name: String): Boolean {
         val first = name.firstOrNull() ?: return false

--- a/backend/src/main/kotlin/com/moneat/logs/services/LogQueryParser.kt
+++ b/backend/src/main/kotlin/com/moneat/logs/services/LogQueryParser.kt
@@ -598,8 +598,8 @@ class LogQueryParser {
         // which cause "Block structure mismatch" when SELECT aliases them with toString())
         val fields = listOf("message", "body", "service", "environment", "host", "container_name")
 
-        // hasTokenCaseInsensitive rejects needles containing separator chars (hyphens, dots, etc.)
-        val hasSeparators = term.any { it == '-' || it == '.' || it == '/' || it == ':' || it == ' ' }
+        // ClickHouse rejects any hasTokenCaseInsensitive needle containing non-alphanumeric separators.
+        val isSimpleToken = term.all { it.isLetterOrDigit() }
 
         return if (isWildcard) {
             val pattern = wildcardToLikePattern(term)
@@ -607,7 +607,7 @@ class LogQueryParser {
             "(" + fields.joinToString(" OR ") { field ->
                 "$field ILIKE '$escaped'"
             } + ")"
-        } else if (isPhrase || hasSeparators) {
+        } else if (isPhrase || !isSimpleToken) {
             // Phrase search or terms with separators: use ILIKE for substring match
             val escaped = escapeFn(term)
             "(" + fields.joinToString(" OR ") { field ->

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
@@ -99,6 +99,24 @@ class ClickHouseClientTest {
     }
 
     @Test
+    fun `execute records HTTP failures and preserves the response body`() = runBlocking {
+        OperationalMetrics.resetForTest()
+        val errorBody = "Code: 36. DB::Exception: Invalid query"
+        withClickHouseMockServer({ exchange ->
+            exchange.respond(400, errorBody, "text/plain")
+        }) {
+            val response = ClickHouseClient.execute("SELECT * FROM logs")
+            assertEquals(400, response.status.value)
+            assertEquals(errorBody, response.bodyAsText())
+        }
+
+        val rendered = OperationalMetrics.scrape()
+        assertContains(rendered, "moneat_clickhouse_requests_total")
+        assertContains(rendered, "operation=\"execute\"")
+        assertContains(rendered, "status=\"http_400\"")
+    }
+
+    @Test
     fun `executeWithFormat records ClickHouse error body codes`() = runBlocking {
         OperationalMetrics.resetForTest()
         withClickHouseMockServer({ exchange ->

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8262,9 +8262,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9659,9 +9659,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/emails/package-lock.json
+++ b/emails/package-lock.json
@@ -622,9 +622,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -664,9 +664,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2272,9 +2272,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- route separated log terms through valid substring matching
- add safe diagnostics for failed ClickHouse requests
- update vulnerable transitive dependencies required by the security gate
- cover parser and HTTP failure behavior