### PR TITLE
fix: restore mobile token authentication

### DIFF
--- a/backend/features/auth/src/main/kotlin/com/moneat/auth/routes/AuthRoutes.kt
+++ b/backend/features/auth/src/main/kotlin/com/moneat/auth/routes/AuthRoutes.kt
@@ -23,6 +23,7 @@ import com.moneat.config.EnvConfig
 import com.moneat.events.models.CompleteOnboardingRequest
 import com.moneat.events.models.ForgotPasswordRequest
 import com.moneat.events.models.LoginRequest
+import com.moneat.events.models.RefreshTokenRequest
 import com.moneat.events.models.ResendVerificationRequest
 import com.moneat.events.models.ResetPasswordRequest
 import com.moneat.events.models.SignupRequest
@@ -75,6 +76,10 @@ fun Route.authRoutes(
         post("/reset-password") { handleResetPassword(authService) }
         post("/logout") { handleLogout(authService) }
         post("/refresh") { handleRefreshToken(authService) }
+        route("/mobile") {
+            post("/login") { handleMobileLogin(authService) }
+            post("/refresh") { handleMobileRefreshToken(authService) }
+        }
         get("/github") { handleGitHubOAuth(oauthService) }
         get("/github/callback") { handleGitHubCallback(oauthService) }
         get("/apple") { handleAppleOAuth(oauthService) }
@@ -149,6 +154,21 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleLogin(authServic
                 AuthCookieUtils.clearRefreshCookie(call)
             }
             call.respond(result.copy(refreshToken = null))
+        } else {
+            call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid credentials"))
+        }
+    } catch (e: IllegalArgumentException) {
+        call.respond(HttpStatusCode.Forbidden, ErrorResponse(e.message))
+    }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleMobileLogin(authService: AuthService) {
+    val request = call.receive<LoginRequest>()
+
+    try {
+        val result = authService.login(request)
+        if (result != null) {
+            call.respond(result)
         } else {
             call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Invalid credentials"))
         }
@@ -275,6 +295,27 @@ private suspend fun io.ktor.server.routing.RoutingContext.handleRefreshToken(aut
     } catch (e: IllegalArgumentException) {
         AuthCookieUtils.clearAuthCookie(call)
         AuthCookieUtils.clearRefreshCookie(call)
+        call.respond(
+            HttpStatusCode.Unauthorized,
+            ErrorResponse(e.message)
+        )
+    }
+}
+
+private suspend fun io.ktor.server.routing.RoutingContext.handleMobileRefreshToken(authService: AuthService) {
+    val request = call.receive<RefreshTokenRequest>()
+
+    try {
+        val result = authService.refreshToken(request.refreshToken)
+        if (result != null) {
+            call.respond(result)
+        } else {
+            call.respond(
+                HttpStatusCode.Unauthorized,
+                ErrorResponse("Invalid or expired refresh token")
+            )
+        }
+    } catch (e: IllegalArgumentException) {
         call.respond(
             HttpStatusCode.Unauthorized,
             ErrorResponse(e.message)

--- a/backend/features/auth/src/test/kotlin/com/moneat/routes/AuthRoutesTest.kt
+++ b/backend/features/auth/src/test/kotlin/com/moneat/routes/AuthRoutesTest.kt
@@ -19,7 +19,11 @@ package com.moneat.routes
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.moneat.auth.routes.authRoutes
+import com.moneat.auth.services.AuthService
 import com.moneat.auth.services.OAuthService
+import com.moneat.events.models.AuthResponse
+import com.moneat.events.models.LoginRequest
+import com.moneat.events.models.UserResponse
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Users
@@ -31,8 +35,13 @@ import com.moneat.testsupport.stopTestKoin
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.request.cookie
 import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
@@ -41,6 +50,7 @@ import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.mockk.every
 import io.mockk.mockk
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -93,6 +103,101 @@ class AuthRoutesTest {
 
         // Ensure schema exists (idempotent in H2) and clean between tests
         TestDatabaseHelper.resetSchema(Users, Organizations, Memberships)
+    }
+
+    @Test
+    fun `mobile login returns refresh token without browser cookies`() = testApplication {
+        installPlugins()
+        val authService = mockk<AuthService>()
+        every {
+            authService.login(LoginRequest("oncall@example.com", "correct-password"))
+        } returns authResponse("access-token", "refresh-token")
+        routing {
+            authRoutes(
+                authService = authService,
+                oauthService = mockk(relaxed = true)
+            )
+        }
+
+        val response =
+            client.post("/auth/mobile/login") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"email":"oncall@example.com","password":"correct-password"}""")
+            }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"token\":\"access-token\""))
+        assertTrue(response.bodyAsText().contains("\"refreshToken\":\"refresh-token\""))
+        assertTrue(response.headers.getAll(HttpHeaders.SetCookie).isNullOrEmpty())
+    }
+
+    @Test
+    fun `mobile login rejects invalid credentials`() = testApplication {
+        installPlugins()
+        val authService = mockk<AuthService>()
+        every { authService.login(any()) } returns null
+        routing {
+            authRoutes(
+                authService = authService,
+                oauthService = mockk(relaxed = true)
+            )
+        }
+
+        val response =
+            client.post("/auth/mobile/login") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"email":"oncall@example.com","password":"wrong-password"}""")
+            }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid credentials"))
+    }
+
+    @Test
+    fun `mobile refresh rotates token pair without browser cookies`() = testApplication {
+        installPlugins()
+        val authService = mockk<AuthService>()
+        every { authService.refreshToken("refresh-token") } returns
+            authResponse("rotated-access-token", "rotated-refresh-token")
+        routing {
+            authRoutes(
+                authService = authService,
+                oauthService = mockk(relaxed = true)
+            )
+        }
+
+        val response =
+            client.post("/auth/mobile/refresh") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"refreshToken":"refresh-token"}""")
+            }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(response.bodyAsText().contains("\"token\":\"rotated-access-token\""))
+        assertTrue(response.bodyAsText().contains("\"refreshToken\":\"rotated-refresh-token\""))
+        assertTrue(response.headers.getAll(HttpHeaders.SetCookie).isNullOrEmpty())
+    }
+
+    @Test
+    fun `mobile refresh rejects invalid refresh token`() = testApplication {
+        installPlugins()
+        val authService = mockk<AuthService>()
+        every { authService.refreshToken("invalid-refresh-token") } returns null
+        routing {
+            authRoutes(
+                authService = authService,
+                oauthService = mockk(relaxed = true)
+            )
+        }
+
+        val response =
+            client.post("/auth/mobile/refresh") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"refreshToken":"invalid-refresh-token"}""")
+            }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertTrue(response.bodyAsText().contains("Invalid or expired refresh token"))
     }
 
     @Test
@@ -272,6 +377,18 @@ class AuthRoutesTest {
             }
         }
     }
+
+    private fun authResponse(token: String, refreshToken: String) =
+        AuthResponse(
+            token = token,
+            refreshToken = refreshToken,
+            expiresIn = 3600,
+            user = UserResponse(
+                id = "019f8f42-0000-7000-8000-000000000001",
+                email = "oncall@example.com",
+                name = "On Call"
+            )
+        )
 
     @AfterTest
     fun teardownKoin() {

--- a/dashboard/src/lib/api/modules/__tests__/auth.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/auth.test.ts
@@ -107,6 +107,25 @@ describe('authMethods', () => {
       expect(result).toEqual(authResponse)
       expect(globalThis.sessionStorage?.getItem('authenticated')).toBe('true')
     })
+
+    it('logs a native app in without marking the browser authenticated', async () => {
+      const authResponse = {
+        token: 'jwt-token',
+        refreshToken: 'refresh-token',
+        user: { id: USER_ID_ALICE, email: 'a@b.com' },
+      }
+      server.use(
+        http.post(`${API_BASE}/auth/mobile/login`, async ({ request }) => {
+          const body = await request.json()
+          expect(body).toEqual({ email: 'a@b.com', password: TEST_PASSWORD })
+          return HttpResponse.json(authResponse)
+        })
+      )
+
+      const result = await api.mobileLogin('a@b.com', TEST_PASSWORD)
+      expect(result).toEqual(authResponse)
+      expect(globalThis.sessionStorage?.getItem('authenticated')).toBeNull()
+    })
   })
 
   // ──── SSO ────

--- a/dashboard/src/lib/api/modules/auth.ts
+++ b/dashboard/src/lib/api/modules/auth.ts
@@ -16,7 +16,12 @@
 
 import { setDemoEpoch } from '../../demo'
 import type { ApiClientCore } from '../client'
-import type { AuthResponse, SignupLegalConsent, SsoConfig } from '../types'
+import type {
+  AuthResponse,
+  MobileAuthResponse,
+  SignupLegalConsent,
+  SsoConfig,
+} from '../types'
 
 export function authMethods(core: ApiClientCore) {
   const base = core.API_BASE
@@ -54,6 +59,15 @@ export function authMethods(core: ApiClientCore) {
       globalThis.sessionStorage?.setItem('authenticated', 'true')
       return response
     },
+
+    mobileLogin: async (
+      email: string,
+      password: string
+    ): Promise<MobileAuthResponse> =>
+      core.request<MobileAuthResponse>(`${authBase}/auth/mobile/login`, {
+        method: 'POST',
+        body: JSON.stringify({ email, password }),
+      }),
 
     initSso: async (
       email?: string,

--- a/dashboard/src/lib/api/types/auth.ts
+++ b/dashboard/src/lib/api/types/auth.ts
@@ -26,6 +26,10 @@ export interface AuthResponse {
   }
 }
 
+export interface MobileAuthResponse extends AuthResponse {
+  refreshToken: string
+}
+
 export interface SignupLegalConsent {
   acceptTerms: boolean
   acceptPrivacy: boolean

--- a/dashboard/src/routes/__tests__/login-route.test.tsx
+++ b/dashboard/src/routes/__tests__/login-route.test.tsx
@@ -7,6 +7,7 @@ const {mockApi, mockNavigate, mockTrackEvent} = vi.hoisted(() => ({
   mockApi: {
     isAuthenticated: vi.fn(),
     login: vi.fn(),
+    mobileLogin: vi.fn(),
     logout: vi.fn(),
     initSso: vi.fn(),
   },
@@ -64,7 +65,7 @@ function beforeLoadContext(search: Record<string, unknown>): LoginBeforeLoadCont
   return {search} as unknown as LoginBeforeLoadContext
 }
 
-async function submitEmailLogin() {
+async function submitEmailLogin(method: 'web' | 'mobile' = 'web') {
   const LoginPage = Route.options.component as ComponentType
 
   render(<LoginPage />)
@@ -74,7 +75,8 @@ async function submitEmailLogin() {
   fireEvent.click(screen.getByRole('button', {name: 'Sign in'}))
 
   await waitFor(() => {
-    expect(mockApi.login).toHaveBeenCalledWith('test@example.com', 'password')
+    const login = method === 'mobile' ? mockApi.mobileLogin : mockApi.login
+    expect(login).toHaveBeenCalledWith('test@example.com', 'password')
   })
 }
 
@@ -83,6 +85,7 @@ describe('login route', () => {
     vi.clearAllMocks()
     mockApi.isAuthenticated.mockReturnValue(false)
     mockApi.login.mockResolvedValue({token: 'token-1'})
+    mockApi.mobileLogin.mockResolvedValue({token: 'token-1', refreshToken: 'refresh-token-1'})
     window.history.replaceState(null, '', '/login')
   })
 
@@ -152,9 +155,47 @@ describe('login route', () => {
   it('logs out authenticated mobile redirect sessions before loading the page', () => {
     mockApi.isAuthenticated.mockReturnValue(true)
 
-    Route.options.beforeLoad?.(beforeLoadContext({redirect_uri: 'bandapella://auth'}))
+    Route.options.beforeLoad?.(beforeLoadContext({redirect_uri: 'moneat://auth'}))
 
     expect(mockApi.logout).toHaveBeenCalled()
+  })
+
+  it('does not treat unapproved redirect URIs as mobile login callbacks', () => {
+    mockApi.isAuthenticated.mockReturnValue(true)
+
+    expect(() => {
+      Route.options.beforeLoad?.(beforeLoadContext({redirect_uri: 'moneat://settings'}))
+    }).toThrow(expect.objectContaining({to: '/', search: {view: 'overview'}}))
+    expect(mockApi.logout).not.toHaveBeenCalled()
+  })
+
+  it('returns mobile login tokens to the native callback fragment', async () => {
+    window.history.replaceState(null, '', '/login?redirect_uri=moneat%3A%2F%2Fauth')
+    const originalLocation = window.location
+    const assign = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: {...originalLocation, assign} as Location,
+      writable: true,
+      configurable: true,
+    })
+
+    try {
+      await submitEmailLogin('mobile')
+
+      await waitFor(() => {
+        expect(mockApi.mobileLogin).toHaveBeenCalledWith('test@example.com', 'password')
+        expect(mockApi.login).not.toHaveBeenCalled()
+        expect(assign).toHaveBeenCalledWith(
+          'moneat://auth#token=token-1&refreshToken=refresh-token-1'
+        )
+      })
+    } finally {
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+        configurable: true,
+      })
+    }
   })
 
   it('redirects authenticated users without special params to the app overview', () => {

--- a/dashboard/src/routes/login.tsx
+++ b/dashboard/src/routes/login.tsx
@@ -35,8 +35,24 @@ interface InternalRouteTarget {
   readonly hash?: string
 }
 
+const MOBILE_AUTH_CALLBACK_URL = 'moneat://auth'
+
 function normalizePostLoginRedirect(value: unknown): string | undefined {
   return normalizeInternalRedirectPath(value)
+}
+
+function normalizeMobileAuthCallback(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  return value.trim() === MOBILE_AUTH_CALLBACK_URL ? MOBILE_AUTH_CALLBACK_URL : undefined
+}
+
+function mobileAuthCallbackUrl(
+  redirectUri: string,
+  token: string,
+  refreshToken: string
+): string {
+  const params = new URLSearchParams({token, refreshToken})
+  return `${redirectUri}#${params.toString()}`
 }
 
 function buildInviteRedirectPath(value: unknown): string | undefined {
@@ -89,12 +105,12 @@ function resolveSubmitPostLoginPath(queryPostLoginPath: string | undefined): str
 export const Route = createFileRoute('/login')({
   beforeLoad: ({ search }) => {
     const s = search as Record<string, unknown>
-    const redirectUri = s.redirect_uri as string | undefined
+    const mobileAuthCallback = normalizeMobileAuthCallback(s.redirect_uri)
     const postLoginRedirect = normalizePostLoginRedirect(s.redirect)
 
     // If user is already authenticated AND redirect_uri exists (mobile login),
     // log them out automatically so they can log in fresh
-    if (api.isAuthenticated() && redirectUri) {
+    if (api.isAuthenticated() && mobileAuthCallback) {
       api.logout()
       return
     }
@@ -120,6 +136,7 @@ export const Route = createFileRoute('/login')({
 function LoginPage() {
   const navigate = useNavigate()
   const searchParams = new URLSearchParams(window.location.search)
+  const mobileAuthCallback = normalizeMobileAuthCallback(searchParams.get('redirect_uri'))
   const [queryPostLoginPath] = useState(() => resolveQueryPostLoginPath(searchParams))
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -135,6 +152,13 @@ function LoginPage() {
     setError('')
 
     try {
+      if (mobileAuthCallback) {
+        const {token, refreshToken} = await api.mobileLogin(email, password)
+        trackEvent('Login', { method: 'email' })
+        globalThis.window.location.assign(mobileAuthCallbackUrl(mobileAuthCallback, token, refreshToken))
+        return
+      }
+
       await api.login(email, password)
       trackEvent('Login', { method: 'email' })
       const target = internalRouteTarget(resolveSubmitPostLoginPath(queryPostLoginPath))


### PR DESCRIPTION
## Summary

- add dedicated mobile login and refresh endpoints that return access and refresh tokens in JSON without setting browser cookies
- route the approved `moneat://auth` callback through the mobile login contract
- return the token pair in the native deep-link fragment while preserving the existing web-cookie login flow
- reject unapproved redirect URIs and cover the backend and dashboard behavior with focused tests

## Why

The mobile app stores access and refresh tokens in secure storage, but the current web authentication flow intentionally moves refresh tokens into HTTP-only cookies and returns `refreshToken: null`. React Native cannot depend on that browser-cookie contract, so mobile relaunch and token refresh require an explicit token transport.

## Impact

Native clients can receive and rotate a refresh token without weakening the browser authentication flow. Web sign-in continues to use HTTP-only cookies.

## Validation

- `./gradlew :features:auth:test --tests com.moneat.routes.AuthRoutesTest --no-daemon`
- `npm run test -- src/lib/api/modules/__tests__/auth.test.ts src/routes/__tests__/login-route.test.tsx`
- `npm run typecheck`
- targeted ESLint for the five changed dashboard files
- `git diff --check`
