### PR TITLE
fix: initialize on-call API services

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -51,17 +51,40 @@ class OnCallModule :
     EnterpriseModule,
     McpToolContributor,
     OnCallBridge {
-    private lateinit var escalationEngine: EscalationEngine
-    private lateinit var onCallAlertService: OnCallAlertService
-    private lateinit var pushNotificationService: PushNotificationService
-    private var slackUserGroupSyncService: SlackUserGroupSyncService? = null
-    private var onCallHandoffService: OnCallHandoffService? = null
-    private var shiftChangeNotifier: ShiftChangeNotifier? = null
     private val priorityService = PriorityService()
     private val businessHoursService = BusinessHoursService()
     private val escalationPolicyService = EscalationPolicyService()
     private val onCallScheduleService = OnCallScheduleService()
     private val onCallIncidentService = OnCallIncidentService()
+    private val pushNotificationService = PushNotificationService()
+    private val slackService = SlackService()
+    private val redisClient = RedisClient()
+    private val escalationEngine =
+        EscalationEngine(
+            escalationPolicyService = escalationPolicyService,
+            onCallScheduleService = onCallScheduleService,
+            pushNotificationService = pushNotificationService,
+            slackService = slackService,
+            redisClient = redisClient,
+        )
+    private val onCallAlertService = OnCallAlertService(escalationEngine = escalationEngine)
+    private val slackUserGroupSyncService =
+        SlackUserGroupSyncService(
+            onCallScheduleService = onCallScheduleService,
+            slackService = slackService,
+            redisClient = redisClient,
+        )
+    private val onCallHandoffService =
+        OnCallHandoffService(
+            onCallScheduleService = onCallScheduleService,
+            pushNotificationService = pushNotificationService,
+            redisClient = redisClient,
+        )
+    private val shiftChangeNotifier =
+        ShiftChangeNotifier(
+            onCallScheduleService = onCallScheduleService,
+            pushNotificationService = pushNotificationService,
+        )
 
     override val name: String = "On-Call"
     override val licenseFeature: String = "oncall"
@@ -88,58 +111,19 @@ class OnCallModule :
     }
 
     override fun startBackgroundJobs(application: Application) {
-        val escalationPolicyService = EscalationPolicyService()
-        pushNotificationService = PushNotificationService()
-        val slackService = SlackService()
-        val redisClient = RedisClient()
-
-        escalationEngine =
-            EscalationEngine(
-                escalationPolicyService = escalationPolicyService,
-                onCallScheduleService = onCallScheduleService,
-                pushNotificationService = pushNotificationService,
-                slackService = slackService,
-                redisClient = redisClient,
-            )
-
-        onCallAlertService =
-            OnCallAlertService(
-                escalationEngine = escalationEngine,
-            )
-
-        slackUserGroupSyncService =
-            SlackUserGroupSyncService(
-                onCallScheduleService = onCallScheduleService,
-                slackService = slackService,
-                redisClient = redisClient,
-            )
-
-        onCallHandoffService =
-            OnCallHandoffService(
-                onCallScheduleService = onCallScheduleService,
-                pushNotificationService = pushNotificationService,
-                redisClient = redisClient,
-            )
-
-        shiftChangeNotifier =
-            ShiftChangeNotifier(
-                onCallScheduleService = onCallScheduleService,
-                pushNotificationService = pushNotificationService,
-            )
-
         logger.info { "Starting on-call enterprise background jobs" }
         escalationEngine.start()
-        slackUserGroupSyncService?.start()
-        onCallHandoffService?.start()
-        shiftChangeNotifier?.start()
+        slackUserGroupSyncService.start()
+        onCallHandoffService.start()
+        shiftChangeNotifier.start()
     }
 
     override fun stopBackgroundJobs() {
         logger.info { "Stopping on-call enterprise background jobs" }
         escalationEngine.stop()
-        slackUserGroupSyncService?.stop()
-        onCallHandoffService?.stop()
-        shiftChangeNotifier?.stop()
+        slackUserGroupSyncService.stop()
+        onCallHandoffService.stop()
+        shiftChangeNotifier.stop()
     }
 
     // OnCallBridge implementation

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -56,35 +56,47 @@ class OnCallModule :
     private val escalationPolicyService = EscalationPolicyService()
     private val onCallScheduleService = OnCallScheduleService()
     private val onCallIncidentService = OnCallIncidentService()
-    private val pushNotificationService = PushNotificationService()
-    private val slackService = SlackService()
-    private val redisClient = RedisClient()
-    private val escalationEngine =
-        EscalationEngine(
-            escalationPolicyService = escalationPolicyService,
-            onCallScheduleService = onCallScheduleService,
-            pushNotificationService = pushNotificationService,
-            slackService = slackService,
-            redisClient = redisClient,
-        )
-    private val onCallAlertService = OnCallAlertService(escalationEngine = escalationEngine)
-    private val slackUserGroupSyncService =
-        SlackUserGroupSyncService(
-            onCallScheduleService = onCallScheduleService,
-            slackService = slackService,
-            redisClient = redisClient,
-        )
-    private val onCallHandoffService =
-        OnCallHandoffService(
-            onCallScheduleService = onCallScheduleService,
-            pushNotificationService = pushNotificationService,
-            redisClient = redisClient,
-        )
-    private val shiftChangeNotifier =
-        ShiftChangeNotifier(
-            onCallScheduleService = onCallScheduleService,
-            pushNotificationService = pushNotificationService,
-        )
+    private val pushNotificationService by lazy { PushNotificationService() }
+    private val slackService by lazy { SlackService() }
+    private val redisClient by lazy { RedisClient() }
+    private val escalationEngineDelegate =
+        lazy {
+            EscalationEngine(
+                escalationPolicyService = escalationPolicyService,
+                onCallScheduleService = onCallScheduleService,
+                pushNotificationService = pushNotificationService,
+                slackService = slackService,
+                redisClient = redisClient,
+            )
+        }
+    private val escalationEngine by escalationEngineDelegate
+    private val onCallAlertService by lazy { OnCallAlertService(escalationEngine = escalationEngine) }
+    private val slackUserGroupSyncServiceDelegate =
+        lazy {
+            SlackUserGroupSyncService(
+                onCallScheduleService = onCallScheduleService,
+                slackService = slackService,
+                redisClient = redisClient,
+            )
+        }
+    private val slackUserGroupSyncService by slackUserGroupSyncServiceDelegate
+    private val onCallHandoffServiceDelegate =
+        lazy {
+            OnCallHandoffService(
+                onCallScheduleService = onCallScheduleService,
+                pushNotificationService = pushNotificationService,
+                redisClient = redisClient,
+            )
+        }
+    private val onCallHandoffService by onCallHandoffServiceDelegate
+    private val shiftChangeNotifierDelegate =
+        lazy {
+            ShiftChangeNotifier(
+                onCallScheduleService = onCallScheduleService,
+                pushNotificationService = pushNotificationService,
+            )
+        }
+    private val shiftChangeNotifier by shiftChangeNotifierDelegate
 
     override val name: String = "On-Call"
     override val licenseFeature: String = "oncall"
@@ -120,10 +132,10 @@ class OnCallModule :
 
     override fun stopBackgroundJobs() {
         logger.info { "Stopping on-call enterprise background jobs" }
-        escalationEngine.stop()
-        slackUserGroupSyncService.stop()
-        onCallHandoffService.stop()
-        shiftChangeNotifier.stop()
+        if (escalationEngineDelegate.isInitialized()) escalationEngine.stop()
+        if (slackUserGroupSyncServiceDelegate.isInitialized()) slackUserGroupSyncService.stop()
+        if (onCallHandoffServiceDelegate.isInitialized()) onCallHandoffService.stop()
+        if (shiftChangeNotifierDelegate.isInitialized()) shiftChangeNotifier.stop()
     }
 
     // OnCallBridge implementation

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/OnCallModuleTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/OnCallModuleTest.kt
@@ -1,0 +1,53 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class OnCallModuleTest {
+    @Test
+    fun `registers API routes before scheduler jobs start`() {
+        val previousFrontendUrl = System.getProperty("FRONTEND_URL")
+        System.setProperty("FRONTEND_URL", "https://app.moneat.test")
+        try {
+            testApplication {
+                application {
+                    install(Authentication) {
+                        jwt("auth-jwt") {
+                            verifier(
+                                JWT
+                                    .require(Algorithm.HMAC256("on-call-module-test-secret"))
+                                    .build(),
+                            )
+                            validate { JWTPrincipal(it.payload) }
+                        }
+                    }
+                    routing {
+                        OnCallModule().registerRoutes(this)
+                    }
+                }
+
+                assertEquals(HttpStatusCode.Unauthorized, client.get("/v1/on-call/schedules").status)
+            }
+        } finally {
+            if (previousFrontendUrl == null) {
+                System.clearProperty("FRONTEND_URL")
+            } else {
+                System.setProperty("FRONTEND_URL", previousFrontendUrl)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Initializes route-facing On-Call services independently from scheduler polling. Adds a regression test for API route registration before scheduler startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-call service initialization and background job start/stop behavior for more reliable lifecycle management.
  * Ensured on-call API routes are registered and available before scheduler jobs begin running.
* **Tests**
  * Added an end-to-end route test verifying unauthenticated requests to on-call schedules are rejected (401 Unauthorized).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->