### PR TITLE
fix: stabilize API role observability reads

### DIFF
--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -296,7 +296,7 @@ class OperationalMetricsTest {
         every { RedisConfig.isConnected() } returns true
         every { RedisConfig.sync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } throws
-            IllegalStateException("NOGROUP No such key '$streamKey' or consumer group '$consumerGroup'")
+            IllegalStateException("ERR no such key '$streamKey'")
         every { redis.llen(dlqKey) } returns 0L
 
         OperationalMetrics.registerWorkerQueues("Empty", streamKey, dlqKey, consumerGroup)

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -286,6 +286,33 @@ class OperationalMetricsTest {
     }
 
     @Test
+    fun `renders zero stream queue depth when the stream does not exist`() {
+        val streamKey = "moneat:empty:queue:stream"
+        val dlqKey = "moneat:empty:dlq:stream"
+        val consumerGroup = "moneat:empty:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.sync() } returns redis
+        every { redis.xpending(streamKey, consumerGroup) } throws
+            IllegalStateException("NOGROUP No such key '$streamKey' or consumer group '$consumerGroup'")
+        every { redis.llen(dlqKey) } returns 0L
+
+        OperationalMetrics.registerWorkerQueues("Empty", streamKey, dlqKey, consumerGroup)
+
+        val queueLine = metricLine(
+            OperationalMetrics.scrape(),
+            "moneat_worker_queue_depth",
+            "queue_key=\"$streamKey\"",
+            "queue_type=\"primary\"",
+            "worker=\"Empty\"",
+        )
+
+        assertTrue(queueLine.endsWith(" 0.0"), queueLine)
+    }
+
+    @Test
     fun `renders ingestion queue mode defaults`() {
         OperationalMetrics.bindSystemMetrics()
 

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -745,7 +745,9 @@ object OperationalMetrics {
                 ?.lag
                 ?: 0L
             (pendingMessages + lagMessages).toDouble()
-        }.getOrElse { Double.NaN }
+        }.getOrElse { error ->
+            if (error.isMissingRedisStreamError()) 0.0 else Double.NaN
+        }
 
     private fun readStreamPendingMessages(streamKey: String, consumerGroup: String): Double {
         if (!RedisConfig.isConnected()) return Double.NaN

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -117,8 +117,8 @@ class OnCallModule :
     }
 
     override fun contributeTools(registry: McpToolRegistry) {
-        registry.register(ListIncidentsTool())
-        registry.register(GetIncidentTool())
+        registry.register(ListIncidentsTool { onCallAlertService })
+        registry.register(GetIncidentTool { onCallAlertService })
         registry.register(ListSchedulesTool())
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/mcp/OnCallTool.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/mcp/OnCallTool.kt
@@ -5,7 +5,6 @@
 package com.moneat.enterprise.oncall.mcp
 
 import com.moneat.enterprise.oncall.alertIdForResource
-import com.moneat.enterprise.oncall.services.EscalationEngineHolder
 import com.moneat.enterprise.oncall.services.OnCallAlertService
 import com.moneat.enterprise.oncall.services.OnCallScheduleService
 import com.moneat.mcp.models.McpContext
@@ -28,12 +27,9 @@ private val scheduleService = OnCallScheduleService()
 private const val DEFAULT_INCIDENT_LIMIT = 50
 private const val MAX_INCIDENT_LIMIT = 200
 
-private fun getIncidentService(): OnCallAlertService? {
-    val engine = EscalationEngineHolder.instance ?: return null
-    return OnCallAlertService(engine)
-}
-
-class ListIncidentsTool : McpTool {
+class ListIncidentsTool(
+    private val incidentService: () -> OnCallAlertService,
+) : McpTool {
     override val name = "list_incidents"
     override val description = "List on-call incidents"
     override val inputSchema = InputSchema(
@@ -60,8 +56,7 @@ class ListIncidentsTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val svc = getIncidentService()
-            ?: return errorResult("On-call module not initialized")
+        val svc = incidentService()
         val status = args["status"]?.jsonPrimitive?.content
         val priority = args["priority"]?.jsonPrimitive?.content
         val limit = (args["limit"]?.jsonPrimitive?.intOrNull ?: DEFAULT_INCIDENT_LIMIT)
@@ -78,7 +73,9 @@ class ListIncidentsTool : McpTool {
     }
 }
 
-class GetIncidentTool : McpTool {
+class GetIncidentTool(
+    private val incidentService: () -> OnCallAlertService,
+) : McpTool {
     override val name = "get_incident"
     override val description =
         "Get on-call incident details and timeline"
@@ -93,8 +90,7 @@ class GetIncidentTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val svc = getIncidentService()
-            ?: return errorResult("On-call module not initialized")
+        val svc = incidentService()
         val incidentResourceId = args.stringContent("incident_id")
             ?: return errorResult("incident_id is required")
         val incidentId = transaction {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/mcp/OnCallTool.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/mcp/OnCallTool.kt
@@ -90,12 +90,12 @@ class GetIncidentTool(
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
-        val svc = incidentService()
         val incidentResourceId = args.stringContent("incident_id")
             ?: return errorResult("incident_id is required")
         val incidentId = transaction {
             alertIdForResource(context.organizationId, incidentResourceId)
         } ?: return errorResult("Incident not found: $incidentResourceId")
+        val svc = incidentService()
         val incident = svc.getAlert(
             incidentId,
             context.userId

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/mcp/OnCallToolTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/mcp/OnCallToolTest.kt
@@ -56,4 +56,21 @@ class OnCallToolTest {
         assertFalse(result.isError)
         assertEquals("[]", result.content.single().text)
     }
+
+    @Test
+    fun `get incident validates its id before initializing the service`() {
+        var serviceInitialized = false
+        val tool = GetIncidentTool {
+            serviceInitialized = true
+            mockk()
+        }
+
+        val result = runBlocking {
+            tool.execute(JsonObject(emptyMap()), context)
+        }
+
+        assertFalse(serviceInitialized)
+        assertTrue(result.isError)
+        assertEquals("incident_id is required", result.content.single().text)
+    }
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/mcp/OnCallToolTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/mcp/OnCallToolTest.kt
@@ -1,0 +1,59 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall.mcp
+
+import com.moneat.enterprise.oncall.services.OnCallAlertService
+import com.moneat.mcp.models.McpContext
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OnCallToolTest {
+    private val context = McpContext(
+        organizationId = 42,
+        userId = 7,
+        tokenId = 1,
+        scopes = emptySet(),
+        sessionId = "test-session",
+    )
+
+    @Test
+    fun `list incidents initializes its service without scheduler jobs`() {
+        val service = mockk<OnCallAlertService>()
+        every {
+            service.listAlerts(
+                organizationId = 42,
+                status = "triggered",
+                priority = null,
+                limit = 50,
+                currentUserId = 7,
+            )
+        } returns emptyList()
+        var serviceInitialized = false
+        val tool = ListIncidentsTool {
+            serviceInitialized = true
+            service
+        }
+
+        assertFalse(serviceInitialized)
+
+        val result = runBlocking {
+            tool.execute(
+                JsonObject(mapOf("status" to JsonPrimitive("triggered"))),
+                context,
+            )
+        }
+
+        assertTrue(serviceInitialized)
+        assertFalse(result.isError)
+        assertEquals("[]", result.content.single().text)
+    }
+}


### PR DESCRIPTION
## Summary

- initialize on-call MCP reads in API-only containers
- report empty Redis ingestion streams as zero-depth queues
- cover both beta regressions with focused tests

## Validation

- full backend test suite
- full Detekt
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Monitoring now reports worker queue depth as `0.0` when the configured Redis stream is missing, instead of an invalid metric value.
  - On-call incident tools now initialize their alert service at the right time and validate required inputs before using it, improving reliability during invocation.

- **Tests**
  - Added/extended unit tests to cover missing worker streams for metrics and to confirm on-call tools defer service initialization and error on missing `incident_id`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->