### PR TITLE
fix: isolate ingestion metric reads

### DIFF
--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -92,7 +92,7 @@ class OperationalMetricsTest {
         val pendingStart = "${System.currentTimeMillis() - 10_000L}-0"
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
@@ -200,7 +200,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
@@ -243,7 +243,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
@@ -274,7 +274,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
@@ -308,7 +308,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } throws IllegalStateException("redis down")
         every { redis.llen(dlqKey) } returns 0L
@@ -334,7 +334,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } throws
             IllegalStateException("ERR no such key '$streamKey'")
@@ -372,7 +372,7 @@ class OperationalMetricsTest {
         val oldStreamId = "${System.currentTimeMillis() - 10_000L}-0"
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
@@ -406,7 +406,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
@@ -448,7 +448,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(primaryKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
@@ -482,7 +482,7 @@ class OperationalMetricsTest {
         val redis = mockk<RedisCommands<String, String>>()
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } throws
             IllegalStateException("NOGROUP No such key '$streamKey' or consumer group '$consumerGroup'")

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -84,6 +84,47 @@ class OperationalMetricsTest {
     }
 
     @Test
+    fun `renders source neutral queue gauges from consumer backlog on the monitoring connection`() {
+        val streamKey = "moneat:logs:queue:stream"
+        val dlqKey = "moneat:logs:dlq:stream"
+        val consumerGroup = "moneat:logs:workers"
+        val redis = mockk<RedisCommands<String, String>>()
+        val pendingStart = "${System.currentTimeMillis() - 10_000L}-0"
+
+        mockkObject(RedisConfig)
+        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.monitoringSync() } returns redis
+        every {
+            redis.xpending(streamKey, consumerGroup)
+        } returns PendingMessages(2, Range.create(pendingStart, pendingStart), mapOf("worker-1" to 2L))
+        every {
+            redis.xinfoGroups(streamKey)
+        } returns listOf(mapOf("name" to consumerGroup, "lag" to 3L))
+        every { redis.xlen(dlqKey) } returns 4L
+
+        OperationalMetrics.registerIngestionQueue(
+            pipeline = IngestionPipeline.LOGS,
+            streamKey = streamKey,
+            dlqStreamKey = dlqKey,
+            consumerGroup = consumerGroup,
+            capacity = 250_000,
+        )
+
+        val rendered = OperationalMetrics.scrape()
+        val queueLine = metricLine(rendered, "moneat_ingestion_queue_depth", "pipeline=\"logs\"")
+        val ageLine = metricLine(
+            rendered,
+            "moneat_ingestion_queue_oldest_message_age_seconds",
+            "pipeline=\"logs\"",
+        )
+        val dlqLine = metricLine(rendered, "moneat_ingestion_dlq_depth", "pipeline=\"logs\"")
+
+        assertTrue(queueLine.endsWith(" 5.0"), queueLine)
+        assertTrue(ageLine.substringAfterLast(' ').toDouble() >= 9.0, ageLine)
+        assertTrue(dlqLine.endsWith(" 4.0"), dlqLine)
+    }
+
+    @Test
     fun `renders clickhouse request counters and histogram`() {
         OperationalMetrics.recordClickHouseRequest("execute", "success", 0.02)
 
@@ -160,7 +201,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(3, Range.create("1-0", "3-0"), mapOf("worker-1" to 3L))
@@ -203,7 +244,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(4, Range.create("1-0", "4-0"), mapOf("worker-1" to 4L))
@@ -234,7 +275,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(5, Range.create("1-0", "5-0"), mapOf("worker-1" to 5L))
@@ -268,7 +309,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } throws IllegalStateException("redis down")
         every { redis.llen(dlqKey) } returns 0L
 
@@ -294,7 +335,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } throws
             IllegalStateException("ERR no such key '$streamKey'")
         every { redis.llen(dlqKey) } returns 0L
@@ -332,7 +373,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(2, Range.create(oldStreamId, oldStreamId), mapOf("worker-1" to 2L))
@@ -366,7 +407,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -408,7 +449,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(primaryKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(primaryKey) } returns listOf(
@@ -442,7 +483,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } throws
             IllegalStateException("NOGROUP No such key '$streamKey' or consumer group '$consumerGroup'")
 

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -40,6 +40,9 @@ object RedisConfig {
 
     @Volatile
     private var connection: StatefulRedisConnection<String, String>? = null
+
+    @Volatile
+    private var monitoringConnection: StatefulRedisConnection<String, String>? = null
     private val blockingConnections = mutableListOf<StatefulRedisConnection<String, String>>()
 
     fun init(redisUrl: String) {
@@ -50,10 +53,24 @@ object RedisConfig {
             .build()
         client = RedisClient.create(resources, uri)
         connection = client!!.connect()
+        monitoringConnection = client!!.connect()
     }
 
     fun sync(): RedisCommands<String, String> {
         val conn = checkNotNull(connection) { "RedisConfig is not initialized. Call init() first." }
+        return conn.sync()
+    }
+
+    /**
+     * Returns commands on the connection reserved for operational metric reads.
+     *
+     * Intake requests can keep the primary Redis connection busy during bursts. Keeping metric reads on a
+     * separate connection prevents Prometheus gauges from degrading to NaN while queue admission is active.
+     */
+    fun monitoringSync(): RedisCommands<String, String> {
+        val conn = checkNotNull(monitoringConnection) {
+            "RedisConfig monitoring connection is not initialized. Call init() first."
+        }
         return conn.sync()
     }
 
@@ -100,6 +117,8 @@ object RedisConfig {
     fun isInitialized(): Boolean = connection != null
 
     fun close() {
+        monitoringConnection?.close()
+        monitoringConnection = null
         connection?.close()
         connection = null
         synchronized(blockingConnections) {

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -114,6 +114,8 @@ object RedisConfig {
 
     fun isConnected(): Boolean = connection?.isOpen == true
 
+    fun isMonitoringConnected(): Boolean = monitoringConnection?.isOpen == true
+
     fun isInitialized(): Boolean = connection != null
 
     fun close() {

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -266,8 +266,10 @@ object OperationalMetrics {
     ) {
         registerIngestionQueueCapacity(pipeline, capacity)
         registeredIngestionQueueMeters.computeIfAbsent(pipeline.id) {
-            Gauge.builder(INGESTION_QUEUE_DEPTH, streamKey) { key -> readQueueDepth(key) }
-                .description("Current number of retained entries in an ingestion queue.")
+            Gauge.builder(INGESTION_QUEUE_DEPTH, streamKey) { key ->
+                readStreamBacklogMessages(key, consumerGroup)
+            }
+                .description("Current pending and unconsumed entries in an ingestion queue.")
                 .tags(tags("pipeline" to pipeline.id))
                 .register(registry)
             Gauge.builder(INGESTION_QUEUE_OLDEST_MESSAGE_AGE_SECONDS, streamKey) { key ->
@@ -729,14 +731,14 @@ object OperationalMetrics {
     private fun readQueueDepth(queueKey: String, consumerGroup: String? = null): Double {
         if (!RedisConfig.isConnected()) return Double.NaN
         if (consumerGroup != null) return readStreamBacklogMessages(queueKey, consumerGroup)
-        return runCatching { RedisConfig.sync().xlen(queueKey).toDouble() }
-            .recoverCatching { RedisConfig.sync().llen(queueKey).toDouble() }
+        return runCatching { RedisConfig.monitoringSync().xlen(queueKey).toDouble() }
+            .recoverCatching { RedisConfig.monitoringSync().llen(queueKey).toDouble() }
             .getOrElse { Double.NaN }
     }
 
     private fun readStreamBacklogMessages(streamKey: String, consumerGroup: String): Double =
         runCatching {
-            val redis = RedisConfig.sync()
+            val redis = RedisConfig.monitoringSync()
             val pendingMessages = redis.xpending(streamKey, consumerGroup).count
             val lagMessages = redis.xinfoGroups(streamKey)
                 .asSequence()
@@ -751,14 +753,14 @@ object OperationalMetrics {
 
     private fun readStreamPendingMessages(streamKey: String, consumerGroup: String): Double {
         if (!RedisConfig.isConnected()) return Double.NaN
-        return runCatching { RedisConfig.sync().xpending(streamKey, consumerGroup).count.toDouble() }
+        return runCatching { RedisConfig.monitoringSync().xpending(streamKey, consumerGroup).count.toDouble() }
             .getOrElse { Double.NaN }
     }
 
     private fun readStreamOldestMessageAgeSeconds(streamKey: String, consumerGroup: String?): Double {
         if (!RedisConfig.isConnected()) return Double.NaN
         return runCatching {
-            val redis = RedisConfig.sync()
+            val redis = RedisConfig.monitoringSync()
             if (consumerGroup == null) {
                 return readOldestStreamEntryAgeSeconds(redis, streamKey)
             }

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -196,7 +196,7 @@ object OperationalMetrics {
         val meterKey = "$normalizedWorkerName|$queueKey|$normalizedQueueType"
         registeredQueueMeters.computeIfAbsent(meterKey) {
             Gauge.builder(WORKER_QUEUE_DEPTH, queueKey) { key -> readQueueDepth(key, consumerGroup) }
-                .description("Current Redis queue depth for registered worker queues.")
+                .description("Current Redis queue depth, using pending plus lag for stream consumer groups.")
                 .tags(
                     tags(
                         "worker" to normalizedWorkerName,
@@ -729,7 +729,7 @@ object OperationalMetrics {
     }
 
     private fun readQueueDepth(queueKey: String, consumerGroup: String? = null): Double {
-        if (!RedisConfig.isConnected()) return Double.NaN
+        if (!RedisConfig.isMonitoringConnected()) return Double.NaN
         if (consumerGroup != null) return readStreamBacklogMessages(queueKey, consumerGroup)
         return runCatching { RedisConfig.monitoringSync().xlen(queueKey).toDouble() }
             .recoverCatching { RedisConfig.monitoringSync().llen(queueKey).toDouble() }
@@ -752,13 +752,13 @@ object OperationalMetrics {
         }
 
     private fun readStreamPendingMessages(streamKey: String, consumerGroup: String): Double {
-        if (!RedisConfig.isConnected()) return Double.NaN
+        if (!RedisConfig.isMonitoringConnected()) return Double.NaN
         return runCatching { RedisConfig.monitoringSync().xpending(streamKey, consumerGroup).count.toDouble() }
             .getOrElse { Double.NaN }
     }
 
     private fun readStreamOldestMessageAgeSeconds(streamKey: String, consumerGroup: String?): Double {
-        if (!RedisConfig.isConnected()) return Double.NaN
+        if (!RedisConfig.isMonitoringConnected()) return Double.NaN
         return runCatching {
             val redis = RedisConfig.monitoringSync()
             if (consumerGroup == null) {

--- a/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
@@ -51,7 +51,7 @@ class OperationalMetricsAlertCoverageTest {
         val unconsumedId = "${System.currentTimeMillis() - 10_000L}-0"
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
@@ -90,7 +90,7 @@ class OperationalMetricsAlertCoverageTest {
         val lastDeliveredId = "${System.currentTimeMillis() - 20_000L}-0"
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
@@ -128,7 +128,7 @@ class OperationalMetricsAlertCoverageTest {
         val oldestId = "${System.currentTimeMillis() - 10_000L}-0"
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
@@ -165,7 +165,7 @@ class OperationalMetricsAlertCoverageTest {
         }
 
         mockkObject(RedisConfig)
-        every { RedisConfig.isConnected() } returns true
+        every { RedisConfig.isMonitoringConnected() } returns true
         every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(4, Range.create("1-0", "4-0"), mapOf("worker-1" to 4L))

--- a/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
@@ -52,7 +52,7 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -91,7 +91,7 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -129,7 +129,7 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -166,7 +166,7 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isConnected() } returns true
-        every { RedisConfig.sync() } returns redis
+        every { RedisConfig.monitoringSync() } returns redis
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(4, Range.create("1-0", "4-0"), mapOf("worker-1" to 4L))
         every { redis.xinfoGroups(streamKey) } returns listOf(


### PR DESCRIPTION
## Summary

- isolate operational Redis reads from intake traffic
- report queue backlog from pending and unconsumed entries
- cover source-neutral queue gauges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operational monitoring for ingestion queue depth, oldest message age, and dead-letter queue depth.
  * Queue depth metrics now reflect pending and unconsumed consumer-group entries.

* **Bug Fixes**
  * Improved monitoring metric reliability by isolating monitoring reads from primary Redis operations.
  * Updated queue and stream age metrics to use consistent monitoring data sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->