### PR TITLE
fix: heal ingestion metric redis reads

### DIFF
--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/OperationalMetricsTest.kt
@@ -93,7 +93,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(2, Range.create(pendingStart, pendingStart), mapOf("worker-1" to 2L))
@@ -201,7 +201,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(3, Range.create("1-0", "3-0"), mapOf("worker-1" to 3L))
@@ -244,7 +244,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(4, Range.create("1-0", "4-0"), mapOf("worker-1" to 4L))
@@ -275,7 +275,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(5, Range.create("1-0", "5-0"), mapOf("worker-1" to 5L))
@@ -309,7 +309,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every { redis.xpending(streamKey, consumerGroup) } throws IllegalStateException("redis down")
         every { redis.llen(dlqKey) } returns 0L
 
@@ -335,7 +335,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every { redis.xpending(streamKey, consumerGroup) } throws
             IllegalStateException("ERR no such key '$streamKey'")
         every { redis.llen(dlqKey) } returns 0L
@@ -373,7 +373,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every {
             redis.xpending(streamKey, consumerGroup)
         } returns PendingMessages(2, Range.create(oldStreamId, oldStreamId), mapOf("worker-1" to 2L))
@@ -407,7 +407,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -449,7 +449,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every { redis.xpending(primaryKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(primaryKey) } returns listOf(
@@ -483,7 +483,7 @@ class OperationalMetricsTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        mockMonitoringRedis(redis)
         every { redis.xpending(streamKey, consumerGroup) } throws
             IllegalStateException("NOGROUP No such key '$streamKey' or consumer group '$consumerGroup'")
 
@@ -595,6 +595,12 @@ class OperationalMetricsTest {
 
     private fun assertHasApplicationTag(rendered: String) {
         assertContains(rendered, "application=\"moneat-backend\"")
+    }
+
+    private fun mockMonitoringRedis(redis: RedisCommands<String, String>) {
+        every { RedisConfig.withMonitoringSync<Double>(any()) } answers {
+            firstArg<(RedisCommands<String, String>) -> Double>()(redis)
+        }
     }
 
     private fun metricLine(rendered: String, metricName: String, vararg labels: String): String =

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -19,8 +19,10 @@ package com.moneat.config
 import com.moneat.utils.suspendRunCatching
 import io.ktor.server.application.Application
 import io.ktor.server.application.log
+import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
+import io.lettuce.core.SocketOptions
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.reactive.RedisReactiveCommands
@@ -28,11 +30,18 @@ import io.lettuce.core.api.sync.RedisCommands
 import io.lettuce.core.resource.ClientResources
 import io.netty.resolver.DefaultAddressResolverGroup
 import java.time.Duration
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 private const val BLOCKING_COMMAND_TIMEOUT_SECONDS = 15L
+private const val MONITORING_COMMAND_TIMEOUT_SECONDS = 2L
+private const val MONITORING_RECONNECT_COOLDOWN_SECONDS = 10L
 
 // Blocking command timeout for workers using XREADGROUP BLOCK. Each worker gets its own connection.
 private val BLOCKING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(BLOCKING_COMMAND_TIMEOUT_SECONDS)
+private val MONITORING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(MONITORING_COMMAND_TIMEOUT_SECONDS)
+private val MONITORING_RECONNECT_COOLDOWN: Duration = Duration.ofSeconds(MONITORING_RECONNECT_COOLDOWN_SECONDS)
+
+private data class MonitoringRead<T>(val value: T)
 
 object RedisConfig {
     @Volatile
@@ -43,7 +52,10 @@ object RedisConfig {
 
     @Volatile
     private var monitoringConnection: StatefulRedisConnection<String, String>? = null
-    private val monitoringConnectionLock = Any()
+    private val monitoringConnectionLock = ReentrantReadWriteLock()
+
+    @Volatile
+    private var monitoringReconnectAllowedAtNanos = 0L
     private val blockingConnections = mutableListOf<StatefulRedisConnection<String, String>>()
 
     fun init(redisUrl: String) {
@@ -52,9 +64,19 @@ object RedisConfig {
         val resources = ClientResources.builder()
             .addressResolverGroup(DefaultAddressResolverGroup.INSTANCE)
             .build()
-        client = RedisClient.create(resources, uri)
+        client = RedisClient.create(resources, uri).also {
+            it.setOptions(
+                ClientOptions.builder()
+                    .socketOptions(
+                        SocketOptions.builder()
+                            .connectTimeout(MONITORING_COMMAND_TIMEOUT)
+                            .build()
+                    )
+                    .build()
+            )
+        }
         connection = client!!.connect()
-        monitoringConnection = client!!.connect()
+        monitoringConnection = client!!.connect().also { it.timeout = MONITORING_COMMAND_TIMEOUT }
     }
 
     fun sync(): RedisCommands<String, String> {
@@ -68,12 +90,44 @@ object RedisConfig {
      * Intake requests can keep the primary Redis connection busy during bursts. Keeping metric reads on a
      * separate connection prevents Prometheus gauges from degrading to NaN while queue admission is active.
      */
-    fun <T> withMonitoringSync(operation: (RedisCommands<String, String>) -> T): T =
-        synchronized(monitoringConnectionLock) {
-            val monitoring = reconnectClosedMonitoringConnection(monitoringConnection, client)
-                .also { monitoringConnection = it }
-            operation(monitoring?.sync() ?: sync())
+    fun <T> withMonitoringSync(operation: (RedisCommands<String, String>) -> T): T {
+        withOpenMonitoringConnection(operation)?.let { return it.value }
+        reconnectMonitoringConnectionIfDue()
+        return withOpenMonitoringConnection(operation)?.value ?: operation(sync())
+    }
+
+    private fun <T> withOpenMonitoringConnection(
+        operation: (RedisCommands<String, String>) -> T
+    ): MonitoringRead<T>? {
+        val readLock = monitoringConnectionLock.readLock()
+        if (!readLock.tryLock()) return null
+        return try {
+            val monitoring = monitoringConnection?.takeIf { it.isOpen } ?: return null
+            MonitoringRead(operation(monitoring.sync()))
+        } finally {
+            readLock.unlock()
         }
+    }
+
+    private fun reconnectMonitoringConnectionIfDue() {
+        val now = System.nanoTime()
+        if (now < monitoringReconnectAllowedAtNanos) return
+
+        val writeLock = monitoringConnectionLock.writeLock()
+        if (!writeLock.tryLock()) return
+        try {
+            if (monitoringConnection?.isOpen == true) return
+            val attemptStartedAt = System.nanoTime()
+            if (attemptStartedAt < monitoringReconnectAllowedAtNanos) return
+            monitoringReconnectAllowedAtNanos = attemptStartedAt + MONITORING_RECONNECT_COOLDOWN.toNanos()
+            reconnectClosedMonitoringConnection(monitoringConnection, client)?.let { replacement ->
+                monitoringConnection = replacement
+                monitoringReconnectAllowedAtNanos = 0L
+            }
+        } finally {
+            writeLock.unlock()
+        }
+    }
 
     /** Returns a dedicated blocking connection for a single worker. Each call creates a new connection. */
     fun newStatefulBlockingConnection(): StatefulRedisConnection<String, String> {
@@ -120,9 +174,12 @@ object RedisConfig {
     fun isInitialized(): Boolean = connection != null
 
     fun close() {
-        synchronized(monitoringConnectionLock) {
+        val writeLock = monitoringConnectionLock.writeLock()
+        writeLock.lock()
+        try {
             monitoringConnection?.close()
             monitoringConnection = null
+            monitoringReconnectAllowedAtNanos = 0L
             connection?.close()
             connection = null
             synchronized(blockingConnections) {
@@ -131,6 +188,8 @@ object RedisConfig {
             }
             client?.shutdown()
             client = null
+        } finally {
+            writeLock.unlock()
         }
     }
 }
@@ -142,7 +201,9 @@ internal fun reconnectClosedMonitoringConnection(
     if (current?.isOpen == true) return current
     return runCatching {
         current?.close()
-        checkNotNull(client) { "RedisConfig is not initialized. Call init() first." }.connect()
+        checkNotNull(client) { "RedisConfig is not initialized. Call init() first." }
+            .connect()
+            .also { it.timeout = MONITORING_COMMAND_TIMEOUT }
     }.getOrNull()
 }
 

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -43,6 +43,7 @@ object RedisConfig {
 
     @Volatile
     private var monitoringConnection: StatefulRedisConnection<String, String>? = null
+    private val monitoringConnectionLock = Any()
     private val blockingConnections = mutableListOf<StatefulRedisConnection<String, String>>()
 
     fun init(redisUrl: String) {
@@ -68,10 +69,16 @@ object RedisConfig {
      * separate connection prevents Prometheus gauges from degrading to NaN while queue admission is active.
      */
     fun monitoringSync(): RedisCommands<String, String> {
-        val conn = checkNotNull(monitoringConnection) {
-            "RedisConfig monitoring connection is not initialized. Call init() first."
+        val conn = activeMonitoringConnection()
+        return conn?.sync() ?: sync()
+    }
+
+    private fun activeMonitoringConnection(): StatefulRedisConnection<String, String>? {
+        monitoringConnection?.takeIf { it.isOpen }?.let { return it }
+        return synchronized(monitoringConnectionLock) {
+            reconnectClosedMonitoringConnection(monitoringConnection, client)
+                .also { monitoringConnection = it }
         }
-        return conn.sync()
     }
 
     /** Returns a dedicated blocking connection for a single worker. Each call creates a new connection. */
@@ -114,13 +121,15 @@ object RedisConfig {
 
     fun isConnected(): Boolean = connection?.isOpen == true
 
-    fun isMonitoringConnected(): Boolean = monitoringConnection?.isOpen == true
+    fun isMonitoringConnected(): Boolean = monitoringConnection?.isOpen == true || isConnected()
 
     fun isInitialized(): Boolean = connection != null
 
     fun close() {
-        monitoringConnection?.close()
-        monitoringConnection = null
+        synchronized(monitoringConnectionLock) {
+            monitoringConnection?.close()
+            monitoringConnection = null
+        }
         connection?.close()
         connection = null
         synchronized(blockingConnections) {
@@ -130,6 +139,17 @@ object RedisConfig {
         client?.shutdown()
         client = null
     }
+}
+
+internal fun reconnectClosedMonitoringConnection(
+    current: StatefulRedisConnection<String, String>?,
+    client: RedisClient?,
+): StatefulRedisConnection<String, String>? {
+    if (current?.isOpen == true) return current
+    return runCatching {
+        current?.close()
+        checkNotNull(client) { "RedisConfig is not initialized. Call init() first." }.connect()
+    }.getOrNull()
 }
 
 fun Application.configureRedis() {

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -68,18 +68,12 @@ object RedisConfig {
      * Intake requests can keep the primary Redis connection busy during bursts. Keeping metric reads on a
      * separate connection prevents Prometheus gauges from degrading to NaN while queue admission is active.
      */
-    fun monitoringSync(): RedisCommands<String, String> {
-        val conn = activeMonitoringConnection()
-        return conn?.sync() ?: sync()
-    }
-
-    private fun activeMonitoringConnection(): StatefulRedisConnection<String, String>? {
-        monitoringConnection?.takeIf { it.isOpen }?.let { return it }
-        return synchronized(monitoringConnectionLock) {
-            reconnectClosedMonitoringConnection(monitoringConnection, client)
+    fun <T> withMonitoringSync(operation: (RedisCommands<String, String>) -> T): T =
+        synchronized(monitoringConnectionLock) {
+            val monitoring = reconnectClosedMonitoringConnection(monitoringConnection, client)
                 .also { monitoringConnection = it }
+            operation(monitoring?.sync() ?: sync())
         }
-    }
 
     /** Returns a dedicated blocking connection for a single worker. Each call creates a new connection. */
     fun newStatefulBlockingConnection(): StatefulRedisConnection<String, String> {
@@ -129,15 +123,15 @@ object RedisConfig {
         synchronized(monitoringConnectionLock) {
             monitoringConnection?.close()
             monitoringConnection = null
+            connection?.close()
+            connection = null
+            synchronized(blockingConnections) {
+                blockingConnections.forEach { it.close() }
+                blockingConnections.clear()
+            }
+            client?.shutdown()
+            client = null
         }
-        connection?.close()
-        connection = null
-        synchronized(blockingConnections) {
-            blockingConnections.forEach { it.close() }
-            blockingConnections.clear()
-        }
-        client?.shutdown()
-        client = null
     }
 }
 

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -35,6 +35,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 private const val BLOCKING_COMMAND_TIMEOUT_SECONDS = 15L
 private const val MONITORING_COMMAND_TIMEOUT_SECONDS = 2L
 private const val MONITORING_RECONNECT_COOLDOWN_SECONDS = 10L
+private const val REDIS_NOT_INITIALIZED_MESSAGE = "RedisConfig is not initialized. Call init() first."
 
 // Blocking command timeout for workers using XREADGROUP BLOCK. Each worker gets its own connection.
 private val BLOCKING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(BLOCKING_COMMAND_TIMEOUT_SECONDS)
@@ -80,7 +81,7 @@ object RedisConfig {
     }
 
     fun sync(): RedisCommands<String, String> {
-        val conn = checkNotNull(connection) { "RedisConfig is not initialized. Call init() first." }
+        val conn = checkNotNull(connection) { REDIS_NOT_INITIALIZED_MESSAGE }
         return conn.sync()
     }
 
@@ -131,7 +132,7 @@ object RedisConfig {
 
     /** Returns a dedicated blocking connection for a single worker. Each call creates a new connection. */
     fun newStatefulBlockingConnection(): StatefulRedisConnection<String, String> {
-        val c = checkNotNull(client) { "RedisConfig is not initialized. Call init() first." }
+        val c = checkNotNull(client) { REDIS_NOT_INITIALIZED_MESSAGE }
         val conn = c.connect().also { it.timeout = BLOCKING_COMMAND_TIMEOUT }
         synchronized(blockingConnections) { blockingConnections.add(conn) }
         return conn
@@ -158,12 +159,12 @@ object RedisConfig {
     }
 
     fun async(): RedisAsyncCommands<String, String> {
-        val conn = checkNotNull(connection) { "RedisConfig is not initialized. Call init() first." }
+        val conn = checkNotNull(connection) { REDIS_NOT_INITIALIZED_MESSAGE }
         return conn.async()
     }
 
     fun reactive(): RedisReactiveCommands<String, String> {
-        val conn = checkNotNull(connection) { "RedisConfig is not initialized. Call init() first." }
+        val conn = checkNotNull(connection) { REDIS_NOT_INITIALIZED_MESSAGE }
         return conn.reactive()
     }
 
@@ -201,7 +202,7 @@ internal fun reconnectClosedMonitoringConnection(
     if (current?.isOpen == true) return current
     return runCatching {
         current?.close()
-        checkNotNull(client) { "RedisConfig is not initialized. Call init() first." }
+        checkNotNull(client) { REDIS_NOT_INITIALIZED_MESSAGE }
             .connect()
             .also { it.timeout = MONITORING_COMMAND_TIMEOUT }
     }.getOrNull()

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -731,61 +731,69 @@ object OperationalMetrics {
     private fun readQueueDepth(queueKey: String, consumerGroup: String? = null): Double {
         if (!RedisConfig.isMonitoringConnected()) return Double.NaN
         if (consumerGroup != null) return readStreamBacklogMessages(queueKey, consumerGroup)
-        return runCatching { RedisConfig.monitoringSync().xlen(queueKey).toDouble() }
-            .recoverCatching { RedisConfig.monitoringSync().llen(queueKey).toDouble() }
+        return runCatching { RedisConfig.withMonitoringSync { it.xlen(queueKey).toDouble() } }
+            .recoverCatching { RedisConfig.withMonitoringSync { it.llen(queueKey).toDouble() } }
             .getOrElse { Double.NaN }
     }
 
     private fun readStreamBacklogMessages(streamKey: String, consumerGroup: String): Double =
         runCatching {
-            val redis = RedisConfig.monitoringSync()
-            val pendingMessages = redis.xpending(streamKey, consumerGroup).count
-            val lagMessages = redis.xinfoGroups(streamKey)
-                .asSequence()
-                .mapNotNull { parseStreamGroupInfo(it) }
-                .firstOrNull { group -> group.name == consumerGroup }
-                ?.lag
-                ?: 0L
-            (pendingMessages + lagMessages).toDouble()
+            RedisConfig.withMonitoringSync { redis ->
+                val pendingMessages = redis.xpending(streamKey, consumerGroup).count
+                val lagMessages = redis.xinfoGroups(streamKey)
+                    .asSequence()
+                    .mapNotNull { parseStreamGroupInfo(it) }
+                    .firstOrNull { group -> group.name == consumerGroup }
+                    ?.lag
+                    ?: 0L
+                (pendingMessages + lagMessages).toDouble()
+            }
         }.getOrElse { error ->
             if (error.isMissingRedisStreamError()) 0.0 else Double.NaN
         }
 
     private fun readStreamPendingMessages(streamKey: String, consumerGroup: String): Double {
         if (!RedisConfig.isMonitoringConnected()) return Double.NaN
-        return runCatching { RedisConfig.monitoringSync().xpending(streamKey, consumerGroup).count.toDouble() }
+        return runCatching {
+            RedisConfig.withMonitoringSync { it.xpending(streamKey, consumerGroup).count.toDouble() }
+        }
             .getOrElse { Double.NaN }
     }
 
     private fun readStreamOldestMessageAgeSeconds(streamKey: String, consumerGroup: String?): Double {
         if (!RedisConfig.isMonitoringConnected()) return Double.NaN
         return runCatching {
-            val redis = RedisConfig.monitoringSync()
-            if (consumerGroup == null) {
-                return readOldestStreamEntryAgeSeconds(redis, streamKey)
+            RedisConfig.withMonitoringSync { redis ->
+                readStreamOldestMessageAgeSeconds(redis, streamKey, consumerGroup)
             }
-
-            val pending = redis.xpending(streamKey, consumerGroup)
-            if (pending.count > 0) {
-                return streamIdAgeSeconds(pending.messageIds.lower.value)
-            }
-
-            val group = redis.xinfoGroups(streamKey)
-                .asSequence()
-                .mapNotNull(::parseStreamGroupInfo)
-                .firstOrNull { info -> info.name == consumerGroup }
-            if (group == null) return 0.0
-            val lag = group.lag ?: return readOldestStreamEntryAgeSeconds(redis, streamKey)
-            if (lag <= 0 || group.lastDeliveredId == null) return 0.0
-
-            val firstUnconsumed = redis
-                .xrange(streamKey, Range.create(group.lastDeliveredId, "+"), Limit.from(2))
-                .firstOrNull { message -> message.id != group.lastDeliveredId }
-                ?: return 0.0
-            streamIdAgeSeconds(firstUnconsumed.id)
         }.getOrElse { error ->
             if (error.isMissingRedisStreamError()) 0.0 else Double.NaN
         }
+    }
+
+    private fun readStreamOldestMessageAgeSeconds(
+        redis: RedisCommands<String, String>,
+        streamKey: String,
+        consumerGroup: String?,
+    ): Double {
+        if (consumerGroup == null) return readOldestStreamEntryAgeSeconds(redis, streamKey)
+
+        val pending = redis.xpending(streamKey, consumerGroup)
+        if (pending.count > 0) return streamIdAgeSeconds(pending.messageIds.lower.value)
+
+        val group = redis.xinfoGroups(streamKey)
+            .asSequence()
+            .mapNotNull(::parseStreamGroupInfo)
+            .firstOrNull { info -> info.name == consumerGroup }
+        if (group == null) return 0.0
+        val lag = group.lag ?: return readOldestStreamEntryAgeSeconds(redis, streamKey)
+        if (lag <= 0 || group.lastDeliveredId == null) return 0.0
+
+        val firstUnconsumed = redis
+            .xrange(streamKey, Range.create(group.lastDeliveredId, "+"), Limit.from(2))
+            .firstOrNull { message -> message.id != group.lastDeliveredId }
+            ?: return 0.0
+        return streamIdAgeSeconds(firstUnconsumed.id)
     }
 
     private fun readOldestStreamEntryAgeSeconds(

--- a/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
@@ -1,0 +1,62 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.config
+
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class RedisConfigMonitoringConnectionTest {
+    @Test
+    fun `keeps an open monitoring connection`() {
+        val current = mockk<StatefulRedisConnection<String, String>>()
+        val client = mockk<RedisClient>()
+        every { current.isOpen } returns true
+
+        assertSame(current, reconnectClosedMonitoringConnection(current, client))
+        verify(exactly = 0) { client.connect() }
+    }
+
+    @Test
+    fun `replaces a closed monitoring connection`() {
+        val current = mockk<StatefulRedisConnection<String, String>>()
+        val replacement = mockk<StatefulRedisConnection<String, String>>()
+        val client = mockk<RedisClient>()
+        every { current.isOpen } returns false
+        every { current.close() } just runs
+        every { client.connect() } returns replacement
+
+        assertSame(replacement, reconnectClosedMonitoringConnection(current, client))
+        verify(exactly = 1) { current.close() }
+        verify(exactly = 1) { client.connect() }
+    }
+
+    @Test
+    fun `returns null when a monitoring reconnect fails`() {
+        val client = mockk<RedisClient>()
+        every { client.connect() } throws IllegalStateException("redis unavailable")
+
+        assertNull(reconnectClosedMonitoringConnection(null, client))
+    }
+}

--- a/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
@@ -46,10 +46,12 @@ class RedisConfigMonitoringConnectionTest {
         every { current.isOpen } returns false
         every { current.close() } just runs
         every { client.connect() } returns replacement
+        every { replacement.timeout = any() } just runs
 
         assertSame(replacement, reconnectClosedMonitoringConnection(current, client))
         verify(exactly = 1) { current.close() }
         verify(exactly = 1) { client.connect() }
+        verify(exactly = 1) { replacement.timeout = any() }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/monitoring/OperationalMetricsAlertCoverageTest.kt
@@ -52,7 +52,9 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        every { RedisConfig.withMonitoringSync<Double>(any()) } answers {
+            firstArg<(RedisCommands<String, String>) -> Double>()(redis)
+        }
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -91,7 +93,9 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        every { RedisConfig.withMonitoringSync<Double>(any()) } answers {
+            firstArg<(RedisCommands<String, String>) -> Double>()(redis)
+        }
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -129,7 +133,9 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        every { RedisConfig.withMonitoringSync<Double>(any()) } answers {
+            firstArg<(RedisCommands<String, String>) -> Double>()(redis)
+        }
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(0, Range.create("0-0", "0-0"), emptyMap())
         every { redis.xinfoGroups(streamKey) } returns listOf(
@@ -166,7 +172,9 @@ class OperationalMetricsAlertCoverageTest {
 
         mockkObject(RedisConfig)
         every { RedisConfig.isMonitoringConnected() } returns true
-        every { RedisConfig.monitoringSync() } returns redis
+        every { RedisConfig.withMonitoringSync<Double>(any()) } answers {
+            firstArg<(RedisCommands<String, String>) -> Double>()(redis)
+        }
         every { redis.xpending(streamKey, consumerGroup) } returns
             PendingMessages(4, Range.create("1-0", "4-0"), mapOf("worker-1" to 4L))
         every { redis.xinfoGroups(streamKey) } returns listOf(


### PR DESCRIPTION
## Summary

- reconnect failed Redis monitoring channels
- fall back to the healthy primary channel when needed
- cover reconnection behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Redis monitoring during unexpected monitoring connection shutdowns.
  * Monitoring now reconnects automatically when available, and safely falls back to the primary Redis connection when needed.
  * Updated connection-status checks to reflect active connectivity more accurately.
  * Redis-backed operational metrics (queue depth and stream metrics) are now computed with more robust monitoring synchronization, with consistent fallback behavior.
* **Tests**
  * Added and updated unit tests to cover monitoring reconnection and metric read paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->