### PR TITLE
fix: recover Redis metric reads

### DIFF
--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -45,7 +45,7 @@ private val BLOCKING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(BLOCKING_COM
 private val MONITORING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(MONITORING_COMMAND_TIMEOUT_SECONDS)
 private val MONITORING_RECONNECT_COOLDOWN: Duration = Duration.ofSeconds(MONITORING_RECONNECT_COOLDOWN_SECONDS)
 
-private sealed interface MonitoringRead<out T> {
+internal sealed interface MonitoringRead<out T> {
     data class Success<T>(val value: T) : MonitoringRead<T>
 
     data class ConnectionFailure(
@@ -62,7 +62,7 @@ object RedisConfig {
 
     @Volatile
     private var monitoringConnection: StatefulRedisConnection<String, String>? = null
-    private val monitoringConnectionLock = ReentrantReadWriteLock()
+    private val monitoringConnectionLock = ReentrantReadWriteLock(true)
 
     @Volatile
     private var monitoringReconnectAllowedAtNanos = 0L
@@ -101,20 +101,12 @@ object RedisConfig {
      * separate connection prevents Prometheus gauges from degrading to NaN while queue admission is active.
      */
     fun <T> withMonitoringSync(operation: (RedisCommands<String, String>) -> T): T {
-        when (val initialRead = withOpenMonitoringConnection(operation)) {
-            is MonitoringRead.Success -> return initialRead.value
-            is MonitoringRead.ConnectionFailure -> invalidateMonitoringConnection(initialRead.connection)
-            null -> Unit
-        }
-        reconnectMonitoringConnectionIfDue()
-        return when (val retriedRead = withOpenMonitoringConnection(operation)) {
-            is MonitoringRead.Success -> retriedRead.value
-            is MonitoringRead.ConnectionFailure -> {
-                invalidateMonitoringConnection(retriedRead.connection)
-                operation(sync())
-            }
-            null -> operation(sync())
-        }
+        return readMonitoringWithRecovery(
+            read = { withOpenMonitoringConnection(operation) },
+            invalidate = ::invalidateMonitoringConnection,
+            reconnect = ::reconnectMonitoringConnectionIfDue,
+            primaryRead = { operation(sync()) },
+        )
     }
 
     private fun <T> withOpenMonitoringConnection(
@@ -124,12 +116,7 @@ object RedisConfig {
         if (!readLock.tryLock()) return null
         return try {
             val monitoring = monitoringConnection?.takeIf { it.isOpen } ?: return null
-            try {
-                MonitoringRead.Success(operation(monitoring.sync()))
-            } catch (error: RedisException) {
-                if (!isMonitoringConnectionFailure(error)) throw error
-                MonitoringRead.ConnectionFailure(monitoring)
-            }
+            executeMonitoringRead(monitoring, operation)
         } finally {
             readLock.unlock()
         }
@@ -139,12 +126,11 @@ object RedisConfig {
         failedConnection: StatefulRedisConnection<String, String>
     ) {
         val writeLock = monitoringConnectionLock.writeLock()
-        if (!writeLock.tryLock()) return
+        writeLock.lock()
         try {
             if (monitoringConnection !== failedConnection) return
             failedConnection.close()
             monitoringConnection = null
-            monitoringReconnectAllowedAtNanos = 0L
         } finally {
             writeLock.unlock()
         }
@@ -152,22 +138,26 @@ object RedisConfig {
 
     private fun reconnectMonitoringConnectionIfDue() {
         val now = System.nanoTime()
-        if (now < monitoringReconnectAllowedAtNanos) return
+        if (isMonitoringReconnectCoolingDown(now)) return
 
         val writeLock = monitoringConnectionLock.writeLock()
         if (!writeLock.tryLock()) return
         try {
             if (monitoringConnection?.isOpen == true) return
             val attemptStartedAt = System.nanoTime()
-            if (attemptStartedAt < monitoringReconnectAllowedAtNanos) return
+            if (isMonitoringReconnectCoolingDown(attemptStartedAt)) return
             monitoringReconnectAllowedAtNanos = attemptStartedAt + MONITORING_RECONNECT_COOLDOWN.toNanos()
             reconnectClosedMonitoringConnection(monitoringConnection, client)?.let { replacement ->
                 monitoringConnection = replacement
-                monitoringReconnectAllowedAtNanos = 0L
             }
         } finally {
             writeLock.unlock()
         }
+    }
+
+    private fun isMonitoringReconnectCoolingDown(now: Long): Boolean {
+        val allowedAt = monitoringReconnectAllowedAtNanos
+        return allowedAt != 0L && now - allowedAt < 0L
     }
 
     /** Returns a dedicated blocking connection for a single worker. Each call creates a new connection. */
@@ -250,6 +240,39 @@ internal fun reconnectClosedMonitoringConnection(
 
 internal fun isMonitoringConnectionFailure(error: RedisException): Boolean =
     error is RedisCommandTimeoutException || error is RedisConnectionException
+
+internal fun <T> executeMonitoringRead(
+    connection: StatefulRedisConnection<String, String>,
+    operation: (RedisCommands<String, String>) -> T,
+): MonitoringRead<T> =
+    try {
+        MonitoringRead.Success(operation(connection.sync()))
+    } catch (error: RedisException) {
+        if (!isMonitoringConnectionFailure(error)) throw error
+        MonitoringRead.ConnectionFailure(connection)
+    }
+
+internal fun <T> readMonitoringWithRecovery(
+    read: () -> MonitoringRead<T>?,
+    invalidate: (StatefulRedisConnection<String, String>) -> Unit,
+    reconnect: () -> Unit,
+    primaryRead: () -> T,
+): T {
+    when (val initialRead = read()) {
+        is MonitoringRead.Success -> return initialRead.value
+        is MonitoringRead.ConnectionFailure -> invalidate(initialRead.connection)
+        null -> Unit
+    }
+    reconnect()
+    return when (val retriedRead = read()) {
+        is MonitoringRead.Success -> retriedRead.value
+        is MonitoringRead.ConnectionFailure -> {
+            invalidate(retriedRead.connection)
+            primaryRead()
+        }
+        null -> primaryRead()
+    }
+}
 
 fun Application.configureRedis() {
     // Skip Redis in test environment if REDIS_URL is not set

--- a/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/RedisConfig.kt
@@ -20,7 +20,10 @@ import com.moneat.utils.suspendRunCatching
 import io.ktor.server.application.Application
 import io.ktor.server.application.log
 import io.lettuce.core.ClientOptions
+import io.lettuce.core.RedisCommandTimeoutException
 import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisConnectionException
+import io.lettuce.core.RedisException
 import io.lettuce.core.RedisURI
 import io.lettuce.core.SocketOptions
 import io.lettuce.core.api.StatefulRedisConnection
@@ -42,7 +45,13 @@ private val BLOCKING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(BLOCKING_COM
 private val MONITORING_COMMAND_TIMEOUT: Duration = Duration.ofSeconds(MONITORING_COMMAND_TIMEOUT_SECONDS)
 private val MONITORING_RECONNECT_COOLDOWN: Duration = Duration.ofSeconds(MONITORING_RECONNECT_COOLDOWN_SECONDS)
 
-private data class MonitoringRead<T>(val value: T)
+private sealed interface MonitoringRead<out T> {
+    data class Success<T>(val value: T) : MonitoringRead<T>
+
+    data class ConnectionFailure(
+        val connection: StatefulRedisConnection<String, String>
+    ) : MonitoringRead<Nothing>
+}
 
 object RedisConfig {
     @Volatile
@@ -92,9 +101,20 @@ object RedisConfig {
      * separate connection prevents Prometheus gauges from degrading to NaN while queue admission is active.
      */
     fun <T> withMonitoringSync(operation: (RedisCommands<String, String>) -> T): T {
-        withOpenMonitoringConnection(operation)?.let { return it.value }
+        when (val initialRead = withOpenMonitoringConnection(operation)) {
+            is MonitoringRead.Success -> return initialRead.value
+            is MonitoringRead.ConnectionFailure -> invalidateMonitoringConnection(initialRead.connection)
+            null -> Unit
+        }
         reconnectMonitoringConnectionIfDue()
-        return withOpenMonitoringConnection(operation)?.value ?: operation(sync())
+        return when (val retriedRead = withOpenMonitoringConnection(operation)) {
+            is MonitoringRead.Success -> retriedRead.value
+            is MonitoringRead.ConnectionFailure -> {
+                invalidateMonitoringConnection(retriedRead.connection)
+                operation(sync())
+            }
+            null -> operation(sync())
+        }
     }
 
     private fun <T> withOpenMonitoringConnection(
@@ -104,9 +124,29 @@ object RedisConfig {
         if (!readLock.tryLock()) return null
         return try {
             val monitoring = monitoringConnection?.takeIf { it.isOpen } ?: return null
-            MonitoringRead(operation(monitoring.sync()))
+            try {
+                MonitoringRead.Success(operation(monitoring.sync()))
+            } catch (error: RedisException) {
+                if (!isMonitoringConnectionFailure(error)) throw error
+                MonitoringRead.ConnectionFailure(monitoring)
+            }
         } finally {
             readLock.unlock()
+        }
+    }
+
+    private fun invalidateMonitoringConnection(
+        failedConnection: StatefulRedisConnection<String, String>
+    ) {
+        val writeLock = monitoringConnectionLock.writeLock()
+        if (!writeLock.tryLock()) return
+        try {
+            if (monitoringConnection !== failedConnection) return
+            failedConnection.close()
+            monitoringConnection = null
+            monitoringReconnectAllowedAtNanos = 0L
+        } finally {
+            writeLock.unlock()
         }
     }
 
@@ -208,6 +248,9 @@ internal fun reconnectClosedMonitoringConnection(
     }.getOrNull()
 }
 
+internal fun isMonitoringConnectionFailure(error: RedisException): Boolean =
+    error is RedisCommandTimeoutException || error is RedisConnectionException
+
 fun Application.configureRedis() {
     // Skip Redis in test environment if REDIS_URL is not set
     val redisUrl =
@@ -219,7 +262,7 @@ fun Application.configureRedis() {
         }
 
     suspendRunCatching {
-        log.info("Connecting to Redis at $redisUrl...")
+        log.info("Connecting to Redis...")
         RedisConfig.init(redisUrl)
         log.info("Redis connection established")
         // Note: Shutdown is handled by BackgroundJobs to ensure correct ordering

--- a/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
@@ -17,6 +17,9 @@
 package com.moneat.config
 
 import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisCommandExecutionException
+import io.lettuce.core.RedisCommandTimeoutException
+import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.api.StatefulRedisConnection
 import io.mockk.every
 import io.mockk.just
@@ -24,8 +27,10 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class RedisConfigMonitoringConnectionTest {
     @Test
@@ -60,5 +65,12 @@ class RedisConfigMonitoringConnectionTest {
         every { client.connect() } throws IllegalStateException("redis unavailable")
 
         assertNull(reconnectClosedMonitoringConnection(null, client))
+    }
+
+    @Test
+    fun `classifies monitoring connection failures for recovery`() {
+        assertTrue(isMonitoringConnectionFailure(RedisCommandTimeoutException("timed out")))
+        assertTrue(isMonitoringConnectionFailure(RedisConnectionException("disconnected")))
+        assertFalse(isMonitoringConnectionFailure(RedisCommandExecutionException("NOGROUP")))
     }
 }

--- a/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/RedisConfigMonitoringConnectionTest.kt
@@ -21,12 +21,15 @@ import io.lettuce.core.RedisCommandExecutionException
 import io.lettuce.core.RedisCommandTimeoutException
 import io.lettuce.core.RedisConnectionException
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -72,5 +75,104 @@ class RedisConfigMonitoringConnectionTest {
         assertTrue(isMonitoringConnectionFailure(RedisCommandTimeoutException("timed out")))
         assertTrue(isMonitoringConnectionFailure(RedisConnectionException("disconnected")))
         assertFalse(isMonitoringConnectionFailure(RedisCommandExecutionException("NOGROUP")))
+    }
+
+    @Test
+    fun `preserves redis command execution failures`() {
+        val connection = mockk<StatefulRedisConnection<String, String>>()
+        val commands = mockk<RedisCommands<String, String>>()
+        val failure = RedisCommandExecutionException("NOGROUP")
+        every { connection.sync() } returns commands
+
+        val thrown = assertFailsWith<RedisCommandExecutionException> {
+            executeMonitoringRead(connection) { throw failure }
+        }
+
+        assertSame(failure, thrown)
+    }
+
+    @Test
+    fun `returns the failed connection for a monitoring timeout`() {
+        val connection = mockk<StatefulRedisConnection<String, String>>()
+        val commands = mockk<RedisCommands<String, String>>()
+        every { connection.sync() } returns commands
+
+        val result = executeMonitoringRead(connection) {
+            throw RedisCommandTimeoutException("timed out")
+        }
+
+        assertEquals(MonitoringRead.ConnectionFailure(connection), result)
+    }
+
+    @Test
+    fun `returns a successful monitoring read without reconnecting`() {
+        val reconnect = mockk<() -> Unit>(relaxed = true)
+        val primaryRead = mockk<() -> String>(relaxed = true)
+
+        val result = readMonitoringWithRecovery(
+            read = { MonitoringRead.Success("monitoring") },
+            invalidate = {},
+            reconnect = reconnect,
+            primaryRead = primaryRead,
+        )
+
+        assertEquals("monitoring", result)
+        verify(exactly = 0) { reconnect() }
+        verify(exactly = 0) { primaryRead() }
+    }
+
+    @Test
+    fun `invalidates a failed monitoring read and returns the retry`() {
+        val failed = mockk<StatefulRedisConnection<String, String>>()
+        val invalidated = mutableListOf<StatefulRedisConnection<String, String>>()
+        var attempt = 0
+
+        val result = readMonitoringWithRecovery(
+            read = {
+                attempt += 1
+                if (attempt == 1) MonitoringRead.ConnectionFailure(failed) else MonitoringRead.Success("retry")
+            },
+            invalidate = invalidated::add,
+            reconnect = {},
+            primaryRead = { "primary" },
+        )
+
+        assertEquals("retry", result)
+        assertEquals(listOf(failed), invalidated)
+        assertEquals(2, attempt)
+    }
+
+    @Test
+    fun `falls back to primary when a retried monitoring read fails`() {
+        val first = mockk<StatefulRedisConnection<String, String>>()
+        val second = mockk<StatefulRedisConnection<String, String>>()
+        val invalidated = mutableListOf<StatefulRedisConnection<String, String>>()
+        var attempt = 0
+
+        val result = readMonitoringWithRecovery(
+            read = {
+                attempt += 1
+                MonitoringRead.ConnectionFailure(if (attempt == 1) first else second)
+            },
+            invalidate = invalidated::add,
+            reconnect = {},
+            primaryRead = { "primary" },
+        )
+
+        assertEquals("primary", result)
+        assertEquals(listOf(first, second), invalidated)
+        assertEquals(2, attempt)
+    }
+
+    @Test
+    fun `falls back to primary when no monitoring connection is available`() {
+        val result = readMonitoringWithRecovery(
+            read = { null },
+            invalidate = {},
+            reconnect = {},
+            primaryRead = { "primary" },
+        )
+
+        assertEquals("primary", result)
     }
 }


### PR DESCRIPTION
## Summary

- recover timed-out Redis monitoring reads
- fall back to the healthy primary connection
- avoid logging Redis connection credentials

## Validation

- focused Redis and operational metrics tests
- Detekt
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis monitoring connection recovery with a structured two-attempt flow, including invalidation/retry and reliable fallback to the primary Redis connection.
  * Tightened error handling so only Redis connection/timeouts trigger monitoring recovery, while other Redis errors continue to surface normally.
  * Added stronger monitoring recovery coverage to ensure correct behavior for successful reads, timeouts, recoverable vs non-recoverable failures, and fallback scenarios.
  * Reduced sensitive Redis connection details in connection setup logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->