### PR TITLE
fix: report ingestion DLQ depth

### DIFF
--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
@@ -100,7 +100,12 @@ object IngestionQueueClient {
         queueKey: String,
         payload: String,
     ): String? {
-        val spec = IngestionQueueSettings.spec(pipeline, queueKey, "$queueKey:dlq", workerCount = 1)
+        val spec = IngestionQueueSettings.spec(
+            pipeline,
+            queueKey,
+            IngestionQueueSettings.defaultDlqKey(queueKey),
+            workerCount = 1,
+        )
         OperationalMetrics.registerIngestionQueue(
             pipeline = pipeline,
             streamKey = spec.streamKey,

--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueSettings.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueSettings.kt
@@ -27,6 +27,8 @@ private const val DEFAULT_MAX_PENDING_ENTRIES = 250_000L
 private const val DEFAULT_DLQ_STREAM_MAX_LEN = 10_000L
 private const val DEFAULT_MAX_CONCURRENT_BATCHES = 2
 private const val MIN_STREAM_BATCH_SIZE = 1
+private const val QUEUE_KEY_SUFFIX = ":queue"
+private const val DLQ_KEY_SUFFIX = ":dlq"
 
 data class IngestionQueueSpec(
     val pipeline: IngestionPipeline,
@@ -43,6 +45,9 @@ data class IngestionQueueSpec(
 )
 
 object IngestionQueueSettings {
+    fun defaultDlqKey(queueKey: String): String =
+        queueKey.removeSuffix(QUEUE_KEY_SUFFIX) + DLQ_KEY_SUFFIX
+
     fun spec(
         pipeline: IngestionPipeline,
         queueKey: String,

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
@@ -24,10 +24,13 @@ import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.XAddArgs
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkObject
+import io.mockk.verify
 import mu.KLogger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -76,6 +79,42 @@ class IngestionQueueClientTest {
 
         assertEquals("1-0", streamId)
         assertTrue(OperationalMetrics.scrape().contains("outcome=\"accepted\""))
+    }
+
+    @Test
+    fun `enqueue registers the sibling dlq stream key`() {
+        mockkObject(OperationalMetrics)
+        every {
+            OperationalMetrics.registerIngestionQueue(any(), any(), any(), any(), any())
+        } just runs
+        every { OperationalMetrics.recordIngestionAdmission(any(), any()) } just runs
+        every {
+            redis.eval<String>(
+                any<String>(),
+                ScriptOutputType.VALUE,
+                arrayOf("moneat:logs:queue:stream"),
+                "250000",
+                "payload",
+                "logs",
+                any<String>(),
+            )
+        } returns "1-0"
+
+        try {
+            IngestionQueueClient.enqueue(IngestionPipeline.LOGS, "moneat:logs:queue", "payload")
+
+            verify(exactly = 1) {
+                OperationalMetrics.registerIngestionQueue(
+                    pipeline = IngestionPipeline.LOGS,
+                    streamKey = "moneat:logs:queue:stream",
+                    dlqStreamKey = "moneat:logs:dlq:stream",
+                    consumerGroup = IngestionPipeline.LOGS.consumerGroup,
+                    capacity = 250_000L,
+                )
+            }
+        } finally {
+            unmockkObject(OperationalMetrics)
+        }
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueSettingsTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueSettingsTest.kt
@@ -41,6 +41,12 @@ class IngestionQueueSettingsTest {
     }
 
     @Test
+    fun `default dlq key is a sibling of the queue key`() {
+        assertEquals("moneat:logs:dlq", IngestionQueueSettings.defaultDlqKey("moneat:logs:queue"))
+        assertEquals("custom:dlq", IngestionQueueSettings.defaultDlqKey("custom"))
+    }
+
+    @Test
     fun `spec applies env overrides and worker controls`() {
         mockkObject(EnvConfig)
         every { EnvConfig.get(any()) } returns null


### PR DESCRIPTION
Aligns queue admission metrics with the DLQ streams consumed by workers. Adds focused key and registration coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default dead-letter queue key derivation to consistently create a sibling key for ingestion queues.
  * Improved handling for custom queue names without the standard queue suffix.

* **Tests**
  * Added coverage verifying dead-letter queue key generation and operational metrics registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->