### PR TITLE
fix: make ingestion metrics worker-owned

### DIFF
--- a/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
+++ b/backend/src/main/kotlin/com/moneat/ingestion/queue/IngestionQueueClient.kt
@@ -106,13 +106,6 @@ object IngestionQueueClient {
             IngestionQueueSettings.defaultDlqKey(queueKey),
             workerCount = 1,
         )
-        OperationalMetrics.registerIngestionQueue(
-            pipeline = pipeline,
-            streamKey = spec.streamKey,
-            dlqStreamKey = spec.dlqStreamKey,
-            consumerGroup = spec.consumerGroup,
-            capacity = spec.maxPendingEntries,
-        )
         return try {
             val streamId = admit(RedisConfig.sync(), spec, payload, System.currentTimeMillis())
             if (streamId == null) {

--- a/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/ingestion/queue/IngestionQueueClientTest.kt
@@ -82,7 +82,7 @@ class IngestionQueueClientTest {
     }
 
     @Test
-    fun `enqueue registers the sibling dlq stream key`() {
+    fun `enqueue leaves queue state metrics to workers`() {
         mockkObject(OperationalMetrics)
         every {
             OperationalMetrics.registerIngestionQueue(any(), any(), any(), any(), any())
@@ -103,14 +103,8 @@ class IngestionQueueClientTest {
         try {
             IngestionQueueClient.enqueue(IngestionPipeline.LOGS, "moneat:logs:queue", "payload")
 
-            verify(exactly = 1) {
-                OperationalMetrics.registerIngestionQueue(
-                    pipeline = IngestionPipeline.LOGS,
-                    streamKey = "moneat:logs:queue:stream",
-                    dlqStreamKey = "moneat:logs:dlq:stream",
-                    consumerGroup = IngestionPipeline.LOGS.consumerGroup,
-                    capacity = 250_000L,
-                )
+            verify(exactly = 0) {
+                OperationalMetrics.registerIngestionQueue(any(), any(), any(), any(), any())
             }
         } finally {
             unmockkObject(OperationalMetrics)


### PR DESCRIPTION
## Summary

- register queue-state gauges only in ingestion workers
- keep API admission metrics unchanged
- prevent duplicate non-numeric queue series

## Validation

- focused queue tests
- Detekt
- Claude review: approved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingestion queue metric handling by ensuring queue state metrics are recorded by workers rather than during message enqueueing.
  * Preserved existing queue capacity, availability, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->