### PR TITLE
fix: deliver critical on-call push alerts

### DIFF
--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
@@ -21,8 +21,19 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -33,26 +44,83 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.slf4j.LoggerFactory
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 
 private const val TOKEN_LOG_SUFFIX_LENGTH = 4
+private const val IOS_PLATFORM = "IOS"
+private const val INCIDENT_CATEGORY_ID = "INCIDENT_ALERT"
+private const val DEVICE_NOT_REGISTERED_ERROR = "DeviceNotRegistered"
+private const val EXPO_PUSH_ENDPOINT = "https://exp.host/--/api/v2/push/send"
+private const val EXPO_RECEIPTS_ENDPOINT = "https://exp.host/--/api/v2/push/getReceipts"
+private const val RECEIPT_CHECK_ATTEMPTS = 3
+private val RECEIPT_INITIAL_DELAY = 15.minutes
+private val RECEIPT_RETRY_DELAY = 5.minutes
+private val DEFAULT_SOUND = JsonPrimitive("default")
+private val IOS_CRITICAL_SOUND =
+    buildJsonObject {
+        put("critical", true)
+        put("name", "default")
+        put("volume", 1.0)
+    }
+private val EXPO_JSON =
+    Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+internal data class OnCallMessageContent(
+    val title: String,
+    val body: String,
+    val data: Map<String, String>,
+    val isCritical: Boolean,
+    val categoryId: String?,
+)
+
+internal fun expoSound(
+    platform: String,
+    isCritical: Boolean,
+): JsonElement =
+    if (isCritical && platform.equals(IOS_PLATFORM, ignoreCase = true)) {
+        IOS_CRITICAL_SOUND
+    } else {
+        DEFAULT_SOUND
+    }
+
+internal fun buildOnCallMessage(
+    device: PushNotificationService.RegisteredDevice,
+    content: OnCallMessageContent,
+): PushNotificationService.ExpoMessage =
+    PushNotificationService.ExpoMessage(
+        to = device.token,
+        title = content.title,
+        body = content.body,
+        data = content.data,
+        sound = expoSound(device.platform, content.isCritical),
+        channelId = if (content.isCritical) "critical" else "default",
+        interruptionLevel = if (content.isCritical) "critical" else null,
+        categoryId = content.categoryId,
+    )
 
 class PushNotificationService {
     private val logger = LoggerFactory.getLogger(PushNotificationService::class.java)
+    private val receiptScope =
+        CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.IO +
+                CoroutineName("expo-push-receipts"),
+        )
 
     private val httpClient =
         HttpClient(CIO) {
             install(ContentNegotiation) {
                 json(
-                    Json {
-                        ignoreUnknownKeys = true
-                        encodeDefaults = true
-                    },
+                    EXPO_JSON,
                 )
             }
         }
 
     private val expoAccessToken = EnvConfig.get("EXPO_TOKEN", "")
-    private val expoPushEndpoint = "https://exp.host/--/api/v2/push/send"
 
     @Serializable
     data class ExpoMessage(
@@ -60,10 +128,11 @@ class PushNotificationService {
         val title: String,
         val body: String,
         val data: Map<String, String> = emptyMap(),
-        val sound: String = "default",
+        val sound: JsonElement = DEFAULT_SOUND,
         val priority: String = "high",
         val channelId: String = "default",
         val interruptionLevel: String? = null,
+        val categoryId: String? = null,
     )
 
     @Serializable
@@ -79,6 +148,33 @@ class PushNotificationService {
         val details: Map<String, String>? = null,
     )
 
+    @Serializable
+    data class ExpoReceiptRequest(
+        val ids: List<String>,
+    )
+
+    @Serializable
+    data class ExpoReceiptResponse(
+        val data: Map<String, ExpoReceipt>? = null,
+    )
+
+    @Serializable
+    data class ExpoReceipt(
+        val status: String,
+        val message: String? = null,
+        val details: Map<String, String>? = null,
+    )
+
+    internal data class RegisteredDevice(
+        val token: String,
+        val platform: String,
+    )
+
+    private data class PendingReceipt(
+        val ticketId: String,
+        val token: String,
+    )
+
     suspend fun sendOnCallAlert(
         userId: Int,
         alertId: Int,
@@ -88,54 +184,42 @@ class PushNotificationService {
         idKey: String = "alertId",
         body: String = "Tap to view alert details",
     ) {
-        val tokens = getUserDeviceTokens(userId)
+        val devices = getUserDevicesForPush(userId)
 
-        if (tokens.isEmpty()) {
+        if (devices.isEmpty()) {
             logger.info("No device tokens found for user $userId - push notification skipped for alert $alertId")
             return
         }
 
         val alertResourceId = transaction { alertResourceId(alertId) }
         val isCritical = AlertPriority.fromString(priority) in setOf(AlertPriority.P0, AlertPriority.P1)
-        val channelId = if (isCritical) "critical" else "default"
-        val interruptionLevel = if (isCritical) "critical" else null
 
         val messages =
-            tokens.map { token ->
-                ExpoMessage(
-                    to = token,
-                    title = "[$priority] $title",
-                    body = body,
-                    data =
-                        mapOf(
-                            "type" to payloadType,
-                            idKey to alertResourceId,
-                            "priority" to priority,
+            devices.map { device ->
+                buildOnCallMessage(
+                    device = device,
+                    content =
+                        OnCallMessageContent(
+                            title = "[$priority] $title",
+                            body = body,
+                            data =
+                                mapOf(
+                                    "type" to payloadType,
+                                    idKey to alertResourceId,
+                                    "priority" to priority,
+                                ),
+                            isCritical = isCritical,
+                            categoryId = INCIDENT_CATEGORY_ID.takeIf { payloadType == "incident" },
                         ),
-                    channelId = channelId,
-                    interruptionLevel = interruptionLevel,
                 )
             }
 
-        try {
-            val response =
-                httpClient.post(expoPushEndpoint) {
-                    contentType(ContentType.Application.Json)
-                    if (expoAccessToken.isNotEmpty()) {
-                        header("Authorization", "Bearer $expoAccessToken")
-                    }
-                    setBody(messages)
-                }
-
-            handleExpoResponse(userId, tokens, response)
-        } catch (e: Exception) {
-            logger.error("Failed to send push notification", e)
-        }
+        postMessages(userId, devices, messages)
     }
 
     private suspend fun handleExpoResponse(
         userId: Int,
-        tokens: List<String>,
+        devices: List<RegisteredDevice>,
         response: HttpResponse,
     ) {
         val body = response.bodyAsText()
@@ -144,9 +228,18 @@ class PushNotificationService {
             return
         }
 
-        val result = Json.decodeFromString<ExpoResponse>(body)
-        result.data?.forEachIndexed { index, ticket ->
-            handleExpoTicket(userId, tokens[index], ticket)
+        val result = EXPO_JSON.decodeFromString<ExpoResponse>(body)
+        val pendingReceipts =
+            result.data.orEmpty().mapIndexedNotNull { index, ticket ->
+                val device = devices.getOrNull(index)
+                if (device == null) {
+                    logger.warn("Expo returned more push tickets than submitted messages")
+                    return@mapIndexedNotNull null
+                }
+                handleExpoTicket(userId, device.token, ticket)
+            }
+        if (pendingReceipts.isNotEmpty()) {
+            scheduleReceiptChecks(userId, pendingReceipts)
         }
     }
 
@@ -154,18 +247,24 @@ class PushNotificationService {
         userId: Int,
         token: String,
         ticket: ExpoTicket,
-    ) {
+    ): PendingReceipt? {
         if (ticket.status == "error") {
             logger.error(
                 "Push failed for token ${redactToken(token)}: ${ticket.message} (details: ${ticket.details})",
             )
-            if (ticket.details?.get("error") == "DeviceNotRegistered") {
+            if (ticket.details?.get("error") == DEVICE_NOT_REGISTERED_ERROR) {
                 removeDeviceToken(token)
             }
-            return
+            return null
         }
 
+        val ticketId = ticket.id
+        if (ticketId == null) {
+            logger.warn("Expo accepted a push for user $userId without returning a receipt ticket")
+            return null
+        }
         logger.info("Push ticket ok for user $userId, ticketId=${ticket.id}, token=${redactToken(token)}")
+        return PendingReceipt(ticketId, token)
     }
 
     suspend fun sendIncidentAlert(
@@ -194,17 +293,17 @@ class PushNotificationService {
         userId: Int,
         scheduleName: String,
     ) {
-        val tokens = getUserDeviceTokens(userId)
+        val devices = getUserDevicesForPush(userId)
 
-        if (tokens.isEmpty()) {
+        if (devices.isEmpty()) {
             logger.debug("No device tokens found for user $userId")
             return
         }
 
         val messages =
-            tokens.map { token ->
+            devices.map { device ->
                 ExpoMessage(
-                    to = token,
+                    to = device.token,
                     title = "You are now on-call",
                     body = "You are now the primary on-call for $scheduleName",
                     data =
@@ -212,30 +311,14 @@ class PushNotificationService {
                             "type" to "on_call_assignment",
                             "scheduleName" to scheduleName,
                         ),
+                    sound = expoSound(device.platform, isCritical = true),
                     priority = "high",
                     channelId = "critical",
                     interruptionLevel = "critical",
                 )
             }
 
-        try {
-            val response =
-                httpClient.post(expoPushEndpoint) {
-                    contentType(ContentType.Application.Json)
-                    if (expoAccessToken.isNotEmpty()) {
-                        header("Authorization", "Bearer $expoAccessToken")
-                    }
-                    setBody(messages)
-                }
-
-            if (response.status.value in 200..299) {
-                logger.info("Sent on-call assignment alert to ${tokens.size} device(s) for user $userId")
-            } else {
-                logger.error("Push notification request failed: ${response.status}")
-            }
-        } catch (e: Exception) {
-            logger.error("Failed to send push notification", e)
-        }
+        postMessages(userId, devices, messages)
     }
 
     suspend fun sendPush(
@@ -244,49 +327,145 @@ class PushNotificationService {
         body: String,
         data: Map<String, String> = emptyMap(),
     ) {
-        val tokens = getUserDeviceTokens(userId)
+        val devices = getUserDevicesForPush(userId)
 
-        if (tokens.isEmpty()) {
+        if (devices.isEmpty()) {
             logger.debug("No device tokens found for user $userId")
             return
         }
 
         val messages =
-            tokens.map { token ->
+            devices.map { device ->
                 ExpoMessage(
-                    to = token,
+                    to = device.token,
                     title = title,
                     body = body,
                     data = data,
                 )
             }
 
+        postMessages(userId, devices, messages)
+    }
+
+    private suspend fun postMessages(
+        userId: Int,
+        devices: List<RegisteredDevice>,
+        messages: List<ExpoMessage>,
+    ) {
         try {
             val response =
-                httpClient.post(expoPushEndpoint) {
+                httpClient.post(EXPO_PUSH_ENDPOINT) {
                     contentType(ContentType.Application.Json)
-                    if (expoAccessToken.isNotEmpty()) {
-                        header("Authorization", "Bearer $expoAccessToken")
-                    }
+                    addExpoAuthorization()
                     setBody(messages)
                 }
 
-            if (response.status.value in 200..299) {
-                logger.info("Sent push notification to ${tokens.size} device(s) for user $userId")
-            } else {
-                logger.error("Push notification request failed: ${response.status}")
-            }
+            handleExpoResponse(userId, devices, response)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logger.error("Failed to send push notification", e)
         }
+    }
+
+    private fun scheduleReceiptChecks(
+        userId: Int,
+        receipts: List<PendingReceipt>,
+    ) {
+        receiptScope.launch {
+            delay(RECEIPT_INITIAL_DELAY)
+            checkReceipts(userId, receipts)
+        }
+    }
+
+    private suspend fun checkReceipts(
+        userId: Int,
+        receipts: List<PendingReceipt>,
+    ) {
+        var pending = receipts.associateBy { it.ticketId }
+        repeat(RECEIPT_CHECK_ATTEMPTS) { attempt ->
+            pending = fetchReceipts(userId, pending)
+            if (pending.isEmpty()) {
+                return
+            }
+            if (attempt < RECEIPT_CHECK_ATTEMPTS - 1) {
+                delay(RECEIPT_RETRY_DELAY)
+            }
+        }
+        logger.warn(
+            "Expo receipts remained unavailable for user $userId after $RECEIPT_CHECK_ATTEMPTS attempts: " +
+                pending.keys.joinToString(),
+        )
+    }
+
+    private suspend fun fetchReceipts(
+        userId: Int,
+        pending: Map<String, PendingReceipt>,
+    ): Map<String, PendingReceipt> =
+        try {
+            val response =
+                httpClient.post(EXPO_RECEIPTS_ENDPOINT) {
+                    contentType(ContentType.Application.Json)
+                    addExpoAuthorization()
+                    setBody(ExpoReceiptRequest(pending.keys.toList()))
+                }
+            val body = response.bodyAsText()
+            if (response.status.value !in 200..299) {
+                logger.error("Expo receipt request failed HTTP ${response.status}: $body")
+                pending
+            } else {
+                val result = EXPO_JSON.decodeFromString<ExpoReceiptResponse>(body)
+                result.data.orEmpty().forEach { (ticketId, receipt) ->
+                    pending[ticketId]?.let { handleExpoReceipt(userId, it, receipt) }
+                }
+                pending - result.data.orEmpty().keys
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to fetch Expo push receipts for user $userId", e)
+            pending
         }
 
-    private fun getUserDeviceTokens(userId: Int): List<String> =
+    private fun handleExpoReceipt(
+        userId: Int,
+        pending: PendingReceipt,
+        receipt: ExpoReceipt,
+    ) {
+        if (receipt.status == "ok") {
+            logger.info(
+                "Push receipt ok for user $userId, ticketId=${pending.ticketId}, " +
+                    "token=${redactToken(pending.token)}",
+            )
+            return
+        }
+
+        logger.error(
+            "Push receipt failed for user $userId, ticketId=${pending.ticketId}, " +
+                "token=${redactToken(pending.token)}: ${receipt.message} (details: ${receipt.details})",
+        )
+        if (receipt.details?.get("error") == DEVICE_NOT_REGISTERED_ERROR) {
+            removeDeviceToken(pending.token)
+        }
+    }
+
+    private fun io.ktor.client.request.HttpRequestBuilder.addExpoAuthorization() {
+        if (expoAccessToken.isNotEmpty()) {
+            header("Authorization", "Bearer $expoAccessToken")
+        }
+    }
+
+    private fun getUserDevicesForPush(userId: Int): List<RegisteredDevice> =
         transaction {
             UserDeviceTokens
                 .selectAll()
                 .where { UserDeviceTokens.userId eq userId }
-                .map { it[UserDeviceTokens.deviceToken] }
+                .map {
+                    RegisteredDevice(
+                        token = it[UserDeviceTokens.deviceToken],
+                        platform = it[UserDeviceTokens.platform],
+                    )
+                }
         }
 
     fun registerDeviceToken(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
@@ -83,7 +83,7 @@ internal fun expoSound(
     platform: String,
     isCritical: Boolean,
 ): JsonElement =
-    if (isCritical && platform.equals(IOS_PLATFORM, ignoreCase = true)) {
+    if (isCritical && platform.uppercase() == IOS_PLATFORM) {
         IOS_CRITICAL_SOUND
     } else {
         DEFAULT_SOUND

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
@@ -12,6 +12,7 @@ import com.moneat.enterprise.oncall.models.UserDeviceTokens
 import com.moneat.enterprise.oncall.userResourceId
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -52,6 +53,7 @@ private const val INCIDENT_CATEGORY_ID = "INCIDENT_ALERT"
 private const val DEVICE_NOT_REGISTERED_ERROR = "DeviceNotRegistered"
 private const val EXPO_PUSH_ENDPOINT = "https://exp.host/--/api/v2/push/send"
 private const val EXPO_RECEIPTS_ENDPOINT = "https://exp.host/--/api/v2/push/getReceipts"
+private const val EXPO_REQUEST_TIMEOUT_MILLIS = 10_000L
 private const val RECEIPT_CHECK_ATTEMPTS = 3
 private val RECEIPT_INITIAL_DELAY = 15.minutes
 private val RECEIPT_RETRY_DELAY = 5.minutes
@@ -113,6 +115,11 @@ class PushNotificationService {
 
     private val httpClient =
         HttpClient(CIO) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = EXPO_REQUEST_TIMEOUT_MILLIS
+                connectTimeoutMillis = EXPO_REQUEST_TIMEOUT_MILLIS
+                socketTimeoutMillis = EXPO_REQUEST_TIMEOUT_MILLIS
+            }
             install(ContentNegotiation) {
                 json(
                     EXPO_JSON,

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/PushNotificationService.kt
@@ -441,15 +441,14 @@ class PushNotificationService {
     ) {
         if (receipt.status == "ok") {
             logger.info(
-                "Push receipt ok for user $userId, ticketId=${pending.ticketId}, " +
-                    "token=${redactToken(pending.token)}",
+                "Push receipt ok for user $userId, ticketId=${pending.ticketId}",
             )
             return
         }
 
         logger.error(
             "Push receipt failed for user $userId, ticketId=${pending.ticketId}, " +
-                "token=${redactToken(pending.token)}: ${receipt.message} (details: ${receipt.details})",
+                "message=${receipt.message} (details: ${receipt.details})",
         )
         if (receipt.details?.get("error") == DEVICE_NOT_REGISTERED_ERROR) {
             removeDeviceToken(pending.token)

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/services/PushNotificationServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/services/PushNotificationServiceTest.kt
@@ -1,0 +1,91 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.oncall.services
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PushNotificationServiceTest {
+    private val json =
+        Json {
+            encodeDefaults = true
+            explicitNulls = false
+    }
+
+    @Test
+    fun `critical iOS messages request the APNs critical default sound`() {
+        val message =
+            buildOnCallMessage(
+                device = PushNotificationService.RegisteredDevice("ExponentPushToken[ios]", "IOS"),
+                content =
+                    OnCallMessageContent(
+                        title = "[P0] Host down",
+                        body = "Tap to view incident details",
+                        data = mapOf("incidentId" to "7f9a9ea6-83a1-4aaf-a028-6839f3ad45d6"),
+                        isCritical = true,
+                        categoryId = "INCIDENT_ALERT",
+                    ),
+            )
+
+        val sound = message.sound as JsonObject
+        assertEquals(JsonPrimitive(true), sound["critical"])
+        assertEquals(JsonPrimitive("default"), sound["name"])
+        assertEquals(JsonPrimitive(1.0), sound["volume"])
+        assertEquals("critical", message.channelId)
+        assertEquals("critical", message.interruptionLevel)
+        assertEquals("INCIDENT_ALERT", message.categoryId)
+        assertTrue(
+            json.encodeToString(message).contains(
+                "\"sound\":{\"critical\":true,\"name\":\"default\",\"volume\":1.0}",
+            ),
+        )
+    }
+
+    @Test
+    fun `critical Android messages retain ordinary sound for the critical channel`() {
+        val message =
+            buildOnCallMessage(
+                device = PushNotificationService.RegisteredDevice("ExponentPushToken[android]", "ANDROID"),
+                content =
+                    OnCallMessageContent(
+                        title = "[P0] Host down",
+                        body = "Tap to view incident details",
+                        data = emptyMap(),
+                        isCritical = true,
+                        categoryId = null,
+                    ),
+            )
+
+        assertEquals(JsonPrimitive("default"), message.sound)
+        assertEquals("critical", message.channelId)
+        assertEquals("critical", message.interruptionLevel)
+    }
+
+    @Test
+    fun `non-critical iOS messages retain the standard notification sound`() {
+        val message =
+            buildOnCallMessage(
+                device = PushNotificationService.RegisteredDevice("ExponentPushToken[ios]", "IOS"),
+                content =
+                    OnCallMessageContent(
+                        title = "[P2] Elevated latency",
+                        body = "Tap to view incident details",
+                        data = emptyMap(),
+                        isCritical = false,
+                        categoryId = "INCIDENT_ALERT",
+                    ),
+            )
+
+        assertEquals(JsonPrimitive("default"), message.sound)
+        assertEquals("default", message.channelId)
+        assertNull(message.interruptionLevel)
+    }
+}


### PR DESCRIPTION
## Summary

- send the native iOS critical-sound payload for critical on-call notifications
- preserve Android critical-channel delivery
- check Expo delivery receipts and remove invalid device tokens

## Validation

- `./gradlew :ee:test :ee:detekt --no-daemon`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced push notifications with platform-specific sound settings and critical alert behavior (including iOS critical sound and Android critical channel/interruption settings).
  * Notifications now carry optional category information and include richer delivery status tracking with ticket/receipt polling.
* **Bug Fixes**
  * Improved handling of delivery outcomes, including cleanup of unregistered device tokens and correct propagation of cancellation.
* **Tests**
  * Added automated coverage verifying sound/interruption behavior for critical vs non-critical messages on both iOS and Android.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->