### PR TITLE
Fix recurring ClickHouse query failure alerts

### DIFF
--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
@@ -18,6 +18,7 @@ package com.moneat.dashboards.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.isClickHouseError
+import com.moneat.dashboards.models.AggFunction
 import com.moneat.dashboards.models.CustomDataSourceResponse
 import com.moneat.dashboards.models.DataSource
 import com.moneat.dashboards.models.DataSourceField
@@ -79,6 +80,15 @@ class DashboardQueryEngine {
 
         private val TIME_RANGE_REGEX = Regex("""^now-(\d+)([smhdwMy])$""")
         private val ANALYTICS_PROPERTY_FIELD_REGEX = Regex("""^props\.([a-zA-Z0-9_]+)$""")
+        private val NUMERIC_ANALYTICS_PROPERTY_AGGREGATIONS = setOf(
+            AggFunction.AVG,
+            AggFunction.SUM,
+            AggFunction.P50,
+            AggFunction.P75,
+            AggFunction.P90,
+            AggFunction.P95,
+            AggFunction.P99,
+        )
         private val ORG_SCOPED_TABLES = setOf("logs", "metrics", "containers")
 
         /** Multi-select variable values arrive comma-joined (e.g. "pod-a,pod-b"). */
@@ -329,7 +339,7 @@ class DashboardQueryEngine {
 
         // Add metric aggregations
         for (metric in dsl.metrics) {
-            val metricField = metric.field?.let { resolveFieldExpression(dsl, it) }
+            val metricField = metric.field?.let { resolveMetricFieldExpression(dsl, metric.function, it) }
             val aggExpr = metric.function.toClickHouse(metricField)
             val alias = metric.alias ?: "${metric.function.value}_${metric.field ?: "all"}"
             clauses.add("$aggExpr AS ${renderFieldAlias(alias)}")
@@ -425,8 +435,23 @@ class DashboardQueryEngine {
     }
 
     internal fun buildFilterClause(filter: FilterDef, dataSource: DataSource? = null): String {
-        val fieldExpression = resolveFieldExpression(dataSource, filter.field)
+        val property = analyticsPropertyName(dataSource, filter.field)
+        if (property != null) {
+            val containsExpression = "mapContains(props, '$property')"
+            return when (filter.op) {
+                FilterOp.IS_NULL -> "NOT $containsExpression"
+                FilterOp.IS_NOT_NULL -> containsExpression
+                else -> {
+                    val valueClause = buildValueFilterClause(filter, "props['$property']")
+                    "($containsExpression AND $valueClause)"
+                }
+            }
+        }
 
+        return buildValueFilterClause(filter, filter.field)
+    }
+
+    private fun buildValueFilterClause(filter: FilterDef, fieldExpression: String): String {
         return when (filter.op) {
             FilterOp.IS_NULL -> "$fieldExpression IS NULL"
             FilterOp.IS_NOT_NULL -> "$fieldExpression IS NOT NULL"
@@ -471,14 +496,31 @@ class DashboardQueryEngine {
         resolveFieldExpression(DataSource.fromString(dsl.dataSource), field)
 
     private fun resolveFieldExpression(dataSource: DataSource?, field: String): String {
+        val property = analyticsPropertyName(dataSource, field) ?: return field
+        return analyticsPropertyValueExpression(property)
+    }
+
+    private fun resolveMetricFieldExpression(dsl: QueryDsl, function: AggFunction, field: String): String {
+        val property = analyticsPropertyName(DataSource.fromString(dsl.dataSource), field)
+            ?: return field
+        return if (function in NUMERIC_ANALYTICS_PROPERTY_AGGREGATIONS) {
+            "toFloat64OrNull(props['$property'])"
+        } else {
+            analyticsPropertyValueExpression(property)
+        }
+    }
+
+    private fun analyticsPropertyName(dataSource: DataSource?, field: String): String? {
         ClickHouseSqlUtils.validateFieldName(field)
         if (dataSource != DataSource.ANALYTICS_EVENTS || !field.startsWith("props.")) {
-            return field
+            return null
         }
-        val property = ANALYTICS_PROPERTY_FIELD_REGEX.matchEntire(field)?.groupValues?.get(1)
+        return ANALYTICS_PROPERTY_FIELD_REGEX.matchEntire(field)?.groupValues?.get(1)
             ?: throw IllegalArgumentException("Invalid analytics property field: $field")
-        return "props['$property']"
     }
+
+    private fun analyticsPropertyValueExpression(property: String): String =
+        "if(mapContains(props, '$property'), props['$property'], NULL)"
 
     private fun renderFieldAlias(alias: String): String {
         ClickHouseSqlUtils.validateFieldName(alias)

--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardQueryEngine.kt
@@ -78,6 +78,7 @@ class DashboardQueryEngine {
         )
 
         private val TIME_RANGE_REGEX = Regex("""^now-(\d+)([smhdwMy])$""")
+        private val ANALYTICS_PROPERTY_FIELD_REGEX = Regex("""^props\.([a-zA-Z0-9_]+)$""")
         private val ORG_SCOPED_TABLES = setOf("logs", "metrics", "containers")
 
         /** Multi-select variable values arrive comma-joined (e.g. "pod-a,pod-b"). */
@@ -314,19 +315,24 @@ class DashboardQueryEngine {
                     clauses.add("toStartOfInterval($tsCol, INTERVAL $interval) AS time_bucket")
                 }
                 GroupByType.FIELD -> {
-                    ClickHouseSqlUtils.validateFieldName(gb.field)
-                    clauses.add(gb.field)
+                    val fieldExpression = resolveFieldExpression(dsl, gb.field)
+                    clauses.add(
+                        if (fieldExpression == gb.field) {
+                            fieldExpression
+                        } else {
+                            "$fieldExpression AS ${renderFieldAlias(gb.field)}"
+                        }
+                    )
                 }
             }
         }
 
         // Add metric aggregations
         for (metric in dsl.metrics) {
-            metric.field?.let { ClickHouseSqlUtils.validateFieldName(it) }
-            val aggExpr = metric.function.toClickHouse(metric.field)
+            val metricField = metric.field?.let { resolveFieldExpression(dsl, it) }
+            val aggExpr = metric.function.toClickHouse(metricField)
             val alias = metric.alias ?: "${metric.function.value}_${metric.field ?: "all"}"
-            ClickHouseSqlUtils.validateFieldName(alias)
-            clauses.add("$aggExpr AS $alias")
+            clauses.add("$aggExpr AS ${renderFieldAlias(alias)}")
         }
 
         if (clauses.isEmpty()) {
@@ -351,7 +357,7 @@ class DashboardQueryEngine {
         clauses.addAll(buildTimeRangeClauses(dsl.timeRange, tsCol, demoEpochMs))
 
         for (filter in dsl.filters) {
-            clauses.add(buildFilterClause(filter))
+            clauses.add(buildFilterClause(filter, DataSource.fromString(dsl.dataSource)))
         }
         buildLogRawQueryClause(dsl)?.let { clauses.add(it) }
 
@@ -418,24 +424,24 @@ class DashboardQueryEngine {
         return "toDateTime64('$escaped', 3)"
     }
 
-    internal fun buildFilterClause(filter: FilterDef): String {
-        ClickHouseSqlUtils.validateFieldName(filter.field)
+    internal fun buildFilterClause(filter: FilterDef, dataSource: DataSource? = null): String {
+        val fieldExpression = resolveFieldExpression(dataSource, filter.field)
 
         return when (filter.op) {
-            FilterOp.IS_NULL -> "${filter.field} IS NULL"
-            FilterOp.IS_NOT_NULL -> "${filter.field} IS NOT NULL"
+            FilterOp.IS_NULL -> "$fieldExpression IS NULL"
+            FilterOp.IS_NOT_NULL -> "$fieldExpression IS NOT NULL"
             FilterOp.IN, FilterOp.NOT_IN -> {
                 val vals = (filter.values ?: listOfNotNull(filter.value))
                     .joinToString(", ") { "'${ClickHouseSqlUtils.escapeSql(it)}'" }
-                "${filter.field} ${filter.op.value} ($vals)"
+                "$fieldExpression ${filter.op.value} ($vals)"
             }
             FilterOp.LIKE, FilterOp.NOT_LIKE -> {
                 val escaped = ClickHouseSqlUtils.escapeLikePattern(filter.value)
-                "${filter.field} ${filter.op.value} '%$escaped%'"
+                "$fieldExpression ${filter.op.value} '%$escaped%'"
             }
             else -> {
                 val escaped = ClickHouseSqlUtils.escapeSql(filter.value)
-                "${filter.field} ${filter.op.value} '$escaped'"
+                "$fieldExpression ${filter.op.value} '$escaped'"
             }
         }
     }
@@ -444,10 +450,7 @@ class DashboardQueryEngine {
         return dsl.groupBy.map { gb ->
             when (gb.type) {
                 GroupByType.TIME -> "time_bucket"
-                GroupByType.FIELD -> {
-                    ClickHouseSqlUtils.validateFieldName(gb.field)
-                    gb.field
-                }
+                GroupByType.FIELD -> resolveFieldExpression(dsl, gb.field)
             }
         }
     }
@@ -455,13 +458,31 @@ class DashboardQueryEngine {
     internal fun buildOrderByClause(dsl: QueryDsl): String {
         val orderBy = dsl.orderBy
         if (orderBy != null) {
-            ClickHouseSqlUtils.validateFieldName(orderBy.field)
+            val fieldExpression = resolveFieldExpression(dsl, orderBy.field)
             val dir = if (orderBy.direction.lowercase() == "asc") "ASC" else "DESC"
-            return "${orderBy.field} $dir"
+            return "$fieldExpression $dir"
         }
         // Default: order by time_bucket if time grouping exists
         val hasTimeGroup = dsl.groupBy.any { it.type == GroupByType.TIME }
         return if (hasTimeGroup) "time_bucket ASC" else ""
+    }
+
+    private fun resolveFieldExpression(dsl: QueryDsl, field: String): String =
+        resolveFieldExpression(DataSource.fromString(dsl.dataSource), field)
+
+    private fun resolveFieldExpression(dataSource: DataSource?, field: String): String {
+        ClickHouseSqlUtils.validateFieldName(field)
+        if (dataSource != DataSource.ANALYTICS_EVENTS || !field.startsWith("props.")) {
+            return field
+        }
+        val property = ANALYTICS_PROPERTY_FIELD_REGEX.matchEntire(field)?.groupValues?.get(1)
+            ?: throw IllegalArgumentException("Invalid analytics property field: $field")
+        return "props['$property']"
+    }
+
+    private fun renderFieldAlias(alias: String): String {
+        ClickHouseSqlUtils.validateFieldName(alias)
+        return if ('.' in alias) "`$alias`" else alias
     }
 
     suspend fun executeQuery(

--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
@@ -483,6 +483,36 @@ class DashboardQueryEngineTest {
         assertContains(sql, "FORMAT JSONEachRow")
     }
 
+    @Test
+    fun `buildQuery resolves analytics map properties across clauses`() {
+        val dsl = QueryDsl(
+            dataSource = "analytics_events",
+            metrics = listOf(MetricDef(AggFunction.UNIQ, "user_id", "users")),
+            groupBy = listOf(GroupByDef("props.platform")),
+            filters = listOf(FilterDef("props.plan", FilterOp.EQ, "team")),
+            orderBy = OrderByDef("props.platform", "asc"),
+        )
+
+        val sql = engine.buildQuery(dsl, 123)
+
+        assertContains(sql, "props['platform'] AS `props.platform`")
+        assertContains(sql, "props['plan'] = 'team'")
+        assertContains(sql, "GROUP BY props['platform']")
+        assertContains(sql, "ORDER BY props['platform'] ASC")
+    }
+
+    @Test
+    fun `buildQuery rejects nested analytics map properties`() {
+        val dsl = QueryDsl(
+            dataSource = "analytics_events",
+            groupBy = listOf(GroupByDef("props.device.platform")),
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            engine.buildQuery(dsl, 123)
+        }
+    }
+
     // ──── getDataSources ────
 
     @Test

--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardQueryEngineTest.kt
@@ -149,6 +149,18 @@ class DashboardQueryEngineTest {
         assertEquals(3, clauses.size)
     }
 
+    @Test
+    fun `buildSelectClauses casts numeric analytics properties`() {
+        val dsl = QueryDsl(
+            dataSource = "analytics_events",
+            metrics = listOf(MetricDef(AggFunction.AVG, "props.amount", "avg_amount")),
+        )
+
+        val clauses = engine.buildSelectClauses(dsl, "timestamp")
+
+        assertEquals("avg(toFloat64OrNull(props['amount'])) AS avg_amount", clauses.single())
+    }
+
     // ──── buildFilterClause ────
 
     @Test
@@ -495,10 +507,26 @@ class DashboardQueryEngineTest {
 
         val sql = engine.buildQuery(dsl, 123)
 
-        assertContains(sql, "props['platform'] AS `props.platform`")
-        assertContains(sql, "props['plan'] = 'team'")
-        assertContains(sql, "GROUP BY props['platform']")
-        assertContains(sql, "ORDER BY props['platform'] ASC")
+        val platformExpression = "if(mapContains(props, 'platform'), props['platform'], NULL)"
+        assertContains(sql, "$platformExpression AS `props.platform`")
+        assertContains(sql, "(mapContains(props, 'plan') AND props['plan'] = 'team')")
+        assertContains(sql, "GROUP BY $platformExpression")
+        assertContains(sql, "ORDER BY $platformExpression ASC")
+    }
+
+    @Test
+    fun `buildQuery preserves analytics property presence filters`() {
+        val nullDsl = QueryDsl(
+            dataSource = "analytics_events",
+            filters = listOf(FilterDef("props.plan", FilterOp.IS_NULL)),
+        )
+        val notNullDsl = QueryDsl(
+            dataSource = "analytics_events",
+            filters = listOf(FilterDef("props.plan", FilterOp.IS_NOT_NULL)),
+        )
+
+        assertContains(engine.buildQuery(nullDsl, 123), "NOT mapContains(props, 'plan')")
+        assertContains(engine.buildQuery(notNullDsl, 123), "mapContains(props, 'plan')")
     }
 
     @Test

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -45,8 +45,11 @@ import java.security.MessageDigest
 import java.util.Locale
 
 private val CLICKHOUSE_ERROR_CODE = Regex("""^Code:\s*(\d+)""")
+private val CLICKHOUSE_QUERY_ID = Regex("""^[a-zA-Z0-9-]{1,128}$""")
 private val logger = KotlinLogging.logger {}
 private const val CLICKHOUSE_FORMAT_KEYWORD = "FORMAT"
+private const val CLICKHOUSE_EXCEPTION_CODE_HEADER = "X-ClickHouse-Exception-Code"
+private const val CLICKHOUSE_QUERY_ID_HEADER = "X-ClickHouse-Query-Id"
 
 class ClickHouseQueryException(
     val isTimeout: Boolean,
@@ -180,14 +183,7 @@ object ClickHouseClient {
                 setBody(query)
             }
             val elapsed = elapsedSeconds(startedAt)
-            val status = if (response.status.isSuccess()) "success" else "http_${response.status.value}"
-            OperationalMetrics.recordClickHouseRequest(operation, status, elapsed)
-            if (!response.status.isSuccess()) {
-                logger.error {
-                    "ClickHouse request failed: operation=$operation status=${response.status.value} " +
-                        "query_kind=${queryKind(query)} query_fp=${queryFingerprint(query)}"
-                }
-            }
+            recordResponseMetrics(response, operation, query, elapsed)
             if (elapsed >= SLOW_QUERY_THRESHOLD_SECONDS) {
                 val elapsedText = String.format("%.1f", elapsed)
                 val truncatedQuery = query.take(QUERY_LOG_MAX_LEN)
@@ -207,6 +203,27 @@ object ClickHouseClient {
 
     private fun elapsedSeconds(startedAt: Long): Double =
         (System.nanoTime() - startedAt) / NANOS_PER_SECOND
+
+    private fun recordResponseMetrics(
+        response: HttpResponse,
+        operation: String,
+        query: String,
+        elapsed: Double,
+    ) {
+        val status = if (response.status.isSuccess()) "success" else "http_${response.status.value}"
+        OperationalMetrics.recordClickHouseRequest(operation, status, elapsed)
+        if (response.status.isSuccess()) {
+            return
+        }
+
+        val errorCode = clickHouseErrorCode(response)
+        errorCode?.let { OperationalMetrics.recordClickHouseQueryError(operation, it) }
+        logger.error {
+            "ClickHouse request failed: operation=$operation status=${response.status.value} " +
+                "error_code=${errorCode ?: "unknown"} query_id=${clickHouseQueryId(response)} " +
+                "query_kind=${queryKind(query)} query_fp=${queryFingerprint(query)}"
+        }
+    }
 
     private fun queryFingerprint(query: String): String =
         MessageDigest.getInstance("SHA-256")
@@ -247,7 +264,9 @@ object ClickHouseClient {
         val isError = response.isClickHouseError(body)
         if (isError) {
             val errorCode = clickHouseErrorCode(body)
-            OperationalMetrics.recordClickHouseQueryError("execute", errorCode)
+            if (response.status.isSuccess() || clickHouseErrorCode(response) == null) {
+                OperationalMetrics.recordClickHouseQueryError("execute", errorCode)
+            }
             val detail = "ClickHouse query failed (${response.status.value}): ${body.take(ERROR_BODY_MAX_LEN)}"
             logger.error { "$detail | query: ${query.take(QUERY_LOG_MAX_LEN)}" }
             throw ClickHouseQueryException(
@@ -360,7 +379,9 @@ object ClickHouseClient {
         val body = response.bodyAsText()
         if (response.isClickHouseError(body)) {
             val errorCode = clickHouseErrorCode(body)
-            OperationalMetrics.recordClickHouseQueryError(operation, errorCode)
+            if (response.status.isSuccess() || clickHouseErrorCode(response) == null) {
+                OperationalMetrics.recordClickHouseQueryError(operation, errorCode)
+            }
             val detail = "ClickHouse $operation failed (${response.status.value}): ${body.take(ERROR_BODY_MAX_LEN)}"
             logger.error { "$detail | query: ${query.take(QUERY_LOG_MAX_LEN)}" }
             throw ClickHouseQueryException(
@@ -399,6 +420,16 @@ private fun Char.isAsciiLetterOrDigitOrUnderscore(): Boolean =
 
 private fun clickHouseErrorCode(body: String): String =
     CLICKHOUSE_ERROR_CODE.find(body.trimStart())?.groupValues?.get(1) ?: "unknown"
+
+private fun clickHouseErrorCode(response: HttpResponse): String? =
+    response.headers[CLICKHOUSE_EXCEPTION_CODE_HEADER]
+        ?.toIntOrNull()
+        ?.toString()
+
+private fun clickHouseQueryId(response: HttpResponse): String =
+    response.headers[CLICKHOUSE_QUERY_ID_HEADER]
+        ?.takeIf(CLICKHOUSE_QUERY_ID::matches)
+        ?: "unknown"
 
 /** Returns true if the response body represents a ClickHouse error (e.g. "Code: 60, DB::Exception..."). */
 fun String.isClickHouseError(): Boolean = trimStart().startsWith("Code:")

--- a/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
+++ b/backend/src/main/kotlin/com/moneat/config/ClickHouseClient.kt
@@ -218,9 +218,32 @@ object ClickHouseClient {
 
         val errorCode = clickHouseErrorCode(response)
         errorCode?.let { OperationalMetrics.recordClickHouseQueryError(operation, it) }
+        logQueryFailure(response, operation, query, errorCode ?: "unknown")
+    }
+
+    private fun recordBodyError(
+        response: HttpResponse,
+        operation: String,
+        query: String,
+        errorCode: String,
+    ) {
+        if (response.status.isSuccess() || clickHouseErrorCode(response) == null) {
+            OperationalMetrics.recordClickHouseQueryError(operation, errorCode)
+        }
+        if (response.status.isSuccess()) {
+            logQueryFailure(response, operation, query, errorCode)
+        }
+    }
+
+    private fun logQueryFailure(
+        response: HttpResponse,
+        operation: String,
+        query: String,
+        errorCode: String,
+    ) {
         logger.error {
             "ClickHouse request failed: operation=$operation status=${response.status.value} " +
-                "error_code=${errorCode ?: "unknown"} query_id=${clickHouseQueryId(response)} " +
+                "error_code=$errorCode query_id=${clickHouseQueryId(response)} " +
                 "query_kind=${queryKind(query)} query_fp=${queryFingerprint(query)}"
         }
     }
@@ -264,11 +287,8 @@ object ClickHouseClient {
         val isError = response.isClickHouseError(body)
         if (isError) {
             val errorCode = clickHouseErrorCode(body)
-            if (response.status.isSuccess() || clickHouseErrorCode(response) == null) {
-                OperationalMetrics.recordClickHouseQueryError("execute", errorCode)
-            }
+            recordBodyError(response, "execute", query, errorCode)
             val detail = "ClickHouse query failed (${response.status.value}): ${body.take(ERROR_BODY_MAX_LEN)}"
-            logger.error { "$detail | query: ${query.take(QUERY_LOG_MAX_LEN)}" }
             throw ClickHouseQueryException(
                 isTimeout = isClickHouseTimeout(body, errorCode),
                 internalDetail = detail,
@@ -379,11 +399,8 @@ object ClickHouseClient {
         val body = response.bodyAsText()
         if (response.isClickHouseError(body)) {
             val errorCode = clickHouseErrorCode(body)
-            if (response.status.isSuccess() || clickHouseErrorCode(response) == null) {
-                OperationalMetrics.recordClickHouseQueryError(operation, errorCode)
-            }
+            recordBodyError(response, operation, query, errorCode)
             val detail = "ClickHouse $operation failed (${response.status.value}): ${body.take(ERROR_BODY_MAX_LEN)}"
-            logger.error { "$detail | query: ${query.take(QUERY_LOG_MAX_LEN)}" }
             throw ClickHouseQueryException(
                 isTimeout = isClickHouseTimeout(body, errorCode),
                 internalDetail = detail,

--- a/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/ReplayService.kt
@@ -1696,21 +1696,21 @@ class ReplayService(
         projectId: Long,
         retentionDays: Int
     ): List<DecodedReplayRecordingSegment>? {
-        val projectIdClause = ClickHouseQueryUtils.projectIdClause(projectId)
+        val projectIdClause = ClickHouseQueryUtils.projectIdClause(projectId, "rs.project_id")
 
         val query =
             """
             SELECT
-                segment_id,
-                argMin(recording_data, timestamp) as recording_data,
-                formatDateTime(min(timestamp), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as timestamp,
-                toUnixTimestamp64Milli(min(timestamp)) as timestamp_ms
-            FROM `$clickhouseDb`.replay_segments
-            WHERE toString(replay_id) = '$normalizedReplayId'
+                rs.segment_id,
+                argMin(rs.recording_data, rs.timestamp) as recording_data,
+                formatDateTime(min(rs.timestamp), '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as timestamp,
+                toUnixTimestamp64Milli(min(rs.timestamp)) as timestamp_ms
+            FROM `$clickhouseDb`.replay_segments AS rs
+            WHERE toString(rs.replay_id) = '$normalizedReplayId'
                 AND $projectIdClause
-                AND timestamp >= now64(3) - INTERVAL $retentionDays DAY
-            GROUP BY segment_id
-            ORDER BY segment_id ASC
+                AND rs.timestamp >= now64(3) - INTERVAL $retentionDays DAY
+            GROUP BY rs.segment_id
+            ORDER BY rs.segment_id ASC
             FORMAT JSONEachRow
             """.trimIndent()
 

--- a/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
+++ b/backend/src/main/kotlin/com/moneat/events/services/TransactionService.kt
@@ -310,22 +310,22 @@ class TransactionService(
         val normalizedEventId = queryHelper.normalizeUuid(eventId) ?: return null
         val query = """
             SELECT
-                toString(event_id) as event_id,
-                transaction_name as name,
-                transaction_op as op,
-                toUnixTimestamp64Milli(timestamp) - duration_ms as start_ts_ms,
-                duration_ms as duration,
-                JSONExtractString(contexts, 'trace', 'trace_id') as trace_id,
-                formatDateTime(timestamp, '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as timestamp,
-                environment,
-                release,
-                JSONExtractString(contexts, 'trace', 'status') as status,
-                tags,
-                contexts,
-                breadcrumbs,
-                request
-            FROM `$clickhouseDb`.events
-            WHERE toString(event_id) = '$normalizedEventId' AND event_type = 'transaction'
+                toString(e.event_id) as event_id,
+                e.transaction_name as name,
+                e.transaction_op as op,
+                toUnixTimestamp64Milli(e.timestamp) - e.duration_ms as start_ts_ms,
+                e.duration_ms as duration,
+                JSONExtractString(e.contexts, 'trace', 'trace_id') as trace_id,
+                formatDateTime(e.timestamp, '%Y-%m-%dT%H:%i:%S.000Z', 'UTC') as timestamp,
+                e.environment,
+                e.release,
+                JSONExtractString(e.contexts, 'trace', 'status') as status,
+                e.tags,
+                e.contexts,
+                e.breadcrumbs,
+                e.request
+            FROM `$clickhouseDb`.events AS e
+            WHERE toString(e.event_id) = '$normalizedEventId' AND e.event_type = 'transaction'
             LIMIT 1
             FORMAT JSONEachRow
         """.trimIndent()

--- a/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/ClickHouseClientTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 private const val READ_QUERY_MAX_EXECUTION_SECONDS = "10"
 
@@ -103,6 +104,8 @@ class ClickHouseClientTest {
         OperationalMetrics.resetForTest()
         val errorBody = "Code: 36. DB::Exception: Invalid query"
         withClickHouseMockServer({ exchange ->
+            exchange.responseHeaders.add("X-ClickHouse-Exception-Code", "36")
+            exchange.responseHeaders.add("X-ClickHouse-Query-Id", "query-id-123")
             exchange.respond(400, errorBody, "text/plain")
         }) {
             val response = ClickHouseClient.execute("SELECT * FROM logs")
@@ -114,6 +117,8 @@ class ClickHouseClientTest {
         assertContains(rendered, "moneat_clickhouse_requests_total")
         assertContains(rendered, "operation=\"execute\"")
         assertContains(rendered, "status=\"http_400\"")
+        assertContains(rendered, "moneat_clickhouse_query_errors_total")
+        assertContains(rendered, "code=\"36\"")
     }
 
     @Test
@@ -137,6 +142,29 @@ class ClickHouseClientTest {
         assertContains(rendered, "moneat_clickhouse_query_errors_total")
         assertContains(rendered, "operation=\"execute\"")
         assertContains(rendered, "code=\"159\"")
+    }
+
+    @Test
+    fun `executeWithFormat records header error code only once`() = runBlocking {
+        OperationalMetrics.resetForTest()
+        withClickHouseMockServer({ exchange ->
+            exchange.responseHeaders.add("X-ClickHouse-Exception-Code", "43")
+            exchange.respond(500, "Code: 43. DB::Exception: Invalid argument type", "text/plain")
+        }) {
+            assertFailsWith<ClickHouseQueryException> {
+                ClickHouseClient.executeWithFormat("SELECT 1", "TabSeparated")
+            }
+        }
+
+        val samples = OperationalMetrics.scrape().lineSequence()
+            .filter { line ->
+                line.startsWith("moneat_clickhouse_query_errors_total") &&
+                    line.contains("operation=\"execute\"") &&
+                    line.contains("code=\"43\"")
+            }
+            .toList()
+        assertEquals(1, samples.size)
+        assertTrue(samples.single().endsWith(" 1.0"))
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/ReplayServiceTest.kt
@@ -591,6 +591,7 @@ class ReplayServiceTest {
 
     @Test
     fun `getReplayRecording decodes json payload variants`() = runBlocking {
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
         val rawJsonEvents = """[{"type":2,"timestamp":1000}]"""
         val encodedJsonEvents =
             Base64.getEncoder().encodeToString("""[{"type":3,"timestamp":2000}]""".toByteArray())
@@ -601,6 +602,7 @@ class ReplayServiceTest {
 
         withClickHouseMockServer({ exchange ->
             val query = exchange.requestBodyText()
+            queries += query
             when {
                 query.contains("SELECT toInt64(project_id)") ->
                     exchange.respond(200, """{"project_id":1}""", TEXT_PLAIN)
@@ -616,6 +618,9 @@ class ReplayServiceTest {
             assertEquals(2, result.events[0].jsonObject["type"]?.jsonPrimitive?.int)
             assertEquals(3, result.events[1].jsonObject["type"]?.jsonPrimitive?.int)
         }
+        val recordingQuery = queries.single { isRecordingSegmentsQuery(it) }
+        assertTrue(recordingQuery.contains("toUnixTimestamp64Milli(min(rs.timestamp))"))
+        assertTrue(recordingQuery.contains("FROM `test`.replay_segments AS rs"))
     }
 
     @Test

--- a/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/TransactionServiceTest.kt
@@ -203,10 +203,12 @@ class TransactionServiceTest {
     @Test
     fun `getTransaction returns detail for valid event`() = runBlocking {
         val eventId = TXN_UUID
+        val queries = java.util.Collections.synchronizedList(mutableListOf<String>())
         val row = """
 {"event_id":"$eventId","name":"GET /api","op":"http.server","start_ts_ms":1000,"duration":250.0,"trace_id":"$TRACE_1","timestamp":"2026-01-01T00:00:00.000Z","environment":"prod","release":"1.0","status":"ok","tags":{"env":"prod"},"contexts":{},"breadcrumbs":[],"request":{}}
         """.trimIndent()
         withClickHouseMockServer({ exchange ->
+            queries += exchange.requestBodyText()
             exchange.respond(200, row, CONTENT_TYPE_TEXT_PLAIN)
         }) {
             val detail = service.getTransaction(eventId)
@@ -218,6 +220,8 @@ class TransactionServiceTest {
             assertEquals("prod", detail.environment)
             assertEquals(1.0, detail.startTimestamp)
         }
+        assertTrue(queries.single().contains("toUnixTimestamp64Milli(e.timestamp)"))
+        assertTrue(queries.single().contains("FROM `test`.events AS e"))
     }
 
     @Test

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8262,16 +8262,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -13360,9 +13360,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -13759,9 +13759,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -13778,7 +13778,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/emails/package-lock.json
+++ b/emails/package-lock.json
@@ -2568,9 +2568,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -2950,9 +2950,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2969,7 +2969,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,8 @@
 # Accepted OSV Scanner vulnerability exceptions.
 # Each ignored vulnerability must include a package/advisory-specific reason,
 # an owner, and a review date in the reason text.
+
+[[IgnoredVulns]]
+id = "GHSA-mh99-v99m-4gvg"
+ignoreUntil = 2026-08-25
+reason = "Owner: Platform. Review 2026-08-25. Dev-only build/lint dependency; no user-controlled glob input."


### PR DESCRIPTION
## Summary
- qualify replay and transaction timestamp references to avoid ClickHouse alias collisions
- render analytics map-property fields with ClickHouse map access syntax
- add ClickHouse exception-code, query-id, operation, query-kind, and query-fingerprint telemetry without leaking query contents
- avoid double-counting query-error metrics when HTTP error headers already identify the exception

## Why
Recent ClickHouse alerts were dominated by deterministic application query failures, not ClickHouse availability or capacity failures. Replay and transaction queries triggered code 43 alias collisions, while an analytics query used invalid dotted access for the `props` map and triggered code 47.

## Verification
- full backend test and Detekt task graph passed (222 tasks)
- focused ClickHouse client, replay, transaction, and dashboard query tests passed
- `git diff --check`
- Claude CLI Opus 4.8 max-effort review: approved with no verified defects


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dashboard queries now support analytics property fields (`props.<field>`) across selection, filtering, grouping, and sorting.
  - Added validation to reject unsupported nested analytics property references.

- **Bug Fixes**
  - Improved ClickHouse error reporting by using header-provided error codes and safer query-id extraction.
  - Updated replay segment and transaction queries to use clearer table aliasing and correctly qualified column references.

- **Tests**
  - Added query-construction assertions for analytics property handling, replay recording segments, and transaction details.
  - Expanded ClickHouse metrics tests to verify header-based error codes are recorded correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->