### PR TITLE
fix: expose copyable service DSNs and repair setup links

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8262,9 +8262,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9659,9 +9659,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13360,9 +13360,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -15766,9 +15766,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/dashboard/src/components/projects/ServiceSettingsCard.tsx
+++ b/dashboard/src/components/projects/ServiceSettingsCard.tsx
@@ -23,6 +23,7 @@ import {
   Copy,
   ExternalLink,
   Gamepad2,
+  KeyRound,
   Layers,
   Loader2,
   Monitor,
@@ -35,11 +36,13 @@ import {
   Trash2,
 } from 'lucide-react'
 import {api} from '@/lib/api'
+import {backendBaseUrl} from '@/lib/backend-url'
 import {trackEvent} from '@/lib/analytics'
 import {APP_OVERVIEW_SEARCH} from '@/lib/overview-route'
 import {getPlatformInfo, platforms, type PlatformType} from '@/routes/projects'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
+import {CopyField} from '@/components/ui/copy-field'
 import {SectionCard} from '@/components/ui/section-card'
 import {Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle} from '@/components/ui/dialog'
 import {Input} from '@/components/ui/input'
@@ -72,8 +75,10 @@ interface ServiceSettingsCardProps {
 /**
  * Editing surface for a single service, shared by the Setup page and the
  * legacy /projects/$projectId/settings route. Sections are gated by the service's
- * enabled telemetry sources: Sentry slug/CLI/DSN-targets only with the Sentry SDK
- * source; short OTLP/Datadog pointers with those sources. General + Danger always.
+ * enabled telemetry sources: slug, CLI config, and copyable DSNs with the Sentry
+ * SDK source; endpoint plus key/doc pointers with OTLP and Datadog. Because this
+ * card also renders inside /setup, those pointers link off the page (settings,
+ * the infrastructure tab, docs) rather than back at it. General + Danger always.
  *
  * Loads its own service by id, so callers that switch services should pass a
  * `key={serviceId}` to reset local edits on change.
@@ -94,10 +99,8 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
   const [localFramework, setLocalFramework] = useState<string | undefined>(undefined)
   const [platformFilter, setPlatformFilter] = useState<PlatformFilter>('all')
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [copiedSlug, setCopiedSlug] = useState(false)
   const [copiedConfig, setCopiedConfig] = useState(false)
   const [orgSlug, setOrgSlug] = useState<string | null>(null)
-  const copiedSlugResetId = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null)
   const copiedConfigResetId = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null)
 
   const hasSentry = sourceIds.includes('sentry-sdk')
@@ -122,9 +125,6 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
 
   useEffect(() => {
     return () => {
-      if (copiedSlugResetId.current !== null) {
-        globalThis.clearTimeout(copiedSlugResetId.current)
-      }
       if (copiedConfigResetId.current !== null) {
         globalThis.clearTimeout(copiedConfigResetId.current)
       }
@@ -189,10 +189,22 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
     return <div className="text-sm text-muted-foreground">Loading service…</div>
   }
 
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'https://api.moneat.io'
   const sentryCliConfig = orgSlug
-    ? `[defaults]\nurl=${backendUrl}\norg=${orgSlug}\nproject=${project.slug}`
+    ? `[defaults]\nurl=${backendBaseUrl}\norg=${orgSlug}\nproject=${project.slug}`
     : null
+
+  // One DSN per platform target for multiplatform frameworks, otherwise the
+  // single default key. `project.dsn` is the default key repeated, so it is only
+  // a fallback for services whose keys the API did not expand.
+  const targetDsns = project.keys
+    .filter((key) => Boolean(key.dsn))
+    .map((key) => ({
+      id: key.platformTarget ?? 'default',
+      label: key.platformTarget ? getPlatformInfo(key.platformTarget)?.name ?? key.platformTarget : 'DSN',
+      dsn: key.dsn,
+    }))
+  const fallbackDsns = project.dsn ? [{id: 'default', label: 'DSN', dsn: project.dsn}] : []
+  const dsnEntries = targetDsns.length > 0 ? targetDsns : fallbackDsns
 
   const initialFramework = getPlatformInfo(project.framework)?.id ?? 'other'
   const name = localName ?? project.name
@@ -223,18 +235,6 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
 
     if (Object.keys(updates).length === 0) return
     updateServiceMutation.mutate(updates)
-  }
-
-  const copySlug = () => {
-    navigator.clipboard.writeText(project.slug)
-    setCopiedSlug(true)
-    if (copiedSlugResetId.current !== null) {
-      globalThis.clearTimeout(copiedSlugResetId.current)
-    }
-    copiedSlugResetId.current = globalThis.setTimeout(() => {
-      setCopiedSlug(false)
-      copiedSlugResetId.current = null
-    }, COPIED_STATE_RESET_MS)
   }
 
   const copyConfig = () => {
@@ -288,18 +288,12 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
 
         {hasSentry && (
           <>
-            <div className="space-y-1.5">
-              <Label htmlFor="service-slug" className="text-xs">
-                Service slug
-              </Label>
-              <div className="flex gap-2">
-                <Input id="service-slug" value={project.slug} readOnly className="h-8 bg-muted" />
-                <Button type="button" variant="outline" size="icon" className="h-8 w-8 shrink-0" onClick={copySlug}>
-                  {copiedSlug ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                </Button>
-              </div>
-              <p className="text-[11px] text-muted-foreground">Used for Sentry CLI and API endpoints</p>
-            </div>
+            <CopyField
+              id="service-slug"
+              label="Service slug"
+              value={project.slug}
+              hint="Used for Sentry CLI and API endpoints"
+            />
 
             {sentryCliConfig && (
               <div className="space-y-1.5">
@@ -459,32 +453,76 @@ export function ServiceSettingsCard({serviceId, sourceIds, onDeleted}: ServiceSe
         )}
       </SectionCard>
 
-      {hasOtel && (
-        <SectionCard title="OpenTelemetry" icon={RadioTower} bodyClassName="space-y-2">
+      {hasSentry && (
+        <SectionCard title="DSN" icon={KeyRound} bodyClassName="space-y-3">
           <p className="text-xs text-muted-foreground">
-            Send telemetry with the resource attribute <code className="font-mono text-[11px]">service.name</code> set
-            to this service.
+            Pass this to <code className="font-mono text-[11px]">Sentry.init()</code> in a Sentry-compatible SDK to
+            send events to this service. A DSN is safe to ship in client apps — it only allows sending.
           </p>
-          <Link to="/setup" search={{tab: 'services', service: serviceId}}>
-            <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
-              <ExternalLink className="h-3.5 w-3.5" />
-              View ingestion setup
+          {dsnEntries.length > 0 ? (
+            dsnEntries.map((entry) => <CopyField key={entry.id} label={entry.label} value={entry.dsn} />)
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              No DSN yet. Add a target platform above to generate one.
+            </p>
+          )}
+        </SectionCard>
+      )}
+
+      {hasOtel && (
+        <SectionCard title="OpenTelemetry" icon={RadioTower} bodyClassName="space-y-3">
+          <CopyField
+            label="OTLP endpoint"
+            value={backendBaseUrl}
+            hint={
+              <>
+                Set <code className="font-mono">OTEL_EXPORTER_OTLP_ENDPOINT</code> to this — exporters append{' '}
+                <code className="font-mono">/v1/traces</code>, <code className="font-mono">/v1/metrics</code>, and{' '}
+                <code className="font-mono">/v1/logs</code>.
+              </>
+            }
+          />
+          <p className="text-xs text-muted-foreground">
+            Authenticate with an OTLP API key, then map the incoming{' '}
+            <code className="font-mono text-[11px]">service.name</code> resource attribute to this service.
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            <Button asChild variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
+              <Link to="/settings" search={{tab: 'api-keys'}}>
+                <KeyRound className="h-3.5 w-3.5" />
+                OTLP API keys
+              </Link>
             </Button>
-          </Link>
+            <Button asChild variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
+              <a href="/docs/opentelemetry" target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="h-3.5 w-3.5" />
+                Ingestion docs
+              </a>
+            </Button>
+          </div>
         </SectionCard>
       )}
 
       {hasDatadog && (
-        <SectionCard title="Datadog Agent" icon={ServerCog} bodyClassName="space-y-2">
+        <SectionCard title="Datadog Agent" icon={ServerCog} bodyClassName="space-y-3">
           <p className="text-xs text-muted-foreground">
-            Point a compatible agent at Moneat and tag it with this service.
+            Point a compatible agent at Moneat and tag it with this service. The agent setup builder generates a
+            ready-to-paste config with an organization agent key.
           </p>
-          <Link to="/setup" search={{tab: 'services', service: serviceId}}>
-            <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
-              <ExternalLink className="h-3.5 w-3.5" />
-              View ingestion setup
+          <div className="flex flex-wrap gap-1.5">
+            <Button asChild variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
+              <Link to="/setup" search={{tab: 'infrastructure'}}>
+                <ServerCog className="h-3.5 w-3.5" />
+                Agent setup
+              </Link>
             </Button>
-          </Link>
+            <Button asChild variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
+              <a href="/docs/datadog-agent/agent-setup" target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="h-3.5 w-3.5" />
+                Ingestion docs
+              </a>
+            </Button>
+          </div>
         </SectionCard>
       )}
 

--- a/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
+++ b/dashboard/src/components/projects/__tests__/ServiceSettingsCard.test.tsx
@@ -31,7 +31,8 @@ const mockProject = {
   name: 'Test Service',
   slug: 'test-service',
   framework: 'react',
-  keys: [],
+  keys: [{platformTarget: null, dsn: 'https://abc123@api.moneat.io/1'}],
+  dsn: 'https://abc123@api.moneat.io/1',
 }
 
 const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, 'clipboard')
@@ -83,6 +84,7 @@ describe('ServiceSettingsCard', () => {
     await screen.findByText('General')
     expect(screen.queryByLabelText('Service slug')).not.toBeInTheDocument()
     expect(screen.queryByText('Sentry CLI Configuration')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('DSN')).not.toBeInTheDocument()
     // The OpenTelemetry pointer shows instead.
     expect(screen.getByText('OpenTelemetry')).toBeInTheDocument()
   })
@@ -157,7 +159,7 @@ describe('ServiceSettingsCard', () => {
     mockApi.getProject.mockResolvedValueOnce({
       ...mockProject,
       framework: 'unity',
-      keys: [{platformTarget: 'android'}],
+      keys: [{platformTarget: 'android', dsn: 'https://android-key@api.moneat.io/1'}],
     })
 
     renderCard(['sentry-sdk'])
@@ -178,11 +180,58 @@ describe('ServiceSettingsCard', () => {
     expect(screen.queryByLabelText('Service slug')).not.toBeInTheDocument()
   })
 
-  it('points setup guidance to the Setup page', async () => {
+  it('shows the copyable DSN for Sentry services', async () => {
+    const writeText = stubClipboard()
+
+    renderCard(['sentry-sdk'])
+    const dsnInput = (await screen.findByLabelText('DSN')) as HTMLInputElement
+    expect(dsnInput.value).toBe('https://abc123@api.moneat.io/1')
+
+    fireEvent.click(screen.getByRole('button', {name: /Copy dsn/i}))
+    expect(writeText).toHaveBeenCalledWith('https://abc123@api.moneat.io/1')
+  })
+
+  it('shows one labelled DSN per platform target', async () => {
+    mockApi.getProject.mockResolvedValueOnce({
+      ...mockProject,
+      framework: 'unity',
+      keys: [
+        {platformTarget: 'android', dsn: 'https://android-key@api.moneat.io/1'},
+        {platformTarget: 'ios', dsn: 'https://ios-key@api.moneat.io/1'},
+      ],
+    })
+
+    renderCard(['sentry-sdk'])
+    expect(((await screen.findByLabelText('Android')) as HTMLInputElement).value).toBe(
+      'https://android-key@api.moneat.io/1'
+    )
+    expect((screen.getByLabelText('iOS') as HTMLInputElement).value).toBe('https://ios-key@api.moneat.io/1')
+    expect(screen.queryByLabelText('DSN')).not.toBeInTheDocument()
+  })
+
+  it('explains the empty DSN state instead of rendering a blank field', async () => {
+    mockApi.getProject.mockResolvedValueOnce({...mockProject, keys: [], dsn: ''})
+
+    renderCard(['sentry-sdk'])
+    expect(await screen.findByText('No DSN yet. Add a target platform above to generate one.')).toBeInTheDocument()
+    expect(screen.queryByLabelText('DSN')).not.toBeInTheDocument()
+  })
+
+  it('points OpenTelemetry setup at the OTLP endpoint, keys, and docs — not back at this page', async () => {
     renderCard(['opentelemetry'])
 
-    const setupButton = await screen.findByRole('button', {name: /View ingestion setup/})
-    expect(setupButton.closest('a')).toHaveAttribute('to', '/setup')
+    expect(((await screen.findByLabelText('OTLP endpoint')) as HTMLInputElement).value).toBeTruthy()
+    // The router Link is mocked as a bare anchor, so match on its content.
+    expect(screen.getByText('OTLP API keys').closest('a')).toHaveAttribute('to', '/settings')
+    expect(screen.getByText('Ingestion docs').closest('a')).toHaveAttribute('href', '/docs/opentelemetry')
+  })
+
+  it('points Datadog setup at the infrastructure agent builder', async () => {
+    renderCard(['datadog-agent'])
+
+    const agentLink = (await screen.findByText('Agent setup')).closest('a')
+    expect(agentLink).toHaveAttribute('to', '/setup')
+    expect(screen.getByText('Ingestion docs').closest('a')).toHaveAttribute('href', '/docs/datadog-agent/agent-setup')
   })
 
   it('deletes the selected service and calls the supplied delete callback', async () => {

--- a/dashboard/src/components/ui/__tests__/copy-field.test.tsx
+++ b/dashboard/src/components/ui/__tests__/copy-field.test.tsx
@@ -1,0 +1,82 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {CopyField} from '../copy-field'
+
+// These tests drive the button with fireEvent rather than userEvent, because
+// userEvent.setup() installs its own navigator.clipboard stub over ours.
+
+const originalClipboard = Object.getOwnPropertyDescriptor(globalThis.navigator, 'clipboard')
+
+function setClipboard(clipboard: unknown) {
+  Object.defineProperty(globalThis.navigator, 'clipboard', {configurable: true, value: clipboard})
+}
+
+afterEach(() => {
+  if (originalClipboard) {
+    Object.defineProperty(globalThis.navigator, 'clipboard', originalClipboard)
+  } else {
+    delete (globalThis.navigator as {clipboard?: unknown}).clipboard
+  }
+})
+
+describe('CopyField', () => {
+  it('labels the read-only value and copies it', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({writeText})
+    const onCopied = vi.fn()
+
+    render(<CopyField label="DSN" value="https://abc123@api.moneat.io/1" onCopied={onCopied} />)
+
+    const input = screen.getByLabelText('DSN') as HTMLInputElement
+    expect(input.value).toBe('https://abc123@api.moneat.io/1')
+    expect(input.readOnly).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', {name: 'Copy dsn'}))
+
+    expect(writeText).toHaveBeenCalledWith('https://abc123@api.moneat.io/1')
+    await waitFor(() => expect(screen.getByRole('button', {name: 'DSN copied'})).toBeInTheDocument())
+    expect(onCopied).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays silent when the clipboard write is rejected', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    setClipboard({writeText})
+    const onCopied = vi.fn()
+
+    render(<CopyField label="DSN" value="https://abc123@api.moneat.io/1" onCopied={onCopied} />)
+    fireEvent.click(screen.getByRole('button', {name: 'Copy dsn'}))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled())
+    expect(onCopied).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', {name: 'Copy dsn'})).toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: 'DSN copied'})).not.toBeInTheDocument()
+  })
+
+  it('stays silent when no clipboard is available', async () => {
+    setClipboard(undefined)
+    const onCopied = vi.fn()
+
+    render(<CopyField label="OTLP endpoint" value="https://api.moneat.io" onCopied={onCopied} />)
+    fireEvent.click(screen.getByRole('button', {name: 'Copy otlp endpoint'}))
+
+    await Promise.resolve()
+    expect(onCopied).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', {name: 'Copy otlp endpoint'})).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/ui/copy-field.tsx
+++ b/dashboard/src/components/ui/copy-field.tsx
@@ -1,0 +1,95 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useEffect, useId, useRef, useState} from 'react'
+import {Check, Copy} from 'lucide-react'
+import {Button} from '@/components/ui/button'
+import {Input} from '@/components/ui/input'
+import {Label} from '@/components/ui/label'
+import {cn} from '@/lib/utils'
+
+const COPIED_STATE_RESET_MS = 2000
+
+export interface CopyFieldProps {
+  /** Field label. Also the accessible name of the value input. */
+  readonly label: string
+  readonly value: string
+  /** Helper text under the field. */
+  readonly hint?: React.ReactNode
+  /** Machine data (IDs, DSNs, endpoints) renders monospace. Defaults to true. */
+  readonly mono?: boolean
+  readonly id?: string
+  readonly className?: string
+  /** Fired after the value reaches the clipboard — for analytics. */
+  readonly onCopied?: () => void
+}
+
+/**
+ * A read-only value with a copy button — the standard way to hand a user a
+ * string they need to paste elsewhere (DSNs, endpoints, slugs). Selecting the
+ * input selects the whole value, so keyboard and clipboard both work.
+ */
+export function CopyField({label, value, hint, mono = true, id, className, onCopied}: CopyFieldProps) {
+  const generatedId = useId()
+  const fieldId = id ?? generatedId
+  const [copied, setCopied] = useState(false)
+  const resetId = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetId.current !== null) globalThis.clearTimeout(resetId.current)
+    }
+  }, [])
+
+  const handleCopy = () => {
+    navigator.clipboard?.writeText(value)
+    onCopied?.()
+    setCopied(true)
+    if (resetId.current !== null) globalThis.clearTimeout(resetId.current)
+    resetId.current = globalThis.setTimeout(() => {
+      setCopied(false)
+      resetId.current = null
+    }, COPIED_STATE_RESET_MS)
+  }
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <Label htmlFor={fieldId} className="text-xs">
+        {label}
+      </Label>
+      <div className="flex gap-2">
+        <Input
+          id={fieldId}
+          value={value}
+          readOnly
+          onFocus={(event) => event.target.select()}
+          className={cn('h-8 bg-muted', mono && 'font-mono text-xs')}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          aria-label={copied ? `${label} copied` : `Copy ${label.toLowerCase()}`}
+          onClick={handleCopy}
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        </Button>
+      </div>
+      {hint && <p className="text-[11px] text-muted-foreground">{hint}</p>}
+    </div>
+  )
+}

--- a/dashboard/src/components/ui/copy-field.tsx
+++ b/dashboard/src/components/ui/copy-field.tsx
@@ -54,8 +54,14 @@ export function CopyField({label, value, hint, mono = true, id, className, onCop
     }
   }, [])
 
-  const handleCopy = () => {
-    navigator.clipboard?.writeText(value)
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+    } catch {
+      // No clipboard (insecure context) or the user denied it — leave the
+      // button alone rather than reporting a copy that never happened.
+      return
+    }
     onCopied?.()
     setCopied(true)
     if (resetId.current !== null) globalThis.clearTimeout(resetId.current)

--- a/emails/package-lock.json
+++ b/emails/package-lock.json
@@ -664,9 +664,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1164,9 +1164,9 @@
       "license": "MIT"
     },
     "node_modules/degit": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
-      "integrity": "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.6.tgz",
+      "integrity": "sha512-UzjEf67itNZtQF4ZFSNYT+JY78VKtkRJPnksn1tVDAX74Ar0zMqnB5UvsiAjIOBiIHv3BbAPCEJDn/zasbV5rw==",
       "license": "MIT",
       "bin": {
         "degit": "degit"
@@ -2200,9 +2200,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2568,9 +2568,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -4804,9 +4804,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,8 +1,3 @@
 # Accepted OSV Scanner vulnerability exceptions.
 # Each ignored vulnerability must include a package/advisory-specific reason,
 # an owner, and a review date in the reason text.
-
-[[IgnoredVulns]]
-id = "GHSA-mh99-v99m-4gvg"
-ignoreUntil = 2026-08-25
-reason = "Owner: Platform. Review 2026-08-25. Dev-only build/lint dependency; no user-controlled glob input."


### PR DESCRIPTION
## Problem

Two issues on the service configuration surface (`/setup` → Services & SDKs, and the legacy `/projects/$projectId/settings` route):

1. **No copyable DSN.** The card offered the Sentry CLI config (`[defaults] url/org/project`) but never the DSN itself, so there was no way to get the one string an SDK needs into the clipboard. The API already returns it — `GET /projects/{id}` includes `dsn` and a `dsn` per platform-target key — the UI just never rendered it.
2. **"View ingestion setup" went nowhere.** Both the OpenTelemetry and Datadog cards linked to `/setup?tab=services&service=<id>`, which is the page the card already renders on. Clicking updated the search params and left the user exactly where they were.

## Changes

**DSN section** (Sentry SDK source only): a new `DSN` card lists every client key as a read-only monospace field with a copy button — one labelled row per platform target for multiplatform frameworks (Unity, React Native, Flutter), a single `DSN` row otherwise. Empty state explains how to generate one rather than rendering a blank field.

**OpenTelemetry card:** shows the OTLP endpoint inline (copyable, with the `/v1/traces|metrics|logs` suffix note), and replaces the dead button with real destinations — OTLP API keys in Settings, and `/docs/opentelemetry`.

**Datadog card:** links to the infrastructure agent builder (`/setup?tab=infrastructure`, where agent keys and the generated config live) and `/docs/datadog-agent/agent-setup`.

**`CopyField` primitive** (`components/ui/copy-field.tsx`): read-only value + copy button, per the internal style guide — monospace for machine data, compact `h-8` control, `aria-label` on the icon-only button, focus selects the whole value. Replaces the hand-rolled service-slug field and its duplicated copy-state/timeout bookkeeping.

Pointer buttons switched to `Button asChild` + `Link` so an anchor is no longer wrapping a button.

## Notes

- Frontend only — the backend already returns full DSNs on this endpoint.
- OTLP routing is by explicit service mapping (Settings → API Keys → OpenTelemetry), so the card's copy now says that instead of implying `service.name` auto-binds to the service.

## Testing

- `npx vitest run` — 250 files / 2380 tests pass, including 6 new/updated cases covering the single DSN, per-target DSNs, the empty state, and both pointer cards' link targets.
- `npm run typecheck` and `npm run lint` clean.
- Not exercised in a running app — the local worktree's ClickHouse database isn't provisioned (`moneat setup` needed), so this is verified by tests and against the existing primitives rather than in a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added copyable fields for project slugs and Sentry DSNs.
  - Displays platform-specific Sentry DSNs when available, with a project-level fallback.
  - Expanded OpenTelemetry and Datadog setup guidance with endpoints, configuration links, and documentation.
  - Added clearer copy feedback and helpful messaging when DSN values are unavailable.

- **Bug Fixes**
  - Improved service configuration details and setup links for telemetry integrations.
  - Copy actions now handle unavailable or unsuccessful clipboard access gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->