### PR TITLE
Honor organization alert silences across all delivery paths

### DIFF
--- a/backend/features/incident/src/main/kotlin/com/moneat/incident/IncidentModule.kt
+++ b/backend/features/incident/src/main/kotlin/com/moneat/incident/IncidentModule.kt
@@ -35,7 +35,7 @@ class IncidentModule : EnterpriseModule {
     override fun koinModules(): List<Module> =
         listOf(
             module {
-                single { IncidentService(get(), get<ResourceOwnershipRepository>()) }
+                single { IncidentService(get(), get<ResourceOwnershipRepository>(), get()) }
             }
         )
 

--- a/backend/features/incident/src/test/kotlin/com/moneat/incident/IncidentFeatureRegistryTest.kt
+++ b/backend/features/incident/src/test/kotlin/com/moneat/incident/IncidentFeatureRegistryTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.incident
 
+import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.incident.services.IncidentService
@@ -68,6 +69,7 @@ class IncidentFeatureRegistryTest {
                 module {
                     single { mockk<WorkflowService>(relaxed = true) }
                     single { mockk<ResourceOwnershipRepository>(relaxed = true) }
+                    single { mockk<AlertSilenceService>(relaxed = true) }
                 },
                 *IncidentModule().koinModules().toTypedArray(),
             )

--- a/backend/features/incident/src/test/kotlin/com/moneat/services/IncidentServiceExtendedTest.kt
+++ b/backend/features/incident/src/test/kotlin/com/moneat/services/IncidentServiceExtendedTest.kt
@@ -27,6 +27,7 @@ import com.moneat.incident.models.IncidentProviderConfigs
 import com.moneat.incident.models.IncidentRoutingRules
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.incident.services.IncidentService
 import com.moneat.monitor.repositories.ResourceOwnershipRepository
 import com.moneat.shared.models.EscalationPolicies
@@ -38,6 +39,7 @@ import com.moneat.testsupport.TestDatabaseHelper
 import com.moneat.workflows.services.WorkflowService
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -64,7 +66,8 @@ class IncidentServiceExtendedTest {
     private var orgId: Int = 0
     private var providerConfigId: Int = 0
     private val workflowService: WorkflowService = mockk(relaxed = true)
-    private val service = IncidentService(workflowService)
+    private val alertSilenceService: AlertSilenceService = mockk()
+    private val service = IncidentService(workflowService, alertSilenceService = alertSilenceService)
     private val testProviderType = "test_provider_ext"
 
     companion object {
@@ -120,6 +123,9 @@ class IncidentServiceExtendedTest {
 
         mockkObject(EnvConfig)
         every { EnvConfig.get("ONCALL_ENABLED", "false") } returns "false"
+        clearMocks(workflowService, alertSilenceService)
+        coEvery { workflowService.publishAlertTriggered(any()) } returns true
+        every { alertSilenceService.isOrganizationSilenced(any(), any()) } returns false
     }
 
     @AfterTest
@@ -178,6 +184,27 @@ class IncidentServiceExtendedTest {
         assertTrue(logs[0][IncidentEventLog.success])
         assertEquals("inc-123", logs[0][IncidentEventLog.providerIncidentId])
         assertEquals(AlertStatus.FIRING.name, logs[0][IncidentEventLog.incidentStatus])
+    }
+
+    @Test
+    fun `fireAlert skips incident providers when workflow delivery is suppressed`() = runBlocking {
+        IncidentTestHelper.registerMockProvider(testProviderType)
+        coEvery { workflowService.publishAlertTriggered(any()) } returns false
+
+        service.fireAlert(makeEvent())
+
+        assertEquals(0L, IncidentTestHelper.getEventLogCount(orgId))
+    }
+
+    @Test
+    fun `fireAlert without workflow skips incident providers during organization silence`() = runBlocking {
+        IncidentTestHelper.registerMockProvider(testProviderType)
+        every { alertSilenceService.isOrganizationSilenced(orgId, any()) } returns true
+
+        service.fireAlert(makeEvent(), publishWorkflow = false)
+
+        assertEquals(0L, IncidentTestHelper.getEventLogCount(orgId))
+        coVerify(exactly = 0) { workflowService.publishAlertTriggered(any()) }
     }
 
     @Test

--- a/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
+++ b/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
@@ -76,7 +76,7 @@ class MonitoringModule : EnterpriseModule {
                 single<HostAlertRepository> { HostAlertRepositoryImpl() }
 
                 single { MonitorService(get(), get(), get(), get()) }
-                single { MonitorAlertService(get(), get()) }
+                single { MonitorAlertService(get(), get(), get()) }
                 single<ResourceOwnershipRepository> { ResourceOwnershipRepositoryImpl() }
                 single {
                     ResourceCatalogService(

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/MonitoringFeatureRegistryTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitoring/MonitoringFeatureRegistryTest.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.monitoring
 
+import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.incident.services.IncidentService
@@ -94,6 +95,7 @@ class MonitoringFeatureRegistryTest {
                     single { mockk<RetentionPolicyService>(relaxed = true) }
                     single { mockk<IncidentService>(relaxed = true) }
                     single { mockk<WorkflowService>(relaxed = true) }
+                    single { mockk<AlertSilenceService>(relaxed = true) }
                     single { mockk<ResourceCatalogTeamResolver>(relaxed = true) }
                 },
                 *MonitoringModule().koinModules().toTypedArray(),

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -884,6 +884,34 @@ class WorkflowServiceTest {
         }
 
     @Test
+    fun `organization silence records resolution without publishing workflow`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Muted resolution workflow",
+                        triggerName = "alert.resolved",
+                        steps = emptyList()
+                    )
+                )
+            publish(workflow.id)
+            every { alertSilenceService.isOrganizationSilenced(orgId, any()) } returns false
+            assertTrue(service.publishAlertTriggered(alertEvent()))
+
+            every { alertSilenceService.isOrganizationSilenced(orgId, any()) } returns true
+            assertFalse(service.publishAlertTriggered(alertEvent().copy(status = AlertStatus.RESOLVED)))
+
+            assertTrue(service.listRuns(orgId, workflow.id).isEmpty())
+            transaction {
+                val episode = AlertEpisodes.selectAll().single()
+                assertEquals("RESOLVED", episode[AlertEpisodes.status])
+                assertNotNull(episode[AlertEpisodes.resolvedAt])
+            }
+            Unit
+        }
+
+    @Test
     fun `re-fired alert episode is not blocked by historical workflow runs`() =
         runBlocking {
             val workflow =

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -22,6 +22,8 @@ import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
 import com.moneat.alerts.models.IncidentSeverity
+import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
@@ -91,6 +93,7 @@ class WorkflowServiceTest {
     private val emailService = mockk<EmailService>(relaxed = true)
     private val slackService = mockk<SlackService>()
     private val discordService = mockk<DiscordService>()
+    private val alertSilenceService = mockk<AlertSilenceService>()
     private lateinit var workflowEngine: FakeWorkflowExecutionEngine
     private lateinit var service: WorkflowService
     private var orgId: Int = 0
@@ -107,13 +110,20 @@ class WorkflowServiceTest {
         TransactionManager.defaultDatabase = db
         resetWorkflowSchema()
         workflowEngine = FakeWorkflowExecutionEngine()
-        clearMocks(emailService, slackService, discordService)
+        clearMocks(emailService, slackService, discordService, alertSilenceService)
         every { emailService.sendEmail(any(), any(), any(), any(), any()) } just runs
         coEvery { slackService.sendWorkflowMessage(any(), any(), any()) } returns true
         coEvery { slackService.sendWorkflowAlertMessage(any(), any(), any()) } returns true
         coEvery { discordService.sendWorkflowMessage(any(), any(), any(), any()) } returns true
         coEvery { discordService.sendWorkflowAlertMessage(any(), any(), any()) } returns true
-        service = WorkflowService(emailService, slackService, discordService, executionEngine = workflowEngine)
+        every { alertSilenceService.isOrganizationSilenced(any(), any()) } returns false
+        service = WorkflowService(
+            emailService,
+            slackService,
+            discordService,
+            executionEngine = workflowEngine,
+            alertEpisodeService = AlertEpisodeService(alertSilenceService)
+        )
         orgId = seedOrganizationWithMembers()
     }
 
@@ -840,6 +850,40 @@ class WorkflowServiceTest {
         }
 
     @Test
+    fun `organization silence records firing without reserving notification`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    CreateWorkflowRequest(
+                        name = "Muted alert workflow",
+                        triggerName = "alert.triggered",
+                        steps = emptyList()
+                    )
+                )
+            publish(workflow.id)
+            every { alertSilenceService.isOrganizationSilenced(orgId, any()) } returns true
+
+            assertFalse(service.publishAlertTriggered(alertEvent()))
+            assertTrue(service.listRuns(orgId, workflow.id).isEmpty())
+            transaction {
+                val episode = AlertEpisodes.selectAll().single()
+                assertEquals(0, episode[AlertEpisodes.notificationCount])
+                assertNull(episode[AlertEpisodes.lastNotificationAt])
+            }
+
+            every { alertSilenceService.isOrganizationSilenced(orgId, any()) } returns false
+            assertTrue(service.publishAlertTriggered(alertEvent()))
+            assertEquals(1, service.listRuns(orgId, workflow.id).size)
+            transaction {
+                val episode = AlertEpisodes.selectAll().single()
+                assertEquals(1, episode[AlertEpisodes.notificationCount])
+                assertNotNull(episode[AlertEpisodes.lastNotificationAt])
+            }
+            Unit
+        }
+
+    @Test
     fun `re-fired alert episode is not blocked by historical workflow runs`() =
         runBlocking {
             val workflow =
@@ -963,6 +1007,27 @@ class WorkflowServiceTest {
                 ).sorted(),
                 service.listRuns(orgId, workflow.id).map { it.onceFor }.sorted()
             )
+        }
+
+    @Test
+    fun `organization silence suppresses security signal workflows`() =
+        runBlocking {
+            val workflow =
+                service.createWorkflow(
+                    orgId,
+                    validRequest(
+                        name = "Muted security signal",
+                        triggerName = "security.signal",
+                        steps = emptyList(),
+                        onceForTemplate = listOf("security.rule_id", "security.resource")
+                    )
+                )
+            publish(workflow.id)
+            every { alertSilenceService.isOrganizationSilenced(orgId, any()) } returns true
+
+            service.publishSecuritySignals(orgId, listOf(createdSignal("rule-muted", "high")))
+
+            assertTrue(service.listRuns(orgId, workflow.id).isEmpty())
         }
 
     @Test

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/WorkflowServiceTest.kt
@@ -912,6 +912,18 @@ class WorkflowServiceTest {
         }
 
     @Test
+    fun `organization silence suppresses resolution without existing episode`() =
+        runBlocking {
+            every { alertSilenceService.isOrganizationSilenced(orgId, any()) } returns true
+
+            assertFalse(service.publishAlertTriggered(alertEvent().copy(status = AlertStatus.RESOLVED)))
+
+            transaction {
+                assertTrue(AlertEpisodes.selectAll().toList().isEmpty())
+            }
+        }
+
+    @Test
     fun `re-fired alert episode is not blocked by historical workflow runs`() =
         runBlocking {
             val workflow =

--- a/backend/src/main/kotlin/com/moneat/alerts/services/AlertEpisodeService.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/services/AlertEpisodeService.kt
@@ -74,7 +74,12 @@ private fun AlertLifecycleEvent.episodeIdentity(): AlertEpisodeIdentity =
         deduplicationKey = deduplicationKey,
     )
 
-class AlertEpisodeService {
+class AlertEpisodeService(
+    private val alertSilenceService: AlertSilenceService = AlertSilenceService()
+) {
+    fun isOrganizationSilenced(organizationId: Int): Boolean =
+        alertSilenceService.isOrganizationSilenced(organizationId)
+
     fun recordFiring(
         event: AlertLifecycleEvent,
         now: Instant = Clock.System.now()
@@ -85,6 +90,17 @@ class AlertEpisodeService {
             now = now,
             reservePublication = true
         )
+
+    fun recordFiringWithoutNotification(
+        event: AlertLifecycleEvent,
+        now: Instant = Clock.System.now()
+    ): AlertEpisodeContext? =
+        recordFiring(
+            identity = event.episodeIdentity(),
+            metadata = event.displayMetadata(),
+            now = now,
+            reservePublication = false
+        )?.episode
 
     fun ensureOpenEpisodeForWorkflow(
         event: AlertLifecycleEvent,

--- a/backend/src/main/kotlin/com/moneat/alerts/services/AlertSilenceService.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/services/AlertSilenceService.kt
@@ -1,0 +1,45 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.alerts.services
+
+import com.moneat.shared.models.AlertSilencePeriods
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class AlertSilenceService {
+    fun isOrganizationSilenced(
+        organizationId: Int,
+        now: Instant = Clock.System.now()
+    ): Boolean =
+        transaction {
+            AlertSilencePeriods
+                .selectAll()
+                .where {
+                    (AlertSilencePeriods.organization_id eq organizationId) and
+                        (AlertSilencePeriods.starts_at lessEq now) and
+                        (AlertSilencePeriods.ends_at greaterEq now)
+                }
+                .limit(1)
+                .any()
+        }
+}

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -17,6 +17,7 @@
 package com.moneat.di
 
 import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.events.repositories.EventRepository
 import com.moneat.events.repositories.EventRepositoryImpl
 import com.moneat.events.repositories.IssueRepository
@@ -55,7 +56,8 @@ val sharedModule = module {
     single { SlackService() }
     single { DiscordService() }
     single { AlertNotificationPreferencesService() }
-    single { AlertEpisodeService() }
+    single { AlertSilenceService() }
+    single { AlertEpisodeService(get()) }
 
     single { RetentionPolicyService(get()) }
     single { RetentionBackgroundService(get()) }

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
@@ -20,6 +20,7 @@ import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.config.EnvConfig
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.incident.models.IncidentEventLog
@@ -57,6 +58,7 @@ import kotlin.time.Clock
 class IncidentService(
     private val workflowService: WorkflowService = WorkflowService(),
     private val ownershipRepository: ResourceOwnershipRepository = NoopResourceOwnershipRepository,
+    private val alertSilenceService: AlertSilenceService = AlertSilenceService(),
 ) {
     private val logger = LoggerFactory.getLogger(IncidentService::class.java)
     private val json = Json { ignoreUnknownKeys = true }
@@ -82,6 +84,8 @@ class IncidentService(
         event: AlertLifecycleEvent,
         publishWorkflow: Boolean = true
     ) {
+        if (!shouldDeliverAlert(event, publishWorkflow)) return
+
         // Check if native on-call is enabled
         val onCallEnabled = EnvConfig.get("ONCALL_ENABLED", "false").toBoolean()
 
@@ -90,14 +94,6 @@ class IncidentService(
                 triggerNativeEscalation(event)
             }.getOrElse { e ->
                 logger.error("Error triggering native escalation", e)
-            }
-        }
-
-        if (publishWorkflow) {
-            suspendRunCatching {
-                workflowService.publishAlertTriggered(event)
-            }.getOrElse { e ->
-                logger.error("Error publishing alert-triggered workflow", e)
             }
         }
 
@@ -145,6 +141,27 @@ class IncidentService(
             }
         }.getOrElse { e ->
             logger.error("Error firing alert", e)
+        }
+    }
+
+    private suspend fun shouldDeliverAlert(
+        event: AlertLifecycleEvent,
+        publishWorkflow: Boolean
+    ): Boolean {
+        if (publishWorkflow) {
+            return suspendRunCatching {
+                workflowService.publishAlertTriggered(event)
+            }.getOrElse { error ->
+                logger.error("Error publishing alert-triggered workflow; delivering incident alert", error)
+                true
+            }
+        }
+
+        return runCatching {
+            !alertSilenceService.isOrganizationSilenced(event.organizationId)
+        }.getOrElse { error ->
+            logger.error("Error checking alert silence; delivering incident alert", error)
+            true
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -22,6 +22,7 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.incident.services.IncidentService
 import com.moneat.monitor.models.AlertData
 import com.moneat.monitor.models.CreateSilencePeriodRequest
@@ -56,7 +57,6 @@ import kotlinx.serialization.json.jsonObject
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.core.greaterEq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.notInList
@@ -207,6 +207,7 @@ private fun rollupDiskPercentExpr(): String =
 class MonitorAlertService(
     private val incidentService: IncidentService = IncidentService(),
     private val workflowService: WorkflowService = WorkflowService(),
+    private val alertSilenceService: AlertSilenceService = AlertSilenceService(),
 ) {
     private val config = ApplicationConfig("application.conf")
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
@@ -459,10 +460,6 @@ class MonitorAlertService(
         val now = Clock.System.now()
         if (isThrottledByInterval(alert.lastTriggeredAt, now)) {
             setAlertTriggeredState(alertKey, isThrottled = true)
-            return
-        }
-
-        if (isAnySilenceActive(organizationId)) {
             return
         }
 
@@ -1027,8 +1024,6 @@ class MonitorAlertService(
             }
         }
 
-        if (isAnySilenceActive(host.organizationId)) return
-
         sendHostStatusNotification(host, newStatus)
     }
 
@@ -1187,18 +1182,8 @@ class MonitorAlertService(
 
     // --- Silence Period Methods ---
 
-    fun isAnySilenceActive(organizationId: Int): Boolean {
-        val now = Clock.System.now()
-        return transaction {
-            AlertSilencePeriods
-                .selectAll()
-                .where {
-                    (AlertSilencePeriods.organization_id eq organizationId) and
-                        (AlertSilencePeriods.starts_at lessEq now) and
-                        (AlertSilencePeriods.ends_at greaterEq now)
-                }.count() > 0
-        }
-    }
+    fun isAnySilenceActive(organizationId: Int): Boolean =
+        alertSilenceService.isOrganizationSilenced(organizationId)
 
     fun listSilencePeriods(organizationId: Int): List<SilencePeriodResponse> {
         return transaction {

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -871,6 +871,12 @@ class WorkflowService(
 
     private suspend fun publishResolvedAlertEvent(event: AlertLifecycleEvent): Boolean {
         val episode = alertEpisodeService.recordResolved(event) ?: return true
+        if (isAlertDeliverySilenced(event.organizationId)) {
+            logger.info {
+                "Resolved alert delivery suppressed by an active silence for organization ${event.organizationId}"
+            }
+            return false
+        }
         if (!episode.shouldPublish) return false
         suspendRunCatching {
             publishAlertWorkflowTriggers(event, episode)

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -870,13 +870,14 @@ class WorkflowService(
         }
 
     private suspend fun publishResolvedAlertEvent(event: AlertLifecycleEvent): Boolean {
-        val episode = alertEpisodeService.recordResolved(event) ?: return true
+        val episode = alertEpisodeService.recordResolved(event)
         if (isAlertDeliverySilenced(event.organizationId)) {
             logger.info {
                 "Resolved alert delivery suppressed by an active silence for organization ${event.organizationId}"
             }
             return false
         }
+        if (episode == null) return true
         if (!episode.shouldPublish) return false
         suspendRunCatching {
             publishAlertWorkflowTriggers(event, episode)

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -842,6 +842,13 @@ class WorkflowService(
         if (event.status == AlertStatus.RESOLVED) {
             return publishResolvedAlertEvent(event)
         }
+        if (isAlertDeliverySilenced(event.organizationId)) {
+            alertEpisodeService.recordFiringWithoutNotification(event)
+            logger.info {
+                "Alert delivery suppressed by an active silence for organization ${event.organizationId}"
+            }
+            return false
+        }
         val episode = alertEpisodeService.recordFiring(event) ?: return true
         if (!episode.shouldPublish) return false
         suspendRunCatching {
@@ -851,6 +858,16 @@ class WorkflowService(
         }
         return true
     }
+
+    private fun isAlertDeliverySilenced(organizationId: Int): Boolean =
+        runCatching {
+            alertEpisodeService.isOrganizationSilenced(organizationId)
+        }.getOrElse { error ->
+            logger.error(error) {
+                "Failed to check alert silence for organization $organizationId; delivering alert"
+            }
+            false
+        }
 
     private suspend fun publishResolvedAlertEvent(event: AlertLifecycleEvent): Boolean {
         val episode = alertEpisodeService.recordResolved(event) ?: return true
@@ -1022,6 +1039,12 @@ class WorkflowService(
      * fold into an existing open signal (`Updated`) intentionally do not re-trigger.
      */
     suspend fun publishSecuritySignals(organizationId: Int, signals: List<SignalOutcome>) {
+        if (isAlertDeliverySilenced(organizationId)) {
+            logger.info {
+                "Security signal delivery suppressed by an active silence for organization $organizationId"
+            }
+            return
+        }
         signals
             .filter { it is SignalOutcome.Created || it is SignalOutcome.Escalated }
             .forEach { signal ->

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertEpisodeServiceTest.kt
@@ -88,6 +88,22 @@ class AlertEpisodeServiceTest {
     }
 
     @Test
+    fun `firing recorded without notification remains immediately publishable`() {
+        val now = Instant.parse("2026-06-02T12:00:00Z")
+
+        val muted = service.recordFiringWithoutNotification(alertEvent(), now)
+        val unmuted = service.recordFiring(alertEvent(), now + 1.hours)
+
+        assertNotNull(muted)
+        assertEquals(0, muted.notificationCount)
+        assertNull(muted.lastNotificationAt)
+        assertNotNull(unmuted)
+        assertTrue(unmuted.shouldPublish)
+        assertEquals(1, unmuted.notificationSequence)
+        assertEquals(muted.id, unmuted.episode.id)
+    }
+
+    @Test
     fun `firing episode persists alert display metadata`() {
         val now = Instant.parse("2026-06-02T12:00:00Z")
 


### PR DESCRIPTION
## Summary
- centralize active organization-silence checks for alert delivery
- suppress workflow notifications, native on-call escalation, external incident providers, and security-signal workflows while muted
- keep alert evaluation and episode state current so delivery resumes cleanly after the silence expires

## Verification
- `./gradlew test --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"`
- `./gradlew detekt --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-level alert silencing across incident alerts, monitoring notifications, and workflow deliveries.
  * Silenced alerts are recorded without sending notifications and can resume normal delivery after the silence ends.
  * Added consistent handling for active silence periods across alert workflows.

* **Bug Fixes**
  * Prevented alert-triggered and security-signal workflows from running for silenced organizations.
  * Added fallback behavior to preserve alert delivery when silence checks fail.
  * Prevented silenced alert resolutions from publishing workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->