### PR TITLE
feat: add provider-neutral AI runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,12 +216,63 @@ APPLE_KEY_ID=
 APPLE_PRIVATE_KEY=
 
 # ----------------------------------------------------------------------------
-# AI Chat Assistant (OpenAI)
-# Automatically enabled for admin users when API key is set
+# AI Chat Assistant (provider-neutral runtime)
+# Automatically enabled for admin users once a provider is configured: either an
+# API key resolves, or AI_AUTH_TYPE=none points at a keyless local endpoint.
+# Keep real keys out of committed files; leave the *_API_KEY values blank here.
 # ----------------------------------------------------------------------------
+# Provider dialect: openai, openai-compatible, or anthropic.
+# Use openai-compatible for any vendor-agnostic or self-hosted endpoint that
+# speaks the OpenAI Chat Completions API (vLLM, Ollama, LM Studio, and hosted
+# OpenAI-compatible gateways).
+AI_PROVIDER=openai
+
+# API base URL. Defaults to https://api.openai.com for openai/openai-compatible
+# and https://api.anthropic.com for anthropic. Point openai-compatible at your
+# own endpoint, e.g. http://localhost:11434 or https://gateway.internal/v1; the
+# runtime appends /v1 itself and won't double it when the URL already ends in /v1.
+# AI_BASE_URL=
+
+# Model identifier sent to the provider. Defaults to gpt-4o-mini for
+# openai/openai-compatible and claude-sonnet-4-20250514 for anthropic.
+# AI_MODEL=gpt-4o-mini
+
+# Provider-neutral API key. When unset the runtime falls back to
+# OPENAI_API_KEY (openai/openai-compatible) or ANTHROPIC_API_KEY (anthropic).
+AI_API_KEY=
+
+# Authentication scheme:
+#   default - Bearer for the openai dialects, x-api-key for anthropic (default).
+#   bearer  - always send "Authorization: Bearer <key>".
+#   header  - send a custom header (see AI_AUTH_HEADER / AI_AUTH_PREFIX).
+#   none    - send no auth header (for unauthenticated local gateways).
+# AI_AUTH_TYPE=default
+
+# Custom auth header, used only when AI_AUTH_TYPE=header. The header value is
+# "<AI_AUTH_PREFIX> <key>", or just <key> when no prefix is set. For example
+# AI_AUTH_HEADER=api-key with no prefix, or AI_AUTH_HEADER=Authorization with
+# AI_AUTH_PREFIX=Bearer.
+# AI_AUTH_HEADER=Authorization
+# AI_AUTH_PREFIX=Bearer
+
+# Per-request timeout in milliseconds (default 120000, must be positive).
+# AI_REQUEST_TIMEOUT_MS=120000
+
+# Retries after a failed request, 0-5 (default 2).
+# AI_MAX_RETRIES=2
+
+# Comma-separated capabilities the endpoint supports: json_mode, streaming,
+# tool_calling. Defaults to all three for the openai dialects and
+# streaming,tool_calling for anthropic. Narrow this when a compatible endpoint
+# does not implement every capability.
+# AI_CAPABILITIES=json_mode,streaming,tool_calling
+
+# Legacy fallbacks, still honored when the matching AI_* values above are unset.
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 OPENAI_MAX_TOKENS=2048
+ANTHROPIC_API_KEY=
+# ANTHROPIC_MODEL=claude-sonnet-4-20250514
 
 # ----------------------------------------------------------------------------
 # Miscellaneous

--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,8 @@ AI_PROVIDER=openai
 # and https://api.anthropic.com for anthropic. Point openai-compatible at your
 # own endpoint, e.g. http://localhost:11434 or https://gateway.internal/v1; the
 # runtime appends /v1 itself and won't double it when the URL already ends in /v1.
+# Required when AI_AUTH_TYPE=none: keyless mode has no default and never falls
+# back to a public provider endpoint, so AI_BASE_URL must be set explicitly.
 # AI_BASE_URL=
 
 # Model identifier sent to the provider. Defaults to gpt-4o-mini for

--- a/ESSENTIAL_ENV_VARS.md
+++ b/ESSENTIAL_ENV_VARS.md
@@ -35,6 +35,28 @@ Workflow runtime variables are required when `WORKFLOWS_ENABLED=true` (the defau
 
 Workflow secrets must be distinct from `JWT_SECRET` and `DATA_SOURCE_ENCRYPTION_KEY`.
 
+## AI Chat Assistant
+
+The in-app AI assistant is optional and turns on for admin users once a provider is
+configured: either an API key resolves (`AI_API_KEY` or a legacy provider key), or
+`AI_AUTH_TYPE=none` points the runtime at a keyless local endpoint. The runtime is
+provider-neutral: point it at OpenAI, Anthropic, or any OpenAI-compatible endpoint. Set
+`AI_PROVIDER=openai-compatible` for the vendor-agnostic, self-hosted path (vLLM, Ollama,
+LM Studio, and hosted OpenAI-compatible gateways). Keep API keys out of committed files.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AI_PROVIDER` | `openai` | Provider dialect: `openai`, `openai-compatible`, or `anthropic`. Use `openai-compatible` for any endpoint that speaks the OpenAI Chat Completions API. |
+| `AI_BASE_URL` | Provider default | API base URL. Defaults to `https://api.openai.com` for the `openai` dialects and `https://api.anthropic.com` for `anthropic`. Set your own endpoint for `openai-compatible`; give the provider root or a URL already ending in `/v1`, and the runtime appends `/v1` once without doubling it. |
+| `AI_MODEL` | Provider default | Model identifier. Defaults to `gpt-4o-mini` for the `openai` dialects and `claude-sonnet-4-20250514` for `anthropic`. |
+| `AI_API_KEY` | none | Provider-neutral API key. Falls back to `OPENAI_API_KEY` (`openai`/`openai-compatible`) or `ANTHROPIC_API_KEY` (`anthropic`) when unset. |
+| `AI_AUTH_TYPE` | `default` | Auth scheme: `default` (Bearer for the `openai` dialects, `x-api-key` for `anthropic`), `bearer`, `header`, or `none`. |
+| `AI_AUTH_HEADER` | `Authorization` | Header name, used only when `AI_AUTH_TYPE=header`. |
+| `AI_AUTH_PREFIX` | none | Value prefix, used only when `AI_AUTH_TYPE=header`; the header value becomes `<prefix> <key>`, or just `<key>` with no prefix. |
+| `AI_REQUEST_TIMEOUT_MS` | `120000` | Per-request timeout in milliseconds. Must be positive. |
+| `AI_MAX_RETRIES` | `2` | Retries after a failed request, `0`-`5`. |
+| `AI_CAPABILITIES` | Provider default | Comma-separated features the endpoint supports: `json_mode`, `streaming`, `tool_calling`. Defaults to all three for the `openai` dialects and `streaming,tool_calling` for `anthropic`. Narrow it when a compatible endpoint lacks a capability. |
+
 ## Operational Rollout Controls
 
 These variables are optional. Ingestion queues use Redis Streams by default.

--- a/ESSENTIAL_ENV_VARS.md
+++ b/ESSENTIAL_ENV_VARS.md
@@ -47,7 +47,7 @@ LM Studio, and hosted OpenAI-compatible gateways). Keep API keys out of committe
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `AI_PROVIDER` | `openai` | Provider dialect: `openai`, `openai-compatible`, or `anthropic`. Use `openai-compatible` for any endpoint that speaks the OpenAI Chat Completions API. |
-| `AI_BASE_URL` | Provider default | API base URL. Defaults to `https://api.openai.com` for the `openai` dialects and `https://api.anthropic.com` for `anthropic`. Set your own endpoint for `openai-compatible`; give the provider root or a URL already ending in `/v1`, and the runtime appends `/v1` once without doubling it. |
+| `AI_BASE_URL` | Provider default (required when `AI_AUTH_TYPE=none`) | API base URL. Defaults to `https://api.openai.com` for the `openai` dialects and `https://api.anthropic.com` for `anthropic`. Set your own endpoint for `openai-compatible`; give the provider root or a URL already ending in `/v1`, and the runtime appends `/v1` once without doubling it. Keyless mode (`AI_AUTH_TYPE=none`) has no default and never falls back to a public provider endpoint, so it must be set explicitly. |
 | `AI_MODEL` | Provider default | Model identifier. Defaults to `gpt-4o-mini` for the `openai` dialects and `claude-sonnet-4-20250514` for `anthropic`. |
 | `AI_API_KEY` | none | Provider-neutral API key. Falls back to `OPENAI_API_KEY` (`openai`/`openai-compatible`) or `ANTHROPIC_API_KEY` (`anthropic`) when unset. |
 | `AI_AUTH_TYPE` | `default` | Auth scheme: `default` (Bearer for the `openai` dialects, `x-api-key` for `anthropic`), `bearer`, `header`, or `none`. |

--- a/backend/src/main/kotlin/com/moneat/config/EnvironmentValidator.kt
+++ b/backend/src/main/kotlin/com/moneat/config/EnvironmentValidator.kt
@@ -159,6 +159,9 @@ class EnvironmentValidator {
     private fun validateAiRuntimeConfig(errors: MutableList<String>) {
         validateAllowedValue("AI_PROVIDER", SUPPORTED_AI_PROVIDERS, errors)
         validateAllowedValue("AI_AUTH_TYPE", SUPPORTED_AI_AUTH_TYPES, errors)
+        if (getConfigValue("AI_AUTH_TYPE")?.trim()?.equals("none", ignoreCase = true) == true) {
+            validateRequired("AI_BASE_URL", "AI authentication is disabled", errors)
+        }
         validatePositiveLong("AI_REQUEST_TIMEOUT_MS", errors)
         validateIntegerRange("AI_MAX_RETRIES", 0..AI_MAX_RETRIES_LIMIT, errors)
         validateAiCapabilities(errors)

--- a/backend/src/main/kotlin/com/moneat/config/EnvironmentValidator.kt
+++ b/backend/src/main/kotlin/com/moneat/config/EnvironmentValidator.kt
@@ -23,6 +23,10 @@ import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 private const val GOOGLE_ADS_CONNECTOR_ENABLED_REASON = "Google Ads connector is enabled"
+private const val AI_MAX_RETRIES_LIMIT = 5
+private val SUPPORTED_AI_PROVIDERS = setOf("openai", "openai-compatible", "anthropic")
+private val SUPPORTED_AI_AUTH_TYPES = setOf("default", "bearer", "header", "none")
+private val SUPPORTED_AI_CAPABILITIES = setOf("json_mode", "streaming", "tool_calling")
 
 class EnvironmentValidator {
 
@@ -128,11 +132,7 @@ class EnvironmentValidator {
             validateRequired("EXPO_TOKEN", "On-Call mobile push notifications are enabled", errors)
         }
 
-        // Validate AI Chat configuration when API key is present
-        val openAiApiKey = getConfigValue("OPENAI_API_KEY")
-        if (!openAiApiKey.isNullOrBlank()) {
-            logger.info { "OpenAI API key detected - AI chat will be available for admin users" }
-        }
+        validateAiRuntimeConfig(errors)
 
         // Validate Datadog Agent configuration when enabled
         val ddAgentHost = getConfigValue("DD_AGENT_HOST")
@@ -154,6 +154,62 @@ class EnvironmentValidator {
 
         validateProcessRole(errors)
         validateWorkflowRuntimeConfig(errors)
+    }
+
+    private fun validateAiRuntimeConfig(errors: MutableList<String>) {
+        validateAllowedValue("AI_PROVIDER", SUPPORTED_AI_PROVIDERS, errors)
+        validateAllowedValue("AI_AUTH_TYPE", SUPPORTED_AI_AUTH_TYPES, errors)
+        validatePositiveLong("AI_REQUEST_TIMEOUT_MS", errors)
+        validateIntegerRange("AI_MAX_RETRIES", 0..AI_MAX_RETRIES_LIMIT, errors)
+        validateAiCapabilities(errors)
+
+        val aiConfigured = listOf("AI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "AI_AUTH_TYPE")
+            .any { key -> !getConfigValue(key).isNullOrBlank() }
+        if (aiConfigured) {
+            logger.info { "AI provider configuration detected - AI features will be evaluated for availability" }
+        }
+    }
+
+    private fun validateAllowedValue(
+        envVar: String,
+        allowedValues: Set<String>,
+        errors: MutableList<String>
+    ) {
+        val value = getConfigValue(envVar)?.trim()?.lowercase()?.takeIf { it.isNotBlank() } ?: return
+        if (value !in allowedValues) {
+            errors.add("REQUIRED: $envVar must be one of ${allowedValues.sorted().joinToString()} when set.")
+        }
+    }
+
+    private fun validatePositiveLong(envVar: String, errors: MutableList<String>) {
+        val value = getConfigValue(envVar)?.takeIf { it.isNotBlank() } ?: return
+        if (value.toLongOrNull()?.let { it > 0 } != true) {
+            errors.add("REQUIRED: $envVar must be a positive integer when set.")
+        }
+    }
+
+    private fun validateIntegerRange(
+        envVar: String,
+        range: IntRange,
+        errors: MutableList<String>
+    ) {
+        val value = getConfigValue(envVar)?.takeIf { it.isNotBlank() } ?: return
+        if (value.toIntOrNull() !in range) {
+            errors.add("REQUIRED: $envVar must be between ${range.first} and ${range.last} when set.")
+        }
+    }
+
+    private fun validateAiCapabilities(errors: MutableList<String>) {
+        val configured = getConfigValue("AI_CAPABILITIES")?.takeIf { it.isNotBlank() } ?: return
+        val unsupported = configured
+            .split(',')
+            .map { value -> value.trim().lowercase().replace('-', '_') }
+            .filter { value -> value.isNotBlank() && value !in SUPPORTED_AI_CAPABILITIES }
+        if (unsupported.isNotEmpty()) {
+            errors.add(
+                "REQUIRED: AI_CAPABILITIES contains unsupported values: ${unsupported.distinct().joinToString()}."
+            )
+        }
     }
 
     private fun validateGoogleAdsConnectorConfig(errors: MutableList<String>) {

--- a/backend/src/test/kotlin/com/moneat/config/EnvironmentValidatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/EnvironmentValidatorTest.kt
@@ -134,6 +134,44 @@ class EnvironmentValidatorTest {
     }
 
     @Test
+    fun `validate accepts provider-neutral AI configuration`() {
+        withSystemProperties(
+            mapOf(
+                "AI_PROVIDER" to "openai-compatible",
+                "AI_AUTH_TYPE" to "none",
+                "AI_REQUEST_TIMEOUT_MS" to "45000",
+                "AI_MAX_RETRIES" to "3",
+                "AI_CAPABILITIES" to "tool-calling,streaming"
+            )
+        ) {
+            val result = EnvironmentValidator().validate()
+
+            assertFalse(result.errors.any { it.contains("AI_") })
+        }
+    }
+
+    @Test
+    fun `validate rejects malformed provider-neutral AI configuration`() {
+        withSystemProperties(
+            mapOf(
+                "AI_PROVIDER" to "mystery",
+                "AI_AUTH_TYPE" to "query-param",
+                "AI_REQUEST_TIMEOUT_MS" to "soon",
+                "AI_MAX_RETRIES" to "6",
+                "AI_CAPABILITIES" to "streaming,telepathy"
+            )
+        ) {
+            val result = EnvironmentValidator().validate()
+
+            assertTrue(result.errors.any { it.contains("AI_PROVIDER") })
+            assertTrue(result.errors.any { it.contains("AI_AUTH_TYPE") })
+            assertTrue(result.errors.any { it.contains("AI_REQUEST_TIMEOUT_MS") })
+            assertTrue(result.errors.any { it.contains("AI_MAX_RETRIES") })
+            assertTrue(result.errors.any { it.contains("AI_CAPABILITIES") })
+        }
+    }
+
+    @Test
     fun `validate checks critical secrets`() {
         val validator = EnvironmentValidator()
         val result = validator.validate()

--- a/backend/src/test/kotlin/com/moneat/config/EnvironmentValidatorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/config/EnvironmentValidatorTest.kt
@@ -139,6 +139,7 @@ class EnvironmentValidatorTest {
             mapOf(
                 "AI_PROVIDER" to "openai-compatible",
                 "AI_AUTH_TYPE" to "none",
+                "AI_BASE_URL" to "http://llm.internal",
                 "AI_REQUEST_TIMEOUT_MS" to "45000",
                 "AI_MAX_RETRIES" to "3",
                 "AI_CAPABILITIES" to "tool-calling,streaming"
@@ -147,6 +148,15 @@ class EnvironmentValidatorTest {
             val result = EnvironmentValidator().validate()
 
             assertFalse(result.errors.any { it.contains("AI_") })
+        }
+    }
+
+    @Test
+    fun `validate requires an explicit AI endpoint when authentication is disabled`() {
+        withSystemProperty("AI_AUTH_TYPE", "none") {
+            val result = EnvironmentValidator().validate()
+
+            assertTrue(result.errors.any { it.contains("AI_BASE_URL") })
         }
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/AiModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/AiModule.kt
@@ -38,7 +38,7 @@ class AiModule : EnterpriseModule {
         val contextAggregator = AiContextAggregator()
         val chatService = EnterpriseAiChatService(llmProvider, contextAggregator, snapshotService)
         val toolRegistry = McpToolRegistry().apply { McpToolRegistrar.registerAll(this) }
-        val assistantService = AiAssistantService(toolRegistry)
+        val assistantService = AiAssistantService(toolRegistry, llmProvider)
 
         route.apply {
             aiEnterpriseRoutes(chatService)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmHttpTransport.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmHttpTransport.kt
@@ -1,0 +1,92 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.ai.llm
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+
+data class LlmHttpRequest(
+    val url: String,
+    val headers: Map<String, String>,
+    val body: String,
+)
+
+data class LlmHttpResponse(
+    val status: Int,
+    val body: String,
+)
+
+fun interface LlmHttpTransport {
+    suspend fun post(request: LlmHttpRequest): LlmHttpResponse
+}
+
+class KtorLlmHttpTransport(
+    requestTimeoutMillis: Long,
+) : LlmHttpTransport {
+    private val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+        engine {
+            requestTimeout = requestTimeoutMillis
+        }
+    }
+
+    override suspend fun post(request: LlmHttpRequest): LlmHttpResponse {
+        val response = client.post(request.url) {
+            contentType(ContentType.Application.Json)
+            headers {
+                request.headers.forEach { (name, value) -> append(name, value) }
+            }
+            setBody(request.body)
+        }
+        return LlmHttpResponse(response.status.value, response.bodyAsText())
+    }
+}
+
+internal suspend fun executeLlmRequest(
+    transport: LlmHttpTransport,
+    request: LlmHttpRequest,
+    maxRetries: Int,
+): LlmHttpResponse {
+    var attempt = 0
+    while (true) {
+        val response = try {
+            transport.post(request)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            if (attempt >= maxRetries) throw exception
+            retryDelay(attempt)
+            attempt += 1
+            continue
+        }
+
+        if (!response.isRetryable() || attempt >= maxRetries) return response
+        retryDelay(attempt)
+        attempt += 1
+    }
+}
+
+private fun LlmHttpResponse.isRetryable(): Boolean = status == HTTP_TOO_MANY_REQUESTS || status >= HTTP_SERVER_ERROR
+
+private suspend fun retryDelay(attempt: Int) {
+    delay(RETRY_BASE_DELAY_MILLIS * (attempt + 1))
+}
+
+private const val HTTP_TOO_MANY_REQUESTS = 429
+private const val HTTP_SERVER_ERROR = 500
+private const val RETRY_BASE_DELAY_MILLIS = 100L

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmHttpTransport.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmHttpTransport.kt
@@ -17,6 +17,11 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
+import java.time.Duration
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.random.Random
 
 data class LlmHttpRequest(
     val url: String,
@@ -27,11 +32,18 @@ data class LlmHttpRequest(
 data class LlmHttpResponse(
     val status: Int,
     val body: String,
+    val headers: Map<String, String> = emptyMap(),
 )
 
 fun interface LlmHttpTransport {
     suspend fun post(request: LlmHttpRequest): LlmHttpResponse
 }
+
+internal class LlmRetryPolicy(
+    val delayAction: suspend (Long) -> Unit = { delayMillis -> delay(delayMillis) },
+    val currentTime: () -> Instant = Instant::now,
+    val jitterSource: (Long) -> Long = ::randomJitter,
+)
 
 class KtorLlmHttpTransport(
     requestTimeoutMillis: Long,
@@ -53,7 +65,13 @@ class KtorLlmHttpTransport(
             }
             setBody(request.body)
         }
-        return LlmHttpResponse(response.status.value, response.bodyAsText())
+        return LlmHttpResponse(
+            status = response.status.value,
+            body = response.bodyAsText(),
+            headers = response.headers.entries().associate { (name, values) ->
+                name to values.firstOrNull().orEmpty()
+            },
+        )
     }
 }
 
@@ -61,6 +79,7 @@ internal suspend fun executeLlmRequest(
     transport: LlmHttpTransport,
     request: LlmHttpRequest,
     maxRetries: Int,
+    retryPolicy: LlmRetryPolicy = LlmRetryPolicy(),
 ): LlmHttpResponse {
     var attempt = 0
     while (true) {
@@ -70,23 +89,71 @@ internal suspend fun executeLlmRequest(
             throw exception
         } catch (exception: Exception) {
             if (attempt >= maxRetries) throw exception
-            retryDelay(attempt)
+            retryPolicy.delayAction(fallbackRetryDelayMillis(attempt, retryPolicy.jitterSource))
             attempt += 1
             continue
         }
 
         if (!response.isRetryable() || attempt >= maxRetries) return response
-        retryDelay(attempt)
+        retryPolicy.delayAction(
+            response.retryDelayMillis(attempt, retryPolicy.currentTime(), retryPolicy.jitterSource),
+        )
         attempt += 1
     }
 }
 
 private fun LlmHttpResponse.isRetryable(): Boolean = status == HTTP_TOO_MANY_REQUESTS || status >= HTTP_SERVER_ERROR
 
-private suspend fun retryDelay(attempt: Int) {
-    delay(RETRY_BASE_DELAY_MILLIS * (attempt + 1))
+private fun LlmHttpResponse.retryDelayMillis(
+    attempt: Int,
+    currentTime: Instant,
+    jitterSource: (Long) -> Long,
+): Long {
+    if (status != HTTP_TOO_MANY_REQUESTS) return fallbackRetryDelayMillis(attempt, jitterSource)
+    val retryAfter = headers.entries
+        .firstOrNull { (name, _) -> name.equals(RETRY_AFTER_HEADER, ignoreCase = true) }
+        ?.value
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?: return fallbackRetryDelayMillis(attempt, jitterSource)
+
+    val delayMillis = retryAfter.toLongOrNull()
+        ?.let(::secondsToMillis)
+        ?: parseRetryAfterDateMillis(retryAfter, currentTime)
+        ?: return fallbackRetryDelayMillis(attempt, jitterSource)
+    return delayMillis.coerceIn(0L, MAX_RETRY_DELAY_MILLIS)
+}
+
+private fun secondsToMillis(seconds: Long): Long = when {
+    seconds <= 0 -> 0
+    seconds >= MAX_RETRY_DELAY_MILLIS / MILLIS_PER_SECOND -> MAX_RETRY_DELAY_MILLIS
+    else -> seconds * MILLIS_PER_SECOND
+}
+
+private fun parseRetryAfterDateMillis(value: String, currentTime: Instant): Long? = runCatching {
+    val retryAt = ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant()
+    Duration.between(currentTime, retryAt).toMillis().coerceAtLeast(0)
+}.getOrNull()
+
+private fun fallbackRetryDelayMillis(attempt: Int, jitterSource: (Long) -> Long): Long {
+    val multiplier = 1L shl attempt.coerceIn(0, MAX_BACKOFF_EXPONENT)
+    val baseDelay = (RETRY_BASE_DELAY_MILLIS * multiplier).coerceAtMost(MAX_RETRY_DELAY_MILLIS)
+    val maxJitter = minOf(baseDelay / 2, MAX_RETRY_JITTER_MILLIS)
+    val jitter = jitterSource(maxJitter).coerceIn(0L, maxJitter)
+    return (baseDelay + jitter).coerceAtMost(MAX_RETRY_DELAY_MILLIS)
+}
+
+private fun randomJitter(maxInclusive: Long): Long = if (maxInclusive <= 0) {
+    0
+} else {
+    Random.nextLong(maxInclusive + 1)
 }
 
 private const val HTTP_TOO_MANY_REQUESTS = 429
 private const val HTTP_SERVER_ERROR = 500
 private const val RETRY_BASE_DELAY_MILLIS = 100L
+private const val MAX_RETRY_DELAY_MILLIS = 60_000L
+private const val MAX_RETRY_JITTER_MILLIS = 250L
+private const val MAX_BACKOFF_EXPONENT = 8
+private const val MILLIS_PER_SECOND = 1_000L
+private const val RETRY_AFTER_HEADER = "Retry-After"

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProvider.kt
@@ -63,7 +63,7 @@ data class LlmMessage(
 data class LlmToolCall(
     val id: String,
     val name: String,
-    val arguments: JsonObject,
+    val arguments: JsonObject?,
 )
 
 data class LlmTool(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProvider.kt
@@ -5,42 +5,98 @@
 package com.moneat.enterprise.ai.llm
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
- * Provider-agnostic interface for LLM chat completions.
- * Implementations wrap specific providers (OpenAI, Anthropic, etc.).
+ * Provider-neutral interface used by every enterprise AI surface.
+ *
+ * Provider wire formats are translated at the adapter boundary. Callers only
+ * deal in messages, tools, capabilities, token usage, and streamed text.
  */
 interface LlmProvider {
     /** Execute a chat completion and return a structured response. */
-    suspend fun chatCompletion(messages: List<LlmMessage>, config: LlmConfig = LlmConfig()): LlmResponse
+    suspend fun chatCompletion(
+        messages: List<LlmMessage>,
+        config: LlmConfig = LlmConfig(),
+        tools: List<LlmTool> = emptyList(),
+    ): LlmResponse
 
-    /** Provider identifier (e.g. "openai", "anthropic"). */
+    /**
+     * Stream response text through a provider-neutral callback.
+     *
+     * Adapters may override this with native provider streaming. The default
+     * keeps callers vendor-neutral and provides a safe single-chunk fallback.
+     */
+    suspend fun streamChatCompletion(
+        messages: List<LlmMessage>,
+        config: LlmConfig = LlmConfig(),
+        tools: List<LlmTool> = emptyList(),
+        onTextChunk: suspend (String) -> Unit,
+    ): LlmResponse {
+        val response = chatCompletion(messages, config, tools)
+        if (response.content.isNotEmpty()) onTextChunk(response.content)
+        return response
+    }
+
+    /** Provider identifier such as `openai`, `openai-compatible`, or `anthropic`. */
     fun provider(): String
 
-    /** Model identifier (e.g. "gpt-4o-mini", "claude-sonnet-4-20250514"). */
+    /** Configured model identifier. */
     fun model(): String
 
     /** Whether this provider is configured and available. */
     fun isEnabled(): Boolean
+
+    /** Capabilities supported by this configured adapter. */
+    fun capabilities(): Set<LlmCapability>
 }
 
 @Serializable
 data class LlmMessage(
     val role: String,
-    val content: String,
+    val content: String? = null,
+    val toolCallId: String? = null,
+    val toolCalls: List<LlmToolCall> = emptyList(),
+)
+
+@Serializable
+data class LlmToolCall(
+    val id: String,
+    val name: String,
+    val arguments: JsonObject,
+)
+
+data class LlmTool(
+    val name: String,
+    val description: String,
+    val parameters: JsonObject,
 )
 
 data class LlmConfig(
     val maxTokens: Int = 4096,
     val temperature: Double = 0.3,
     val jsonMode: Boolean = true,
+    val toolChoice: LlmToolChoice = LlmToolChoice.AUTO,
 )
+
+enum class LlmToolChoice {
+    AUTO,
+    NONE,
+    REQUIRED,
+}
+
+enum class LlmCapability {
+    JSON_MODE,
+    STREAMING,
+    TOOL_CALLING,
+}
 
 @Serializable
 data class LlmResponse(
     val content: String,
-    val inputTokens: Int,
-    val outputTokens: Int,
-    val model: String,
-    val provider: String,
+    val toolCalls: List<LlmToolCall> = emptyList(),
+    val inputTokens: Int = 0,
+    val outputTokens: Int = 0,
+    val model: String = "",
+    val provider: String = "",
 )

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderFactory.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderFactory.kt
@@ -4,7 +4,6 @@
 
 package com.moneat.enterprise.ai.llm
 
-import com.moneat.config.EnvConfig
 import com.moneat.enterprise.ai.llm.providers.AnthropicProvider
 import com.moneat.enterprise.ai.llm.providers.OpenAiProvider
 import mu.KotlinLogging
@@ -12,25 +11,25 @@ import mu.KotlinLogging
 private val logger = KotlinLogging.logger {}
 
 /**
- * Factory that returns the configured LLM provider based on environment variables.
- *
- * Configuration:
- *   AI_PROVIDER = "openai" | "anthropic"  (default: "openai")
+ * Creates the one configured provider used by all enterprise AI surfaces.
  */
 object LlmProviderFactory {
 
     fun create(): LlmProvider {
-        val providerName = EnvConfig.get("AI_PROVIDER", "openai").lowercase()
-        val provider = when (providerName) {
-            "anthropic" -> AnthropicProvider()
-            else -> OpenAiProvider()
+        val settings = LlmProviderSettingsLoader.load()
+        val provider = when (settings.kind) {
+            LlmProviderKind.ANTHROPIC -> AnthropicProvider(settings)
+            LlmProviderKind.OPENAI,
+            LlmProviderKind.OPENAI_COMPATIBLE,
+            -> OpenAiProvider(settings)
         }
-        logger.info { "LLM provider configured: ${provider.provider()} / ${provider.model()}" }
+        logger.info {
+            "LLM provider configured: ${provider.provider()} / ${provider.model()} " +
+                "(${provider.capabilities().joinToString()})"
+        }
         return provider
     }
 
-    /** Check whether any AI provider is configured. */
-    fun isAnyProviderEnabled(): Boolean {
-        return OpenAiProvider().isEnabled() || AnthropicProvider().isEnabled()
-    }
+    /** Check whether the configured AI provider has usable authentication. */
+    fun isAnyProviderEnabled(): Boolean = LlmProviderSettingsLoader.load().isEnabled
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettings.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettings.kt
@@ -69,7 +69,8 @@ object LlmProviderSettingsLoader {
 
     fun load(get: (String) -> String? = EnvConfig::get): LlmProviderSettings {
         val kind = LlmProviderKind.fromConfig(get("AI_PROVIDER") ?: LlmProviderKind.OPENAI.configValue)
-        val baseUrl = get("AI_BASE_URL")?.trimEnd('/') ?: defaultBaseUrl(kind)
+        val configuredBaseUrl = get("AI_BASE_URL")?.takeIf(String::isNotBlank)?.trimEnd('/')
+        val baseUrl = configuredBaseUrl ?: defaultBaseUrl(kind)
         val model = get("AI_MODEL")?.takeIf(String::isNotBlank) ?: legacyModel(kind, get)
         val timeout = parseLongOrDefault("AI_REQUEST_TIMEOUT_MS", get, DEFAULT_TIMEOUT_MILLIS)
         val maxRetries = parseIntOrDefault("AI_MAX_RETRIES", get, DEFAULT_MAX_RETRIES)
@@ -77,11 +78,16 @@ object LlmProviderSettingsLoader {
             ?.let(::parseCapabilities)
             ?: defaultCapabilities(kind)
 
+        val authentication = loadAuthentication(kind, get)
+        require(authentication != LlmAuthentication.None || configuredBaseUrl != null) {
+            "AI_BASE_URL must be set explicitly when AI_AUTH_TYPE is none"
+        }
+
         return LlmProviderSettings(
             kind = kind,
             baseUrl = baseUrl,
             model = model,
-            authentication = loadAuthentication(kind, get),
+            authentication = authentication,
             requestTimeoutMillis = timeout,
             maxRetries = maxRetries,
             capabilities = capabilities,
@@ -105,10 +111,7 @@ object LlmProviderSettingsLoader {
             "bearer" -> LlmAuthentication.Bearer(apiKey)
             "header" -> LlmAuthentication.Header(
                 name = get("AI_AUTH_HEADER")?.takeIf(String::isNotBlank) ?: "Authorization",
-                value = get("AI_AUTH_PREFIX")
-                    ?.takeIf(String::isNotBlank)
-                    ?.let { prefix -> "$prefix $apiKey" }
-                    ?: apiKey,
+                value = prefixedApiKey(apiKey, get("AI_AUTH_PREFIX")),
             )
             "none" -> LlmAuthentication.None
             else -> throw IllegalArgumentException(
@@ -122,6 +125,14 @@ object LlmProviderSettingsLoader {
         LlmProviderKind.OPENAI,
         LlmProviderKind.OPENAI_COMPATIBLE,
         -> LlmAuthentication.Bearer(apiKey)
+    }
+
+    private fun prefixedApiKey(apiKey: String, configuredPrefix: String?): String {
+        if (apiKey.isBlank()) return ""
+        return configuredPrefix
+            ?.takeIf(String::isNotBlank)
+            ?.let { prefix -> "$prefix $apiKey" }
+            ?: apiKey
     }
 
     private fun defaultBaseUrl(kind: LlmProviderKind): String = when (kind) {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettings.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettings.kt
@@ -68,13 +68,18 @@ object LlmProviderSettingsLoader {
     private const val DEFAULT_MAX_RETRIES = 2
 
     fun load(get: (String) -> String? = EnvConfig::get): LlmProviderSettings {
-        val kind = LlmProviderKind.fromConfig(get("AI_PROVIDER") ?: LlmProviderKind.OPENAI.configValue)
+        val kind = LlmProviderKind.fromConfig(
+            get("AI_PROVIDER")?.trim()?.takeIf(String::isNotEmpty)
+                ?: LlmProviderKind.OPENAI.configValue,
+        )
         val configuredBaseUrl = get("AI_BASE_URL")?.takeIf(String::isNotBlank)?.trimEnd('/')
         val baseUrl = configuredBaseUrl ?: defaultBaseUrl(kind)
         val model = get("AI_MODEL")?.takeIf(String::isNotBlank) ?: legacyModel(kind, get)
         val timeout = parseLongOrDefault("AI_REQUEST_TIMEOUT_MS", get, DEFAULT_TIMEOUT_MILLIS)
         val maxRetries = parseIntOrDefault("AI_MAX_RETRIES", get, DEFAULT_MAX_RETRIES)
         val capabilities = get("AI_CAPABILITIES")
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
             ?.let(::parseCapabilities)
             ?: defaultCapabilities(kind)
 
@@ -171,7 +176,7 @@ object LlmProviderSettingsLoader {
         key: String,
         get: (String) -> String?,
         default: Long,
-    ): Long = get(key)?.let { raw ->
+    ): Long = get(key)?.trim()?.takeIf(String::isNotEmpty)?.let { raw ->
         raw.toLongOrNull() ?: throw IllegalArgumentException("$key must be an integer")
     } ?: default
 
@@ -179,7 +184,7 @@ object LlmProviderSettingsLoader {
         key: String,
         get: (String) -> String?,
         default: Int,
-    ): Int = get(key)?.let { raw ->
+    ): Int = get(key)?.trim()?.takeIf(String::isNotEmpty)?.let { raw ->
         raw.toIntOrNull() ?: throw IllegalArgumentException("$key must be an integer")
     } ?: default
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettings.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettings.kt
@@ -1,0 +1,174 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.ai.llm
+
+import com.moneat.config.EnvConfig
+
+enum class LlmProviderKind(val configValue: String) {
+    OPENAI("openai"),
+    OPENAI_COMPATIBLE("openai-compatible"),
+    ANTHROPIC("anthropic"),
+    ;
+
+    companion object {
+        fun fromConfig(value: String): LlmProviderKind = entries.firstOrNull {
+            it.configValue == value.trim().lowercase()
+        } ?: throw IllegalArgumentException(
+            "Unsupported AI_PROVIDER '$value'. Expected openai, openai-compatible, or anthropic.",
+        )
+    }
+}
+
+sealed interface LlmAuthentication {
+    data class Bearer(val token: String) : LlmAuthentication
+    data class Header(val name: String, val value: String) : LlmAuthentication
+    data object None : LlmAuthentication
+}
+
+data class LlmProviderSettings(
+    val kind: LlmProviderKind,
+    val baseUrl: String,
+    val model: String,
+    val authentication: LlmAuthentication,
+    val requestTimeoutMillis: Long,
+    val maxRetries: Int,
+    val capabilities: Set<LlmCapability>,
+) {
+    init {
+        require(baseUrl.isNotBlank()) { "AI provider base URL cannot be blank" }
+        require(model.isNotBlank()) { "AI provider model cannot be blank" }
+        require(requestTimeoutMillis > 0) { "AI_REQUEST_TIMEOUT_MS must be positive" }
+        require(maxRetries in 0..MAX_RETRIES_LIMIT) {
+            "AI_MAX_RETRIES must be between 0 and $MAX_RETRIES_LIMIT"
+        }
+    }
+
+    val isEnabled: Boolean
+        get() = when (val auth = authentication) {
+            is LlmAuthentication.Bearer -> auth.token.isNotBlank()
+            is LlmAuthentication.Header -> auth.name.isNotBlank() && auth.value.isNotBlank()
+            LlmAuthentication.None -> true
+        }
+
+    fun endpoint(path: String): String {
+        val normalizedBaseUrl = baseUrl.trimEnd('/')
+        val apiRoot = if (normalizedBaseUrl.endsWith("/v1")) normalizedBaseUrl else "$normalizedBaseUrl/v1"
+        return "$apiRoot/${path.trimStart('/')}"
+    }
+
+    companion object {
+        const val MAX_RETRIES_LIMIT = 5
+    }
+}
+
+object LlmProviderSettingsLoader {
+    private const val DEFAULT_TIMEOUT_MILLIS = 120_000L
+    private const val DEFAULT_MAX_RETRIES = 2
+
+    fun load(get: (String) -> String? = EnvConfig::get): LlmProviderSettings {
+        val kind = LlmProviderKind.fromConfig(get("AI_PROVIDER") ?: LlmProviderKind.OPENAI.configValue)
+        val baseUrl = get("AI_BASE_URL")?.trimEnd('/') ?: defaultBaseUrl(kind)
+        val model = get("AI_MODEL")?.takeIf(String::isNotBlank) ?: legacyModel(kind, get)
+        val timeout = parseLongOrDefault("AI_REQUEST_TIMEOUT_MS", get, DEFAULT_TIMEOUT_MILLIS)
+        val maxRetries = parseIntOrDefault("AI_MAX_RETRIES", get, DEFAULT_MAX_RETRIES)
+        val capabilities = get("AI_CAPABILITIES")
+            ?.let(::parseCapabilities)
+            ?: defaultCapabilities(kind)
+
+        return LlmProviderSettings(
+            kind = kind,
+            baseUrl = baseUrl,
+            model = model,
+            authentication = loadAuthentication(kind, get),
+            requestTimeoutMillis = timeout,
+            maxRetries = maxRetries,
+            capabilities = capabilities,
+        )
+    }
+
+    private fun loadAuthentication(
+        kind: LlmProviderKind,
+        get: (String) -> String?,
+    ): LlmAuthentication {
+        val sharedKey = get("AI_API_KEY")?.takeIf(String::isNotBlank)
+        val providerKey = when (kind) {
+            LlmProviderKind.ANTHROPIC -> get("ANTHROPIC_API_KEY")?.takeIf(String::isNotBlank)
+            LlmProviderKind.OPENAI,
+            LlmProviderKind.OPENAI_COMPATIBLE,
+            -> get("OPENAI_API_KEY")?.takeIf(String::isNotBlank)
+        }
+        val apiKey = sharedKey ?: providerKey.orEmpty()
+        return when (get("AI_AUTH_TYPE")?.trim()?.lowercase()) {
+            null, "", "default" -> defaultAuthentication(kind, apiKey)
+            "bearer" -> LlmAuthentication.Bearer(apiKey)
+            "header" -> LlmAuthentication.Header(
+                name = get("AI_AUTH_HEADER")?.takeIf(String::isNotBlank) ?: "Authorization",
+                value = get("AI_AUTH_PREFIX")
+                    ?.takeIf(String::isNotBlank)
+                    ?.let { prefix -> "$prefix $apiKey" }
+                    ?: apiKey,
+            )
+            "none" -> LlmAuthentication.None
+            else -> throw IllegalArgumentException(
+                "Unsupported AI_AUTH_TYPE. Expected default, bearer, header, or none.",
+            )
+        }
+    }
+
+    private fun defaultAuthentication(kind: LlmProviderKind, apiKey: String): LlmAuthentication = when (kind) {
+        LlmProviderKind.ANTHROPIC -> LlmAuthentication.Header("x-api-key", apiKey)
+        LlmProviderKind.OPENAI,
+        LlmProviderKind.OPENAI_COMPATIBLE,
+        -> LlmAuthentication.Bearer(apiKey)
+    }
+
+    private fun defaultBaseUrl(kind: LlmProviderKind): String = when (kind) {
+        LlmProviderKind.ANTHROPIC -> "https://api.anthropic.com"
+        LlmProviderKind.OPENAI,
+        LlmProviderKind.OPENAI_COMPATIBLE,
+        -> "https://api.openai.com"
+    }
+
+    private fun legacyModel(kind: LlmProviderKind, get: (String) -> String?): String = when (kind) {
+        LlmProviderKind.ANTHROPIC -> get("ANTHROPIC_MODEL") ?: "claude-sonnet-4-20250514"
+        LlmProviderKind.OPENAI,
+        LlmProviderKind.OPENAI_COMPATIBLE,
+        -> get("OPENAI_MODEL") ?: "gpt-4o-mini"
+    }
+
+    private fun defaultCapabilities(kind: LlmProviderKind): Set<LlmCapability> = when (kind) {
+        LlmProviderKind.ANTHROPIC -> setOf(LlmCapability.STREAMING, LlmCapability.TOOL_CALLING)
+        LlmProviderKind.OPENAI,
+        LlmProviderKind.OPENAI_COMPATIBLE,
+        -> LlmCapability.entries.toSet()
+    }
+
+    private fun parseCapabilities(value: String): Set<LlmCapability> = value
+        .split(',')
+        .map(String::trim)
+        .filter(String::isNotBlank)
+        .map { raw ->
+            LlmCapability.entries.firstOrNull { capability ->
+                capability.name.equals(raw.replace('-', '_'), ignoreCase = true)
+            } ?: throw IllegalArgumentException("Unsupported AI capability '$raw'")
+        }
+        .toSet()
+
+    private fun parseLongOrDefault(
+        key: String,
+        get: (String) -> String?,
+        default: Long,
+    ): Long = get(key)?.let { raw ->
+        raw.toLongOrNull() ?: throw IllegalArgumentException("$key must be an integer")
+    } ?: default
+
+    private fun parseIntOrDefault(
+        key: String,
+        get: (String) -> String?,
+        default: Int,
+    ): Int = get(key)?.let { raw ->
+        raw.toIntOrNull() ?: throw IllegalArgumentException("$key must be an integer")
+    } ?: default
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/AnthropicProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/AnthropicProvider.kt
@@ -212,8 +212,8 @@ class AnthropicProvider(
     }
 
     private fun requireCapabilityForTools(tools: List<LlmTool>) {
-        if (tools.isNotEmpty() && LlmCapability.TOOL_CALLING !in capabilities()) {
-            throw IllegalStateException("Anthropic is not configured for tool calling")
+        check(!(tools.isNotEmpty() && LlmCapability.TOOL_CALLING !in capabilities())) {
+            "Anthropic is not configured for tool calling"
         }
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/AnthropicProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/AnthropicProvider.kt
@@ -127,33 +127,38 @@ class AnthropicProvider(
             }
 
             flushToolResults()
-            result += when (message.role) {
-                "assistant" -> assistantMessage(message)
-                else -> textMessage("user", message.content.orEmpty())
+            when (message.role) {
+                "assistant" -> assistantMessage(message)?.let { result += it }
+                else -> message.content
+                    ?.takeIf(String::isNotBlank)
+                    ?.let { content -> result += textMessage("user", content) }
             }
         }
         flushToolResults()
         return JsonArray(result)
     }
 
-    private fun assistantMessage(message: LlmMessage): JsonObject = buildJsonObject {
-        put("role", "assistant")
-        put("content", buildJsonArray {
-            message.content?.takeIf(String::isNotBlank)?.let { content ->
-                add(buildJsonObject {
-                    put("type", "text")
-                    put("text", content)
-                })
-            }
-            message.toolCalls.forEach { call ->
-                add(buildJsonObject {
-                    put("type", "tool_use")
-                    put("id", call.id)
-                    put("name", call.name)
-                    put("input", call.arguments)
-                })
-            }
-        })
+    private fun assistantMessage(message: LlmMessage): JsonObject? {
+        if (message.content.isNullOrBlank() && message.toolCalls.isEmpty()) return null
+        return buildJsonObject {
+            put("role", "assistant")
+            put("content", buildJsonArray {
+                message.content?.takeIf(String::isNotBlank)?.let { content ->
+                    add(buildJsonObject {
+                        put("type", "text")
+                        put("text", content)
+                    })
+                }
+                message.toolCalls.forEach { call ->
+                    add(buildJsonObject {
+                        put("type", "tool_use")
+                        put("id", call.id)
+                        put("name", call.name)
+                        put("input", call.arguments ?: JsonObject(emptyMap()))
+                    })
+                }
+            })
+        }
     }
 
     private fun textMessage(role: String, content: String): JsonObject = buildJsonObject {
@@ -183,7 +188,7 @@ class AnthropicProvider(
             LlmToolCall(
                 id = id,
                 name = name,
-                arguments = value["input"] as? JsonObject ?: JsonObject(emptyMap()),
+                arguments = value["input"] as? JsonObject,
             )
         }
         val usage = response["usage"]?.jsonObject

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/AnthropicProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/AnthropicProvider.kt
@@ -4,101 +4,216 @@
 
 package com.moneat.enterprise.ai.llm.providers
 
-import com.moneat.config.EnvConfig
+import com.moneat.enterprise.ai.llm.KtorLlmHttpTransport
+import com.moneat.enterprise.ai.llm.LlmAuthentication
+import com.moneat.enterprise.ai.llm.LlmCapability
 import com.moneat.enterprise.ai.llm.LlmConfig
+import com.moneat.enterprise.ai.llm.LlmHttpRequest
+import com.moneat.enterprise.ai.llm.LlmHttpTransport
 import com.moneat.enterprise.ai.llm.LlmMessage
 import com.moneat.enterprise.ai.llm.LlmProvider
+import com.moneat.enterprise.ai.llm.LlmProviderKind
+import com.moneat.enterprise.ai.llm.LlmProviderSettings
+import com.moneat.enterprise.ai.llm.LlmProviderSettingsLoader
 import com.moneat.enterprise.ai.llm.LlmResponse
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import com.moneat.enterprise.ai.llm.LlmTool
+import com.moneat.enterprise.ai.llm.LlmToolCall
+import com.moneat.enterprise.ai.llm.LlmToolChoice
+import com.moneat.enterprise.ai.llm.executeLlmRequest
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
-class AnthropicProvider : LlmProvider {
-
+class AnthropicProvider(
+    private val settings: LlmProviderSettings = LlmProviderSettingsLoader.load(),
+    private val transport: LlmHttpTransport = KtorLlmHttpTransport(settings.requestTimeoutMillis),
+) : LlmProvider {
     private val json = Json { ignoreUnknownKeys = true }
-    private val client = HttpClient(CIO) {
-        install(ContentNegotiation) { json(json) }
-        engine { requestTimeout = 120_000 }
+
+    init {
+        require(settings.kind == LlmProviderKind.ANTHROPIC) {
+            "AnthropicProvider requires anthropic settings"
+        }
     }
 
-    private val apiKey: String get() = EnvConfig.get("ANTHROPIC_API_KEY", "")
-    private val modelName: String get() = EnvConfig.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
-    private val maxTokensCfg: Int get() = EnvConfig.get("ANTHROPIC_MAX_TOKENS", "16384").toIntOrNull() ?: 16384
+    override fun provider(): String = settings.kind.configValue
 
-    override fun provider() = "anthropic"
-    override fun model() = modelName
-    override fun isEnabled() = apiKey.isNotBlank()
+    override fun model(): String = settings.model
 
-    override suspend fun chatCompletion(messages: List<LlmMessage>, config: LlmConfig): LlmResponse {
-        // Anthropic separates the system message from conversation messages
-        val systemText = messages.filter { it.role == "system" }.joinToString("\n\n") { it.content }
-        val conversationMessages = messages.filter { it.role != "system" }
-            .map { AnthropicMsg(it.role, it.content) }
+    override fun isEnabled(): Boolean = settings.isEnabled
 
-        val request = AnthropicRequest(
-            model = modelName,
-            max_tokens = minOf(config.maxTokens, maxTokensCfg),
-            system = systemText.ifBlank { null },
-            messages = conversationMessages,
+    override fun capabilities(): Set<LlmCapability> = settings.capabilities
+
+    override suspend fun chatCompletion(
+        messages: List<LlmMessage>,
+        config: LlmConfig,
+        tools: List<LlmTool>,
+    ): LlmResponse {
+        requireCapabilityForTools(tools)
+        val requestBody = buildRequest(messages, config, tools)
+        val response = executeLlmRequest(
+            transport = transport,
+            request = LlmHttpRequest(
+                url = settings.endpoint("messages"),
+                headers = requestHeaders(settings.authentication),
+                body = json.encodeToString(JsonObject.serializer(), requestBody),
+            ),
+            maxRetries = settings.maxRetries,
         )
-
-        val response = client.post("https://api.anthropic.com/v1/messages") {
-            contentType(ContentType.Application.Json)
-            header("x-api-key", apiKey)
-            header("anthropic-version", "2023-06-01")
-            setBody(request)
+        if (response.status !in HTTP_SUCCESS_RANGE) {
+            logger.error { "Anthropic completion failed with HTTP ${response.status}" }
+            throw IllegalStateException("Anthropic completion failed with HTTP ${response.status}")
         }
 
-        val body = response.bodyAsText()
-        if (response.status != HttpStatusCode.OK) {
-            logger.error { "Anthropic API error (${response.status}): $body" }
-            throw RuntimeException("Anthropic API error ${response.status.value}: $body")
+        return parseResponse(json.parseToJsonElement(response.body).jsonObject)
+    }
+
+    private fun buildRequest(
+        messages: List<LlmMessage>,
+        config: LlmConfig,
+        tools: List<LlmTool>,
+    ): JsonObject = buildJsonObject {
+        put("model", settings.model)
+        put("max_tokens", config.maxTokens)
+        put("temperature", config.temperature)
+        val system = messages
+            .filter { message -> message.role == "system" }
+            .mapNotNull(LlmMessage::content)
+            .joinToString("\n\n")
+        if (system.isNotBlank()) put("system", system)
+        put("messages", buildMessages(messages.filterNot { message -> message.role == "system" }))
+        if (tools.isNotEmpty() && config.toolChoice != LlmToolChoice.NONE) {
+            put("tools", JsonArray(tools.map(::toAnthropicTool)))
+            put("tool_choice", buildJsonObject {
+                put("type", if (config.toolChoice == LlmToolChoice.REQUIRED) "any" else "auto")
+            })
+        }
+    }
+
+    private fun buildMessages(messages: List<LlmMessage>): JsonArray {
+        val result = mutableListOf<JsonElement>()
+        val toolResults = mutableListOf<JsonElement>()
+
+        fun flushToolResults() {
+            if (toolResults.isEmpty()) return
+            result += buildJsonObject {
+                put("role", "user")
+                put("content", JsonArray(toolResults.toList()))
+            }
+            toolResults.clear()
         }
 
-        val parsed = json.decodeFromString(AnthropicResponse.serializer(), body)
-        val textContent = parsed.content.firstOrNull { it.type == "text" }?.text ?: ""
+        messages.forEach { message ->
+            if (message.role == "tool") {
+                toolResults += buildJsonObject {
+                    put("type", "tool_result")
+                    put("tool_use_id", message.toolCallId.orEmpty())
+                    put("content", message.content.orEmpty())
+                }
+                return@forEach
+            }
 
+            flushToolResults()
+            result += when (message.role) {
+                "assistant" -> assistantMessage(message)
+                else -> textMessage("user", message.content.orEmpty())
+            }
+        }
+        flushToolResults()
+        return JsonArray(result)
+    }
+
+    private fun assistantMessage(message: LlmMessage): JsonObject = buildJsonObject {
+        put("role", "assistant")
+        put("content", buildJsonArray {
+            message.content?.takeIf(String::isNotBlank)?.let { content ->
+                add(buildJsonObject {
+                    put("type", "text")
+                    put("text", content)
+                })
+            }
+            message.toolCalls.forEach { call ->
+                add(buildJsonObject {
+                    put("type", "tool_use")
+                    put("id", call.id)
+                    put("name", call.name)
+                    put("input", call.arguments)
+                })
+            }
+        })
+    }
+
+    private fun textMessage(role: String, content: String): JsonObject = buildJsonObject {
+        put("role", role)
+        put("content", content)
+    }
+
+    private fun toAnthropicTool(tool: LlmTool): JsonObject = buildJsonObject {
+        put("name", tool.name)
+        put("description", tool.description)
+        put("input_schema", tool.parameters)
+    }
+
+    private fun parseResponse(response: JsonObject): LlmResponse {
+        val blocks = response["content"]?.jsonArray.orEmpty()
+        val text = blocks.mapNotNull { block ->
+            block.jsonObject.takeIf { it["type"]?.jsonPrimitive?.contentOrNull == "text" }
+                ?.get("text")
+                ?.jsonPrimitive
+                ?.contentOrNull
+        }.joinToString("")
+        val toolCalls = blocks.mapNotNull { block ->
+            val value = block.jsonObject
+            if (value["type"]?.jsonPrimitive?.contentOrNull != "tool_use") return@mapNotNull null
+            val id = value["id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            val name = value["name"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            LlmToolCall(
+                id = id,
+                name = name,
+                arguments = value["input"] as? JsonObject ?: JsonObject(emptyMap()),
+            )
+        }
+        val usage = response["usage"]?.jsonObject
         return LlmResponse(
-            content = textContent,
-            inputTokens = parsed.usage?.input_tokens ?: 0,
-            outputTokens = parsed.usage?.output_tokens ?: 0,
-            model = modelName,
-            provider = "anthropic",
+            content = text,
+            toolCalls = toolCalls,
+            inputTokens = usage?.get("input_tokens")?.jsonPrimitive?.intOrNull ?: 0,
+            outputTokens = usage?.get("output_tokens")?.jsonPrimitive?.intOrNull ?: 0,
+            model = response["model"]?.jsonPrimitive?.contentOrNull ?: settings.model,
+            provider = provider(),
         )
     }
 
-    // Internal DTOs
-    @Serializable data class AnthropicMsg(val role: String, val content: String)
+    private fun requestHeaders(authentication: LlmAuthentication): Map<String, String> {
+        val authHeaders = when (authentication) {
+            is LlmAuthentication.Bearer -> mapOf("Authorization" to "Bearer ${authentication.token}")
+            is LlmAuthentication.Header -> mapOf(authentication.name to authentication.value)
+            LlmAuthentication.None -> emptyMap()
+        }
+        return authHeaders + ("anthropic-version" to ANTHROPIC_VERSION)
+    }
 
-    @Serializable data class AnthropicRequest(
-        val model: String,
-        val max_tokens: Int,
-        val system: String? = null,
-        val messages: List<AnthropicMsg>,
-    )
+    private fun requireCapabilityForTools(tools: List<LlmTool>) {
+        if (tools.isNotEmpty() && LlmCapability.TOOL_CALLING !in capabilities()) {
+            throw IllegalStateException("Anthropic is not configured for tool calling")
+        }
+    }
 
-    @Serializable data class AnthropicContentBlock(val type: String, val text: String = "")
-
-    @Serializable data class AnthropicUsage(val input_tokens: Int = 0, val output_tokens: Int = 0)
-
-    @Serializable data class AnthropicResponse(
-        val id: String = "",
-        val content: List<AnthropicContentBlock> = emptyList(),
-        val usage: AnthropicUsage? = null,
-        @SerialName("stop_reason") val stopReason: String? = null,
-    )
+    private companion object {
+        const val ANTHROPIC_VERSION = "2023-06-01"
+        val HTTP_SUCCESS_RANGE = 200..299
+    }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/OpenAiProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/OpenAiProvider.kt
@@ -102,8 +102,8 @@ class OpenAiProvider(
     }
 
     private fun requireCapabilityForTools(tools: List<LlmTool>) {
-        if (tools.isNotEmpty() && LlmCapability.TOOL_CALLING !in capabilities()) {
-            throw IllegalStateException("${provider()} is not configured for tool calling")
+        check(!(tools.isNotEmpty() && LlmCapability.TOOL_CALLING !in capabilities())) {
+            "${provider()} is not configured for tool calling"
         }
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/OpenAiProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/OpenAiProvider.kt
@@ -64,7 +64,8 @@ class OpenAiProvider(
             messages = messages.map(::toOpenAiMessage),
             tools = tools.takeIf(List<LlmTool>::isNotEmpty)?.map(::toOpenAiTool),
             toolChoice = tools.takeIf(List<LlmTool>::isNotEmpty)?.let { config.toolChoice.toWireValue() },
-            maxTokens = config.maxTokens,
+            maxTokens = config.maxTokens.takeIf { settings.kind == LlmProviderKind.OPENAI_COMPATIBLE },
+            maxCompletionTokens = config.maxTokens.takeIf { settings.kind == LlmProviderKind.OPENAI },
             temperature = config.temperature,
             responseFormat = if (config.jsonMode && LlmCapability.JSON_MODE in capabilities()) {
                 OpenAiFormat("json_object")
@@ -116,7 +117,9 @@ class OpenAiProvider(
                 type = "function",
                 function = OpenAiToolCallFunction(
                     name = call.name,
-                    arguments = json.encodeToString(JsonObject.serializer(), call.arguments),
+                    arguments = call.arguments
+                        ?.let { arguments -> json.encodeToString(JsonObject.serializer(), arguments) }
+                        ?: EMPTY_TOOL_ARGUMENTS,
                 ),
             )
         },
@@ -130,7 +133,11 @@ class OpenAiProvider(
     private fun toLlmToolCall(call: OpenAiToolCall): LlmToolCall {
         val arguments = runCatching {
             json.parseToJsonElement(call.function.arguments).jsonObject
-        }.getOrDefault(JsonObject(emptyMap()))
+        }.onFailure { error ->
+            logger.warn(error) {
+                "${provider()} returned invalid arguments for tool ${call.function.name}"
+            }
+        }.getOrNull()
         return LlmToolCall(call.id, call.function.name, arguments)
     }
 
@@ -143,6 +150,7 @@ class OpenAiProvider(
     private fun LlmToolChoice.toWireValue(): String = name.lowercase()
 
     private companion object {
+        const val EMPTY_TOOL_ARGUMENTS = "{}"
         val HTTP_SUCCESS_RANGE = 200..299
     }
 }
@@ -164,7 +172,8 @@ private data class OpenAiRequest(
     val messages: List<OpenAiMessage>,
     val tools: List<OpenAiTool>? = null,
     @SerialName("tool_choice") val toolChoice: String? = null,
-    @SerialName("max_tokens") val maxTokens: Int,
+    @SerialName("max_tokens") val maxTokens: Int? = null,
+    @SerialName("max_completion_tokens") val maxCompletionTokens: Int? = null,
     val temperature: Double,
     @SerialName("response_format") val responseFormat: OpenAiFormat? = null,
 )

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/OpenAiProvider.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/llm/providers/OpenAiProvider.kt
@@ -4,100 +4,209 @@
 
 package com.moneat.enterprise.ai.llm.providers
 
-import com.moneat.config.EnvConfig
+import com.moneat.enterprise.ai.llm.KtorLlmHttpTransport
+import com.moneat.enterprise.ai.llm.LlmAuthentication
+import com.moneat.enterprise.ai.llm.LlmCapability
 import com.moneat.enterprise.ai.llm.LlmConfig
+import com.moneat.enterprise.ai.llm.LlmHttpRequest
+import com.moneat.enterprise.ai.llm.LlmHttpTransport
 import com.moneat.enterprise.ai.llm.LlmMessage
 import com.moneat.enterprise.ai.llm.LlmProvider
+import com.moneat.enterprise.ai.llm.LlmProviderKind
+import com.moneat.enterprise.ai.llm.LlmProviderSettings
+import com.moneat.enterprise.ai.llm.LlmProviderSettingsLoader
 import com.moneat.enterprise.ai.llm.LlmResponse
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
+import com.moneat.enterprise.ai.llm.LlmTool
+import com.moneat.enterprise.ai.llm.LlmToolCall
+import com.moneat.enterprise.ai.llm.LlmToolChoice
+import com.moneat.enterprise.ai.llm.executeLlmRequest
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
-class OpenAiProvider : LlmProvider {
-
-    private val json = Json { ignoreUnknownKeys = true }
-    private val client = HttpClient(CIO) {
-        install(ContentNegotiation) { json(json) }
-        engine { requestTimeout = 120_000 }
+class OpenAiProvider(
+    private val settings: LlmProviderSettings = LlmProviderSettingsLoader.load(),
+    private val transport: LlmHttpTransport = KtorLlmHttpTransport(settings.requestTimeoutMillis),
+) : LlmProvider {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
     }
 
-    private val apiKey: String get() = EnvConfig.get("OPENAI_API_KEY", "")
-    private val modelName: String get() = EnvConfig.get("OPENAI_MODEL", "gpt-4o-mini")
+    init {
+        require(settings.kind == LlmProviderKind.OPENAI || settings.kind == LlmProviderKind.OPENAI_COMPATIBLE) {
+            "OpenAiProvider requires openai or openai-compatible settings"
+        }
+    }
 
-    override fun provider() = "openai"
-    override fun model() = modelName
-    override fun isEnabled() = apiKey.isNotBlank()
+    override fun provider(): String = settings.kind.configValue
 
-    override suspend fun chatCompletion(messages: List<LlmMessage>, config: LlmConfig): LlmResponse {
+    override fun model(): String = settings.model
+
+    override fun isEnabled(): Boolean = settings.isEnabled
+
+    override fun capabilities(): Set<LlmCapability> = settings.capabilities
+
+    override suspend fun chatCompletion(
+        messages: List<LlmMessage>,
+        config: LlmConfig,
+        tools: List<LlmTool>,
+    ): LlmResponse {
+        requireCapabilityForTools(tools)
         val request = OpenAiRequest(
-            model = modelName,
-            messages = messages.map { OpenAiMsg(it.role, it.content) },
-            max_tokens = config.maxTokens,
+            model = settings.model,
+            messages = messages.map(::toOpenAiMessage),
+            tools = tools.takeIf(List<LlmTool>::isNotEmpty)?.map(::toOpenAiTool),
+            toolChoice = tools.takeIf(List<LlmTool>::isNotEmpty)?.let { config.toolChoice.toWireValue() },
+            maxTokens = config.maxTokens,
             temperature = config.temperature,
-            response_format = if (config.jsonMode) OpenAiFormat("json_object") else null,
+            responseFormat = if (config.jsonMode && LlmCapability.JSON_MODE in capabilities()) {
+                OpenAiFormat("json_object")
+            } else {
+                null
+            },
         )
 
-        val response = client.post("https://api.openai.com/v1/chat/completions") {
-            contentType(ContentType.Application.Json)
-            header("Authorization", "Bearer $apiKey")
-            setBody(request)
+        val response = executeLlmRequest(
+            transport = transport,
+            request = LlmHttpRequest(
+                url = settings.endpoint("chat/completions"),
+                headers = requestHeaders(settings.authentication),
+                body = json.encodeToString(request),
+            ),
+            maxRetries = settings.maxRetries,
+        )
+        if (response.status !in HTTP_SUCCESS_RANGE) {
+            logger.error { "${provider()} completion failed with HTTP ${response.status}" }
+            throw IllegalStateException("${provider()} completion failed with HTTP ${response.status}")
         }
 
-        val body = response.bodyAsText()
-        if (response.status != HttpStatusCode.OK) {
-            logger.error { "OpenAI API error (${response.status}): $body" }
-            throw RuntimeException("OpenAI API error ${response.status.value}: $body")
-        }
-
-        val parsed = json.decodeFromString(OpenAiResponse.serializer(), body)
+        val parsed = json.decodeFromString(OpenAiResponse.serializer(), response.body)
         val choice = parsed.choices.firstOrNull()
+            ?: throw IllegalStateException("${provider()} returned no completion choices")
         return LlmResponse(
-            content = choice?.message?.content ?: "",
-            inputTokens = parsed.usage?.prompt_tokens ?: 0,
-            outputTokens = parsed.usage?.completion_tokens ?: 0,
-            model = modelName,
-            provider = "openai",
+            content = choice.message.content.orEmpty(),
+            toolCalls = choice.message.toolCalls.orEmpty().map(::toLlmToolCall),
+            inputTokens = parsed.usage?.promptTokens ?: 0,
+            outputTokens = parsed.usage?.completionTokens ?: 0,
+            model = parsed.model.ifBlank { settings.model },
+            provider = provider(),
         )
     }
 
-    // Internal DTOs
-    @Serializable data class OpenAiMsg(val role: String, val content: String)
+    private fun requireCapabilityForTools(tools: List<LlmTool>) {
+        if (tools.isNotEmpty() && LlmCapability.TOOL_CALLING !in capabilities()) {
+            throw IllegalStateException("${provider()} is not configured for tool calling")
+        }
+    }
 
-    @Serializable data class OpenAiFormat(val type: String)
-
-    @Serializable data class OpenAiRequest(
-        val model: String,
-        val messages: List<OpenAiMsg>,
-        val max_tokens: Int = 4096,
-        val temperature: Double = 0.3,
-        val response_format: OpenAiFormat? = null,
+    private fun toOpenAiMessage(message: LlmMessage): OpenAiMessage = OpenAiMessage(
+        role = message.role,
+        content = message.content,
+        toolCallId = message.toolCallId,
+        toolCalls = message.toolCalls.takeIf(List<LlmToolCall>::isNotEmpty)?.map { call ->
+            OpenAiToolCall(
+                id = call.id,
+                type = "function",
+                function = OpenAiToolCallFunction(
+                    name = call.name,
+                    arguments = json.encodeToString(JsonObject.serializer(), call.arguments),
+                ),
+            )
+        },
     )
 
-    @Serializable data class OpenAiChoice(val message: OpenAiMsg, val finish_reason: String? = null)
-
-    @Serializable
-    data class OpenAiUsage(
-        val prompt_tokens: Int = 0,
-        val completion_tokens: Int = 0,
-        val total_tokens: Int = 0,
+    private fun toOpenAiTool(tool: LlmTool): OpenAiTool = OpenAiTool(
+        type = "function",
+        function = OpenAiFunction(tool.name, tool.description, tool.parameters),
     )
 
-    @Serializable
-    data class OpenAiResponse(
-        val choices: List<OpenAiChoice> = emptyList(),
-        val usage: OpenAiUsage? = null,
-    )
+    private fun toLlmToolCall(call: OpenAiToolCall): LlmToolCall {
+        val arguments = runCatching {
+            json.parseToJsonElement(call.function.arguments).jsonObject
+        }.getOrDefault(JsonObject(emptyMap()))
+        return LlmToolCall(call.id, call.function.name, arguments)
+    }
+
+    private fun requestHeaders(authentication: LlmAuthentication): Map<String, String> = when (authentication) {
+        is LlmAuthentication.Bearer -> mapOf("Authorization" to "Bearer ${authentication.token}")
+        is LlmAuthentication.Header -> mapOf(authentication.name to authentication.value)
+        LlmAuthentication.None -> emptyMap()
+    }
+
+    private fun LlmToolChoice.toWireValue(): String = name.lowercase()
+
+    private companion object {
+        val HTTP_SUCCESS_RANGE = 200..299
+    }
 }
+
+@Serializable
+private data class OpenAiMessage(
+    val role: String = "",
+    val content: String? = null,
+    @SerialName("tool_call_id") val toolCallId: String? = null,
+    @SerialName("tool_calls") val toolCalls: List<OpenAiToolCall>? = null,
+)
+
+@Serializable
+private data class OpenAiFormat(val type: String)
+
+@Serializable
+private data class OpenAiRequest(
+    val model: String,
+    val messages: List<OpenAiMessage>,
+    val tools: List<OpenAiTool>? = null,
+    @SerialName("tool_choice") val toolChoice: String? = null,
+    @SerialName("max_tokens") val maxTokens: Int,
+    val temperature: Double,
+    @SerialName("response_format") val responseFormat: OpenAiFormat? = null,
+)
+
+@Serializable
+private data class OpenAiTool(
+    val type: String,
+    val function: OpenAiFunction,
+)
+
+@Serializable
+private data class OpenAiFunction(
+    val name: String,
+    val description: String,
+    val parameters: JsonObject,
+)
+
+@Serializable
+private data class OpenAiResponse(
+    val model: String = "",
+    val choices: List<OpenAiChoice> = emptyList(),
+    val usage: OpenAiUsage? = null,
+)
+
+@Serializable
+private data class OpenAiChoice(val message: OpenAiMessage)
+
+@Serializable
+private data class OpenAiToolCall(
+    val id: String,
+    val type: String,
+    val function: OpenAiToolCallFunction,
+)
+
+@Serializable
+private data class OpenAiToolCallFunction(
+    val name: String,
+    val arguments: String,
+)
+
+@Serializable
+private data class OpenAiUsage(
+    @SerialName("prompt_tokens") val promptTokens: Int = 0,
+    @SerialName("completion_tokens") val completionTokens: Int = 0,
+)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiAssistantService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiAssistantService.kt
@@ -4,9 +4,14 @@
 
 package com.moneat.enterprise.ai.services
 
-import com.moneat.config.EnvConfig
 import com.moneat.config.ClickHouseClient
 import com.moneat.enterprise.ai.llm.CostRegistry
+import com.moneat.enterprise.ai.llm.LlmConfig
+import com.moneat.enterprise.ai.llm.LlmMessage
+import com.moneat.enterprise.ai.llm.LlmProvider
+import com.moneat.enterprise.ai.llm.LlmProviderFactory
+import com.moneat.enterprise.ai.llm.LlmResponse
+import com.moneat.enterprise.ai.llm.LlmTool
 import com.moneat.enterprise.ai.models.AiAssistantConfirmRequest
 import com.moneat.enterprise.ai.models.AiAssistantConfirmResponse
 import com.moneat.enterprise.ai.models.AssistantConfirmationNeededEvent
@@ -14,25 +19,13 @@ import com.moneat.enterprise.ai.models.AssistantDoneEvent
 import com.moneat.enterprise.ai.models.AssistantResponseEvent
 import com.moneat.enterprise.ai.models.AssistantToolInvokingEvent
 import com.moneat.enterprise.ai.models.AssistantToolResultEvent
+import com.moneat.mcp.models.McpContext
 import com.moneat.mcp.protocol.McpToolRegistry
 import com.moneat.mcp.protocol.ToolDefinition
-import com.moneat.mcp.models.McpContext
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
+import com.moneat.utils.ClickHouseSqlUtils
 import io.ktor.http.isSuccess
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -41,14 +34,13 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import mu.KotlinLogging
-import com.moneat.utils.ClickHouseSqlUtils
 import java.io.Writer
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import kotlin.time.Clock
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Clock
 
 private val logger = KotlinLogging.logger {}
 private val json = Json {
@@ -61,7 +53,7 @@ private const val NANOS_PER_MILLI = 1_000_000.0
 
 class AiAssistantService(
     private val toolRegistry: McpToolRegistry,
-    private val llmClient: AssistantLlmClient = OpenAiAssistantLlmClient(),
+    private val llmProvider: LlmProvider = LlmProviderFactory.create(),
 ) {
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
     private val conversations = ConcurrentHashMap<String, ConversationState>()
@@ -84,7 +76,7 @@ class AiAssistantService(
         val state = getOrCreateConversation(conversationId, projectId)
         return state.mutex.withLock {
             refreshTimeContext(state, userTimezone)
-            state.messages.add(AssistantMessage(role = "user", content = normalizedMessage))
+            state.messages.add(LlmMessage(role = "user", content = normalizedMessage))
 
             val outcome = runAssistantLoop(
                 state = state,
@@ -186,7 +178,7 @@ class AiAssistantService(
             }
 
             state.messages.add(
-                AssistantMessage(
+                LlmMessage(
                     role = "tool",
                     content = toolSummary,
                     toolCallId = pending.toolCallId,
@@ -230,12 +222,20 @@ class AiAssistantService(
     ): LoopOutcome {
         val toolDefinitions = toolRegistry.listTools()
         val toolMap = toolDefinitions.associateBy { it.name }
-        val llmTools = toolDefinitions.map { def -> toLlmFunction(def) }
+        val llmTools = toolDefinitions.map(::toLlmTool)
 
         repeat(MAX_TOOL_ROUNDS) {
             val startedAtMs = Clock.System.now().toEpochMilliseconds()
             val startedAtNs = System.nanoTime()
-            val completion = llmClient.complete(state.messages.toList(), llmTools)
+            val completion = llmProvider.chatCompletion(
+                messages = state.messages.toList(),
+                config = LlmConfig(
+                    maxTokens = ASSISTANT_MAX_TOKENS,
+                    temperature = ASSISTANT_TEMPERATURE,
+                    jsonMode = false,
+                ),
+                tools = llmTools,
+            )
             val durationMs = (System.nanoTime() - startedAtNs) / NANOS_PER_MILLI
             persistLlmGeneration(
                 state = state,
@@ -248,7 +248,7 @@ class AiAssistantService(
             if (completion.toolCalls.isEmpty()) {
                 val responseContent = completion.content.ifBlank { DEFAULT_EMPTY_RESPONSE }
                 state.messages.add(
-                    AssistantMessage(
+                    LlmMessage(
                         role = "assistant",
                         content = responseContent,
                     ),
@@ -257,7 +257,7 @@ class AiAssistantService(
             }
 
             state.messages.add(
-                AssistantMessage(
+                LlmMessage(
                     role = "assistant",
                     content = completion.content.ifBlank { null },
                     toolCalls = completion.toolCalls,
@@ -265,13 +265,13 @@ class AiAssistantService(
             )
 
             for (toolCall in completion.toolCalls) {
-                val args = parseToolArguments(toolCall.arguments)
+                val args = toolCall.arguments
                 val definition = toolMap[toolCall.name]
 
                 if (definition == null) {
                     val unknownToolSummary = "Unknown MCP tool: ${toolCall.name}"
                     state.messages.add(
-                        AssistantMessage(
+                        LlmMessage(
                             role = "tool",
                             content = unknownToolSummary,
                             toolCallId = toolCall.id,
@@ -310,7 +310,7 @@ class AiAssistantService(
                 )
                 val summary = summarizeToolResult(toolResult)
                 state.messages.add(
-                    AssistantMessage(
+                    LlmMessage(
                         role = "tool",
                         content = summary,
                         toolCallId = toolCall.id,
@@ -322,7 +322,7 @@ class AiAssistantService(
 
         val limitMessage = "I reached the MCP tool iteration limit. Please refine the question and try again."
         state.messages.add(
-            AssistantMessage(
+            LlmMessage(
                 role = "assistant",
                 content = limitMessage,
             ),
@@ -367,16 +367,7 @@ class AiAssistantService(
         }
     }
 
-    private fun parseToolArguments(raw: String): JsonObject {
-        if (raw.isBlank()) return JsonObject(emptyMap())
-        return try {
-            json.parseToJsonElement(raw).jsonObject
-        } catch (_: Exception) {
-            JsonObject(emptyMap())
-        }
-    }
-
-    private fun toLlmFunction(tool: ToolDefinition): AssistantFunction {
+    private fun toLlmTool(tool: ToolDefinition): LlmTool {
         val requiredValues = tool.inputSchema.required.map { JsonPrimitive(it) }
         val rawParameters = JsonObject(
             mapOf(
@@ -387,7 +378,7 @@ class AiAssistantService(
         )
         val sanitizedParameters = sanitizeSchemaElement(rawParameters).jsonObject
 
-        return AssistantFunction(
+        return LlmTool(
             name = tool.name,
             description = tool.description,
             parameters = sanitizedParameters,
@@ -417,7 +408,7 @@ class AiAssistantService(
 
     private suspend fun persistLlmGeneration(
         state: ConversationState,
-        completion: AssistantCompletion,
+        completion: LlmResponse,
         userId: Int,
         startedAtMs: Long,
         durationMs: Double,
@@ -513,7 +504,7 @@ class AiAssistantService(
                 id = normalizedConversationId,
                 projectId = projectId,
                 messages = mutableListOf(
-                    AssistantMessage(role = "system", content = loadSystemPrompt()),
+                    LlmMessage(role = "system", content = loadSystemPrompt()),
                 ),
             )
         }
@@ -554,12 +545,12 @@ class AiAssistantService(
         val systemIdx = state.messages.indexOfFirst { it.role == "system" }
         val content = "${loadSystemPrompt()}\n\n${buildTimeContext(userTimezone)}"
         if (systemIdx >= 0) {
-            state.messages[systemIdx] = AssistantMessage(
+            state.messages[systemIdx] = LlmMessage(
                 role = "system",
                 content = content,
             )
         } else {
-            state.messages.add(0, AssistantMessage(role = "system", content = content))
+            state.messages.add(0, LlmMessage(role = "system", content = content))
         }
     }
 
@@ -588,89 +579,10 @@ class AiAssistantService(
     }
 }
 
-interface AssistantLlmClient {
-    suspend fun complete(
-        messages: List<AssistantMessage>,
-        tools: List<AssistantFunction>,
-    ): AssistantCompletion
-}
-
-class OpenAiAssistantLlmClient : AssistantLlmClient {
-    private val client = HttpClient(CIO) {
-        install(ContentNegotiation) {
-            json(json)
-        }
-        engine {
-            requestTimeout = 120_000
-        }
-    }
-
-    private val apiKey: String get() = EnvConfig.get("OPENAI_API_KEY", "")
-    private val modelName: String get() = EnvConfig.get("OPENAI_MODEL", "gpt-4o-mini")
-
-    override suspend fun complete(
-        messages: List<AssistantMessage>,
-        tools: List<AssistantFunction>,
-    ): AssistantCompletion {
-        if (apiKey.isBlank()) {
-            throw IllegalStateException("OPENAI_API_KEY is not configured")
-        }
-
-        val request = OpenAiCompletionRequest(
-            model = modelName,
-            messages = messages.map { msg -> msg.toOpenAiMessage() },
-            tools = tools.map { function ->
-                OpenAiTool(
-                    type = "function",
-                    function = OpenAiFunction(
-                        name = function.name,
-                        description = function.description,
-                        parameters = function.parameters,
-                    ),
-                )
-            },
-            toolChoice = "auto",
-            temperature = ASSISTANT_TEMPERATURE,
-            maxTokens = ASSISTANT_MAX_TOKENS,
-        )
-
-        val response = client.post("https://api.openai.com/v1/chat/completions") {
-            contentType(ContentType.Application.Json)
-            header("Authorization", "Bearer $apiKey")
-            setBody(request)
-        }
-
-        val rawBody = response.bodyAsText()
-        if (response.status != HttpStatusCode.OK) {
-            logger.error { "OpenAI assistant completion failed (${response.status}): $rawBody" }
-            throw RuntimeException("OpenAI API error ${response.status.value}: $rawBody")
-        }
-
-        val parsed = json.decodeFromString(OpenAiCompletionResponse.serializer(), rawBody)
-        val message = parsed.choices.firstOrNull()?.message
-            ?: throw IllegalStateException("OpenAI returned no choices")
-
-        return AssistantCompletion(
-            content = message.content.orEmpty(),
-            toolCalls = message.toolCalls.orEmpty().map { call ->
-                AssistantToolCall(
-                    id = call.id,
-                    name = call.function.name,
-                    arguments = call.function.arguments,
-                )
-            },
-            inputTokens = parsed.usage?.promptTokens ?: 0,
-            outputTokens = parsed.usage?.completionTokens ?: 0,
-            model = parsed.model.ifBlank { modelName },
-            provider = "openai",
-        )
-    }
-}
-
 private data class ConversationState(
     val id: String,
     var projectId: Long?,
-    val messages: MutableList<AssistantMessage>,
+    val messages: MutableList<LlmMessage>,
     val mutex: Mutex = Mutex(),
 )
 
@@ -692,119 +604,3 @@ private sealed interface LoopOutcome {
         val args: JsonObject,
     ) : LoopOutcome
 }
-
-data class AssistantFunction(
-    val name: String,
-    val description: String,
-    val parameters: JsonObject,
-)
-
-data class AssistantCompletion(
-    val content: String,
-    val toolCalls: List<AssistantToolCall>,
-    val inputTokens: Int = 0,
-    val outputTokens: Int = 0,
-    val model: String = "",
-    val provider: String = "",
-)
-
-data class AssistantToolCall(
-    val id: String,
-    val name: String,
-    val arguments: String,
-)
-
-data class AssistantMessage(
-    val role: String,
-    val content: String? = null,
-    val toolCallId: String? = null,
-    val toolCalls: List<AssistantToolCall> = emptyList(),
-)
-
-private fun AssistantMessage.toOpenAiMessage(): OpenAiMessage {
-    val mappedToolCalls = toolCalls.takeIf { it.isNotEmpty() }?.map { call ->
-        OpenAiToolCall(
-            id = call.id,
-            type = "function",
-            function = OpenAiToolCallFunction(
-                name = call.name,
-                arguments = call.arguments,
-            ),
-        )
-    }
-
-    return OpenAiMessage(
-        role = role,
-        content = content,
-        toolCallId = toolCallId,
-        toolCalls = mappedToolCalls,
-    )
-}
-
-@Serializable
-private data class OpenAiCompletionRequest(
-    val model: String,
-    val messages: List<OpenAiMessage>,
-    val tools: List<OpenAiTool>,
-    @SerialName("tool_choice") val toolChoice: String = "auto",
-    val temperature: Double = 0.2,
-    @SerialName("max_tokens") val maxTokens: Int = 2_048,
-)
-
-@Serializable
-private data class OpenAiTool(
-    val type: String,
-    val function: OpenAiFunction,
-)
-
-@Serializable
-private data class OpenAiFunction(
-    val name: String,
-    val description: String,
-    val parameters: JsonObject,
-)
-
-@Serializable
-private data class OpenAiMessage(
-    val role: String,
-    val content: String? = null,
-    @SerialName("tool_call_id") val toolCallId: String? = null,
-    @SerialName("tool_calls") val toolCalls: List<OpenAiToolCall>? = null,
-)
-
-@Serializable
-private data class OpenAiCompletionResponse(
-    val model: String = "",
-    val choices: List<OpenAiChoice> = emptyList(),
-    val usage: OpenAiUsage? = null,
-)
-
-@Serializable
-private data class OpenAiChoice(
-    val message: OpenAiMessageResponse,
-)
-
-@Serializable
-private data class OpenAiMessageResponse(
-    val content: String? = null,
-    @SerialName("tool_calls") val toolCalls: List<OpenAiToolCall>? = null,
-)
-
-@Serializable
-private data class OpenAiToolCall(
-    val id: String,
-    val type: String,
-    val function: OpenAiToolCallFunction,
-)
-
-@Serializable
-private data class OpenAiToolCallFunction(
-    val name: String,
-    val arguments: String,
-)
-
-@Serializable
-private data class OpenAiUsage(
-    @SerialName("prompt_tokens") val promptTokens: Int = 0,
-    @SerialName("completion_tokens") val completionTokens: Int = 0,
-)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiAssistantService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/ai/services/AiAssistantService.kt
@@ -266,6 +266,18 @@ class AiAssistantService(
 
             for (toolCall in completion.toolCalls) {
                 val args = toolCall.arguments
+                if (args == null) {
+                    val invalidArgumentsSummary = "Invalid arguments for MCP tool: ${toolCall.name}"
+                    state.messages.add(
+                        LlmMessage(
+                            role = "tool",
+                            content = invalidArgumentsSummary,
+                            toolCallId = toolCall.id,
+                        ),
+                    )
+                    onToolResult(toolCall.name, invalidArgumentsSummary, true)
+                    continue
+                }
                 val definition = toolMap[toolCall.name]
 
                 if (definition == null) {

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderContractTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderContractTest.kt
@@ -1,0 +1,227 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.ai.llm
+
+import com.moneat.enterprise.ai.llm.providers.AnthropicProvider
+import com.moneat.enterprise.ai.llm.providers.OpenAiProvider
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class LlmProviderContractTest {
+    @Test
+    fun `OpenAI adapter satisfies the provider-neutral tool contract`() = runBlocking {
+        val transport = RecordingTransport(OPENAI_RESPONSE)
+        val provider = OpenAiProvider(
+            settings = settings(
+                kind = LlmProviderKind.OPENAI_COMPATIBLE,
+                baseUrl = "https://compatible.example/api",
+                authentication = LlmAuthentication.Bearer("test-key"),
+            ),
+            transport = transport,
+        )
+
+        assertProviderContract(provider, transport, "openai-compatible")
+        assertTrue(
+            transport.requests.all { request ->
+                request.url == "https://compatible.example/api/v1/chat/completions"
+            },
+        )
+        assertTrue(transport.requests.all { request -> request.headers["Authorization"] == "Bearer test-key" })
+        assertTrue(transport.requests.all { request -> "\"tools\"" in request.body })
+    }
+
+    @Test
+    fun `Anthropic adapter satisfies the same provider-neutral tool contract`() = runBlocking {
+        val transport = RecordingTransport(ANTHROPIC_RESPONSE)
+        val provider = AnthropicProvider(
+            settings = settings(
+                kind = LlmProviderKind.ANTHROPIC,
+                baseUrl = "https://anthropic.example/api",
+                authentication = LlmAuthentication.Header("x-api-key", "test-key"),
+            ),
+            transport = transport,
+        )
+
+        assertProviderContract(provider, transport, "anthropic")
+        assertTrue(transport.requests.all { request -> request.url == "https://anthropic.example/api/v1/messages" })
+        assertTrue(transport.requests.all { request -> request.headers["x-api-key"] == "test-key" })
+        assertTrue(transport.requests.all { request -> request.headers["anthropic-version"] == "2023-06-01" })
+        assertTrue(transport.requests.all { request -> "\"tools\"" in request.body })
+    }
+
+    @Test
+    fun `retryable responses honor the configured retry budget`() = runBlocking {
+        val transport = SequencedTransport(
+            mutableListOf(
+                LlmHttpResponse(429, "rate limited"),
+                LlmHttpResponse(200, OPENAI_RESPONSE),
+            ),
+        )
+        val provider = OpenAiProvider(
+            settings = settings(
+                kind = LlmProviderKind.OPENAI,
+                maxRetries = 1,
+            ),
+            transport = transport,
+        )
+
+        val response = provider.chatCompletion(listOf(LlmMessage("user", "Summarize")))
+
+        assertEquals("Inspecting", response.content)
+        assertEquals(2, transport.callCount)
+    }
+
+    @Test
+    fun `tool calls fail before transport when the configured endpoint lacks capability`() = runBlocking {
+        val transport = RecordingTransport(OPENAI_RESPONSE)
+        val provider = OpenAiProvider(
+            settings = settings(
+                kind = LlmProviderKind.OPENAI_COMPATIBLE,
+                capabilities = setOf(LlmCapability.STREAMING),
+            ),
+            transport = transport,
+        )
+
+        assertFailsWith<IllegalStateException> {
+            provider.chatCompletion(
+                messages = listOf(LlmMessage("user", "Inspect")),
+                tools = listOf(incidentTool()),
+            )
+        }
+        assertTrue(transport.requests.isEmpty())
+    }
+
+    private suspend fun assertProviderContract(
+        provider: LlmProvider,
+        transport: RecordingTransport,
+        expectedProvider: String,
+    ) {
+        val messages = listOf(
+            LlmMessage("system", "Use evidence"),
+            LlmMessage("user", "Inspect incident inc-1"),
+        )
+        val response = provider.chatCompletion(
+            messages = messages,
+            config = LlmConfig(maxTokens = 512, temperature = 0.1, jsonMode = false),
+            tools = listOf(incidentTool()),
+        )
+
+        assertEquals("Inspecting", response.content)
+        assertEquals("call-1", response.toolCalls.single().id)
+        assertEquals("get_incident", response.toolCalls.single().name)
+        assertEquals("inc-1", (response.toolCalls.single().arguments["id"] as? JsonPrimitive)?.content)
+        assertEquals(12, response.inputTokens)
+        assertEquals(4, response.outputTokens)
+        assertEquals(expectedProvider, response.provider)
+        assertTrue(LlmCapability.TOOL_CALLING in provider.capabilities())
+
+        val chunks = mutableListOf<String>()
+        provider.streamChatCompletion(
+            messages = messages,
+            config = LlmConfig(jsonMode = false),
+            tools = listOf(incidentTool()),
+            onTextChunk = chunks::add,
+        )
+        assertEquals(listOf("Inspecting"), chunks)
+        assertEquals(2, transport.requests.size)
+    }
+
+    private fun incidentTool(): LlmTool = LlmTool(
+        name = "get_incident",
+        description = "Get one incident",
+        parameters = JsonObject(
+            mapOf(
+                "type" to JsonPrimitive("object"),
+                "properties" to JsonObject(
+                    mapOf("id" to JsonObject(mapOf("type" to JsonPrimitive("string")))),
+                ),
+            ),
+        ),
+    )
+
+    private fun settings(
+        kind: LlmProviderKind,
+        baseUrl: String = "https://provider.example",
+        authentication: LlmAuthentication = LlmAuthentication.Bearer("test-key"),
+        maxRetries: Int = 0,
+        capabilities: Set<LlmCapability> = LlmCapability.entries.toSet(),
+    ): LlmProviderSettings = LlmProviderSettings(
+        kind = kind,
+        baseUrl = baseUrl,
+        model = "test-model",
+        authentication = authentication,
+        requestTimeoutMillis = 5_000,
+        maxRetries = maxRetries,
+        capabilities = capabilities,
+    )
+
+    private class RecordingTransport(
+        private val responseBody: String,
+    ) : LlmHttpTransport {
+        val requests = mutableListOf<LlmHttpRequest>()
+
+        override suspend fun post(request: LlmHttpRequest): LlmHttpResponse {
+            requests += request
+            return LlmHttpResponse(200, responseBody)
+        }
+    }
+
+    private class SequencedTransport(
+        private val responses: MutableList<LlmHttpResponse>,
+    ) : LlmHttpTransport {
+        var callCount = 0
+            private set
+
+        override suspend fun post(request: LlmHttpRequest): LlmHttpResponse {
+            callCount += 1
+            return responses.removeFirst()
+        }
+    }
+
+    private companion object {
+        val OPENAI_RESPONSE =
+            """
+            {
+              "model": "test-model",
+              "choices": [{
+                "message": {
+                  "content": "Inspecting",
+                  "tool_calls": [{
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                      "name": "get_incident",
+                      "arguments": "{\"id\":\"inc-1\"}"
+                    }
+                  }]
+                }
+              }],
+              "usage": {"prompt_tokens": 12, "completion_tokens": 4}
+            }
+            """.trimIndent()
+
+        val ANTHROPIC_RESPONSE =
+            """
+            {
+              "model": "test-model",
+              "content": [
+                {"type": "text", "text": "Inspecting"},
+                {
+                  "type": "tool_use",
+                  "id": "call-1",
+                  "name": "get_incident",
+                  "input": {"id": "inc-1"}
+                }
+              ],
+              "usage": {"input_tokens": 12, "output_tokens": 4}
+            }
+            """.trimIndent()
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderContractTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderContractTest.kt
@@ -7,11 +7,17 @@ package com.moneat.enterprise.ai.llm
 import com.moneat.enterprise.ai.llm.providers.AnthropicProvider
 import com.moneat.enterprise.ai.llm.providers.OpenAiProvider
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LlmProviderContractTest {
@@ -35,6 +41,8 @@ class LlmProviderContractTest {
         )
         assertTrue(transport.requests.all { request -> request.headers["Authorization"] == "Bearer test-key" })
         assertTrue(transport.requests.all { request -> "\"tools\"" in request.body })
+        assertTrue(transport.requests.all { request -> "\"max_tokens\"" in request.body })
+        assertTrue(transport.requests.all { request -> "\"max_completion_tokens\"" !in request.body })
     }
 
     @Test
@@ -79,6 +87,84 @@ class LlmProviderContractTest {
     }
 
     @Test
+    fun `rate limit retries honor Retry-After`() = runBlocking {
+        val transport = SequencedTransport(
+            mutableListOf(
+                LlmHttpResponse(429, "rate limited", mapOf("Retry-After" to "3")),
+                LlmHttpResponse(200, OPENAI_RESPONSE),
+            ),
+        )
+        val observedDelays = mutableListOf<Long>()
+
+        val response = executeLlmRequest(
+            transport = transport,
+            request = LlmHttpRequest("https://provider.example", emptyMap(), "{}"),
+            maxRetries = 1,
+            retryPolicy = LlmRetryPolicy(
+                delayAction = { delayMillis -> observedDelays += delayMillis },
+                currentTime = { Instant.parse("2026-08-22T00:00:00Z") },
+                jitterSource = { 0 },
+            ),
+        )
+
+        assertEquals(200, response.status)
+        assertEquals(listOf(3_000L), observedDelays)
+        assertEquals(2, transport.callCount)
+    }
+
+    @Test
+    fun `official OpenAI requests use the modern completion token field`() = runBlocking {
+        val transport = RecordingTransport(OPENAI_RESPONSE)
+        val provider = OpenAiProvider(
+            settings = settings(kind = LlmProviderKind.OPENAI),
+            transport = transport,
+        )
+
+        provider.chatCompletion(listOf(LlmMessage("user", "Summarize")))
+
+        val body = transport.requests.single().body
+        assertTrue("\"max_completion_tokens\"" in body)
+        assertFalse("\"max_tokens\"" in body)
+    }
+
+    @Test
+    fun `malformed OpenAI tool arguments remain distinguishable`() = runBlocking {
+        val provider = OpenAiProvider(
+            settings = settings(kind = LlmProviderKind.OPENAI_COMPATIBLE),
+            transport = RecordingTransport(OPENAI_MALFORMED_TOOL_RESPONSE),
+        )
+
+        val response = provider.chatCompletion(
+            messages = listOf(LlmMessage("user", "Inspect")),
+            tools = listOf(incidentTool()),
+        )
+
+        assertNull(response.toolCalls.single().arguments)
+    }
+
+    @Test
+    fun `Anthropic adapter skips messages without text or tool calls`() = runBlocking {
+        val transport = RecordingTransport(ANTHROPIC_RESPONSE)
+        val provider = AnthropicProvider(
+            settings = settings(kind = LlmProviderKind.ANTHROPIC),
+            transport = transport,
+        )
+
+        provider.chatCompletion(
+            messages = listOf(
+                LlmMessage("user"),
+                LlmMessage("assistant"),
+                LlmMessage("user", "Inspect"),
+            ),
+        )
+
+        val messages = Json.parseToJsonElement(transport.requests.single().body)
+            .jsonObject["messages"]
+            ?.jsonArray
+        assertEquals(1, messages?.size)
+    }
+
+    @Test
     fun `tool calls fail before transport when the configured endpoint lacks capability`() = runBlocking {
         val transport = RecordingTransport(OPENAI_RESPONSE)
         val provider = OpenAiProvider(
@@ -116,7 +202,7 @@ class LlmProviderContractTest {
         assertEquals("Inspecting", response.content)
         assertEquals("call-1", response.toolCalls.single().id)
         assertEquals("get_incident", response.toolCalls.single().name)
-        assertEquals("inc-1", (response.toolCalls.single().arguments["id"] as? JsonPrimitive)?.content)
+        assertEquals("inc-1", (response.toolCalls.single().arguments?.get("id") as? JsonPrimitive)?.content)
         assertEquals(12, response.inputTokens)
         assertEquals(4, response.outputTokens)
         assertEquals(expectedProvider, response.provider)
@@ -221,6 +307,21 @@ class LlmProviderContractTest {
                 }
               ],
               "usage": {"input_tokens": 12, "output_tokens": 4}
+            }
+            """.trimIndent()
+
+        val OPENAI_MALFORMED_TOOL_RESPONSE =
+            """
+            {
+              "choices": [{
+                "message": {
+                  "tool_calls": [{
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "get_incident", "arguments": "not-json"}
+                  }]
+                }
+              }]
             }
             """.trimIndent()
     }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettingsTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettingsTest.kt
@@ -6,6 +6,7 @@ package com.moneat.enterprise.ai.llm
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 
@@ -69,5 +70,34 @@ class LlmProviderSettingsTest {
         assertFailsWith<IllegalArgumentException> {
             LlmProviderSettingsLoader.load(mapOf("AI_MAX_RETRIES" to "often")::get)
         }
+    }
+
+    @Test
+    fun `no-auth mode requires an explicit endpoint`() {
+        assertFailsWith<IllegalArgumentException> {
+            LlmProviderSettingsLoader.load(mapOf("AI_AUTH_TYPE" to "none")::get)
+        }
+
+        val settings = LlmProviderSettingsLoader.load(
+            mapOf(
+                "AI_PROVIDER" to "openai-compatible",
+                "AI_AUTH_TYPE" to "none",
+                "AI_BASE_URL" to "http://llm.internal",
+            )::get,
+        )
+        assertIs<LlmAuthentication.None>(settings.authentication)
+    }
+
+    @Test
+    fun `auth prefix cannot enable an empty custom header key`() {
+        val settings = LlmProviderSettingsLoader.load(
+            mapOf(
+                "AI_AUTH_TYPE" to "header",
+                "AI_AUTH_PREFIX" to "Bearer",
+            )::get,
+        )
+
+        assertFalse(settings.isEnabled)
+        assertEquals("", assertIs<LlmAuthentication.Header>(settings.authentication).value)
     }
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettingsTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettingsTest.kt
@@ -73,6 +73,23 @@ class LlmProviderSettingsTest {
     }
 
     @Test
+    fun `blank optional settings use provider defaults`() {
+        val settings = LlmProviderSettingsLoader.load(
+            mapOf(
+                "AI_PROVIDER" to "  ",
+                "AI_REQUEST_TIMEOUT_MS" to " ",
+                "AI_MAX_RETRIES" to "\t",
+                "AI_CAPABILITIES" to "\n",
+            )::get,
+        )
+
+        assertEquals(LlmProviderKind.OPENAI, settings.kind)
+        assertEquals(120_000, settings.requestTimeoutMillis)
+        assertEquals(2, settings.maxRetries)
+        assertEquals(LlmCapability.entries.toSet(), settings.capabilities)
+    }
+
+    @Test
     fun `no-auth mode requires an explicit endpoint`() {
         assertFailsWith<IllegalArgumentException> {
             LlmProviderSettingsLoader.load(mapOf("AI_AUTH_TYPE" to "none")::get)

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettingsTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/llm/LlmProviderSettingsTest.kt
@@ -1,0 +1,73 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.ai.llm
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class LlmProviderSettingsTest {
+    @Test
+    fun `loads a fully configurable OpenAI-compatible endpoint`() {
+        val environment = mapOf(
+            "AI_PROVIDER" to "openai-compatible",
+            "AI_BASE_URL" to "http://llm.internal/v1/",
+            "AI_MODEL" to "local-model",
+            "AI_API_KEY" to "local-secret",
+            "AI_AUTH_TYPE" to "header",
+            "AI_AUTH_HEADER" to "X-Api-Key",
+            "AI_REQUEST_TIMEOUT_MS" to "45000",
+            "AI_MAX_RETRIES" to "3",
+            "AI_CAPABILITIES" to "tool-calling,streaming",
+        )
+
+        val settings = LlmProviderSettingsLoader.load(environment::get)
+
+        assertEquals(LlmProviderKind.OPENAI_COMPATIBLE, settings.kind)
+        assertEquals("http://llm.internal/v1", settings.baseUrl)
+        assertEquals("local-model", settings.model)
+        assertEquals("http://llm.internal/v1/chat/completions", settings.endpoint("chat/completions"))
+        assertEquals(45_000, settings.requestTimeoutMillis)
+        assertEquals(3, settings.maxRetries)
+        assertEquals(setOf(LlmCapability.TOOL_CALLING, LlmCapability.STREAMING), settings.capabilities)
+        val authentication = assertIs<LlmAuthentication.Header>(settings.authentication)
+        assertEquals("X-Api-Key", authentication.name)
+        assertEquals("local-secret", authentication.value)
+    }
+
+    @Test
+    fun `legacy provider keys remain compatible`() {
+        val settings = LlmProviderSettingsLoader.load(
+            mapOf(
+                "AI_PROVIDER" to "anthropic",
+                "AI_API_KEY" to "",
+                "ANTHROPIC_API_KEY" to "legacy-key",
+                "ANTHROPIC_MODEL" to "legacy-model",
+            )::get,
+        )
+
+        assertEquals("legacy-model", settings.model)
+        assertEquals("https://api.anthropic.com", settings.baseUrl)
+        assertEquals("legacy-key", assertIs<LlmAuthentication.Header>(settings.authentication).value)
+    }
+
+    @Test
+    fun `unknown providers fail closed`() {
+        assertFailsWith<IllegalArgumentException> {
+            LlmProviderSettingsLoader.load(mapOf("AI_PROVIDER" to "mystery")::get)
+        }
+    }
+
+    @Test
+    fun `malformed numeric settings fail closed`() {
+        assertFailsWith<IllegalArgumentException> {
+            LlmProviderSettingsLoader.load(mapOf("AI_REQUEST_TIMEOUT_MS" to "eventually")::get)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LlmProviderSettingsLoader.load(mapOf("AI_MAX_RETRIES" to "often")::get)
+        }
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiAssistantServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiAssistantServiceTest.kt
@@ -217,6 +217,51 @@ class AiAssistantServiceTest {
         assertEquals("string", levelsSchema["items"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
     }
 
+    @Test
+    fun `assistant never executes a tool with malformed arguments`() = runBlocking {
+        var executions = 0
+        val registry = McpToolRegistry()
+        registry.register(
+            object : McpTool {
+                override val name = "list_issues"
+                override val description = "List issues"
+                override val inputSchema = InputSchema()
+                override suspend fun execute(args: JsonObject, context: McpContext): ToolCallResult {
+                    executions += 1
+                    return ToolCallResult(content = listOf(ToolContent(text = "unexpected")))
+                }
+            },
+        )
+        val fakeClient = FakeLlmProvider(
+            completions = mutableListOf(
+                LlmResponse(
+                    content = "",
+                    toolCalls = listOf(LlmToolCall("call-invalid", "list_issues", null)),
+                ),
+                LlmResponse(content = "I could not run that tool."),
+            ),
+        )
+        val writer = StringWriter()
+
+        AiAssistantService(registry, fakeClient).streamAssistant(
+            writer = writer,
+            userId = 1,
+            orgId = 1,
+            message = "list issues",
+            conversationId = null,
+        )
+
+        val events = parseEvents(writer.toString())
+        assertEquals(0, executions)
+        assertEquals(2, fakeClient.callCount)
+        assertTrue(
+            events.any { event ->
+                event["type"]?.jsonPrimitive?.content == "tool_result" &&
+                    event["isError"]?.jsonPrimitive?.content == "true"
+            },
+        )
+    }
+
     private fun parseEvents(raw: String): List<JsonObject> {
         val events = mutableListOf<JsonObject>()
         raw.lineSequence()

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiAssistantServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/ai/services/AiAssistantServiceTest.kt
@@ -4,6 +4,13 @@
 
 package com.moneat.enterprise.ai.services
 
+import com.moneat.enterprise.ai.llm.LlmCapability
+import com.moneat.enterprise.ai.llm.LlmConfig
+import com.moneat.enterprise.ai.llm.LlmMessage
+import com.moneat.enterprise.ai.llm.LlmProvider
+import com.moneat.enterprise.ai.llm.LlmResponse
+import com.moneat.enterprise.ai.llm.LlmTool
+import com.moneat.enterprise.ai.llm.LlmToolCall
 import com.moneat.enterprise.ai.models.AiAssistantConfirmRequest
 import com.moneat.mcp.auth.McpScopes
 import com.moneat.mcp.models.McpContext
@@ -47,19 +54,19 @@ class AiAssistantServiceTest {
             },
         )
 
-        val fakeClient = FakeAssistantLlmClient(
+        val fakeClient = FakeLlmProvider(
             completions = mutableListOf(
-                AssistantCompletion(
+                LlmResponse(
                     content = "",
                     toolCalls = listOf(
-                        AssistantToolCall(
+                        LlmToolCall(
                             id = "call-1",
                             name = "list_issues",
-                            arguments = """{"limit":5}""",
+                            arguments = JsonObject(mapOf("limit" to JsonPrimitive(5))),
                         ),
                     ),
                 ),
-                AssistantCompletion(content = "There are 2 active issues.", toolCalls = emptyList()),
+                LlmResponse(content = "There are 2 active issues."),
             ),
         )
 
@@ -102,19 +109,19 @@ class AiAssistantServiceTest {
             },
         )
 
-        val fakeClient = FakeAssistantLlmClient(
+        val fakeClient = FakeLlmProvider(
             completions = mutableListOf(
-                AssistantCompletion(
+                LlmResponse(
                     content = "I can create that host.",
                     toolCalls = listOf(
-                        AssistantToolCall(
+                        LlmToolCall(
                             id = "call-2",
                             name = "create_project",
-                            arguments = """{"name":"edge-01"}""",
+                            arguments = JsonObject(mapOf("name" to JsonPrimitive("edge-01"))),
                         ),
                     ),
                 ),
-                AssistantCompletion(content = "Done. Project edge-01 has been created.", toolCalls = emptyList()),
+                LlmResponse(content = "Done. Project edge-01 has been created."),
             ),
         )
 
@@ -180,9 +187,9 @@ class AiAssistantServiceTest {
             },
         )
 
-        val fakeClient = FakeAssistantLlmClient(
+        val fakeClient = FakeLlmProvider(
             completions = mutableListOf(
-                AssistantCompletion(content = "No tool call required.", toolCalls = emptyList()),
+                LlmResponse(content = "No tool call required."),
             ),
         )
         val service = AiAssistantService(registry, fakeClient)
@@ -226,23 +233,32 @@ class AiAssistantServiceTest {
     }
 }
 
-private class FakeAssistantLlmClient(
-    private val completions: MutableList<AssistantCompletion>,
-) : AssistantLlmClient {
+private class FakeLlmProvider(
+    private val completions: MutableList<LlmResponse>,
+) : LlmProvider {
     var callCount: Int = 0
         private set
-    var capturedTools: List<AssistantFunction> = emptyList()
+    var capturedTools: List<LlmTool> = emptyList()
         private set
 
-    override suspend fun complete(
-        messages: List<AssistantMessage>,
-        tools: List<AssistantFunction>,
-    ): AssistantCompletion {
+    override suspend fun chatCompletion(
+        messages: List<LlmMessage>,
+        config: LlmConfig,
+        tools: List<LlmTool>,
+    ): LlmResponse {
         callCount += 1
         capturedTools = tools
         if (completions.isEmpty()) {
-            return AssistantCompletion(content = "No more completions configured.", toolCalls = emptyList())
+            return LlmResponse(content = "No more completions configured.")
         }
         return completions.removeAt(0)
     }
+
+    override fun provider(): String = "fake"
+
+    override fun model(): String = "fake-model"
+
+    override fun isEnabled(): Boolean = true
+
+    override fun capabilities(): Set<LlmCapability> = LlmCapability.entries.toSet()
 }


### PR DESCRIPTION
## Summary
- share one AI provider contract across chat surfaces
- support configurable OpenAI-compatible and Anthropic adapters
- validate and document runtime settings

## Testing
- backend test suite
- core and enterprise Detekt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure the AI assistant with OpenAI, OpenAI-compatible, or Anthropic providers.
  - Customize endpoints, models, authentication, timeouts, retries, and capabilities.
  - Added tool calling, structured responses, and streaming support.
  - Legacy OpenAI settings and API-key fallbacks remain supported.

- **Documentation**
  - Added guidance for provider configuration, authentication, and keyless endpoint requirements.

- **Bug Fixes**
  - Improved retry handling for temporary failures and rate limits.
  - Added clearer validation errors for invalid AI settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->