### PR TITLE
fix(alerts): identify filesystem in disk alerts

### DIFF
--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -52,8 +52,10 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -83,6 +85,7 @@ private const val MEM_TOTAL_METRIC = "system.mem.total"
 private const val DISK_PERCENT_METRIC = "system.disk.percent"
 private const val DISK_USED_METRIC = "system.disk.used"
 private const val DISK_TOTAL_METRIC = "system.disk.total"
+private const val DISK_ALERT_METRIC = "disk_percent"
 private const val DISK_ID_EXPRESSION = """
     if(
         metric_identity != '',
@@ -104,6 +107,45 @@ private fun String.escapeHtml(): String =
         .replace(">", "&gt;")
         .replace("\"", "&quot;")
         .replace("'", "&#39;")
+
+internal data class CurrentMetricReading(
+    val value: Double,
+    val resourceLabel: String? = null,
+)
+
+private data class AlertTriggerContext(
+    val currentReading: CurrentMetricReading,
+    val alertKey: String,
+    val now: Instant,
+)
+
+internal fun diskResourceLabel(metricIdentity: String): String? {
+    if (metricIdentity.isBlank() || metricIdentity == "default") return null
+
+    val dimensions = metricIdentity
+        .split('|')
+        .mapNotNull { part ->
+            val separator = part.indexOf('=')
+            if (separator <= 0 || separator == part.lastIndex) {
+                null
+            } else {
+                part.substring(0, separator) to part.substring(separator + 1)
+            }
+        }.toMap()
+    val rawDevice = listOf("device_name", "device", "system.filesystem.device")
+        .firstNotNullOfOrNull(dimensions::get)
+    val device = rawDevice?.let { if (it.startsWith('/')) it else "/dev/$it" }
+    val mountPoint = listOf("mount_point", "mountpoint", "system.filesystem.mountpoint")
+        .firstNotNullOfOrNull(dimensions::get)
+
+    return when {
+        device != null && mountPoint != null -> "$device at $mountPoint"
+        device != null -> device
+        mountPoint != null -> mountPoint
+        dimensions.isEmpty() -> if (metricIdentity.startsWith('/')) metricIdentity else "/dev/$metricIdentity"
+        else -> null
+    }
+}
 
 private fun memoryPercentMetricFilter(): String =
     "metric_name IN ('$MEM_AVAILABLE_METRIC','$MEM_USED_METRIC','$MEM_TOTAL_METRIC')"
@@ -445,8 +487,8 @@ class MonitorAlertService(
         organizationId: Int
     ) {
         val alertKey = hostAlertRedisKey(alert)
-        val currentValue = getCurrentMetricValue(alert.hostId, alert.organizationId, alert.metric) ?: return
-        val triggered = isThresholdTriggered(alert.condition, currentValue, alert.threshold)
+        val currentReading = getCurrentMetricReading(alert.hostId, alert.organizationId, alert.metric) ?: return
+        val triggered = isThresholdTriggered(alert.condition, currentReading.value, alert.threshold)
 
         if (!triggered) {
             handleRecoveredAlert(alert, hostName, organizationId, alertKey)
@@ -463,7 +505,12 @@ class MonitorAlertService(
             return
         }
 
-        triggerAlert(alert, hostName, organizationId, currentValue, alertKey, now)
+        triggerAlertWithContext(
+            alert,
+            hostName,
+            organizationId,
+            AlertTriggerContext(currentReading, alertKey, now),
+        )
     }
 
     private suspend fun handleRecoveredAlert(
@@ -564,14 +611,28 @@ class MonitorAlertService(
         alertKey: String,
         now: Instant
     ) {
+        triggerAlertWithContext(
+            alert,
+            hostName,
+            organizationId,
+            AlertTriggerContext(CurrentMetricReading(currentValue), alertKey, now),
+        )
+    }
+
+    private suspend fun triggerAlertWithContext(
+        alert: AlertData,
+        hostName: String,
+        organizationId: Int,
+        context: AlertTriggerContext,
+    ) {
         logger.info {
             "Alert ${alert.id} triggered for host ${alert.hostId}: " +
-                "${alert.metric} ${alert.condition} ${alert.threshold} (current: $currentValue)"
+                "${alert.metric} ${alert.condition} ${alert.threshold} (current: ${context.currentReading.value})"
         }
 
-        setAlertTriggeredState(alertKey)
-        updateLastTriggeredAt(alert, now)
-        sendAlertNotification(alert, hostName, organizationId, currentValue)
+        setAlertTriggeredState(context.alertKey)
+        updateLastTriggeredAt(alert, context.now)
+        sendAlertNotificationWithContext(alert, hostName, organizationId, context.currentReading)
     }
 
     private fun wasAlertTriggered(
@@ -685,7 +746,13 @@ class MonitorAlertService(
         hostId: Int,
         organizationId: Int,
         metric: String
-    ): Double? {
+    ): Double? = getCurrentMetricReading(hostId, organizationId, metric)?.value
+
+    internal suspend fun getCurrentMetricReading(
+        hostId: Int,
+        organizationId: Int,
+        metric: String,
+    ): CurrentMetricReading? {
         val query = currentMetricValueQuery(hostId, organizationId, metric) ?: return null
 
         return suspendRunCatching {
@@ -703,7 +770,13 @@ class MonitorAlertService(
             val result = json.parseToJsonElement(body).jsonObject
             val data = result["data"]?.jsonArray?.firstOrNull()?.jsonArray ?: return null
 
-            data[0].toString().replace("\"", "").toDoubleOrNull()
+            val value = data[0].jsonPrimitive.contentOrNull?.toDoubleOrNull() ?: return null
+            val resourceLabel = if (metric == DISK_ALERT_METRIC) {
+                data.getOrNull(1)?.jsonPrimitive?.contentOrNull?.let(::diskResourceLabel)
+            } else {
+                null
+            }
+            CurrentMetricReading(value, resourceLabel)
         }.getOrElse { e ->
             logger.error(e) { "Error fetching metric value" }
             null
@@ -715,7 +788,7 @@ class MonitorAlertService(
         organizationId: Int,
         metric: String
     ): String? {
-        if (metric == "disk_percent") {
+        if (metric == DISK_ALERT_METRIC) {
             return diskPercentCurrentMetricQuery(hostId, organizationId)
         }
 
@@ -749,7 +822,8 @@ class MonitorAlertService(
     ): String =
         """
         SELECT
-            max(pct) AS value
+            pct AS value,
+            disk_identity
         FROM (
             SELECT
                 $DISK_ID_EXPRESSION AS disk_identity,
@@ -761,6 +835,9 @@ class MonitorAlertService(
               AND timestamp >= now64(3) - INTERVAL $CURRENT_METRIC_LOOKBACK_MINUTES MINUTE
             GROUP BY disk_identity
         )
+        WHERE pct IS NOT NULL
+        ORDER BY pct DESC
+        LIMIT 1
         FORMAT JSONCompact
         """.trimIndent()
 
@@ -908,8 +985,22 @@ class MonitorAlertService(
         organizationId: Int,
         currentValue: Double
     ) {
+        sendAlertNotificationWithContext(
+            alert,
+            hostName,
+            organizationId,
+            CurrentMetricReading(currentValue),
+        )
+    }
+
+    internal suspend fun sendAlertNotificationWithContext(
+        alert: AlertData,
+        hostName: String,
+        organizationId: Int,
+        currentReading: CurrentMetricReading,
+    ) {
         val metricLabel = getMetricLabel(alert.metric)
-        val formattedValue = formatMetricValue(alert.metric, currentValue)
+        val formattedValue = formatMetricValue(alert.metric, currentReading.value)
         val formattedThreshold = formatMetricValue(alert.metric, alert.threshold)
         val hostResourceId = hostResourceId(alert.hostId, organizationId)
         val dashboardUrl = hostDashboardUrl(alert.hostId, organizationId)
@@ -920,15 +1011,19 @@ class MonitorAlertService(
                 "current_value" to JsonPrimitive(formattedValue),
                 "threshold" to JsonPrimitive(formattedThreshold)
             )
+        currentReading.resourceLabel?.let { metadata["resource_label"] = JsonPrimitive(it) }
         hostResourceId?.let { metadata["host_id"] = JsonPrimitive(it) }
+
+        val resourceSuffix = currentReading.resourceLabel?.let { " ($it)" }.orEmpty()
+        val resourceDescription = currentReading.resourceLabel?.let { "\nFilesystem: $it" }.orEmpty()
 
         val alertPriority = hostAlertPriorityOverride(alert)
         val alertLifecycleEvent =
             AlertLifecycleEvent(
-                title = "$hostName - $metricLabel ${alert.condition} ${alert.threshold}",
+                title = "$hostName - $metricLabel$resourceSuffix ${alert.condition} ${alert.threshold}",
                 description =
                 "Metric: $metricLabel\nCondition: ${alert.condition} $formattedThreshold" +
-                    "\nCurrent Value: $formattedValue",
+                    "\nCurrent Value: $formattedValue$resourceDescription",
                 priority = alertPriority ?: AlertPriority.P1,
                 status = AlertStatus.FIRING,
                 source = AlertSource.HOST_ALERT,

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -836,7 +836,7 @@ class MonitorAlertService(
             GROUP BY disk_identity
         )
         WHERE pct IS NOT NULL
-        ORDER BY pct DESC
+        ORDER BY pct DESC, disk_identity ASC
         LIMIT 1
         FORMAT JSONCompact
         """.trimIndent()

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -23,8 +23,10 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.incident.services.IncidentService
 import com.moneat.monitor.models.AlertData
 import com.moneat.monitor.models.CreateSilencePeriodRequest
+import com.moneat.monitor.services.CurrentMetricReading
 import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.monitor.services.MonitorService
+import com.moneat.monitor.services.diskResourceLabel
 import com.moneat.shared.models.AlertSilencePeriods
 import com.moneat.shared.models.HostAlertSettings
 import com.moneat.shared.models.HostAlertTemplateStates
@@ -266,7 +268,10 @@ class MonitorAlertServiceCoverageTest {
         assertTrue(query.contains("GROUP BY disk_identity"))
         assertTrue(query.contains("tags['device_name']"))
         assertTrue(query.contains("tags['mountpoint']"))
-        assertTrue(query.contains("max(pct)"))
+        assertTrue(query.contains("pct AS value"))
+        assertTrue(query.contains("disk_identity"))
+        assertTrue(query.contains("ORDER BY pct DESC"))
+        assertTrue(query.contains("LIMIT 1"))
         assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.percent')"))
         assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.used')"))
         assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.total')"))
@@ -474,6 +479,32 @@ class MonitorAlertServiceCoverageTest {
         }
 
     @Test
+    fun `getCurrentMetricReading preserves the fullest disk identity`() =
+        runBlocking {
+            val body =
+                """{"data":[["87.5","device_name=sda|mount_point=/mnt/volume_nyc3_01"]]}"""
+            val http = mockk<HttpResponse>()
+            every { http.status } returns HttpStatusCode.OK
+            coEvery { http.bodyAsText(any()) } returns body
+            coEvery { ClickHouseClient.execute(any()) } returns http
+
+            val reading = service.getCurrentMetricReading(153, 1, "disk_percent")
+
+            assertEquals(87.5, reading?.value)
+            assertEquals("/dev/sda at /mnt/volume_nyc3_01", reading?.resourceLabel)
+        }
+
+    @Test
+    fun `diskResourceLabel supports device mount and legacy identities`() {
+        assertEquals(
+            "/dev/sda at /mnt/data",
+            diskResourceLabel("device_name=sda|mountpoint=/mnt/data"),
+        )
+        assertEquals("/dev/vda1", diskResourceLabel("vda1"))
+        assertNull(diskResourceLabel("default"))
+    }
+
+    @Test
     fun `getCurrentMetricValue returns null for unsuccessful ClickHouse response`() =
         runBlocking {
             val http = mockk<HttpResponse>()
@@ -550,6 +581,45 @@ class MonitorAlertServiceCoverageTest {
 
             coVerify(exactly = 1) {
                 workflowService.publishAlertTriggered(any())
+            }
+        }
+
+    @Test
+    fun `disk alert notification identifies the fullest filesystem`() =
+        runBlocking {
+            val alert =
+                AlertData(
+                    id = 1,
+                    hostId = 1,
+                    organizationId = 1,
+                    metric = "disk_percent",
+                    condition = ">",
+                    threshold = 75.0,
+                    durationSeconds = 300,
+                    enabled = true,
+                    lastTriggeredAt = null,
+                    createdAt = Clock.System.now(),
+                    scope = MonitorService.ALERT_SCOPE_HOST,
+                    templateAlertId = null,
+                )
+
+            service.sendAlertNotificationWithContext(
+                alert,
+                "host-a",
+                1,
+                CurrentMetricReading(81.2, "/dev/sda at /mnt/volume_nyc3_01"),
+            )
+
+            coVerify(exactly = 1) {
+                workflowService.publishAlertTriggered(
+                    match {
+                        it.title ==
+                            "host-a - Disk Usage (/dev/sda at /mnt/volume_nyc3_01) > 75.0" &&
+                            it.description.contains("Filesystem: /dev/sda at /mnt/volume_nyc3_01") &&
+                            it.metadata["resource_label"]?.toString() ==
+                            "\"/dev/sda at /mnt/volume_nyc3_01\""
+                    }
+                )
             }
         }
 

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -270,7 +270,7 @@ class MonitorAlertServiceCoverageTest {
         assertTrue(query.contains("tags['mountpoint']"))
         assertTrue(query.contains("pct AS value"))
         assertTrue(query.contains("disk_identity"))
-        assertTrue(query.contains("ORDER BY pct DESC"))
+        assertTrue(query.contains("ORDER BY pct DESC, disk_identity ASC"))
         assertTrue(query.contains("LIMIT 1"))
         assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.percent')"))
         assertTrue(query.contains("argMaxIf(value, timestamp, metric_name = 'system.disk.used')"))


### PR DESCRIPTION
## Summary
- return the fullest disk identity from alert evaluation
- format device and mount-point context into disk alert titles, descriptions, and metadata
- keep non-disk alert behavior unchanged

## Verification
- ./gradlew :test --tests com.moneat.services.MonitorAlertServiceCoverageTest -x jacocoTestReport --no-daemon
- ./gradlew detekt --no-daemon
- git diff --check
- production query returns the fullest current filesystem and its metric identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk alerts now identify the affected filesystem or device.
  * Resource labels appear in alert titles, descriptions, and metadata.
  * Disk monitoring selects the highest reported usage value for alert evaluation, with consistent handling when values are tied.

* **Bug Fixes**
  * Improved handling of missing or invalid metric values to prevent parsing issues.
  * Disk alert notifications now consistently preserve the selected filesystem identity across alert details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->