### PR TITLE
Show mounted filesystem disk tiles on hosts

### DIFF
--- a/backend/features/monitoring/src/main/kotlin/com/moneat/monitor/services/ResourceCatalogService.kt
+++ b/backend/features/monitoring/src/main/kotlin/com/moneat/monitor/services/ResourceCatalogService.kt
@@ -25,6 +25,7 @@ import com.moneat.monitor.models.CatalogResource
 import com.moneat.monitor.models.CatalogResourceTelemetry
 import com.moneat.monitor.models.CatalogVulnerabilityCounts
 import com.moneat.monitor.models.ContainerMetricDataPoint
+import com.moneat.monitor.models.FilesystemMetricSeries
 import com.moneat.monitor.models.HostData
 import com.moneat.monitor.models.LatestMetrics
 import com.moneat.monitor.models.MetricDataPoint
@@ -511,9 +512,14 @@ class ResourceCatalogService(
         val nowSeconds = telemetryNowSeconds(demoEpochMs)
         val points = monitorService
             .getHistoricalMetrics(hostId, nowSeconds - rangeSeconds, nowSeconds, null)
-            .dataPoints
+        val filesystemSeries = monitorService.getHistoricalFilesystemMetrics(
+            hostId,
+            nowSeconds - rangeSeconds,
+            nowSeconds,
+            points.intervalSeconds,
+        )
         fun col(value: (MetricDataPoint) -> Double?): List<Pair<Long, Double?>> =
-            points.map { (it.timestamp * MILLIS_PER_SECOND) to value(it) }
+            points.dataPoints.map { (it.timestamp * MILLIS_PER_SECOND) to value(it) }
         return buildList {
             metricOrNull(
                 "cpu",
@@ -529,8 +535,7 @@ class ResourceCatalogService(
                 listOf(lineOrNull("Memory", col { it.memPercent?.toDouble() })),
             )
                 ?.let { add(it) }
-            metricOrNull("disk", "Disk usage", "%", listOf(lineOrNull("Disk", col { it.diskPercent?.toDouble() })))
-                ?.let { add(it) }
+            addFilesystemMetrics(filesystemSeries, col { it.diskPercent?.toDouble() })
             metricOrNull(
                 "load",
                 "Load average",
@@ -550,6 +555,28 @@ class ResourceCatalogService(
                     lineOrNull("Sent", col { it.netSentBytes?.toDouble() }),
                 ),
             )?.let { add(it) }
+        }
+    }
+
+    private fun MutableList<ResourceTelemetryMetric>.addFilesystemMetrics(
+        filesystemSeries: List<FilesystemMetricSeries>,
+        legacyPoints: List<Pair<Long, Double?>>,
+    ) {
+        if (filesystemSeries.isEmpty()) {
+            metricOrNull("disk", "Disk usage", "%", listOf(lineOrNull("Disk", legacyPoints)))?.let(::add)
+            return
+        }
+        filesystemSeries.forEach { filesystem ->
+            val points = filesystem.dataPoints.map { point ->
+                (point.timestamp * MILLIS_PER_SECOND) to point.percent.toDouble()
+            }
+            val label = if (filesystem.label == "Disk") "Disk usage" else "Disk usage (${filesystem.label})"
+            metricOrNull(
+                key = "disk:${filesystem.identity}",
+                label = label,
+                unit = "%",
+                lines = listOf(lineOrNull(filesystem.label, points)),
+            )?.let(::add)
         }
     }
 

--- a/backend/features/monitoring/src/test/kotlin/com/moneat/monitor/services/ResourceCatalogServiceTest.kt
+++ b/backend/features/monitoring/src/test/kotlin/com/moneat/monitor/services/ResourceCatalogServiceTest.kt
@@ -21,6 +21,8 @@ import com.moneat.monitor.models.CatalogResourceTelemetry
 import com.moneat.monitor.models.CatalogSecurityFinding
 import com.moneat.monitor.models.ContainerMetricDataPoint
 import com.moneat.monitor.models.ContainerMetricsResponse
+import com.moneat.monitor.models.FilesystemMetricDataPoint
+import com.moneat.monitor.models.FilesystemMetricSeries
 import com.moneat.monitor.models.HistoricalMetricsResponse
 import com.moneat.monitor.models.HostData
 import com.moneat.monitor.models.LatestMetrics
@@ -761,6 +763,9 @@ class ResourceCatalogServiceTest {
                 metricPoint(timestamp = 2000, cpu = 18f, mem = 45f),
             ),
         )
+        coEvery {
+            monitorService.getHistoricalFilesystemMetrics(HOST_ID, any(), any(), any())
+        } returns emptyList()
         val service = ResourceCatalogService(
             monitorService = monitorService,
             queryClient = NoopResourceCatalogQueryClient,
@@ -780,6 +785,74 @@ class ResourceCatalogServiceTest {
         assertEquals(1_000_000L, cpu.lines.first().points.first().ts)
         // A column with no samples (disk) is omitted rather than emitted empty.
         assertTrue(telemetry.metrics.none { it.key == "disk" })
+    }
+
+    @Test
+    fun `host telemetry exposes one disk tile series per filesystem`() = runBlocking {
+        val monitorService = mockk<MonitorService>()
+        every { monitorService.listHosts(ORGANIZATION_ID) } returns
+            listOf(hostData(HOST_ID, ORGANIZATION_ID, HOSTNAME, "online"))
+        coEvery { monitorService.getHistoricalMetrics(HOST_ID, any(), any(), null) } returns HistoricalMetricsResponse(
+            systemId = "sys",
+            from = 0,
+            to = 0,
+            intervalSeconds = 300,
+            dataPoints = listOf(metricPoint(timestamp = 1000, cpu = 12f, mem = 40f, disk = 67f)),
+        )
+        coEvery {
+            monitorService.getHistoricalFilesystemMetrics(HOST_ID, any(), any(), 300)
+        } returns listOf(
+            FilesystemMetricSeries(
+                identity = "device_name=sda",
+                label = "/dev/sda",
+                dataPoints = listOf(FilesystemMetricDataPoint(timestamp = 1000, percent = 12.5f)),
+            ),
+            FilesystemMetricSeries(
+                identity = "device_name=vda1|mount_point=/",
+                label = "/dev/vda1 at /",
+                dataPoints = listOf(FilesystemMetricDataPoint(timestamp = 1000, percent = 67f)),
+            ),
+        )
+        val service = ResourceCatalogService(
+            monitorService = monitorService,
+            queryClient = NoopResourceCatalogQueryClient,
+            securityReader = NoopResourceSecurityReader,
+        )
+
+        val telemetry = service.getResourceTelemetry(hostTelemetryRequest(hostId = HOST_ID, rangeSeconds = 86_400))
+
+        val disks = telemetry.metrics.filter { it.key.startsWith("disk:") }
+        assertEquals(listOf("Disk usage (/dev/sda)", "Disk usage (/dev/vda1 at /)"), disks.map { it.label })
+        assertEquals(listOf(12.5, 67.0), disks.map { it.lines.single().points.single().value })
+        assertTrue(telemetry.metrics.none { it.key == "disk" })
+    }
+
+    @Test
+    fun `host telemetry falls back to the legacy aggregate disk series`() = runBlocking {
+        val monitorService = mockk<MonitorService>()
+        every { monitorService.listHosts(ORGANIZATION_ID) } returns
+            listOf(hostData(HOST_ID, ORGANIZATION_ID, HOSTNAME, "online"))
+        coEvery { monitorService.getHistoricalMetrics(HOST_ID, any(), any(), null) } returns HistoricalMetricsResponse(
+            systemId = "sys",
+            from = 0,
+            to = 0,
+            intervalSeconds = 300,
+            dataPoints = listOf(metricPoint(timestamp = 1000, cpu = 12f, mem = 40f, disk = 67f)),
+        )
+        coEvery {
+            monitorService.getHistoricalFilesystemMetrics(HOST_ID, any(), any(), 300)
+        } returns emptyList()
+        val service = ResourceCatalogService(
+            monitorService = monitorService,
+            queryClient = NoopResourceCatalogQueryClient,
+            securityReader = NoopResourceSecurityReader,
+        )
+
+        val telemetry = service.getResourceTelemetry(hostTelemetryRequest(hostId = HOST_ID, rangeSeconds = 86_400))
+
+        val disk = telemetry.metrics.single { it.key == "disk" }
+        assertEquals("Disk usage", disk.label)
+        assertEquals(67.0, disk.lines.single().points.single().value)
     }
 
     @Test
@@ -913,12 +986,12 @@ class ResourceCatalogServiceTest {
         assertTrue(noOrg.metrics.isEmpty())
     }
 
-    private fun metricPoint(timestamp: Long, cpu: Float, mem: Float): MetricDataPoint =
+    private fun metricPoint(timestamp: Long, cpu: Float, mem: Float, disk: Float? = null): MetricDataPoint =
         MetricDataPoint(
             timestamp = timestamp,
             cpuPercent = cpu,
             memPercent = mem,
-            diskPercent = null,
+            diskPercent = disk,
             netRecvBytes = 10,
             netSentBytes = 20,
             load1 = 0.5f,

--- a/backend/src/main/kotlin/com/moneat/monitor/models/MonitorModels.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/models/MonitorModels.kt
@@ -121,6 +121,19 @@ data class MetricDataPoint(
 )
 
 @Serializable
+data class FilesystemMetricDataPoint(
+    val timestamp: Long,
+    val percent: Float
+)
+
+@Serializable
+data class FilesystemMetricSeries(
+    val identity: String,
+    val label: String,
+    @SerialName("data_points") val dataPoints: List<FilesystemMetricDataPoint>
+)
+
+@Serializable
 data class ContainerStatsResponse(
     val containers: List<ContainerStats>
 )

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorService.kt
@@ -30,6 +30,8 @@ import com.moneat.monitor.models.ContainerStats
 import com.moneat.monitor.models.ContainerWithSystem
 import com.moneat.monitor.models.CreateAlertData
 import com.moneat.monitor.models.CreateAlertRequest
+import com.moneat.monitor.models.FilesystemMetricDataPoint
+import com.moneat.monitor.models.FilesystemMetricSeries
 import com.moneat.monitor.models.HistoricalMetricsResponse
 import com.moneat.monitor.models.HostData
 import com.moneat.monitor.models.LatestMetrics
@@ -178,6 +180,11 @@ class MonitorService(
         private const val HIST_COL_TEMP_MAX = 9
         private const val HIST_COL_GPU_PERCENT = 10
         private const val HIST_COL_BATTERY_PERCENT = 11
+
+        // JSONCompact column indices — per-filesystem historical metrics query
+        // SELECT: ts(0), metric_identity(1), disk_percent(2)
+        private const val FILESYSTEM_HIST_COL_IDENTITY = 1
+        private const val FILESYSTEM_HIST_COL_PERCENT = 2
 
         // JSONCompact column indices — single-host container stats query
         // SELECT: name(0), container_id(1), image(2), state(3), cpu_percent(4),
@@ -867,6 +874,72 @@ class MonitorService(
                 intervalSeconds = rollupInterval,
                 dataPoints = dataPoints
             )
+        }
+
+    /**
+     * Get historical disk utilization grouped by stable filesystem identity.
+     */
+    suspend fun getHistoricalFilesystemMetrics(
+        hostId: Int,
+        fromTimestamp: Long,
+        toTimestamp: Long,
+        intervalSeconds: Int,
+    ): List<FilesystemMetricSeries> =
+        CacheService.cached(
+            "cache:monitor_filesystem_hist:$hostId:$fromTimestamp:$toTimestamp:$intervalSeconds",
+            MONITOR_HISTORY_CACHE_TTL_SECONDS,
+        ) {
+            val host = getHostById(hostId) ?: return@cached emptyList()
+            val clampedWindow = clampRangeToRetention(hostId, fromTimestamp, toTimestamp)
+                ?: return@cached emptyList()
+            val (effectiveFrom, effectiveTo) = clampedWindow
+            val rollupInterval = max(intervalSeconds, INTERVAL_ONE_MINUTE)
+            val query =
+                """
+                SELECT
+                    toUnixTimestamp(toStartOfInterval(bucket_start, INTERVAL $rollupInterval second)) as ts,
+                    metric_identity,
+                    ${rollupDiskPercentExpr()} as disk_percent
+                FROM `$clickhouseDb`.metrics_rollup_1m
+                WHERE ${clickHouseOrgClause(host.organizationId)}
+                  AND host_id = $hostId
+                  AND metric_name IN ($DISK_METRIC_NAMES_SQL)
+                  AND bucket_start >= fromUnixTimestamp64Milli(${effectiveFrom * MILLIS_PER_SECOND_LONG})
+                  AND bucket_start <= fromUnixTimestamp64Milli(${effectiveTo * MILLIS_PER_SECOND_LONG})
+                GROUP BY ts, metric_identity
+                HAVING disk_percent IS NOT NULL
+                ORDER BY metric_identity, ts
+                FORMAT JSONCompact
+                """.trimIndent()
+
+            val body = hostRepository.executeClickHouseQuery(query)
+            suspendRunCatching {
+                val json = Json { ignoreUnknownKeys = true }
+                val rows = json.parseToJsonElement(body)
+                    .jsonObject["data"]
+                    ?.jsonArray
+                    ?: return@cached emptyList()
+                val pointsByIdentity = linkedMapOf<String, MutableList<FilesystemMetricDataPoint>>()
+                rows.forEach { row ->
+                    val arr = row.jsonArray
+                    val timestamp = arr.stringAt(0).toLongOrNull() ?: return@forEach
+                    val percent = arr.floatAt(FILESYSTEM_HIST_COL_PERCENT) ?: return@forEach
+                    val identity = arr.stringAt(FILESYSTEM_HIST_COL_IDENTITY).ifBlank { "default" }
+                    pointsByIdentity.getOrPut(identity, ::mutableListOf).add(
+                        FilesystemMetricDataPoint(timestamp = timestamp, percent = percent)
+                    )
+                }
+                pointsByIdentity.map { (identity, points) ->
+                    FilesystemMetricSeries(
+                        identity = identity,
+                        label = diskResourceLabel(identity) ?: "Disk",
+                        dataPoints = points,
+                    )
+                }
+            }.getOrElse { e ->
+                logger.error(e) { "Failed to parse historical filesystem metrics" }
+                emptyList()
+            }
         }
 
     /**

--- a/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorServiceExtendedTest.kt
@@ -492,6 +492,35 @@ class MonitorServiceExtendedTest {
         assertEquals(60.0f, result.dataPoints[1].cpuPercent)
     }
 
+    @Test
+    fun `getHistoricalFilesystemMetrics keeps mounted disks in separate series`() = runBlocking {
+        every { hostRepo.getById(1) } returns testHost
+        coEvery { retentionPolicyService.getRetentionDaysForHost(1) } returns 7
+        val querySlot = io.mockk.slot<String>()
+        val nowEpoch = Clock.System.now().epochSeconds
+        coEvery { hostRepo.executeClickHouseQuery(capture(querySlot)) } returns
+            """
+            {
+                "data": [
+                    ["${nowEpoch - 60}", "device_name=sda", 12.5],
+                    ["$nowEpoch", "device_name=sda", 13.0],
+                    ["$nowEpoch", "device_name=vda1|mount_point=/", 67.0]
+                ]
+            }
+            """.trimIndent()
+
+        val result = service.getHistoricalFilesystemMetrics(1, nowEpoch - 3600, nowEpoch, 60)
+
+        assertEquals(2, result.size)
+        assertEquals("/dev/sda", result[0].label)
+        assertEquals(listOf(12.5f, 13.0f), result[0].dataPoints.map { it.percent })
+        assertEquals("/dev/vda1 at /", result[1].label)
+        assertEquals(67.0f, result[1].dataPoints.single().percent)
+        assertTrue(querySlot.captured.contains("GROUP BY ts, metric_identity"))
+        assertTrue(querySlot.captured.contains("ORDER BY metric_identity, ts"))
+        assertTrue(querySlot.captured.contains("metric_name IN ('system.disk.percent'"))
+    }
+
     // ──── getContainerHistoricalMetrics ────
 
     @Test

--- a/dashboard/src/components/monitoring/catalog/ResourceDetailPanel.tsx
+++ b/dashboard/src/components/monitoring/catalog/ResourceDetailPanel.tsx
@@ -208,11 +208,12 @@ function unitFormatters(unit: string): {value: (v: number) => string; tick?: (v:
 /** Map one backend telemetry metric to MetricChart props. */
 function metricChartProps(metric: TelemetryMetric): MetricChartSpec {
   const fmt = unitFormatters(metric.unit)
+  const metricType = metric.key.split(':', 1)[0]
   return {
     title: metric.label,
     subtitle: metric.unit || undefined,
-    icon: METRIC_ICON[metric.key] ?? Activity,
-    iconClass: METRIC_ICON_CLASS[metric.key],
+    icon: METRIC_ICON[metricType] ?? Activity,
+    iconClass: METRIC_ICON_CLASS[metricType],
     lines: metric.lines,
     yDomain: metric.unit === '%' ? PCT_DOMAIN : undefined,
     formatValue: fmt.value,

--- a/dashboard/src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx
+++ b/dashboard/src/components/monitoring/catalog/__tests__/ResourceCatalog.test.tsx
@@ -222,6 +222,36 @@ describe('ResourceCatalog', () => {
     expect(onSelect).not.toHaveBeenCalled()
   })
 
+  it('renders a disk usage tile for each filesystem reported by a host', async () => {
+    const onSelect = vi.fn()
+    mockApi.get.mockResolvedValue({
+      kind: 'host',
+      rangeSeconds: 86_400,
+      intervalSeconds: 300,
+      metrics: [
+        {
+          key: 'disk:device_name=sda',
+          label: 'Disk usage (/dev/sda)',
+          unit: '%',
+          lines: [{name: '/dev/sda', points: [{ts: 1, value: 12.5}]}],
+        },
+        {
+          key: 'disk:device_name=vda1|mount_point=/',
+          label: 'Disk usage (/dev/vda1 at /)',
+          unit: '%',
+          lines: [{name: '/dev/vda1 at /', points: [{ts: 1, value: 67}]}],
+        },
+      ],
+    })
+
+    renderWithQueryClient(<ResourceDetailPanel resource={emptyResource} onSelect={onSelect} />)
+
+    expect(await screen.findByText('Disk usage (/dev/sda)')).toBeInTheDocument()
+    expect(screen.getByText('Disk usage (/dev/vda1 at /)')).toBeInTheDocument()
+    expect(document.querySelectorAll('.lucide-hard-drive')).toHaveLength(2)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
   it('shows telemetry load failures in the detail panel', async () => {
     const onSelect = vi.fn()
 


### PR DESCRIPTION
## Summary
- query historical disk usage per stable filesystem identity
- render one existing host disk chart tile per filesystem, with device and mount labels
- preserve the legacy aggregate disk tile when per-filesystem data is unavailable

## Verification
- Gradle MonitorServiceExtendedTest target passed
- Gradle ResourceCatalogServiceTest passed
- Gradle Detekt passed
- focused ResourceCatalog Vitest passed
- dashboard lint passed
- dashboard typecheck passed
- git diff check passed

## Manual verification
- Browser smoke was not available because private worktree setup could not reach ubuntu1 (10.0.0.10:22 timeout).

Backlog: TASK-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Host monitoring now displays disk usage separately for each filesystem, with labeled metrics and historical data.
  - Added support for viewing filesystem-specific disk activity over time.

- **Bug Fixes**
  - Disk metrics now display the correct icons and colors, including composite metric keys.
  - Preserved the existing aggregate disk usage display when filesystem-specific data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->