### PR TITLE
feat: add controlled native incident rollout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,6 +169,15 @@ LEGAL_PRIVACY_VERSION=2026-02-08
 MONEAT_LICENSE_KEY=
 
 # ----------------------------------------------------------------------------
+# Feature Flags
+# Selects which feature-flag environment this deployment evaluates flags against
+# (staged rollouts such as native incident response are targeted by organization
+# and environment). Optional; defaults to "production". Each deployment must set
+# this to the environment its flag rules are configured for, e.g. "staging".
+# ----------------------------------------------------------------------------
+MONEAT_FEATURE_FLAG_ENVIRONMENT=production
+
+# ----------------------------------------------------------------------------
 # SSO (OIDC)
 # OpenID Connect single sign-on. Works with any OIDC provider (Authentik,
 # Authelia, Keycloak, Okta, Azure AD, etc.). No license key required.

--- a/ESSENTIAL_ENV_VARS.md
+++ b/ESSENTIAL_ENV_VARS.md
@@ -76,6 +76,7 @@ These variables are optional. Ingestion queues use Redis Streams by default.
 | `INGESTION_<PIPELINE>_STREAM_MAXLEN` | `250000` | Deprecated compatibility alias for that pipeline's admission capacity. Primary streams are no longer trimmed. |
 | `INGESTION_<PIPELINE>_DLQ_STREAM_MAXLEN` | `10000` | Approximate maximum length for the DLQ stream. |
 | `GOOGLE_ADS_API_VERSION` | `v24` | Google Ads API version used by the connector client. |
+| `MONEAT_FEATURE_FLAG_ENVIRONMENT` | `production` | Feature-flag environment this deployment evaluates flags against. Optional. Each deployment must set it to the environment its staged rollout rules (such as native incident response) are configured for; a mismatch resolves flags in the wrong environment. |
 
 Redis Streams are the durable ingestion buffer. Run Redis with persistence and HA appropriate for production, and
 alert on pending entries, oldest pending age, and DLQ growth.

--- a/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/FeatureFlagsModule.kt
+++ b/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/FeatureFlagsModule.kt
@@ -17,19 +17,24 @@
 package com.moneat.featureflags
 
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.enterprise.NativeIncidentRolloutBridge
 import com.moneat.featureflags.routes.featureFlagRoutes
 import com.moneat.featureflags.services.FeatureFlagEvaluator
 import com.moneat.featureflags.services.FeatureFlagEventService
+import com.moneat.featureflags.services.FeatureFlagNativeIncidentRolloutBridge
 import com.moneat.featureflags.services.FeatureFlagService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
 
-class FeatureFlagsModule : EnterpriseModule {
+class FeatureFlagsModule :
+    EnterpriseModule,
+    NativeIncidentRolloutBridge {
     override val name: String = "Feature Flags"
 
     private val featureFlagService = FeatureFlagService()
     private val evaluator = FeatureFlagEvaluator()
     private val eventService = FeatureFlagEventService()
+    private val nativeIncidentRolloutBridge = FeatureFlagNativeIncidentRolloutBridge(featureFlagService, evaluator)
 
     override fun registerRoutes(route: Route) {
         route.featureFlagRoutes(
@@ -42,4 +47,7 @@ class FeatureFlagsModule : EnterpriseModule {
     override fun startBackgroundJobs(application: Application) = Unit
 
     override fun stopBackgroundJobs() = Unit
+
+    override fun status(organizationId: Int, environment: String) =
+        nativeIncidentRolloutBridge.status(organizationId, environment)
 }

--- a/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/FeatureFlagsModule.kt
+++ b/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/FeatureFlagsModule.kt
@@ -26,15 +26,17 @@ import com.moneat.featureflags.services.FeatureFlagService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
 
-class FeatureFlagsModule :
+class FeatureFlagsModule(
+    private val featureFlagService: FeatureFlagService = FeatureFlagService(),
+    private val evaluator: FeatureFlagEvaluator = FeatureFlagEvaluator(),
+    nativeIncidentRolloutBridge: NativeIncidentRolloutBridge =
+        FeatureFlagNativeIncidentRolloutBridge(featureFlagService, evaluator),
+) :
     EnterpriseModule,
-    NativeIncidentRolloutBridge {
+    NativeIncidentRolloutBridge by nativeIncidentRolloutBridge {
     override val name: String = "Feature Flags"
 
-    private val featureFlagService = FeatureFlagService()
-    private val evaluator = FeatureFlagEvaluator()
     private val eventService = FeatureFlagEventService()
-    private val nativeIncidentRolloutBridge = FeatureFlagNativeIncidentRolloutBridge(featureFlagService, evaluator)
 
     override fun registerRoutes(route: Route) {
         route.featureFlagRoutes(
@@ -47,7 +49,4 @@ class FeatureFlagsModule :
     override fun startBackgroundJobs(application: Application) = Unit
 
     override fun stopBackgroundJobs() = Unit
-
-    override fun status(organizationId: Int, environment: String) =
-        nativeIncidentRolloutBridge.status(organizationId, environment)
 }

--- a/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/routes/FeatureFlagRoutes.kt
+++ b/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/routes/FeatureFlagRoutes.kt
@@ -240,10 +240,12 @@ private fun Route.flagManagementRoutes(
         }
 
         delete {
-            val context = call.requireFeatureFlagAdmin(membershipService) ?: return@delete
-            val flagKey = call.parameters["flagKey"].orEmpty()
-            val deleted = featureFlagService.archiveFlag(context.organizationId, context.userId, flagKey)
-            if (deleted) call.respond(HttpStatusCode.NoContent) else call.respondNotFound(FEATURE_FLAG_NOT_FOUND)
+            call.respondHandlingBadRequest {
+                val context = call.requireFeatureFlagAdmin(membershipService) ?: return@respondHandlingBadRequest
+                val flagKey = call.parameters["flagKey"].orEmpty()
+                val deleted = featureFlagService.archiveFlag(context.organizationId, context.userId, flagKey)
+                if (deleted) call.respond(HttpStatusCode.NoContent) else call.respondNotFound(FEATURE_FLAG_NOT_FOUND)
+            }
         }
 
         put("/config/{environmentKey}") {

--- a/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagNativeIncidentRolloutBridge.kt
+++ b/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagNativeIncidentRolloutBridge.kt
@@ -1,0 +1,108 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.featureflags.services
+
+import com.moneat.enterprise.NATIVE_INCIDENT_ROLLOUT_FLAG_KEY
+import com.moneat.enterprise.NativeIncidentRolloutBridge
+import com.moneat.enterprise.NativeIncidentRolloutState
+import com.moneat.enterprise.NativeIncidentRolloutStatus
+import com.moneat.featureflags.models.FLAG_KEY_TYPE_SERVER
+import com.moneat.featureflags.models.FeatureFlagSnapshotFlag
+import com.moneat.featureflags.models.FeatureFlagValueType
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import java.util.concurrent.ConcurrentHashMap
+import java.util.logging.Level
+import java.util.logging.Logger
+
+private val logger = Logger.getLogger(FeatureFlagNativeIncidentRolloutBridge::class.java.name)
+private const val DISABLED_VARIANT_KEY = "disabled"
+private const val ENABLED_VARIANT_KEY = "enabled"
+private val emptyTargetingRules = JsonObject(mapOf("rules" to JsonArray(emptyList())))
+
+class FeatureFlagNativeIncidentRolloutBridge(
+    private val featureFlagService: FeatureFlagService,
+    private val evaluator: FeatureFlagEvaluator,
+) : NativeIncidentRolloutBridge {
+    private val provisionedOrganizations = ConcurrentHashMap<Int, Boolean>()
+
+    override fun status(organizationId: Int, environment: String): NativeIncidentRolloutStatus =
+        runCatching {
+            provisionedOrganizations.computeIfAbsent(organizationId) {
+                featureFlagService.ensureNativeIncidentRolloutFlag(organizationId)
+                true
+            }
+            val snapshot =
+                featureFlagService.getSnapshot(organizationId, environment)
+                    ?: return disabled(environment, NativeIncidentRolloutState.ENVIRONMENT_NOT_FOUND)
+            val flag = snapshot.flags.singleOrNull { it.key == NATIVE_INCIDENT_ROLLOUT_FLAG_KEY }
+            if (flag == null) {
+                return disabled(environment, NativeIncidentRolloutState.FLAG_NOT_FOUND)
+            }
+            if (!isCanonicalReservedFlag(flag)) {
+                return disabled(environment, NativeIncidentRolloutState.EVALUATION_ERROR)
+            }
+            val response =
+                evaluator.evaluate(
+                    snapshot = snapshot,
+                    flagKey = NATIVE_INCIDENT_ROLLOUT_FLAG_KEY,
+                    context = JsonObject(mapOf("targetingKey" to JsonPrimitive(organizationId))),
+                    expectedType = FeatureFlagValueType.BOOLEAN,
+                    keyType = FLAG_KEY_TYPE_SERVER,
+                )
+            if (response.errorCode != null) {
+                return disabled(environment, NativeIncidentRolloutState.EVALUATION_ERROR)
+            }
+            val enabled = (response.value as? JsonPrimitive)?.booleanOrNull == true
+            NativeIncidentRolloutStatus(
+                enabled = enabled,
+                environment = environment,
+                state = if (enabled) {
+                    NativeIncidentRolloutState.ENABLED
+                } else {
+                    NativeIncidentRolloutState.DISABLED
+                },
+            )
+        }.getOrElse { error ->
+            logger.log(
+                Level.SEVERE,
+                "Native incident rollout evaluation failed for organization $organizationId in $environment",
+                error,
+            )
+            disabled(environment, NativeIncidentRolloutState.EVALUATION_ERROR)
+        }
+
+    private fun disabled(environment: String, state: NativeIncidentRolloutState) =
+        NativeIncidentRolloutStatus(enabled = false, environment = environment, state = state)
+
+    private fun isCanonicalReservedFlag(flag: FeatureFlagSnapshotFlag): Boolean {
+        val variants =
+            flag.variants.associate { variant ->
+                variant.key to (variant.value as? JsonPrimitive)?.booleanOrNull
+            }
+        return flag.valueType == FeatureFlagValueType.BOOLEAN &&
+            !flag.clientVisible &&
+            flag.config.defaultVariantKey == ENABLED_VARIANT_KEY &&
+            flag.config.offVariantKey == DISABLED_VARIANT_KEY &&
+            flag.config.rules == emptyTargetingRules &&
+            variants.size == 2 &&
+            variants[DISABLED_VARIANT_KEY] == false &&
+            variants[ENABLED_VARIANT_KEY] == true
+    }
+}

--- a/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagService.kt
+++ b/backend/features/featureflags/src/main/kotlin/com/moneat/featureflags/services/FeatureFlagService.kt
@@ -18,6 +18,7 @@ package com.moneat.featureflags.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
+import com.moneat.enterprise.NATIVE_INCIDENT_ROLLOUT_FLAG_KEY
 import com.moneat.featureflags.models.CreateFeatureFlagEnvironmentRequest
 import com.moneat.featureflags.models.CreateFeatureFlagRequest
 import com.moneat.featureflags.models.CreateFeatureFlagSdkKeyResponse
@@ -77,6 +78,7 @@ import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.plus
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
@@ -97,6 +99,10 @@ private const val DEFAULT_ANALYTICS_HOURS = 24
 private const val ANALYTICS_LIMIT = 25
 private const val ETAG_HASH_LENGTH = 24
 private const val DEFAULT_RULES_JSON = """{"rules":[]}"""
+private const val NATIVE_INCIDENT_DISABLED_VARIANT = "disabled"
+private const val NATIVE_INCIDENT_ENABLED_VARIANT = "enabled"
+private val nativeIncidentInitializedAuditJson =
+    "{\"key\":\"$NATIVE_INCIDENT_ROLLOUT_FLAG_KEY\",\"default\":\"disabled\"}"
 private val FEATURE_FLAG_KEY_REGEX = Regex("^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,254}$")
 private val ENVIRONMENT_KEY_REGEX = Regex("^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
@@ -104,7 +110,7 @@ private data class FeatureFlagAuditRecord(
     val organizationId: Int,
     val environmentId: Int?,
     val flagId: Int?,
-    val actorUserId: Int,
+    val actorUserId: Int?,
     val eventType: String,
     val before: String?,
     val after: String?,
@@ -156,13 +162,13 @@ class FeatureFlagService {
                     (FeatureFlags.organizationId eq organizationId) and FeatureFlags.archivedAt.isNull()
                 }
                 .forEach { flagRow ->
-                    val defaultVariant = firstVariantKey(flagRow[FeatureFlags.id])
+                    val (defaultVariant, offVariant) = initialConfigVariantKeys(flagRow)
                     FeatureFlagEnvironmentConfigs.insert {
                         it[flagId] = flagRow[FeatureFlags.id]
                         it[environmentId] = id
                         it[enabled] = false
                         it[defaultVariantKey] = defaultVariant
-                        it[offVariantKey] = defaultVariant
+                        it[offVariantKey] = offVariant
                         it[rulesJson] = DEFAULT_RULES_JSON
                         it[version] = 1
                         it[updatedBy] = actorUserId
@@ -212,6 +218,7 @@ class FeatureFlagService {
         actorUserId: Int,
         request: CreateFeatureFlagRequest,
     ): FeatureFlagResponse {
+        requireUserManagedFlagKey(request.key)
         validateFlagKey(request.key)
         val variantKeys = validateVariantSet(request.valueType, request.variants)
         val defaultVariant = request.defaultVariantKey ?: request.variants.first().key
@@ -295,6 +302,7 @@ class FeatureFlagService {
         flagKey: String,
         request: UpdateFeatureFlagRequest,
     ): FeatureFlagResponse? {
+        requireUserManagedFlagKey(flagKey)
         val now = Clock.System.now()
         val environmentKeys = mutableListOf<String>()
         return transaction {
@@ -344,6 +352,7 @@ class FeatureFlagService {
     }
 
     fun archiveFlag(organizationId: Int, actorUserId: Int, flagKey: String): Boolean {
+        requireUserManagedFlagKey(flagKey)
         val now = Clock.System.now()
         val environmentKeys = mutableListOf<String>()
         val archived = transaction {
@@ -382,6 +391,7 @@ class FeatureFlagService {
         environmentKey: String,
         request: UpdateFeatureFlagConfigRequest,
     ): FeatureFlagConfigResponse? {
+        validateSystemFlagConfig(flagKey, request)
         val now = Clock.System.now()
         val response = transaction {
             val flagRow = findFlagRow(organizationId, flagKey) ?: return@transaction null
@@ -713,6 +723,70 @@ class FeatureFlagService {
         return snapshot
     }
 
+    /**
+     * Lazily provisions the reserved native incident rollout flag for organizations created after V176.
+     * Existing reserved flags are never rewritten; malformed or archived definitions therefore fail closed.
+     */
+    fun ensureNativeIncidentRolloutFlag(organizationId: Int) {
+        val environmentsToInvalidate = mutableSetOf<String>()
+        transaction {
+            val environments = ensureDefaultEnvironmentsInTransaction(organizationId)
+            val existing =
+                FeatureFlags
+                    .selectAll()
+                    .where {
+                        (FeatureFlags.organizationId eq organizationId) and
+                            (FeatureFlags.key eq NATIVE_INCIDENT_ROLLOUT_FLAG_KEY)
+                    }.singleOrNull()
+            if (existing != null) {
+                if (existing[FeatureFlags.archivedAt] != null ||
+                    existing[FeatureFlags.valueType] != FeatureFlagValueType.BOOLEAN.name
+                ) {
+                    return@transaction
+                }
+                ensureNativeIncidentConfigs(existing[FeatureFlags.id], environments, environmentsToInvalidate)
+                return@transaction
+            }
+
+            val now = Clock.System.now()
+            val inserted = insertNativeIncidentFlagIfAbsent(organizationId, now)
+            val flagRow =
+                checkNotNull(
+                    FeatureFlags
+                        .selectAll()
+                        .where {
+                            (FeatureFlags.organizationId eq organizationId) and
+                                (FeatureFlags.key eq NATIVE_INCIDENT_ROLLOUT_FLAG_KEY)
+                        }.singleOrNull(),
+                ) { "Native incident rollout flag disappeared after initialization" }
+            if (flagRow[FeatureFlags.archivedAt] != null ||
+                flagRow[FeatureFlags.valueType] != FeatureFlagValueType.BOOLEAN.name
+            ) {
+                return@transaction
+            }
+            val flagId = flagRow[FeatureFlags.id]
+            if (inserted) {
+                replaceVariants(flagId, nativeIncidentVariants(), now)
+            }
+            ensureNativeIncidentConfigs(flagId, environments, environmentsToInvalidate)
+            if (inserted) {
+                audit(
+                    FeatureFlagAuditRecord(
+                        organizationId = organizationId,
+                        environmentId = null,
+                        flagId = flagId,
+                        actorUserId = null,
+                        eventType = "system_flag.initialized",
+                        before = null,
+                        after = nativeIncidentInitializedAuditJson,
+                        now = now,
+                    ),
+                )
+            }
+        }
+        environmentsToInvalidate.forEach { environment -> invalidateEnvironment(organizationId, environment) }
+    }
+
     fun listAuditEvents(organizationId: Int, limit: Int = ANALYTICS_LIMIT): List<FeatureFlagAuditEventResponse> {
         return transaction {
             val rows = FeatureFlagAuditEvents
@@ -958,6 +1032,93 @@ class FeatureFlagService {
                 it[createdAt] = now
                 it[updatedAt] = now
             }
+        }
+    }
+
+    private fun ensureNativeIncidentConfigs(
+        flagId: Int,
+        environments: List<ResultRow>,
+        environmentsToInvalidate: MutableSet<String>,
+    ) {
+        val now = Clock.System.now()
+        environments.forEach { environment ->
+            val environmentId = environment[FeatureFlagEnvironments.id]
+            if (findConfigRow(flagId, environmentId) == null) {
+                val insert = FeatureFlagEnvironmentConfigs.insertIgnore {
+                    it[FeatureFlagEnvironmentConfigs.flagId] = flagId
+                    it[FeatureFlagEnvironmentConfigs.environmentId] = environmentId
+                    it[enabled] = false
+                    it[defaultVariantKey] = NATIVE_INCIDENT_ENABLED_VARIANT
+                    it[offVariantKey] = NATIVE_INCIDENT_DISABLED_VARIANT
+                    it[rulesJson] = DEFAULT_RULES_JSON
+                    it[version] = 1
+                    it[updatedBy] = null
+                    it[createdAt] = now
+                    it[updatedAt] = now
+                }
+                if (insert.insertedCount > 0) {
+                    incrementEnvironmentVersionInTransaction(environmentId, now)
+                    environmentsToInvalidate += environment[FeatureFlagEnvironments.key]
+                }
+            }
+        }
+    }
+
+    private fun insertNativeIncidentFlagIfAbsent(organizationId: Int, now: Instant): Boolean =
+        FeatureFlags
+            .insertIgnore {
+                it[FeatureFlags.organizationId] = organizationId
+                it[key] = NATIVE_INCIDENT_ROLLOUT_FLAG_KEY
+                it[name] = "Native incident response"
+                it[description] =
+                    "Controls native incident response independently of external incident-provider passthrough."
+                it[valueType] = FeatureFlagValueType.BOOLEAN.name
+                it[clientVisible] = false
+                it[tags] = json.encodeToString(listOf("system", "incident-response", "rollout"))
+                it[createdBy] = null
+                it[createdAt] = now
+                it[updatedAt] = now
+            }
+            .insertedCount > 0
+
+    private fun initialConfigVariantKeys(flagRow: ResultRow): Pair<String?, String?> =
+        if (flagRow[FeatureFlags.key] == NATIVE_INCIDENT_ROLLOUT_FLAG_KEY) {
+            NATIVE_INCIDENT_ENABLED_VARIANT to NATIVE_INCIDENT_DISABLED_VARIANT
+        } else {
+            val firstVariant = firstVariantKey(flagRow[FeatureFlags.id])
+            firstVariant to firstVariant
+        }
+
+    private fun nativeIncidentVariants(): List<FeatureFlagVariantRequest> =
+        listOf(
+            FeatureFlagVariantRequest(
+                key = NATIVE_INCIDENT_DISABLED_VARIANT,
+                name = "Disabled",
+                value = JsonPrimitive(false),
+            ),
+            FeatureFlagVariantRequest(
+                key = NATIVE_INCIDENT_ENABLED_VARIANT,
+                name = "Enabled",
+                value = JsonPrimitive(true),
+            ),
+        )
+
+    private fun requireUserManagedFlagKey(flagKey: String) {
+        require(flagKey != NATIVE_INCIDENT_ROLLOUT_FLAG_KEY) {
+            "The native incident rollout flag is system managed; update its environment config instead"
+        }
+    }
+
+    private fun validateSystemFlagConfig(flagKey: String, request: UpdateFeatureFlagConfigRequest) {
+        if (flagKey != NATIVE_INCIDENT_ROLLOUT_FLAG_KEY) return
+        require(request.defaultVariantKey == null || request.defaultVariantKey == NATIVE_INCIDENT_ENABLED_VARIANT) {
+            "The native incident rollout default variant must remain enabled"
+        }
+        require(request.offVariantKey == null || request.offVariantKey == NATIVE_INCIDENT_DISABLED_VARIANT) {
+            "The native incident rollout off variant must remain disabled"
+        }
+        require(request.rules == null || request.rules == parseElement(DEFAULT_RULES_JSON)) {
+            "The native incident rollout flag does not support targeting rules"
         }
     }
 

--- a/backend/features/featureflags/src/test/kotlin/com/moneat/featureflags/FeatureFlagServiceTest.kt
+++ b/backend/features/featureflags/src/test/kotlin/com/moneat/featureflags/FeatureFlagServiceTest.kt
@@ -17,6 +17,8 @@
 package com.moneat.featureflags
 
 import com.moneat.config.ClickHouseClient
+import com.moneat.enterprise.NATIVE_INCIDENT_ROLLOUT_FLAG_KEY
+import com.moneat.enterprise.NativeIncidentRolloutState
 import com.moneat.featureflags.models.CreateFeatureFlagEnvironmentRequest
 import com.moneat.featureflags.models.CreateFeatureFlagRequest
 import com.moneat.featureflags.models.FeatureFlagAuditEvents
@@ -33,6 +35,8 @@ import com.moneat.featureflags.models.FeatureFlags
 import com.moneat.featureflags.models.UpdateFeatureFlagConfigRequest
 import com.moneat.featureflags.models.UpdateFeatureFlagRequest
 import com.moneat.featureflags.services.FeatureFlagService
+import com.moneat.featureflags.services.FeatureFlagEvaluator
+import com.moneat.featureflags.services.FeatureFlagNativeIncidentRolloutBridge
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Users
 import com.moneat.testsupport.TestDatabaseHelper
@@ -43,11 +47,13 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -74,7 +80,9 @@ class FeatureFlagServiceTest {
     fun setupDatabase() {
         if (db == null) {
             db = Database.connect(
-                url = "jdbc:h2:mem:moneat_feature_flag_service;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                url =
+                "jdbc:h2:mem:moneat_feature_flag_service;MODE=MYSQL;" +
+                    "DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
                 driver = "org.h2.Driver"
             )
         }
@@ -93,6 +101,98 @@ class FeatureFlagServiceTest {
         createSchema()
         seedActor()
         service = FeatureFlagService()
+    }
+
+    @Test
+    fun `native incident rollout flag is provisioned disabled and only its config is mutable`() {
+        service.ensureNativeIncidentRolloutFlag(SERVICE_TEST_ORG_ID)
+
+        val flag = service.getFlag(SERVICE_TEST_ORG_ID, NATIVE_INCIDENT_ROLLOUT_FLAG_KEY)
+        assertNotNull(flag)
+        assertEquals(FeatureFlagValueType.BOOLEAN, flag.valueType)
+        assertFalse(flag.clientVisible)
+        assertEquals(listOf("disabled", "enabled"), flag.variants.map { it.key })
+        assertTrue(flag.configs.all { !it.enabled })
+        assertTrue(flag.configs.all { it.defaultVariantKey == "enabled" })
+        assertTrue(flag.configs.all { it.offVariantKey == "disabled" })
+        assertEquals("system_flag.initialized", service.listAuditEvents(SERVICE_TEST_ORG_ID).single().eventType)
+
+        val enabled =
+            service.updateConfig(
+                organizationId = SERVICE_TEST_ORG_ID,
+                actorUserId = SERVICE_TEST_USER_ID,
+                flagKey = NATIVE_INCIDENT_ROLLOUT_FLAG_KEY,
+                environmentKey = "production",
+                request = UpdateFeatureFlagConfigRequest(enabled = true),
+            )
+        assertNotNull(enabled)
+        assertTrue(enabled.enabled)
+
+        assertFailsWith<IllegalArgumentException> {
+            service.updateFlag(
+                SERVICE_TEST_ORG_ID,
+                SERVICE_TEST_USER_ID,
+                NATIVE_INCIDENT_ROLLOUT_FLAG_KEY,
+                UpdateFeatureFlagRequest(name = "Unsafe rewrite"),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.archiveFlag(
+                SERVICE_TEST_ORG_ID,
+                SERVICE_TEST_USER_ID,
+                NATIVE_INCIDENT_ROLLOUT_FLAG_KEY,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.updateConfig(
+                organizationId = SERVICE_TEST_ORG_ID,
+                actorUserId = SERVICE_TEST_USER_ID,
+                flagKey = NATIVE_INCIDENT_ROLLOUT_FLAG_KEY,
+                environmentKey = "production",
+                request = UpdateFeatureFlagConfigRequest(offVariantKey = "enabled"),
+            )
+        }
+    }
+
+    @Test
+    fun `native incident rollout bridge evaluates independently by environment`() {
+        val bridge = FeatureFlagNativeIncidentRolloutBridge(service, FeatureFlagEvaluator())
+
+        val initialProduction = bridge.status(SERVICE_TEST_ORG_ID, "production")
+        assertFalse(initialProduction.enabled)
+        assertEquals(NativeIncidentRolloutState.DISABLED, initialProduction.state)
+
+        service.updateConfig(
+            organizationId = SERVICE_TEST_ORG_ID,
+            actorUserId = SERVICE_TEST_USER_ID,
+            flagKey = NATIVE_INCIDENT_ROLLOUT_FLAG_KEY,
+            environmentKey = "production",
+            request = UpdateFeatureFlagConfigRequest(enabled = true),
+        )
+
+        val production = bridge.status(SERVICE_TEST_ORG_ID, "production")
+        val staging = bridge.status(SERVICE_TEST_ORG_ID, "staging")
+        assertTrue(production.enabled)
+        assertEquals(NativeIncidentRolloutState.ENABLED, production.state)
+        assertFalse(staging.enabled)
+        assertEquals(NativeIncidentRolloutState.DISABLED, staging.state)
+    }
+
+    @Test
+    fun `native incident rollout bridge fails closed for a tampered reserved variant`() {
+        service.ensureNativeIncidentRolloutFlag(SERVICE_TEST_ORG_ID)
+        transaction {
+            FeatureFlagVariants.update({ FeatureFlagVariants.key eq "disabled" }) {
+                it[valueJson] = "true"
+            }
+        }
+
+        val status =
+            FeatureFlagNativeIncidentRolloutBridge(service, FeatureFlagEvaluator())
+                .status(SERVICE_TEST_ORG_ID, "production")
+
+        assertFalse(status.enabled)
+        assertEquals(NativeIncidentRolloutState.EVALUATION_ERROR, status.state)
     }
 
     @Test

--- a/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/SummaryTool.kt
+++ b/backend/features/mcp/src/main/kotlin/com/moneat/mcp/tools/SummaryTool.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.mcp.tools
 
+import com.moneat.enterprise.FeatureRegistry
 import com.moneat.mcp.models.McpContext
 import com.moneat.mcp.protocol.InputSchema
 import com.moneat.mcp.protocol.McpTool
@@ -128,7 +129,9 @@ class GetWeeklyReportTool : McpTool {
     }
 }
 
-class GetIncidentContextTool : McpTool {
+class GetIncidentContextTool(
+    private val nativeIncidentEntitlement: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEnabled,
+) : McpTool {
     override val name = "get_incident_context"
     override val description =
         "Get correlated context for an incident " +
@@ -146,6 +149,10 @@ class GetIncidentContextTool : McpTool {
         args: JsonObject,
         context: McpContext
     ): ToolCallResult {
+        if (!nativeIncidentEntitlement(context.organizationId)) {
+            FeatureRegistry.recordNativeIncidentRolloutDecision("ai", "denied")
+            return errorResult("Native incident response is not enabled for this organization")
+        }
         val incidentId = args["incident_id"]?.jsonPrimitive
             ?.content
             ?.toUuidOrNull()

--- a/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/SummaryToolTest.kt
+++ b/backend/features/mcp/src/test/kotlin/com/moneat/mcp/tools/SummaryToolTest.kt
@@ -1,0 +1,49 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.mcp.tools
+
+import com.moneat.mcp.models.McpContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SummaryToolTest {
+    @Test
+    fun `incident context fails closed when native incident response is disabled`() = runBlocking {
+        val tool = GetIncidentContextTool(nativeIncidentEntitlement = { false })
+        val context =
+            McpContext(
+                organizationId = 42,
+                userId = 7,
+                tokenId = 3,
+                scopes = emptySet(),
+                sessionId = "test-session",
+            )
+
+        val result =
+            tool.execute(
+                JsonObject(mapOf("incident_id" to JsonPrimitive("11111111-1111-4111-8111-111111111111"))),
+                context,
+            )
+
+        assertTrue(result.isError)
+        assertEquals("Native incident response is not enabled for this organization", result.content.single().text)
+    }
+}

--- a/backend/features/workflows/src/test/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutorTest.kt
+++ b/backend/features/workflows/src/test/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutorTest.kt
@@ -144,7 +144,8 @@ class WorkflowTrustedActionExecutorTest {
                 dashboardService = dashboardService,
                 monitorService = monitorService,
                 monitorAlertServiceProvider = { monitorAlertService },
-                statusPageService = statusPageService
+                statusPageService = statusPageService,
+                nativeIncidentEntitlement = { true },
             )
     }
 
@@ -393,6 +394,38 @@ class WorkflowTrustedActionExecutorTest {
             )
 
         assertEquals(true, result["requires_enterprise"]?.jsonPrimitive?.content?.toBoolean())
+    }
+
+    @Test
+    fun `on-call incident declaration fails closed before invoking enterprise bridge`() {
+        val bridge = mockk<OnCallBridge>()
+        val disabledExecutor =
+            WorkflowTrustedActionExecutor(
+                logService = logService,
+                dashboardService = dashboardService,
+                monitorService = monitorService,
+                monitorAlertServiceProvider = { monitorAlertService },
+                statusPageService = statusPageService,
+                nativeIncidentEntitlement = { false },
+            )
+        mockkObject(FeatureRegistry)
+        try {
+            every { FeatureRegistry.getOnCallBridge() } returns bridge
+
+            assertFailsWith<IllegalStateException> {
+                runBlocking {
+                    disabledExecutor.execute(
+                        orgId,
+                        WorkflowTrustedActionExecutor.ON_CALL_DECLARE_INCIDENT_STEP,
+                        mapOf("title" to "Checkout outage", "incident_severity" to "SEV-1"),
+                        actorUserId = 99,
+                    )
+                }
+            }
+            coVerify(exactly = 0) { bridge.declareIncident(any()) }
+        } finally {
+            unmockkObject(FeatureRegistry)
+        }
     }
 
     @Test

--- a/backend/src/main/kotlin/com/moneat/config/EnvConfig.kt
+++ b/backend/src/main/kotlin/com/moneat/config/EnvConfig.kt
@@ -82,6 +82,11 @@ object EnvConfig {
             get() = get("SELF_HOSTED", "false").toBoolean()
     }
 
+    object FeatureFlags {
+        val environment: String
+            get() = get("MONEAT_FEATURE_FLAG_ENVIRONMENT", "production").trim().ifBlank { "production" }
+    }
+
     // Demo mode configuration
     object Demo {
         val enabled: Boolean

--- a/backend/src/main/kotlin/com/moneat/enterprise/FeatureRegistry.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/FeatureRegistry.kt
@@ -20,6 +20,7 @@ import com.moneat.authz.PermissionBridge
 import com.moneat.config.EnvConfig
 import com.moneat.enterprise.license.LicenseInfo
 import com.moneat.enterprise.license.LicenseValidator
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.workflows.WorkflowApprovalBridge
 import com.moneat.workflows.WorkflowConnectionVault
 import com.moneat.workflows.WorkflowPremiumConnectorBridge
@@ -185,6 +186,42 @@ object FeatureRegistry {
         return modules.filterIsInstance<DetectionSignalEvidenceBridge>().firstOrNull()
     }
 
+    /** Resolve the native incident rollout for an organization. Missing dependencies fail closed. */
+    fun nativeIncidentRolloutStatus(organizationId: Int): NativeIncidentRolloutStatus {
+        val environment = EnvConfig.FeatureFlags.environment
+        if (!hasModule(ON_CALL_MODULE_NAME)) {
+            return NativeIncidentRolloutStatus(
+                enabled = false,
+                environment = environment,
+                state = NativeIncidentRolloutState.MODULE_UNAVAILABLE,
+            )
+        }
+        val bridge = modules.filterIsInstance<NativeIncidentRolloutBridge>().firstOrNull()
+            ?: return NativeIncidentRolloutStatus(
+                enabled = false,
+                environment = environment,
+                state = NativeIncidentRolloutState.PROVIDER_UNAVAILABLE,
+            )
+        return suspendRunCatching { bridge.status(organizationId, environment) }
+            .getOrElse { error ->
+                logger.error(error) {
+                    "Native incident rollout provider failed for organization $organizationId in $environment"
+                }
+                NativeIncidentRolloutStatus(
+                    enabled = false,
+                    environment = environment,
+                    state = NativeIncidentRolloutState.EVALUATION_ERROR,
+                )
+            }
+    }
+
+    fun isNativeIncidentResponseEnabled(organizationId: Int): Boolean =
+        nativeIncidentRolloutStatus(organizationId).enabled
+
+    fun recordNativeIncidentRolloutDecision(surface: String, outcome: String) {
+        OperationalMetrics.recordNativeIncidentRolloutDecision(surface, outcome)
+    }
+
     fun resolveIngestionRateLimitKey(rateLimitName: String, call: ApplicationCall): String? =
         modules
             .filterIsInstance<IngestionRateLimitKeyResolver>()
@@ -217,4 +254,6 @@ object FeatureRegistry {
         license = null
         initialized = false
     }
+
+    private const val ON_CALL_MODULE_NAME = "On-Call"
 }

--- a/backend/src/main/kotlin/com/moneat/enterprise/NativeIncidentRollout.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/NativeIncidentRollout.kt
@@ -38,6 +38,6 @@ data class NativeIncidentRolloutStatus(
  * Runtime bridge implemented by the open-source feature flag module.
  * Native incident consumers use this instead of depending on feature flag persistence directly.
  */
-interface NativeIncidentRolloutBridge {
+fun interface NativeIncidentRolloutBridge {
     fun status(organizationId: Int, environment: String): NativeIncidentRolloutStatus
 }

--- a/backend/src/main/kotlin/com/moneat/enterprise/NativeIncidentRollout.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/NativeIncidentRollout.kt
@@ -1,0 +1,43 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.enterprise
+
+const val NATIVE_INCIDENT_ROLLOUT_FLAG_KEY = "moneat.system.native-incident-response"
+
+enum class NativeIncidentRolloutState {
+    ENABLED,
+    DISABLED,
+    ENVIRONMENT_NOT_FOUND,
+    FLAG_NOT_FOUND,
+    EVALUATION_ERROR,
+    PROVIDER_UNAVAILABLE,
+    MODULE_UNAVAILABLE,
+}
+
+data class NativeIncidentRolloutStatus(
+    val enabled: Boolean,
+    val environment: String,
+    val state: NativeIncidentRolloutState,
+)
+
+/**
+ * Runtime bridge implemented by the open-source feature flag module.
+ * Native incident consumers use this instead of depending on feature flag persistence directly.
+ */
+interface NativeIncidentRolloutBridge {
+    fun status(organizationId: Int, environment: String): NativeIncidentRolloutStatus
+}

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -495,6 +495,17 @@ object OperationalMetrics {
         ).increment()
     }
 
+    fun recordNativeIncidentRolloutDecision(surface: String, outcome: String) {
+        counter(
+            NATIVE_INCIDENT_ROLLOUT_DECISIONS,
+            "Native incident operations gated by rollout state, grouped by surface and outcome.",
+            tags(
+                "surface" to surface,
+                "outcome" to outcome,
+            ),
+        ).increment()
+    }
+
     fun scrape(): String = registry.scrape()
 
     fun resetForTest() {
@@ -937,6 +948,7 @@ object OperationalMetrics {
     private const val WORKFLOW_EXECUTIONS = "moneat_workflow_executions"
     private const val WORKFLOW_EXECUTION_DURATION = "moneat_workflow_execution_duration"
     private const val WORKFLOW_RATE_LIMITED = "moneat_workflow_rate_limited"
+    private const val NATIVE_INCIDENT_ROLLOUT_DECISIONS = "moneat_native_incident_rollout_decisions"
     private const val NANOS_PER_SECOND = 1_000_000_000
     private const val MILLIS_PER_SECOND = 1_000
     private const val HEALTHY_VALUE = 1L

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowTrustedActionExecutor.kt
@@ -29,6 +29,7 @@ import com.moneat.monitor.repositories.HostAlertRepositoryImpl
 import com.moneat.monitor.repositories.HostRepositoryImpl
 import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.monitor.services.MonitorService
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.shared.models.Hosts
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Projects
@@ -72,7 +73,8 @@ class WorkflowTrustedActionExecutor(
     private val dashboardService: DashboardService = DashboardService.create(),
     private val monitorService: MonitorService = MonitorService(HostRepositoryImpl(), HostAlertRepositoryImpl()),
     private val monitorAlertServiceProvider: () -> MonitorAlertService = { MonitorAlertService() },
-    private val statusPageService: StatusPageService = StatusPageService()
+    private val statusPageService: StatusPageService = StatusPageService(),
+    private val nativeIncidentEntitlement: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEnabled,
 ) {
     private val json = workflowJson
 
@@ -310,6 +312,10 @@ class WorkflowTrustedActionExecutor(
         actorUserId: Int?,
         idempotencyKey: String?,
     ): Map<String, JsonElement> {
+        if (!nativeIncidentEntitlement(organizationId)) {
+            OperationalMetrics.recordNativeIncidentRolloutDecision("workflow", "denied")
+            throw IllegalStateException("Native incident response is not enabled for this organization")
+        }
         val bridge = FeatureRegistry.getOnCallBridge()
             ?: return mapOf(
                 "requires_enterprise" to JsonPrimitive(true),

--- a/backend/src/main/resources/db/migration/V157__native_incident_rollout_flag.sql
+++ b/backend/src/main/resources/db/migration/V157__native_incident_rollout_flag.sql
@@ -1,0 +1,85 @@
+INSERT INTO feature_flag_environments (organization_id, key, name)
+SELECT o.id, defaults.key, defaults.name
+FROM organizations o
+CROSS JOIN (
+    VALUES
+        ('production', 'Production'),
+        ('staging', 'Staging'),
+        ('development', 'Development')
+) AS defaults(key, name)
+ON CONFLICT (organization_id, key) DO NOTHING;
+
+INSERT INTO feature_flags (
+    organization_id,
+    key,
+    name,
+    description,
+    value_type,
+    client_visible,
+    tags
+)
+SELECT
+    o.id,
+    'moneat.system.native-incident-response',
+    'Native incident response',
+    'Controls native incident response independently of external incident-provider passthrough.',
+    'BOOLEAN',
+    FALSE,
+    '["system","incident-response","rollout"]'::jsonb
+FROM organizations o
+ON CONFLICT (organization_id, key) DO NOTHING;
+
+INSERT INTO feature_flag_variants (flag_id, key, name, value_json, sort_order)
+SELECT f.id, variants.key, variants.name, variants.value_json, variants.sort_order
+FROM feature_flags f
+CROSS JOIN (
+    VALUES
+        ('disabled', 'Disabled', 'false'::jsonb, 0),
+        ('enabled', 'Enabled', 'true'::jsonb, 1)
+) AS variants(key, name, value_json, sort_order)
+WHERE f.key = 'moneat.system.native-incident-response'
+  AND f.value_type = 'BOOLEAN'
+ON CONFLICT (flag_id, key) DO NOTHING;
+
+INSERT INTO feature_flag_environment_configs (
+    flag_id,
+    environment_id,
+    enabled,
+    default_variant_key,
+    off_variant_key,
+    rules_json
+)
+SELECT
+    f.id,
+    e.id,
+    FALSE,
+    'enabled',
+    'disabled',
+    '{"rules":[]}'::jsonb
+FROM feature_flags f
+JOIN feature_flag_environments e ON e.organization_id = f.organization_id
+WHERE f.key = 'moneat.system.native-incident-response'
+  AND f.value_type = 'BOOLEAN'
+ON CONFLICT (flag_id, environment_id) DO NOTHING;
+
+INSERT INTO feature_flag_audit_events (
+    organization_id,
+    flag_id,
+    event_type,
+    after_json
+)
+SELECT
+    f.organization_id,
+    f.id,
+    'system_flag.initialized',
+    '{"key":"moneat.system.native-incident-response","default":"disabled"}'::jsonb
+FROM feature_flags f
+WHERE f.key = 'moneat.system.native-incident-response'
+  AND f.value_type = 'BOOLEAN'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM feature_flag_audit_events a
+      WHERE a.organization_id = f.organization_id
+        AND a.flag_id = f.id
+        AND a.event_type = 'system_flag.initialized'
+  );

--- a/backend/src/test/kotlin/com/moneat/enterprise/FeatureRegistryNativeIncidentRolloutTest.kt
+++ b/backend/src/test/kotlin/com/moneat/enterprise/FeatureRegistryNativeIncidentRolloutTest.kt
@@ -1,0 +1,88 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.enterprise
+
+import io.ktor.server.application.Application
+import io.ktor.server.routing.Route
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FeatureRegistryNativeIncidentRolloutTest {
+    @AfterTest
+    fun reset() {
+        FeatureRegistry.resetForTest()
+        System.clearProperty(FEATURE_FLAG_ENVIRONMENT_VARIABLE)
+    }
+
+    @Test
+    fun `native incident rollout fails closed without module or provider`() {
+        System.setProperty(FEATURE_FLAG_ENVIRONMENT_VARIABLE, "staging")
+
+        val noModule = FeatureRegistry.nativeIncidentRolloutStatus(1)
+        assertFalse(noModule.enabled)
+        assertEquals("staging", noModule.environment)
+        assertEquals(NativeIncidentRolloutState.MODULE_UNAVAILABLE, noModule.state)
+
+        FeatureRegistry.registerForTest(TestModule("On-Call"))
+        val noProvider = FeatureRegistry.nativeIncidentRolloutStatus(1)
+        assertFalse(noProvider.enabled)
+        assertEquals(NativeIncidentRolloutState.PROVIDER_UNAVAILABLE, noProvider.state)
+    }
+
+    @Test
+    fun `native incident rollout delegates organization and environment to provider`() {
+        System.setProperty(FEATURE_FLAG_ENVIRONMENT_VARIABLE, "development")
+        val provider = RecordingRolloutModule()
+        FeatureRegistry.registerForTest(TestModule("On-Call"), provider)
+
+        val status = FeatureRegistry.nativeIncidentRolloutStatus(42)
+
+        assertTrue(status.enabled)
+        assertEquals(42 to "development", provider.lastRequest)
+        assertEquals(NativeIncidentRolloutState.ENABLED, status.state)
+    }
+
+    private open class TestModule(override val name: String) : EnterpriseModule {
+        override fun registerRoutes(route: Route) = Unit
+
+        override fun startBackgroundJobs(application: Application) = Unit
+
+        override fun stopBackgroundJobs() = Unit
+    }
+
+    private class RecordingRolloutModule :
+        TestModule("Feature Flags"),
+        NativeIncidentRolloutBridge {
+        var lastRequest: Pair<Int, String>? = null
+
+        override fun status(organizationId: Int, environment: String): NativeIncidentRolloutStatus {
+            lastRequest = organizationId to environment
+            return NativeIncidentRolloutStatus(
+                enabled = true,
+                environment = environment,
+                state = NativeIncidentRolloutState.ENABLED,
+            )
+        }
+    }
+
+    private companion object {
+        const val FEATURE_FLAG_ENVIRONMENT_VARIABLE = "MONEAT_FEATURE_FLAG_ENVIRONMENT"
+    }
+}

--- a/dashboard/src/docs/pages/on-call.mdx
+++ b/dashboard/src/docs/pages/on-call.mdx
@@ -182,6 +182,31 @@ You can filter the timeline by **event type**, **provenance**, and **visibility*
 
 An active incident can be resolved from its detail page, with an optional resolution note. Adding notes and resolving both record events on the timeline.
 
+## Native incident rollout and rollback
+
+Native incident response ships behind a staged rollout so it can be turned on for specific organizations and turned off cleanly if needed. The rollout is controlled entirely from the server.
+
+### Enabling
+
+- The rollout is gated by the reserved, server-only flag key `moneat.system.native-incident-response`. It is not client-visible and is evaluated on the backend.
+- Enable it **by organization and environment** through **Feature Flags**. Each deployment evaluates flags for the environment set in `MONEAT_FEATURE_FLAG_ENVIRONMENT` (default `production`), so target the environment your rules are configured for.
+- Verify the result for the current organization with `GET /v1/on-call/incident-response/capabilities`. It returns `enabled`, the resolved `environment`, and a `state` explaining the decision.
+- Configuration changes are recorded in the existing **feature-flag audit log** — no separate audit trail.
+
+When the rollout is disabled for an organization, the dashboard hides the Incidents and Configuration tabs and the alert **Declare Incident** action. The backend independently rejects native incident routes and commands from every origin, including Slack and workflows, and the `get_incident_context` AI/MCP tool fails closed. The metric `moneat_native_incident_rollout_decisions` records denied and deferred surfaces so you can watch a rollout converge.
+
+### Rolling back
+
+Disabling the flag rolls the feature back without data loss:
+
+- Native incident routes, dashboard surfaces, Slack actions, workflows, and AI tools stop serving native incident operations.
+- Outbox delivery of native incident events is **deferred** rather than dropped — deferral does not consume delivery attempts and never discards events. Re-enabling the flag resumes delivery of the queued events from where it left off.
+- **External incident-provider passthrough is unaffected.** Forwarded provider incidents continue to deliver and synchronize regardless of this rollout.
+
+:::info[Propagation]
+Rollout state is cached per process. Allow up to **30 seconds** for a change to converge across all running processes before expecting the new behavior everywhere.
+:::
+
 ## Notification Channels
 
 Moneat supports multiple notification channels for on-call alerts:

--- a/dashboard/src/hooks/__tests__/useNativeIncidentRollout.test.tsx
+++ b/dashboard/src/hooks/__tests__/useNativeIncidentRollout.test.tsx
@@ -1,0 +1,102 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {renderHook, waitFor} from '@testing-library/react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+
+const {mockApi} = vi.hoisted(() => ({
+  mockApi: {getNativeIncidentCapabilities: vi.fn()},
+}))
+
+vi.mock('@/lib/api', () => ({api: mockApi}))
+
+import {nativeIncidentUnavailableCopy, useNativeIncidentRollout} from '../useNativeIncidentRollout'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false}},
+  })
+  return ({children}: {children: React.ReactNode}) =>
+    React.createElement(QueryClientProvider, {client: queryClient}, children)
+}
+
+describe('useNativeIncidentRollout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports enabled with state and environment when the capability is on', async () => {
+    mockApi.getNativeIncidentCapabilities.mockResolvedValue({
+      enabled: true,
+      environment: 'production',
+      state: 'ENABLED',
+      externalProviderPassthroughAffected: false,
+    })
+
+    const {result} = renderHook(() => useNativeIncidentRollout(), {wrapper: createWrapper()})
+
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+    expect(result.current.state).toBe('ENABLED')
+    expect(result.current.environment).toBe('production')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('reports disabled while preserving the reason state', async () => {
+    mockApi.getNativeIncidentCapabilities.mockResolvedValue({
+      enabled: false,
+      environment: 'production',
+      state: 'DISABLED',
+      externalProviderPassthroughAffected: false,
+    })
+
+    const {result} = renderHook(() => useNativeIncidentRollout(), {wrapper: createWrapper()})
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.enabled).toBe(false)
+    expect(result.current.state).toBe('DISABLED')
+  })
+
+  it('fails closed when the capability request errors', async () => {
+    mockApi.getNativeIncidentCapabilities.mockRejectedValue(new Error('boom'))
+
+    const {result} = renderHook(() => useNativeIncidentRollout(), {wrapper: createWrapper()})
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.enabled).toBe(false)
+  })
+})
+
+describe('nativeIncidentUnavailableCopy', () => {
+  it('invites a retry for transient states and query errors', () => {
+    expect(nativeIncidentUnavailableCopy({state: 'EVALUATION_ERROR', isError: false}).title).toMatch(
+      /temporarily unavailable/i
+    )
+    expect(nativeIncidentUnavailableCopy({state: 'PROVIDER_UNAVAILABLE', isError: false}).title).toMatch(
+      /temporarily unavailable/i
+    )
+    expect(nativeIncidentUnavailableCopy({state: undefined, isError: true}).title).toMatch(
+      /temporarily unavailable/i
+    )
+  })
+
+  it('points at the administrator for a deliberate disable', () => {
+    const copy = nativeIncidentUnavailableCopy({state: 'DISABLED', isError: false})
+    expect(copy.title).toMatch(/not available/i)
+    expect(copy.description).toMatch(/administrator/i)
+  })
+})

--- a/dashboard/src/hooks/__tests__/useNativeIncidentRollout.test.tsx
+++ b/dashboard/src/hooks/__tests__/useNativeIncidentRollout.test.tsx
@@ -20,7 +20,7 @@ import {renderHook, waitFor} from '@testing-library/react'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 
 const {mockApi} = vi.hoisted(() => ({
-  mockApi: {getNativeIncidentCapabilities: vi.fn()},
+  mockApi: {getCurrentUser: vi.fn(), getNativeIncidentCapabilities: vi.fn()},
 }))
 
 vi.mock('@/lib/api', () => ({api: mockApi}))
@@ -38,6 +38,7 @@ function createWrapper() {
 describe('useNativeIncidentRollout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockApi.getCurrentUser.mockResolvedValue({orgId: 'organization-one'})
   })
 
   it('reports enabled with state and environment when the capability is on', async () => {

--- a/dashboard/src/hooks/useNativeIncidentRollout.ts
+++ b/dashboard/src/hooks/useNativeIncidentRollout.ts
@@ -1,0 +1,82 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import {useQuery} from '@tanstack/react-query'
+import {api} from '@/lib/api'
+import type {NativeIncidentCapabilities, NativeIncidentRolloutState} from '@/lib/api/types'
+
+export const NATIVE_INCIDENT_ROLLOUT_QUERY_KEY = ['native-incident-rollout'] as const
+
+export interface NativeIncidentRollout {
+  /** True once the capability has loaded and native incident response is enabled. */
+  readonly enabled: boolean
+  /** True while the capability decision is still being resolved. */
+  readonly isLoading: boolean
+  readonly isError: boolean
+  readonly state?: NativeIncidentRolloutState
+  readonly environment?: string
+  readonly data?: NativeIncidentCapabilities
+}
+
+/**
+ * Whether native incident dashboard surfaces and actions may be shown for the
+ * current organization. The backend independently enforces the rollout; this
+ * hook only gates the UI so disabled organizations never invoke native incident
+ * controls. Callers should hold their own native incident/config queries with
+ * `enabled: rollout.enabled` so nothing fires while loading or disabled.
+ *
+ * The 30s stale window matches the backend's cached rollout convergence window.
+ */
+export function useNativeIncidentRollout(): NativeIncidentRollout {
+  const {data, isLoading, isError} = useQuery({
+    queryKey: NATIVE_INCIDENT_ROLLOUT_QUERY_KEY,
+    queryFn: () => api.getNativeIncidentCapabilities(),
+    staleTime: 30_000,
+  })
+  return {
+    enabled: data?.enabled === true,
+    isLoading,
+    isError,
+    state: data?.state,
+    environment: data?.environment,
+    data,
+  }
+}
+
+/**
+ * Calm, source-neutral copy for the native incident unavailable state. Transient
+ * failures invite a retry; a deliberate disable points at the administrator.
+ */
+export function nativeIncidentUnavailableCopy(
+  rollout: Pick<NativeIncidentRollout, 'state' | 'isError'>
+): {title: string; description: string} {
+  const transient =
+    rollout.isError ||
+    rollout.state === 'EVALUATION_ERROR' ||
+    rollout.state === 'PROVIDER_UNAVAILABLE'
+  if (transient) {
+    return {
+      title: 'Incident response is temporarily unavailable',
+      description:
+        'We could not confirm incident response availability for your organization. This is usually temporary — try again in a moment.',
+    }
+  }
+  return {
+    title: 'Incident response is not available',
+    description:
+      'Native incident response is not enabled for your organization in this environment. Contact your administrator to request access.',
+  }
+}

--- a/dashboard/src/hooks/useNativeIncidentRollout.ts
+++ b/dashboard/src/hooks/useNativeIncidentRollout.ts
@@ -16,9 +16,11 @@
 
 import {useQuery} from '@tanstack/react-query'
 import {api} from '@/lib/api'
+import {API_BASE} from '@/lib/api/client'
 import type {NativeIncidentCapabilities, NativeIncidentRolloutState} from '@/lib/api/types'
 
-export const NATIVE_INCIDENT_ROLLOUT_QUERY_KEY = ['native-incident-rollout'] as const
+export const nativeIncidentRolloutQueryKey = (organizationId: string) =>
+  ['native-incident-rollout', API_BASE, organizationId] as const
 
 export interface NativeIncidentRollout {
   /** True once the capability has loaded and native incident response is enabled. */
@@ -41,18 +43,26 @@ export interface NativeIncidentRollout {
  * The 30s stale window matches the backend's cached rollout convergence window.
  */
 export function useNativeIncidentRollout(): NativeIncidentRollout {
-  const {data, isLoading, isError} = useQuery({
-    queryKey: NATIVE_INCIDENT_ROLLOUT_QUERY_KEY,
+  const currentUser = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: () => api.getCurrentUser(),
+  })
+  const organizationId = currentUser.data?.orgId
+  const capability = useQuery({
+    queryKey: nativeIncidentRolloutQueryKey(organizationId ?? 'unresolved'),
     queryFn: () => api.getNativeIncidentCapabilities(),
+    enabled: organizationId !== undefined && !currentUser.isFetching,
     staleTime: 30_000,
   })
+  const isLoading = currentUser.isLoading || currentUser.isFetching || capability.isLoading
+  const isError = currentUser.isError || capability.isError
   return {
-    enabled: data?.enabled === true,
+    enabled: capability.data?.enabled === true,
     isLoading,
     isError,
-    state: data?.state,
-    environment: data?.environment,
-    data,
+    state: capability.data?.state,
+    environment: capability.data?.environment,
+    data: capability.data,
   }
 }
 

--- a/dashboard/src/lib/api/modules/__tests__/on-call.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/on-call.test.ts
@@ -503,6 +503,73 @@ describe('onCallMethods', () => {
     })
   })
 
+  // ──── Native incident rollout capabilities ────
+
+  describe('getNativeIncidentCapabilities', () => {
+    it('parses an enabled capability payload', async () => {
+      server.use(
+        http.get(`${API_BASE}/on-call/incident-response/capabilities`, () =>
+          HttpResponse.json({
+            enabled: true,
+            environment: 'production',
+            state: 'ENABLED',
+            externalProviderPassthroughAffected: false,
+          })
+        )
+      )
+      const result = await api.getNativeIncidentCapabilities()
+      expect(result).toEqual({
+        enabled: true,
+        environment: 'production',
+        state: 'ENABLED',
+        externalProviderPassthroughAffected: false,
+      })
+    })
+
+    it('preserves reason states while reporting disabled', async () => {
+      server.use(
+        http.get(`${API_BASE}/on-call/incident-response/capabilities`, () =>
+          HttpResponse.json({
+            enabled: false,
+            environment: 'staging',
+            state: 'FLAG_NOT_FOUND',
+            externalProviderPassthroughAffected: false,
+          })
+        )
+      )
+      const result = await api.getNativeIncidentCapabilities()
+      expect(result.enabled).toBe(false)
+      expect(result.environment).toBe('staging')
+      expect(result.state).toBe('FLAG_NOT_FOUND')
+    })
+
+    it('fails closed and normalizes an unexpected payload', async () => {
+      server.use(
+        http.get(`${API_BASE}/on-call/incident-response/capabilities`, () =>
+          HttpResponse.json({enabled: 'yes', state: 'SOMETHING_NEW'})
+        )
+      )
+      const result = await api.getNativeIncidentCapabilities()
+      expect(result).toEqual({
+        enabled: false,
+        environment: '',
+        state: 'EVALUATION_ERROR',
+        externalProviderPassthroughAffected: false,
+      })
+    })
+
+    it('fails closed when enabled conflicts with the rollout state', async () => {
+      server.use(
+        http.get(`${API_BASE}/on-call/incident-response/capabilities`, () =>
+          HttpResponse.json({enabled: true, environment: 'production', state: 'EVALUATION_ERROR'})
+        )
+      )
+      const result = await api.getNativeIncidentCapabilities()
+      expect(result.enabled).toBe(false)
+      expect(result.state).toBe('EVALUATION_ERROR')
+    })
+  })
+
   // ──── On-Call Incidents ────
 
   describe('getOnCallIncidents', () => {

--- a/dashboard/src/lib/api/modules/on-call.ts
+++ b/dashboard/src/lib/api/modules/on-call.ts
@@ -63,7 +63,7 @@ import type {
   NativeIncidentRolloutState,
 } from '../types'
 
-const NATIVE_INCIDENT_ROLLOUT_STATES: readonly NativeIncidentRolloutState[] = [
+const NATIVE_INCIDENT_ROLLOUT_STATES: ReadonlySet<NativeIncidentRolloutState> = new Set([
   'ENABLED',
   'DISABLED',
   'ENVIRONMENT_NOT_FOUND',
@@ -71,7 +71,7 @@ const NATIVE_INCIDENT_ROLLOUT_STATES: readonly NativeIncidentRolloutState[] = [
   'EVALUATION_ERROR',
   'PROVIDER_UNAVAILABLE',
   'MODULE_UNAVAILABLE',
-]
+])
 
 /**
  * Normalize the native incident capability payload into a strict, gating-safe
@@ -82,7 +82,7 @@ const NATIVE_INCIDENT_ROLLOUT_STATES: readonly NativeIncidentRolloutState[] = [
 function normalizeNativeIncidentCapabilities(raw: unknown): NativeIncidentCapabilities {
   const value = (raw ?? {}) as Record<string, unknown>
   const state = value.state
-  const normalizedState = NATIVE_INCIDENT_ROLLOUT_STATES.includes(state as NativeIncidentRolloutState)
+  const normalizedState = NATIVE_INCIDENT_ROLLOUT_STATES.has(state as NativeIncidentRolloutState)
     ? (state as NativeIncidentRolloutState)
     : 'EVALUATION_ERROR'
   return {

--- a/dashboard/src/lib/api/modules/on-call.ts
+++ b/dashboard/src/lib/api/modules/on-call.ts
@@ -59,7 +59,39 @@ import type {
   IncidentFormStage,
   IncidentRoleDefinition,
   CreateIncidentRoleInput,
+  NativeIncidentCapabilities,
+  NativeIncidentRolloutState,
 } from '../types'
+
+const NATIVE_INCIDENT_ROLLOUT_STATES: readonly NativeIncidentRolloutState[] = [
+  'ENABLED',
+  'DISABLED',
+  'ENVIRONMENT_NOT_FOUND',
+  'FLAG_NOT_FOUND',
+  'EVALUATION_ERROR',
+  'PROVIDER_UNAVAILABLE',
+  'MODULE_UNAVAILABLE',
+]
+
+/**
+ * Normalize the native incident capability payload into a strict, gating-safe
+ * shape. `enabled` is the single source of truth for whether native incident
+ * surfaces may render, so anything other than an explicit `true` fails closed,
+ * and an unrecognized state degrades to `EVALUATION_ERROR`.
+ */
+function normalizeNativeIncidentCapabilities(raw: unknown): NativeIncidentCapabilities {
+  const value = (raw ?? {}) as Record<string, unknown>
+  const state = value.state
+  const normalizedState = NATIVE_INCIDENT_ROLLOUT_STATES.includes(state as NativeIncidentRolloutState)
+    ? (state as NativeIncidentRolloutState)
+    : 'EVALUATION_ERROR'
+  return {
+    enabled: value.enabled === true && normalizedState === 'ENABLED',
+    environment: typeof value.environment === 'string' ? value.environment : '',
+    state: normalizedState,
+    externalProviderPassthroughAffected: value.externalProviderPassthroughAffected === true,
+  }
+}
 
 function appendAlertStatusFilters(
   params: URLSearchParams,
@@ -235,6 +267,16 @@ export function onCallMethods(core: ApiClientCore) {
       core.request<void>(`${base}/devices/${encodeURIComponent(token)}`, {
         method: 'DELETE',
       }),
+
+    // ──── Native incident rollout ────
+
+    // Server-authoritative capability check gating native incident dashboard
+    // surfaces and actions. The backend independently enforces the rollout; this
+    // only drives what the dashboard reveals.
+    getNativeIncidentCapabilities: (): Promise<NativeIncidentCapabilities> =>
+      core
+        .request<unknown>(`${base}/on-call/incident-response/capabilities`)
+        .then(normalizeNativeIncidentCapabilities),
 
     declareIncidentFromAlert: (alertId: string, data: DeclareIncidentInput) =>
       core.request<OnCallIncident>(

--- a/dashboard/src/lib/api/types/on-call.ts
+++ b/dashboard/src/lib/api/types/on-call.ts
@@ -298,3 +298,28 @@ export interface OnCallContactSettings {
   onCallPhoneConsentedAt: string | null
   onCallPhoneConsentVersion: string | null
 }
+
+/**
+ * Server-authoritative rollout state for native incident response. The backend
+ * decides `enabled`; the remaining states carry the reason so the dashboard can
+ * show a calm, accurate unavailable message. Mirrors the backend enum returned
+ * by `GET /v1/on-call/incident-response/capabilities`.
+ */
+export type NativeIncidentRolloutState =
+  | 'ENABLED'
+  | 'DISABLED'
+  | 'ENVIRONMENT_NOT_FOUND'
+  | 'FLAG_NOT_FOUND'
+  | 'EVALUATION_ERROR'
+  | 'PROVIDER_UNAVAILABLE'
+  | 'MODULE_UNAVAILABLE'
+
+export interface NativeIncidentCapabilities {
+  /** Whether native incident dashboard surfaces and actions may be shown. */
+  enabled: boolean
+  /** Feature-flag environment the decision was evaluated in. */
+  environment: string
+  state: NativeIncidentRolloutState
+  /** Always false: forwarded external-provider incident passthrough is never gated by this rollout. */
+  externalProviderPassthroughAffected: boolean
+}

--- a/dashboard/src/routes/__tests__/on-call-rollout-gating.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call-rollout-gating.test.tsx
@@ -1,0 +1,186 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {screen, waitFor} from '@testing-library/react'
+import {clearAuthStorage, renderRoute} from '@/test/utils'
+
+const ALERT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const INCIDENT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+const {mockApi, mockCapabilities, mockPathname, mockParams, mockNavigate} = vi.hoisted(() => ({
+  mockApi: {
+    getNativeIncidentCapabilities: vi.fn(),
+    getOnCallIncidents: vi.fn(),
+    getOnCallIncident: vi.fn(),
+    getIncidentTypes: vi.fn(),
+    getIncidentCustomFields: vi.fn(),
+    getIncidentForms: vi.fn(),
+    getIncidentRoles: vi.fn(),
+    getAlert: vi.fn(),
+    getAlertTimeline: vi.fn(),
+    viewAlert: vi.fn(),
+    acknowledgeAlert: vi.fn(),
+    resolveAlert: vi.fn(),
+    markAlertUnavailable: vi.fn(),
+    addAlertNote: vi.fn(),
+    declareIncidentFromAlert: vi.fn(),
+  },
+  mockCapabilities: {current: {enabled: false, environment: 'production', state: 'DISABLED', externalProviderPassthroughAffected: false}},
+  mockPathname: {current: '/on-call'},
+  mockParams: {current: {} as Record<string, string>},
+  mockNavigate: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({api: mockApi}))
+vi.mock('@/hooks/useToast', () => ({useToast: () => ({toast: vi.fn()})}))
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    useParams: () => mockParams.current,
+  }),
+  Link: ({children, to, ...props}: {children: React.ReactNode; to?: string}) =>
+    React.createElement('a', {href: typeof to === 'string' ? to : '#', ...props}, children),
+  Outlet: () => <div data-testid="outlet" />,
+  useNavigate: () => mockNavigate,
+  useRouterState: (opts?: {select?: (s: {location: {pathname: string}}) => unknown}) => {
+    const state = {location: {pathname: mockPathname.current}}
+    return opts?.select ? opts.select(state) : state
+  },
+}))
+
+import {Route as OnCallShellRoute} from '../on-call'
+import {Route as IncidentsRoute} from '../on-call.incidents'
+import {Route as IncidentDetailRoute} from '../on-call.incidents.$incidentId'
+import {Route as IncidentConfigurationRoute} from '../on-call.incident-configuration'
+import {Route as AlertDetailRoute} from '../on-call.alerts.$alertId'
+
+const ENABLED = {enabled: true, environment: 'production', state: 'ENABLED', externalProviderPassthroughAffected: false}
+const DISABLED = {enabled: false, environment: 'production', state: 'DISABLED', externalProviderPassthroughAffected: false}
+
+const triggeredAlert = {
+  id: ALERT_ID,
+  title: 'Payments outage',
+  description: 'Payments API is down',
+  priority: 'P0',
+  status: 'TRIGGERED',
+  alertSource: 'monitor',
+  triggeredAt: '2026-06-05T12:00:00.000Z',
+}
+
+describe('native incident rollout gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearAuthStorage()
+    mockCapabilities.current = DISABLED
+    mockPathname.current = '/on-call'
+    mockParams.current = {}
+    mockApi.getNativeIncidentCapabilities.mockImplementation(() =>
+      Promise.resolve(mockCapabilities.current)
+    )
+  })
+
+  describe('on-call shell tabs', () => {
+    it('hides Incidents and Configuration when the rollout is disabled', async () => {
+      mockCapabilities.current = DISABLED
+      renderRoute(OnCallShellRoute)
+
+      expect(await screen.findByText('Alerts')).toBeInTheDocument()
+      await waitFor(() => expect(mockApi.getNativeIncidentCapabilities).toHaveBeenCalled())
+
+      expect(screen.getByText('Overview')).toBeInTheDocument()
+      expect(screen.getByText('Teams')).toBeInTheDocument()
+      expect(screen.getByText('Schedules')).toBeInTheDocument()
+      expect(screen.getByText('Escalation Policies')).toBeInTheDocument()
+      expect(screen.queryByText('Incidents')).toBeNull()
+      expect(screen.queryByText('Configuration')).toBeNull()
+    })
+
+    it('shows Incidents and Configuration when the rollout is enabled', async () => {
+      mockCapabilities.current = ENABLED
+      renderRoute(OnCallShellRoute)
+
+      expect(await screen.findByText('Incidents')).toBeInTheDocument()
+      expect(screen.getByText('Configuration')).toBeInTheDocument()
+      expect(screen.getByText('Alerts')).toBeInTheDocument()
+    })
+  })
+
+  describe('incident list route', () => {
+    it('renders an unavailable state and never fetches incidents when disabled', async () => {
+      mockCapabilities.current = DISABLED
+      mockPathname.current = '/on-call/incidents'
+      renderRoute(IncidentsRoute)
+
+      expect(await screen.findByText(/not available/i)).toBeInTheDocument()
+      await waitFor(() => expect(mockApi.getNativeIncidentCapabilities).toHaveBeenCalled())
+      expect(mockApi.getOnCallIncidents).not.toHaveBeenCalled()
+      expect(screen.queryByRole('button', {name: /Declare incident/})).toBeNull()
+    })
+  })
+
+  describe('incident detail route', () => {
+    it('renders an unavailable state and never fetches the incident when disabled', async () => {
+      mockCapabilities.current = DISABLED
+      mockParams.current = {incidentId: INCIDENT_ID}
+      renderRoute(IncidentDetailRoute)
+
+      expect(await screen.findByText(/not available/i)).toBeInTheDocument()
+      await waitFor(() => expect(mockApi.getNativeIncidentCapabilities).toHaveBeenCalled())
+      expect(mockApi.getOnCallIncident).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('incident configuration route', () => {
+    it('renders an unavailable state and never fetches configuration when disabled', async () => {
+      mockCapabilities.current = DISABLED
+      renderRoute(IncidentConfigurationRoute)
+
+      expect(await screen.findByText(/not available/i)).toBeInTheDocument()
+      await waitFor(() => expect(mockApi.getNativeIncidentCapabilities).toHaveBeenCalled())
+      expect(mockApi.getIncidentTypes).not.toHaveBeenCalled()
+      expect(mockApi.getIncidentCustomFields).not.toHaveBeenCalled()
+      expect(mockApi.getIncidentForms).not.toHaveBeenCalled()
+      expect(mockApi.getIncidentRoles).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('alert detail declare control', () => {
+    beforeEach(() => {
+      mockParams.current = {alertId: ALERT_ID}
+      mockApi.getAlert.mockResolvedValue(triggeredAlert)
+      mockApi.getAlertTimeline.mockResolvedValue([])
+      mockApi.viewAlert.mockResolvedValue(undefined)
+    })
+
+    it('hides Declare Incident when the rollout is disabled', async () => {
+      mockCapabilities.current = DISABLED
+      renderRoute(AlertDetailRoute)
+
+      expect(await screen.findByText('Payments outage')).toBeInTheDocument()
+      await waitFor(() => expect(mockApi.getNativeIncidentCapabilities).toHaveBeenCalled())
+      expect(screen.queryByText('Declare Incident')).toBeNull()
+    })
+
+    it('shows Declare Incident when the rollout is enabled', async () => {
+      mockCapabilities.current = ENABLED
+      renderRoute(AlertDetailRoute)
+
+      expect(await screen.findByText('Declare Incident')).toBeInTheDocument()
+    })
+  })
+})

--- a/dashboard/src/routes/__tests__/on-call-rollout-gating.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call-rollout-gating.test.tsx
@@ -24,6 +24,7 @@ const INCIDENT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 const {mockApi, mockCapabilities, mockPathname, mockParams, mockNavigate} = vi.hoisted(() => ({
   mockApi: {
+    getCurrentUser: vi.fn(),
     getNativeIncidentCapabilities: vi.fn(),
     getOnCallIncidents: vi.fn(),
     getOnCallIncident: vi.fn(),
@@ -89,6 +90,7 @@ describe('native incident rollout gating', () => {
     mockCapabilities.current = DISABLED
     mockPathname.current = '/on-call'
     mockParams.current = {}
+    mockApi.getCurrentUser.mockResolvedValue({orgId: 'organization-one'})
     mockApi.getNativeIncidentCapabilities.mockImplementation(() =>
       Promise.resolve(mockCapabilities.current)
     )

--- a/dashboard/src/routes/__tests__/on-call.incident-configuration.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call.incident-configuration.test.tsx
@@ -21,6 +21,7 @@ import {renderRoute} from '@/test/utils'
 
 const {mockApi} = vi.hoisted(() => ({
   mockApi: {
+    getCurrentUser: vi.fn(),
     getIncidentTypes: vi.fn(),
     getIncidentCustomFields: vi.fn(),
     getIncidentForms: vi.fn(),
@@ -171,6 +172,7 @@ describe('IncidentConfiguration', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockApi.getCurrentUser.mockResolvedValue({orgId: 'organization-one'})
     // Native incident rollout enabled so the configuration surface renders.
     mockApi.getNativeIncidentCapabilities.mockResolvedValue({
       enabled: true,

--- a/dashboard/src/routes/__tests__/on-call.incident-configuration.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call.incident-configuration.test.tsx
@@ -29,6 +29,7 @@ const {mockApi} = vi.hoisted(() => ({
     createIncidentCustomField: vi.fn(),
     createIncidentForm: vi.fn(),
     createIncidentRole: vi.fn(),
+    getNativeIncidentCapabilities: vi.fn(),
   },
 }))
 
@@ -170,6 +171,13 @@ describe('IncidentConfiguration', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Native incident rollout enabled so the configuration surface renders.
+    mockApi.getNativeIncidentCapabilities.mockResolvedValue({
+      enabled: true,
+      environment: 'production',
+      state: 'ENABLED',
+      externalProviderPassthroughAffected: false,
+    })
     mockApi.getIncidentTypes.mockResolvedValue([
       {id: 't1', key: 'security', name: 'Security incident', version: 2, enabled: true, description: 'Handle breaches'},
     ])

--- a/dashboard/src/routes/__tests__/on-call.incidents.declare.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call.incidents.declare.test.tsx
@@ -23,6 +23,7 @@ const NEW_INCIDENT_ID = 'f0000000-0000-4000-8000-000000000001'
 
 const {mockApi, mockNavigate} = vi.hoisted(() => ({
   mockApi: {
+    getCurrentUser: vi.fn(),
     getOnCallIncidents: vi.fn(),
     declareOnCallIncident: vi.fn(),
     getIncidentTypes: vi.fn(),
@@ -47,6 +48,7 @@ import {Route} from '../on-call.incidents'
 describe('standalone incident declaration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockApi.getCurrentUser.mockResolvedValue({orgId: 'organization-one'})
     mockApi.getOnCallIncidents.mockResolvedValue([])
     mockApi.getIncidentTypes.mockResolvedValue([])
     mockApi.getIncidentForms.mockResolvedValue([])

--- a/dashboard/src/routes/__tests__/on-call.incidents.declare.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call.incidents.declare.test.tsx
@@ -27,6 +27,7 @@ const {mockApi, mockNavigate} = vi.hoisted(() => ({
     declareOnCallIncident: vi.fn(),
     getIncidentTypes: vi.fn(),
     getIncidentForms: vi.fn(),
+    getNativeIncidentCapabilities: vi.fn(),
   },
   mockNavigate: vi.fn(),
 }))
@@ -50,6 +51,13 @@ describe('standalone incident declaration', () => {
     mockApi.getIncidentTypes.mockResolvedValue([])
     mockApi.getIncidentForms.mockResolvedValue([])
     mockApi.declareOnCallIncident.mockResolvedValue({id: NEW_INCIDENT_ID})
+    // Native incident rollout enabled so declaration behavior stays covered.
+    mockApi.getNativeIncidentCapabilities.mockResolvedValue({
+      enabled: true,
+      environment: 'production',
+      state: 'ENABLED',
+      externalProviderPassthroughAffected: false,
+    })
   })
 
   it('declares a standalone LIVE incident and navigates to it', async () => {

--- a/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
@@ -39,6 +39,7 @@ const {
     markAlertUnavailable: vi.fn(),
     addAlertNote: vi.fn(),
     declareIncidentFromAlert: vi.fn(),
+    getNativeIncidentCapabilities: vi.fn(),
     getOnCallIncidents: vi.fn(),
     getOnCallIncident: vi.fn(),
     getOnCallIncidentTimeline: vi.fn(),
@@ -481,6 +482,13 @@ describe('overview alert and incident dashboard', () => {
     mockApi.markAlertUnavailable.mockResolvedValue(undefined)
     mockApi.addAlertNote.mockResolvedValue(alertTimeline[1])
     mockApi.declareIncidentFromAlert.mockResolvedValue(declaredIncident)
+    // Native incident rollout enabled so existing incident/declare coverage holds.
+    mockApi.getNativeIncidentCapabilities.mockResolvedValue({
+      enabled: true,
+      environment: 'production',
+      state: 'ENABLED',
+      externalProviderPassthroughAffected: false,
+    })
     mockApi.getOnCallIncidents.mockResolvedValue([declaredIncident])
     mockApi.getOnCallIncident.mockResolvedValue(declaredIncident)
     mockApi.getOnCallIncidentTimeline.mockResolvedValue(declaredIncidentTimeline)

--- a/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
@@ -12,6 +12,7 @@ const {
   mockNavigate,
 } = vi.hoisted(() => ({
   mockApi: {
+    getCurrentUser: vi.fn(),
     isAuthenticated: vi.fn(),
     checkAuth: vi.fn(),
     getProjects: vi.fn(),
@@ -414,6 +415,7 @@ describe('overview alert and incident dashboard', () => {
     mockRoutePathname.current = '/'
     mockApi.isAuthenticated.mockReturnValue(true)
     mockApi.checkAuth.mockResolvedValue(true)
+    mockApi.getCurrentUser.mockResolvedValue({orgId: 'organization-one'})
     mockApi.getProjects.mockResolvedValue([project])
     mockApi.getProjectStats.mockResolvedValue(projectStats)
     mockApi.getOrganizationIssues.mockResolvedValue([issue])

--- a/dashboard/src/routes/on-call.alerts.$alertId.tsx
+++ b/dashboard/src/routes/on-call.alerts.$alertId.tsx
@@ -37,6 +37,7 @@ import {cn} from '@/lib/utils'
 import {isUuidResourceId} from '@/lib/api/utils'
 import {IncidentDeclarationForm} from '@/components/on-call/IncidentDeclarationForm'
 import type {DeclareIncidentInput} from '@/lib/api/types'
+import {useNativeIncidentRollout} from '@/hooks/useNativeIncidentRollout'
 
 export const Route = createFileRoute('/on-call/alerts/$alertId')({
   component: AlertDetailPage,
@@ -119,6 +120,7 @@ function AlertDetailPage() {
   const {toast} = useToast()
   const [note, setNote] = useState('')
   const [declareOpen, setDeclareOpen] = useState(false)
+  const nativeIncidentRollout = useNativeIncidentRollout()
   const normalizedAlertId = alertId.trim()
   const hasValidAlertId = isUuidResourceId(normalizedAlertId)
   const alertQueryKey = ['alert', normalizedAlertId] as const
@@ -354,34 +356,36 @@ function AlertDetailPage() {
               I'm not available
             </Button>
 
-            <Dialog open={declareOpen} onOpenChange={setDeclareOpen}>
-              <DialogTrigger asChild>
-                <Button variant="link" size="sm" className="h-auto p-0 text-muted-foreground hover:text-foreground text-xs">
-                  Declare Incident
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-                <DialogHeader>
-                  <DialogTitle>Declare incident</DialogTitle>
-                  <DialogDescription>
-                    Declare an incident from this alert. Details are prefilled and stay editable.
-                  </DialogDescription>
-                </DialogHeader>
-                {declareOpen && (
-                  <IncidentDeclarationForm
-                    defaults={{
-                      title: alert.title,
-                      description: alert.description || '',
-                      severity: 'SEV-2',
-                    }}
-                    originHint={`Declaring from alert "${alert.title}" — the alert will be linked to the new incident.`}
-                    isSubmitting={declareMutation.isPending}
-                    onSubmit={(input) => declareMutation.mutate(input)}
-                    onCancel={() => setDeclareOpen(false)}
-                  />
-                )}
-              </DialogContent>
-            </Dialog>
+            {nativeIncidentRollout.enabled && (
+              <Dialog open={declareOpen} onOpenChange={setDeclareOpen}>
+                <DialogTrigger asChild>
+                  <Button variant="link" size="sm" className="h-auto p-0 text-muted-foreground hover:text-foreground text-xs">
+                    Declare Incident
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+                  <DialogHeader>
+                    <DialogTitle>Declare incident</DialogTitle>
+                    <DialogDescription>
+                      Declare an incident from this alert. Details are prefilled and stay editable.
+                    </DialogDescription>
+                  </DialogHeader>
+                  {declareOpen && (
+                    <IncidentDeclarationForm
+                      defaults={{
+                        title: alert.title,
+                        description: alert.description || '',
+                        severity: 'SEV-2',
+                      }}
+                      originHint={`Declaring from alert "${alert.title}" — the alert will be linked to the new incident.`}
+                      isSubmitting={declareMutation.isPending}
+                      onSubmit={(input) => declareMutation.mutate(input)}
+                      onCancel={() => setDeclareOpen(false)}
+                    />
+                  )}
+                </DialogContent>
+              </Dialog>
+            )}
           </div>
         </div>
       )}

--- a/dashboard/src/routes/on-call.incident-configuration.tsx
+++ b/dashboard/src/routes/on-call.incident-configuration.tsx
@@ -17,7 +17,7 @@
 import {useState} from 'react'
 import {createFileRoute} from '@tanstack/react-router'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
-import {History, Info, Plus, Trash2} from 'lucide-react'
+import {History, Info, Plus, ShieldAlert, Trash2} from 'lucide-react'
 
 import {api} from '@/lib/api'
 import type {
@@ -58,6 +58,10 @@ import {
 } from '@/components/ui/select'
 import {useToast} from '@/hooks/useToast'
 import {
+  nativeIncidentUnavailableCopy,
+  useNativeIncidentRollout,
+} from '@/hooks/useNativeIncidentRollout'
+import {
   FIELD_VALUE_TYPES,
   FIELD_VALUE_TYPE_LABELS,
   FORM_STAGES,
@@ -96,6 +100,21 @@ function slugify(value: string, separator: '_' | '-'): string {
 }
 
 function IncidentConfiguration() {
+  const rollout = useNativeIncidentRollout()
+
+  if (rollout.isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <div className="animate-spin rounded-full h-8 w-8 border-2 border-muted border-t-primary" />
+      </div>
+    )
+  }
+
+  if (!rollout.enabled) {
+    const copy = nativeIncidentUnavailableCopy(rollout)
+    return <EmptyState icon={ShieldAlert} title={copy.title} description={copy.description} />
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex items-start gap-2 rounded-lg border border-info-border bg-info-bg px-3 py-2 text-sm">

--- a/dashboard/src/routes/on-call.incidents.$incidentId.tsx
+++ b/dashboard/src/routes/on-call.incidents.$incidentId.tsx
@@ -47,6 +47,10 @@ import {
 import {useState} from 'react'
 import type {ReactNode} from 'react'
 import {isUuidResourceId} from '@/lib/api/utils'
+import {
+  nativeIncidentUnavailableCopy,
+  useNativeIncidentRollout,
+} from '@/hooks/useNativeIncidentRollout'
 import {incidentStatusConfig, isResolvableIncidentStatus} from '@/lib/incident-status'
 import {IncidentTimelinePanel} from '@/components/on-call/IncidentTimelinePanel'
 import {IncidentRolesPanel} from '@/components/on-call/IncidentRolesPanel'
@@ -70,6 +74,7 @@ function DeclaredIncidentDetailComponent() {
   const [resolveOpen, setResolveOpen] = useState(false)
   const [resolutionNote, setResolutionNote] = useState('')
   const [note, setNote] = useState('')
+  const rollout = useNativeIncidentRollout()
   const normalizedIncidentId = incidentId.trim()
   const hasValidIncidentId = isUuidResourceId(normalizedIncidentId)
   const incidentKey = ['declared-incident', normalizedIncidentId]
@@ -77,7 +82,9 @@ function DeclaredIncidentDetailComponent() {
   const {data: incident, isLoading} = useQuery({
     queryKey: incidentKey,
     queryFn: () => api.getOnCallIncident(normalizedIncidentId),
-    enabled: hasValidIncidentId,
+    // Hold the incident fetch (and the child panels' native queries) until the
+    // rollout is confirmed enabled.
+    enabled: hasValidIncidentId && rollout.enabled,
   })
 
   const refreshIncident = () => queryClient.invalidateQueries({queryKey: incidentKey})
@@ -112,6 +119,19 @@ function DeclaredIncidentDetailComponent() {
       toast({title: 'Error', description: error.message, variant: 'destructive'})
     },
   })
+
+  if (rollout.isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted border-t-primary" />
+      </div>
+    )
+  }
+
+  if (!rollout.enabled) {
+    const copy = nativeIncidentUnavailableCopy(rollout)
+    return <EmptyState icon={AlertTriangle} title={copy.title} description={copy.description} />
+  }
 
   if (isLoading) {
     return (

--- a/dashboard/src/routes/on-call.incidents.tsx
+++ b/dashboard/src/routes/on-call.incidents.tsx
@@ -44,6 +44,10 @@ import {useToast} from '@/hooks/useToast'
 import {incidentStatusConfig} from '@/lib/incident-status'
 import type {DeclareIncidentInput, OnCallIncidentStatus} from '@/lib/api/types'
 import {IncidentDeclarationForm} from '@/components/on-call/IncidentDeclarationForm'
+import {
+  nativeIncidentUnavailableCopy,
+  useNativeIncidentRollout,
+} from '@/hooks/useNativeIncidentRollout'
 
 export const Route = createFileRoute('/on-call/incidents')({
   component: DeclaredIncidents,
@@ -98,6 +102,7 @@ function DeclaredIncidents() {
     useState<IncidentStatusFilter>(DEFAULT_DECLARED_INCIDENT_STATUS_FILTER)
   const [severityFilter, setSeverityFilter] = useState<IncidentSeverityFilter>('all')
   const [declareOpen, setDeclareOpen] = useState(false)
+  const rollout = useNativeIncidentRollout()
   const isDetailRoute = pathname.startsWith('/on-call/incidents/')
 
   const declareMutation = useMutation({
@@ -124,6 +129,8 @@ function DeclaredIncidents() {
       return api.getOnCallIncidents(filters)
     },
     refetchInterval: 30000,
+    // Never fetch native incidents while the rollout is loading or disabled.
+    enabled: rollout.enabled,
   })
 
   const activeCount = incidents?.filter(i => i.status === 'ACTIVE').length || 0
@@ -132,6 +139,24 @@ function DeclaredIncidents() {
 
   if (isDetailRoute) {
     return <Outlet />
+  }
+
+  if (rollout.isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <div className="animate-spin rounded-full h-8 w-8 border-2 border-muted border-t-primary" />
+      </div>
+    )
+  }
+
+  if (!rollout.enabled) {
+    const copy = nativeIncidentUnavailableCopy(rollout)
+    return (
+      <div className="space-y-4">
+        <PageHeader icon={ShieldAlert} title="Incidents" description="Manage user-declared incidents" />
+        <EmptyState icon={ShieldAlert} title={copy.title} description={copy.description} />
+      </div>
+    )
   }
 
   return (

--- a/dashboard/src/routes/on-call.tsx
+++ b/dashboard/src/routes/on-call.tsx
@@ -18,6 +18,7 @@ import {createFileRoute, Link, Outlet, useRouterState} from '@tanstack/react-rou
 import {Bell, Calendar, ListChecks, AlertTriangle, Settings2, Shield, Users2} from 'lucide-react'
 import {cn} from '@/lib/utils'
 import {PageHeader} from '@/components/ui/page-header'
+import {useNativeIncidentRollout} from '@/hooks/useNativeIncidentRollout'
 
 export const Route = createFileRoute('/on-call')({
   component: OnCallLayout,
@@ -38,9 +39,17 @@ const tabs = [
   },
 ]
 
+// Tabs that expose native incident response and stay hidden unless the rollout
+// is enabled for the organization.
+const NATIVE_INCIDENT_TAB_IDS = new Set(['incidents', 'incident-configuration'])
+
 function OnCallLayout() {
   const router = useRouterState()
   const currentPath = router.location.pathname
+  const nativeIncidentRollout = useNativeIncidentRollout()
+  const visibleTabs = tabs.filter((tab) =>
+    NATIVE_INCIDENT_TAB_IDS.has(tab.id) ? nativeIncidentRollout.enabled : true
+  )
 
   return (
     <div className="px-6 py-4 space-y-4">
@@ -53,7 +62,7 @@ function OnCallLayout() {
       {/* Tab Navigation */}
       <div className="border-b">
         <nav className="flex gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {tabs.map((tab) => {
+          {visibleTabs.map((tab) => {
             const isActive = tab.href === '/on-call'
               ? currentPath === '/on-call'
               : currentPath.startsWith(tab.href)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.incidents.commands
 
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.monitoring.OperationalMetrics
 
 fun interface IncidentEntitlement {
     fun isEnabled(organizationId: Int): Boolean
@@ -16,7 +17,7 @@ fun interface IncidentCommandAuthorizer {
 
 class IncidentCommandPolicy(
     private val entitlement: IncidentEntitlement = IncidentEntitlement {
-        FeatureRegistry.hasModule(ON_CALL_MODULE_NAME)
+        FeatureRegistry.isNativeIncidentResponseEnabled(it)
     },
     private val authorizer: IncidentCommandAuthorizer = IncidentCommandAuthorizer { actor, _ ->
         actor.organizationId > 0 && actor.userId > 0
@@ -25,6 +26,7 @@ class IncidentCommandPolicy(
     fun requireAllowed(command: IncidentCommand) {
         val actor = command.actor
         if (!entitlement.isEnabled(actor.organizationId)) {
+            OperationalMetrics.recordNativeIncidentRolloutDecision("command", "denied")
             throw IncidentCommandDeniedException("Native incident response is not enabled for this organization")
         }
         if (!authorizer.isAllowed(actor, command.type)) {
@@ -36,7 +38,6 @@ class IncidentCommandPolicy(
     }
 
     companion object {
-        private const val ON_CALL_MODULE_NAME = "On-Call"
         private const val MAX_COMMAND_KEY_LENGTH = 160
 
         fun allowForTests(): IncidentCommandPolicy =

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentOutboxService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/IncidentOutboxService.kt
@@ -4,10 +4,13 @@
 
 package com.moneat.enterprise.incidents.events
 
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.incidents.commands.IncidentEntitlement
 import com.moneat.enterprise.incidents.models.IncidentDeliveryStatus
 import com.moneat.enterprise.incidents.models.IncidentOutboxStatus
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxDeliveries
 import com.moneat.enterprise.incidents.models.NativeIncidentOutboxEvents
+import com.moneat.monitoring.OperationalMetrics
 import kotlinx.serialization.json.JsonElement
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -90,6 +93,9 @@ class IncidentOutboxService(
     consumers: List<NativeIncidentEventConsumer>,
     private val workerId: String = "incident-outbox-${Uuid.random()}",
     private val clock: Clock = Clock.System,
+    private val entitlement: IncidentEntitlement = IncidentEntitlement {
+        FeatureRegistry.isNativeIncidentResponseEnabled(it)
+    },
 ) {
     private val logger = LoggerFactory.getLogger(IncidentOutboxService::class.java)
     private val consumersByName = consumers.associateBy { it.name }
@@ -106,7 +112,11 @@ class IncidentOutboxService(
         var processed = 0
         repeat(limit) {
             val event = claimNextEvent() ?: return processed
-            processEvent(event)
+            if (entitlement.isEnabled(event.organizationId)) {
+                processEvent(event)
+            } else {
+                deferEventForRollout(event)
+            }
             processed += 1
         }
         return processed
@@ -230,6 +240,32 @@ class IncidentOutboxService(
             failed -> rescheduleEvent(event.id, "One or more consumers require retry")
             else -> markEventPublished(event.id)
         }
+    }
+
+    private fun deferEventForRollout(event: NativeIncidentDomainEvent) {
+        transaction {
+            val row =
+                NativeIncidentOutboxEvents
+                    .selectAll()
+                    .where { NativeIncidentOutboxEvents.id eq event.id }
+                    .single()
+            val now = clock.now()
+            NativeIncidentOutboxEvents.update({ NativeIncidentOutboxEvents.id eq event.id }) {
+                it[status] = IncidentOutboxStatus.PENDING.wire
+                it[attemptCount] = (row[NativeIncidentOutboxEvents.attemptCount] - 1).coerceAtLeast(0)
+                it[availableAt] = now.plus(ROLLOUT_DEFER_DURATION)
+                it[leasedAt] = null
+                it[leaseOwner] = null
+                it[lastError] = ROLLOUT_DISABLED_MESSAGE
+                it[updatedAt] = now
+            }
+        }
+        OperationalMetrics.recordNativeIncidentRolloutDecision("outbox", "deferred")
+        logger.debug(
+            "Deferred native incident outbox event {} for organization {} while rollout is disabled",
+            event.resourceId,
+            event.organizationId,
+        )
     }
 
     private fun ensureDeliveries(event: NativeIncidentDomainEvent) {
@@ -442,6 +478,8 @@ class IncidentOutboxService(
         private const val MAX_ERROR_LENGTH = 4_000
         private const val MAX_BACKOFF_SECONDS = 300
         private const val MAX_BACKOFF_EXPONENT = 8
+        private const val ROLLOUT_DISABLED_MESSAGE = "Native incident rollout is disabled; delivery is deferred"
         private val LEASE_DURATION = 5.minutes
+        private val ROLLOUT_DEFER_DURATION = 30.seconds
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentConfigurationRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentConfigurationRoutes.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.oncall.routes
 
 import com.moneat.enterprise.incidents.commands.IncidentCommandException
+import com.moneat.enterprise.incidents.commands.IncidentEntitlement
 import com.moneat.enterprise.incidents.config.CreateIncidentCustomField
 import com.moneat.enterprise.incidents.config.CreateIncidentForm
 import com.moneat.enterprise.incidents.config.CreateIncidentType
@@ -86,9 +87,11 @@ data class CreateIncidentRoleRequest(
 internal fun Route.registerIncidentConfigurationRoutes(
     service: IncidentConfigurationService,
     responderService: IncidentResponderService,
+    incidentEntitlement: IncidentEntitlement,
 ) {
     route("/v1/on-call/incident-configuration") {
         authenticate("auth-jwt") {
+            installNativeIncidentRolloutGate("NativeIncidentConfigurationGate", incidentEntitlement)
             route("/types") {
                 get {
                     val context = call.requireUserContext() ?: return@get

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -7,10 +7,13 @@ package com.moneat.enterprise.oncall.routes
 import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.alerts.models.IncidentSeverity
 import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.NativeIncidentRolloutStatus
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.commands.IncidentCommandConflictException
 import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
+import com.moneat.enterprise.incidents.commands.IncidentEntitlement
 import com.moneat.enterprise.incidents.commands.IncidentCommandException
 import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.enterprise.incidents.commands.LinkOnCallAlertCommand
@@ -35,6 +38,7 @@ import com.moneat.enterprise.oncall.models.OnCallIncidents
 import com.moneat.enterprise.oncall.services.OnCallAlertService
 import com.moneat.enterprise.oncall.services.OnCallIncidentService
 import com.moneat.org.services.OrgRole
+import com.moneat.monitoring.OperationalMetrics
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Users
 import com.moneat.shared.services.toUuidOrNull
@@ -42,6 +46,9 @@ import com.moneat.utils.ErrorResponse
 import com.moneat.utils.MessageResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.application.isHandled
+import io.ktor.server.auth.AuthenticationChecked
 import io.ktor.server.auth.authenticate
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -154,27 +161,73 @@ data class ResolveIncidentRequest(
     val note: String? = null,
 )
 
+@Serializable
+data class NativeIncidentRolloutResponse(
+    val enabled: Boolean,
+    val environment: String,
+    val state: String,
+    val externalProviderPassthroughAffected: Boolean,
+)
+
+private data class IncidentRouteServices(
+    val alertServiceProvider: () -> OnCallAlertService,
+    val incidentService: OnCallIncidentService,
+    val configurationService: IncidentConfigurationService,
+    val responderService: IncidentResponderService,
+    val timelineService: IncidentTimelineService,
+)
+
 fun Route.incidentRoutes(
     alertServiceProvider: () -> OnCallAlertService,
     onCallIncidentService: OnCallIncidentService = OnCallIncidentService(),
+    incidentEntitlement: IncidentEntitlement = IncidentEntitlement {
+        FeatureRegistry.isNativeIncidentResponseEnabled(it)
+    },
+    rolloutStatusProvider: (Int) -> NativeIncidentRolloutStatus = FeatureRegistry::nativeIncidentRolloutStatus,
 ) {
-    val configurationService = IncidentConfigurationService()
-    val responderService = IncidentResponderService()
-    val timelineService = IncidentTimelineService()
-    registerAlertRoutes(alertServiceProvider, onCallIncidentService)
-    registerDeclaredIncidentRoutes(
-        alertServiceProvider,
-        onCallIncidentService,
-        configurationService,
-        responderService,
-        timelineService,
+    val services =
+        IncidentRouteServices(
+            alertServiceProvider = alertServiceProvider,
+            incidentService = onCallIncidentService,
+            configurationService = IncidentConfigurationService(),
+            responderService = IncidentResponderService(),
+            timelineService = IncidentTimelineService(),
+        )
+    registerIncidentRolloutStatusRoute(rolloutStatusProvider)
+    registerAlertRoutes(services.alertServiceProvider, services.incidentService, incidentEntitlement)
+    registerDeclaredIncidentRoutes(services, incidentEntitlement)
+    registerIncidentConfigurationRoutes(
+        services.configurationService,
+        services.responderService,
+        incidentEntitlement,
     )
-    registerIncidentConfigurationRoutes(configurationService, responderService)
+}
+
+private fun Route.registerIncidentRolloutStatusRoute(
+    rolloutStatusProvider: (Int) -> NativeIncidentRolloutStatus,
+) {
+    route("/v1/on-call/incident-response/capabilities") {
+        authenticate("auth-jwt") {
+            get {
+                val organizationId = call.requireOrganizationId() ?: return@get
+                val status = rolloutStatusProvider(organizationId)
+                call.respond(
+                    NativeIncidentRolloutResponse(
+                        enabled = status.enabled,
+                        environment = status.environment,
+                        state = status.state.name,
+                        externalProviderPassthroughAffected = false,
+                    ),
+                )
+            }
+        }
+    }
 }
 
 private fun Route.registerAlertRoutes(
     alertServiceProvider: () -> OnCallAlertService,
     onCallIncidentService: OnCallIncidentService,
+    incidentEntitlement: IncidentEntitlement,
 ) {
     route("/v1/on-call/alerts") {
         authenticate("auth-jwt") {
@@ -187,31 +240,59 @@ private fun Route.registerAlertRoutes(
             registerAddAlertNoteRoute(alertServiceProvider)
             registerViewAlertRoute(alertServiceProvider)
             registerUnavailableAlertRoute(alertServiceProvider)
-            registerDeclareIncidentFromAlertRoute(alertServiceProvider, onCallIncidentService)
+            registerDeclareIncidentFromAlertRoute(
+                alertServiceProvider,
+                onCallIncidentService,
+                incidentEntitlement,
+            )
         }
     }
 }
 
 private fun Route.registerDeclaredIncidentRoutes(
-    alertServiceProvider: () -> OnCallAlertService,
-    onCallIncidentService: OnCallIncidentService,
-    configurationService: IncidentConfigurationService,
-    responderService: IncidentResponderService,
-    timelineService: IncidentTimelineService,
+    services: IncidentRouteServices,
+    incidentEntitlement: IncidentEntitlement,
 ) {
     route("/v1/on-call/incidents") {
         authenticate("auth-jwt") {
-            registerDeclareIncidentRoute(onCallIncidentService, configurationService)
-            registerListDeclaredIncidentsRoute(onCallIncidentService)
-            registerGetDeclaredIncidentRoute(onCallIncidentService)
-            registerResolveDeclaredIncidentRoute(onCallIncidentService)
-            registerAddAlertToIncidentRoute(alertServiceProvider, onCallIncidentService)
-            registerIncidentSourceRoutes(onCallIncidentService)
-            registerIncidentResponderRoutes(onCallIncidentService, responderService)
-            registerIncidentTimelineRoutes(timelineService)
-            registerAddIncidentNoteRoute(onCallIncidentService)
+            installNativeIncidentRolloutGate("NativeIncidentRoutesGate", incidentEntitlement)
+            registerDeclareIncidentRoute(services.incidentService, services.configurationService)
+            registerListDeclaredIncidentsRoute(services.incidentService)
+            registerGetDeclaredIncidentRoute(services.incidentService)
+            registerResolveDeclaredIncidentRoute(services.incidentService)
+            registerAddAlertToIncidentRoute(services.alertServiceProvider, services.incidentService)
+            registerIncidentSourceRoutes(services.incidentService)
+            registerIncidentResponderRoutes(services.incidentService, services.responderService)
+            registerIncidentTimelineRoutes(services.timelineService)
+            registerAddIncidentNoteRoute(services.incidentService)
         }
     }
+}
+
+internal fun Route.installNativeIncidentRolloutGate(
+    pluginName: String,
+    incidentEntitlement: IncidentEntitlement,
+) {
+    install(
+        createRouteScopedPlugin(pluginName) {
+            on(AuthenticationChecked) { call ->
+                if (call.isHandled) return@on
+                val organizationId = call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
+                if (organizationId == null) {
+                    OperationalMetrics.recordNativeIncidentRolloutDecision("http", "denied")
+                    call.respond(HttpStatusCode.Forbidden, ErrorResponse("Organization context is required"))
+                    return@on
+                }
+                if (!incidentEntitlement.isEnabled(organizationId)) {
+                    OperationalMetrics.recordNativeIncidentRolloutDecision("http", "denied")
+                    call.respond(
+                        HttpStatusCode.Forbidden,
+                        ErrorResponse("Native incident response is not enabled for this organization"),
+                    )
+                }
+            }
+        },
+    )
 }
 
 private fun Route.registerIncidentSourceRoutes(onCallIncidentService: OnCallIncidentService) {
@@ -735,9 +816,18 @@ private fun Route.registerUnavailableAlertRoute(alertServiceProvider: () -> OnCa
 private fun Route.registerDeclareIncidentFromAlertRoute(
     alertServiceProvider: () -> OnCallAlertService,
     onCallIncidentService: OnCallIncidentService,
+    incidentEntitlement: IncidentEntitlement,
 ) {
     post("/{alertId}/declare-incident") {
         val context = call.requireUserContext() ?: return@post
+        if (!incidentEntitlement.isEnabled(context.organizationId)) {
+            OperationalMetrics.recordNativeIncidentRolloutDecision("http", "denied")
+            call.respond(
+                HttpStatusCode.Forbidden,
+                ErrorResponse("Native incident response is not enabled for this organization"),
+            )
+            return@post
+        }
         val alertId = call.requireAlertId(context.organizationId, "alertId") ?: return@post
         val alertService = alertServiceProvider()
         if (!call.ensureAlertInOrganization(alertService, alertId, context.organizationId)) return@post

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -70,6 +70,8 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.uuid.Uuid
 
+private const val JWT_AUTH_PROVIDER = "auth-jwt"
+
 private const val DEFAULT_INCIDENT_LIMIT = 50
 private const val MIN_INCIDENT_LIMIT = 1
 private const val MAX_INCIDENT_LIMIT = 200
@@ -207,7 +209,7 @@ private fun Route.registerIncidentRolloutStatusRoute(
     rolloutStatusProvider: (Int) -> NativeIncidentRolloutStatus,
 ) {
     route("/v1/on-call/incident-response/capabilities") {
-        authenticate("auth-jwt") {
+        authenticate(JWT_AUTH_PROVIDER) {
             get {
                 val organizationId = call.requireOrganizationId() ?: return@get
                 val status = rolloutStatusProvider(organizationId)
@@ -230,7 +232,7 @@ private fun Route.registerAlertRoutes(
     incidentEntitlement: IncidentEntitlement,
 ) {
     route("/v1/on-call/alerts") {
-        authenticate("auth-jwt") {
+        authenticate(JWT_AUTH_PROVIDER) {
             registerListAlertsRoute(alertServiceProvider)
             registerGetAlertRoute(alertServiceProvider)
             registerAlertTimelineRoute(alertServiceProvider)
@@ -254,7 +256,7 @@ private fun Route.registerDeclaredIncidentRoutes(
     incidentEntitlement: IncidentEntitlement,
 ) {
     route("/v1/on-call/incidents") {
-        authenticate("auth-jwt") {
+        authenticate(JWT_AUTH_PROVIDER) {
             installNativeIncidentRolloutGate("NativeIncidentRoutesGate", incidentEntitlement)
             registerDeclareIncidentRoute(services.incidentService, services.configurationService)
             registerListDeclaredIncidentsRoute(services.incidentService)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -282,7 +282,7 @@ internal fun Route.installNativeIncidentRolloutGate(
                 val organizationId = call.principal<JWTPrincipal>()?.currentOrgIdOrNull()
                 if (organizationId == null) {
                     OperationalMetrics.recordNativeIncidentRolloutDecision("http", "denied")
-                    call.respond(HttpStatusCode.Forbidden, ErrorResponse("Organization context is required"))
+                    call.respond(HttpStatusCode.Unauthorized, ErrorResponse("Organization context is required"))
                     return@on
                 }
                 if (!incidentEntitlement.isEnabled(organizationId)) {

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandServiceTest.kt
@@ -378,12 +378,16 @@ class IncidentCommandServiceTest {
             deniedService.execute(
                 DeclareIncidentCommand(
                     commandKey = "not-entitled",
-                    actor = actor(),
+                    actor = IncidentCommandActor(member.organizationId, member.userId, "SLACK"),
                     title = "Denied",
                     description = null,
                     severity = "SEV-3",
                 ),
             )
+        }
+        transaction {
+            assertEquals(0, NativeIncidentCommands.selectAll().count())
+            assertEquals(0, NativeIncidentOutboxEvents.selectAll().count())
         }
 
         val incident = service.execute(

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/IncidentOutboxServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/IncidentOutboxServiceTest.kt
@@ -10,6 +10,7 @@ import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.commands.IncidentEntitlement
 import com.moneat.enterprise.incidents.commands.UpdateIncidentCommand
 import com.moneat.enterprise.incidents.models.IncidentDeliveryStatus
 import com.moneat.enterprise.incidents.models.IncidentOutboxStatus
@@ -49,10 +50,38 @@ class IncidentOutboxServiceTest {
     }
 
     @Test
+    fun `disabled rollout defers events without attempts or data loss and resumes after enablement`() = runBlocking {
+        declare("rollout-deferred")
+        val consumer = RecordingConsumer()
+        var rolloutEnabled = false
+        val service =
+            IncidentOutboxService(
+                consumers = listOf(consumer),
+                workerId = "rollout-worker",
+                clock = clock,
+                entitlement = IncidentEntitlement { rolloutEnabled },
+            )
+
+        assertEquals(1, service.processBatch())
+        assertEquals(emptyList(), consumer.attemptedKeys)
+        transaction {
+            val event = NativeIncidentOutboxEvents.selectAll().single()
+            assertEquals(IncidentOutboxStatus.PENDING.wire, event[NativeIncidentOutboxEvents.status])
+            assertEquals(0, event[NativeIncidentOutboxEvents.attemptCount])
+            assertEquals(0, NativeIncidentOutboxDeliveries.selectAll().count())
+        }
+
+        rolloutEnabled = true
+        clock.advance(31.seconds)
+        assertEquals(1, service.processBatch())
+        assertEquals(listOf("${member.organizationId}:rollout-deferred:recording"), consumer.completedKeys)
+    }
+
+    @Test
     fun `retries failed delivery without duplicating a completed consumer effect`() = runBlocking {
         declare("outbox-retry")
         val consumer = RecordingConsumer(failuresRemaining = 1)
-        val service = IncidentOutboxService(listOf(consumer), workerId = "test-worker", clock = clock)
+        val service = rolloutEnabledService(consumer, "test-worker")
 
         assertEquals(1, service.processBatch())
         assertEquals(1, consumer.attemptedKeys.size)
@@ -93,7 +122,7 @@ class IncidentOutboxServiceTest {
             }
         }
         val consumer = RecordingConsumer()
-        val restarted = IncidentOutboxService(listOf(consumer), workerId = "restarted-worker", clock = clock)
+        val restarted = rolloutEnabledService(consumer, "restarted-worker")
 
         assertEquals(1, restarted.processBatch())
         assertEquals(listOf("${member.organizationId}:outbox-crash:recording"), consumer.completedKeys)
@@ -112,7 +141,7 @@ class IncidentOutboxServiceTest {
             ),
         )
         val consumer = RecordingConsumer(failuresRemaining = 1)
-        val service = IncidentOutboxService(listOf(consumer), workerId = "ordering-worker", clock = clock)
+        val service = rolloutEnabledService(consumer, "ordering-worker")
 
         assertEquals(1, service.processBatch(limit = 2))
         assertEquals(listOf("INCIDENT_DECLARE"), consumer.attemptedEventTypes)
@@ -139,7 +168,7 @@ class IncidentOutboxServiceTest {
             ),
         )
         val consumer = RecordingConsumer(failuresRemaining = 8)
-        val service = IncidentOutboxService(listOf(consumer), workerId = "dead-letter-worker", clock = clock)
+        val service = rolloutEnabledService(consumer, "dead-letter-worker")
 
         repeat(8) {
             assertEquals(1, service.processBatch(limit = 2))
@@ -183,6 +212,14 @@ class IncidentOutboxServiceTest {
                 description = null,
                 severity = "SEV-1",
             ),
+        )
+
+    private fun rolloutEnabledService(consumer: NativeIncidentEventConsumer, workerId: String) =
+        IncidentOutboxService(
+            consumers = listOf(consumer),
+            workerId = workerId,
+            clock = clock,
+            entitlement = IncidentEntitlement { true },
         )
 
     private fun actor() = IncidentCommandActor(member.organizationId, member.userId, "REST")

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
@@ -8,8 +8,11 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.moneat.enterprise.incidents.IncidentTestDatabase
 import com.moneat.enterprise.incidents.SeededMember
+import com.moneat.enterprise.NativeIncidentRolloutState
+import com.moneat.enterprise.NativeIncidentRolloutStatus
 import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
+import com.moneat.enterprise.incidents.commands.IncidentEntitlement
 import com.moneat.enterprise.oncall.services.OnCallIncidentService
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.delete
@@ -58,6 +61,39 @@ class IncidentRoutesTest {
     @AfterEach
     fun tearDown() {
         IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `disabled rollout denies native routes and reports preserved external passthrough`() = testApplication {
+        application { installIncidentRoutes(rolloutEnabled = false) }
+
+        val incidents = client.get("/v1/on-call/incidents") { authorize() }
+        val configuration = client.get("/v1/on-call/incident-configuration/types") { authorize() }
+        val alertDeclaration = client.post("/v1/on-call/alerts/not-a-uuid/declare-incident") {
+            authorize()
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            setBody("""{"title":"blocked","severity":"SEV-2"}""")
+        }
+        val capabilities = client.get("/v1/on-call/incident-response/capabilities") { authorize() }
+
+        assertEquals(HttpStatusCode.Forbidden, incidents.status)
+        assertEquals(HttpStatusCode.Forbidden, configuration.status)
+        assertEquals(HttpStatusCode.Forbidden, alertDeclaration.status)
+        assertEquals(HttpStatusCode.OK, capabilities.status)
+        val body = capabilities.jsonObject()
+        assertEquals(false, body["enabled"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals("production", body.requiredString("environment"))
+        assertEquals("DISABLED", body.requiredString("state"))
+        assertEquals(false, body["externalProviderPassthroughAffected"]?.jsonPrimitive?.content?.toBoolean())
+    }
+
+    @Test
+    fun `rollout gate fails closed when organization context is missing`() = testApplication {
+        application { installIncidentRoutes() }
+
+        val response = client.get("/v1/on-call/incidents") { authorizeWithoutOrganization() }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
     }
 
     @Test
@@ -348,7 +384,7 @@ class IncidentRoutesTest {
         assertEquals(HttpStatusCode.OK, selfRemoval.status)
     }
 
-    private fun Application.installIncidentRoutes() {
+    private fun Application.installIncidentRoutes(rolloutEnabled: Boolean = true) {
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         install(Authentication) {
             jwt("auth-jwt") {
@@ -368,6 +404,19 @@ class IncidentRoutesTest {
                 onCallIncidentService = OnCallIncidentService(
                     IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()),
                 ),
+                incidentEntitlement = IncidentEntitlement { rolloutEnabled },
+                rolloutStatusProvider = {
+                    NativeIncidentRolloutStatus(
+                        enabled = rolloutEnabled,
+                        environment = "production",
+                        state =
+                            if (rolloutEnabled) {
+                                NativeIncidentRolloutState.ENABLED
+                            } else {
+                                NativeIncidentRolloutState.DISABLED
+                            },
+                    )
+                },
             )
         }
     }
@@ -434,6 +483,17 @@ class IncidentRoutesTest {
                 .withAudience(AUDIENCE)
                 .withClaim("userId", userId)
                 .withClaim("orgId", member.organizationId)
+                .sign(Algorithm.HMAC256(JWT_SECRET)),
+        )
+    }
+
+    private fun io.ktor.client.request.HttpRequestBuilder.authorizeWithoutOrganization() {
+        bearerAuth(
+            JWT
+                .create()
+                .withIssuer(ISSUER)
+                .withAudience(AUDIENCE)
+                .withClaim("userId", member.userId)
                 .sign(Algorithm.HMAC256(JWT_SECRET)),
         )
     }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
@@ -93,7 +93,7 @@ class IncidentRoutesTest {
 
         val response = client.get("/v1/on-call/incidents") { authorizeWithoutOrganization() }
 
-        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a reserved per-organization, per-environment rollout flag for native incident response
- enforce the rollout across native HTTP, command/Slack-origin, workflow, AI/MCP, dashboard, and outbox surfaces while preserving OSS provider passthrough
- add audited configuration, rollout metrics, safe outbox deferral, documentation, and focused backend/frontend coverage

## Verification
- `./gradlew :features:featureflags:test --tests com.moneat.featureflags.FeatureFlagServiceTest :ee:test --tests com.moneat.enterprise.oncall.routes.IncidentRoutesTest :features:featureflags:detekt :ee:detekt --no-daemon`
- `python3 scripts/check-migration-versions.py --base-ref origin/develop`
- `git diff --check origin/develop...HEAD`
- prior full backend feature graph and dashboard build/test verification recorded in TASK-1.49
- Claude Opus 4.8 max-effort final review: no blocking findings; hot-path provisioning and missing-org fail-closed hardening applied

## Local environment note
- `moneat setup` could not reach the private dev host over SSH, so real-PostgreSQL migration execution is deferred to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization- and environment-based staged rollout controls for native incident response.
  * Added capability status reporting for enabled, disabled, and unavailable states.
  * Added deployment configuration for selecting the feature-flag environment.

* **Improvements**
  * Native incident pages, configuration, declarations, workflow actions, and AI/MCP access now respect rollout status.
  * Disabled rollouts preserve pending events and resume processing when re-enabled.
  * Added clearer unavailable-state messaging and fail-closed behavior.

* **Bug Fixes**
  * Invalid feature-flag deletion requests now return a clear `400 Bad Request` response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->