### PR TITLE
feat(incidents): enforce enterprise entitlements and quotas

### DIFF
--- a/backend/features/billing/build.gradle.kts
+++ b/backend/features/billing/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.kotlinx.datetime)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
+    implementation(libs.exposed.kotlin.datetime)
     implementation(libs.stripe.java)
     implementation(libs.sentry.kotlin)
     implementation(libs.kotlin.logging)

--- a/backend/features/billing/src/main/kotlin/com/moneat/billing/BillingModule.kt
+++ b/backend/features/billing/src/main/kotlin/com/moneat/billing/BillingModule.kt
@@ -24,10 +24,12 @@ import com.moneat.billing.routes.stripeWebhookRoutes
 import com.moneat.billing.services.AdminBillingService
 import com.moneat.billing.services.BillingBackgroundService
 import com.moneat.billing.services.BillingQuotaService
+import com.moneat.billing.services.BillingNativeIncidentEntitlementBridge
 import com.moneat.billing.services.EntitlementService
 import com.moneat.billing.services.PricingTierService
 import com.moneat.billing.services.StripeService
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.enterprise.NativeIncidentEntitlementBridge
 import com.moneat.shared.repositories.OrganizationRepository
 import io.ktor.server.application.Application
 import io.ktor.server.auth.authenticate
@@ -44,7 +46,11 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 import java.util.concurrent.atomic.AtomicReference
 
-class BillingModule : EnterpriseModule {
+class BillingModule(
+    nativeIncidentEntitlementBridge: NativeIncidentEntitlementBridge =
+        BillingNativeIncidentEntitlementBridge(),
+) : EnterpriseModule,
+    NativeIncidentEntitlementBridge by nativeIncidentEntitlementBridge {
     override val name: String = "Billing"
     private val runningBackgroundJobs = AtomicReference<RunningBillingJobs?>(null)
     private val lifecycleLock = Any()

--- a/backend/features/billing/src/main/kotlin/com/moneat/billing/models/NativeIncidentUsageModels.kt
+++ b/backend/features/billing/src/main/kotlin/com/moneat/billing/models/NativeIncidentUsageModels.kt
@@ -1,0 +1,64 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.billing.models
+
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.jsonb
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestamp
+import kotlin.time.Clock
+
+object NativeIncidentPlanEntitlements : Table("native_incident_plan_entitlements") {
+    val tierName = varchar("tier_name", 50)
+    val enabled = bool("enabled").default(false)
+    val quotas = jsonb("quotas")
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    override val primaryKey = PrimaryKey(tierName)
+}
+
+object NativeIncidentUsageEvents : Table("native_incident_usage_events") {
+    val id = long("id").autoIncrement()
+    val organizationId = integer("organization_id").references(Organizations.id)
+    val quotaKey = varchar("quota_key", 80)
+    val windowKey = varchar("window_key", 20)
+    val idempotencyKey = varchar("idempotency_key", 200)
+    val quantity = long("quantity")
+    val recordedAt = timestamp("recorded_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(organizationId, quotaKey, windowKey, idempotencyKey)
+    }
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object NativeIncidentUsageCounters : Table("native_incident_usage_counters") {
+    val id = long("id").autoIncrement()
+    val organizationId = integer("organization_id").references(Organizations.id)
+    val quotaKey = varchar("quota_key", 80)
+    val windowKey = varchar("window_key", 20)
+    val used = long("used").default(0)
+    val limitSnapshot = long("limit_snapshot")
+    val updatedAt = timestamp("updated_at").clientDefault { Clock.System.now() }
+
+    init {
+        uniqueIndex(organizationId, quotaKey, windowKey)
+    }
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/backend/features/billing/src/main/kotlin/com/moneat/billing/services/BillingNativeIncidentEntitlementBridge.kt
+++ b/backend/features/billing/src/main/kotlin/com/moneat/billing/services/BillingNativeIncidentEntitlementBridge.kt
@@ -1,0 +1,360 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.billing.services
+
+import com.moneat.billing.models.NativeIncidentUsageCounters
+import com.moneat.billing.models.NativeIncidentUsageEvents
+import com.moneat.billing.models.NativeIncidentPlanEntitlements
+import com.moneat.config.EnvConfig
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.NativeIncidentEntitlementBridge
+import com.moneat.enterprise.NativeIncidentEntitlementStatus
+import com.moneat.enterprise.NativeIncidentQuotaDecision
+import com.moneat.enterprise.NativeIncidentQuotaKey
+import com.moneat.enterprise.NativeIncidentQuotaStatus
+import com.moneat.enterprise.NativeIncidentQuotaWindow
+import com.moneat.monitoring.OperationalMetrics
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+
+class BillingNativeIncidentEntitlementBridge(
+    private val pricingTierService: PricingTierService = PricingTierService(),
+) : NativeIncidentEntitlementBridge {
+    override fun isEnabled(organizationId: Int): Boolean = resolveAccess(organizationId).enabled
+
+    override fun status(organizationId: Int): NativeIncidentEntitlementStatus {
+        require(organizationId > 0) { "Organization ID must be positive" }
+        val access = resolveAccess(organizationId)
+        if (!access.enabled) {
+            return NativeIncidentEntitlementStatus(
+                enabled = false,
+                plan = access.plan,
+                reason = access.reason,
+            )
+        }
+        return NativeIncidentEntitlementStatus(
+            enabled = true,
+            plan = access.plan,
+            quotas = transaction { quotaStatuses(organizationId, access.limits) },
+        )
+    }
+
+    override fun consume(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        quantity: Long,
+        idempotencyKey: String,
+    ): NativeIncidentQuotaDecision {
+        require(quantity > 0) { "Quota quantity must be positive" }
+        require(idempotencyKey.isNotBlank()) { "Quota idempotency key is required" }
+        val access = resolveAccess(organizationId)
+        if (!access.enabled) return deniedForEntitlement(quotaKey, access.reason)
+        return transaction {
+            mutateUsage(
+                UsageMutationRequest(
+                    organizationId = organizationId,
+                    quotaKey = quotaKey,
+                    idempotencyKey = idempotencyKey,
+                    limit = access.limits[quotaKey] ?: 0,
+                    target = UsageTarget.Increment(quantity),
+                ),
+            )
+        }.also { recordDecision(quotaKey, it) }
+    }
+
+    override fun reconcile(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        authoritativeUsage: Long,
+        idempotencyKey: String,
+    ): NativeIncidentQuotaDecision {
+        require(authoritativeUsage >= 0) { "Authoritative quota usage cannot be negative" }
+        require(idempotencyKey.isNotBlank()) { "Quota idempotency key is required" }
+        val access = resolveAccess(organizationId)
+        if (!access.enabled) return deniedForEntitlement(quotaKey, access.reason)
+        return transaction {
+            mutateUsage(
+                UsageMutationRequest(
+                    organizationId = organizationId,
+                    quotaKey = quotaKey,
+                    idempotencyKey = "reconcile:$idempotencyKey:$authoritativeUsage",
+                    limit = access.limits[quotaKey] ?: 0,
+                    target = UsageTarget.Authoritative(authoritativeUsage),
+                ),
+            )
+        }.also { recordDecision(quotaKey, it) }
+    }
+
+    private fun mutateUsage(request: UsageMutationRequest): NativeIncidentQuotaDecision {
+        val organizationId = request.organizationId
+        val quotaKey = request.quotaKey
+        val idempotencyKey = request.idempotencyKey
+        val limit = request.limit
+        val windowKey = windowKey(quotaKey)
+        existingEvent(organizationId, quotaKey, windowKey, idempotencyKey)?.let {
+            return decision(quotaKey, limit, currentUsage(organizationId, quotaKey, windowKey), replayed = true)
+        }
+        NativeIncidentUsageCounters.insertIgnore {
+            it[NativeIncidentUsageCounters.organizationId] = organizationId
+            it[NativeIncidentUsageCounters.quotaKey] = quotaKey.wire
+            it[NativeIncidentUsageCounters.windowKey] = windowKey
+            it[used] = 0
+            it[limitSnapshot] = limit
+        }
+        val counter =
+            NativeIncidentUsageCounters
+                .selectAll()
+                .where {
+                    counterIdentity(organizationId, quotaKey, windowKey)
+                }.forUpdate()
+                .single()
+        existingEvent(organizationId, quotaKey, windowKey, idempotencyKey)?.let {
+            return decision(
+                quotaKey = quotaKey,
+                limit = limit,
+                used = counter[NativeIncidentUsageCounters.used],
+                replayed = true,
+            )
+        }
+        val previousUsage = counter[NativeIncidentUsageCounters.used]
+        val nextUsage = request.target.desiredUsage(previousUsage).coerceAtLeast(0)
+        if (request.target.rejectOverLimit && nextUsage > limit) {
+            return quotaExceededDecision(quotaKey, limit, previousUsage)
+        }
+        NativeIncidentUsageEvents.insert {
+            it[NativeIncidentUsageEvents.organizationId] = organizationId
+            it[NativeIncidentUsageEvents.quotaKey] = quotaKey.wire
+            it[NativeIncidentUsageEvents.windowKey] = windowKey
+            it[NativeIncidentUsageEvents.idempotencyKey] = idempotencyKey
+            it[quantity] = nextUsage - previousUsage
+        }
+        NativeIncidentUsageCounters.update({
+            counterIdentity(organizationId, quotaKey, windowKey)
+        }) {
+            it[used] = nextUsage
+            it[limitSnapshot] = limit
+            it[updatedAt] = Clock.System.now()
+        }
+        return decision(quotaKey, limit, nextUsage)
+    }
+
+    private fun quotaStatuses(
+        organizationId: Int,
+        limits: Map<NativeIncidentQuotaKey, Long>,
+    ): Map<NativeIncidentQuotaKey, NativeIncidentQuotaStatus> {
+        val windows = NativeIncidentQuotaKey.entries.associateWith(::windowKey)
+        val counters = NativeIncidentUsageCounters
+            .selectAll()
+            .where { NativeIncidentUsageCounters.organizationId eq organizationId }
+            .associateBy {
+                it[NativeIncidentUsageCounters.quotaKey] to it[NativeIncidentUsageCounters.windowKey]
+            }
+        return NativeIncidentQuotaKey.entries.associateWith { key ->
+            val used = counters[key.wire to windows.getValue(key)]?.get(NativeIncidentUsageCounters.used) ?: 0
+            NativeIncidentQuotaStatus(
+                key = key,
+                limit = limits[key] ?: 0,
+                used = used,
+            )
+        }
+    }
+
+    private fun currentUsage(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        windowKey: String,
+    ): Long =
+        NativeIncidentUsageCounters
+            .selectAll()
+            .where { counterIdentity(organizationId, quotaKey, windowKey) }
+            .singleOrNull()
+            ?.get(NativeIncidentUsageCounters.used)
+            ?: 0
+
+    private fun existingEvent(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        windowKey: String,
+        idempotencyKey: String,
+    ) =
+        NativeIncidentUsageEvents
+            .selectAll()
+            .where {
+                (NativeIncidentUsageEvents.organizationId eq organizationId) and
+                    (NativeIncidentUsageEvents.quotaKey eq quotaKey.wire) and
+                    (NativeIncidentUsageEvents.windowKey eq windowKey) and
+                    (NativeIncidentUsageEvents.idempotencyKey eq idempotencyKey)
+            }.singleOrNull()
+
+    private fun counterIdentity(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        windowKey: String,
+    ) =
+        (NativeIncidentUsageCounters.organizationId eq organizationId) and
+            (NativeIncidentUsageCounters.quotaKey eq quotaKey.wire) and
+            (NativeIncidentUsageCounters.windowKey eq windowKey)
+
+    private fun resolveAccess(organizationId: Int): NativeIncidentPlanAccess {
+        if (EnvConfig.SelfHost.enabled) {
+            val licensed = FeatureRegistry.activeLicense?.features?.contains(ON_CALL_LICENSE_FEATURE) == true
+            return NativeIncidentPlanAccess(
+                enabled = licensed,
+                plan = FeatureRegistry.activeLicense?.plan ?: "SELF_HOSTED",
+                reason = if (licensed) null else "Native incident response requires the on-call license feature",
+                limits = NativeIncidentQuotaKey.entries.associateWith { UNLIMITED_QUOTA },
+            )
+        }
+        val tier = pricingTierService.getEffectiveTierForOrganization(organizationId).tier
+        val planEntitlement = transaction {
+            NativeIncidentPlanEntitlements
+                .selectAll()
+                .where { NativeIncidentPlanEntitlements.tierName eq tier.tierName.uppercase() }
+                .singleOrNull()
+        } ?: return NativeIncidentPlanAccess(
+            enabled = false,
+            plan = tier.tierName,
+            reason = "Native incident response is not configured for the current plan",
+            limits = emptyMap(),
+        )
+        val configuredQuotas = runCatching {
+            Json.decodeFromString<Map<String, Long>>(planEntitlement[NativeIncidentPlanEntitlements.quotas])
+        }.getOrElse {
+            return NativeIncidentPlanAccess(
+                enabled = false,
+                plan = tier.tierName,
+                reason = "Native incident response quotas are invalid for the current plan",
+                limits = emptyMap(),
+            )
+        }
+        val enabled = planEntitlement[NativeIncidentPlanEntitlements.enabled]
+        return NativeIncidentPlanAccess(
+            enabled = enabled,
+            plan = tier.tierName,
+            reason = if (enabled) null else PLAN_UPGRADE_MESSAGE,
+            limits = NativeIncidentQuotaKey.entries.associateWith { key ->
+                configuredQuotas[key.wire]?.coerceAtLeast(0) ?: 0
+            },
+        )
+    }
+
+    private fun windowKey(quotaKey: NativeIncidentQuotaKey): String =
+        when (quotaKey.window) {
+            NativeIncidentQuotaWindow.CAPACITY -> CAPACITY_WINDOW
+            NativeIncidentQuotaWindow.MONTHLY -> {
+                val date = Clock.System.now().toLocalDateTime(TimeZone.UTC).date
+                date.year.toString().padStart(YEAR_WIDTH, '0') +
+                    "-" + date.month.ordinal.inc().toString().padStart(MONTH_WIDTH, '0')
+            }
+        }
+
+    private fun deniedForEntitlement(
+        quotaKey: NativeIncidentQuotaKey,
+        reason: String?,
+    ): NativeIncidentQuotaDecision =
+        NativeIncidentQuotaDecision(
+            allowed = false,
+            status = NativeIncidentQuotaStatus(quotaKey, limit = 0, used = 0),
+            message = reason ?: PLAN_UPGRADE_MESSAGE,
+        ).also { recordDecision(quotaKey, it) }
+
+    private fun decision(
+        quotaKey: NativeIncidentQuotaKey,
+        limit: Long,
+        used: Long,
+        replayed: Boolean = false,
+    ): NativeIncidentQuotaDecision =
+        NativeIncidentQuotaDecision(
+            allowed = true,
+            status = NativeIncidentQuotaStatus(quotaKey, limit, used),
+            replayed = replayed,
+        )
+
+    private fun quotaExceededDecision(
+        quotaKey: NativeIncidentQuotaKey,
+        limit: Long,
+        used: Long,
+    ): NativeIncidentQuotaDecision =
+        NativeIncidentQuotaDecision(
+            allowed = false,
+            status = NativeIncidentQuotaStatus(quotaKey, limit, used),
+            message = quotaExhaustedMessage(quotaKey),
+        )
+
+    private fun quotaExhaustedMessage(quotaKey: NativeIncidentQuotaKey): String =
+        "${quotaKey.wire.replace('_', ' ')} quota is exhausted; upgrade the plan or reduce usage"
+
+    private fun recordDecision(quotaKey: NativeIncidentQuotaKey, decision: NativeIncidentQuotaDecision) {
+        val outcome = when {
+            decision.replayed -> "replayed"
+            decision.allowed -> "allowed"
+            else -> "denied"
+        }
+        OperationalMetrics.recordNativeIncidentQuotaDecision(quotaKey.wire, outcome)
+    }
+
+    private data class NativeIncidentPlanAccess(
+        val enabled: Boolean,
+        val plan: String,
+        val reason: String?,
+        val limits: Map<NativeIncidentQuotaKey, Long>,
+    )
+
+    private data class UsageMutationRequest(
+        val organizationId: Int,
+        val quotaKey: NativeIncidentQuotaKey,
+        val idempotencyKey: String,
+        val limit: Long,
+        val target: UsageTarget,
+    )
+
+    private sealed interface UsageTarget {
+        val rejectOverLimit: Boolean
+
+        fun desiredUsage(previousUsage: Long): Long
+
+        data class Increment(val quantity: Long) : UsageTarget {
+            override val rejectOverLimit: Boolean = true
+
+            override fun desiredUsage(previousUsage: Long): Long = previousUsage + quantity
+        }
+
+        data class Authoritative(val usage: Long) : UsageTarget {
+            override val rejectOverLimit: Boolean = false
+
+            override fun desiredUsage(previousUsage: Long): Long = usage
+        }
+    }
+
+    private companion object {
+        const val CAPACITY_WINDOW = "capacity"
+        const val ON_CALL_LICENSE_FEATURE = "oncall"
+        const val PLAN_UPGRADE_MESSAGE = "Native incident response is not available on the current plan"
+        const val UNLIMITED_QUOTA = 9_007_199_254_740_000L
+        const val YEAR_WIDTH = 4
+        const val MONTH_WIDTH = 2
+    }
+}

--- a/backend/features/billing/src/test/kotlin/com/moneat/billing/services/BillingNativeIncidentEntitlementBridgeTest.kt
+++ b/backend/features/billing/src/test/kotlin/com/moneat/billing/services/BillingNativeIncidentEntitlementBridgeTest.kt
@@ -1,0 +1,191 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.billing.services
+
+import com.moneat.billing.models.NativeIncidentUsageCounters
+import com.moneat.billing.models.NativeIncidentUsageEvents
+import com.moneat.billing.models.NativeIncidentPlanEntitlements
+import com.moneat.billing.models.PricingTierConfigResponse
+import com.moneat.enterprise.NativeIncidentQuotaKey
+import com.moneat.shared.models.Organizations
+import com.moneat.testsupport.TestDatabaseHelper
+import io.mockk.every
+import io.mockk.mockk
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BillingNativeIncidentEntitlementBridgeTest {
+    private lateinit var service: BillingNativeIncidentEntitlementBridge
+    private var organizationId: Int = 0
+
+    @BeforeTest
+    fun setup() {
+        TransactionManager.defaultDatabase = Database.connect(
+            url = "jdbc:h2:mem:native_incident_entitlements_${UUID.randomUUID()};" +
+                "MODE=MYSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+            driver = "org.h2.Driver",
+        )
+        TestDatabaseHelper.resetSchemaForH2WithJsonb(
+            NativeIncidentPlanEntitlements,
+            NativeIncidentUsageEvents,
+            NativeIncidentUsageCounters,
+        )
+        organizationId = transaction {
+            Organizations.insert {
+                it[name] = "Incident quota test"
+                it[slug] = "incident-quota-test"
+            } get Organizations.id
+        }
+        val tier = mockk<PricingTierConfigResponse>()
+        every { tier.tierName } returns "PRO"
+        transaction {
+            NativeIncidentPlanEntitlements.insert {
+                it[tierName] = "PRO"
+                it[enabled] = true
+                it[quotas] = """{"native_incidents":2}"""
+            }
+        }
+        val pricingTierService = mockk<PricingTierService>()
+        every { pricingTierService.getEffectiveTierForOrganization(organizationId) } returns
+            EffectiveTierContext(
+                tier = tier,
+                subscriptionId = null,
+                subscriptionStatus = "active",
+                paygBudgetCents = 0,
+                paygUsedUnits = 0,
+                paygUsedMicros = 0,
+                pendingMeterUnits = 0,
+                currentPeriodStart = null,
+                currentPeriodEnd = null,
+            )
+        service = BillingNativeIncidentEntitlementBridge(pricingTierService)
+    }
+
+    @Test
+    fun `usage admission is organization scoped idempotent and quota bounded`() {
+        val first = service.consume(organizationId, NativeIncidentQuotaKey.NATIVE_INCIDENTS, 1, "declare-1")
+        val replay = service.consume(organizationId, NativeIncidentQuotaKey.NATIVE_INCIDENTS, 1, "declare-1")
+        val second = service.consume(organizationId, NativeIncidentQuotaKey.NATIVE_INCIDENTS, 1, "declare-2")
+        val denied = service.consume(organizationId, NativeIncidentQuotaKey.NATIVE_INCIDENTS, 1, "declare-3")
+
+        assertTrue(first.allowed)
+        assertTrue(replay.allowed)
+        assertTrue(replay.replayed)
+        assertTrue(second.allowed)
+        assertFalse(denied.allowed)
+        assertEquals(2, denied.status.used)
+        assertEquals(2, denied.status.limit)
+        transaction {
+            assertEquals(2, NativeIncidentUsageEvents.selectAll().count())
+            assertEquals(2, NativeIncidentUsageCounters.selectAll().single()[NativeIncidentUsageCounters.used])
+        }
+    }
+
+    @Test
+    fun `reconciliation repairs usage and a previously denied retry can proceed`() {
+        service.consume(organizationId, NativeIncidentQuotaKey.NATIVE_INCIDENTS, 1, "declare-1")
+        service.consume(organizationId, NativeIncidentQuotaKey.NATIVE_INCIDENTS, 1, "declare-2")
+        assertFalse(
+            service.consume(
+                organizationId,
+                NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+                1,
+                "declare-after-reconcile",
+            ).allowed,
+        )
+
+        val reconciled = service.reconcile(
+            organizationId,
+            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            authoritativeUsage = 1,
+            idempotencyKey = "daily-count",
+        )
+        val admitted = service.consume(
+            organizationId,
+            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            1,
+            "declare-after-reconcile",
+        )
+
+        assertTrue(reconciled.allowed)
+        assertEquals(1, reconciled.status.used)
+        assertTrue(admitted.allowed)
+        assertEquals(2, admitted.status.used)
+        assertEquals(
+            2,
+            service.status(organizationId).quotas.getValue(NativeIncidentQuotaKey.NATIVE_INCIDENTS).used,
+        )
+    }
+
+    @Test
+    fun `reconciliation records authoritative overage without rejecting the repair`() {
+        val reconciled = service.reconcile(
+            organizationId,
+            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            authoritativeUsage = 3,
+            idempotencyKey = "over-limit-count",
+        )
+        val replay = service.reconcile(
+            organizationId,
+            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            authoritativeUsage = 3,
+            idempotencyKey = "over-limit-count",
+        )
+
+        assertTrue(reconciled.allowed)
+        assertTrue(reconciled.status.exhausted)
+        assertEquals(3, reconciled.status.used)
+        assertTrue(replay.allowed)
+        assertTrue(replay.replayed)
+    }
+
+    @Test
+    fun `reconciliation applies a newer authoritative value when the retry key is reused`() {
+        val first = service.reconcile(
+            organizationId,
+            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            authoritativeUsage = 1,
+            idempotencyKey = "periodic-count",
+        )
+        val updated = service.reconcile(
+            organizationId,
+            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            authoritativeUsage = 2,
+            idempotencyKey = "periodic-count",
+        )
+        val replay = service.reconcile(
+            organizationId,
+            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            authoritativeUsage = 2,
+            idempotencyKey = "periodic-count",
+        )
+
+        assertEquals(1, first.status.used)
+        assertEquals(2, updated.status.used)
+        assertFalse(updated.replayed)
+        assertTrue(replay.replayed)
+    }
+}

--- a/backend/src/main/kotlin/com/moneat/enterprise/FeatureRegistry.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/FeatureRegistry.kt
@@ -215,8 +215,52 @@ object FeatureRegistry {
             }
     }
 
+    /** Resolve the paid-plan entitlement and quota state. Missing billing dependencies fail closed. */
+    fun nativeIncidentEntitlementStatus(organizationId: Int): NativeIncidentEntitlementStatus {
+        val bridge = modules.filterIsInstance<NativeIncidentEntitlementBridge>().firstOrNull()
+            ?: return NativeIncidentEntitlementStatus(
+                enabled = false,
+                plan = "UNKNOWN",
+                reason = "Native incident billing entitlement provider is unavailable",
+            )
+        return suspendRunCatching { bridge.status(organizationId) }
+            .getOrElse { error ->
+                logger.error(error) {
+                    "Native incident entitlement provider failed for organization $organizationId"
+                }
+                NativeIncidentEntitlementStatus(
+                    enabled = false,
+                    plan = "UNKNOWN",
+                    reason = "Native incident billing entitlement evaluation failed",
+                )
+            }
+    }
+
     fun isNativeIncidentResponseEnabled(organizationId: Int): Boolean =
-        nativeIncidentRolloutStatus(organizationId).enabled
+        nativeIncidentRolloutStatus(organizationId).enabled &&
+            isNativeIncidentEntitlementEnabled(organizationId)
+
+    fun consumeNativeIncidentQuota(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        quantity: Long,
+        idempotencyKey: String,
+    ): NativeIncidentQuotaDecision {
+        val bridge = modules.filterIsInstance<NativeIncidentEntitlementBridge>().firstOrNull()
+            ?: return unavailableQuotaDecision(quotaKey)
+        return bridge.consume(organizationId, quotaKey, quantity, idempotencyKey)
+    }
+
+    fun reconcileNativeIncidentQuota(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        authoritativeUsage: Long,
+        idempotencyKey: String,
+    ): NativeIncidentQuotaDecision {
+        val bridge = modules.filterIsInstance<NativeIncidentEntitlementBridge>().firstOrNull()
+            ?: return unavailableQuotaDecision(quotaKey)
+        return bridge.reconcile(organizationId, quotaKey, authoritativeUsage, idempotencyKey)
+    }
 
     fun recordNativeIncidentRolloutDecision(surface: String, outcome: String) {
         OperationalMetrics.recordNativeIncidentRolloutDecision(surface, outcome)
@@ -253,6 +297,24 @@ object FeatureRegistry {
         modules.clear()
         license = null
         initialized = false
+    }
+
+    private fun unavailableQuotaDecision(quotaKey: NativeIncidentQuotaKey): NativeIncidentQuotaDecision =
+        NativeIncidentQuotaDecision(
+            allowed = false,
+            status = NativeIncidentQuotaStatus(quotaKey, limit = 0, used = 0),
+            message = "Native incident billing entitlement provider is unavailable",
+        )
+
+    private fun isNativeIncidentEntitlementEnabled(organizationId: Int): Boolean {
+        val bridge = modules.filterIsInstance<NativeIncidentEntitlementBridge>().firstOrNull() ?: return false
+        return suspendRunCatching { bridge.isEnabled(organizationId) }
+            .getOrElse { error ->
+                logger.error(error) {
+                    "Native incident entitlement provider failed for organization $organizationId"
+                }
+                false
+            }
     }
 
     private const val ON_CALL_MODULE_NAME = "On-Call"

--- a/backend/src/main/kotlin/com/moneat/enterprise/NativeIncidentEntitlements.kt
+++ b/backend/src/main/kotlin/com/moneat/enterprise/NativeIncidentEntitlements.kt
@@ -1,0 +1,84 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.enterprise
+
+/** Stable billing keys shared by native incident response and later alert-route tasks. */
+enum class NativeIncidentQuotaKey(val wire: String, val window: NativeIncidentQuotaWindow) {
+    NATIVE_INCIDENTS("native_incidents", NativeIncidentQuotaWindow.MONTHLY),
+    RESPONDERS("responders", NativeIncidentQuotaWindow.CAPACITY),
+    INTEGRATIONS("integrations", NativeIncidentQuotaWindow.CAPACITY),
+    AI_RUNS("ai_runs", NativeIncidentQuotaWindow.MONTHLY),
+    TRANSCRIPTION_MINUTES("transcription_minutes", NativeIncidentQuotaWindow.MONTHLY),
+    RETAINED_EVIDENCE_BYTES("retained_evidence_bytes", NativeIncidentQuotaWindow.CAPACITY),
+    ENABLED_ALERT_ROUTES("enabled_alert_routes", NativeIncidentQuotaWindow.CAPACITY),
+    ACTIVE_ALERT_GROUPS("active_alert_groups", NativeIncidentQuotaWindow.CAPACITY),
+    ROUTE_CREATED_INCIDENTS("route_created_incidents", NativeIncidentQuotaWindow.MONTHLY),
+    AUTOMATIC_CORRELATIONS("automatic_correlations", NativeIncidentQuotaWindow.MONTHLY),
+    AI_ASSISTED_CORRELATIONS("ai_assisted_correlations", NativeIncidentQuotaWindow.MONTHLY),
+}
+
+enum class NativeIncidentQuotaWindow {
+    CAPACITY,
+    MONTHLY,
+}
+
+data class NativeIncidentQuotaStatus(
+    val key: NativeIncidentQuotaKey,
+    val limit: Long,
+    val used: Long,
+) {
+    val remaining: Long = (limit - used).coerceAtLeast(0)
+    val exhausted: Boolean = used >= limit
+}
+
+data class NativeIncidentEntitlementStatus(
+    val enabled: Boolean,
+    val plan: String,
+    val reason: String? = null,
+    val quotas: Map<NativeIncidentQuotaKey, NativeIncidentQuotaStatus> = emptyMap(),
+)
+
+data class NativeIncidentQuotaDecision(
+    val allowed: Boolean,
+    val status: NativeIncidentQuotaStatus,
+    val message: String? = null,
+    val replayed: Boolean = false,
+)
+
+/**
+ * Runtime bridge implemented by billing. Calls may occur inside an existing Exposed transaction;
+ * implementations must preserve that transaction so admission and the protected mutation are atomic.
+ */
+interface NativeIncidentEntitlementBridge {
+    fun status(organizationId: Int): NativeIncidentEntitlementStatus
+
+    fun isEnabled(organizationId: Int): Boolean = status(organizationId).enabled
+
+    fun consume(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        quantity: Long,
+        idempotencyKey: String,
+    ): NativeIncidentQuotaDecision
+
+    fun reconcile(
+        organizationId: Int,
+        quotaKey: NativeIncidentQuotaKey,
+        authoritativeUsage: Long,
+        idempotencyKey: String,
+    ): NativeIncidentQuotaDecision
+}

--- a/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
+++ b/backend/src/main/kotlin/com/moneat/monitoring/OperationalMetrics.kt
@@ -506,6 +506,17 @@ object OperationalMetrics {
         ).increment()
     }
 
+    fun recordNativeIncidentQuotaDecision(quotaKey: String, outcome: String) {
+        counter(
+            NATIVE_INCIDENT_QUOTA_DECISIONS,
+            "Native incident quota admissions grouped by bounded quota key and outcome.",
+            tags(
+                "quota_key" to quotaKey,
+                "outcome" to outcome,
+            ),
+        ).increment()
+    }
+
     fun scrape(): String = registry.scrape()
 
     fun resetForTest() {
@@ -949,6 +960,7 @@ object OperationalMetrics {
     private const val WORKFLOW_EXECUTION_DURATION = "moneat_workflow_execution_duration"
     private const val WORKFLOW_RATE_LIMITED = "moneat_workflow_rate_limited"
     private const val NATIVE_INCIDENT_ROLLOUT_DECISIONS = "moneat_native_incident_rollout_decisions"
+    private const val NATIVE_INCIDENT_QUOTA_DECISIONS = "moneat_native_incident_quota_decisions"
     private const val NANOS_PER_SECOND = 1_000_000_000
     private const val MILLIS_PER_SECOND = 1_000
     private const val HEALTHY_VALUE = 1L

--- a/backend/src/main/resources/db/migration/V158__native_incident_entitlements_and_usage.sql
+++ b/backend/src/main/resources/db/migration/V158__native_incident_entitlements_and_usage.sql
@@ -1,0 +1,57 @@
+CREATE TABLE native_incident_plan_entitlements (
+    tier_name VARCHAR(50) PRIMARY KEY,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    quotas JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_native_incident_plan_quota_object CHECK (jsonb_typeof(quotas) = 'object')
+);
+
+INSERT INTO native_incident_plan_entitlements (tier_name, enabled, quotas)
+VALUES
+    ('FREE', FALSE, '{}'::jsonb),
+    ('PRO', TRUE, '{
+          "native_incidents":25,"responders":5,"integrations":2,"ai_runs":25,
+          "transcription_minutes":120,"retained_evidence_bytes":1073741824,
+          "enabled_alert_routes":10,"active_alert_groups":50,"route_created_incidents":25,
+          "automatic_correlations":250,"ai_assisted_correlations":25
+        }'::jsonb),
+    ('TEAM', TRUE, '{
+          "native_incidents":250,"responders":25,"integrations":10,"ai_runs":500,
+          "transcription_minutes":2000,"retained_evidence_bytes":26843545600,
+          "enabled_alert_routes":100,"active_alert_groups":1000,"route_created_incidents":500,
+          "automatic_correlations":10000,"ai_assisted_correlations":1000
+        }'::jsonb),
+    ('BUSINESS', TRUE, '{
+          "native_incidents":2500,"responders":250,"integrations":50,"ai_runs":10000,
+          "transcription_minutes":50000,"retained_evidence_bytes":536870912000,
+          "enabled_alert_routes":1000,"active_alert_groups":10000,"route_created_incidents":10000,
+          "automatic_correlations":250000,"ai_assisted_correlations":25000
+        }'::jsonb);
+
+CREATE TABLE native_incident_usage_events (
+    id BIGSERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    quota_key VARCHAR(80) NOT NULL,
+    window_key VARCHAR(20) NOT NULL,
+    idempotency_key VARCHAR(200) NOT NULL,
+    quantity BIGINT NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_usage_event
+        UNIQUE (organization_id, quota_key, window_key, idempotency_key)
+);
+
+CREATE INDEX idx_native_incident_usage_events_org_recorded
+    ON native_incident_usage_events(organization_id, recorded_at DESC);
+
+CREATE TABLE native_incident_usage_counters (
+    id BIGSERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    quota_key VARCHAR(80) NOT NULL,
+    window_key VARCHAR(20) NOT NULL,
+    used BIGINT NOT NULL DEFAULT 0,
+    limit_snapshot BIGINT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_native_incident_usage_counter UNIQUE (organization_id, quota_key, window_key),
+    CONSTRAINT chk_native_incident_usage_counter_used CHECK (used >= 0),
+    CONSTRAINT chk_native_incident_usage_counter_limit CHECK (limit_snapshot >= 0)
+);

--- a/backend/src/test/kotlin/com/moneat/enterprise/FeatureRegistryNativeIncidentRolloutTest.kt
+++ b/backend/src/test/kotlin/com/moneat/enterprise/FeatureRegistryNativeIncidentRolloutTest.kt
@@ -59,6 +59,25 @@ class FeatureRegistryNativeIncidentRolloutTest {
         assertEquals(NativeIncidentRolloutState.ENABLED, status.state)
     }
 
+    @Test
+    fun `native incident availability requires rollout and paid entitlement independently`() {
+        System.setProperty(FEATURE_FLAG_ENVIRONMENT_VARIABLE, "production")
+        FeatureRegistry.registerForTest(
+            TestModule("On-Call"),
+            RecordingRolloutModule(),
+            EntitlementModule(enabled = false),
+        )
+        assertFalse(FeatureRegistry.isNativeIncidentResponseEnabled(42))
+
+        FeatureRegistry.resetForTest()
+        FeatureRegistry.registerForTest(
+            TestModule("On-Call"),
+            RecordingRolloutModule(),
+            EntitlementModule(enabled = true),
+        )
+        assertTrue(FeatureRegistry.isNativeIncidentResponseEnabled(42))
+    }
+
     private open class TestModule(override val name: String) : EnterpriseModule {
         override fun registerRoutes(route: Route) = Unit
 
@@ -80,6 +99,31 @@ class FeatureRegistryNativeIncidentRolloutTest {
                 state = NativeIncidentRolloutState.ENABLED,
             )
         }
+    }
+
+    private class EntitlementModule(private val enabled: Boolean) :
+        TestModule("Billing"),
+        NativeIncidentEntitlementBridge {
+        override fun status(organizationId: Int): NativeIncidentEntitlementStatus =
+            NativeIncidentEntitlementStatus(enabled = enabled, plan = "TEST")
+
+        override fun consume(
+            organizationId: Int,
+            quotaKey: NativeIncidentQuotaKey,
+            quantity: Long,
+            idempotencyKey: String,
+        ): NativeIncidentQuotaDecision =
+            NativeIncidentQuotaDecision(
+                allowed = enabled,
+                status = NativeIncidentQuotaStatus(quotaKey, limit = 1, used = 0),
+            )
+
+        override fun reconcile(
+            organizationId: Int,
+            quotaKey: NativeIncidentQuotaKey,
+            authoritativeUsage: Long,
+            idempotencyKey: String,
+        ): NativeIncidentQuotaDecision = consume(organizationId, quotaKey, 1, idempotencyKey)
     }
 
     private companion object {

--- a/dashboard/src/hooks/__tests__/useNativeIncidentRollout.test.tsx
+++ b/dashboard/src/hooks/__tests__/useNativeIncidentRollout.test.tsx
@@ -46,6 +46,10 @@ describe('useNativeIncidentRollout', () => {
       enabled: true,
       environment: 'production',
       state: 'ENABLED',
+      entitlementEnabled: true,
+      plan: 'TEAM',
+      entitlementReason: null,
+      quotas: {},
       externalProviderPassthroughAffected: false,
     })
 

--- a/dashboard/src/lib/api/modules/__tests__/on-call.test.ts
+++ b/dashboard/src/lib/api/modules/__tests__/on-call.test.ts
@@ -513,6 +513,12 @@ describe('onCallMethods', () => {
             enabled: true,
             environment: 'production',
             state: 'ENABLED',
+            entitlementEnabled: true,
+            plan: 'TEAM',
+            entitlementReason: null,
+            quotas: {
+              native_incidents: {limit: 250, used: 10, remaining: 240, exhausted: false},
+            },
             externalProviderPassthroughAffected: false,
           })
         )
@@ -522,6 +528,12 @@ describe('onCallMethods', () => {
         enabled: true,
         environment: 'production',
         state: 'ENABLED',
+        entitlementEnabled: true,
+        plan: 'TEAM',
+        entitlementReason: null,
+        quotas: {
+          native_incidents: {limit: 250, used: 10, remaining: 240, exhausted: false},
+        },
         externalProviderPassthroughAffected: false,
       })
     })
@@ -554,6 +566,10 @@ describe('onCallMethods', () => {
         enabled: false,
         environment: '',
         state: 'EVALUATION_ERROR',
+        entitlementEnabled: false,
+        plan: 'UNKNOWN',
+        entitlementReason: null,
+        quotas: {},
         externalProviderPassthroughAffected: false,
       })
     })
@@ -567,6 +583,26 @@ describe('onCallMethods', () => {
       const result = await api.getNativeIncidentCapabilities()
       expect(result.enabled).toBe(false)
       expect(result.state).toBe('EVALUATION_ERROR')
+    })
+
+    it('fails closed when rollout is enabled but the plan entitlement is disabled', async () => {
+      server.use(
+        http.get(`${API_BASE}/on-call/incident-response/capabilities`, () =>
+          HttpResponse.json({
+            enabled: false,
+            environment: 'production',
+            state: 'ENABLED',
+            entitlementEnabled: false,
+            plan: 'FREE',
+            entitlementReason: 'Upgrade the plan',
+            quotas: {},
+          })
+        )
+      )
+      const result = await api.getNativeIncidentCapabilities()
+      expect(result.enabled).toBe(false)
+      expect(result.entitlementEnabled).toBe(false)
+      expect(result.entitlementReason).toBe('Upgrade the plan')
     })
   })
 

--- a/dashboard/src/lib/api/modules/on-call.ts
+++ b/dashboard/src/lib/api/modules/on-call.ts
@@ -86,11 +86,42 @@ function normalizeNativeIncidentCapabilities(raw: unknown): NativeIncidentCapabi
     ? (state as NativeIncidentRolloutState)
     : 'EVALUATION_ERROR'
   return {
-    enabled: value.enabled === true && normalizedState === 'ENABLED',
+    enabled:
+      value.enabled === true && normalizedState === 'ENABLED' && value.entitlementEnabled === true,
     environment: typeof value.environment === 'string' ? value.environment : '',
     state: normalizedState,
+    entitlementEnabled: value.entitlementEnabled === true,
+    plan: typeof value.plan === 'string' ? value.plan : 'UNKNOWN',
+    entitlementReason:
+      typeof value.entitlementReason === 'string' ? value.entitlementReason : null,
+    quotas: normalizeNativeIncidentQuotas(value.quotas),
     externalProviderPassthroughAffected: value.externalProviderPassthroughAffected === true,
   }
+}
+
+function normalizeNativeIncidentQuotas(
+  raw: unknown
+): NativeIncidentCapabilities['quotas'] {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return {}
+  return Object.fromEntries(
+    Object.entries(raw).flatMap(([key, candidate]) => {
+      if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) return []
+      const quota = candidate as Record<string, unknown>
+      if (
+        typeof quota.limit !== 'number' ||
+        typeof quota.used !== 'number' ||
+        typeof quota.remaining !== 'number'
+      ) {
+        return []
+      }
+      return [[key, {
+        limit: quota.limit,
+        used: quota.used,
+        remaining: quota.remaining,
+        exhausted: quota.exhausted === true,
+      }]]
+    })
+  )
 }
 
 function appendAlertStatusFilters(

--- a/dashboard/src/lib/api/types/on-call.ts
+++ b/dashboard/src/lib/api/types/on-call.ts
@@ -320,6 +320,18 @@ export interface NativeIncidentCapabilities {
   /** Feature-flag environment the decision was evaluated in. */
   environment: string
   state: NativeIncidentRolloutState
+  /** Paid-plan entitlement is evaluated independently from rollout state. */
+  entitlementEnabled: boolean
+  plan: string
+  entitlementReason: string | null
+  quotas: Record<string, NativeIncidentQuotaStatus>
   /** Always false: forwarded external-provider incident passthrough is never gated by this rollout. */
   externalProviderPassthroughAffected: boolean
+}
+
+export interface NativeIncidentQuotaStatus {
+  limit: number
+  used: number
+  remaining: number
+  exhausted: boolean
 }

--- a/dashboard/src/routes/__tests__/on-call-rollout-gating.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call-rollout-gating.test.tsx
@@ -41,7 +41,16 @@ const {mockApi, mockCapabilities, mockPathname, mockParams, mockNavigate} = vi.h
     addAlertNote: vi.fn(),
     declareIncidentFromAlert: vi.fn(),
   },
-  mockCapabilities: {current: {enabled: false, environment: 'production', state: 'DISABLED', externalProviderPassthroughAffected: false}},
+  mockCapabilities: {current: {
+    enabled: false,
+    environment: 'production',
+    state: 'DISABLED',
+    entitlementEnabled: true,
+    plan: 'TEAM',
+    entitlementReason: null,
+    quotas: {},
+    externalProviderPassthroughAffected: false,
+  }},
   mockPathname: {current: '/on-call'},
   mockParams: {current: {} as Record<string, string>},
   mockNavigate: vi.fn(),
@@ -70,8 +79,26 @@ import {Route as IncidentDetailRoute} from '../on-call.incidents.$incidentId'
 import {Route as IncidentConfigurationRoute} from '../on-call.incident-configuration'
 import {Route as AlertDetailRoute} from '../on-call.alerts.$alertId'
 
-const ENABLED = {enabled: true, environment: 'production', state: 'ENABLED', externalProviderPassthroughAffected: false}
-const DISABLED = {enabled: false, environment: 'production', state: 'DISABLED', externalProviderPassthroughAffected: false}
+const ENABLED = {
+  enabled: true,
+  environment: 'production',
+  state: 'ENABLED',
+  entitlementEnabled: true,
+  plan: 'TEAM',
+  entitlementReason: null,
+  quotas: {},
+  externalProviderPassthroughAffected: false,
+}
+const DISABLED = {
+  enabled: false,
+  environment: 'production',
+  state: 'DISABLED',
+  entitlementEnabled: true,
+  plan: 'TEAM',
+  entitlementReason: null,
+  quotas: {},
+  externalProviderPassthroughAffected: false,
+}
 
 const triggeredAlert = {
   id: ALERT_ID,

--- a/dashboard/src/routes/__tests__/on-call.incident-configuration.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call.incident-configuration.test.tsx
@@ -178,6 +178,10 @@ describe('IncidentConfiguration', () => {
       enabled: true,
       environment: 'production',
       state: 'ENABLED',
+      entitlementEnabled: true,
+      plan: 'TEAM',
+      entitlementReason: null,
+      quotas: {},
       externalProviderPassthroughAffected: false,
     })
     mockApi.getIncidentTypes.mockResolvedValue([

--- a/dashboard/src/routes/__tests__/on-call.incidents.declare.test.tsx
+++ b/dashboard/src/routes/__tests__/on-call.incidents.declare.test.tsx
@@ -58,6 +58,10 @@ describe('standalone incident declaration', () => {
       enabled: true,
       environment: 'production',
       state: 'ENABLED',
+      entitlementEnabled: true,
+      plan: 'TEAM',
+      entitlementReason: null,
+      quotas: {},
       externalProviderPassthroughAffected: false,
     })
   })

--- a/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
+++ b/dashboard/src/routes/__tests__/overview-alert-incident-coverage.test.tsx
@@ -489,6 +489,10 @@ describe('overview alert and incident dashboard', () => {
       enabled: true,
       environment: 'production',
       state: 'ENABLED',
+      entitlementEnabled: true,
+      plan: 'TEAM',
+      entitlementReason: null,
+      quotas: {},
       externalProviderPassthroughAffected: false,
     })
     mockApi.getOnCallIncidents.mockResolvedValue([declaredIncident])

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.incidents.commands
 
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.NativeIncidentQuotaKey
 import com.moneat.monitoring.OperationalMetrics
 
 fun interface IncidentEntitlement {
@@ -15,12 +16,24 @@ fun interface IncidentCommandAuthorizer {
     fun isAllowed(actor: IncidentCommandActor, commandType: IncidentCommandType): Boolean
 }
 
+fun interface IncidentQuotaAdmission {
+    fun consume(command: IncidentCommand): com.moneat.enterprise.NativeIncidentQuotaDecision
+}
+
 class IncidentCommandPolicy(
     private val entitlement: IncidentEntitlement = IncidentEntitlement {
         FeatureRegistry.isNativeIncidentResponseEnabled(it)
     },
     private val authorizer: IncidentCommandAuthorizer = IncidentCommandAuthorizer { actor, _ ->
         actor.organizationId > 0 && actor.userId > 0
+    },
+    private val quotaAdmission: IncidentQuotaAdmission = IncidentQuotaAdmission { command ->
+        FeatureRegistry.consumeNativeIncidentQuota(
+            organizationId = command.actor.organizationId,
+            quotaKey = NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+            quantity = 1,
+            idempotencyKey = "incident:${command.commandKey}",
+        )
     },
 ) {
     fun requireAllowed(command: IncidentCommand) {
@@ -37,6 +50,16 @@ class IncidentCommandPolicy(
         require(actor.origin.isNotBlank()) { "Incident command origin is required" }
     }
 
+    fun requireQuota(command: IncidentCommand) {
+        if (command !is DeclareIncidentCommand) return
+        val decision = quotaAdmission.consume(command)
+        if (!decision.allowed) {
+            throw IncidentCommandQuotaExceededException(
+                decision.message ?: "Native incident quota is exhausted; upgrade the plan or reduce usage",
+            )
+        }
+    }
+
     companion object {
         private const val MAX_COMMAND_KEY_LENGTH = 160
 
@@ -44,6 +67,16 @@ class IncidentCommandPolicy(
             IncidentCommandPolicy(
                 entitlement = IncidentEntitlement { true },
                 authorizer = IncidentCommandAuthorizer { _, _ -> true },
+                quotaAdmission = IncidentQuotaAdmission {
+                    com.moneat.enterprise.NativeIncidentQuotaDecision(
+                        allowed = true,
+                        status = com.moneat.enterprise.NativeIncidentQuotaStatus(
+                            NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+                            limit = Long.MAX_VALUE,
+                            used = 0,
+                        ),
+                    )
+                },
             )
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
@@ -74,6 +74,7 @@ class IncidentCommandService(
         transaction {
             requireActorMembership(command.actor)
             replayResult(command)?.let { return@transaction it }
+            policy.requireQuota(command)
             val mutation = applyCommand(command)
             recordCommand(command, mutation)
             if (mutation.changed) {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommands.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommands.kt
@@ -293,3 +293,5 @@ class IncidentCommandDeniedException(message: String) : IncidentCommandException
 class IncidentCommandConflictException(message: String) : IncidentCommandException(message)
 
 class IncidentCommandNotFoundException(message: String) : IncidentCommandException(message)
+
+class IncidentCommandQuotaExceededException(message: String) : IncidentCommandException(message)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -8,6 +8,7 @@ import com.moneat.auth.currentOrgIdOrNull
 import com.moneat.alerts.models.IncidentSeverity
 import com.moneat.alerts.models.AlertEpisodes
 import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.NativeIncidentEntitlementStatus
 import com.moneat.enterprise.NativeIncidentRolloutStatus
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
@@ -16,6 +17,7 @@ import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
 import com.moneat.enterprise.incidents.commands.IncidentEntitlement
 import com.moneat.enterprise.incidents.commands.IncidentCommandException
 import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
+import com.moneat.enterprise.incidents.commands.IncidentCommandQuotaExceededException
 import com.moneat.enterprise.incidents.commands.LinkOnCallAlertCommand
 import com.moneat.enterprise.incidents.commands.IncidentSourceReference
 import com.moneat.enterprise.incidents.commands.LinkIncidentSourceCommand
@@ -109,6 +111,7 @@ internal fun incidentCommandStatus(error: IncidentCommandException): HttpStatusC
         is IncidentCommandDeniedException -> HttpStatusCode.Forbidden
         is IncidentCommandNotFoundException -> HttpStatusCode.NotFound
         is IncidentCommandConflictException -> HttpStatusCode.Conflict
+        is IncidentCommandQuotaExceededException -> HttpStatusCode.TooManyRequests
         else -> HttpStatusCode.BadRequest
     }
 
@@ -168,7 +171,19 @@ data class NativeIncidentRolloutResponse(
     val enabled: Boolean,
     val environment: String,
     val state: String,
+    val entitlementEnabled: Boolean,
+    val plan: String,
+    val entitlementReason: String? = null,
+    val quotas: Map<String, NativeIncidentQuotaResponse>,
     val externalProviderPassthroughAffected: Boolean,
+)
+
+@Serializable
+data class NativeIncidentQuotaResponse(
+    val limit: Long,
+    val used: Long,
+    val remaining: Long,
+    val exhausted: Boolean,
 )
 
 private data class IncidentRouteServices(
@@ -186,6 +201,8 @@ fun Route.incidentRoutes(
         FeatureRegistry.isNativeIncidentResponseEnabled(it)
     },
     rolloutStatusProvider: (Int) -> NativeIncidentRolloutStatus = FeatureRegistry::nativeIncidentRolloutStatus,
+    entitlementStatusProvider: (Int) -> NativeIncidentEntitlementStatus =
+        FeatureRegistry::nativeIncidentEntitlementStatus,
 ) {
     val services =
         IncidentRouteServices(
@@ -195,7 +212,7 @@ fun Route.incidentRoutes(
             responderService = IncidentResponderService(),
             timelineService = IncidentTimelineService(),
         )
-    registerIncidentRolloutStatusRoute(rolloutStatusProvider)
+    registerIncidentRolloutStatusRoute(rolloutStatusProvider, entitlementStatusProvider)
     registerAlertRoutes(services.alertServiceProvider, services.incidentService, incidentEntitlement)
     registerDeclaredIncidentRoutes(services, incidentEntitlement)
     registerIncidentConfigurationRoutes(
@@ -207,17 +224,30 @@ fun Route.incidentRoutes(
 
 private fun Route.registerIncidentRolloutStatusRoute(
     rolloutStatusProvider: (Int) -> NativeIncidentRolloutStatus,
+    entitlementStatusProvider: (Int) -> NativeIncidentEntitlementStatus,
 ) {
     route("/v1/on-call/incident-response/capabilities") {
         authenticate(JWT_AUTH_PROVIDER) {
             get {
                 val organizationId = call.requireOrganizationId() ?: return@get
-                val status = rolloutStatusProvider(organizationId)
+                val rollout = rolloutStatusProvider(organizationId)
+                val entitlement = entitlementStatusProvider(organizationId)
                 call.respond(
                     NativeIncidentRolloutResponse(
-                        enabled = status.enabled,
-                        environment = status.environment,
-                        state = status.state.name,
+                        enabled = rollout.enabled && entitlement.enabled,
+                        environment = rollout.environment,
+                        state = rollout.state.name,
+                        entitlementEnabled = entitlement.enabled,
+                        plan = entitlement.plan,
+                        entitlementReason = entitlement.reason,
+                        quotas = entitlement.quotas.mapKeys { it.key.wire }.mapValues { (_, quota) ->
+                            NativeIncidentQuotaResponse(
+                                limit = quota.limit,
+                                used = quota.used,
+                                remaining = quota.remaining,
+                                exhausted = quota.exhausted,
+                            )
+                        },
                         externalProviderPassthroughAffected = false,
                     ),
                 )

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandServiceTest.kt
@@ -431,6 +431,89 @@ class IncidentCommandServiceTest {
         }
     }
 
+    @Test
+    fun `quota exhaustion rejects declaration without mutation`() {
+        val quotaDeniedService =
+            IncidentCommandService(
+                policy = IncidentCommandPolicy(
+                    entitlement = IncidentEntitlement { true },
+                    authorizer = IncidentCommandAuthorizer { _, _ -> true },
+                    quotaAdmission = IncidentQuotaAdmission {
+                        com.moneat.enterprise.NativeIncidentQuotaDecision(
+                            allowed = false,
+                            status = com.moneat.enterprise.NativeIncidentQuotaStatus(
+                                com.moneat.enterprise.NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+                                limit = 1,
+                                used = 1,
+                            ),
+                            message = "native incidents quota is exhausted; upgrade the plan or reduce usage",
+                        )
+                    },
+                ),
+            )
+
+        val error = assertFailsWith<IncidentCommandQuotaExceededException> {
+            quotaDeniedService.execute(
+                DeclareIncidentCommand(
+                    commandKey = "quota-denied",
+                    actor = actor(),
+                    title = "Denied by quota",
+                    description = null,
+                    severity = "SEV-3",
+                ),
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("upgrade the plan"))
+        transaction {
+            assertEquals(0, NativeIncidentCommands.selectAll().count())
+            assertEquals(0, NativeIncidentOutboxEvents.selectAll().count())
+        }
+    }
+
+    @Test
+    fun `declaration replay returns before quota admission`() {
+        var quotaAdmissions = 0
+        val quotaAwareService =
+            IncidentCommandService(
+                policy = IncidentCommandPolicy(
+                    entitlement = IncidentEntitlement { true },
+                    authorizer = IncidentCommandAuthorizer { _, _ -> true },
+                    quotaAdmission = IncidentQuotaAdmission {
+                        quotaAdmissions += 1
+                        com.moneat.enterprise.NativeIncidentQuotaDecision(
+                            allowed = true,
+                            status = com.moneat.enterprise.NativeIncidentQuotaStatus(
+                                key = com.moneat.enterprise.NativeIncidentQuotaKey.NATIVE_INCIDENTS,
+                                limit = 10,
+                                used = quotaAdmissions.toLong(),
+                            ),
+                        )
+                    },
+                ),
+            )
+        val command = DeclareIncidentCommand(
+            commandKey = "quota-replay",
+            actor = actor(),
+            title = "Replay-safe declaration",
+            description = null,
+            severity = "SEV-3",
+        )
+
+        val declared = quotaAwareService.execute(command)
+        val replay = quotaAwareService.execute(command)
+
+        assertEquals(declared.incidentId, replay.incidentId)
+        assertEquals(declared.incidentResourceId, replay.incidentResourceId)
+        assertEquals(declared.version, replay.version)
+        assertTrue(replay.replayed)
+        assertEquals(1, quotaAdmissions)
+        transaction {
+            assertEquals(1, NativeIncidentCommands.selectAll().count())
+            assertEquals(1, NativeIncidentOutboxEvents.selectAll().count())
+        }
+    }
+
     private fun actor() = IncidentCommandActor(member.organizationId, member.userId, "REST")
 
     private fun seedAlert(deduplicationKey: String): Int =

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
@@ -10,6 +10,7 @@ import com.moneat.enterprise.incidents.IncidentTestDatabase
 import com.moneat.enterprise.incidents.SeededMember
 import com.moneat.enterprise.NativeIncidentRolloutState
 import com.moneat.enterprise.NativeIncidentRolloutStatus
+import com.moneat.enterprise.NativeIncidentEntitlementStatus
 import com.moneat.enterprise.incidents.commands.IncidentCommandPolicy
 import com.moneat.enterprise.incidents.commands.IncidentCommandService
 import com.moneat.enterprise.incidents.commands.IncidentEntitlement
@@ -84,6 +85,25 @@ class IncidentRoutesTest {
         assertEquals(false, body["enabled"]?.jsonPrimitive?.content?.toBoolean())
         assertEquals("production", body.requiredString("environment"))
         assertEquals("DISABLED", body.requiredString("state"))
+        assertEquals(true, body["entitlementEnabled"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals("TEST", body.requiredString("plan"))
+        assertEquals(false, body["externalProviderPassthroughAffected"]?.jsonPrimitive?.content?.toBoolean())
+    }
+
+    @Test
+    fun `plan entitlement independently denies native routes`() = testApplication {
+        application { installIncidentRoutes(entitlementEnabled = false) }
+
+        val incidents = client.get("/v1/on-call/incidents") { authorize() }
+        val capabilities = client.get("/v1/on-call/incident-response/capabilities") { authorize() }
+
+        assertEquals(HttpStatusCode.Forbidden, incidents.status)
+        assertEquals(HttpStatusCode.OK, capabilities.status)
+        val body = capabilities.jsonObject()
+        assertEquals(false, body["enabled"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals("ENABLED", body["state"]?.jsonPrimitive?.content)
+        assertEquals(false, body["entitlementEnabled"]?.jsonPrimitive?.content?.toBoolean())
+        assertEquals("Upgrade the plan", body.requiredString("entitlementReason"))
         assertEquals(false, body["externalProviderPassthroughAffected"]?.jsonPrimitive?.content?.toBoolean())
     }
 
@@ -384,7 +404,10 @@ class IncidentRoutesTest {
         assertEquals(HttpStatusCode.OK, selfRemoval.status)
     }
 
-    private fun Application.installIncidentRoutes(rolloutEnabled: Boolean = true) {
+    private fun Application.installIncidentRoutes(
+        rolloutEnabled: Boolean = true,
+        entitlementEnabled: Boolean = true,
+    ) {
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         install(Authentication) {
             jwt("auth-jwt") {
@@ -404,7 +427,7 @@ class IncidentRoutesTest {
                 onCallIncidentService = OnCallIncidentService(
                     IncidentCommandService(policy = IncidentCommandPolicy.allowForTests()),
                 ),
-                incidentEntitlement = IncidentEntitlement { rolloutEnabled },
+                incidentEntitlement = IncidentEntitlement { rolloutEnabled && entitlementEnabled },
                 rolloutStatusProvider = {
                     NativeIncidentRolloutStatus(
                         enabled = rolloutEnabled,
@@ -415,6 +438,13 @@ class IncidentRoutesTest {
                             } else {
                                 NativeIncidentRolloutState.DISABLED
                             },
+                    )
+                },
+                entitlementStatusProvider = {
+                    NativeIncidentEntitlementStatus(
+                        enabled = entitlementEnabled,
+                        plan = "TEST",
+                        reason = if (entitlementEnabled) null else "Upgrade the plan",
                     )
                 },
             )


### PR DESCRIPTION
## Summary
- add plan-scoped native incident entitlement and quota contracts
- persist organization-scoped idempotent usage and reconciliation with V158
- enforce declaration quotas and expose fail-closed capability status to the dashboard
- preserve OSS external incident-provider forwarding outside native usage

## Verification
- backend broad feature and EE test graph
- focused billing entitlement and IncidentCommandService tests
- backend Detekt
- dashboard lint, typecheck, and 111 focused tests
- migration version checker and git diff --check
- Claude Opus 4.8 review: no blocking findings; applied reconciliation and replay regression improvements

Backlog: TASK-1.50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan-based entitlements for native incident response.
  * Added quota tracking with usage, remaining capacity, and exhaustion details.
  * Native incident access now requires both rollout availability and entitlement.
  * Incident declarations enforce quotas and return a clear rate-limit response when capacity is exceeded.
  * Capabilities responses now include plan, entitlement status, upgrade reason, and quota information.

* **Bug Fixes**
  * Added idempotent usage handling and reconciliation to support safe retries and accurate quota recovery.

* **Tests**
  * Expanded coverage for entitlement gating, quota enforcement, retries, and usage reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->