### PR TITLE
feat(incidents): complete triage and merge lifecycle

### DIFF
--- a/backend/src/main/resources/db/migration/V159__native_incident_triage_and_merge.sql
+++ b/backend/src/main/resources/db/migration/V159__native_incident_triage_and_merge.sql
@@ -1,0 +1,36 @@
+-- Triage incidents may stay unclassified until acceptance, and merging becomes a
+-- terminal outcome that is distinct from cancellation and decline.
+
+ALTER TABLE on_call_incidents
+    ALTER COLUMN severity DROP NOT NULL;
+
+ALTER TABLE on_call_incidents
+    ADD COLUMN merged_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN merged_into_incident_id INTEGER
+        REFERENCES on_call_incidents(id) ON DELETE CASCADE;
+
+ALTER TABLE on_call_incidents
+    DROP CONSTRAINT IF EXISTS chk_native_incident_status;
+
+ALTER TABLE on_call_incidents
+    ADD CONSTRAINT chk_native_incident_status CHECK (
+        status IN (
+            'TRIAGE', 'ACTIVE', 'RESOLVED', 'POST_INCIDENT',
+            'CLOSED', 'CANCELLED', 'DECLINED', 'MERGED'
+        )
+    ),
+    -- Severity is only required once the incident has been accepted out of triage.
+    ADD CONSTRAINT chk_native_incident_triage_severity CHECK (
+        severity IS NOT NULL OR accepted_at IS NULL
+    ),
+    ADD CONSTRAINT chk_native_incident_merged_state CHECK (
+        (status = 'MERGED' AND merged_at IS NOT NULL AND merged_into_incident_id IS NOT NULL)
+        OR (status <> 'MERGED' AND merged_at IS NULL AND merged_into_incident_id IS NULL)
+    ),
+    ADD CONSTRAINT chk_native_incident_merge_target CHECK (
+        merged_into_incident_id IS NULL OR merged_into_incident_id <> id
+    );
+
+CREATE INDEX idx_on_call_incidents_merged_into
+    ON on_call_incidents(merged_into_incident_id)
+    WHERE merged_into_incident_id IS NOT NULL;

--- a/backend/src/main/resources/db/migration/V159__native_incident_triage_and_merge.sql
+++ b/backend/src/main/resources/db/migration/V159__native_incident_triage_and_merge.sql
@@ -7,7 +7,7 @@ ALTER TABLE on_call_incidents
 ALTER TABLE on_call_incidents
     ADD COLUMN merged_at TIMESTAMP WITH TIME ZONE,
     ADD COLUMN merged_into_incident_id INTEGER
-        REFERENCES on_call_incidents(id) ON DELETE CASCADE;
+        REFERENCES on_call_incidents(id) ON DELETE RESTRICT;
 
 ALTER TABLE on_call_incidents
     DROP CONSTRAINT IF EXISTS chk_native_incident_status;

--- a/dashboard/src/components/on-call/incident-modeling.ts
+++ b/dashboard/src/components/on-call/incident-modeling.ts
@@ -274,8 +274,12 @@ export function timelineEventStyle(eventType: string): TimelineEventStyle {
   )
 }
 
-/** Incident severity mapped onto the shared status badge language. */
-export function severityBadgeVariant(severity: string): BadgeProps['variant'] {
+/**
+ * Incident severity mapped onto the shared status badge language. Triage incidents may not
+ * carry a severity yet, so an absent value reads as neutral.
+ */
+export function severityBadgeVariant(severity?: string): BadgeProps['variant'] {
+  if (!severity) return 'neutral'
   const severityMatch = /^SEV-?(\d)/i.exec(severity)
   const severityLevel = severityMatch?.[1]
   if (severityLevel === '0' || severityLevel === '1') return 'danger'

--- a/dashboard/src/lib/api/types/on-call.ts
+++ b/dashboard/src/lib/api/types/on-call.ts
@@ -159,6 +159,7 @@ export type OnCallIncidentStatus =
   | 'CLOSED'
   | 'CANCELLED'
   | 'DECLINED'
+  | 'MERGED'
 
 export type OnCallIncidentMode = 'LIVE' | 'RETROSPECTIVE' | 'TEST'
 
@@ -170,7 +171,8 @@ export interface OnCallIncident {
   title: string
   description?: string
   summary?: string
-  severity: string
+  // Triage incidents stay unclassified until they are accepted.
+  severity?: string
   status: OnCallIncidentStatus
   mode?: OnCallIncidentMode
   visibility?: OnCallIncidentVisibility
@@ -188,6 +190,8 @@ export interface OnCallIncident {
   closedAt?: string
   cancelledAt?: string
   declinedAt?: string
+  mergedAt?: string
+  mergedIntoIncidentId?: string
   alertCount: number
   alerts?: Array<{ id: string; title: string; status: string; priority?: string }>
   createdAt: string

--- a/dashboard/src/lib/incident-status.ts
+++ b/dashboard/src/lib/incident-status.ts
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import type {LucideIcon} from 'lucide-react'
-import {Archive, Ban, CheckCircle2, ClipboardCheck, Clock, XCircle, Zap} from 'lucide-react'
+import {Archive, Ban, CheckCircle2, ClipboardCheck, Clock, Merge, XCircle, Zap} from 'lucide-react'
 
 import type {BadgeProps} from '@/components/ui/badge'
 import type {StatusTone} from '@/components/ui/status-dot'
@@ -40,6 +40,7 @@ const INCIDENT_STATUS_CONFIG: Record<OnCallIncidentStatus, IncidentStatusConfig>
   CLOSED: {variant: 'neutral', icon: Archive, label: 'Closed', tone: 'neutral'},
   CANCELLED: {variant: 'neutral', icon: Ban, label: 'Cancelled', tone: 'neutral'},
   DECLINED: {variant: 'neutral', icon: XCircle, label: 'Declined', tone: 'neutral'},
+  MERGED: {variant: 'neutral', icon: Merge, label: 'Merged', tone: 'neutral'},
 }
 
 function fallbackLabel(status: string): string {

--- a/dashboard/src/routes/on-call.incidents.$incidentId.tsx
+++ b/dashboard/src/routes/on-call.incidents.$incidentId.tsx
@@ -186,7 +186,7 @@ function DeclaredIncidentDetailComponent() {
               {statusCfg.label}
             </Badge>
             <Badge variant={severityBadgeVariant(incident.severity)} size="sm">
-              {incident.severity}
+              {incident.severity ?? 'Unclassified'}
             </Badge>
             {mode !== 'LIVE' && (
               <Badge variant={modeMeta.variant} size="sm">
@@ -350,7 +350,9 @@ function DeclaredIncidentDetailComponent() {
               </Badge>
             </DetailRow>
             <DetailRow label="Severity">
-              <Badge variant={severityBadgeVariant(incident.severity)}>{incident.severity}</Badge>
+              <Badge variant={severityBadgeVariant(incident.severity)}>
+                {incident.severity ?? 'Unclassified'}
+              </Badge>
             </DetailRow>
             <DetailRow label="Mode">
               <Badge variant={modeMeta.variant}>{modeMeta.label}</Badge>

--- a/dashboard/src/routes/on-call.incidents.tsx
+++ b/dashboard/src/routes/on-call.incidents.tsx
@@ -59,8 +59,12 @@ type IncidentSeverityFilter = IncidentSeverity | 'all'
 
 const DEFAULT_DECLARED_INCIDENT_STATUS_FILTER: OnCallIncidentStatus = 'ACTIVE'
 
-// Incident severity mapped onto the shared status language.
-function severityTone(severity: string): StatusTone {
+// Incident severity mapped onto the shared status language. Triage incidents may not
+// carry a severity yet, so an absent value reads as unclassified.
+const UNCLASSIFIED_SEVERITY_LABEL = 'Unclassified'
+
+function severityTone(severity: string | undefined): StatusTone {
+  if (!severity) return 'neutral'
   const severityMatch = /^SEV-?(\d)/i.exec(severity)
   const severityLevel = severityMatch?.[1]
   if (severityLevel === '0' || severityLevel === '1') return 'danger'
@@ -69,7 +73,7 @@ function severityTone(severity: string): StatusTone {
   return 'neutral'
 }
 
-function severityBadgeVariant(severity: string): BadgeProps['variant'] {
+function severityBadgeVariant(severity: string | undefined): BadgeProps['variant'] {
   switch (severityTone(severity)) {
     case 'danger':
       return 'danger'
@@ -319,7 +323,7 @@ function DeclaredIncidents() {
                       </div>
                       <div className="flex items-center gap-2 flex-shrink-0">
                         <Badge variant={severityBadgeVariant(incident.severity)} size="sm">
-                          {incident.severity}
+                          {incident.severity ?? UNCLASSIFIED_SEVERITY_LABEL}
                         </Badge>
                         <Badge variant={statusCfg.variant} size="sm" className="gap-1">
                           <StatusIcon className="h-3 w-3" />

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/IncidentDomainGlossary.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/IncidentDomainGlossary.kt
@@ -13,7 +13,7 @@ enum class IncidentDomainObject(
     NATIVE_INCIDENT(
         apiName = "native_incident",
         owner = "enterprise incident response",
-        lifecycle = "triage through post-incident closure",
+        lifecycle = "triage through post-incident closure, decline, or terminal merge",
     ),
     FORWARDED_PROVIDER_INCIDENT(
         apiName = "forwarded_provider_incident",

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandFingerprint.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandFingerprint.kt
@@ -28,6 +28,7 @@ internal object IncidentCommandFingerprint {
         when (command) {
             is DeclareIncidentCommand,
             is AcceptIncidentCommand,
+            is DeclineIncidentCommand,
             is MergeIncidentCommand,
             is UpdateIncidentCommand,
             is TransitionIncidentCommand,
@@ -60,7 +61,14 @@ internal object IncidentCommandFingerprint {
                     command.initialStatus.wire,
                     command.onCallAlertId?.toString(),
                 )
-            is AcceptIncidentCommand -> listOf(command.incidentId.toString())
+            is AcceptIncidentCommand ->
+                listOf(
+                    command.incidentId.toString(),
+                    command.severity,
+                    command.incidentTypeResourceId,
+                    canonicalDetails(command.formValues),
+                )
+            is DeclineIncidentCommand -> listOf(command.incidentId.toString(), command.reason)
             is MergeIncidentCommand -> listOf(command.incidentId.toString(), command.sourceIncidentId.toString())
             is UpdateIncidentCommand ->
                 listOf(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
@@ -6,10 +6,78 @@ package com.moneat.enterprise.incidents.commands
 
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.enterprise.NativeIncidentQuotaKey
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
 import com.moneat.monitoring.OperationalMetrics
 
 fun interface IncidentEntitlement {
     fun isEnabled(organizationId: Int): Boolean
+}
+
+/**
+ * Capability groups an incident command belongs to. Triage incidents are unclassified, so they
+ * expose investigation and staffing capabilities but withhold the commitments that only make
+ * sense once the incident has been accepted.
+ */
+enum class IncidentCapability(val wire: String) {
+    LIFECYCLE("LIFECYCLE"),
+    INVESTIGATION("INVESTIGATION"),
+    ROLES("ROLES"),
+    PARTICIPATION("PARTICIPATION"),
+    ESCALATION("ESCALATION"),
+    ACTIONS("ACTIONS"),
+    FOLLOW_UPS("FOLLOW_UPS"),
+    STATUS_PAGE_COMMUNICATION("STATUS_PAGE_COMMUNICATION"),
+}
+
+/** Central answer to "may this capability be used while the incident is still in triage?". */
+object IncidentTriageCapabilityPolicy {
+    private val TRIAGE_CAPABILITIES =
+        setOf(
+            IncidentCapability.LIFECYCLE,
+            IncidentCapability.INVESTIGATION,
+            IncidentCapability.ROLES,
+            IncidentCapability.PARTICIPATION,
+            IncidentCapability.ESCALATION,
+        )
+
+    private val COMMAND_CAPABILITIES =
+        mapOf(
+            IncidentCommandType.DECLARE to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.ACCEPT to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.DECLINE to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.MERGE to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.UPDATE to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.TRANSITION to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.RESOLVE to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.CANCEL to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.REOPEN to IncidentCapability.LIFECYCLE,
+            IncidentCommandType.ASSIGN_ROLE to IncidentCapability.ROLES,
+            IncidentCommandType.CLAIM_ROLE to IncidentCapability.ROLES,
+            IncidentCommandType.UNASSIGN_ROLE to IncidentCapability.ROLES,
+            IncidentCommandType.HANDOVER_ROLE to IncidentCapability.ROLES,
+            IncidentCommandType.JOIN to IncidentCapability.PARTICIPATION,
+            IncidentCommandType.OBSERVE to IncidentCapability.PARTICIPATION,
+            IncidentCommandType.LEAVE to IncidentCapability.PARTICIPATION,
+            IncidentCommandType.ADD_TIMELINE_EVENT to IncidentCapability.INVESTIGATION,
+            IncidentCommandType.LINK_ON_CALL_ALERT to IncidentCapability.INVESTIGATION,
+            IncidentCommandType.LINK_SOURCE to IncidentCapability.INVESTIGATION,
+            IncidentCommandType.UNLINK_SOURCE to IncidentCapability.INVESTIGATION,
+            IncidentCommandType.ADD_ACTION to IncidentCapability.ACTIONS,
+        )
+
+    fun capabilityOf(commandType: IncidentCommandType): IncidentCapability =
+        COMMAND_CAPABILITIES[commandType] ?: IncidentCapability.LIFECYCLE
+
+    fun permits(capability: IncidentCapability): Boolean = capability in TRIAGE_CAPABILITIES
+
+    fun requireAllowed(status: NativeIncidentStatus, commandType: IncidentCommandType) {
+        if (status != NativeIncidentStatus.TRIAGE) return
+        val capability = capabilityOf(commandType)
+        if (permits(capability)) return
+        throw IncidentCommandDeniedException(
+            "${capability.wire} is unavailable until the incident is accepted out of triage",
+        )
+    }
 }
 
 fun interface IncidentCommandAuthorizer {
@@ -58,6 +126,11 @@ class IncidentCommandPolicy(
                 decision.message ?: "Native incident quota is exhausted; upgrade the plan or reduce usage",
             )
         }
+    }
+
+    /** Applied once the incident's current status is known, so triage restrictions stay central. */
+    fun requireCapabilityAllowed(command: ExistingIncidentCommand, status: NativeIncidentStatus) {
+        IncidentTriageCapabilityPolicy.requireAllowed(status, command.type)
     }
 
     companion object {

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandPolicy.kt
@@ -40,33 +40,34 @@ object IncidentTriageCapabilityPolicy {
             IncidentCapability.ESCALATION,
         )
 
-    private val COMMAND_CAPABILITIES =
-        mapOf(
-            IncidentCommandType.DECLARE to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.ACCEPT to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.DECLINE to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.MERGE to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.UPDATE to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.TRANSITION to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.RESOLVE to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.CANCEL to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.REOPEN to IncidentCapability.LIFECYCLE,
-            IncidentCommandType.ASSIGN_ROLE to IncidentCapability.ROLES,
-            IncidentCommandType.CLAIM_ROLE to IncidentCapability.ROLES,
-            IncidentCommandType.UNASSIGN_ROLE to IncidentCapability.ROLES,
-            IncidentCommandType.HANDOVER_ROLE to IncidentCapability.ROLES,
-            IncidentCommandType.JOIN to IncidentCapability.PARTICIPATION,
-            IncidentCommandType.OBSERVE to IncidentCapability.PARTICIPATION,
-            IncidentCommandType.LEAVE to IncidentCapability.PARTICIPATION,
-            IncidentCommandType.ADD_TIMELINE_EVENT to IncidentCapability.INVESTIGATION,
-            IncidentCommandType.LINK_ON_CALL_ALERT to IncidentCapability.INVESTIGATION,
-            IncidentCommandType.LINK_SOURCE to IncidentCapability.INVESTIGATION,
-            IncidentCommandType.UNLINK_SOURCE to IncidentCapability.INVESTIGATION,
-            IncidentCommandType.ADD_ACTION to IncidentCapability.ACTIONS,
-        )
-
     fun capabilityOf(commandType: IncidentCommandType): IncidentCapability =
-        COMMAND_CAPABILITIES[commandType] ?: IncidentCapability.LIFECYCLE
+        when (commandType) {
+            IncidentCommandType.DECLARE,
+            IncidentCommandType.ACCEPT,
+            IncidentCommandType.DECLINE,
+            IncidentCommandType.MERGE,
+            IncidentCommandType.UPDATE,
+            IncidentCommandType.TRANSITION,
+            IncidentCommandType.RESOLVE,
+            IncidentCommandType.CANCEL,
+            IncidentCommandType.REOPEN,
+            -> IncidentCapability.LIFECYCLE
+            IncidentCommandType.ASSIGN_ROLE,
+            IncidentCommandType.CLAIM_ROLE,
+            IncidentCommandType.UNASSIGN_ROLE,
+            IncidentCommandType.HANDOVER_ROLE,
+            -> IncidentCapability.ROLES
+            IncidentCommandType.JOIN,
+            IncidentCommandType.OBSERVE,
+            IncidentCommandType.LEAVE,
+            -> IncidentCapability.PARTICIPATION
+            IncidentCommandType.ADD_TIMELINE_EVENT,
+            IncidentCommandType.LINK_ON_CALL_ALERT,
+            IncidentCommandType.LINK_SOURCE,
+            IncidentCommandType.UNLINK_SOURCE,
+            -> IncidentCapability.INVESTIGATION
+            IncidentCommandType.ADD_ACTION -> IncidentCapability.ACTIONS
+        }
 
     fun permits(capability: IncidentCapability): Boolean = capability in TRIAGE_CAPABILITIES
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandService.kt
@@ -6,11 +6,15 @@ package com.moneat.enterprise.incidents.commands
 
 import com.moneat.alerts.models.IncidentSeverity
 import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.enterprise.incidents.config.IncidentConfigurationService
+import com.moneat.enterprise.incidents.config.ResolvedIncidentForm
 import com.moneat.enterprise.incidents.events.IncidentOutboxWriter
 import com.moneat.enterprise.incidents.events.PendingNativeIncidentDomainEvent
 import com.moneat.enterprise.incidents.models.NativeIncidentCommands
 import com.moneat.enterprise.incidents.models.NativeIncidentAlertEpisodeLinks
 import com.moneat.enterprise.incidents.models.NativeIncidentFormSubmissions
+import com.moneat.enterprise.incidents.models.NativeIncidentTypes
+import com.moneat.enterprise.incidents.models.IncidentFormStage
 import com.moneat.enterprise.incidents.models.IncidentParticipationType
 import com.moneat.enterprise.incidents.models.IncidentRoleEndReason
 import com.moneat.enterprise.incidents.models.NativeIncidentHandovers
@@ -33,6 +37,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
@@ -51,6 +56,7 @@ class IncidentCommandService(
     private val policy: IncidentCommandPolicy = IncidentCommandPolicy(),
     private val outboxWriter: IncidentOutboxWriter = IncidentOutboxWriter(),
     private val timelineWriter: IncidentTimelineWriter = IncidentTimelineWriter(),
+    private val configurationService: IncidentConfigurationService = IncidentConfigurationService(),
 ) {
     fun execute(command: IncidentCommand): IncidentCommandResult {
         policy.requireAllowed(command)
@@ -95,7 +101,8 @@ class IncidentCommandService(
     private fun applyCommand(command: IncidentCommand): IncidentMutation =
         when (command) {
             is DeclareIncidentCommand -> declare(command)
-            is AcceptIncidentCommand -> transition(command, NativeIncidentStatus.ACTIVE, null)
+            is AcceptIncidentCommand -> accept(command)
+            is DeclineIncidentCommand -> transition(command, NativeIncidentStatus.DECLINED, command.reason)
             is MergeIncidentCommand -> merge(command)
             is UpdateIncidentCommand -> update(command)
             is TransitionIncidentCommand -> transition(command, command.targetStatus, command.note)
@@ -170,12 +177,12 @@ class IncidentCommandService(
         val title = command.title.trim()
         require(title.isNotEmpty()) { "Incident title is required" }
         require(title.length <= MAX_TITLE_LENGTH) { "Incident title is too long" }
-        val severity =
-            requireNotNull(IncidentSeverity.fromString(command.severity)) {
-                "Invalid incident severity: ${command.severity}"
-            }.wire
         require(command.initialStatus in DECLARABLE_STATUSES) {
             "Incidents can only be declared in TRIAGE or ACTIVE status"
+        }
+        val severity = command.severity?.let(::requireSeverity)
+        require(severity != null || command.initialStatus == NativeIncidentStatus.TRIAGE) {
+            "Incident severity is required to declare an active incident"
         }
         command.onCallAlertId?.let { requireAlert(command.actor.organizationId, it) }
         val now = Clock.System.now()
@@ -205,6 +212,8 @@ class IncidentCommandService(
                 it[closedAt] = null
                 it[cancelledAt] = null
                 it[declinedAt] = null
+                it[mergedAt] = null
+                it[mergedIntoIncidentId] = null
                 it[createdAt] = now
                 it[updatedAt] = now
             }.value
@@ -255,9 +264,7 @@ class IncidentCommandService(
 
     private fun update(command: UpdateIncidentCommand): IncidentMutation {
         val current = requireIncident(command)
-        val severity = command.severity?.let {
-            requireNotNull(IncidentSeverity.fromString(it)) { "Invalid incident severity: $it" }.wire
-        }
+        val severity = command.severity?.let(::requireSeverity)
         command.title?.let {
             require(it.isNotBlank()) { "Incident title is required" }
             require(it.trim().length <= MAX_TITLE_LENGTH) { "Incident title is too long" }
@@ -298,10 +305,18 @@ class IncidentCommandService(
         val current = requireIncident(command)
         val currentStatus = statusOf(current)
         if (currentStatus == target) return loadMutation(command.incidentId, changed = false)
-        if (target !in allowedTransitions.getValue(currentStatus)) {
-            throw IncidentCommandConflictException(
-                "Cannot transition incident from ${currentStatus.wire} to ${target.wire}",
-            )
+        requireTransitionAllowed(currentStatus, target)
+        if (target in ACCEPTED_STATUSES) {
+            if (currentStatus == NativeIncidentStatus.TRIAGE) {
+                requireAcceptanceSatisfied(
+                    organizationId = command.actor.organizationId,
+                    incidentTypeResourceId = incidentTypeResourceId(command.actor.organizationId, current),
+                    formValues = emptyMap(),
+                    severity = current[OnCallIncidents.severity],
+                )
+            } else {
+                require(current[OnCallIncidents.severity] != null) { SEVERITY_REQUIRED_MESSAGE }
+            }
         }
         val now = Clock.System.now()
         val nextVersion = current[OnCallIncidents.version] + 1
@@ -310,24 +325,7 @@ class IncidentCommandService(
                 it[status] = target.wire
                 it[version] = nextVersion
                 it[updatedAt] = now
-                when (target) {
-                    NativeIncidentStatus.TRIAGE -> {
-                        it[triagedAt] = now
-                        clearTerminalState(it)
-                    }
-                    NativeIncidentStatus.ACTIVE -> {
-                        it[acceptedAt] = now
-                        clearTerminalState(it)
-                    }
-                    NativeIncidentStatus.RESOLVED -> {
-                        it[resolvedBy] = command.actor.userId
-                        it[resolvedAt] = now
-                    }
-                    NativeIncidentStatus.POST_INCIDENT -> it[postIncidentAt] = now
-                    NativeIncidentStatus.CLOSED -> it[closedAt] = now
-                    NativeIncidentStatus.CANCELLED -> it[cancelledAt] = now
-                    NativeIncidentStatus.DECLINED -> it[declinedAt] = now
-                }
+                applyStatusTimestamps(it, target, command.actor.userId, now)
             }
         requireVersionUpdate(updated, command.incidentId)
         insertTimelineEvent(
@@ -341,6 +339,140 @@ class IncidentCommandService(
             ),
         )
         return loadMutation(command.incidentId)
+    }
+
+    /**
+     * Accepting classifies a triage incident and moves it into the active response in one
+     * versioned mutation, so severity, incident type, and the acceptance form land together.
+     */
+    private fun accept(command: AcceptIncidentCommand): IncidentMutation {
+        val current = requireIncident(command)
+        val currentStatus = statusOf(current)
+        if (currentStatus == NativeIncidentStatus.ACTIVE) return loadMutation(command.incidentId, changed = false)
+        requireTransitionAllowed(currentStatus, NativeIncidentStatus.ACTIVE)
+        val severity = command.severity?.let(::requireSeverity) ?: current[OnCallIncidents.severity]
+        val organizationId = command.actor.organizationId
+        val typeResourceId =
+            command.incidentTypeResourceId.cleaned() ?: incidentTypeResourceId(organizationId, current)
+        val acceptance =
+            requireAcceptanceSatisfied(organizationId, typeResourceId, command.formValues, severity)
+        val now = Clock.System.now()
+        val nextVersion = current[OnCallIncidents.version] + 1
+        val updated =
+            OnCallIncidents.update({ versionPredicate(command, current) }) {
+                it[status] = NativeIncidentStatus.ACTIVE.wire
+                it[OnCallIncidents.severity] = severity
+                it[incidentTypeDefinitionId] =
+                    acceptance.incidentTypeDefinitionId ?: current[OnCallIncidents.incidentTypeDefinitionId]
+                it[OnCallIncidents.incidentType] =
+                    acceptance.incidentTypeName ?: current[OnCallIncidents.incidentType]
+                it[acceptedAt] = now
+                it[version] = nextVersion
+                it[updatedAt] = now
+                clearTerminalState(it)
+            }
+        requireVersionUpdate(updated, command.incidentId)
+        recordAcceptanceSubmission(command, acceptance, now)
+        insertTimelineEvent(
+            command,
+            CommandTimelineEvent(
+                command.incidentId,
+                command.commandKey,
+                NativeIncidentStatus.ACTIVE.timelineEventType(),
+                transitionDetails(command.actor.origin, null, currentStatus) +
+                    ("severity" to JsonPrimitive(severity)),
+                now,
+            ),
+        )
+        return loadMutation(command.incidentId)
+    }
+
+    private fun recordAcceptanceSubmission(
+        command: AcceptIncidentCommand,
+        acceptance: ResolvedIncidentForm,
+        now: kotlin.time.Instant,
+    ) {
+        if (acceptance.formDefinitionId == null && acceptance.values.isEmpty()) return
+        NativeIncidentFormSubmissions.insert {
+            it[resourceId] = Uuid.random()
+            it[organizationId] = command.actor.organizationId
+            it[incidentId] = command.incidentId
+            it[formId] = acceptance.formDefinitionId
+            it[stage] = IncidentFormStage.ACCEPTANCE.wire
+            it[definitionSnapshot] = acceptance.definitionSnapshot
+            it[valuesSnapshot] = acceptance.values
+            it[submittedBy] = command.actor.userId
+            it[submittedAt] = now
+        }
+    }
+
+    /**
+     * A triage incident only leaves triage once it carries a severity and satisfies the
+     * organization's configured acceptance form.
+     */
+    private fun requireAcceptanceSatisfied(
+        organizationId: Int,
+        incidentTypeResourceId: String?,
+        formValues: Map<String, JsonElement>,
+        severity: String?,
+    ): ResolvedIncidentForm {
+        require(severity != null) { SEVERITY_REQUIRED_MESSAGE }
+        return configurationService.resolveForm(
+            organizationId = organizationId,
+            incidentTypeResourceId = incidentTypeResourceId,
+            stage = IncidentFormStage.ACCEPTANCE,
+            submittedValues = formValues,
+        )
+    }
+
+    private fun incidentTypeResourceId(organizationId: Int, current: ResultRow): String? {
+        val definitionId = current[OnCallIncidents.incidentTypeDefinitionId] ?: return null
+        return NativeIncidentTypes
+            .selectAll()
+            .where {
+                (NativeIncidentTypes.id eq definitionId) and
+                    (NativeIncidentTypes.organizationId eq organizationId)
+            }.singleOrNull()
+            ?.get(NativeIncidentTypes.resourceId)
+            ?.toString()
+    }
+
+    private fun requireSeverity(value: String): String =
+        requireNotNull(IncidentSeverity.fromString(value)) { "Invalid incident severity: $value" }.wire
+
+    private fun requireTransitionAllowed(current: NativeIncidentStatus, target: NativeIncidentStatus) {
+        if (target in allowedTransitions.getValue(current)) return
+        throw IncidentCommandConflictException(
+            "Cannot transition incident from ${current.wire} to ${target.wire}",
+        )
+    }
+
+    private fun applyStatusTimestamps(
+        statement: UpdateBuilder<*>,
+        target: NativeIncidentStatus,
+        actorUserId: Int,
+        now: kotlin.time.Instant,
+    ) {
+        when (target) {
+            NativeIncidentStatus.TRIAGE -> {
+                statement[OnCallIncidents.triagedAt] = now
+                clearTerminalState(statement)
+            }
+            NativeIncidentStatus.ACTIVE -> {
+                statement[OnCallIncidents.acceptedAt] = now
+                clearTerminalState(statement)
+            }
+            NativeIncidentStatus.RESOLVED -> {
+                statement[OnCallIncidents.resolvedBy] = actorUserId
+                statement[OnCallIncidents.resolvedAt] = now
+            }
+            NativeIncidentStatus.POST_INCIDENT -> statement[OnCallIncidents.postIncidentAt] = now
+            NativeIncidentStatus.CLOSED -> statement[OnCallIncidents.closedAt] = now
+            NativeIncidentStatus.CANCELLED -> statement[OnCallIncidents.cancelledAt] = now
+            NativeIncidentStatus.DECLINED -> statement[OnCallIncidents.declinedAt] = now
+            // MERGED is written only by the merge command, which also records the merge target.
+            NativeIncidentStatus.MERGED -> error("MERGED is only reachable through a merge command")
+        }
     }
 
     private fun assignRole(command: AssignIncidentRoleCommand): IncidentMutation {
@@ -766,27 +898,20 @@ class IncidentCommandService(
         )
     }
 
+    /**
+     * Merging retires the source incident into the target. The source keeps its own timeline and
+     * command history; only its links move, and it lands in the terminal MERGED status that
+     * records where it went.
+     */
     private fun merge(command: MergeIncidentCommand): IncidentMutation {
         require(command.incidentId != command.sourceIncidentId) { "Cannot merge an incident into itself" }
         val target = requireIncident(command)
         val source = requireIncident(command.actor.organizationId, command.sourceIncidentId)
-        val sourceStatus = statusOf(source)
-        if (NativeIncidentStatus.CANCELLED !in allowedTransitions.getValue(sourceStatus)) {
-            throw IncidentCommandConflictException("An incident in ${sourceStatus.wire} status cannot be merged")
-        }
-        val sourceAlerts =
-            OnCallIncidentAlerts
-                .selectAll()
-                .where { OnCallIncidentAlerts.incidentId eq command.sourceIncidentId }
-                .map { it[OnCallIncidentAlerts.alertId] }
-        OnCallIncidentAlerts.update({ OnCallIncidentAlerts.incidentId eq command.sourceIncidentId }) {
-            it[incidentId] = command.incidentId
-        }
-        sourceAlerts.forEach { alertId ->
-            OnCallAlerts.update({ OnCallAlerts.id eq alertId }) {
-                it[declaredIncidentId] = command.incidentId
-            }
-        }
+        alreadyMergedResult(command, source)?.let { return it }
+        requireMergeable(statusOf(target), statusOf(source))
+        transferOnCallAlertLinks(command)
+        transferAlertEpisodeLinks(command)
+        transferSourceLinks(command)
         val now = Clock.System.now()
         val targetVersion = target[OnCallIncidents.version] + 1
         requireVersionUpdate(
@@ -802,11 +927,104 @@ class IncidentCommandService(
                 (OnCallIncidents.organizationId eq command.actor.organizationId) and
                 (OnCallIncidents.version eq source[OnCallIncidents.version])
         }) {
-            it[status] = NativeIncidentStatus.CANCELLED.wire
+            it[status] = NativeIncidentStatus.MERGED.wire
             it[version] = sourceVersion
-            it[cancelledAt] = now
+            it[mergedAt] = now
+            it[mergedIntoIncidentId] = command.incidentId
             it[updatedAt] = now
         }.also { requireVersionUpdate(it, command.sourceIncidentId) }
+        recordMergeEvents(command, source, target, sourceVersion, now)
+        return loadMutation(command.incidentId)
+    }
+
+    /** A repeated merge of the same pair converges instead of failing. */
+    private fun alreadyMergedResult(command: MergeIncidentCommand, source: ResultRow): IncidentMutation? {
+        if (statusOf(source) != NativeIncidentStatus.MERGED) return null
+        if (source[OnCallIncidents.mergedIntoIncidentId] == command.incidentId) {
+            return loadMutation(command.incidentId, changed = false)
+        }
+        throw IncidentCommandConflictException("Incident is already merged into another incident")
+    }
+
+    private fun requireMergeable(targetStatus: NativeIncidentStatus, sourceStatus: NativeIncidentStatus) {
+        if (targetStatus !in MERGE_TARGET_STATUSES) {
+            throw IncidentCommandConflictException(
+                "Incidents cannot be merged into an incident in ${targetStatus.wire} status",
+            )
+        }
+        if (NativeIncidentStatus.MERGED !in allowedTransitions.getValue(sourceStatus)) {
+            throw IncidentCommandConflictException("An incident in ${sourceStatus.wire} status cannot be merged")
+        }
+    }
+
+    private fun transferOnCallAlertLinks(command: MergeIncidentCommand) {
+        val sourceAlerts =
+            OnCallIncidentAlerts
+                .selectAll()
+                .where { OnCallIncidentAlerts.incidentId eq command.sourceIncidentId }
+                .map { it[OnCallIncidentAlerts.alertId] }
+        if (sourceAlerts.isEmpty()) return
+        OnCallIncidentAlerts.update({ OnCallIncidentAlerts.incidentId eq command.sourceIncidentId }) {
+            it[incidentId] = command.incidentId
+        }
+        sourceAlerts.forEach { alertId ->
+            OnCallAlerts.update({ OnCallAlerts.id eq alertId }) {
+                it[declaredIncidentId] = command.incidentId
+            }
+        }
+    }
+
+    private fun transferAlertEpisodeLinks(command: MergeIncidentCommand) {
+        val targetEpisodes =
+            NativeIncidentAlertEpisodeLinks
+                .selectAll()
+                .where { NativeIncidentAlertEpisodeLinks.incidentId eq command.incidentId }
+                .mapTo(mutableSetOf()) { it[NativeIncidentAlertEpisodeLinks.alertEpisodeId] }
+        if (targetEpisodes.isNotEmpty()) {
+            NativeIncidentAlertEpisodeLinks.deleteWhere {
+                (incidentId eq command.sourceIncidentId) and (alertEpisodeId inList targetEpisodes)
+            }
+        }
+        NativeIncidentAlertEpisodeLinks.update({
+            NativeIncidentAlertEpisodeLinks.incidentId eq command.sourceIncidentId
+        }) {
+            it[incidentId] = command.incidentId
+        }
+    }
+
+    private fun transferSourceLinks(command: MergeIncidentCommand) {
+        val targetSources =
+            NativeIncidentSourceLinks
+                .selectAll()
+                .where { NativeIncidentSourceLinks.incidentId eq command.incidentId }
+                .mapTo(mutableSetOf()) {
+                    it[NativeIncidentSourceLinks.sourceType] to it[NativeIncidentSourceLinks.sourceKey]
+                }
+        val duplicateIds =
+            NativeIncidentSourceLinks
+                .selectAll()
+                .where { NativeIncidentSourceLinks.incidentId eq command.sourceIncidentId }
+                .filter {
+                    (it[NativeIncidentSourceLinks.sourceType] to it[NativeIncidentSourceLinks.sourceKey]) in
+                        targetSources
+                }.map { it[NativeIncidentSourceLinks.id].value }
+        if (duplicateIds.isNotEmpty()) {
+            NativeIncidentSourceLinks.deleteWhere { id inList duplicateIds }
+        }
+        NativeIncidentSourceLinks.update({
+            NativeIncidentSourceLinks.incidentId eq command.sourceIncidentId
+        }) {
+            it[incidentId] = command.incidentId
+        }
+    }
+
+    private fun recordMergeEvents(
+        command: MergeIncidentCommand,
+        source: ResultRow,
+        target: ResultRow,
+        sourceVersion: Int,
+        now: kotlin.time.Instant,
+    ) {
         val details = mapOf(
             "origin" to JsonPrimitive(command.actor.origin),
             "sourceIncidentId" to JsonPrimitive(source[OnCallIncidents.resourceId].toString()),
@@ -827,7 +1045,7 @@ class IncidentCommandService(
             CommandTimelineEvent(
                 command.sourceIncidentId,
                 "${command.commandKey}:source",
-                "MERGED_INTO_INCIDENT",
+                NativeIncidentStatus.MERGED.timelineEventType(),
                 details,
                 now,
             ),
@@ -839,14 +1057,19 @@ class IncidentCommandService(
                 eventType = "INCIDENT_MERGED_SOURCE",
                 aggregateVersion = sourceVersion,
                 idempotencyKey = "${command.commandKey}:source",
-                payload = details + ("status" to JsonPrimitive(NativeIncidentStatus.CANCELLED.wire)),
+                payload = details +
+                    mapOf(
+                        "status" to JsonPrimitive(NativeIncidentStatus.MERGED.wire),
+                        "mergedIntoIncidentId" to JsonPrimitive(target[OnCallIncidents.resourceId].toString()),
+                        "mergedAt" to JsonPrimitive(now.toString()),
+                    ),
             ),
         )
-        return loadMutation(command.incidentId)
     }
 
     private fun requireIncident(command: ExistingIncidentCommand): ResultRow {
         val row = requireIncident(command.actor.organizationId, command.incidentId)
+        policy.requireCapabilityAllowed(command, statusOf(row))
         command.expectedVersion?.let { expected ->
             if (row[OnCallIncidents.version] != expected) {
                 throw IncidentCommandConflictException(
@@ -1100,6 +1323,7 @@ class IncidentCommandService(
             NativeIncidentStatus.CLOSED -> "CLOSED"
             NativeIncidentStatus.CANCELLED -> "CANCELLED"
             NativeIncidentStatus.DECLINED -> "DECLINED"
+            NativeIncidentStatus.MERGED -> "MERGED_INTO_INCIDENT"
         }
 
     private fun transitionDetails(
@@ -1132,6 +1356,8 @@ class IncidentCommandService(
         statement[OnCallIncidents.closedAt] = null
         statement[OnCallIncidents.cancelledAt] = null
         statement[OnCallIncidents.declinedAt] = null
+        statement[OnCallIncidents.mergedAt] = null
+        statement[OnCallIncidents.mergedIntoIncidentId] = null
     }
 
     private fun ExposedSQLException.violatesConstraint(constraintName: String): Boolean =
@@ -1155,7 +1381,7 @@ class IncidentCommandService(
         val incidentId: Int,
         val incidentResourceId: String,
         val title: String,
-        val severity: String,
+        val severity: String?,
         val status: NativeIncidentStatus,
         val version: Int,
         val changed: Boolean,
@@ -1176,19 +1402,40 @@ class IncidentCommandService(
         private const val MAX_TITLE_LENGTH = 255
         private const val MAX_TIMELINE_EVENT_TYPE_LENGTH = 80
         private const val MAX_SOURCE_KEY_LENGTH = 500
+        private const val SEVERITY_REQUIRED_MESSAGE =
+            "Incident severity is required before an incident is accepted"
         private val SAFE_EXTERNAL_SOURCE_SCHEMES = setOf("http", "https")
 
         private val DECLARABLE_STATUSES = setOf(NativeIncidentStatus.TRIAGE, NativeIncidentStatus.ACTIVE)
+
+        /** Statuses that represent an accepted incident, so leaving triage for them needs acceptance. */
+        private val ACCEPTED_STATUSES = setOf(
+            NativeIncidentStatus.ACTIVE,
+            NativeIncidentStatus.RESOLVED,
+            NativeIncidentStatus.POST_INCIDENT,
+            NativeIncidentStatus.CLOSED,
+        )
+
+        /** An incident can absorb a merge unless it has itself been closed out or merged away. */
+        private val MERGE_TARGET_STATUSES = setOf(
+            NativeIncidentStatus.TRIAGE,
+            NativeIncidentStatus.ACTIVE,
+            NativeIncidentStatus.RESOLVED,
+            NativeIncidentStatus.POST_INCIDENT,
+            NativeIncidentStatus.CLOSED,
+        )
 
         private val allowedTransitions = mapOf(
             NativeIncidentStatus.TRIAGE to setOf(
                 NativeIncidentStatus.ACTIVE,
                 NativeIncidentStatus.DECLINED,
                 NativeIncidentStatus.CANCELLED,
+                NativeIncidentStatus.MERGED,
             ),
             NativeIncidentStatus.ACTIVE to setOf(
                 NativeIncidentStatus.RESOLVED,
                 NativeIncidentStatus.CANCELLED,
+                NativeIncidentStatus.MERGED,
             ),
             NativeIncidentStatus.RESOLVED to setOf(
                 NativeIncidentStatus.POST_INCIDENT,
@@ -1202,6 +1449,8 @@ class IncidentCommandService(
             NativeIncidentStatus.CLOSED to setOf(NativeIncidentStatus.ACTIVE),
             NativeIncidentStatus.CANCELLED to setOf(NativeIncidentStatus.ACTIVE),
             NativeIncidentStatus.DECLINED to setOf(NativeIncidentStatus.ACTIVE),
+            // MERGED is terminal: a merged incident is never reopened or transitioned again.
+            NativeIncidentStatus.MERGED to emptySet(),
         )
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommands.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommands.kt
@@ -19,6 +19,7 @@ data class IncidentCommandActor(
 enum class IncidentCommandType(val wire: String) {
     DECLARE("DECLARE"),
     ACCEPT("ACCEPT"),
+    DECLINE("DECLINE"),
     MERGE("MERGE"),
     UPDATE("UPDATE"),
     TRANSITION("TRANSITION"),
@@ -52,7 +53,8 @@ data class DeclareIncidentCommand(
     val title: String,
     val description: String?,
     val summary: String? = null,
-    val severity: String,
+    /** Triage declarations may stay unclassified; ACTIVE declarations must carry a severity. */
+    val severity: String? = null,
     val mode: NativeIncidentMode = NativeIncidentMode.LIVE,
     val visibility: NativeIncidentVisibility = NativeIncidentVisibility.ORGANIZATION,
     val incidentType: String? = null,
@@ -71,13 +73,30 @@ sealed interface ExistingIncidentCommand : IncidentCommand {
     val incidentId: Int
 }
 
+/**
+ * Accepting a triage incident classifies it. Severity is required by the time the incident
+ * becomes ACTIVE, and the organization's ACCEPTANCE form is validated against [formValues].
+ */
 data class AcceptIncidentCommand(
     override val commandKey: String,
     override val actor: IncidentCommandActor,
     override val incidentId: Int,
     override val expectedVersion: Int? = null,
+    val severity: String? = null,
+    val incidentTypeResourceId: String? = null,
+    val formValues: Map<String, JsonElement> = emptyMap(),
 ) : ExistingIncidentCommand {
     override val type = IncidentCommandType.ACCEPT
+}
+
+data class DeclineIncidentCommand(
+    override val commandKey: String,
+    override val actor: IncidentCommandActor,
+    override val incidentId: Int,
+    val reason: String? = null,
+    override val expectedVersion: Int? = null,
+) : ExistingIncidentCommand {
+    override val type = IncidentCommandType.DECLINE
 }
 
 data class MergeIncidentCommand(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
@@ -6,6 +6,8 @@ package com.moneat.enterprise.incidents.events
 
 import com.moneat.alerts.models.IncidentSeverity
 import com.moneat.workflows.services.WorkflowService
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
 class WorkflowIncidentEventConsumer(
@@ -15,26 +17,34 @@ class WorkflowIncidentEventConsumer(
 
     override suspend fun consume(event: NativeIncidentDomainEvent, deliveryKey: String) {
         require(deliveryKey.isNotBlank()) { "Workflow incident delivery key is required" }
-        val title = event.payload.getValue("title").jsonPrimitive.content
-        val severity =
-            requireNotNull(IncidentSeverity.fromString(event.payload.getValue("severity").jsonPrimitive.content)) {
-                "Incident event has invalid severity"
-            }
         when (event.eventType) {
             "INCIDENT_DECLARE" ->
                 workflowService.publishDeclaredIncidentCreated(
                     organizationId = event.organizationId,
                     incidentId = event.incidentId,
-                    title = title,
-                    severity = severity,
+                    title = event.title(),
+                    severity = event.severity(),
                 )
             "INCIDENT_RESOLVE" ->
                 workflowService.publishDeclaredIncidentResolved(
                     organizationId = event.organizationId,
                     incidentId = event.incidentId,
-                    title = title,
-                    severity = severity,
+                    title = event.title(),
+                    severity = event.severity(),
                 )
+            else -> Unit
         }
+    }
+
+    private fun NativeIncidentDomainEvent.title(): String = payload.getValue("title").jsonPrimitive.content
+
+    /** Triage incidents can still be unclassified, so workflows see the lowest severity until acceptance. */
+    private fun NativeIncidentDomainEvent.severity(): IncidentSeverity {
+        val raw = (payload["severity"] as? JsonPrimitive)?.contentOrNull ?: return UNCLASSIFIED_SEVERITY
+        return requireNotNull(IncidentSeverity.fromString(raw)) { "Incident event has invalid severity" }
+    }
+
+    private companion object {
+        private val UNCLASSIFIED_SEVERITY = IncidentSeverity.SEV4
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumer.kt
@@ -18,13 +18,8 @@ class WorkflowIncidentEventConsumer(
     override suspend fun consume(event: NativeIncidentDomainEvent, deliveryKey: String) {
         require(deliveryKey.isNotBlank()) { "Workflow incident delivery key is required" }
         when (event.eventType) {
-            "INCIDENT_DECLARE" ->
-                workflowService.publishDeclaredIncidentCreated(
-                    organizationId = event.organizationId,
-                    incidentId = event.incidentId,
-                    title = event.title(),
-                    severity = event.severity(),
-                )
+            "INCIDENT_DECLARE" -> if (event.status() == ACCEPTED_STATUS) event.publishCreatedWorkflow()
+            "INCIDENT_ACCEPT" -> event.publishCreatedWorkflow()
             "INCIDENT_RESOLVE" ->
                 workflowService.publishDeclaredIncidentResolved(
                     organizationId = event.organizationId,
@@ -36,15 +31,27 @@ class WorkflowIncidentEventConsumer(
         }
     }
 
+    private suspend fun NativeIncidentDomainEvent.publishCreatedWorkflow() {
+        workflowService.publishDeclaredIncidentCreated(
+            organizationId = organizationId,
+            incidentId = incidentId,
+            title = title(),
+            severity = severity(),
+        )
+    }
+
     private fun NativeIncidentDomainEvent.title(): String = payload.getValue("title").jsonPrimitive.content
 
-    /** Triage incidents can still be unclassified, so workflows see the lowest severity until acceptance. */
     private fun NativeIncidentDomainEvent.severity(): IncidentSeverity {
-        val raw = (payload["severity"] as? JsonPrimitive)?.contentOrNull ?: return UNCLASSIFIED_SEVERITY
+        val raw = (payload["severity"] as? JsonPrimitive)?.contentOrNull
+            ?: error("Accepted incident event is missing severity")
         return requireNotNull(IncidentSeverity.fromString(raw)) { "Incident event has invalid severity" }
     }
 
+    private fun NativeIncidentDomainEvent.status(): String? =
+        (payload["status"] as? JsonPrimitive)?.contentOrNull
+
     private companion object {
-        private val UNCLASSIFIED_SEVERITY = IncidentSeverity.SEV4
+        private const val ACCEPTED_STATUS = "ACTIVE"
     }
 }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/models/IncidentModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/models/IncidentModels.kt
@@ -24,7 +24,11 @@ enum class NativeIncidentStatus(val wire: String) {
     CLOSED("CLOSED"),
     CANCELLED("CANCELLED"),
     DECLINED("DECLINED"),
+    MERGED("MERGED"),
     ;
+
+    /** MERGED is the only outcome that permanently retires an incident aggregate. */
+    val terminal: Boolean get() = this == MERGED
 
     companion object {
         fun fromWire(value: String): NativeIncidentStatus? =

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -313,7 +313,7 @@ object OnCallIncidents : IntIdTable("on_call_incidents") {
     val declinedAt = timestamp("declined_at").nullable()
     val mergedAt = timestamp("merged_at").nullable()
     val mergedIntoIncidentId =
-        integer("merged_into_incident_id").references(id, onDelete = ReferenceOption.CASCADE).nullable()
+        integer("merged_into_incident_id").references(id, onDelete = ReferenceOption.RESTRICT).nullable()
     val createdAt = timestamp("created_at")
     val updatedAt = timestamp("updated_at")
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -4,6 +4,7 @@
 
 package com.moneat.enterprise.oncall.models
 
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
 import com.moneat.enterprise.incidents.models.NativeIncidentTypes
 import com.moneat.shared.models.EscalationPolicies
 import com.moneat.shared.models.OnCallSchedules
@@ -23,7 +24,13 @@ import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ColumnType
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.neq
+import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.datetime.timestamp
 import org.jetbrains.exposed.v1.javatime.time
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
@@ -283,7 +290,9 @@ object OnCallIncidents : IntIdTable("on_call_incidents") {
     val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
     val title = varchar("title", 255)
     val description = text("description").nullable()
-    val severity = varchar("severity", 10)
+
+    /** Triage incidents stay unclassified until acceptance, so severity is optional there. */
+    val severity = varchar("severity", 10).nullable()
     val status = varchar("status", 20).default("ACTIVE")
     val mode = varchar("mode", 24).default("LIVE")
     val visibility = varchar("visibility", 24).default("ORGANIZATION")
@@ -302,8 +311,24 @@ object OnCallIncidents : IntIdTable("on_call_incidents") {
     val closedAt = timestamp("closed_at").nullable()
     val cancelledAt = timestamp("cancelled_at").nullable()
     val declinedAt = timestamp("declined_at").nullable()
+    val mergedAt = timestamp("merged_at").nullable()
+    val mergedIntoIncidentId =
+        integer("merged_into_incident_id").references(id, onDelete = ReferenceOption.CASCADE).nullable()
     val createdAt = timestamp("created_at")
     val updatedAt = timestamp("updated_at")
+
+    init {
+        // Severity is only required once the incident has been accepted out of triage.
+        check("chk_native_incident_triage_severity") {
+            severity.isNotNull() or acceptedAt.isNull()
+        }
+        check("chk_native_incident_merged_state") {
+            ((status eq NativeIncidentStatus.MERGED.wire) and
+                mergedAt.isNotNull() and mergedIntoIncidentId.isNotNull()) or
+                ((status neq NativeIncidentStatus.MERGED.wire) and
+                    mergedAt.isNull() and mergedIntoIncidentId.isNull())
+        }
+    }
 }
 
 @Serializable
@@ -312,7 +337,7 @@ data class OnCallIncident(
     @SerialName("organizationId") val organizationResourceId: String,
     val title: String,
     val description: String? = null,
-    val severity: String,
+    val severity: String? = null,
     val status: String,
     val mode: String = "LIVE",
     val visibility: String = "ORGANIZATION",
@@ -331,6 +356,8 @@ data class OnCallIncident(
     val closedAt: String? = null,
     val cancelledAt: String? = null,
     val declinedAt: String? = null,
+    val mergedAt: String? = null,
+    @SerialName("mergedIntoIncidentId") val mergedIntoIncidentResourceId: String? = null,
     val alertCount: Int = 0,
     val alerts: List<OnCallAlert> = emptyList(),
     val createdAt: String,

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/models/OnCallModels.kt
@@ -328,6 +328,9 @@ object OnCallIncidents : IntIdTable("on_call_incidents") {
                 ((status neq NativeIncidentStatus.MERGED.wire) and
                     mergedAt.isNull() and mergedIntoIncidentId.isNull())
         }
+        check("chk_native_incident_merge_target") {
+            mergedIntoIncidentId.isNull() or (mergedIntoIncidentId neq id)
+        }
     }
 }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutes.kt
@@ -10,7 +10,11 @@ import com.moneat.alerts.models.AlertEpisodes
 import com.moneat.enterprise.FeatureRegistry
 import com.moneat.enterprise.NativeIncidentEntitlementStatus
 import com.moneat.enterprise.NativeIncidentRolloutStatus
+import com.moneat.enterprise.incidents.commands.AcceptIncidentCommand
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
+import com.moneat.enterprise.incidents.commands.DeclineIncidentCommand
+import com.moneat.enterprise.incidents.commands.MergeIncidentCommand
+import com.moneat.enterprise.incidents.commands.IncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.commands.IncidentCommandConflictException
 import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
@@ -186,6 +190,26 @@ data class NativeIncidentQuotaResponse(
     val exhausted: Boolean,
 )
 
+@Serializable
+data class AcceptIncidentRequest(
+    val severity: String? = null,
+    val incidentTypeId: String? = null,
+    val fields: Map<String, JsonElement> = emptyMap(),
+    val expectedVersion: Int? = null,
+)
+
+@Serializable
+data class DeclineIncidentRequest(
+    val reason: String? = null,
+    val expectedVersion: Int? = null,
+)
+
+@Serializable
+data class MergeIncidentRequest(
+    val sourceIncidentId: String,
+    val expectedVersion: Int? = null,
+)
+
 private data class IncidentRouteServices(
     val alertServiceProvider: () -> OnCallAlertService,
     val incidentService: OnCallIncidentService,
@@ -292,6 +316,7 @@ private fun Route.registerDeclaredIncidentRoutes(
             registerListDeclaredIncidentsRoute(services.incidentService)
             registerGetDeclaredIncidentRoute(services.incidentService)
             registerResolveDeclaredIncidentRoute(services.incidentService)
+            registerTriageCommandRoutes(services.incidentService)
             registerAddAlertToIncidentRoute(services.alertServiceProvider, services.incidentService)
             registerIncidentSourceRoutes(services.incidentService)
             registerIncidentResponderRoutes(services.incidentService, services.responderService)
@@ -464,7 +489,6 @@ private fun Route.registerDeclareIncidentRoute(
     post {
         val context = call.requireUserContext() ?: return@post
         val request = call.receive<DeclareIncidentRequest>()
-        val severity = call.requireIncidentSeverity(request.severity) ?: return@post
         try {
             val incident =
                 declareIncident(
@@ -472,7 +496,6 @@ private fun Route.registerDeclareIncidentRoute(
                         call = call,
                         context = context,
                         request = request,
-                        severity = severity,
                         onCallAlertId = null,
                         incidentService = onCallIncidentService,
                         configurationService = configurationService,
@@ -864,7 +887,6 @@ private fun Route.registerDeclareIncidentFromAlertRoute(
         val alertService = alertServiceProvider()
         if (!call.ensureAlertInOrganization(alertService, alertId, context.organizationId)) return@post
         val request = call.receive<DeclareIncidentRequest>()
-        val incidentSeverity = call.requireIncidentSeverity(request.severity) ?: return@post
 
         try {
             val incident =
@@ -873,7 +895,6 @@ private fun Route.registerDeclareIncidentFromAlertRoute(
                         call = call,
                         context = context,
                         request = request,
-                        severity = incidentSeverity,
                         onCallAlertId = alertId,
                         incidentService = onCallIncidentService,
                         configurationService = IncidentConfigurationService(),
@@ -892,7 +913,6 @@ private data class IncidentDeclaration(
     val call: ApplicationCall,
     val context: OnCallUserContext,
     val request: DeclareIncidentRequest,
-    val severity: String,
     val onCallAlertId: Int?,
     val incidentService: OnCallIncidentService,
     val configurationService: IncidentConfigurationService,
@@ -908,6 +928,7 @@ private suspend fun declareIncident(declaration: IncidentDeclaration): OnCallInc
             ?: throw IllegalArgumentException("Invalid incident visibility")
     val initialStatus = NativeIncidentStatus.fromWire(request.initialStatus.trim().uppercase())
         ?: throw IllegalArgumentException("Invalid incident status")
+    val severity = declarationSeverity(request.severity, initialStatus)
     val resolvedForm =
         declaration.configurationService.resolveForm(
             organizationId = declaration.context.organizationId,
@@ -926,7 +947,7 @@ private suspend fun declareIncident(declaration: IncidentDeclaration): OnCallInc
             title = request.title,
             description = request.description,
             summary = request.summary,
-            severity = declaration.severity,
+            severity = severity,
             mode = mode,
             visibility = visibility,
             incidentType = resolvedForm.incidentTypeName,
@@ -940,19 +961,14 @@ private suspend fun declareIncident(declaration: IncidentDeclaration): OnCallInc
     )
 }
 
-private suspend fun ApplicationCall.requireIncidentSeverity(severity: String?): String? {
-    val trimmedSeverity = severity?.trim()
-    if (trimmedSeverity.isNullOrBlank()) {
-        respond(HttpStatusCode.BadRequest, ErrorResponse("Missing incident severity"))
+// Triage declarations may stay unclassified; every other initial status needs a severity.
+private fun declarationSeverity(severity: String?, initialStatus: NativeIncidentStatus): String? {
+    val trimmedSeverity = severity?.trim()?.takeIf(String::isNotEmpty)
+    if (trimmedSeverity == null) {
+        require(initialStatus == NativeIncidentStatus.TRIAGE) { "Missing incident severity" }
         return null
     }
-
-    val incidentSeverity = IncidentSeverity.wireValue(trimmedSeverity)
-    if (incidentSeverity == null) {
-        respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid incident severity"))
-        return null
-    }
-    return incidentSeverity
+    return requireNotNull(IncidentSeverity.wireValue(trimmedSeverity)) { "Invalid incident severity" }
 }
 
 private fun Route.registerListDeclaredIncidentsRoute(onCallIncidentService: OnCallIncidentService) {
@@ -1005,6 +1021,110 @@ private fun Route.registerResolveDeclaredIncidentRoute(onCallIncidentService: On
         } else {
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Failed to resolve incident"))
         }
+    }
+}
+
+/**
+ * Accept, decline, and merge run through the shared command contract: opaque UUID params,
+ * optional expected-version optimistic concurrency, and Idempotency-Key replay.
+ */
+private fun Route.registerTriageCommandRoutes(onCallIncidentService: OnCallIncidentService) {
+    registerAcceptIncidentRoute(onCallIncidentService)
+    registerDeclineIncidentRoute(onCallIncidentService)
+    registerMergeIncidentRoute(onCallIncidentService)
+}
+
+private fun Route.registerAcceptIncidentRoute(onCallIncidentService: OnCallIncidentService) {
+    post("/{id}/accept") {
+        val context = call.requireUserContext() ?: return@post
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@post
+        val request = call.receiveNullable<AcceptIncidentRequest>() ?: AcceptIncidentRequest()
+        call.runIncidentCommand(onCallIncidentService, incidentId) {
+            AcceptIncidentCommand(
+                commandKey = call.incidentCommandKey("accept"),
+                actor = IncidentCommandActor(context.organizationId, context.userId, "REST"),
+                incidentId = incidentId,
+                expectedVersion = request.expectedVersion,
+                severity = request.severity,
+                incidentTypeResourceId = request.incidentTypeId,
+                formValues = request.fields,
+            )
+        }
+    }
+}
+
+private fun Route.registerDeclineIncidentRoute(onCallIncidentService: OnCallIncidentService) {
+    post("/{id}/decline") {
+        val context = call.requireUserContext() ?: return@post
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@post
+        val request = call.receiveNullable<DeclineIncidentRequest>() ?: DeclineIncidentRequest()
+        call.runIncidentCommand(onCallIncidentService, incidentId) {
+            DeclineIncidentCommand(
+                commandKey = call.incidentCommandKey("decline"),
+                actor = IncidentCommandActor(context.organizationId, context.userId, "REST"),
+                incidentId = incidentId,
+                reason = request.reason,
+                expectedVersion = request.expectedVersion,
+            )
+        }
+    }
+}
+
+private fun Route.registerMergeIncidentRoute(onCallIncidentService: OnCallIncidentService) {
+    post("/{id}/merge") {
+        val context = call.requireUserContext() ?: return@post
+        val incidentId = call.requireIncidentId(context.organizationId) ?: return@post
+        val request = call.receive<MergeIncidentRequest>()
+        val sourceIncidentId =
+            call.requireMergeSourceIncidentId(request.sourceIncidentId, context.organizationId) ?: return@post
+        call.runIncidentCommand(onCallIncidentService, incidentId) {
+            MergeIncidentCommand(
+                commandKey = call.incidentCommandKey("merge"),
+                actor = IncidentCommandActor(context.organizationId, context.userId, "REST"),
+                incidentId = incidentId,
+                sourceIncidentId = sourceIncidentId,
+                expectedVersion = request.expectedVersion,
+            )
+        }
+    }
+}
+
+private suspend fun ApplicationCall.requireMergeSourceIncidentId(
+    raw: String,
+    organizationId: Int,
+): Int? {
+    val resourceId = parseOnCallResourceId(raw)
+    if (resourceId == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid source incident ID"))
+        return null
+    }
+    val id =
+        transaction {
+            OnCallIncidents
+                .selectAll()
+                .where {
+                    (OnCallIncidents.resourceId eq resourceId) and
+                        (OnCallIncidents.organizationId eq organizationId)
+                }.firstOrNull()
+                ?.get(OnCallIncidents.id)
+                ?.value
+        }
+    if (id == null) respond(HttpStatusCode.NotFound, ErrorResponse("Source incident not found"))
+    return id
+}
+
+private suspend fun ApplicationCall.runIncidentCommand(
+    onCallIncidentService: OnCallIncidentService,
+    incidentId: Int,
+    command: () -> IncidentCommand,
+) {
+    try {
+        onCallIncidentService.executeIncidentCommand(command())
+        respond(checkNotNull(onCallIncidentService.getIncident(incidentId)))
+    } catch (error: IncidentCommandException) {
+        respondIncidentCommandFailure(error)
+    } catch (error: IllegalArgumentException) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse(error.message))
     }
 }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallIncidentService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/services/OnCallIncidentService.kt
@@ -371,6 +371,8 @@ class OnCallIncidentService(
             closedAt = row[OnCallIncidents.closedAt]?.toString(),
             cancelledAt = row[OnCallIncidents.cancelledAt]?.toString(),
             declinedAt = row[OnCallIncidents.declinedAt]?.toString(),
+            mergedAt = row[OnCallIncidents.mergedAt]?.toString(),
+            mergedIntoIncidentResourceId = resourceIds.incidentOrNull(row[OnCallIncidents.mergedIntoIncidentId]),
             alertCount = alerts.size,
             alerts = alerts,
             createdAt = row[OnCallIncidents.createdAt].toString(),
@@ -445,7 +447,8 @@ class OnCallIncidentService(
             organizationResourceId = organizationResourceId(organizationId),
             users = userResponseData(userIds),
             incidentResourceIds = incidentResourceIds(
-                alertRows.mapNotNull { row -> row[OnCallAlerts.declaredIncidentId] }
+                alertRows.mapNotNull { row -> row[OnCallAlerts.declaredIncidentId] } +
+                    incidentRows.mapNotNull { row -> row[OnCallIncidents.mergedIntoIncidentId] }
             ),
             policyResourceIds = escalationPolicyResourceIds(
                 alertRows.mapNotNull { row -> row[OnCallAlerts.escalationPolicyId] }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentDomainGlossaryTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/IncidentDomainGlossaryTest.kt
@@ -36,8 +36,12 @@ class IncidentDomainGlossaryTest {
     @Test
     fun `canonical lifecycle mode visibility and ownership values are explicit`() {
         assertEquals(
-            setOf("TRIAGE", "ACTIVE", "RESOLVED", "POST_INCIDENT", "CLOSED", "CANCELLED", "DECLINED"),
+            setOf("TRIAGE", "ACTIVE", "RESOLVED", "POST_INCIDENT", "CLOSED", "CANCELLED", "DECLINED", "MERGED"),
             NativeIncidentStatus.entries.mapTo(mutableSetOf(), NativeIncidentStatus::wire),
+        )
+        assertEquals(
+            setOf(NativeIncidentStatus.MERGED),
+            NativeIncidentStatus.entries.filterTo(mutableSetOf(), NativeIncidentStatus::terminal),
         )
         assertEquals(
             setOf("LIVE", "RETROSPECTIVE", "TEST"),
@@ -74,5 +78,41 @@ class IncidentDomainGlossaryTest {
         assertFalse(encoded.contains("internalId"))
         assertFalse(encoded.contains("\"organizationId\":7"))
         assertFalse(encoded.contains("\"declaredBy\":11"))
+    }
+
+    @Test
+    fun `triage incidents serialize without a severity and merged incidents carry their target`() {
+        val triage = Json.encodeToString(
+            OnCallIncident(
+                id = "0f0d6d31-1d3f-4a0b-8a06-2fd1a4c0f9a1",
+                organizationResourceId = "8eb53cb5-c34c-49af-827d-956abf96394c",
+                title = "Unclassified report",
+                status = NativeIncidentStatus.TRIAGE.wire,
+                declaredByResourceId = "b0c4fec4-7257-42d7-83aa-a32329cbec6f",
+                declaredAt = "2026-08-22T20:00:00Z",
+                createdAt = "2026-08-22T20:00:00Z",
+                updatedAt = "2026-08-22T20:00:00Z",
+            ),
+        )
+        assertFalse(triage.contains("\"severity\""))
+
+        val merged = Json.encodeToString(
+            OnCallIncident(
+                id = "0f0d6d31-1d3f-4a0b-8a06-2fd1a4c0f9a1",
+                organizationResourceId = "8eb53cb5-c34c-49af-827d-956abf96394c",
+                title = "Duplicate report",
+                severity = "SEV-2",
+                status = NativeIncidentStatus.MERGED.wire,
+                declaredByResourceId = "b0c4fec4-7257-42d7-83aa-a32329cbec6f",
+                declaredAt = "2026-08-22T20:00:00Z",
+                mergedAt = "2026-08-22T21:00:00Z",
+                mergedIntoIncidentResourceId = "5f9a0a0c-4d1f-4c1a-9d6f-2c1f8ba4b0d2",
+                createdAt = "2026-08-22T20:00:00Z",
+                updatedAt = "2026-08-22T21:00:00Z",
+            ),
+        )
+        assertTrue(merged.contains("\"status\":\"MERGED\""))
+        assertTrue(merged.contains("\"mergedAt\":\"2026-08-22T21:00:00Z\""))
+        assertTrue(merged.contains("\"mergedIntoIncidentId\":\"5f9a0a0c-4d1f-4c1a-9d6f-2c1f8ba4b0d2\""))
     }
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentCommandServiceTest.kt
@@ -188,7 +188,7 @@ class IncidentCommandServiceTest {
     }
 
     @Test
-    fun `merge moves linked on-call alerts and cancels the source incident`() {
+    fun `merge moves linked on-call alerts and retires the source incident`() {
         val target = service.execute(declareCommand("merge-target", actor()))
         val source = service.execute(declareCommand("merge-source", actor()))
         val alertId = seedAlert("merge-alert")
@@ -213,7 +213,9 @@ class IncidentCommandServiceTest {
                 OnCallAlerts.selectAll().where { OnCallAlerts.id eq alertId }.single()[OnCallAlerts.declaredIncidentId],
             )
             val sourceRow = OnCallIncidents.selectAll().where { OnCallIncidents.id eq source.incidentId }.single()
-            assertEquals(NativeIncidentStatus.CANCELLED.wire, sourceRow[OnCallIncidents.status])
+            assertEquals(NativeIncidentStatus.MERGED.wire, sourceRow[OnCallIncidents.status])
+            assertEquals(target.incidentId, sourceRow[OnCallIncidents.mergedIntoIncidentId])
+            assertNotNull(sourceRow[OnCallIncidents.mergedAt])
             assertEquals(3, sourceRow[OnCallIncidents.version])
         }
     }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentTriageCapabilityPolicyTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentTriageCapabilityPolicyTest.kt
@@ -1,0 +1,81 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.commands
+
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IncidentTriageCapabilityPolicyTest {
+    @Test
+    fun `triage permits investigation roles participation and escalation`() {
+        listOf(
+            IncidentCapability.LIFECYCLE,
+            IncidentCapability.INVESTIGATION,
+            IncidentCapability.ROLES,
+            IncidentCapability.PARTICIPATION,
+            IncidentCapability.ESCALATION,
+        ).forEach { capability ->
+            assertTrue(IncidentTriageCapabilityPolicy.permits(capability), capability.wire)
+        }
+    }
+
+    @Test
+    fun `triage withholds actions follow-ups and status-page communication`() {
+        listOf(
+            IncidentCapability.ACTIONS,
+            IncidentCapability.FOLLOW_UPS,
+            IncidentCapability.STATUS_PAGE_COMMUNICATION,
+        ).forEach { capability ->
+            assertFalse(IncidentTriageCapabilityPolicy.permits(capability), capability.wire)
+        }
+    }
+
+    @Test
+    fun `command types map onto their capability group`() {
+        assertEquals(
+            IncidentCapability.ACTIONS,
+            IncidentTriageCapabilityPolicy.capabilityOf(IncidentCommandType.ADD_ACTION),
+        )
+        assertEquals(
+            IncidentCapability.INVESTIGATION,
+            IncidentTriageCapabilityPolicy.capabilityOf(IncidentCommandType.LINK_SOURCE),
+        )
+        assertEquals(
+            IncidentCapability.ROLES,
+            IncidentTriageCapabilityPolicy.capabilityOf(IncidentCommandType.CLAIM_ROLE),
+        )
+        assertEquals(
+            IncidentCapability.PARTICIPATION,
+            IncidentTriageCapabilityPolicy.capabilityOf(IncidentCommandType.OBSERVE),
+        )
+        assertEquals(
+            IncidentCapability.LIFECYCLE,
+            IncidentTriageCapabilityPolicy.capabilityOf(IncidentCommandType.DECLINE),
+        )
+    }
+
+    @Test
+    fun `restrictions apply only while the incident is in triage`() {
+        assertFailsWith<IncidentCommandDeniedException> {
+            IncidentTriageCapabilityPolicy.requireAllowed(
+                NativeIncidentStatus.TRIAGE,
+                IncidentCommandType.ADD_ACTION,
+            )
+        }
+        NativeIncidentStatus.entries
+            .filter { it != NativeIncidentStatus.TRIAGE }
+            .forEach { status ->
+                IncidentTriageCapabilityPolicy.requireAllowed(status, IncidentCommandType.ADD_ACTION)
+            }
+        IncidentTriageCapabilityPolicy.requireAllowed(
+            NativeIncidentStatus.TRIAGE,
+            IncidentCommandType.ASSIGN_ROLE,
+        )
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentTriageMergeCommandTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentTriageMergeCommandTest.kt
@@ -1,0 +1,596 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.commands
+
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.enterprise.incidents.IncidentTestDatabase
+import com.moneat.enterprise.incidents.SeededMember
+import com.moneat.enterprise.incidents.config.CreateIncidentCustomField
+import com.moneat.enterprise.incidents.config.CreateIncidentForm
+import com.moneat.enterprise.incidents.config.IncidentConfigurationService
+import com.moneat.enterprise.incidents.config.IncidentFormFieldInput
+import com.moneat.enterprise.incidents.models.IncidentCustomFieldValueType
+import com.moneat.enterprise.incidents.models.IncidentFormStage
+import com.moneat.enterprise.incidents.models.IncidentSourceType
+import com.moneat.enterprise.incidents.models.NativeIncidentAlertEpisodeLinks
+import com.moneat.enterprise.incidents.models.NativeIncidentFormSubmissions
+import com.moneat.enterprise.incidents.models.NativeIncidentOutboxEvents
+import com.moneat.enterprise.incidents.models.NativeIncidentSourceLinks
+import com.moneat.enterprise.incidents.models.NativeIncidentStatus
+import com.moneat.enterprise.oncall.models.OnCallAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidentAlerts
+import com.moneat.enterprise.oncall.models.OnCallIncidentTimeline
+import com.moneat.enterprise.oncall.models.OnCallIncidents
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+class IncidentTriageMergeCommandTest {
+    private lateinit var member: SeededMember
+    private lateinit var service: IncidentCommandService
+    private val configurationService = IncidentConfigurationService()
+
+    @BeforeEach
+    fun setUp() {
+        IncidentTestDatabase.reset()
+        member = IncidentTestDatabase.seedMember("triage-merge-org")
+        service = IncidentCommandService(policy = IncidentCommandPolicy.allowForTests())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        IncidentTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `triage declarations may omit severity while active declarations may not`() {
+        val triage = service.execute(triageDeclaration("triage-unclassified"))
+
+        assertEquals(NativeIncidentStatus.TRIAGE, triage.status)
+        transaction {
+            val row = incidentRow(triage.incidentId)
+            assertNull(row[OnCallIncidents.severity])
+            assertNull(row[OnCallIncidents.incidentType])
+            assertNotNull(row[OnCallIncidents.triagedAt])
+            assertNull(row[OnCallIncidents.acceptedAt])
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                DeclareIncidentCommand(
+                    commandKey = "active-without-severity",
+                    actor = actor(),
+                    title = "Active without severity",
+                    description = null,
+                    initialStatus = NativeIncidentStatus.ACTIVE,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `leaving triage requires a severity and records the accepted-at timestamp`() {
+        val triage = service.execute(triageDeclaration("triage-accept"))
+
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                TransitionIncidentCommand(
+                    "transition-without-severity",
+                    actor(),
+                    triage.incidentId,
+                    NativeIncidentStatus.ACTIVE,
+                    expectedVersion = 1,
+                ),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(AcceptIncidentCommand("accept-without-severity", actor(), triage.incidentId, 1))
+        }
+
+        val accepted =
+            service.execute(
+                AcceptIncidentCommand(
+                    commandKey = "accept-with-severity",
+                    actor = actor(),
+                    incidentId = triage.incidentId,
+                    expectedVersion = 1,
+                    severity = "SEV-2",
+                ),
+            )
+
+        assertEquals(NativeIncidentStatus.ACTIVE, accepted.status)
+        assertEquals(2, accepted.version)
+        transaction {
+            val row = incidentRow(triage.incidentId)
+            assertEquals("SEV-2", row[OnCallIncidents.severity])
+            assertNotNull(row[OnCallIncidents.acceptedAt])
+            assertNotNull(row[OnCallIncidents.triagedAt])
+            assertTrue(
+                timelineEventTypes(triage.incidentId).contains("ACCEPTED"),
+            )
+        }
+    }
+
+    @Test
+    fun `acceptance enforces the configured acceptance form and stores its submission`() {
+        configureAcceptanceForm()
+        val triage = service.execute(triageDeclaration("triage-form"))
+
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                AcceptIncidentCommand(
+                    commandKey = "accept-missing-form-values",
+                    actor = actor(),
+                    incidentId = triage.incidentId,
+                    expectedVersion = 1,
+                    severity = "SEV-1",
+                ),
+            )
+        }
+
+        service.execute(
+            AcceptIncidentCommand(
+                commandKey = "accept-with-form-values",
+                actor = actor(),
+                incidentId = triage.incidentId,
+                expectedVersion = 1,
+                severity = "SEV-1",
+                formValues = mapOf("customer_impact" to JsonPrimitive("high")),
+            ),
+        )
+
+        transaction {
+            val submission =
+                NativeIncidentFormSubmissions
+                    .selectAll()
+                    .where {
+                        (NativeIncidentFormSubmissions.incidentId eq triage.incidentId) and
+                            (NativeIncidentFormSubmissions.stage eq IncidentFormStage.ACCEPTANCE.wire)
+                    }.single()
+            assertEquals(
+                "high",
+                submission[NativeIncidentFormSubmissions.valuesSnapshot]
+                    .getValue("customer_impact")
+                    .jsonPrimitive
+                    .content,
+            )
+        }
+    }
+
+    @Test
+    fun `merging transfers every link kind and retires the source into the terminal merged status`() {
+        val target = service.execute(activeDeclaration("merge-target"))
+        val source = service.execute(activeDeclaration("merge-source"))
+        val alertId = seedAlert("merged-alert")
+        val sharedEpisodeId = seedAlertEpisode("shared-episode")
+        val sourceEpisodeId = seedAlertEpisode("source-episode")
+
+        linkEpisode("target-shared-episode", target.incidentId, sharedEpisodeId)
+        linkEpisode("source-shared-episode", source.incidentId, sharedEpisodeId)
+        linkEpisode("source-only-episode", source.incidentId, sourceEpisodeId)
+        linkUrlSource("target-runbook", target.incidentId, "runbook")
+        linkUrlSource("source-runbook", source.incidentId, "runbook")
+        linkUrlSource("source-dashboard", source.incidentId, "dashboard")
+        service.execute(LinkOnCallAlertCommand("link-source-alert", actor(), source.incidentId, alertId))
+
+        val merged =
+            service.execute(
+                MergeIncidentCommand(
+                    commandKey = "merge-full",
+                    actor = actor(),
+                    incidentId = target.incidentId,
+                    sourceIncidentId = source.incidentId,
+                ),
+            )
+
+        assertEquals(NativeIncidentStatus.ACTIVE, merged.status)
+        transaction {
+            assertEquals(
+                target.incidentId,
+                OnCallIncidentAlerts.selectAll().single()[OnCallIncidentAlerts.incidentId],
+            )
+            assertEquals(
+                target.incidentId,
+                OnCallAlerts.selectAll().where { OnCallAlerts.id eq alertId }.single()[OnCallAlerts.declaredIncidentId],
+            )
+            assertEquals(
+                setOf(sharedEpisodeId, sourceEpisodeId),
+                NativeIncidentAlertEpisodeLinks
+                    .selectAll()
+                    .where { NativeIncidentAlertEpisodeLinks.incidentId eq target.incidentId }
+                    .mapTo(mutableSetOf()) { it[NativeIncidentAlertEpisodeLinks.alertEpisodeId] },
+            )
+            assertEquals(
+                0,
+                NativeIncidentAlertEpisodeLinks
+                    .selectAll()
+                    .where { NativeIncidentAlertEpisodeLinks.incidentId eq source.incidentId }
+                    .count()
+                    .toInt(),
+            )
+            val targetSourceKeys =
+                NativeIncidentSourceLinks
+                    .selectAll()
+                    .where { NativeIncidentSourceLinks.incidentId eq target.incidentId }
+                    .map { it[NativeIncidentSourceLinks.sourceKey] }
+            assertEquals(
+                setOf(
+                    "runbook",
+                    "dashboard",
+                    alertResourceId(alertId),
+                    episodeResourceId(sharedEpisodeId),
+                    episodeResourceId(sourceEpisodeId),
+                ),
+                targetSourceKeys.toSet(),
+            )
+            // The duplicated runbook and shared-episode links collapse instead of colliding.
+            assertEquals(targetSourceKeys.size, targetSourceKeys.toSet().size)
+            assertEquals(
+                0,
+                NativeIncidentSourceLinks
+                    .selectAll()
+                    .where { NativeIncidentSourceLinks.incidentId eq source.incidentId }
+                    .count()
+                    .toInt(),
+            )
+
+            val sourceRow = incidentRow(source.incidentId)
+            assertEquals(NativeIncidentStatus.MERGED.wire, sourceRow[OnCallIncidents.status])
+            assertNotNull(sourceRow[OnCallIncidents.mergedAt])
+            assertEquals(target.incidentId, sourceRow[OnCallIncidents.mergedIntoIncidentId])
+            assertNull(sourceRow[OnCallIncidents.cancelledAt])
+            assertNull(sourceRow[OnCallIncidents.declinedAt])
+
+            // The retired incident keeps its own audit history.
+            assertTrue(timelineEventTypes(source.incidentId).contains("DECLARED"))
+            assertTrue(timelineEventTypes(source.incidentId).contains("MERGED_INTO_INCIDENT"))
+
+            val mergeEvent =
+                NativeIncidentOutboxEvents
+                    .selectAll()
+                    .where { NativeIncidentOutboxEvents.eventType eq "INCIDENT_MERGED_SOURCE" }
+                    .single()
+            val payload = mergeEvent[NativeIncidentOutboxEvents.payload]
+            assertEquals(NativeIncidentStatus.MERGED.wire, payload.getValue("status").jsonPrimitive.content)
+            assertNotNull(payload["mergedIntoIncidentId"])
+            assertNotNull(payload["mergedAt"])
+        }
+    }
+
+    @Test
+    fun `merged incidents are terminal and never reopen`() {
+        val target = service.execute(activeDeclaration("terminal-target"))
+        val source = service.execute(activeDeclaration("terminal-source"))
+        service.execute(MergeIncidentCommand("terminal-merge", actor(), target.incidentId, source.incidentId))
+
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(ReopenIncidentCommand("reopen-merged", actor(), source.incidentId))
+        }
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                TransitionIncidentCommand(
+                    "resolve-merged",
+                    actor(),
+                    source.incidentId,
+                    NativeIncidentStatus.RESOLVED,
+                ),
+            )
+        }
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                MergeIncidentCommand("merge-into-merged", actor(), source.incidentId, target.incidentId),
+            )
+        }
+        transaction {
+            assertEquals(NativeIncidentStatus.MERGED.wire, incidentRow(source.incidentId)[OnCallIncidents.status])
+        }
+    }
+
+    @Test
+    fun `repeated merges converge and losing merge races conflict`() {
+        val target = service.execute(activeDeclaration("retry-target"))
+        val source = service.execute(activeDeclaration("retry-source"))
+        val other = service.execute(activeDeclaration("retry-other"))
+
+        val first =
+            service.execute(
+                MergeIncidentCommand("retry-merge", actor(), target.incidentId, source.incidentId, expectedVersion = 1),
+            )
+        val replay =
+            service.execute(
+                MergeIncidentCommand("retry-merge", actor(), target.incidentId, source.incidentId, expectedVersion = 1),
+            )
+        val retryWithNewKey =
+            service.execute(
+                MergeIncidentCommand("retry-merge-again", actor(), target.incidentId, source.incidentId),
+            )
+
+        assertEquals(first.version, replay.version)
+        assertEquals(first.version, retryWithNewKey.version)
+
+        // Another responder already merged this source elsewhere.
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(MergeIncidentCommand("merge-race", actor(), other.incidentId, source.incidentId))
+        }
+        // A stale expected version loses the optimistic-concurrency race on the target.
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                MergeIncidentCommand("stale-merge", actor(), target.incidentId, other.incidentId, expectedVersion = 1),
+            )
+        }
+    }
+
+    @Test
+    fun `merge sources and targets stay inside the caller organization`() {
+        val target = service.execute(activeDeclaration("scoped-target"))
+        val outsider = IncidentTestDatabase.seedMember("other-triage-org")
+        val outsiderActor = IncidentCommandActor(outsider.organizationId, outsider.userId, "REST")
+        val foreignSource =
+            service.execute(
+                DeclareIncidentCommand(
+                    commandKey = "foreign-source",
+                    actor = outsiderActor,
+                    title = "Foreign incident",
+                    description = null,
+                    severity = "SEV-3",
+                ),
+            )
+
+        assertFailsWith<IncidentCommandNotFoundException> {
+            service.execute(
+                MergeIncidentCommand("cross-org-merge", actor(), target.incidentId, foreignSource.incidentId),
+            )
+        }
+        assertFailsWith<IncidentCommandNotFoundException> {
+            service.execute(
+                MergeIncidentCommand("cross-org-target", outsiderActor, target.incidentId, foreignSource.incidentId),
+            )
+        }
+    }
+
+    @Test
+    fun `triage withholds actions until the incident is accepted`() {
+        val triage = service.execute(triageDeclaration("triage-capability"))
+
+        assertFailsWith<IncidentCommandDeniedException> {
+            service.execute(AddIncidentActionCommand("triage-action", actor(), triage.incidentId, "Roll back"))
+        }
+
+        service.execute(
+            AcceptIncidentCommand(
+                commandKey = "accept-for-actions",
+                actor = actor(),
+                incidentId = triage.incidentId,
+                expectedVersion = 1,
+                severity = "SEV-3",
+            ),
+        )
+        val withAction =
+            service.execute(AddIncidentActionCommand("accepted-action", actor(), triage.incidentId, "Roll back"))
+
+        assertEquals(3, withAction.version)
+    }
+
+    @Test
+    fun `triage incidents still support investigation and participation`() {
+        val triage = service.execute(triageDeclaration("triage-investigation"))
+
+        val linked = linkUrlSource("triage-runbook", triage.incidentId, "runbook")
+        val note =
+            service.execute(
+                AddIncidentTimelineEventCommand(
+                    "triage-note",
+                    actor(),
+                    triage.incidentId,
+                    "NOTE",
+                    mapOf("note" to JsonPrimitive("Investigating")),
+                ),
+            )
+
+        assertEquals(2, linked.version)
+        assertEquals(3, note.version)
+    }
+
+    @Test
+    fun `storage rejects unclassified accepted incidents and inconsistent merge state`() {
+        assertFailsWith<Exception> {
+            transaction {
+                insertRawIncident(
+                    status = NativeIncidentStatus.ACTIVE.wire,
+                    severity = null,
+                    accepted = true,
+                )
+            }
+        }
+        assertFailsWith<Exception> {
+            transaction { insertRawIncident(status = NativeIncidentStatus.MERGED.wire, severity = "SEV-2") }
+        }
+        // Triage outcomes that never reached acceptance stay legitimately unclassified.
+        transaction { insertRawIncident(status = NativeIncidentStatus.DECLINED.wire, severity = null) }
+    }
+
+    private fun insertRawIncident(status: String, severity: String?, accepted: Boolean = false): Int {
+        val now = Clock.System.now()
+        return OnCallIncidents.insertAndGetId {
+            it[resourceId] = Uuid.random()
+            it[organizationId] = member.organizationId
+            it[title] = "Raw incident"
+            it[OnCallIncidents.severity] = severity
+            it[OnCallIncidents.status] = status
+            it[version] = 1
+            it[declaredBy] = member.userId
+            it[declaredAt] = now
+            it[acceptedAt] = now.takeIf { accepted }
+            it[createdAt] = now
+            it[updatedAt] = now
+        }.value
+    }
+
+    private fun configureAcceptanceForm() {
+        configurationService.createCustomField(
+            member.organizationId,
+            member.userId,
+            CreateIncidentCustomField(
+                stableKey = "customer_impact",
+                name = "Customer impact",
+                description = null,
+                valueType = IncidentCustomFieldValueType.TEXT,
+                catalogResourceType = null,
+                options = emptyList(),
+            ),
+        )
+        configurationService.createForm(
+            member.organizationId,
+            member.userId,
+            CreateIncidentForm(
+                incidentTypeResourceId = null,
+                stage = IncidentFormStage.ACCEPTANCE,
+                name = "Acceptance",
+                fields = listOf(
+                    IncidentFormFieldInput(
+                        fieldId = customFieldResourceId("customer_impact"),
+                        position = 0,
+                        required = true,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    private fun customFieldResourceId(key: String): String =
+        configurationService
+            .listCustomFields(member.organizationId)
+            .single { it.key == key }
+            .id
+
+    private fun linkEpisode(commandKey: String, incidentId: Int, alertEpisodeId: Int) =
+        service.execute(
+            LinkIncidentSourceCommand(
+                commandKey = commandKey,
+                actor = actor(),
+                incidentId = incidentId,
+                source =
+                    IncidentSourceReference(
+                        sourceType = IncidentSourceType.ALERT_EPISODE,
+                        sourceKey = "resolved-by-service",
+                        alertEpisodeId = alertEpisodeId,
+                    ),
+            ),
+        )
+
+    private fun linkUrlSource(commandKey: String, incidentId: Int, sourceKey: String) =
+        service.execute(
+            LinkIncidentSourceCommand(
+                commandKey = commandKey,
+                actor = actor(),
+                incidentId = incidentId,
+                source =
+                    IncidentSourceReference(
+                        sourceType = IncidentSourceType.URL,
+                        sourceKey = sourceKey,
+                        sourceUrl = "https://example.test/$sourceKey",
+                    ),
+            ),
+        )
+
+    private fun actor() = IncidentCommandActor(member.organizationId, member.userId, "REST")
+
+    private fun triageDeclaration(commandKey: String) =
+        DeclareIncidentCommand(
+            commandKey = commandKey,
+            actor = actor(),
+            title = "Unclassified report",
+            description = null,
+            initialStatus = NativeIncidentStatus.TRIAGE,
+        )
+
+    private fun activeDeclaration(commandKey: String) =
+        DeclareIncidentCommand(
+            commandKey = commandKey,
+            actor = actor(),
+            title = "Checkout unavailable",
+            description = null,
+            severity = "SEV-2",
+        )
+
+    private fun incidentRow(incidentId: Int) =
+        OnCallIncidents.selectAll().where { OnCallIncidents.id eq incidentId }.single()
+
+    private fun timelineEventTypes(incidentId: Int): Set<String> =
+        OnCallIncidentTimeline
+            .selectAll()
+            .where { OnCallIncidentTimeline.incidentId eq incidentId }
+            .mapTo(mutableSetOf()) { it[OnCallIncidentTimeline.eventType] }
+
+    private fun episodeResourceId(episodeId: Int): String =
+        AlertEpisodes
+            .selectAll()
+            .where { AlertEpisodes.id eq episodeId }
+            .single()[AlertEpisodes.resourceId]
+            .toString()
+
+    private fun alertResourceId(alertId: Int): String =
+        OnCallAlerts.selectAll().where { OnCallAlerts.id eq alertId }.single()[OnCallAlerts.resourceId].toString()
+
+    private fun seedAlert(deduplicationKey: String): Int =
+        transaction {
+            val now = Clock.System.now()
+            OnCallAlerts.insertAndGetId {
+                it[organizationId] = member.organizationId
+                it[declaredIncidentId] = null
+                it[escalationPolicyId] = null
+                it[title] = "Database page"
+                it[description] = null
+                it[priority] = "P1"
+                it[status] = "TRIGGERED"
+                it[alertSource] = "TEST"
+                it[OnCallAlerts.deduplicationKey] = deduplicationKey
+                it[currentStep] = 0
+                it[repeatIteration] = 0
+                it[triggeredAt] = now
+                it[acknowledgedAt] = null
+                it[acknowledgedBy] = null
+                it[resolvedAt] = null
+                it[resolvedBy] = null
+                it[metadata] = null
+                it[createdAt] = now
+                it[updatedAt] = now
+            }.value
+        }
+
+    private fun seedAlertEpisode(key: String): Int =
+        transaction {
+            val now = Clock.System.now()
+            AlertEpisodes.insertAndGetId {
+                it[organizationId] = member.organizationId
+                it[sourceName] = "TEST"
+                it[deduplicationKey] = key
+                it[title] = "Episode $key"
+                it[description] = null
+                it[priority] = "P2"
+                it[episodeSeq] = 1
+                it[episodeKey] = "$key-1"
+                it[status] = "FIRING"
+                it[openedAt] = now
+                it[lastSeenAt] = now
+                it[createdAt] = now
+                it[updatedAt] = now
+            }.value
+        }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentTriageMergeCommandTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/commands/IncidentTriageMergeCommandTest.kt
@@ -30,6 +30,7 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -420,6 +421,17 @@ class IncidentTriageMergeCommandTest {
         }
         assertFailsWith<Exception> {
             transaction { insertRawIncident(status = NativeIncidentStatus.MERGED.wire, severity = "SEV-2") }
+        }
+        val selfMergeId =
+            transaction { insertRawIncident(status = NativeIncidentStatus.TRIAGE.wire, severity = null) }
+        assertFailsWith<Exception> {
+            transaction {
+                OnCallIncidents.update({ OnCallIncidents.id eq selfMergeId }) {
+                    it[status] = NativeIncidentStatus.MERGED.wire
+                    it[mergedAt] = Clock.System.now()
+                    it[mergedIntoIncidentId] = selfMergeId
+                }
+            }
         }
         // Triage outcomes that never reached acceptance stay legitimately unclassified.
         transaction { insertRawIncident(status = NativeIncidentStatus.DECLINED.wire, severity = null) }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/incidents/events/WorkflowIncidentEventConsumerTest.kt
@@ -1,0 +1,96 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.incidents.events
+
+import com.moneat.alerts.models.IncidentSeverity
+import com.moneat.workflows.services.WorkflowService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+
+class WorkflowIncidentEventConsumerTest {
+    private val workflowService = mockk<WorkflowService>()
+    private val consumer = WorkflowIncidentEventConsumer(workflowService)
+
+    @Test
+    fun `triage declaration does not publish an accepted incident workflow`() = runBlocking {
+        consumer.consume(
+            event(
+                eventType = "INCIDENT_DECLARE",
+                status = "TRIAGE",
+                severity = null,
+            ),
+            deliveryKey = "workflows:triage-declare",
+        )
+
+        confirmVerified(workflowService)
+    }
+
+    @Test
+    fun `active declaration publishes the created workflow with its real severity`() = runBlocking {
+        coEvery { workflowService.publishDeclaredIncidentCreated(any(), any(), any(), any()) } returns Unit
+
+        consumer.consume(
+            event(
+                eventType = "INCIDENT_DECLARE",
+                status = "ACTIVE",
+                severity = "SEV-2",
+            ),
+            deliveryKey = "workflows:active-declare",
+        )
+
+        coVerify(exactly = 1) {
+            workflowService.publishDeclaredIncidentCreated(7, 42, "Checkout unavailable", IncidentSeverity.SEV2)
+        }
+    }
+
+    @Test
+    fun `accept publishes the classified created workflow exactly once per delivery`() = runBlocking {
+        coEvery { workflowService.publishDeclaredIncidentCreated(any(), any(), any(), any()) } returns Unit
+
+        consumer.consume(
+            event(
+                eventType = "INCIDENT_ACCEPT",
+                status = "ACTIVE",
+                severity = "SEV-1",
+            ),
+            deliveryKey = "workflows:accept",
+        )
+
+        coVerify(exactly = 1) {
+            workflowService.publishDeclaredIncidentCreated(7, 42, "Checkout unavailable", IncidentSeverity.SEV1)
+        }
+    }
+
+    private fun event(
+        eventType: String,
+        status: String,
+        severity: String?,
+    ): NativeIncidentDomainEvent =
+        NativeIncidentDomainEvent(
+            id = 1,
+            resourceId = "event-resource-id",
+            organizationId = 7,
+            incidentId = 42,
+            eventType = eventType,
+            aggregateVersion = 1,
+            idempotencyKey = "incident-command",
+            payload = payload(status, severity),
+            createdAt = "2026-08-23T00:00:00Z",
+        )
+
+    private fun payload(status: String, severity: String?): Map<String, JsonElement> =
+        mapOf(
+            "title" to JsonPrimitive("Checkout unavailable"),
+            "status" to JsonPrimitive(status),
+            "severity" to (severity?.let(::JsonPrimitive) ?: JsonNull),
+        )
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/oncall/routes/IncidentRoutesTest.kt
@@ -404,6 +404,113 @@ class IncidentRoutesTest {
         assertEquals(HttpStatusCode.OK, selfRemoval.status)
     }
 
+    @Test
+    fun `triage commands expose accept decline and merge through the shared command contract`() = testApplication {
+        application { installIncidentRoutes() }
+
+        val triaged = declareTriageIncident("accepted")
+        val declined = declareTriageIncident("declined")
+        val mergeSource = declareTriageIncident("merge-source")
+
+        val missingSeverity = postCommand("/v1/on-call/incidents/$triaged/accept", "{}", "accept-missing")
+        assertEquals(HttpStatusCode.BadRequest, missingSeverity.status)
+
+        val accepted = postCommand(
+            "/v1/on-call/incidents/$triaged/accept",
+            """{"severity":"SEV-2","expectedVersion":1}""",
+            "accept-ok",
+        )
+        assertEquals(HttpStatusCode.OK, accepted.status)
+        assertEquals("ACTIVE", accepted.jsonObject().requiredString("status"))
+        assertEquals("SEV-2", accepted.jsonObject().requiredString("severity"))
+
+        val stale = postCommand(
+            "/v1/on-call/incidents/$triaged/accept",
+            """{"severity":"SEV-1","expectedVersion":1}""",
+            "accept-stale",
+        )
+        assertEquals(HttpStatusCode.Conflict, stale.status)
+
+        val declineResponse = postCommand(
+            "/v1/on-call/incidents/$declined/decline",
+            """{"reason":"Not an incident"}""",
+            "decline-ok",
+        )
+        assertEquals(HttpStatusCode.OK, declineResponse.status)
+        assertEquals("DECLINED", declineResponse.jsonObject().requiredString("status"))
+
+        val merged = postCommand(
+            "/v1/on-call/incidents/$triaged/merge",
+            """{"sourceIncidentId":"$mergeSource"}""",
+            "merge-ok",
+        )
+        assertEquals(HttpStatusCode.OK, merged.status)
+        val mergedSource = client.get("/v1/on-call/incidents/$mergeSource") { authorize() }.jsonObject()
+        assertEquals("MERGED", mergedSource.requiredString("status"))
+        assertEquals(triaged, mergedSource.requiredString("mergedIntoIncidentId"))
+    }
+
+    @Test
+    fun `triage command routes reject malformed unknown and out-of-scope targets`() = testApplication {
+        application { installIncidentRoutes() }
+        val incidentId = declareIncident("command-contract")
+
+        val numericTarget = postCommand("/v1/on-call/incidents/42/accept", "{}", "numeric")
+        assertEquals(HttpStatusCode.BadRequest, numericTarget.status)
+
+        val unknownTarget = postCommand(
+            "/v1/on-call/incidents/${Uuid.random()}/decline",
+            "{}",
+            "unknown-incident",
+        )
+        assertEquals(HttpStatusCode.NotFound, unknownTarget.status)
+
+        val malformedSource = postCommand(
+            "/v1/on-call/incidents/$incidentId/merge",
+            """{"sourceIncidentId":"7"}""",
+            "malformed-source",
+        )
+        assertEquals(HttpStatusCode.BadRequest, malformedSource.status)
+
+        val unknownSource = postCommand(
+            "/v1/on-call/incidents/$incidentId/merge",
+            """{"sourceIncidentId":"${Uuid.random()}"}""",
+            "unknown-source",
+        )
+        assertEquals(HttpStatusCode.NotFound, unknownSource.status)
+
+        val selfMerge = postCommand(
+            "/v1/on-call/incidents/$incidentId/merge",
+            """{"sourceIncidentId":"$incidentId"}""",
+            "self-merge",
+        )
+        assertEquals(HttpStatusCode.BadRequest, selfMerge.status)
+    }
+
+    @Test
+    fun `triage command routes replay a repeated idempotency key`() = testApplication {
+        application { installIncidentRoutes() }
+        val incidentId = declareTriageIncident("replayed")
+
+        val first = postCommand(
+            "/v1/on-call/incidents/$incidentId/accept",
+            """{"severity":"SEV-3"}""",
+            "accept-replay",
+        )
+        val replay = postCommand(
+            "/v1/on-call/incidents/$incidentId/accept",
+            """{"severity":"SEV-3"}""",
+            "accept-replay",
+        )
+
+        assertEquals(HttpStatusCode.OK, first.status)
+        assertEquals(HttpStatusCode.OK, replay.status)
+        assertEquals(
+            first.jsonObject().requiredString("version"),
+            replay.jsonObject().requiredString("version"),
+        )
+    }
+
     private fun Application.installIncidentRoutes(
         rolloutEnabled: Boolean = true,
         entitlementEnabled: Boolean = true,
@@ -489,6 +596,29 @@ class IncidentRoutesTest {
         assertEquals(HttpStatusCode.Created, response.status)
         return Json.parseToJsonElement(response.bodyAsText()).jsonObject.requiredString("id")
     }
+
+    private suspend fun io.ktor.server.testing.ApplicationTestBuilder.declareTriageIncident(name: String): String {
+        val response = client.post("/v1/on-call/incidents") {
+            authorize()
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            header(IDEMPOTENCY_HEADER, "declare-triage-$name")
+            setBody("""{"title":"$name","initialStatus":"TRIAGE"}""")
+        }
+        assertEquals(HttpStatusCode.Created, response.status)
+        return Json.parseToJsonElement(response.bodyAsText()).jsonObject.requiredString("id")
+    }
+
+    private suspend fun io.ktor.server.testing.ApplicationTestBuilder.postCommand(
+        path: String,
+        body: String,
+        idempotencyKey: String,
+    ): HttpResponse =
+        client.post(path) {
+            authorize()
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            header(IDEMPOTENCY_HEADER, idempotencyKey)
+            setBody(body)
+        }
 
     private suspend fun io.ktor.server.testing.ApplicationTestBuilder.linkSource(
         incidentId: String,


### PR DESCRIPTION
## Summary

- add nullable triage classification and explicit accept/decline/merge commands
- model `MERGED` as a distinct terminal outcome and atomically transfer incident links
- expose UUID REST commands with shared rollout, entitlement, authorization, version, and idempotency handling
- align triage capability policy, workflow timing, dashboard contracts, and storage invariants

## Verification

- `./gradlew :ee:test :ee:detekt --no-daemon`
- `npm run lint`
- `npm run typecheck`
- `npm run test -- --run` (263 files, 2510 tests)
- `python3 scripts/check-migration-versions.py --base-ref origin/develop`
- `git diff --check`
- Claude Opus 4.8 max-effort review: no blocking findings; applied non-self-merge storage constraint/test suggestion

## Environment note

The private PostgreSQL worktree setup could not be reached over SSH, so V159 was hand-reviewed and migration numbering was validated locally; CI remains the PostgreSQL integration gate.

Backlog: TASK-1.51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incident triage workflows with accept and decline actions.
  * Triage incidents can be created without an initial severity and classified upon acceptance.
  * Added incident merging, including merge status, destination details, and transferred relationships.
  * Added validation for permissions, self-merges, invalid targets, and stale updates.
* **Bug Fixes**
  * Incidents without severity now display as “Unclassified” with neutral styling.
  * Repeated commands and merges now handle safely and consistently.
* **Workflow Updates**
  * Improved event handling so accepted and active incidents publish the appropriate workflow updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->