### PR TITLE
feat: add versioned enterprise alert routes

### DIFF
--- a/backend/features/incident/src/test/kotlin/com/moneat/services/incident/IncidentProviderRegistryTest.kt
+++ b/backend/features/incident/src/test/kotlin/com/moneat/services/incident/IncidentProviderRegistryTest.kt
@@ -74,7 +74,7 @@ class IncidentProviderRegistryTest {
         assertEquals(null, IncidentProviderRegistry.getProvider(providerType))
     }
 
-    private class TestIncidentProvider(override val providerType: String) : IncidentProvider {
+    private data class TestIncidentProvider(override val providerType: String) : IncidentProvider {
         override suspend fun sendAlert(event: AlertLifecycleEvent, config: ProviderConfig): Result<String> =
             Result.success("ok")
 

--- a/backend/features/incident/src/test/kotlin/com/moneat/services/incident/IncidentProviderRegistryTest.kt
+++ b/backend/features/incident/src/test/kotlin/com/moneat/services/incident/IncidentProviderRegistryTest.kt
@@ -51,8 +51,36 @@ class IncidentProviderRegistryTest {
             }
 
         IncidentProviderRegistry.register(provider)
+        try {
+            assertEquals(provider, IncidentProviderRegistry.getProvider(provider.providerType))
+            assertTrue(provider.providerType in IncidentProviderRegistry.getProviderTypes())
+        } finally {
+            IncidentProviderRegistry.unregister(provider)
+        }
+    }
 
-        assertEquals(provider, IncidentProviderRegistry.getProvider(provider.providerType))
-        assertTrue(provider.providerType in IncidentProviderRegistry.getProviderTypes())
+    @Test
+    fun `unregister removes only the provider instance that is still registered`() {
+        val providerType = "test-provider-${System.nanoTime()}"
+        val first = TestIncidentProvider(providerType)
+        val replacement = TestIncidentProvider(providerType)
+        IncidentProviderRegistry.register(first)
+        IncidentProviderRegistry.register(replacement)
+
+        IncidentProviderRegistry.unregister(first)
+        assertEquals(replacement, IncidentProviderRegistry.getProvider(providerType))
+
+        IncidentProviderRegistry.unregister(replacement)
+        assertEquals(null, IncidentProviderRegistry.getProvider(providerType))
+    }
+
+    private class TestIncidentProvider(override val providerType: String) : IncidentProvider {
+        override suspend fun sendAlert(event: AlertLifecycleEvent, config: ProviderConfig): Result<String> =
+            Result.success("ok")
+
+        override suspend fun resolveAlert(deduplicationKey: String, config: ProviderConfig): Result<String> =
+            Result.success("ok")
+
+        override suspend fun testConnection(config: ProviderConfig): Result<Boolean> = Result.success(true)
     }
 }

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentProviderRegistry.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentProviderRegistry.kt
@@ -34,7 +34,9 @@ object IncidentProviderRegistry {
 
     /** Remove this provider only if it is still the registered instance for its type. */
     fun unregister(provider: IncidentProvider) {
-        providers.remove(provider.providerType, provider)
+        providers.computeIfPresent(provider.providerType) { _, registered ->
+            registered.takeUnless { it === provider }
+        }
     }
 
     /**

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentProviderRegistry.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentProviderRegistry.kt
@@ -32,6 +32,11 @@ object IncidentProviderRegistry {
         providers[provider.providerType] = provider
     }
 
+    /** Remove this provider only if it is still the registered instance for its type. */
+    fun unregister(provider: IncidentProvider) {
+        providers.remove(provider.providerType, provider)
+    }
+
     /**
      * Get a provider by type.
      * @return The provider implementation, or null if not registered

--- a/backend/src/main/resources/db/migration/V160__enterprise_alert_routes.sql
+++ b/backend/src/main/resources/db/migration/V160__enterprise_alert_routes.sql
@@ -1,0 +1,163 @@
+-- Enterprise Alert Routes.
+--
+-- Versioned, organization-scoped routing over a normalized source-neutral alert context.
+-- These tables are independent of the AGPL incident-provider routing rules stored in
+-- incident_routing_rules, which continue to forward alerts to external providers.
+
+CREATE TABLE enterprise_alert_routes (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    route_key VARCHAR(160) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    description TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    position INTEGER NOT NULL,
+    revision INTEGER NOT NULL DEFAULT 1,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    updated_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, resource_id),
+    UNIQUE (organization_id, route_key),
+    UNIQUE (organization_id, position),
+    CONSTRAINT chk_enterprise_alert_routes_position CHECK (position >= 0),
+    CONSTRAINT chk_enterprise_alert_routes_revision CHECK (revision > 0)
+);
+
+CREATE INDEX idx_enterprise_alert_routes_evaluation_order
+    ON enterprise_alert_routes(organization_id, position, id);
+
+CREATE TABLE enterprise_alert_route_condition_groups (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    route_id INTEGER NOT NULL REFERENCES enterprise_alert_routes(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, resource_id),
+    UNIQUE (route_id, position),
+    CONSTRAINT chk_enterprise_alert_route_groups_position CHECK (position >= 0)
+);
+
+CREATE TABLE enterprise_alert_route_conditions (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    group_id INTEGER NOT NULL REFERENCES enterprise_alert_route_condition_groups(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    context_field VARCHAR(48) NOT NULL,
+    metadata_key VARCHAR(160),
+    operator VARCHAR(32) NOT NULL,
+    comparison_values JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, resource_id),
+    UNIQUE (group_id, position),
+    CONSTRAINT chk_enterprise_alert_route_conditions_position CHECK (position >= 0)
+);
+
+CREATE TABLE enterprise_alert_route_actions (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    route_id INTEGER NOT NULL REFERENCES enterprise_alert_routes(id) ON DELETE CASCADE,
+    paging_cadence VARCHAR(32) NOT NULL DEFAULT 'NONE',
+    grouping_behavior VARCHAR(24) NOT NULL DEFAULT 'SUGGESTED',
+    grouping_window_kind VARCHAR(16) NOT NULL DEFAULT 'ROLLING',
+    grouping_window_seconds INTEGER NOT NULL DEFAULT 900,
+    grouping_keys JSONB NOT NULL DEFAULT '[]'::jsonb,
+    incident_creation_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    incident_initial_status VARCHAR(24) NOT NULL DEFAULT 'TRIAGE',
+    incident_title_template TEXT,
+    incident_summary_template TEXT,
+    incident_severity VARCHAR(20),
+    incident_type VARCHAR(120),
+    recovery_cancel_escalations BOOLEAN NOT NULL DEFAULT FALSE,
+    recovery_decline_unaccepted_triage BOOLEAN NOT NULL DEFAULT FALSE,
+    recovery_grace_seconds INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, resource_id),
+    UNIQUE (route_id),
+    CONSTRAINT chk_enterprise_alert_route_paging_cadence CHECK (
+        paging_cadence IN ('NONE', 'FIRST_EPISODE_PER_GROUP', 'EVERY_EPISODE')
+    ),
+    CONSTRAINT chk_enterprise_alert_route_grouping_behavior CHECK (
+        grouping_behavior IN ('SUGGESTED', 'AUTOMATIC')
+    ),
+    CONSTRAINT chk_enterprise_alert_route_grouping_window_kind CHECK (
+        grouping_window_kind IN ('FIXED', 'ROLLING')
+    ),
+    CONSTRAINT chk_enterprise_alert_route_incident_status CHECK (
+        incident_initial_status IN ('TRIAGE', 'ACTIVE')
+    ),
+    CONSTRAINT chk_enterprise_alert_route_grouping_window CHECK (grouping_window_seconds > 0),
+    CONSTRAINT chk_enterprise_alert_route_recovery_grace CHECK (recovery_grace_seconds >= 0)
+);
+
+CREATE TABLE enterprise_alert_route_targets (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    route_id INTEGER NOT NULL REFERENCES enterprise_alert_routes(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    target_kind VARCHAR(32) NOT NULL,
+    escalation_policy_id INTEGER REFERENCES escalation_policies(id) ON DELETE RESTRICT,
+    team_id INTEGER REFERENCES organization_teams(id) ON DELETE RESTRICT,
+    ownership_source VARCHAR(24),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, resource_id),
+    UNIQUE (route_id, position),
+    CONSTRAINT chk_enterprise_alert_route_target_kind CHECK (
+        target_kind IN ('ESCALATION_POLICY', 'TEAM', 'OWNERSHIP_DERIVED')
+    ),
+    CONSTRAINT chk_enterprise_alert_route_target_ownership CHECK (
+        ownership_source IS NULL OR ownership_source IN ('SERVICE', 'TEAM', 'CATALOG')
+    ),
+    CONSTRAINT chk_enterprise_alert_route_target_reference CHECK (
+        (target_kind = 'ESCALATION_POLICY' AND escalation_policy_id IS NOT NULL)
+        OR (target_kind = 'TEAM' AND team_id IS NOT NULL)
+        OR (target_kind = 'OWNERSHIP_DERIVED' AND ownership_source IS NOT NULL)
+    )
+);
+
+CREATE TABLE enterprise_alert_route_commands (
+    id SERIAL PRIMARY KEY,
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    command_key VARCHAR(160) NOT NULL,
+    command_type VARCHAR(24) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    result_route_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, command_key),
+    CONSTRAINT chk_enterprise_alert_route_command_type CHECK (
+        command_type IN ('CREATE', 'UPDATE', 'DELETE', 'REORDER')
+    )
+);
+
+CREATE TABLE enterprise_alert_route_revisions (
+    id SERIAL PRIMARY KEY,
+    resource_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    route_id INTEGER REFERENCES enterprise_alert_routes(id) ON DELETE SET NULL,
+    route_resource_id UUID NOT NULL,
+    revision INTEGER NOT NULL,
+    change_type VARCHAR(24) NOT NULL,
+    actor_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    command_key VARCHAR(160) NOT NULL,
+    request_fingerprint VARCHAR(64) NOT NULL,
+    snapshot JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, resource_id),
+    UNIQUE (organization_id, route_resource_id, revision),
+    CONSTRAINT chk_enterprise_alert_route_revision_number CHECK (revision > 0),
+    CONSTRAINT chk_enterprise_alert_route_change_type CHECK (
+        change_type IN ('CREATED', 'UPDATED', 'REORDERED', 'DELETED')
+    )
+);
+
+CREATE INDEX idx_enterprise_alert_route_revisions_history
+    ON enterprise_alert_route_revisions(organization_id, route_resource_id, revision DESC);
+
+CREATE INDEX idx_enterprise_alert_route_revisions_command
+    ON enterprise_alert_route_revisions(organization_id, command_key);

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRouteCommands.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRouteCommands.kt
@@ -1,0 +1,142 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.commands
+
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingWindowKind
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteOwnershipSource
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import kotlin.uuid.Uuid
+
+data class AlertRouteActor(
+    val organizationId: Int,
+    val userId: Int,
+    val origin: String,
+)
+
+data class AlertRouteConditionInput(
+    val field: AlertRouteContextField,
+    val operator: AlertRouteConditionOperator,
+    val values: List<String> = emptyList(),
+    val metadataKey: String? = null,
+)
+
+data class AlertRouteConditionGroupInput(
+    val conditions: List<AlertRouteConditionInput>,
+)
+
+data class AlertRouteTargetInput(
+    val kind: AlertRouteTargetKind,
+    val escalationPolicyId: Uuid? = null,
+    val teamId: Uuid? = null,
+    val ownershipSource: AlertRouteOwnershipSource? = null,
+)
+
+data class AlertRoutePagingInput(
+    val mode: AlertRoutePagingMode = AlertRoutePagingMode.NONE,
+    val targets: List<AlertRouteTargetInput> = emptyList(),
+)
+
+data class AlertRouteGroupingInput(
+    val behavior: AlertRouteGroupingBehavior = AlertRouteGroupingBehavior.DEFAULT,
+    val keys: List<String> = emptyList(),
+    val windowKind: AlertRouteGroupingWindowKind = AlertRouteGroupingWindowKind.ROLLING,
+    val windowSeconds: Int = DEFAULT_GROUPING_WINDOW_SECONDS,
+)
+
+data class AlertRouteIncidentInput(
+    val create: Boolean = false,
+    val mode: AlertRouteIncidentMode = AlertRouteIncidentMode.TRIAGE,
+    val titleTemplate: String? = null,
+    val summaryTemplate: String? = null,
+    val severity: String? = null,
+    val incidentType: String? = null,
+)
+
+data class AlertRouteRecoveryInput(
+    val cancelEscalations: Boolean = false,
+    val declineUnacceptedTriage: Boolean = false,
+    val graceSeconds: Int = 0,
+)
+
+/** Full desired state of one alert route. Updates replace the whole specification. */
+data class AlertRouteSpecification(
+    val key: String,
+    val name: String,
+    val description: String? = null,
+    val enabled: Boolean = true,
+    val conditionGroups: List<AlertRouteConditionGroupInput> = emptyList(),
+    val paging: AlertRoutePagingInput = AlertRoutePagingInput(),
+    val grouping: AlertRouteGroupingInput = AlertRouteGroupingInput(),
+    val incident: AlertRouteIncidentInput = AlertRouteIncidentInput(),
+    val recovery: AlertRouteRecoveryInput = AlertRouteRecoveryInput(),
+)
+
+enum class AlertRouteCommandType(val wire: String) {
+    CREATE("CREATE"),
+    UPDATE("UPDATE"),
+    DELETE("DELETE"),
+    REORDER("REORDER"),
+}
+
+sealed interface AlertRouteCommand {
+    val commandKey: String
+    val actor: AlertRouteActor
+    val type: AlertRouteCommandType
+}
+
+data class CreateAlertRouteCommand(
+    override val commandKey: String,
+    override val actor: AlertRouteActor,
+    val specification: AlertRouteSpecification,
+) : AlertRouteCommand {
+    override val type = AlertRouteCommandType.CREATE
+}
+
+data class UpdateAlertRouteCommand(
+    override val commandKey: String,
+    override val actor: AlertRouteActor,
+    val routeId: Uuid,
+    val expectedRevision: Int,
+    val specification: AlertRouteSpecification,
+) : AlertRouteCommand {
+    override val type = AlertRouteCommandType.UPDATE
+}
+
+data class DeleteAlertRouteCommand(
+    override val commandKey: String,
+    override val actor: AlertRouteActor,
+    val routeId: Uuid,
+    val expectedRevision: Int,
+) : AlertRouteCommand {
+    override val type = AlertRouteCommandType.DELETE
+}
+
+data class AlertRouteOrderEntry(
+    val routeId: Uuid,
+    val expectedRevision: Int,
+)
+
+data class ReorderAlertRoutesCommand(
+    override val commandKey: String,
+    override val actor: AlertRouteActor,
+    val orderedRoutes: List<AlertRouteOrderEntry>,
+) : AlertRouteCommand {
+    override val type = AlertRouteCommandType.REORDER
+}
+
+data class AlertRouteCommandResult(
+    val routes: List<AlertRouteDefinition>,
+    val replayed: Boolean,
+) {
+    val route: AlertRouteDefinition? get() = routes.firstOrNull()
+}
+
+const val DEFAULT_GROUPING_WINDOW_SECONDS = 900

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRouteFingerprint.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRouteFingerprint.kt
@@ -1,0 +1,94 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.commands
+
+import java.security.MessageDigest
+import java.util.HexFormat
+
+/** Stable hash of a command's request payload, used to distinguish replays from key reuse. */
+internal object AlertRouteFingerprint {
+    private const val SEPARATOR = ""
+
+    fun of(command: AlertRouteCommand): String {
+        val parts = listOf(command.type.wire) + commandParts(command)
+        val digest =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(parts.joinToString(SEPARATOR) { it.orEmpty() }.toByteArray(Charsets.UTF_8))
+        return HexFormat.of().formatHex(digest)
+    }
+
+    private fun commandParts(command: AlertRouteCommand): List<String?> =
+        when (command) {
+            is CreateAlertRouteCommand -> specificationParts(command.specification)
+            is UpdateAlertRouteCommand ->
+                listOf(command.routeId.toString(), command.expectedRevision.toString()) +
+                    specificationParts(command.specification)
+            is DeleteAlertRouteCommand -> listOf(command.routeId.toString(), command.expectedRevision.toString())
+            is ReorderAlertRoutesCommand ->
+                command.orderedRoutes.flatMap { listOf(it.routeId.toString(), it.expectedRevision.toString()) }
+        }
+
+    private fun specificationParts(specification: AlertRouteSpecification): List<String?> =
+        listOf(
+            specification.key,
+            specification.name,
+            specification.description,
+            specification.enabled.toString(),
+            conditionParts(specification),
+            pagingParts(specification),
+            groupingParts(specification),
+            incidentParts(specification),
+            recoveryParts(specification),
+        )
+
+    private fun conditionParts(specification: AlertRouteSpecification): String =
+        specification.conditionGroups.joinToString(";") { group ->
+            group.conditions.joinToString(",") { condition ->
+                listOf(
+                    condition.field.wire,
+                    condition.metadataKey.orEmpty(),
+                    condition.operator.wire,
+                    condition.values.joinToString("+"),
+                ).joinToString(":")
+            }
+        }
+
+    private fun pagingParts(specification: AlertRouteSpecification): String =
+        specification.paging.mode.wire +
+            specification.paging.targets.joinToString(",") { target ->
+                listOf(
+                    target.kind.wire,
+                    target.escalationPolicyId?.toString().orEmpty(),
+                    target.teamId?.toString().orEmpty(),
+                    target.ownershipSource?.wire.orEmpty(),
+                ).joinToString(":")
+            }
+
+    private fun groupingParts(specification: AlertRouteSpecification): String =
+        listOf(
+            specification.grouping.behavior.wire,
+            specification.grouping.keys.joinToString("+"),
+            specification.grouping.windowKind.wire,
+            specification.grouping.windowSeconds.toString(),
+        ).joinToString(":")
+
+    private fun incidentParts(specification: AlertRouteSpecification): String =
+        listOf(
+            specification.incident.create.toString(),
+            specification.incident.mode.wire,
+            specification.incident.titleTemplate.orEmpty(),
+            specification.incident.summaryTemplate.orEmpty(),
+            specification.incident.severity.orEmpty(),
+            specification.incident.incidentType.orEmpty(),
+        ).joinToString(":")
+
+    private fun recoveryParts(specification: AlertRouteSpecification): String =
+        listOf(
+            specification.recovery.cancelEscalations.toString(),
+            specification.recovery.declineUnacceptedTriage.toString(),
+            specification.recovery.graceSeconds.toString(),
+        ).joinToString(":")
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRoutePolicy.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/commands/AlertRoutePolicy.kt
@@ -1,0 +1,112 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.commands
+
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.NativeIncidentQuotaDecision
+import com.moneat.enterprise.NativeIncidentQuotaKey
+import com.moneat.enterprise.NativeIncidentQuotaStatus
+import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
+import com.moneat.enterprise.incidents.commands.IncidentEntitlement
+import com.moneat.enterprise.incidents.commands.IncidentCommandQuotaExceededException
+
+fun interface AlertRouteQuotaAdmission {
+    fun admit(organizationId: Int, enabledRouteCount: Long, idempotencyKey: String): NativeIncidentQuotaDecision
+}
+
+/**
+ * Rollout and authorization gate for alert-route mutations.
+ *
+ * The default entitlement combines the organization-and-environment rollout decision with the paid
+ * native incident-response entitlement. Enabled-route capacity is reconciled through the canonical
+ * billing quota bridge in the same transaction as the protected mutation.
+ */
+class AlertRoutePolicy(
+    private val entitlement: IncidentEntitlement = IncidentEntitlement {
+        FeatureRegistry.isNativeIncidentResponseEnabled(it)
+    },
+    private val quotaAdmission: AlertRouteQuotaAdmission = AlertRouteQuotaAdmission { organizationId, count, key ->
+        val status = FeatureRegistry.nativeIncidentEntitlementStatus(organizationId)
+        val quota = status.quotas[NativeIncidentQuotaKey.ENABLED_ALERT_ROUTES]
+            ?: return@AlertRouteQuotaAdmission unavailableQuotaDecision()
+        if (count > quota.limit) {
+            return@AlertRouteQuotaAdmission NativeIncidentQuotaDecision(
+                allowed = false,
+                status = quota.copy(used = count),
+                message = "Enabled alert route quota is exhausted; disable a route or upgrade the plan",
+            )
+        }
+        FeatureRegistry.reconcileNativeIncidentQuota(
+            organizationId = organizationId,
+            quotaKey = NativeIncidentQuotaKey.ENABLED_ALERT_ROUTES,
+            authoritativeUsage = count,
+            idempotencyKey = key,
+        )
+    },
+) {
+    fun requireAllowed(command: AlertRouteCommand) {
+        val actor = command.actor
+        if (!entitlement.isEnabled(actor.organizationId)) {
+            throw IncidentCommandDeniedException("Native incident response is not enabled for this organization")
+        }
+        requireReadAllowed(actor.organizationId)
+        require(command.commandKey.isNotBlank()) { "Alert route command key is required" }
+        require(command.commandKey.length <= MAX_COMMAND_KEY_LENGTH) { "Alert route command key is too long" }
+        require(actor.origin.isNotBlank()) { "Alert route command origin is required" }
+        require(actor.userId > 0) { "Alert route command actor is required" }
+    }
+
+    fun requireReadAllowed(organizationId: Int) {
+        if (!entitlement.isEnabled(organizationId)) {
+            throw IncidentCommandDeniedException("Native incident response is not enabled for this organization")
+        }
+    }
+
+    fun isEnabled(organizationId: Int): Boolean = entitlement.isEnabled(organizationId)
+
+    fun requireQuota(command: AlertRouteCommand, enabledRouteCount: Long) {
+        val decision = quotaAdmission.admit(
+            organizationId = command.actor.organizationId,
+            enabledRouteCount = enabledRouteCount,
+            idempotencyKey = "alert-route:${command.commandKey}",
+        )
+        if (!decision.allowed) {
+            throw IncidentCommandQuotaExceededException(
+                decision.message ?: "Enabled alert route quota is exhausted",
+            )
+        }
+    }
+
+    companion object {
+        const val MAX_COMMAND_KEY_LENGTH = 160
+        private fun unavailableQuotaDecision() =
+            NativeIncidentQuotaDecision(
+                allowed = false,
+                status = NativeIncidentQuotaStatus(
+                    key = NativeIncidentQuotaKey.ENABLED_ALERT_ROUTES,
+                    limit = 0,
+                    used = 0,
+                ),
+                message = "Enabled alert route quota provider is unavailable",
+            )
+
+        fun allowForTests(): AlertRoutePolicy =
+            AlertRoutePolicy(
+                entitlement = IncidentEntitlement { true },
+                quotaAdmission = AlertRouteQuotaAdmission { _, count, _ ->
+                    NativeIncidentQuotaDecision(
+                        allowed = true,
+                        status = NativeIncidentQuotaStatus(
+                            NativeIncidentQuotaKey.ENABLED_ALERT_ROUTES,
+                            limit = Long.MAX_VALUE,
+                            used = count,
+                        ),
+                    )
+                },
+            )
+
+        fun denyForTests(): AlertRoutePolicy = AlertRoutePolicy(entitlement = IncidentEntitlement { false })
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteContext.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteContext.kt
@@ -9,6 +9,7 @@ import com.moneat.alerts.services.AlertEpisodeContext
 import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import kotlin.uuid.Uuid
 
 /**
@@ -185,7 +186,7 @@ object AlertRouteMetadataPolicy {
         return ApprovedMetadata(approved, dropped.sorted())
     }
 
-    private fun JsonElement.asPlainText(): String? = (this as? JsonPrimitive)?.content
+    private fun JsonElement.asPlainText(): String? = (this as? JsonPrimitive)?.contentOrNull
 }
 
 /** A hand-supplied alert used to preview routes without waiting for a real alert. */

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteContext.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteContext.kt
@@ -1,0 +1,256 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.context
+
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.services.AlertEpisodeContext
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.uuid.Uuid
+
+/**
+ * Episode identity carried alongside an alert.
+ *
+ * Episodes are owned by the open-source alert lifecycle; alert routes read the identity and never
+ * open, close, or renumber episodes themselves.
+ */
+data class AlertRouteEpisodeIdentity(
+    val resourceId: String? = null,
+    val key: String? = null,
+    val sequence: Int? = null,
+    val status: String? = null,
+) {
+    companion object {
+        val UNKNOWN = AlertRouteEpisodeIdentity()
+
+        fun from(episode: AlertEpisodeContext): AlertRouteEpisodeIdentity =
+            AlertRouteEpisodeIdentity(
+                resourceId = episode.resourceId.toString(),
+                key = episode.episodeKey,
+                sequence = episode.episodeSeq,
+                status = episode.status,
+            )
+    }
+}
+
+/** Service, team, and catalog ownership attached to an alert. */
+data class AlertRouteOwnership(
+    val serviceName: String? = null,
+    val teamId: Int? = null,
+    val teamResourceId: Uuid? = null,
+    val teamName: String? = null,
+    val catalogResourceId: String? = null,
+    val escalationPolicyId: Int? = null,
+    val escalationPolicyResourceId: Uuid? = null,
+) {
+    companion object {
+        val NONE = AlertRouteOwnership()
+    }
+}
+
+/**
+ * Normalized, source-neutral view of an alert used by every alert-route condition and template.
+ *
+ * Only approved metadata reaches this type; unapproved keys are dropped by
+ * [AlertRouteMetadataPolicy] and reported in [droppedMetadataKeys] so previews can explain them.
+ */
+data class AlertRouteContext(
+    val organizationId: Int,
+    val source: String,
+    val status: String,
+    val priority: String,
+    val title: String,
+    val description: String,
+    val deduplicationKey: String,
+    val url: String,
+    val episode: AlertRouteEpisodeIdentity = AlertRouteEpisodeIdentity.UNKNOWN,
+    val metadata: Map<String, String> = emptyMap(),
+    val ownership: AlertRouteOwnership = AlertRouteOwnership.NONE,
+    val droppedMetadataKeys: List<String> = emptyList(),
+) {
+    fun value(field: AlertRouteContextField, metadataKey: String? = null): String? =
+        when (field) {
+            AlertRouteContextField.SOURCE -> source
+            AlertRouteContextField.STATUS -> status
+            AlertRouteContextField.PRIORITY -> priority
+            AlertRouteContextField.TITLE -> title
+            AlertRouteContextField.DESCRIPTION -> description
+            AlertRouteContextField.DEDUPLICATION_KEY -> deduplicationKey
+            AlertRouteContextField.URL -> url
+            AlertRouteContextField.METADATA -> metadataKey?.let { metadata[it] }
+            else -> episodeOrOwnershipValue(field)
+        }?.takeIf { it.isNotBlank() }
+
+    private fun episodeOrOwnershipValue(field: AlertRouteContextField): String? =
+        when (field) {
+            AlertRouteContextField.EPISODE_KEY -> episode.key
+            AlertRouteContextField.EPISODE_SEQUENCE -> episode.sequence?.toString()
+            AlertRouteContextField.EPISODE_STATUS -> episode.status
+            AlertRouteContextField.SERVICE -> ownership.serviceName
+            AlertRouteContextField.TEAM -> ownership.teamName
+            AlertRouteContextField.CATALOG_RESOURCE -> ownership.catalogResourceId
+            else -> null
+        }
+
+    /** Resolve a dotted reference such as `alert.title`, `episode.key`, or `metadata.host_id`. */
+    fun reference(path: String): String? {
+        val trimmed = path.trim()
+        val (scope, leaf) = trimmed.split('.', limit = 2).let { it.first() to it.getOrNull(1) }
+        return when (scope.lowercase()) {
+            METADATA_SCOPE -> leaf?.let { metadata[it] }?.takeIf { it.isNotBlank() }
+            OWNERSHIP_SCOPE -> leaf?.let { ownershipReference(it) }
+            EPISODE_SCOPE -> leaf?.let { episodeReference(it) }
+            ALERT_SCOPE -> leaf?.let { alertReference(it) }
+            else -> alertReference(trimmed)
+        }
+    }
+
+    private fun alertReference(leaf: String): String? =
+        AlertRouteContextField.fromWire(leaf)
+            ?.takeIf { it != AlertRouteContextField.METADATA }
+            ?.let { value(it) }
+
+    private fun ownershipReference(leaf: String): String? =
+        when (leaf.lowercase()) {
+            "service" -> ownership.serviceName
+            "team" -> ownership.teamName
+            "catalog_resource", "catalog" -> ownership.catalogResourceId
+            else -> null
+        }?.takeIf { it.isNotBlank() }
+
+    private fun episodeReference(leaf: String): String? =
+        when (leaf.lowercase()) {
+            "id", "resource_id" -> episode.resourceId
+            "key" -> episode.key
+            "sequence" -> episode.sequence?.toString()
+            "status" -> episode.status
+            else -> null
+        }?.takeIf { it.isNotBlank() }
+
+    private companion object {
+        const val METADATA_SCOPE = "metadata"
+        const val OWNERSHIP_SCOPE = "ownership"
+        const val EPISODE_SCOPE = "episode"
+        const val ALERT_SCOPE = "alert"
+    }
+}
+
+/** Approved metadata keys emitted by Moneat alert sources and safe to route or template on. */
+object AlertRouteMetadataPolicy {
+    val APPROVED_KEYS: Set<String> =
+        setOf(
+            "alert.condition",
+            "alert.current_value",
+            "alert.dashboard.title",
+            "alert.display_title",
+            "alert.threshold",
+            "alert.widget.title",
+            "catalog_resource_id",
+            "cluster",
+            "environment",
+            "host_id",
+            "monitor_id",
+            "namespace",
+            "region",
+            "service",
+            "service_name",
+            "team",
+            "triggered_by",
+        )
+
+    data class ApprovedMetadata(
+        val values: Map<String, String>,
+        val dropped: List<String>,
+    )
+
+    fun approve(metadata: Map<String, JsonElement>): ApprovedMetadata {
+        val approved = LinkedHashMap<String, String>()
+        val dropped = mutableListOf<String>()
+        metadata.forEach { (key, element) ->
+            val normalized = key.trim()
+            if (normalized !in APPROVED_KEYS) {
+                dropped.add(normalized)
+                return@forEach
+            }
+            val text = element.asPlainText()
+            if (text == null) {
+                dropped.add(normalized)
+                return@forEach
+            }
+            if (text.isNotBlank()) approved[normalized] = text
+        }
+        return ApprovedMetadata(approved, dropped.sorted())
+    }
+
+    private fun JsonElement.asPlainText(): String? = (this as? JsonPrimitive)?.content
+}
+
+/** A hand-supplied alert used to preview routes without waiting for a real alert. */
+data class AlertRouteSampleInput(
+    val source: String,
+    val status: String = "FIRING",
+    val priority: String = "P3",
+    val title: String = "",
+    val description: String = "",
+    val deduplicationKey: String = "",
+    val url: String = "",
+    val metadata: Map<String, String> = emptyMap(),
+    val episode: AlertRouteEpisodeIdentity = AlertRouteEpisodeIdentity.UNKNOWN,
+)
+
+/** Builds the normalized route context from the shared alert lifecycle event. */
+object AlertRouteContextFactory {
+    fun fromLifecycleEvent(
+        event: AlertLifecycleEvent,
+        episode: AlertRouteEpisodeIdentity = AlertRouteEpisodeIdentity.UNKNOWN,
+        ownership: AlertRouteOwnership = AlertRouteOwnership.NONE,
+    ): AlertRouteContext {
+        val approved = AlertRouteMetadataPolicy.approve(event.metadata)
+        return AlertRouteContext(
+            organizationId = event.organizationId,
+            source = event.source.name,
+            status = event.status.name,
+            priority = event.priority.wire,
+            title = event.title,
+            description = event.description,
+            deduplicationKey = event.deduplicationKey,
+            url = event.moneatUrl,
+            episode = episode,
+            metadata = approved.values,
+            ownership = ownership.mergedWith(approved.values),
+            droppedMetadataKeys = approved.dropped,
+        )
+    }
+
+    fun fromSample(
+        organizationId: Int,
+        sample: AlertRouteSampleInput,
+        ownership: AlertRouteOwnership = AlertRouteOwnership.NONE,
+    ): AlertRouteContext {
+        val approved = AlertRouteMetadataPolicy.approve(sample.metadata.mapValues { JsonPrimitive(it.value) })
+        return AlertRouteContext(
+            organizationId = organizationId,
+            source = sample.source,
+            status = sample.status,
+            priority = sample.priority,
+            title = sample.title,
+            description = sample.description,
+            deduplicationKey = sample.deduplicationKey,
+            url = sample.url,
+            episode = sample.episode,
+            metadata = approved.values,
+            ownership = ownership.mergedWith(approved.values),
+            droppedMetadataKeys = approved.dropped,
+        )
+    }
+
+    private fun AlertRouteOwnership.mergedWith(metadata: Map<String, String>): AlertRouteOwnership =
+        copy(
+            serviceName = serviceName ?: metadata["service"] ?: metadata["service_name"],
+            teamName = teamName ?: metadata["team"],
+            catalogResourceId = catalogResourceId ?: metadata["catalog_resource_id"],
+        )
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteOwnershipResolver.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteOwnershipResolver.kt
@@ -1,0 +1,103 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.context
+
+import com.moneat.monitor.repositories.ResourceOwnership
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.OrganizationTeams
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.uuid.Uuid
+
+/** Resolves service, team, and catalog ownership for an alert from its approved metadata. */
+fun interface AlertRouteOwnershipResolver {
+    fun resolve(organizationId: Int, metadata: Map<String, String>): AlertRouteOwnership
+
+    companion object {
+        val NONE = AlertRouteOwnershipResolver { _, _ -> AlertRouteOwnership.NONE }
+    }
+}
+
+/**
+ * Reads ownership claims from the shared catalog ownership table and organization teams.
+ *
+ * A catalog resource id resolves to its owning team; otherwise a team name or slug in metadata is
+ * matched directly. The owning team's default escalation policy backs OWNERSHIP_DERIVED targets.
+ */
+class DatabaseAlertRouteOwnershipResolver : AlertRouteOwnershipResolver {
+    override fun resolve(organizationId: Int, metadata: Map<String, String>): AlertRouteOwnership {
+        val catalogResourceId = metadata[CATALOG_RESOURCE_KEY]
+        val serviceName = metadata[SERVICE_KEY] ?: metadata[SERVICE_NAME_KEY]
+        val teamHint = metadata[TEAM_KEY]
+        if (catalogResourceId == null && teamHint == null && serviceName == null) {
+            return AlertRouteOwnership.NONE
+        }
+        return transaction {
+            val team =
+                catalogResourceId?.let { teamForCatalogResource(organizationId, it) }
+                    ?: teamHint?.let { teamByNameOrSlug(organizationId, it) }
+            val escalationPolicyId = team?.get(OrganizationTeams.escalationPolicyId)
+            AlertRouteOwnership(
+                serviceName = serviceName,
+                teamId = team?.get(OrganizationTeams.id)?.value,
+                teamResourceId = team?.get(OrganizationTeams.resourceId),
+                teamName = team?.get(OrganizationTeams.name) ?: teamHint,
+                catalogResourceId = catalogResourceId,
+                escalationPolicyId = escalationPolicyId,
+                escalationPolicyResourceId = escalationPolicyId?.let(::escalationPolicyResourceId),
+            )
+        }
+    }
+
+    private fun escalationPolicyResourceId(escalationPolicyId: Int): Uuid? =
+        EscalationPolicies
+            .selectAll()
+            .where { EscalationPolicies.id eq escalationPolicyId }
+            .limit(1)
+            .firstOrNull()
+            ?.get(EscalationPolicies.resourceId)
+
+    private fun teamForCatalogResource(organizationId: Int, catalogResourceId: String): ResultRow? {
+        val teamId =
+            ResourceOwnership
+                .selectAll()
+                .where {
+                    (ResourceOwnership.organization_id eq organizationId) and
+                        (ResourceOwnership.resource_id eq catalogResourceId)
+                }.limit(1)
+                .firstOrNull()
+                ?.get(ResourceOwnership.team_id)
+                ?: return null
+        return OrganizationTeams
+            .selectAll()
+            .where {
+                (OrganizationTeams.organizationId eq organizationId) and
+                    (OrganizationTeams.id eq teamId)
+            }.limit(1)
+            .firstOrNull()
+    }
+
+    private fun teamByNameOrSlug(organizationId: Int, hint: String): ResultRow? {
+        val normalized = hint.trim()
+        if (normalized.isEmpty()) return null
+        return OrganizationTeams
+            .selectAll()
+            .where { OrganizationTeams.organizationId eq organizationId }
+            .firstOrNull { row ->
+                row[OrganizationTeams.name].equals(normalized, ignoreCase = true) ||
+                    row[OrganizationTeams.slug].equals(normalized, ignoreCase = true)
+            }
+    }
+
+    private companion object {
+        const val CATALOG_RESOURCE_KEY = "catalog_resource_id"
+        const val SERVICE_KEY = "service"
+        const val SERVICE_NAME_KEY = "service_name"
+        const val TEAM_KEY = "team"
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteOwnershipResolver.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/context/AlertRouteOwnershipResolver.kt
@@ -31,9 +31,9 @@ fun interface AlertRouteOwnershipResolver {
  */
 class DatabaseAlertRouteOwnershipResolver : AlertRouteOwnershipResolver {
     override fun resolve(organizationId: Int, metadata: Map<String, String>): AlertRouteOwnership {
-        val catalogResourceId = metadata[CATALOG_RESOURCE_KEY]
-        val serviceName = metadata[SERVICE_KEY] ?: metadata[SERVICE_NAME_KEY]
-        val teamHint = metadata[TEAM_KEY]
+        val catalogResourceId = metadata.nonBlankValue(CATALOG_RESOURCE_KEY)
+        val serviceName = metadata.nonBlankValue(SERVICE_KEY, SERVICE_NAME_KEY)
+        val teamHint = metadata.nonBlankValue(TEAM_KEY)
         if (catalogResourceId == null && teamHint == null && serviceName == null) {
             return AlertRouteOwnership.NONE
         }
@@ -93,6 +93,9 @@ class DatabaseAlertRouteOwnershipResolver : AlertRouteOwnershipResolver {
                     row[OrganizationTeams.slug].equals(normalized, ignoreCase = true)
             }
     }
+
+    private fun Map<String, String>.nonBlankValue(vararg keys: String): String? =
+        keys.firstNotNullOfOrNull { key -> get(key)?.trim()?.takeIf(String::isNotEmpty) }
 
     private companion object {
         const val CATALOG_RESOURCE_KEY = "catalog_resource_id"

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluation.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluation.kt
@@ -1,0 +1,128 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.evaluation
+
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingWindowKind
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/** Why one condition matched or did not match. */
+data class AlertRouteConditionExplanation(
+    val field: AlertRouteContextField,
+    val metadataKey: String?,
+    val operator: AlertRouteConditionOperator,
+    val values: List<String>,
+    val actualValue: String?,
+    val matched: Boolean,
+)
+
+/** Explanation for one ORed condition group. */
+data class AlertRouteGroupExplanation(
+    val position: Int,
+    val matched: Boolean,
+    val conditions: List<AlertRouteConditionExplanation>,
+)
+
+/** Per-route outcome of an evaluation, including routes skipped after a earlier route matched. */
+data class AlertRouteEvaluation(
+    val routeId: Uuid,
+    val routeKey: String,
+    val routeName: String,
+    val position: Int,
+    val enabled: Boolean,
+    val matched: Boolean,
+    val selected: Boolean,
+    val reason: AlertRouteEvaluationReason,
+    val groups: List<AlertRouteGroupExplanation>,
+)
+
+enum class AlertRouteEvaluationReason(val wire: String) {
+    SELECTED("SELECTED"),
+    NO_GROUP_MATCHED("NO_GROUP_MATCHED"),
+    ROUTE_DISABLED("ROUTE_DISABLED"),
+    EARLIER_ROUTE_SELECTED("EARLIER_ROUTE_SELECTED"),
+}
+
+/** An escalation policy resolved from a route target, with its public resource id when known. */
+data class AlertRouteEscalationPolicyRef(
+    val id: Int,
+    val resourceId: Uuid?,
+)
+
+/** A team resolved from a route target, with its public resource id when known. */
+data class AlertRouteTeamRef(
+    val id: Int,
+    val resourceId: Uuid?,
+)
+
+/** Paging targets resolved for the selected route. */
+data class AlertRoutePagingResolution(
+    val mode: AlertRoutePagingMode,
+    val escalationPolicies: List<AlertRouteEscalationPolicyRef>,
+    val teams: List<AlertRouteTeamRef>,
+    val unresolvedTargets: List<String>,
+)
+
+/** Grouping plan resolved for the selected route. */
+data class AlertRouteGroupingResolution(
+    val behavior: AlertRouteGroupingBehavior,
+    val automatic: Boolean,
+    val groupKey: String,
+    val keys: List<String>,
+    val unresolvedKeys: List<String>,
+    val windowKind: AlertRouteGroupingWindowKind,
+    val windowSeconds: Int,
+) {
+    /** When the grouping window closes for a group that started at [groupStartedAt]. */
+    fun windowClosesAt(groupStartedAt: Instant, lastAlertAt: Instant): Instant =
+        when (windowKind) {
+            AlertRouteGroupingWindowKind.FIXED -> groupStartedAt + windowSeconds.seconds
+            AlertRouteGroupingWindowKind.ROLLING -> lastAlertAt + windowSeconds.seconds
+        }
+}
+
+/** Incident-creation plan resolved for the selected route, with templates already rendered. */
+data class AlertRouteIncidentResolution(
+    val create: Boolean,
+    val mode: AlertRouteIncidentMode,
+    val title: String?,
+    val summary: String?,
+    val severity: String?,
+    val incidentType: String?,
+    val unresolvedReferences: List<String>,
+)
+
+/** Recovery plan resolved for the selected route. */
+data class AlertRouteRecoveryResolution(
+    val cancelEscalations: Boolean,
+    val declineUnacceptedTriage: Boolean,
+    val graceSeconds: Int,
+)
+
+/** Everything the selected route decides for one alert. */
+data class AlertRouteDecision(
+    val routeId: Uuid,
+    val routeKey: String,
+    val routeName: String,
+    val position: Int,
+    val revision: Int,
+    val paging: AlertRoutePagingResolution,
+    val grouping: AlertRouteGroupingResolution,
+    val incident: AlertRouteIncidentResolution,
+    val recovery: AlertRouteRecoveryResolution,
+)
+
+/** Result of evaluating every route in an organization against one alert context. */
+data class AlertRouteEvaluationResult(
+    val decision: AlertRouteDecision?,
+    val evaluations: List<AlertRouteEvaluation>,
+    val droppedMetadataKeys: List<String>,
+)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluator.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluator.kt
@@ -1,0 +1,289 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.evaluation
+
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.enterprise.alertroutes.context.AlertRouteContext
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionGroupDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteOwnershipSource
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+
+/** Resolves the default escalation policy of a team referenced by a route target. */
+fun interface AlertRouteTeamEscalationResolver {
+    fun escalationPolicy(organizationId: Int, teamId: Int): AlertRouteEscalationPolicyRef?
+
+    companion object {
+        val NONE = AlertRouteTeamEscalationResolver { _, _ -> null }
+    }
+}
+
+/**
+ * Deterministic, ordered first-match evaluation of alert routes.
+ *
+ * Routes are evaluated by ascending position. Within a route, condition groups are ORed and the
+ * conditions inside a group are ANDed. The first matching enabled route wins; every other route is
+ * still explained so preview can show why it was skipped.
+ */
+class AlertRouteEvaluator(
+    private val teamEscalationResolver: AlertRouteTeamEscalationResolver = AlertRouteTeamEscalationResolver.NONE,
+) {
+    fun evaluate(
+        routes: List<AlertRouteDefinition>,
+        context: AlertRouteContext,
+    ): AlertRouteEvaluationResult {
+        val evaluations = mutableListOf<AlertRouteEvaluation>()
+        var selected: AlertRouteDefinition? = null
+        routes
+            .sortedWith(compareBy({ it.position }, { it.id }))
+            .forEach { route ->
+                val evaluation = evaluateRoute(route, context, alreadySelected = selected != null)
+                if (evaluation.selected) selected = route
+                evaluations.add(evaluation)
+            }
+        return AlertRouteEvaluationResult(
+            decision = selected?.let { buildDecision(it, context) },
+            evaluations = evaluations,
+            droppedMetadataKeys = context.droppedMetadataKeys,
+        )
+    }
+
+    private fun evaluateRoute(
+        route: AlertRouteDefinition,
+        context: AlertRouteContext,
+        alreadySelected: Boolean,
+    ): AlertRouteEvaluation {
+        val groups = route.conditionGroups.mapIndexed { index, group -> explainGroup(index, group, context) }
+        val matched = groups.isEmpty() || groups.any { it.matched }
+        val reason =
+            when {
+                !route.enabled -> AlertRouteEvaluationReason.ROUTE_DISABLED
+                !matched -> AlertRouteEvaluationReason.NO_GROUP_MATCHED
+                alreadySelected -> AlertRouteEvaluationReason.EARLIER_ROUTE_SELECTED
+                else -> AlertRouteEvaluationReason.SELECTED
+            }
+        return AlertRouteEvaluation(
+            routeId = route.resourceId,
+            routeKey = route.key,
+            routeName = route.name,
+            position = route.position,
+            enabled = route.enabled,
+            matched = matched,
+            selected = reason == AlertRouteEvaluationReason.SELECTED,
+            reason = reason,
+            groups = groups,
+        )
+    }
+
+    private fun explainGroup(
+        position: Int,
+        group: AlertRouteConditionGroupDefinition,
+        context: AlertRouteContext,
+    ): AlertRouteGroupExplanation {
+        val conditions = group.conditions.map { explainCondition(it, context) }
+        return AlertRouteGroupExplanation(
+            position = position,
+            matched = conditions.isNotEmpty() && conditions.all { it.matched },
+            conditions = conditions,
+        )
+    }
+
+    private fun explainCondition(
+        condition: AlertRouteConditionDefinition,
+        context: AlertRouteContext,
+    ): AlertRouteConditionExplanation {
+        val actual = context.value(condition.field, condition.metadataKey)
+        return AlertRouteConditionExplanation(
+            field = condition.field,
+            metadataKey = condition.metadataKey,
+            operator = condition.operator,
+            values = condition.values,
+            actualValue = actual,
+            matched = matches(condition.operator, actual, condition.values),
+        )
+    }
+
+    private fun matches(
+        operator: AlertRouteConditionOperator,
+        actual: String?,
+        values: List<String>,
+    ): Boolean =
+        when (operator) {
+            AlertRouteConditionOperator.IS_SET -> actual != null
+            AlertRouteConditionOperator.IS_NOT_SET -> actual == null
+            AlertRouteConditionOperator.AT_LEAST_AS_SEVERE_AS -> matchesSeverity(actual, values)
+            else -> matchesValue(operator, actual, values)
+        }
+
+    private fun matchesSeverity(actual: String?, values: List<String>): Boolean {
+        val actualPriority = AlertPriority.fromString(actual) ?: return false
+        val threshold = values.firstNotNullOfOrNull { AlertPriority.fromString(it) } ?: return false
+        return actualPriority.ordinal <= threshold.ordinal
+    }
+
+    private fun matchesValue(
+        operator: AlertRouteConditionOperator,
+        actual: String?,
+        values: List<String>,
+    ): Boolean {
+        if (actual == null) return operator in NEGATIVE_OPERATORS
+        return when (operator) {
+            AlertRouteConditionOperator.EQUALS,
+            AlertRouteConditionOperator.ONE_OF,
+            -> values.any { it.equals(actual, ignoreCase = true) }
+            AlertRouteConditionOperator.NOT_EQUALS,
+            AlertRouteConditionOperator.NOT_ONE_OF,
+            -> values.none { it.equals(actual, ignoreCase = true) }
+            AlertRouteConditionOperator.CONTAINS -> values.any { actual.contains(it, ignoreCase = true) }
+            AlertRouteConditionOperator.NOT_CONTAINS -> values.none { actual.contains(it, ignoreCase = true) }
+            AlertRouteConditionOperator.STARTS_WITH -> values.any { actual.startsWith(it, ignoreCase = true) }
+            AlertRouteConditionOperator.ENDS_WITH -> values.any { actual.endsWith(it, ignoreCase = true) }
+            else -> false
+        }
+    }
+
+    private fun buildDecision(
+        route: AlertRouteDefinition,
+        context: AlertRouteContext,
+    ): AlertRouteDecision =
+        AlertRouteDecision(
+            routeId = route.resourceId,
+            routeKey = route.key,
+            routeName = route.name,
+            position = route.position,
+            revision = route.revision,
+            paging = resolvePaging(route, context),
+            grouping = resolveGrouping(route, context),
+            incident = resolveIncident(route, context),
+            recovery =
+                AlertRouteRecoveryResolution(
+                    cancelEscalations = route.recovery.cancelEscalations,
+                    declineUnacceptedTriage = route.recovery.declineUnacceptedTriage,
+                    graceSeconds = route.recovery.graceSeconds,
+                ),
+        )
+
+    private fun resolvePaging(
+        route: AlertRouteDefinition,
+        context: AlertRouteContext,
+    ): AlertRoutePagingResolution {
+        if (route.paging.mode == AlertRoutePagingMode.NONE) {
+            return AlertRoutePagingResolution(AlertRoutePagingMode.NONE, emptyList(), emptyList(), emptyList())
+        }
+        val escalationPolicies = linkedSetOf<AlertRouteEscalationPolicyRef>()
+        val teams = linkedSetOf<AlertRouteTeamRef>()
+        val unresolved = mutableListOf<String>()
+        route.paging.targets.forEach { target ->
+            val policy = resolveTarget(route.organizationId, target, context, teams)
+            if (policy == null) unresolved.add(target.describe()) else escalationPolicies.add(policy)
+        }
+        return AlertRoutePagingResolution(
+            mode = route.paging.mode,
+            escalationPolicies = escalationPolicies.toList(),
+            teams = teams.toList(),
+            unresolvedTargets = unresolved,
+        )
+    }
+
+    private fun resolveTarget(
+        organizationId: Int,
+        target: AlertRouteTargetDefinition,
+        context: AlertRouteContext,
+        teams: MutableSet<AlertRouteTeamRef>,
+    ): AlertRouteEscalationPolicyRef? =
+        when (target.kind) {
+            AlertRouteTargetKind.ESCALATION_POLICY ->
+                target.escalationPolicyId?.let { AlertRouteEscalationPolicyRef(it, target.escalationPolicyResourceId) }
+            AlertRouteTargetKind.TEAM ->
+                target.teamId
+                    ?.also { teams.add(AlertRouteTeamRef(it, target.teamResourceId)) }
+                    ?.let { teamEscalationResolver.escalationPolicy(organizationId, it) }
+            AlertRouteTargetKind.OWNERSHIP_DERIVED -> resolveOwnershipTarget(target, context, teams)
+        }
+
+    private fun resolveOwnershipTarget(
+        target: AlertRouteTargetDefinition,
+        context: AlertRouteContext,
+        teams: MutableSet<AlertRouteTeamRef>,
+    ): AlertRouteEscalationPolicyRef? {
+        val ownership = context.ownership
+        val dimensionPresent =
+            when (target.ownershipSource) {
+                AlertRouteOwnershipSource.SERVICE -> ownership.serviceName != null
+                AlertRouteOwnershipSource.TEAM -> ownership.teamId != null || ownership.teamName != null
+                AlertRouteOwnershipSource.CATALOG -> ownership.catalogResourceId != null
+                null -> false
+            }
+        if (!dimensionPresent) return null
+        ownership.teamId?.let { teams.add(AlertRouteTeamRef(it, ownership.teamResourceId)) }
+        return ownership.escalationPolicyId?.let {
+            AlertRouteEscalationPolicyRef(it, ownership.escalationPolicyResourceId)
+        }
+    }
+
+    private fun resolveGrouping(
+        route: AlertRouteDefinition,
+        context: AlertRouteContext,
+    ): AlertRouteGroupingResolution {
+        val keys = route.grouping.keys.ifEmpty { DEFAULT_GROUPING_KEYS }
+        val unresolved = mutableListOf<String>()
+        val parts =
+            keys.map { key ->
+                context.reference(key) ?: run {
+                    unresolved.add(key)
+                    ""
+                }
+            }
+        return AlertRouteGroupingResolution(
+            behavior = route.grouping.behavior,
+            automatic = route.grouping.behavior == AlertRouteGroupingBehavior.AUTOMATIC,
+            groupKey = (listOf(route.key) + parts).joinToString(GROUP_KEY_SEPARATOR),
+            keys = keys,
+            unresolvedKeys = unresolved,
+            windowKind = route.grouping.windowKind,
+            windowSeconds = route.grouping.windowSeconds,
+        )
+    }
+
+    private fun resolveIncident(
+        route: AlertRouteDefinition,
+        context: AlertRouteContext,
+    ): AlertRouteIncidentResolution {
+        val title = AlertRouteTemplateRenderer.render(route.incident.titleTemplate, context)
+        val summary = AlertRouteTemplateRenderer.render(route.incident.summaryTemplate, context)
+        return AlertRouteIncidentResolution(
+            create = route.incident.create,
+            mode = route.incident.mode,
+            title = title.text ?: context.title,
+            summary = summary.text,
+            severity = route.incident.severity,
+            incidentType = route.incident.incidentType,
+            unresolvedReferences = (title.unresolvedReferences + summary.unresolvedReferences).distinct(),
+        )
+    }
+
+    private fun AlertRouteTargetDefinition.describe(): String =
+        when (kind) {
+            AlertRouteTargetKind.ESCALATION_POLICY -> "ESCALATION_POLICY"
+            AlertRouteTargetKind.TEAM -> "TEAM:${teamId ?: "unknown"}"
+            AlertRouteTargetKind.OWNERSHIP_DERIVED -> "OWNERSHIP_DERIVED:${ownershipSource?.wire ?: "unknown"}"
+        }
+
+    private companion object {
+        const val GROUP_KEY_SEPARATOR = "|"
+        val DEFAULT_GROUPING_KEYS = listOf("alert.deduplication_key")
+        val NEGATIVE_OPERATORS =
+            setOf(
+                AlertRouteConditionOperator.NOT_EQUALS,
+                AlertRouteConditionOperator.NOT_ONE_OF,
+                AlertRouteConditionOperator.NOT_CONTAINS,
+            )
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteTemplateRenderer.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteTemplateRenderer.kt
@@ -1,0 +1,46 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.evaluation
+
+import com.moneat.enterprise.alertroutes.context.AlertRouteContext
+
+/** A template rendered against the normalized alert context. */
+data class RenderedAlertRouteTemplate(
+    val text: String?,
+    val unresolvedReferences: List<String>,
+)
+
+/**
+ * Renders `{{ alert.title }}`-style references from the normalized alert context.
+ *
+ * Unresolved references render as an empty string and are reported so preview can explain them.
+ */
+object AlertRouteTemplateRenderer {
+    private val PLACEHOLDER = Regex("\\{\\{\\s*([A-Za-z0-9_.]+)\\s*}}")
+
+    fun render(template: String?, context: AlertRouteContext): RenderedAlertRouteTemplate {
+        if (template.isNullOrBlank()) return RenderedAlertRouteTemplate(null, emptyList())
+        val unresolved = linkedSetOf<String>()
+        val text =
+            PLACEHOLDER.replace(template) { match ->
+                val reference = match.groupValues[1]
+                context.reference(reference) ?: run {
+                    unresolved.add(reference)
+                    ""
+                }
+            }
+        return RenderedAlertRouteTemplate(text.trim().takeIf { it.isNotEmpty() }, unresolved.toList())
+    }
+
+    /** Reference paths used by a template, in first-use order. */
+    fun references(template: String?): List<String> {
+        if (template.isNullOrBlank()) return emptyList()
+        return PLACEHOLDER
+            .findAll(template)
+            .map { it.groupValues[1] }
+            .distinct()
+            .toList()
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/models/AlertRouteDefinition.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/models/AlertRouteDefinition.kt
@@ -1,0 +1,91 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.models
+
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+import kotlinx.serialization.json.JsonElement
+
+/** One condition inside a group. Conditions in the same group are ANDed. */
+data class AlertRouteConditionDefinition(
+    val field: AlertRouteContextField,
+    val operator: AlertRouteConditionOperator,
+    val values: List<String> = emptyList(),
+    val metadataKey: String? = null,
+)
+
+/** Groups are ORed with each other. An empty group list matches every alert. */
+data class AlertRouteConditionGroupDefinition(
+    val conditions: List<AlertRouteConditionDefinition>,
+)
+
+/** A static or ownership-derived escalation target. */
+data class AlertRouteTargetDefinition(
+    val kind: AlertRouteTargetKind,
+    val escalationPolicyId: Int? = null,
+    val escalationPolicyResourceId: Uuid? = null,
+    val teamId: Int? = null,
+    val teamResourceId: Uuid? = null,
+    val ownershipSource: AlertRouteOwnershipSource? = null,
+)
+
+data class AlertRoutePagingDefinition(
+    val mode: AlertRoutePagingMode,
+    val targets: List<AlertRouteTargetDefinition>,
+)
+
+data class AlertRouteGroupingDefinition(
+    val behavior: AlertRouteGroupingBehavior,
+    val keys: List<String>,
+    val windowKind: AlertRouteGroupingWindowKind,
+    val windowSeconds: Int,
+)
+
+data class AlertRouteIncidentDefinition(
+    val create: Boolean,
+    val mode: AlertRouteIncidentMode,
+    val titleTemplate: String?,
+    val summaryTemplate: String?,
+    val severity: String?,
+    val incidentType: String?,
+)
+
+data class AlertRouteRecoveryDefinition(
+    val cancelEscalations: Boolean,
+    val declineUnacceptedTriage: Boolean,
+    val graceSeconds: Int,
+)
+
+/** A complete, persisted alert route as evaluated at runtime. */
+data class AlertRouteDefinition(
+    val id: Int,
+    val resourceId: Uuid,
+    val organizationId: Int,
+    val key: String,
+    val name: String,
+    val description: String?,
+    val enabled: Boolean,
+    val position: Int,
+    val revision: Int,
+    val conditionGroups: List<AlertRouteConditionGroupDefinition>,
+    val paging: AlertRoutePagingDefinition,
+    val grouping: AlertRouteGroupingDefinition,
+    val incident: AlertRouteIncidentDefinition,
+    val recovery: AlertRouteRecoveryDefinition,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+)
+
+/** One audited revision of a route. */
+data class AlertRouteRevisionRecord(
+    val id: Uuid,
+    val routeId: Uuid,
+    val revision: Int,
+    val changeType: AlertRouteChangeType,
+    val actorId: Uuid?,
+    val commandKey: String,
+    val snapshot: Map<String, JsonElement>,
+    val createdAt: Instant,
+)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/models/AlertRouteModels.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/models/AlertRouteModels.kt
@@ -1,0 +1,331 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.models
+
+import com.moneat.enterprise.oncall.models.requiredJsonb
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.OrganizationTeams
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ColumnType
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.datetime.timestamp
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.postgresql.util.PGobject
+import kotlin.uuid.Uuid
+
+/** Source-neutral alert context fields available to route conditions, grouping keys, and templates. */
+enum class AlertRouteContextField(val wire: String, val supportsMetadataKey: Boolean = false) {
+    SOURCE("source"),
+    STATUS("status"),
+    PRIORITY("priority"),
+    TITLE("title"),
+    DESCRIPTION("description"),
+    DEDUPLICATION_KEY("deduplication_key"),
+    URL("url"),
+    EPISODE_KEY("episode_key"),
+    EPISODE_SEQUENCE("episode_sequence"),
+    EPISODE_STATUS("episode_status"),
+    METADATA("metadata", supportsMetadataKey = true),
+    SERVICE("service"),
+    TEAM("team"),
+    CATALOG_RESOURCE("catalog_resource"),
+    ;
+
+    companion object {
+        fun fromWire(value: String): AlertRouteContextField? {
+            val normalized = value.trim()
+            return entries.firstOrNull {
+                it.wire.equals(normalized, ignoreCase = true) || it.name == normalized.uppercase()
+            }
+        }
+    }
+}
+
+/** Comparison operators supported by an individual alert-route condition. */
+enum class AlertRouteConditionOperator(
+    val wire: String,
+    val requiresValues: Boolean = true,
+    val priorityOnly: Boolean = false,
+) {
+    EQUALS("EQUALS"),
+    NOT_EQUALS("NOT_EQUALS"),
+    ONE_OF("ONE_OF"),
+    NOT_ONE_OF("NOT_ONE_OF"),
+    CONTAINS("CONTAINS"),
+    NOT_CONTAINS("NOT_CONTAINS"),
+    STARTS_WITH("STARTS_WITH"),
+    ENDS_WITH("ENDS_WITH"),
+    IS_SET("IS_SET", requiresValues = false),
+    IS_NOT_SET("IS_NOT_SET", requiresValues = false),
+    AT_LEAST_AS_SEVERE_AS("AT_LEAST_AS_SEVERE_AS", priorityOnly = true),
+    ;
+
+    companion object {
+        fun fromWire(value: String): AlertRouteConditionOperator? =
+            entries.firstOrNull { it.wire == value.trim().uppercase() }
+    }
+}
+
+/** How a matched route pages responders. */
+enum class AlertRoutePagingMode(val wire: String) {
+    NONE("NONE"),
+    FIRST_EPISODE_PER_GROUP("FIRST_EPISODE_PER_GROUP"),
+    EVERY_EPISODE("EVERY_EPISODE"),
+    ;
+
+    companion object {
+        fun fromWire(value: String): AlertRoutePagingMode? =
+            entries.firstOrNull { it.wire == value.trim().uppercase() }
+    }
+}
+
+/** Whether an escalation target is stated directly or derived from ownership. */
+enum class AlertRouteTargetKind(val wire: String) {
+    ESCALATION_POLICY("ESCALATION_POLICY"),
+    TEAM("TEAM"),
+    OWNERSHIP_DERIVED("OWNERSHIP_DERIVED"),
+    ;
+
+    companion object {
+        fun fromWire(value: String): AlertRouteTargetKind? =
+            entries.firstOrNull { it.wire == value.trim().uppercase() }
+    }
+}
+
+/** Ownership dimension an OWNERSHIP_DERIVED target follows. */
+enum class AlertRouteOwnershipSource(val wire: String) {
+    SERVICE("SERVICE"),
+    TEAM("TEAM"),
+    CATALOG("CATALOG"),
+    ;
+
+    companion object {
+        fun fromWire(value: String): AlertRouteOwnershipSource? =
+            entries.firstOrNull { it.wire == value.trim().uppercase() }
+    }
+}
+
+/** Suggested grouping is the default; automatic grouping requires an explicit per-route opt-in. */
+enum class AlertRouteGroupingBehavior(val wire: String) {
+    SUGGESTED("SUGGESTED"),
+    AUTOMATIC("AUTOMATIC"),
+    ;
+
+    companion object {
+        val DEFAULT = SUGGESTED
+
+        fun fromWire(value: String): AlertRouteGroupingBehavior? =
+            entries.firstOrNull { it.wire == value.trim().uppercase() }
+    }
+}
+
+/** Fixed windows are anchored on the first alert in a group; rolling windows extend on every alert. */
+enum class AlertRouteGroupingWindowKind(val wire: String) {
+    FIXED("FIXED"),
+    ROLLING("ROLLING"),
+    ;
+
+    companion object {
+        fun fromWire(value: String): AlertRouteGroupingWindowKind? =
+            entries.firstOrNull { it.wire == value.trim().uppercase() }
+    }
+}
+
+/** Initial lifecycle status for incidents created by a matched route. */
+enum class AlertRouteIncidentMode(val wire: String) {
+    TRIAGE("TRIAGE"),
+    ACTIVE("ACTIVE"),
+    ;
+
+    companion object {
+        fun fromWire(value: String): AlertRouteIncidentMode? =
+            entries.firstOrNull { it.wire == value.trim().uppercase() }
+    }
+}
+
+/** Audited change kinds recorded against an alert route. */
+enum class AlertRouteChangeType(val wire: String) {
+    CREATED("CREATED"),
+    UPDATED("UPDATED"),
+    REORDERED("REORDERED"),
+    DELETED("DELETED"),
+}
+
+private class JsonbStringListColumnType : ColumnType<List<String>>() {
+    private fun isH2(): Boolean =
+        TransactionManager
+            .currentOrNull()
+            ?.db
+            ?.url
+            ?.contains("h2", ignoreCase = true) == true
+
+    override fun sqlType(): String = if (isH2()) "TEXT" else "JSONB"
+
+    override fun valueFromDB(value: Any): List<String> =
+        when (value) {
+            is PGobject -> value.value?.let { Json.decodeFromString<List<String>>(it) } ?: emptyList()
+            is String -> Json.decodeFromString(value)
+            else -> emptyList()
+        }
+
+    override fun notNullValueToDB(value: List<String>): Any {
+        val encoded = Json.encodeToString(kotlinx.serialization.serializer<List<String>>(), value)
+        if (isH2()) return encoded
+        return PGobject().apply {
+            type = "jsonb"
+            this.value = encoded
+        }
+    }
+}
+
+private fun Table.stringListJsonb(name: String): Column<List<String>> =
+    registerColumn(name, JsonbStringListColumnType())
+
+/** Ordered, versioned alert routes owned by one organization. */
+object EnterpriseAlertRoutes : IntIdTable("enterprise_alert_routes") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val routeKey = varchar("route_key", 160)
+    val name = varchar("name", 200)
+    val description = text("description").nullable()
+    val enabled = bool("enabled").default(true)
+    val position = integer("position")
+    val revision = integer("revision").default(1)
+    val createdBy = integer("created_by").references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val updatedBy = integer("updated_by").references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(organizationId, routeKey)
+        uniqueIndex(organizationId, position)
+        index(false, organizationId, position, id)
+    }
+}
+
+/** Condition groups are ORed together when a route is evaluated. */
+object EnterpriseAlertRouteConditionGroups : IntIdTable("enterprise_alert_route_condition_groups") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val routeId = integer("route_id").references(EnterpriseAlertRoutes.id, onDelete = ReferenceOption.CASCADE)
+    val position = integer("position")
+    val createdAt = timestamp("created_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(routeId, position)
+    }
+}
+
+/** Conditions inside one group are ANDed together. */
+object EnterpriseAlertRouteConditions : IntIdTable("enterprise_alert_route_conditions") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val groupId =
+        integer("group_id").references(EnterpriseAlertRouteConditionGroups.id, onDelete = ReferenceOption.CASCADE)
+    val position = integer("position")
+    val contextField = varchar("context_field", 48)
+    val metadataKey = varchar("metadata_key", 160).nullable()
+    val operator = varchar("operator", 32)
+    val comparisonValues = stringListJsonb("comparison_values")
+    val createdAt = timestamp("created_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(groupId, position)
+    }
+}
+
+/** Paging, grouping, incident-creation, and recovery configuration for one route. */
+object EnterpriseAlertRouteActions : IntIdTable("enterprise_alert_route_actions") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val routeId = integer("route_id").references(EnterpriseAlertRoutes.id, onDelete = ReferenceOption.CASCADE)
+    val pagingMode = varchar("paging_cadence", 32)
+    val groupingBehavior = varchar("grouping_behavior", 24)
+    val groupingWindowKind = varchar("grouping_window_kind", 16)
+    val groupingWindowSeconds = integer("grouping_window_seconds")
+    val groupingKeys = stringListJsonb("grouping_keys")
+    val incidentCreationEnabled = bool("incident_creation_enabled")
+    val incidentCreationMode = varchar("incident_initial_status", 24)
+    val incidentTitleTemplate = text("incident_title_template").nullable()
+    val incidentSummaryTemplate = text("incident_summary_template").nullable()
+    val incidentSeverity = varchar("incident_severity", 20).nullable()
+    val incidentType = varchar("incident_type", 120).nullable()
+    val recoveryCancelEscalations = bool("recovery_cancel_escalations")
+    val recoveryDeclineUnacceptedTriage = bool("recovery_decline_unaccepted_triage")
+    val recoveryGraceSeconds = integer("recovery_grace_seconds")
+    val createdAt = timestamp("created_at")
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(routeId)
+    }
+}
+
+/** Static or ownership-derived escalation targets resolved when a route is selected. */
+object EnterpriseAlertRouteTargets : IntIdTable("enterprise_alert_route_targets") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val routeId = integer("route_id").references(EnterpriseAlertRoutes.id, onDelete = ReferenceOption.CASCADE)
+    val position = integer("position")
+    val targetKind = varchar("target_kind", 32)
+    val escalationPolicyId =
+        integer("escalation_policy_id")
+            .references(EscalationPolicies.id, onDelete = ReferenceOption.RESTRICT)
+            .nullable()
+    val teamId =
+        integer("team_id").references(OrganizationTeams.id, onDelete = ReferenceOption.RESTRICT).nullable()
+    val ownershipSource = varchar("ownership_source", 24).nullable()
+    val createdAt = timestamp("created_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(routeId, position)
+    }
+}
+
+/** Organization-global idempotency record for one accepted alert-route mutation. */
+object EnterpriseAlertRouteCommands : IntIdTable("enterprise_alert_route_commands") {
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val commandKey = varchar("command_key", 160)
+    val commandType = varchar("command_type", 24)
+    val requestFingerprint = varchar("request_fingerprint", 64)
+    val resultRouteIds = stringListJsonb("result_route_ids")
+    val createdAt = timestamp("created_at")
+
+    init {
+        uniqueIndex(organizationId, commandKey)
+    }
+}
+
+/** Append-only audit trail: one row per route changed by an accepted mutation. */
+object EnterpriseAlertRouteRevisions : IntIdTable("enterprise_alert_route_revisions") {
+    val resourceId = uuid("resource_id").clientDefault { Uuid.random() }
+    val organizationId = integer("organization_id").references(Organizations.id, onDelete = ReferenceOption.CASCADE)
+    val routeId =
+        integer("route_id").references(EnterpriseAlertRoutes.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val routeResourceId = uuid("route_resource_id")
+    val revision = integer("revision")
+    val changeType = varchar("change_type", 24)
+    val actorUserId = integer("actor_user_id").references(Users.id, onDelete = ReferenceOption.SET_NULL).nullable()
+    val commandKey = varchar("command_key", 160)
+    val requestFingerprint = varchar("request_fingerprint", 64)
+    val snapshot = requiredJsonb("snapshot")
+    val createdAt = timestamp("created_at")
+
+    init {
+        uniqueIndex(organizationId, resourceId)
+        uniqueIndex(organizationId, routeResourceId, revision)
+        index(false, organizationId, commandKey)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteDtos.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteDtos.kt
@@ -1,0 +1,215 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.routes
+
+import com.moneat.enterprise.alertroutes.commands.DEFAULT_GROUPING_WINDOW_SECONDS
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AlertRouteConditionPayload(
+    val field: String,
+    val operator: String,
+    val values: List<String> = emptyList(),
+    val metadataKey: String? = null,
+)
+
+@Serializable
+data class AlertRouteConditionGroupPayload(
+    val conditions: List<AlertRouteConditionPayload> = emptyList(),
+)
+
+@Serializable
+data class AlertRouteTargetPayload(
+    val kind: String,
+    val escalationPolicyId: String? = null,
+    val teamId: String? = null,
+    val ownershipSource: String? = null,
+)
+
+@Serializable
+data class AlertRoutePagingPayload(
+    val mode: String = "NONE",
+    val targets: List<AlertRouteTargetPayload> = emptyList(),
+)
+
+@Serializable
+data class AlertRouteGroupingPayload(
+    val behavior: String = "SUGGESTED",
+    val keys: List<String> = emptyList(),
+    val windowKind: String = "ROLLING",
+    val windowSeconds: Int = DEFAULT_GROUPING_WINDOW_SECONDS,
+)
+
+@Serializable
+data class AlertRouteIncidentPayload(
+    val create: Boolean = false,
+    val mode: String = "TRIAGE",
+    val titleTemplate: String? = null,
+    val summaryTemplate: String? = null,
+    val severity: String? = null,
+    val incidentType: String? = null,
+)
+
+@Serializable
+data class AlertRouteRecoveryPayload(
+    val cancelEscalations: Boolean = false,
+    val declineUnacceptedTriage: Boolean = false,
+    val graceSeconds: Int = 0,
+)
+
+@Serializable
+data class AlertRouteRequest(
+    val key: String,
+    val name: String,
+    val description: String? = null,
+    val enabled: Boolean = true,
+    val expectedRevision: Int? = null,
+    val conditionGroups: List<AlertRouteConditionGroupPayload> = emptyList(),
+    val paging: AlertRoutePagingPayload = AlertRoutePagingPayload(),
+    val grouping: AlertRouteGroupingPayload = AlertRouteGroupingPayload(),
+    val incident: AlertRouteIncidentPayload = AlertRouteIncidentPayload(),
+    val recovery: AlertRouteRecoveryPayload = AlertRouteRecoveryPayload(),
+)
+
+@Serializable
+data class AlertRouteResponse(
+    val id: String,
+    val key: String,
+    val name: String,
+    val description: String? = null,
+    val enabled: Boolean,
+    val position: Int,
+    val revision: Int,
+    val conditionGroups: List<AlertRouteConditionGroupPayload>,
+    val paging: AlertRoutePagingPayload,
+    val grouping: AlertRouteGroupingPayload,
+    val incident: AlertRouteIncidentPayload,
+    val recovery: AlertRouteRecoveryPayload,
+    val createdAt: String,
+    val updatedAt: String,
+)
+
+@Serializable
+data class ReorderAlertRoutesRequest(
+    val routes: List<AlertRouteOrderPayload>,
+)
+
+@Serializable
+data class AlertRouteOrderPayload(
+    val id: String,
+    val expectedRevision: Int,
+)
+
+@Serializable
+data class AlertRouteSamplePayload(
+    val source: String,
+    val status: String = "FIRING",
+    val priority: String = "P3",
+    val title: String = "",
+    val description: String = "",
+    val deduplicationKey: String = "",
+    val url: String = "",
+    val metadata: Map<String, String> = emptyMap(),
+)
+
+@Serializable
+data class AlertRoutePreviewRequest(
+    val episodeId: String? = null,
+    val sample: AlertRouteSamplePayload? = null,
+    val metadata: Map<String, String> = emptyMap(),
+)
+
+@Serializable
+data class AlertRouteConditionExplanationPayload(
+    val field: String,
+    val operator: String,
+    val values: List<String>,
+    val metadataKey: String? = null,
+    val actualValue: String? = null,
+    val matched: Boolean,
+)
+
+@Serializable
+data class AlertRouteGroupExplanationPayload(
+    val position: Int,
+    val matched: Boolean,
+    val conditions: List<AlertRouteConditionExplanationPayload>,
+)
+
+@Serializable
+data class AlertRouteEvaluationPayload(
+    val routeId: String,
+    val key: String,
+    val name: String,
+    val position: Int,
+    val enabled: Boolean,
+    val matched: Boolean,
+    val selected: Boolean,
+    val reason: String,
+    val groups: List<AlertRouteGroupExplanationPayload>,
+)
+
+@Serializable
+data class AlertRoutePagingResolutionPayload(
+    val mode: String,
+    val escalationPolicyIds: List<String>,
+    val teamIds: List<String>,
+    val unresolvedTargets: List<String>,
+)
+
+@Serializable
+data class AlertRouteGroupingResolutionPayload(
+    val behavior: String,
+    val automatic: Boolean,
+    val groupKey: String,
+    val keys: List<String>,
+    val unresolvedKeys: List<String>,
+    val windowKind: String,
+    val windowSeconds: Int,
+)
+
+@Serializable
+data class AlertRouteIncidentResolutionPayload(
+    val create: Boolean,
+    val mode: String,
+    val title: String? = null,
+    val summary: String? = null,
+    val severity: String? = null,
+    val incidentType: String? = null,
+    val unresolvedReferences: List<String>,
+)
+
+@Serializable
+data class AlertRouteDecisionPayload(
+    val routeId: String,
+    val key: String,
+    val name: String,
+    val position: Int,
+    val revision: Int,
+    val paging: AlertRoutePagingResolutionPayload,
+    val grouping: AlertRouteGroupingResolutionPayload,
+    val incident: AlertRouteIncidentResolutionPayload,
+    val recovery: AlertRouteRecoveryPayload,
+)
+
+@Serializable
+data class AlertRoutePreviewResponse(
+    val matchedRouteId: String? = null,
+    val decision: AlertRouteDecisionPayload? = null,
+    val evaluations: List<AlertRouteEvaluationPayload>,
+    val droppedMetadataKeys: List<String>,
+)
+
+@Serializable
+data class AlertRouteRevisionPayload(
+    val id: String,
+    val routeId: String,
+    val revision: Int,
+    val changeType: String,
+    val actorId: String? = null,
+    val commandKey: String,
+    val snapshot: Map<String, kotlinx.serialization.json.JsonElement>,
+    val createdAt: String,
+)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteMappers.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteMappers.kt
@@ -1,0 +1,272 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.routes
+
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionGroupInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteGroupingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteIncidentInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePagingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteRecoveryInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteOrderEntry
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.AlertRouteTargetInput
+import com.moneat.enterprise.alertroutes.context.AlertRouteSampleInput
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteDecision
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteEvaluationResult
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingWindowKind
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteOwnershipSource
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteRevisionRecord
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import com.moneat.shared.services.toUuidOrNull
+import kotlin.uuid.Uuid
+
+internal fun AlertRouteRequest.toSpecification(): AlertRouteSpecification =
+    AlertRouteSpecification(
+        key = key,
+        name = name,
+        description = description,
+        enabled = enabled,
+        conditionGroups =
+            conditionGroups.map { group ->
+                AlertRouteConditionGroupInput(group.conditions.map { it.toInput() })
+            },
+        paging = paging.toInput(),
+        grouping = grouping.toInput(),
+        incident = incident.toInput(),
+        recovery = recovery.toInput(),
+    )
+
+private fun AlertRouteConditionPayload.toInput(): AlertRouteConditionInput =
+    AlertRouteConditionInput(
+        field = AlertRouteContextField.fromWire(field) ?: invalid("alert route field", field),
+        operator = AlertRouteConditionOperator.fromWire(operator) ?: invalid("alert route operator", operator),
+        values = values,
+        metadataKey = metadataKey?.trim()?.takeIf { it.isNotEmpty() },
+    )
+
+private fun AlertRoutePagingPayload.toInput(): AlertRoutePagingInput =
+    AlertRoutePagingInput(
+        mode = AlertRoutePagingMode.fromWire(mode) ?: invalid("paging mode", mode),
+        targets = targets.map { it.toInput() },
+    )
+
+private fun AlertRouteTargetPayload.toInput(): AlertRouteTargetInput =
+    AlertRouteTargetInput(
+        kind = AlertRouteTargetKind.fromWire(kind) ?: invalid("paging target kind", kind),
+        escalationPolicyId = escalationPolicyId?.let { it.toUuidOrNull() ?: invalid("escalation policy id", it) },
+        teamId = teamId?.let { it.toUuidOrNull() ?: invalid("team id", it) },
+        ownershipSource =
+            ownershipSource?.let { AlertRouteOwnershipSource.fromWire(it) ?: invalid("ownership source", it) },
+    )
+
+private fun AlertRouteGroupingPayload.toInput(): AlertRouteGroupingInput =
+    AlertRouteGroupingInput(
+        behavior = AlertRouteGroupingBehavior.fromWire(behavior) ?: invalid("grouping behavior", behavior),
+        keys = keys,
+        windowKind = AlertRouteGroupingWindowKind.fromWire(windowKind) ?: invalid("grouping window", windowKind),
+        windowSeconds = windowSeconds,
+    )
+
+private fun AlertRouteIncidentPayload.toInput(): AlertRouteIncidentInput =
+    AlertRouteIncidentInput(
+        create = create,
+        mode = AlertRouteIncidentMode.fromWire(mode) ?: invalid("incident mode", mode),
+        titleTemplate = titleTemplate,
+        summaryTemplate = summaryTemplate,
+        severity = severity,
+        incidentType = incidentType,
+    )
+
+private fun AlertRouteRecoveryPayload.toInput(): AlertRouteRecoveryInput =
+    AlertRouteRecoveryInput(
+        cancelEscalations = cancelEscalations,
+        declineUnacceptedTriage = declineUnacceptedTriage,
+        graceSeconds = graceSeconds,
+    )
+
+internal fun AlertRouteSamplePayload.toInput(): AlertRouteSampleInput =
+    AlertRouteSampleInput(
+        source = source,
+        status = status,
+        priority = priority,
+        title = title,
+        description = description,
+        deduplicationKey = deduplicationKey,
+        url = url,
+        metadata = metadata,
+    )
+
+internal fun AlertRouteDefinition.toResponse(): AlertRouteResponse =
+    AlertRouteResponse(
+        id = resourceId.toString(),
+        key = key,
+        name = name,
+        description = description,
+        enabled = enabled,
+        position = position,
+        revision = revision,
+        conditionGroups =
+            conditionGroups.map { group ->
+                AlertRouteConditionGroupPayload(
+                    conditions =
+                        group.conditions.map { condition ->
+                            AlertRouteConditionPayload(
+                                field = condition.field.wire,
+                                operator = condition.operator.wire,
+                                values = condition.values,
+                                metadataKey = condition.metadataKey,
+                            )
+                        },
+                )
+            },
+        paging =
+            AlertRoutePagingPayload(
+                mode = paging.mode.wire,
+                targets =
+                    paging.targets.map { target ->
+                        AlertRouteTargetPayload(
+                            kind = target.kind.wire,
+                            escalationPolicyId = target.escalationPolicyResourceId?.toString(),
+                            teamId = target.teamResourceId?.toString(),
+                            ownershipSource = target.ownershipSource?.wire,
+                        )
+                    },
+            ),
+        grouping =
+            AlertRouteGroupingPayload(
+                behavior = grouping.behavior.wire,
+                keys = grouping.keys,
+                windowKind = grouping.windowKind.wire,
+                windowSeconds = grouping.windowSeconds,
+            ),
+        incident =
+            AlertRouteIncidentPayload(
+                create = incident.create,
+                mode = incident.mode.wire,
+                titleTemplate = incident.titleTemplate,
+                summaryTemplate = incident.summaryTemplate,
+                severity = incident.severity,
+                incidentType = incident.incidentType,
+            ),
+        recovery =
+            AlertRouteRecoveryPayload(
+                cancelEscalations = recovery.cancelEscalations,
+                declineUnacceptedTriage = recovery.declineUnacceptedTriage,
+                graceSeconds = recovery.graceSeconds,
+            ),
+        createdAt = createdAt.toString(),
+        updatedAt = updatedAt.toString(),
+    )
+
+internal fun AlertRouteRevisionRecord.toPayload(): AlertRouteRevisionPayload =
+    AlertRouteRevisionPayload(
+        id = id.toString(),
+        routeId = routeId.toString(),
+        revision = revision,
+        changeType = changeType.wire,
+        actorId = actorId?.toString(),
+        commandKey = commandKey,
+        snapshot = snapshot,
+        createdAt = createdAt.toString(),
+    )
+
+internal fun AlertRouteEvaluationResult.toPreviewResponse(): AlertRoutePreviewResponse =
+    AlertRoutePreviewResponse(
+        matchedRouteId = decision?.routeId?.toString(),
+        decision = decision?.toPayload(),
+        evaluations =
+            evaluations.map { evaluation ->
+                AlertRouteEvaluationPayload(
+                    routeId = evaluation.routeId.toString(),
+                    key = evaluation.routeKey,
+                    name = evaluation.routeName,
+                    position = evaluation.position,
+                    enabled = evaluation.enabled,
+                    matched = evaluation.matched,
+                    selected = evaluation.selected,
+                    reason = evaluation.reason.wire,
+                    groups =
+                        evaluation.groups.map { group ->
+                            AlertRouteGroupExplanationPayload(
+                                position = group.position,
+                                matched = group.matched,
+                                conditions =
+                                    group.conditions.map { condition ->
+                                        AlertRouteConditionExplanationPayload(
+                                            field = condition.field.wire,
+                                            operator = condition.operator.wire,
+                                            values = condition.values,
+                                            metadataKey = condition.metadataKey,
+                                            actualValue = condition.actualValue,
+                                            matched = condition.matched,
+                                        )
+                                    },
+                            )
+                        },
+                )
+            },
+        droppedMetadataKeys = droppedMetadataKeys,
+    )
+
+private fun AlertRouteDecision.toPayload(): AlertRouteDecisionPayload =
+    AlertRouteDecisionPayload(
+        routeId = routeId.toString(),
+        key = routeKey,
+        name = routeName,
+        position = position,
+        revision = revision,
+        paging =
+            AlertRoutePagingResolutionPayload(
+                mode = paging.mode.wire,
+                escalationPolicyIds = paging.escalationPolicies.mapNotNull { it.resourceId?.toString() },
+                teamIds = paging.teams.mapNotNull { it.resourceId?.toString() },
+                unresolvedTargets = paging.unresolvedTargets,
+            ),
+        grouping =
+            AlertRouteGroupingResolutionPayload(
+                behavior = grouping.behavior.wire,
+                automatic = grouping.automatic,
+                groupKey = grouping.groupKey,
+                keys = grouping.keys,
+                unresolvedKeys = grouping.unresolvedKeys,
+                windowKind = grouping.windowKind.wire,
+                windowSeconds = grouping.windowSeconds,
+            ),
+        incident =
+            AlertRouteIncidentResolutionPayload(
+                create = incident.create,
+                mode = incident.mode.wire,
+                title = incident.title,
+                summary = incident.summary,
+                severity = incident.severity,
+                incidentType = incident.incidentType,
+                unresolvedReferences = incident.unresolvedReferences,
+            ),
+        recovery =
+            AlertRouteRecoveryPayload(
+                cancelEscalations = recovery.cancelEscalations,
+                declineUnacceptedTriage = recovery.declineUnacceptedTriage,
+                graceSeconds = recovery.graceSeconds,
+            ),
+    )
+
+internal fun AlertRouteOrderPayload.toInput(): AlertRouteOrderEntry =
+    AlertRouteOrderEntry(
+        routeId = parseRouteId(id),
+        expectedRevision = expectedRevision,
+    )
+
+internal fun parseRouteId(raw: String?): Uuid =
+    raw?.toUuidOrNull() ?: invalid("alert route id", raw.orEmpty())
+
+private fun invalid(label: String, value: String): Nothing =
+    throw IllegalArgumentException("Invalid $label: $value")

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteRoutes.kt
@@ -1,0 +1,192 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.routes
+
+import com.moneat.enterprise.alertroutes.commands.AlertRouteActor
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.DeleteAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.ReorderAlertRoutesCommand
+import com.moneat.enterprise.alertroutes.commands.UpdateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.services.AlertRouteCommandService
+import com.moneat.enterprise.alertroutes.services.AlertRouteEvaluationService
+import com.moneat.enterprise.incidents.commands.IncidentCommandException
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
+import com.moneat.enterprise.oncall.routes.OnCallUserContext
+import com.moneat.enterprise.oncall.routes.incidentCommandKey
+import com.moneat.enterprise.oncall.routes.requireIncidentAdminContext
+import com.moneat.enterprise.oncall.routes.requireUserContext
+import com.moneat.enterprise.oncall.routes.respondIncidentCommandFailure
+import com.moneat.shared.services.toUuidOrNull
+import com.moneat.utils.ErrorResponse
+import com.moneat.utils.MessageResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.auth.authenticate
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+
+private const val ALERT_ROUTE_BASE_PATH = "/v1/on-call/alert-routes"
+
+/**
+ * Administrator APIs for enterprise Alert Routes.
+ *
+ * These routes are distinct from the open-source incident-provider routing rules: they configure
+ * native paging, grouping, incident creation, and recovery, and never change provider forwarding.
+ */
+fun Route.alertRouteRoutes(
+    commandService: AlertRouteCommandService = AlertRouteCommandService(),
+    evaluationService: AlertRouteEvaluationService = AlertRouteEvaluationService(),
+) {
+    route(ALERT_ROUTE_BASE_PATH) {
+        authenticate("auth-jwt") {
+            registerCollectionRoutes(commandService)
+            registerPreviewRoute(evaluationService)
+            registerReorderRoute(commandService)
+            registerItemRoutes(commandService)
+        }
+    }
+}
+
+private fun Route.registerCollectionRoutes(commandService: AlertRouteCommandService) {
+    get {
+        val context = call.requireUserContext() ?: return@get
+        call.respondAlertRouteFailure {
+            call.respond(commandService.list(context.organizationId).map { it.toResponse() })
+        }
+    }
+    post {
+        val context = call.requireIncidentAdminContext() ?: return@post
+        val request = call.receive<AlertRouteRequest>()
+        call.respondAlertRouteFailure {
+            val result =
+                commandService.execute(
+                    CreateAlertRouteCommand(
+                        commandKey = call.incidentCommandKey("alert-route-create"),
+                        actor = context.toActor(),
+                        specification = request.toSpecification(),
+                    ),
+                )
+            val route = result.route ?: throw IncidentCommandNotFoundException("Alert route not found")
+            call.respond(if (result.replayed) HttpStatusCode.OK else HttpStatusCode.Created, route.toResponse())
+        }
+    }
+}
+
+private fun Route.registerPreviewRoute(evaluationService: AlertRouteEvaluationService) {
+    post("/preview") {
+        val context = call.requireUserContext() ?: return@post
+        val request = call.receive<AlertRoutePreviewRequest>()
+        call.respondAlertRouteFailure {
+            val result =
+                when {
+                    request.episodeId != null ->
+                        evaluationService.previewSavedEpisode(
+                            organizationId = context.organizationId,
+                            episodeId =
+                                request.episodeId.toUuidOrNull()
+                                    ?: throw IllegalArgumentException("Invalid alert episode id"),
+                            metadata = request.metadata,
+                        )
+                    request.sample != null ->
+                        evaluationService.preview(context.organizationId, request.sample.toInput())
+                    else -> throw IllegalArgumentException("Preview requires an episode id or a sample alert")
+                }
+            call.respond(result.toPreviewResponse())
+        }
+    }
+}
+
+private fun Route.registerReorderRoute(commandService: AlertRouteCommandService) {
+    post("/reorder") {
+        val context = call.requireIncidentAdminContext() ?: return@post
+        val request = call.receive<ReorderAlertRoutesRequest>()
+        call.respondAlertRouteFailure {
+            val result =
+                commandService.execute(
+                    ReorderAlertRoutesCommand(
+                        commandKey = call.incidentCommandKey("alert-route-reorder"),
+                        actor = context.toActor(),
+                        orderedRoutes = request.routes.map { it.toInput() },
+                    ),
+                )
+            call.respond(result.routes.map { it.toResponse() })
+        }
+    }
+}
+
+private fun Route.registerItemRoutes(commandService: AlertRouteCommandService) {
+    get("/{routeId}") {
+        val context = call.requireUserContext() ?: return@get
+        call.respondAlertRouteFailure {
+            val routeId = parseRouteId(call.parameters["routeId"])
+            call.respond(commandService.get(context.organizationId, routeId).toResponse())
+        }
+    }
+    get("/{routeId}/revisions") {
+        val context = call.requireUserContext() ?: return@get
+        call.respondAlertRouteFailure {
+            val routeId = parseRouteId(call.parameters["routeId"])
+            call.respond(commandService.revisions(context.organizationId, routeId).map { it.toPayload() })
+        }
+    }
+    put("/{routeId}") {
+        val context = call.requireIncidentAdminContext() ?: return@put
+        val request = call.receive<AlertRouteRequest>()
+        call.respondAlertRouteFailure {
+            val result =
+                commandService.execute(
+                    UpdateAlertRouteCommand(
+                        commandKey = call.incidentCommandKey("alert-route-update"),
+                        actor = context.toActor(),
+                        routeId = parseRouteId(call.parameters["routeId"]),
+                        expectedRevision =
+                            requireNotNull(request.expectedRevision) { "Expected revision is required" },
+                        specification = request.toSpecification(),
+                    ),
+                )
+            val route = result.route ?: throw IncidentCommandNotFoundException("Alert route not found")
+            call.respond(route.toResponse())
+        }
+    }
+    delete("/{routeId}") {
+        val context = call.requireIncidentAdminContext() ?: return@delete
+        call.respondAlertRouteFailure {
+            commandService.execute(
+                DeleteAlertRouteCommand(
+                    commandKey = call.incidentCommandKey("alert-route-delete"),
+                    actor = context.toActor(),
+                    routeId = parseRouteId(call.parameters["routeId"]),
+                    expectedRevision = call.expectedRevision(),
+                ),
+            )
+            call.respond(HttpStatusCode.OK, MessageResponse("Alert route deleted"))
+        }
+    }
+}
+
+private fun ApplicationCall.expectedRevision(): Int {
+    val raw = requireNotNull(request.queryParameters["expectedRevision"]) { "Expected revision is required" }
+    return raw.trim().takeIf(String::isNotEmpty)?.toIntOrNull()
+        ?: throw IllegalArgumentException("Invalid expected revision: $raw")
+}
+
+private fun OnCallUserContext.toActor(): AlertRouteActor =
+    AlertRouteActor(organizationId = organizationId, userId = userId, origin = "REST")
+
+private suspend fun ApplicationCall.respondAlertRouteFailure(action: suspend () -> Unit) {
+    try {
+        action()
+    } catch (error: IncidentCommandException) {
+        respondIncidentCommandFailure(error)
+    } catch (error: IllegalArgumentException) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse(error.message))
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteRoutes.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteRoutes.kt
@@ -34,6 +34,7 @@ import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 
 private const val ALERT_ROUTE_BASE_PATH = "/v1/on-call/alert-routes"
+private const val ALERT_ROUTE_ITEM_PATH = "/{routeId}"
 
 /**
  * Administrator APIs for enterprise Alert Routes.
@@ -123,21 +124,21 @@ private fun Route.registerReorderRoute(commandService: AlertRouteCommandService)
 }
 
 private fun Route.registerItemRoutes(commandService: AlertRouteCommandService) {
-    get("/{routeId}") {
+    get(ALERT_ROUTE_ITEM_PATH) {
         val context = call.requireUserContext() ?: return@get
         call.respondAlertRouteFailure {
             val routeId = parseRouteId(call.parameters["routeId"])
             call.respond(commandService.get(context.organizationId, routeId).toResponse())
         }
     }
-    get("/{routeId}/revisions") {
+    get("$ALERT_ROUTE_ITEM_PATH/revisions") {
         val context = call.requireUserContext() ?: return@get
         call.respondAlertRouteFailure {
             val routeId = parseRouteId(call.parameters["routeId"])
             call.respond(commandService.revisions(context.organizationId, routeId).map { it.toPayload() })
         }
     }
-    put("/{routeId}") {
+    put(ALERT_ROUTE_ITEM_PATH) {
         val context = call.requireIncidentAdminContext() ?: return@put
         val request = call.receive<AlertRouteRequest>()
         call.respondAlertRouteFailure {
@@ -156,7 +157,7 @@ private fun Route.registerItemRoutes(commandService: AlertRouteCommandService) {
             call.respond(route.toResponse())
         }
     }
-    delete("/{routeId}") {
+    delete(ALERT_ROUTE_ITEM_PATH) {
         val context = call.requireIncidentAdminContext() ?: return@delete
         call.respondAlertRouteFailure {
             commandService.execute(

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandService.kt
@@ -1,0 +1,528 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.alertroutes.commands.AlertRouteActor
+import com.moneat.enterprise.alertroutes.commands.AlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.AlertRouteCommandResult
+import com.moneat.enterprise.alertroutes.commands.AlertRouteFingerprint
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.AlertRouteTargetInput
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.DeleteAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.ReorderAlertRoutesCommand
+import com.moneat.enterprise.alertroutes.commands.UpdateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.models.AlertRouteChangeType
+import com.moneat.enterprise.alertroutes.models.AlertRouteDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteRevisionRecord
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteActions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteCommands
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditionGroups
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteRevisions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteTargets
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
+import com.moneat.enterprise.incidents.commands.IncidentCommandConflictException
+import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
+import com.moneat.org.services.OrgRole
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.OrganizationTeams
+import com.moneat.shared.models.Organizations
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Organization-scoped CRUD, reorder, and revision history for enterprise Alert Routes.
+ *
+ * Mutations are rollout-gated, idempotent by command key, versioned by route revision, and audited
+ * in `enterprise_alert_route_revisions`. Stale expected revisions are rejected as conflicts.
+ */
+class AlertRouteCommandService(
+    private val policy: AlertRoutePolicy = AlertRoutePolicy(),
+) {
+    fun list(organizationId: Int): List<AlertRouteDefinition> {
+        policy.requireReadAllowed(organizationId)
+        return transaction { AlertRouteReader.load(organizationId) }
+    }
+
+    fun get(organizationId: Int, routeId: Uuid): AlertRouteDefinition {
+        policy.requireReadAllowed(organizationId)
+        return transaction { AlertRouteReader.loadOne(organizationId, routeId) }
+            ?: throw IncidentCommandNotFoundException(ROUTE_NOT_FOUND)
+    }
+
+    fun revisions(organizationId: Int, routeId: Uuid): List<AlertRouteRevisionRecord> {
+        policy.requireReadAllowed(organizationId)
+        return transaction {
+            AlertRouteReader
+                .revisions(organizationId, routeId)
+                .ifEmpty { throw IncidentCommandNotFoundException(ROUTE_NOT_FOUND) }
+        }
+    }
+
+    fun execute(command: AlertRouteCommand): AlertRouteCommandResult {
+        policy.requireAllowed(command)
+        AlertRouteValidator.validate(command)
+        return try {
+            executeTransaction(command)
+        } catch (error: ExposedSQLException) {
+            if (error.sqlState != UNIQUE_VIOLATION_SQL_STATE) throw error
+            transaction { replayResult(command) }
+                ?: throw IncidentCommandConflictException("Alert route mutation conflicts with existing state")
+        }
+    }
+
+    private fun executeTransaction(command: AlertRouteCommand): AlertRouteCommandResult =
+        transaction {
+            requireAdministrator(command.actor)
+            lockOrganization(command.actor.organizationId)
+            replayResult(command)?.let { return@transaction it }
+            val result = when (command) {
+                is CreateAlertRouteCommand -> create(command)
+                is UpdateAlertRouteCommand -> update(command)
+                is DeleteAlertRouteCommand -> delete(command)
+                is ReorderAlertRoutesCommand -> reorder(command)
+            }
+            recordCommand(command, result.routes.map { it.resourceId })
+            result
+        }
+
+    private fun create(command: CreateAlertRouteCommand): AlertRouteCommandResult {
+        val organizationId = command.actor.organizationId
+        val specification = command.specification
+        policy.requireQuota(command, enabledRouteCount(organizationId) + if (specification.enabled) 1 else 0)
+        requireAvailableKey(organizationId, specification.key.trim(), currentRouteId = null)
+        val now = Clock.System.now()
+        val routeResourceId = Uuid.random()
+        val routeId =
+            EnterpriseAlertRoutes.insertAndGetId {
+                it[resourceId] = routeResourceId
+                it[EnterpriseAlertRoutes.organizationId] = organizationId
+                it[routeKey] = specification.key.trim()
+                it[name] = specification.name.trim()
+                it[description] = specification.description?.trim()?.takeIf(String::isNotEmpty)
+                it[enabled] = specification.enabled
+                it[position] = nextPosition(organizationId)
+                it[revision] = INITIAL_REVISION
+                it[createdBy] = command.actor.userId
+                it[updatedBy] = command.actor.userId
+                it[createdAt] = now
+                it[updatedAt] = now
+            }.value
+        writeSpecification(organizationId, routeId, specification, now)
+        val created = requireLoaded(organizationId, routeResourceId)
+        recordRevision(
+            command,
+            AlertRouteRevisionEntry(routeId, routeResourceId, INITIAL_REVISION, AlertRouteChangeType.CREATED, now),
+            created,
+        )
+        return AlertRouteCommandResult(listOf(created), replayed = false)
+    }
+
+    private fun update(command: UpdateAlertRouteCommand): AlertRouteCommandResult {
+        val organizationId = command.actor.organizationId
+        val existing =
+            AlertRouteReader.loadOne(organizationId, command.routeId)
+                ?: throw IncidentCommandNotFoundException(ROUTE_NOT_FOUND)
+        requireCurrentRevision(command.expectedRevision, existing.revision)
+        val desiredEnabledCount =
+            enabledRouteCount(organizationId) +
+                when {
+                    existing.enabled == command.specification.enabled -> 0
+                    command.specification.enabled -> 1
+                    else -> -1
+                }
+        policy.requireQuota(command, desiredEnabledCount)
+        requireAvailableKey(organizationId, command.specification.key.trim(), currentRouteId = existing.id)
+        val now = Clock.System.now()
+        val nextRevision = existing.revision + 1
+        val changed =
+            EnterpriseAlertRoutes.update({
+                (EnterpriseAlertRoutes.id eq existing.id) and (EnterpriseAlertRoutes.revision eq existing.revision)
+            }) {
+                it[routeKey] = command.specification.key.trim()
+                it[name] = command.specification.name.trim()
+                it[description] = command.specification.description?.trim()?.takeIf(String::isNotEmpty)
+                it[enabled] = command.specification.enabled
+                it[revision] = nextRevision
+                it[updatedBy] = command.actor.userId
+                it[updatedAt] = now
+            }
+        if (changed == 0) throw IncidentCommandConflictException(STALE_REVISION)
+        clearSpecification(existing.id)
+        writeSpecification(organizationId, existing.id, command.specification, now)
+        val updated = requireLoaded(organizationId, existing.resourceId)
+        recordRevision(
+            command,
+            AlertRouteRevisionEntry(
+                existing.id,
+                existing.resourceId,
+                nextRevision,
+                AlertRouteChangeType.UPDATED,
+                now,
+            ),
+            updated,
+        )
+        return AlertRouteCommandResult(listOf(updated), replayed = false)
+    }
+
+    private fun delete(command: DeleteAlertRouteCommand): AlertRouteCommandResult {
+        val organizationId = command.actor.organizationId
+        val existing =
+            AlertRouteReader.loadOne(organizationId, command.routeId)
+                ?: throw IncidentCommandNotFoundException(ROUTE_NOT_FOUND)
+        requireCurrentRevision(command.expectedRevision, existing.revision)
+        policy.requireQuota(command, enabledRouteCount(organizationId) - if (existing.enabled) 1 else 0)
+        val now = Clock.System.now()
+        recordRevision(
+            command,
+            AlertRouteRevisionEntry(
+                existing.id,
+                existing.resourceId,
+                existing.revision + 1,
+                AlertRouteChangeType.DELETED,
+                now,
+            ),
+            existing.copy(revision = existing.revision + 1),
+        )
+        val deleted = EnterpriseAlertRoutes.deleteWhere {
+            (EnterpriseAlertRoutes.id eq existing.id) and (EnterpriseAlertRoutes.revision eq existing.revision)
+        }
+        if (deleted == 0) throw IncidentCommandConflictException(STALE_REVISION)
+        return AlertRouteCommandResult(emptyList(), replayed = false)
+    }
+
+    private fun reorder(command: ReorderAlertRoutesCommand): AlertRouteCommandResult {
+        val organizationId = command.actor.organizationId
+        val current = AlertRouteReader.load(organizationId)
+        val orderedRouteIds = command.orderedRoutes.map { it.routeId }
+        require(orderedRouteIds.toSet() == current.map { it.resourceId }.toSet()) {
+            "Reorder must list every alert route in the organization exactly once"
+        }
+        command.orderedRoutes.forEach { entry ->
+            val route = current.first { it.resourceId == entry.routeId }
+            requireCurrentRevision(entry.expectedRevision, route.revision)
+        }
+        policy.requireQuota(command, enabledRouteCount(organizationId))
+        if (current.map { it.resourceId } == orderedRouteIds) {
+            return AlertRouteCommandResult(current, replayed = false)
+        }
+        val now = Clock.System.now()
+        val temporaryStart = (current.maxOfOrNull { it.position } ?: -1) + 1
+        orderedRouteIds.forEachIndexed { index, resourceId ->
+            val route = current.first { it.resourceId == resourceId }
+            val changed =
+                EnterpriseAlertRoutes.update({
+                    (EnterpriseAlertRoutes.id eq route.id) and (EnterpriseAlertRoutes.revision eq route.revision)
+                }) {
+                    it[position] = temporaryStart + index
+                }
+            if (changed == 0) throw IncidentCommandConflictException(STALE_REVISION)
+        }
+        orderedRouteIds.forEachIndexed { index, resourceId ->
+            val route = current.first { it.resourceId == resourceId }
+            val nextRevision = route.revision + 1
+            val changed =
+                EnterpriseAlertRoutes.update({
+                    (EnterpriseAlertRoutes.id eq route.id) and (EnterpriseAlertRoutes.revision eq route.revision)
+                }) {
+                    it[position] = index
+                    it[revision] = nextRevision
+                    it[updatedBy] = command.actor.userId
+                    it[updatedAt] = now
+                }
+            if (changed == 0) throw IncidentCommandConflictException(STALE_REVISION)
+            val reordered = requireLoaded(organizationId, resourceId)
+            recordRevision(
+                command,
+                AlertRouteRevisionEntry(route.id, resourceId, nextRevision, AlertRouteChangeType.REORDERED, now),
+                reordered,
+            )
+        }
+        return AlertRouteCommandResult(AlertRouteReader.load(organizationId), replayed = false)
+    }
+
+    private fun replayResult(command: AlertRouteCommand): AlertRouteCommandResult? {
+        val organizationId = command.actor.organizationId
+        val row =
+            EnterpriseAlertRouteCommands
+                .selectAll()
+                .where {
+                    (EnterpriseAlertRouteCommands.organizationId eq organizationId) and
+                        (EnterpriseAlertRouteCommands.commandKey eq command.commandKey)
+                }.limit(1)
+                .firstOrNull()
+                ?: return null
+        val fingerprint = AlertRouteFingerprint.of(command)
+        if (row[EnterpriseAlertRouteCommands.requestFingerprint] != fingerprint) {
+            throw IncidentCommandConflictException("Alert route command key was already used for another request")
+        }
+        val routes =
+            row[EnterpriseAlertRouteCommands.resultRouteIds]
+                .map(Uuid::parse)
+                .mapNotNull { AlertRouteReader.loadOne(organizationId, it) }
+        return AlertRouteCommandResult(routes, replayed = true)
+    }
+
+    private fun recordCommand(command: AlertRouteCommand, resultRouteIds: List<Uuid>) {
+        EnterpriseAlertRouteCommands.insert {
+            it[EnterpriseAlertRouteCommands.organizationId] = command.actor.organizationId
+            it[EnterpriseAlertRouteCommands.commandKey] = command.commandKey
+            it[EnterpriseAlertRouteCommands.commandType] = command.type.wire
+            it[EnterpriseAlertRouteCommands.requestFingerprint] = AlertRouteFingerprint.of(command)
+            it[EnterpriseAlertRouteCommands.resultRouteIds] = resultRouteIds.map(Uuid::toString)
+            it[EnterpriseAlertRouteCommands.createdAt] = Clock.System.now()
+        }
+    }
+
+    private fun lockOrganization(organizationId: Int) {
+        Organizations
+            .selectAll()
+            .where { Organizations.id eq organizationId }
+            .forUpdate()
+            .single()
+    }
+
+    private fun requireAdministrator(actor: AlertRouteActor) {
+        val role =
+            Memberships
+                .selectAll()
+                .where {
+                    (Memberships.organization_id eq actor.organizationId) and
+                        (Memberships.user_id eq actor.userId)
+                }.limit(1)
+                .firstOrNull()
+                ?.get(Memberships.role)
+                ?: throw IncidentCommandDeniedException("Actor is not a member of the alert route organization")
+        if (OrgRole.fromString(role).level < OrgRole.ADMIN.level) {
+            throw IncidentCommandDeniedException("Alert routes can only be managed by organization administrators")
+        }
+    }
+
+    private fun requireCurrentRevision(expectedRevision: Int, currentRevision: Int) {
+        if (expectedRevision != currentRevision) {
+            throw IncidentCommandConflictException(STALE_REVISION)
+        }
+    }
+
+    private fun requireAvailableKey(organizationId: Int, key: String, currentRouteId: Int?) {
+        val conflict =
+            EnterpriseAlertRoutes
+                .selectAll()
+                .where {
+                    (EnterpriseAlertRoutes.organizationId eq organizationId) and
+                        (EnterpriseAlertRoutes.routeKey eq key)
+                }.limit(1)
+                .firstOrNull()
+                ?.get(EnterpriseAlertRoutes.id)
+                ?.value
+        if (conflict != null && conflict != currentRouteId) {
+            throw IncidentCommandConflictException("Alert route key $key is already in use")
+        }
+    }
+
+    private fun requireLoaded(organizationId: Int, routeResourceId: Uuid): AlertRouteDefinition =
+        AlertRouteReader.loadOne(organizationId, routeResourceId)
+            ?: throw IncidentCommandNotFoundException(ROUTE_NOT_FOUND)
+
+    private fun nextPosition(organizationId: Int): Int =
+        EnterpriseAlertRoutes
+            .selectAll()
+            .where { EnterpriseAlertRoutes.organizationId eq organizationId }
+            .orderBy(EnterpriseAlertRoutes.position to SortOrder.DESC)
+            .limit(1)
+            .firstOrNull()
+            ?.get(EnterpriseAlertRoutes.position)
+            ?.plus(1)
+            ?: 0
+
+    private fun enabledRouteCount(organizationId: Int): Long =
+        EnterpriseAlertRoutes
+            .selectAll()
+            .where {
+                (EnterpriseAlertRoutes.organizationId eq organizationId) and
+                    (EnterpriseAlertRoutes.enabled eq true)
+            }.count()
+
+    private fun clearSpecification(routeId: Int) {
+        val groupIds =
+            EnterpriseAlertRouteConditionGroups
+                .selectAll()
+                .where { EnterpriseAlertRouteConditionGroups.routeId eq routeId }
+                .map { it[EnterpriseAlertRouteConditionGroups.id].value }
+        if (groupIds.isNotEmpty()) {
+            EnterpriseAlertRouteConditions.deleteWhere { groupId inList groupIds }
+            EnterpriseAlertRouteConditionGroups.deleteWhere {
+                EnterpriseAlertRouteConditionGroups.routeId eq routeId
+            }
+        }
+        EnterpriseAlertRouteTargets.deleteWhere { EnterpriseAlertRouteTargets.routeId eq routeId }
+        EnterpriseAlertRouteActions.deleteWhere { EnterpriseAlertRouteActions.routeId eq routeId }
+    }
+
+    private fun writeSpecification(
+        organizationId: Int,
+        routeId: Int,
+        specification: AlertRouteSpecification,
+        now: Instant,
+    ) {
+        EnterpriseAlertRouteActions.insert {
+            it[resourceId] = Uuid.random()
+            it[EnterpriseAlertRouteActions.organizationId] = organizationId
+            it[EnterpriseAlertRouteActions.routeId] = routeId
+            it[pagingMode] = specification.paging.mode.wire
+            it[groupingBehavior] = specification.grouping.behavior.wire
+            it[groupingWindowKind] = specification.grouping.windowKind.wire
+            it[groupingWindowSeconds] = specification.grouping.windowSeconds
+            it[groupingKeys] = specification.grouping.keys
+            it[incidentCreationEnabled] = specification.incident.create
+            it[incidentCreationMode] = specification.incident.mode.wire
+            it[incidentTitleTemplate] = specification.incident.titleTemplate?.trim()?.takeIf(String::isNotEmpty)
+            it[incidentSummaryTemplate] = specification.incident.summaryTemplate?.trim()?.takeIf(String::isNotEmpty)
+            it[incidentSeverity] = specification.incident.severity
+            it[incidentType] = specification.incident.incidentType?.trim()?.takeIf(String::isNotEmpty)
+            it[recoveryCancelEscalations] = specification.recovery.cancelEscalations
+            it[recoveryDeclineUnacceptedTriage] = specification.recovery.declineUnacceptedTriage
+            it[recoveryGraceSeconds] = specification.recovery.graceSeconds
+            it[createdAt] = now
+            it[updatedAt] = now
+        }
+        writeTargets(organizationId, routeId, specification, now)
+        writeConditions(organizationId, routeId, specification, now)
+    }
+
+    private fun writeTargets(
+        organizationId: Int,
+        routeId: Int,
+        specification: AlertRouteSpecification,
+        now: Instant,
+    ) {
+        specification.paging.targets.forEachIndexed { index, target ->
+            EnterpriseAlertRouteTargets.insert {
+                it[resourceId] = Uuid.random()
+                it[EnterpriseAlertRouteTargets.organizationId] = organizationId
+                it[EnterpriseAlertRouteTargets.routeId] = routeId
+                it[position] = index
+                it[targetKind] = target.kind.wire
+                it[escalationPolicyId] = resolveEscalationPolicyId(organizationId, target)
+                it[teamId] = resolveTeamId(organizationId, target)
+                it[ownershipSource] = target.ownershipSource?.wire
+                it[createdAt] = now
+            }
+        }
+    }
+
+    private fun writeConditions(
+        organizationId: Int,
+        routeId: Int,
+        specification: AlertRouteSpecification,
+        now: Instant,
+    ) {
+        specification.conditionGroups.forEachIndexed { groupIndex, group ->
+            val groupId =
+                EnterpriseAlertRouteConditionGroups.insertAndGetId {
+                    it[resourceId] = Uuid.random()
+                    it[EnterpriseAlertRouteConditionGroups.organizationId] = organizationId
+                    it[EnterpriseAlertRouteConditionGroups.routeId] = routeId
+                    it[position] = groupIndex
+                    it[createdAt] = now
+                }.value
+            group.conditions.forEachIndexed { conditionIndex, condition ->
+                EnterpriseAlertRouteConditions.insert {
+                    it[resourceId] = Uuid.random()
+                    it[EnterpriseAlertRouteConditions.organizationId] = organizationId
+                    it[EnterpriseAlertRouteConditions.groupId] = groupId
+                    it[position] = conditionIndex
+                    it[contextField] = condition.field.name
+                    it[metadataKey] = condition.metadataKey?.trim()
+                    it[operator] = condition.operator.wire
+                    it[comparisonValues] = condition.values
+                    it[createdAt] = now
+                }
+            }
+        }
+    }
+
+    private fun resolveEscalationPolicyId(organizationId: Int, target: AlertRouteTargetInput): Int? {
+        if (target.kind != AlertRouteTargetKind.ESCALATION_POLICY) return null
+        val resourceId = requireNotNull(target.escalationPolicyId) { "Escalation policy target is missing an id" }
+        return EscalationPolicies
+            .selectAll()
+            .where {
+                (EscalationPolicies.organizationId eq organizationId) and
+                    (EscalationPolicies.resourceId eq resourceId)
+            }.limit(1)
+            .firstOrNull()
+            ?.get(EscalationPolicies.id)
+            ?.value
+            ?: throw IllegalArgumentException("Unknown escalation policy: $resourceId")
+    }
+
+    private fun resolveTeamId(organizationId: Int, target: AlertRouteTargetInput): Int? {
+        if (target.kind != AlertRouteTargetKind.TEAM) return null
+        val resourceId = requireNotNull(target.teamId) { "Team target is missing an id" }
+        return OrganizationTeams
+            .selectAll()
+            .where {
+                (OrganizationTeams.organizationId eq organizationId) and
+                    (OrganizationTeams.resourceId eq resourceId)
+            }.limit(1)
+            .firstOrNull()
+            ?.get(OrganizationTeams.id)
+            ?.value
+            ?: throw IllegalArgumentException("Unknown team: $resourceId")
+    }
+
+    private fun recordRevision(
+        command: AlertRouteCommand,
+        entry: AlertRouteRevisionEntry,
+        route: AlertRouteDefinition,
+    ) {
+        EnterpriseAlertRouteRevisions.insert {
+            it[resourceId] = Uuid.random()
+            it[EnterpriseAlertRouteRevisions.organizationId] = command.actor.organizationId
+            it[routeId] = entry.routeId
+            it[routeResourceId] = entry.routeResourceId
+            it[revision] = entry.revision
+            it[changeType] = entry.changeType.wire
+            it[actorUserId] = command.actor.userId
+            it[commandKey] = command.commandKey
+            it[requestFingerprint] = AlertRouteFingerprint.of(command)
+            it[snapshot] = AlertRouteSnapshot.of(command, route, entry.changeType)
+            it[createdAt] = entry.at
+        }
+    }
+
+    private data class AlertRouteRevisionEntry(
+        val routeId: Int,
+        val routeResourceId: Uuid,
+        val revision: Int,
+        val changeType: AlertRouteChangeType,
+        val at: Instant,
+    )
+
+    private companion object {
+        const val INITIAL_REVISION = 1
+        const val UNIQUE_VIOLATION_SQL_STATE = "23505"
+        const val ROUTE_NOT_FOUND = "Alert route not found"
+        const val STALE_REVISION = "Alert route revision is stale"
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteEvaluationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteEvaluationService.kt
@@ -1,0 +1,133 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
+import com.moneat.enterprise.alertroutes.context.AlertRouteContext
+import com.moneat.enterprise.alertroutes.context.AlertRouteContextFactory
+import com.moneat.enterprise.alertroutes.context.AlertRouteEpisodeIdentity
+import com.moneat.enterprise.alertroutes.context.AlertRouteMetadataPolicy
+import com.moneat.enterprise.alertroutes.context.AlertRouteOwnershipResolver
+import com.moneat.enterprise.alertroutes.context.AlertRouteSampleInput
+import com.moneat.enterprise.alertroutes.context.DatabaseAlertRouteOwnershipResolver
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteEscalationPolicyRef
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteEvaluationResult
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteEvaluator
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteTeamEscalationResolver
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.OrganizationTeams
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.uuid.Uuid
+
+/** Resolves a team's default escalation policy for TEAM route targets. */
+class DatabaseAlertRouteTeamEscalationResolver : AlertRouteTeamEscalationResolver {
+    override fun escalationPolicy(organizationId: Int, teamId: Int): AlertRouteEscalationPolicyRef? =
+        transaction {
+            val escalationPolicyId =
+                OrganizationTeams
+                    .selectAll()
+                    .where {
+                        (OrganizationTeams.organizationId eq organizationId) and
+                            (OrganizationTeams.id eq teamId)
+                    }.limit(1)
+                    .firstOrNull()
+                    ?.get(OrganizationTeams.escalationPolicyId)
+                    ?: return@transaction null
+            val resourceId =
+                EscalationPolicies
+                    .selectAll()
+                    .where { EscalationPolicies.id eq escalationPolicyId }
+                    .limit(1)
+                    .firstOrNull()
+                    ?.get(EscalationPolicies.resourceId)
+            AlertRouteEscalationPolicyRef(escalationPolicyId, resourceId)
+        }
+}
+
+/**
+ * Evaluates alert routes for real alerts and for preview samples.
+ *
+ * Preview accepts either a saved alert episode or a supplied sample and returns the same
+ * explanation structure used for live evaluation, so operators can see why a route matched.
+ */
+class AlertRouteEvaluationService(
+    private val policy: AlertRoutePolicy = AlertRoutePolicy(),
+    private val ownershipResolver: AlertRouteOwnershipResolver = DatabaseAlertRouteOwnershipResolver(),
+    private val evaluator: AlertRouteEvaluator = AlertRouteEvaluator(DatabaseAlertRouteTeamEscalationResolver()),
+) {
+    /** Evaluate the routes of the event's organization against a live alert. */
+    fun evaluate(
+        event: AlertLifecycleEvent,
+        episode: AlertRouteEpisodeIdentity = AlertRouteEpisodeIdentity.UNKNOWN,
+    ): AlertRouteEvaluationResult {
+        policy.requireReadAllowed(event.organizationId)
+        val approved = AlertRouteMetadataPolicy.approve(event.metadata)
+        val ownership = ownershipResolver.resolve(event.organizationId, approved.values)
+        return evaluateContext(AlertRouteContextFactory.fromLifecycleEvent(event, episode, ownership))
+    }
+
+    /** Explain match and non-match for a supplied alert sample. */
+    fun preview(organizationId: Int, sample: AlertRouteSampleInput): AlertRouteEvaluationResult {
+        policy.requireReadAllowed(organizationId)
+        val ownership = ownershipResolver.resolve(organizationId, sample.metadata)
+        return evaluateContext(AlertRouteContextFactory.fromSample(organizationId, sample, ownership))
+    }
+
+    /** Explain match and non-match for a saved alert episode, optionally enriched with metadata. */
+    fun previewSavedEpisode(
+        organizationId: Int,
+        episodeId: Uuid,
+        metadata: Map<String, String> = emptyMap(),
+    ): AlertRouteEvaluationResult {
+        policy.requireReadAllowed(organizationId)
+        val sample = loadEpisodeSample(organizationId, episodeId, metadata)
+        val ownership = ownershipResolver.resolve(organizationId, sample.metadata)
+        return evaluateContext(AlertRouteContextFactory.fromSample(organizationId, sample, ownership))
+    }
+
+    private fun loadEpisodeSample(
+        organizationId: Int,
+        episodeId: Uuid,
+        metadata: Map<String, String>,
+    ): AlertRouteSampleInput =
+        transaction {
+            val row =
+                AlertEpisodes
+                    .selectAll()
+                    .where {
+                        (AlertEpisodes.organizationId eq organizationId) and
+                            (AlertEpisodes.resourceId eq episodeId)
+                    }.limit(1)
+                    .firstOrNull()
+                    ?: throw IncidentCommandNotFoundException("Alert episode not found")
+            AlertRouteSampleInput(
+                source = row[AlertEpisodes.sourceName],
+                status = row[AlertEpisodes.status],
+                priority = row[AlertEpisodes.priority].orEmpty(),
+                title = row[AlertEpisodes.title].orEmpty(),
+                description = row[AlertEpisodes.description].orEmpty(),
+                deduplicationKey = row[AlertEpisodes.deduplicationKey],
+                metadata = metadata,
+                episode =
+                    AlertRouteEpisodeIdentity(
+                        resourceId = row[AlertEpisodes.resourceId].toString(),
+                        key = row[AlertEpisodes.episodeKey],
+                        sequence = row[AlertEpisodes.episodeSeq],
+                        status = row[AlertEpisodes.status],
+                    ),
+            )
+        }
+
+    private fun evaluateContext(context: AlertRouteContext): AlertRouteEvaluationResult {
+        val routes = transaction { AlertRouteReader.load(context.organizationId) }
+        return evaluator.evaluate(routes, context)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteEvaluationService.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteEvaluationService.kt
@@ -21,6 +21,7 @@ import com.moneat.enterprise.alertroutes.evaluation.AlertRouteTeamEscalationReso
 import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
 import com.moneat.shared.models.EscalationPolicies
 import com.moneat.shared.models.OrganizationTeams
+import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -77,7 +78,8 @@ class AlertRouteEvaluationService(
     /** Explain match and non-match for a supplied alert sample. */
     fun preview(organizationId: Int, sample: AlertRouteSampleInput): AlertRouteEvaluationResult {
         policy.requireReadAllowed(organizationId)
-        val ownership = ownershipResolver.resolve(organizationId, sample.metadata)
+        val approved = AlertRouteMetadataPolicy.approve(sample.metadata.mapValues { JsonPrimitive(it.value) })
+        val ownership = ownershipResolver.resolve(organizationId, approved.values)
         return evaluateContext(AlertRouteContextFactory.fromSample(organizationId, sample, ownership))
     }
 
@@ -89,7 +91,8 @@ class AlertRouteEvaluationService(
     ): AlertRouteEvaluationResult {
         policy.requireReadAllowed(organizationId)
         val sample = loadEpisodeSample(organizationId, episodeId, metadata)
-        val ownership = ownershipResolver.resolve(organizationId, sample.metadata)
+        val approved = AlertRouteMetadataPolicy.approve(sample.metadata.mapValues { JsonPrimitive(it.value) })
+        val ownership = ownershipResolver.resolve(organizationId, approved.values)
         return evaluateContext(AlertRouteContextFactory.fromSample(organizationId, sample, ownership))
     }
 

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteReader.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteReader.kt
@@ -1,0 +1,265 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.alertroutes.models.AlertRouteChangeType
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionGroupDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingWindowKind
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteOwnershipSource
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteRecoveryDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteRevisionRecord
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteActions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditionGroups
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteRevisions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteTargets
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.OrganizationTeams
+import com.moneat.shared.models.Users
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import kotlin.uuid.Uuid
+
+/**
+ * Loads alert routes and their audit history.
+ *
+ * Every function must run inside an existing Exposed transaction; callers own the boundary.
+ */
+internal object AlertRouteReader {
+    fun load(organizationId: Int, routeResourceId: Uuid? = null): List<AlertRouteDefinition> {
+        val routeRows =
+            EnterpriseAlertRoutes
+                .selectAll()
+                .where {
+                    if (routeResourceId == null) {
+                        EnterpriseAlertRoutes.organizationId eq organizationId
+                    } else {
+                        (EnterpriseAlertRoutes.organizationId eq organizationId) and
+                            (EnterpriseAlertRoutes.resourceId eq routeResourceId)
+                    }
+                }.orderBy(
+                    EnterpriseAlertRoutes.position to SortOrder.ASC,
+                    EnterpriseAlertRoutes.id to SortOrder.ASC,
+                ).toList()
+        if (routeRows.isEmpty()) return emptyList()
+        val routeIds = routeRows.map { it[EnterpriseAlertRoutes.id].value }
+        val groupsByRoute = loadConditionGroups(routeIds)
+        val actionsByRoute = loadActions(routeIds)
+        val targetsByRoute = loadTargets(routeIds)
+        return routeRows.map { row ->
+            val routeId = row[EnterpriseAlertRoutes.id].value
+            row.toDefinition(
+                conditionGroups = groupsByRoute[routeId].orEmpty(),
+                actions = actionsByRoute[routeId],
+                targets = targetsByRoute[routeId].orEmpty(),
+            )
+        }
+    }
+
+    fun loadOne(organizationId: Int, routeResourceId: Uuid): AlertRouteDefinition? =
+        load(organizationId, routeResourceId).firstOrNull()
+
+    fun revisions(organizationId: Int, routeResourceId: Uuid): List<AlertRouteRevisionRecord> {
+        val rows =
+            EnterpriseAlertRouteRevisions
+                .selectAll()
+                .where {
+                    (EnterpriseAlertRouteRevisions.organizationId eq organizationId) and
+                        (EnterpriseAlertRouteRevisions.routeResourceId eq routeResourceId)
+                }.orderBy(EnterpriseAlertRouteRevisions.revision to SortOrder.DESC)
+                .toList()
+        val actorResourceIds = actorResourceIds(rows.mapNotNull { it[EnterpriseAlertRouteRevisions.actorUserId] })
+        return rows.map { row ->
+            AlertRouteRevisionRecord(
+                id = row[EnterpriseAlertRouteRevisions.resourceId],
+                routeId = row[EnterpriseAlertRouteRevisions.routeResourceId],
+                revision = row[EnterpriseAlertRouteRevisions.revision],
+                changeType = AlertRouteChangeType.valueOf(row[EnterpriseAlertRouteRevisions.changeType]),
+                actorId = row[EnterpriseAlertRouteRevisions.actorUserId]?.let(actorResourceIds::get),
+                commandKey = row[EnterpriseAlertRouteRevisions.commandKey],
+                snapshot = row[EnterpriseAlertRouteRevisions.snapshot],
+                createdAt = row[EnterpriseAlertRouteRevisions.createdAt],
+            )
+        }
+    }
+
+    private fun actorResourceIds(userIds: List<Int>): Map<Int, Uuid> {
+        if (userIds.isEmpty()) return emptyMap()
+        return Users
+            .selectAll()
+            .where { Users.id inList userIds.distinct() }
+            .associate { it[Users.id] to it[Users.resource_id] }
+    }
+
+    private fun loadConditionGroups(routeIds: List<Int>): Map<Int, List<AlertRouteConditionGroupDefinition>> {
+        val groupRows =
+            EnterpriseAlertRouteConditionGroups
+                .selectAll()
+                .where { EnterpriseAlertRouteConditionGroups.routeId inList routeIds }
+                .orderBy(EnterpriseAlertRouteConditionGroups.position to SortOrder.ASC)
+                .toList()
+        if (groupRows.isEmpty()) return emptyMap()
+        val groupIds = groupRows.map { it[EnterpriseAlertRouteConditionGroups.id].value }
+        val conditionsByGroup =
+            EnterpriseAlertRouteConditions
+                .selectAll()
+                .where { EnterpriseAlertRouteConditions.groupId inList groupIds }
+                .orderBy(EnterpriseAlertRouteConditions.position to SortOrder.ASC)
+                .groupBy({ it[EnterpriseAlertRouteConditions.groupId] }) { row ->
+                    AlertRouteConditionDefinition(
+                        field = AlertRouteContextField.valueOf(row[EnterpriseAlertRouteConditions.contextField]),
+                        operator =
+                            requireNotNull(
+                                AlertRouteConditionOperator.fromWire(row[EnterpriseAlertRouteConditions.operator]),
+                            ) { "Unknown stored alert route condition operator" },
+                        values = row[EnterpriseAlertRouteConditions.comparisonValues],
+                        metadataKey = row[EnterpriseAlertRouteConditions.metadataKey],
+                    )
+                }
+        return groupRows.groupBy({ it[EnterpriseAlertRouteConditionGroups.routeId] }) { row ->
+            AlertRouteConditionGroupDefinition(
+                conditions = conditionsByGroup[row[EnterpriseAlertRouteConditionGroups.id].value].orEmpty(),
+            )
+        }
+    }
+
+    private fun loadActions(routeIds: List<Int>): Map<Int, ResultRow> =
+        EnterpriseAlertRouteActions
+            .selectAll()
+            .where { EnterpriseAlertRouteActions.routeId inList routeIds }
+            .associateBy { it[EnterpriseAlertRouteActions.routeId] }
+
+    private fun loadTargets(routeIds: List<Int>): Map<Int, List<AlertRouteTargetDefinition>> {
+        val rows =
+            EnterpriseAlertRouteTargets
+                .selectAll()
+                .where { EnterpriseAlertRouteTargets.routeId inList routeIds }
+                .orderBy(EnterpriseAlertRouteTargets.position to SortOrder.ASC)
+                .toList()
+        if (rows.isEmpty()) return emptyMap()
+        val policyResourceIds =
+            escalationPolicyResourceIds(rows.mapNotNull { it[EnterpriseAlertRouteTargets.escalationPolicyId] })
+        val teamResourceIds = teamResourceIds(rows.mapNotNull { it[EnterpriseAlertRouteTargets.teamId] })
+        return rows.groupBy({ it[EnterpriseAlertRouteTargets.routeId] }) { row ->
+            val policyId = row[EnterpriseAlertRouteTargets.escalationPolicyId]
+            val teamId = row[EnterpriseAlertRouteTargets.teamId]
+            AlertRouteTargetDefinition(
+                kind = AlertRouteTargetKind.valueOf(row[EnterpriseAlertRouteTargets.targetKind]),
+                escalationPolicyId = policyId,
+                escalationPolicyResourceId = policyId?.let(policyResourceIds::get),
+                teamId = teamId,
+                teamResourceId = teamId?.let(teamResourceIds::get),
+                ownershipSource =
+                    row[EnterpriseAlertRouteTargets.ownershipSource]?.let(AlertRouteOwnershipSource::valueOf),
+            )
+        }
+    }
+
+    private fun escalationPolicyResourceIds(policyIds: List<Int>): Map<Int, Uuid> {
+        if (policyIds.isEmpty()) return emptyMap()
+        return EscalationPolicies
+            .selectAll()
+            .where { EscalationPolicies.id inList policyIds.distinct() }
+            .associate { it[EscalationPolicies.id].value to it[EscalationPolicies.resourceId] }
+    }
+
+    private fun teamResourceIds(teamIds: List<Int>): Map<Int, Uuid> {
+        if (teamIds.isEmpty()) return emptyMap()
+        return OrganizationTeams
+            .selectAll()
+            .where { OrganizationTeams.id inList teamIds.distinct() }
+            .associate { it[OrganizationTeams.id].value to it[OrganizationTeams.resourceId] }
+    }
+
+    private fun ResultRow.toDefinition(
+        conditionGroups: List<AlertRouteConditionGroupDefinition>,
+        actions: ResultRow?,
+        targets: List<AlertRouteTargetDefinition>,
+    ): AlertRouteDefinition =
+        AlertRouteDefinition(
+            id = this[EnterpriseAlertRoutes.id].value,
+            resourceId = this[EnterpriseAlertRoutes.resourceId],
+            organizationId = this[EnterpriseAlertRoutes.organizationId],
+            key = this[EnterpriseAlertRoutes.routeKey],
+            name = this[EnterpriseAlertRoutes.name],
+            description = this[EnterpriseAlertRoutes.description],
+            enabled = this[EnterpriseAlertRoutes.enabled],
+            position = this[EnterpriseAlertRoutes.position],
+            revision = this[EnterpriseAlertRoutes.revision],
+            conditionGroups = conditionGroups,
+            paging =
+                AlertRoutePagingDefinition(
+                    mode =
+                        actions
+                            ?.get(EnterpriseAlertRouteActions.pagingMode)
+                            ?.let(AlertRoutePagingMode::valueOf)
+                            ?: AlertRoutePagingMode.NONE,
+                    targets = targets,
+                ),
+            grouping = actions.toGroupingDefinition(),
+            incident = actions.toIncidentDefinition(),
+            recovery = actions.toRecoveryDefinition(),
+            createdAt = this[EnterpriseAlertRoutes.createdAt],
+            updatedAt = this[EnterpriseAlertRoutes.updatedAt],
+        )
+
+    private fun ResultRow?.toGroupingDefinition(): AlertRouteGroupingDefinition =
+        AlertRouteGroupingDefinition(
+            behavior =
+                this
+                    ?.get(EnterpriseAlertRouteActions.groupingBehavior)
+                    ?.let(AlertRouteGroupingBehavior::valueOf)
+                    ?: AlertRouteGroupingBehavior.DEFAULT,
+            keys = this?.get(EnterpriseAlertRouteActions.groupingKeys).orEmpty(),
+            windowKind =
+                this
+                    ?.get(EnterpriseAlertRouteActions.groupingWindowKind)
+                    ?.let(AlertRouteGroupingWindowKind::valueOf)
+                    ?: AlertRouteGroupingWindowKind.ROLLING,
+            windowSeconds =
+                this?.get(EnterpriseAlertRouteActions.groupingWindowSeconds) ?: DEFAULT_GROUPING_WINDOW_SECONDS,
+        )
+
+    private fun ResultRow?.toIncidentDefinition(): AlertRouteIncidentDefinition =
+        AlertRouteIncidentDefinition(
+            create = this?.get(EnterpriseAlertRouteActions.incidentCreationEnabled) == true,
+            mode =
+                this
+                    ?.get(EnterpriseAlertRouteActions.incidentCreationMode)
+                    ?.let(AlertRouteIncidentMode::valueOf)
+                    ?: AlertRouteIncidentMode.TRIAGE,
+            titleTemplate = this?.get(EnterpriseAlertRouteActions.incidentTitleTemplate),
+            summaryTemplate = this?.get(EnterpriseAlertRouteActions.incidentSummaryTemplate),
+            severity = this?.get(EnterpriseAlertRouteActions.incidentSeverity),
+            incidentType = this?.get(EnterpriseAlertRouteActions.incidentType),
+        )
+
+    private fun ResultRow?.toRecoveryDefinition(): AlertRouteRecoveryDefinition =
+        AlertRouteRecoveryDefinition(
+            cancelEscalations = this?.get(EnterpriseAlertRouteActions.recoveryCancelEscalations) == true,
+            declineUnacceptedTriage =
+                this?.get(EnterpriseAlertRouteActions.recoveryDeclineUnacceptedTriage) == true,
+            graceSeconds = this?.get(EnterpriseAlertRouteActions.recoveryGraceSeconds) ?: 0,
+        )
+
+    private const val DEFAULT_GROUPING_WINDOW_SECONDS = 900
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSnapshot.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteSnapshot.kt
@@ -1,0 +1,260 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.alertroutes.commands.AlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.DeleteAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.ReorderAlertRoutesCommand
+import com.moneat.enterprise.alertroutes.commands.UpdateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.models.AlertRouteChangeType
+import com.moneat.enterprise.alertroutes.models.AlertRouteDefinition
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/** Builds the audited JSON snapshot stored with every alert-route revision. */
+internal object AlertRouteSnapshot {
+    fun of(
+        command: AlertRouteCommand,
+        route: AlertRouteDefinition,
+        changeType: AlertRouteChangeType,
+    ): Map<String, JsonElement> =
+        mapOf(
+            "changeType" to JsonPrimitive(changeType.wire),
+            "revision" to JsonPrimitive(route.revision),
+            "origin" to JsonPrimitive(command.actor.origin),
+            "route" to route(route),
+        ) + commandDetails(command)
+
+    private fun route(route: AlertRouteDefinition): JsonElement =
+        JsonObject(
+            mapOf(
+                "id" to JsonPrimitive(route.resourceId.toString()),
+                "key" to JsonPrimitive(route.key),
+                "name" to JsonPrimitive(route.name),
+                "description" to (route.description?.let(::JsonPrimitive) ?: kotlinx.serialization.json.JsonNull),
+                "enabled" to JsonPrimitive(route.enabled),
+                "position" to JsonPrimitive(route.position),
+                "revision" to JsonPrimitive(route.revision),
+                "conditionGroups" to
+                    JsonArray(
+                        route.conditionGroups.map { group ->
+                            JsonArray(
+                                group.conditions.map { condition ->
+                                    JsonObject(
+                                        mapOf(
+                                            "field" to JsonPrimitive(condition.field.wire),
+                                            "metadataKey" to
+                                                (condition.metadataKey?.let(::JsonPrimitive)
+                                                    ?: kotlinx.serialization.json.JsonNull),
+                                            "operator" to JsonPrimitive(condition.operator.wire),
+                                            "values" to JsonArray(condition.values.map(::JsonPrimitive)),
+                                        ),
+                                    )
+                                },
+                            )
+                        },
+                    ),
+                "paging" to
+                    JsonObject(
+                        mapOf(
+                            "mode" to JsonPrimitive(route.paging.mode.wire),
+                            "targets" to
+                                JsonArray(
+                                    route.paging.targets.map { target ->
+                                        JsonObject(
+                                            mapOf(
+                                                "kind" to JsonPrimitive(target.kind.wire),
+                                                "escalationPolicyId" to
+                                                    (target.escalationPolicyResourceId?.let {
+                                                        JsonPrimitive(it.toString())
+                                                    } ?: kotlinx.serialization.json.JsonNull),
+                                                "teamId" to
+                                                    (target.teamResourceId?.let { JsonPrimitive(it.toString()) }
+                                                        ?: kotlinx.serialization.json.JsonNull),
+                                                "ownershipSource" to
+                                                    (target.ownershipSource?.let { JsonPrimitive(it.wire) }
+                                                        ?: kotlinx.serialization.json.JsonNull),
+                                            ),
+                                        )
+                                    },
+                                ),
+                        ),
+                    ),
+                "grouping" to
+                    JsonObject(
+                        mapOf(
+                            "behavior" to JsonPrimitive(route.grouping.behavior.wire),
+                            "keys" to JsonArray(route.grouping.keys.map(::JsonPrimitive)),
+                            "windowKind" to JsonPrimitive(route.grouping.windowKind.wire),
+                            "windowSeconds" to JsonPrimitive(route.grouping.windowSeconds),
+                        ),
+                    ),
+                "incident" to
+                    JsonObject(
+                        mapOf(
+                            "create" to JsonPrimitive(route.incident.create),
+                            "mode" to JsonPrimitive(route.incident.mode.wire),
+                            "titleTemplate" to
+                                (route.incident.titleTemplate?.let(::JsonPrimitive)
+                                    ?: kotlinx.serialization.json.JsonNull),
+                            "summaryTemplate" to
+                                (route.incident.summaryTemplate?.let(::JsonPrimitive)
+                                    ?: kotlinx.serialization.json.JsonNull),
+                            "severity" to
+                                (route.incident.severity?.let(::JsonPrimitive)
+                                    ?: kotlinx.serialization.json.JsonNull),
+                            "incidentType" to
+                                (route.incident.incidentType?.let(::JsonPrimitive)
+                                    ?: kotlinx.serialization.json.JsonNull),
+                        ),
+                    ),
+                "recovery" to
+                    JsonObject(
+                        mapOf(
+                            "cancelEscalations" to JsonPrimitive(route.recovery.cancelEscalations),
+                            "declineUnacceptedTriage" to
+                                JsonPrimitive(route.recovery.declineUnacceptedTriage),
+                            "graceSeconds" to JsonPrimitive(route.recovery.graceSeconds),
+                        ),
+                    ),
+            ),
+        )
+
+    private fun commandDetails(command: AlertRouteCommand): Map<String, JsonElement> =
+        when (command) {
+            is CreateAlertRouteCommand -> mapOf("specification" to specification(command.specification))
+            is UpdateAlertRouteCommand ->
+                mapOf(
+                    "routeId" to JsonPrimitive(command.routeId.toString()),
+                    "expectedRevision" to JsonPrimitive(command.expectedRevision),
+                    "specification" to specification(command.specification),
+                )
+            is DeleteAlertRouteCommand ->
+                mapOf(
+                    "routeId" to JsonPrimitive(command.routeId.toString()),
+                    "expectedRevision" to JsonPrimitive(command.expectedRevision),
+                )
+            is ReorderAlertRoutesCommand ->
+                mapOf(
+                    "order" to
+                        JsonArray(
+                            command.orderedRoutes.map { entry ->
+                                JsonObject(
+                                    mapOf(
+                                        "routeId" to JsonPrimitive(entry.routeId.toString()),
+                                        "expectedRevision" to JsonPrimitive(entry.expectedRevision),
+                                    ),
+                                )
+                            },
+                        ),
+                )
+        }
+
+    private fun specification(specification: AlertRouteSpecification): JsonElement =
+        JsonObject(
+            mapOf(
+                "key" to JsonPrimitive(specification.key),
+                "name" to JsonPrimitive(specification.name),
+                "description" to
+                    (specification.description?.let(::JsonPrimitive) ?: kotlinx.serialization.json.JsonNull),
+                "enabled" to JsonPrimitive(specification.enabled),
+                "conditionGroups" to conditionGroups(specification),
+                "paging" to paging(specification),
+                "grouping" to grouping(specification),
+                "incident" to incident(specification),
+                "recovery" to recovery(specification),
+            ),
+        )
+
+    private fun conditionGroups(specification: AlertRouteSpecification): JsonElement =
+        JsonArray(
+            specification.conditionGroups.map { group ->
+                JsonArray(
+                    group.conditions.map { condition ->
+                        JsonObject(
+                            mapOf(
+                                "field" to JsonPrimitive(condition.field.wire),
+                                "metadataKey" to
+                                    (condition.metadataKey?.let(::JsonPrimitive)
+                                        ?: kotlinx.serialization.json.JsonNull),
+                                "operator" to JsonPrimitive(condition.operator.wire),
+                                "values" to JsonArray(condition.values.map(::JsonPrimitive)),
+                            ),
+                        )
+                    },
+                )
+            },
+        )
+
+    private fun paging(specification: AlertRouteSpecification): JsonElement =
+        JsonObject(
+            mapOf(
+                "mode" to JsonPrimitive(specification.paging.mode.wire),
+                "targets" to
+                    JsonArray(
+                        specification.paging.targets.map { target ->
+                            JsonObject(
+                                mapOf(
+                                    "kind" to JsonPrimitive(target.kind.wire),
+                                    "escalationPolicyId" to
+                                        (target.escalationPolicyId?.let { JsonPrimitive(it.toString()) }
+                                            ?: kotlinx.serialization.json.JsonNull),
+                                    "teamId" to
+                                        (target.teamId?.let { JsonPrimitive(it.toString()) }
+                                            ?: kotlinx.serialization.json.JsonNull),
+                                    "ownershipSource" to
+                                        (target.ownershipSource?.let { JsonPrimitive(it.wire) }
+                                            ?: kotlinx.serialization.json.JsonNull),
+                                ),
+                            )
+                        },
+                    ),
+            ),
+        )
+
+    private fun grouping(specification: AlertRouteSpecification): JsonElement =
+        JsonObject(
+            mapOf(
+                "behavior" to JsonPrimitive(specification.grouping.behavior.wire),
+                "keys" to JsonArray(specification.grouping.keys.map(::JsonPrimitive)),
+                "windowKind" to JsonPrimitive(specification.grouping.windowKind.wire),
+                "windowSeconds" to JsonPrimitive(specification.grouping.windowSeconds),
+            ),
+        )
+
+    private fun incident(specification: AlertRouteSpecification): JsonElement =
+        JsonObject(
+            mapOf(
+                "create" to JsonPrimitive(specification.incident.create),
+                "mode" to JsonPrimitive(specification.incident.mode.wire),
+                "titleTemplate" to
+                    (specification.incident.titleTemplate?.let(::JsonPrimitive)
+                        ?: kotlinx.serialization.json.JsonNull),
+                "summaryTemplate" to
+                    (specification.incident.summaryTemplate?.let(::JsonPrimitive)
+                        ?: kotlinx.serialization.json.JsonNull),
+                "severity" to
+                    (specification.incident.severity?.let(::JsonPrimitive)
+                        ?: kotlinx.serialization.json.JsonNull),
+                "incidentType" to
+                    (specification.incident.incidentType?.let(::JsonPrimitive)
+                        ?: kotlinx.serialization.json.JsonNull),
+            ),
+        )
+
+    private fun recovery(specification: AlertRouteSpecification): JsonElement =
+        JsonObject(
+            mapOf(
+                "cancelEscalations" to JsonPrimitive(specification.recovery.cancelEscalations),
+                "declineUnacceptedTriage" to
+                    JsonPrimitive(specification.recovery.declineUnacceptedTriage),
+                "graceSeconds" to JsonPrimitive(specification.recovery.graceSeconds),
+            ),
+        )
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteValidator.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteValidator.kt
@@ -1,0 +1,203 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.IncidentSeverity
+import com.moneat.enterprise.alertroutes.commands.AlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.AlertRouteTargetInput
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.DeleteAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.ReorderAlertRoutesCommand
+import com.moneat.enterprise.alertroutes.commands.UpdateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.context.AlertRouteMetadataPolicy
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteTemplateRenderer
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+
+/** Structural validation applied before any alert-route mutation touches storage. */
+internal object AlertRouteValidator {
+    private val KEY_PATTERN = Regex("^[a-z0-9][a-z0-9_-]*$")
+    private const val MAX_KEY_LENGTH = 160
+    private const val MAX_NAME_LENGTH = 200
+    private const val MAX_DESCRIPTION_LENGTH = 2_000
+    private const val MAX_CONDITION_GROUPS = 20
+    private const val MAX_CONDITIONS_PER_GROUP = 20
+    private const val MAX_CONDITION_VALUES = 50
+    private const val MAX_GROUPING_KEYS = 8
+    private const val MAX_TARGETS = 20
+    private const val MAX_TEMPLATE_LENGTH = 2_000
+    private const val MAX_INCIDENT_TYPE_LENGTH = 120
+    private const val MAX_WINDOW_SECONDS = 86_400
+    private const val MAX_GRACE_SECONDS = 86_400
+    private val REFERENCE_SCOPES = setOf("alert", "metadata", "ownership", "episode")
+
+    fun validate(command: AlertRouteCommand) {
+        when (command) {
+            is CreateAlertRouteCommand -> validateSpecification(command.specification)
+            is UpdateAlertRouteCommand -> {
+                validateExpectedRevision(command.expectedRevision)
+                validateSpecification(command.specification)
+            }
+            is DeleteAlertRouteCommand -> validateExpectedRevision(command.expectedRevision)
+            is ReorderAlertRoutesCommand -> {
+                require(command.orderedRoutes.isNotEmpty()) { "Reorder requires at least one alert route" }
+                require(command.orderedRoutes.map { it.routeId }.distinct().size == command.orderedRoutes.size) {
+                    "Reorder must not repeat an alert route"
+                }
+                command.orderedRoutes.forEach { validateExpectedRevision(it.expectedRevision) }
+            }
+        }
+    }
+
+    fun validateSpecification(specification: AlertRouteSpecification) {
+        val key = specification.key.trim()
+        require(key.isNotEmpty() && key.length <= MAX_KEY_LENGTH) { "Alert route key is required" }
+        require(KEY_PATTERN.matches(key)) {
+            "Alert route key may only contain lowercase letters, digits, hyphens, and underscores"
+        }
+        val name = specification.name.trim()
+        require(name.isNotEmpty() && name.length <= MAX_NAME_LENGTH) { "Alert route name is required" }
+        require((specification.description?.length ?: 0) <= MAX_DESCRIPTION_LENGTH) {
+            "Alert route description is too long"
+        }
+        validateConditions(specification)
+        validatePaging(specification)
+        validateGrouping(specification)
+        validateIncident(specification)
+        validateRecovery(specification)
+    }
+
+    private fun validateExpectedRevision(expectedRevision: Int) {
+        require(expectedRevision > 0) { "Expected revision must be positive" }
+    }
+
+    private fun validateConditions(specification: AlertRouteSpecification) {
+        require(specification.conditionGroups.size <= MAX_CONDITION_GROUPS) {
+            "Alert route has too many condition groups"
+        }
+        specification.conditionGroups.forEach { group ->
+            require(group.conditions.isNotEmpty()) { "Every condition group needs at least one condition" }
+            require(group.conditions.size <= MAX_CONDITIONS_PER_GROUP) {
+                "Condition group has too many conditions"
+            }
+            group.conditions.forEach(::validateCondition)
+        }
+    }
+
+    private fun validateCondition(condition: AlertRouteConditionInput) {
+        if (condition.field == AlertRouteContextField.METADATA) {
+            val key = condition.metadataKey?.trim()
+            require(!key.isNullOrEmpty()) { "Metadata conditions require a metadata key" }
+            require(key in AlertRouteMetadataPolicy.APPROVED_KEYS) { "Metadata key $key is not approved for routing" }
+        } else {
+            require(condition.metadataKey == null) {
+                "Metadata key is only valid on metadata conditions"
+            }
+        }
+        require(!condition.operator.priorityOnly || condition.field == AlertRouteContextField.PRIORITY) {
+            "Operator ${condition.operator.wire} is only valid on the priority field"
+        }
+        if (condition.operator.requiresValues) {
+            require(condition.values.isNotEmpty()) { "Operator ${condition.operator.wire} requires at least one value" }
+            require(condition.values.size <= MAX_CONDITION_VALUES) { "Condition has too many comparison values" }
+            require(condition.values.none { it.isBlank() }) { "Condition values cannot be blank" }
+        } else {
+            require(condition.values.isEmpty()) { "Operator ${condition.operator.wire} does not take values" }
+        }
+        if (condition.operator == AlertRouteConditionOperator.AT_LEAST_AS_SEVERE_AS) {
+            require(AlertPriority.fromString(condition.values.first()) != null) {
+                "Invalid alert priority: ${condition.values.first()}"
+            }
+        }
+    }
+
+    private fun validatePaging(specification: AlertRouteSpecification) {
+        val paging = specification.paging
+        require(paging.targets.size <= MAX_TARGETS) { "Alert route has too many paging targets" }
+        if (paging.mode == AlertRoutePagingMode.NONE) return
+        require(paging.targets.isNotEmpty()) { "Paging mode ${paging.mode.wire} requires at least one target" }
+        paging.targets.forEach(::validateTarget)
+    }
+
+    private fun validateTarget(target: AlertRouteTargetInput) {
+        when (target.kind) {
+            AlertRouteTargetKind.ESCALATION_POLICY ->
+                require(target.escalationPolicyId != null) { "Escalation policy targets require an escalation policy" }
+            AlertRouteTargetKind.TEAM ->
+                require(target.teamId != null) { "Team targets require a team" }
+            AlertRouteTargetKind.OWNERSHIP_DERIVED ->
+                require(target.ownershipSource != null) { "Ownership targets require an ownership source" }
+        }
+    }
+
+    private fun validateGrouping(specification: AlertRouteSpecification) {
+        val grouping = specification.grouping
+        require(grouping.keys.size <= MAX_GROUPING_KEYS) { "Alert route has too many grouping keys" }
+        grouping.keys.forEach(::validateReference)
+        require(grouping.windowSeconds in 1..MAX_WINDOW_SECONDS) {
+            "Grouping window must be between 1 and $MAX_WINDOW_SECONDS seconds"
+        }
+    }
+
+    private fun validateIncident(specification: AlertRouteSpecification) {
+        val incident = specification.incident
+        require((incident.titleTemplate?.length ?: 0) <= MAX_TEMPLATE_LENGTH) { "Incident title template is too long" }
+        require((incident.summaryTemplate?.length ?: 0) <= MAX_TEMPLATE_LENGTH) {
+            "Incident summary template is too long"
+        }
+        require((incident.incidentType?.length ?: 0) <= MAX_INCIDENT_TYPE_LENGTH) {
+            "Incident type is too long"
+        }
+        incident.severity?.let {
+            require(IncidentSeverity.fromString(it) != null) { "Invalid incident severity: $it" }
+        }
+        if (incident.create && incident.mode == AlertRouteIncidentMode.ACTIVE) {
+            require(!incident.severity.isNullOrBlank()) { "Incident creation requires a severity" }
+        }
+        templateReferences(incident.titleTemplate, incident.summaryTemplate).forEach(::validateReference)
+    }
+
+    private fun validateRecovery(specification: AlertRouteSpecification) {
+        require(specification.recovery.graceSeconds in 0..MAX_GRACE_SECONDS) {
+            "Recovery grace must be between 0 and $MAX_GRACE_SECONDS seconds"
+        }
+    }
+
+    private fun templateReferences(vararg templates: String?): List<String> =
+        templates.flatMap { template -> AlertRouteTemplateRenderer.references(template) }
+
+    private fun validateReference(reference: String) {
+        val trimmed = reference.trim()
+        require(trimmed.isNotEmpty()) { "Context reference cannot be blank" }
+        val parts = trimmed.split('.', limit = 2)
+        val scope = parts.first().lowercase()
+        require(scope in REFERENCE_SCOPES) { "Unknown context reference scope: $trimmed" }
+        val leaf = parts.getOrNull(1)
+        require(!leaf.isNullOrBlank()) { "Context reference $trimmed is missing a field" }
+        when (scope) {
+            "metadata" ->
+                require(leaf in AlertRouteMetadataPolicy.APPROVED_KEYS) {
+                    "Metadata key $leaf is not approved for routing"
+                }
+            "alert" ->
+                require(
+                    AlertRouteContextField.fromWire(leaf)?.takeIf { it != AlertRouteContextField.METADATA } != null,
+                ) { "Unknown alert field: $leaf" }
+            "ownership" ->
+                require(leaf.lowercase() in OWNERSHIP_LEAVES) { "Unknown ownership field: $leaf" }
+            else ->
+                require(leaf.lowercase() in EPISODE_LEAVES) { "Unknown episode field: $leaf" }
+        }
+    }
+
+    private val OWNERSHIP_LEAVES = setOf("service", "team", "catalog", "catalog_resource")
+    private val EPISODE_LEAVES = setOf("id", "resource_id", "key", "sequence", "status")
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteValidator.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteValidator.kt
@@ -113,8 +113,10 @@ internal object AlertRouteValidator {
             require(condition.values.isEmpty()) { "Operator ${condition.operator.wire} does not take values" }
         }
         if (condition.operator == AlertRouteConditionOperator.AT_LEAST_AS_SEVERE_AS) {
-            require(AlertPriority.fromString(condition.values.first()) != null) {
-                "Invalid alert priority: ${condition.values.first()}"
+            condition.values.forEach { value ->
+                require(AlertPriority.fromString(value) != null) {
+                    "Invalid alert priority: $value"
+                }
             }
         }
     }

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/IncidentDomainGlossary.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/incidents/IncidentDomainGlossary.kt
@@ -30,9 +30,30 @@ enum class IncidentDomainObject(
         owner = "enterprise on-call escalation",
         lifecycle = "triggered through acknowledgement and resolution",
     ),
+    ENTERPRISE_ALERT_ROUTE(
+        apiName = "enterprise_alert_route",
+        owner = "enterprise incident response",
+        lifecycle = "ordered first-match selection of paging, grouping, incident creation, and recovery",
+    ),
+    PROVIDER_ROUTING_RULE(
+        apiName = "provider_routing_rule",
+        owner = "AGPL incident-provider passthrough",
+        lifecycle = "per-provider forwarding selection and priority defaults only",
+    ),
 }
 
 object IncidentDomainGlossary {
+    /**
+     * Routing concepts that are frequently confused.
+     *
+     * [IncidentDomainObject.ENTERPRISE_ALERT_ROUTE] decides native paging, grouping, incident
+     * creation, and recovery from a normalized alert context.
+     * [IncidentDomainObject.PROVIDER_ROUTING_RULE] only decides whether the open-source passthrough
+     * forwards an alert source to a configured external provider. Neither one governs the other.
+     */
+    val ROUTING_OBJECTS: Set<IncidentDomainObject> =
+        setOf(IncidentDomainObject.ENTERPRISE_ALERT_ROUTE, IncidentDomainObject.PROVIDER_ROUTING_RULE)
+
     fun requireCanonicalApiName(value: String): IncidentDomainObject =
         IncidentDomainObject.entries.firstOrNull { it.apiName == value }
             ?: throw IllegalArgumentException("Unknown incident-domain object: $value")

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -11,6 +11,7 @@ import com.moneat.enterprise.OnCallBridge
 import com.moneat.enterprise.OnCallIncidentDeclaration
 import com.moneat.enterprise.OnCallUserInfo
 import com.moneat.enterprise.PriorityInfo
+import com.moneat.enterprise.alertroutes.routes.alertRouteRoutes
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.events.IncidentOutboxService
@@ -126,6 +127,7 @@ class OnCallModule :
             priorityRoutes()
             deviceRoutes()
             incidentRoutes({ onCallAlertService })
+            alertRouteRoutes()
             twilioWebhookRoutes()
             notificationPreferencesRoutes { pushNotificationService }
         }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteOssCompatibilityTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteOssCompatibilityTest.kt
@@ -1,0 +1,214 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes
+
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.enterprise.alertroutes.commands.AlertRouteActor
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionGroupInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.context.AlertRouteSampleInput
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.services.AlertRouteCommandService
+import com.moneat.enterprise.alertroutes.services.AlertRouteEvaluationService
+import com.moneat.enterprise.incidents.IncidentDomainGlossary
+import com.moneat.enterprise.incidents.IncidentDomainObject
+import com.moneat.incident.models.IncidentEventLog
+import com.moneat.incident.models.IncidentProviderConfigs
+import com.moneat.incident.models.IncidentRoutingRules
+import com.moneat.incident.models.ProviderConfig
+import com.moneat.incident.services.IncidentProvider
+import com.moneat.incident.services.IncidentProviderRegistry
+import com.moneat.incident.services.IncidentService
+import com.moneat.workflows.services.WorkflowService
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+/**
+ * Enterprise Alert Routes must not change the open-source incident-provider passthrough.
+ * These tests keep the two routing concepts separate and prove external forwarding still runs.
+ */
+class AlertRouteOssCompatibilityTest {
+    private lateinit var organization: SeededAlertRouteOrganization
+    private lateinit var provider: RecordingIncidentProvider
+
+    @BeforeEach
+    fun setUp() {
+        AlertRouteTestDatabase.reset()
+        organization = AlertRouteTestDatabase.seedOrganization("oss-compat")
+        provider = RecordingIncidentProvider()
+        IncidentProviderRegistry.register(provider)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        AlertRouteTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `the glossary separates enterprise alert routes from provider routing rules`() {
+        val alertRoute = IncidentDomainGlossary.requireCanonicalApiName("enterprise_alert_route")
+        val providerRule = IncidentDomainGlossary.requireCanonicalApiName("provider_routing_rule")
+
+        assertEquals(IncidentDomainObject.ENTERPRISE_ALERT_ROUTE, alertRoute)
+        assertEquals(IncidentDomainObject.PROVIDER_ROUTING_RULE, providerRule)
+        assertNotEquals(alertRoute.owner, providerRule.owner)
+        assertNotEquals(alertRoute.lifecycle, providerRule.lifecycle)
+        assertEquals(IncidentDomainGlossary.ROUTING_OBJECTS, setOf(alertRoute, providerRule))
+    }
+
+    @Test
+    fun `external provider forwarding is unchanged when an alert route also matches the alert`() {
+        val providerConfigId = seedProviderPassthrough()
+        createMatchingAlertRoute()
+        val event = alertEvent()
+        val workflowService = mockk<WorkflowService>()
+        coEvery { workflowService.publishAlertTriggered(event) } returns true
+
+        runBlocking { IncidentService(workflowService = workflowService).fireAlert(event) }
+
+        assertEquals(listOf(event.deduplicationKey), provider.sent.map { it.deduplicationKey })
+        val logged =
+            transaction {
+                IncidentEventLog
+                    .selectAll()
+                    .where { IncidentEventLog.providerConfigId eq providerConfigId }
+                    .map { it[IncidentEventLog.success] to it[IncidentEventLog.providerIncidentId] }
+            }
+        assertEquals(listOf(true to "provider-incident-1"), logged)
+    }
+
+    @Test
+    fun `alert route storage never touches provider routing rules`() {
+        val providerConfigId = seedProviderPassthrough()
+        val workflowService = mockk<WorkflowService>()
+        createMatchingAlertRoute()
+        AlertRouteEvaluationService(policy = AlertRoutePolicy.allowForTests())
+            .preview(
+                organization.organizationId,
+                AlertRouteSampleInput(source = AlertSource.DASHBOARD_ALERT.name),
+            )
+
+        val rules =
+            transaction {
+                IncidentRoutingRules
+                    .selectAll()
+                    .where { IncidentRoutingRules.providerConfigId eq providerConfigId }
+                    .map { it[IncidentRoutingRules.alertSource] to it[IncidentRoutingRules.alertPriority] }
+            }
+        assertEquals(listOf(AlertSource.DASHBOARD_ALERT.name to "P2"), rules)
+        assertTrue(
+            AlertRouteCommandService(policy = AlertRoutePolicy.allowForTests())
+                .list(organization.organizationId)
+                .isNotEmpty(),
+        )
+        assertEquals(
+            "P2",
+            IncidentService(workflowService = workflowService)
+                .resolveAlertPriority(providerConfigId, AlertSource.DASHBOARD_ALERT, null)
+                ?.wire,
+        )
+    }
+
+    private fun alertEvent(): AlertLifecycleEvent =
+        AlertLifecycleEvent(
+            title = "Checkout latency high",
+            description = "p95 latency above 800ms",
+            priority = AlertPriority.P1,
+            status = AlertStatus.FIRING,
+            source = AlertSource.DASHBOARD_ALERT,
+            deduplicationKey = "moneat-dashboard-alert-42",
+            organizationId = organization.organizationId,
+            moneatUrl = "https://moneat.example/alerts/42",
+        )
+
+    private fun seedProviderPassthrough(): Int =
+        transaction {
+            val now = Clock.System.now()
+            val configId =
+                IncidentProviderConfigs.insert {
+                    it[organizationId] = organization.organizationId
+                    it[providerType] = RecordingIncidentProvider.PROVIDER_TYPE
+                    it[name] = "External provider"
+                    it[apiKey] = "secret"
+                    it[configJson] = "{}"
+                    it[enabled] = true
+                    it[createdAt] = now
+                    it[updatedAt] = now
+                }[IncidentProviderConfigs.id].value
+            IncidentRoutingRules.insert {
+                it[providerConfigId] = configId
+                it[alertSource] = AlertSource.DASHBOARD_ALERT.name
+                it[alertPriority] = "P2"
+                it[createdAt] = now
+                it[updatedAt] = now
+            }
+            configId
+        }
+
+    private fun createMatchingAlertRoute() {
+        AlertRouteCommandService(policy = AlertRoutePolicy.allowForTests()).execute(
+            CreateAlertRouteCommand(
+                commandKey = "oss-compat-route",
+                actor = AlertRouteActor(organization.organizationId, organization.adminUserId, "TEST"),
+                specification =
+                    AlertRouteSpecification(
+                        key = "dashboard-alerts",
+                        name = "Dashboard alerts",
+                        conditionGroups =
+                            listOf(
+                                AlertRouteConditionGroupInput(
+                                    listOf(
+                                        AlertRouteConditionInput(
+                                            field = AlertRouteContextField.SOURCE,
+                                            operator = AlertRouteConditionOperator.EQUALS,
+                                            values = listOf(AlertSource.DASHBOARD_ALERT.name),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                    ),
+            ),
+        )
+    }
+}
+
+private class RecordingIncidentProvider : IncidentProvider {
+    val sent = mutableListOf<AlertLifecycleEvent>()
+
+    override val providerType: String = PROVIDER_TYPE
+
+    override suspend fun sendAlert(event: AlertLifecycleEvent, config: ProviderConfig): Result<String> {
+        sent.add(event)
+        return Result.success("provider-incident-1")
+    }
+
+    override suspend fun resolveAlert(deduplicationKey: String, config: ProviderConfig): Result<String> =
+        Result.success(deduplicationKey)
+
+    override suspend fun testConnection(config: ProviderConfig): Result<Boolean> = Result.success(true)
+
+    companion object {
+        const val PROVIDER_TYPE = "test_recording_provider"
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteOssCompatibilityTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteOssCompatibilityTest.kt
@@ -62,6 +62,7 @@ class AlertRouteOssCompatibilityTest {
 
     @AfterEach
     fun tearDown() {
+        IncidentProviderRegistry.unregister(provider)
         AlertRouteTestDatabase.clearReference()
     }
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteTestDatabase.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/AlertRouteTestDatabase.kt
@@ -1,0 +1,201 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes
+
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteActions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditionGroups
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteConditions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteCommands
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteRevisions
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRouteTargets
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
+import com.moneat.enterprise.sso.support.EnterpriseTestDatabaseHelper
+import com.moneat.incident.models.IncidentEventLog
+import com.moneat.incident.models.IncidentProviderConfigs
+import com.moneat.incident.models.IncidentRoutingRules
+import com.moneat.monitor.repositories.ResourceOwnership
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.Memberships
+import com.moneat.shared.models.OnCallSchedules
+import com.moneat.shared.models.OrganizationTeams
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+data class SeededAlertRouteOrganization(
+    val organizationId: Int,
+    val adminUserId: Int,
+)
+
+data class SeededEscalationPolicy(
+    val id: Int,
+    val resourceId: Uuid,
+)
+
+data class SeededTeam(
+    val id: Int,
+    val resourceId: Uuid,
+    val name: String,
+)
+
+object AlertRouteTestDatabase {
+    private var database: Database? = null
+
+    fun reset() {
+        if (database == null) {
+            database = Database.connect(url = H2_URL, driver = "org.h2.Driver")
+        }
+        TransactionManager.defaultDatabase = database
+        EnterpriseTestDatabaseHelper.resetSchema(
+            Users,
+            Organizations,
+            Memberships,
+            OnCallSchedules,
+            EscalationPolicies,
+            OrganizationTeams,
+            ResourceOwnership,
+            AlertEpisodes,
+            IncidentProviderConfigs,
+            IncidentRoutingRules,
+            IncidentEventLog,
+            EnterpriseAlertRoutes,
+            EnterpriseAlertRouteConditionGroups,
+            EnterpriseAlertRouteConditions,
+            EnterpriseAlertRouteActions,
+            EnterpriseAlertRouteTargets,
+            EnterpriseAlertRouteRevisions,
+            EnterpriseAlertRouteCommands,
+        )
+    }
+
+    fun clearReference() {
+        TransactionManager.defaultDatabase = null
+    }
+
+    fun seedOrganization(slug: String = "alert-routes"): SeededAlertRouteOrganization =
+        transaction {
+            val userId =
+                Users.insert {
+                    it[email] = "$slug-admin@example.test"
+                    it[password_hash] = "x"
+                    it[name] = "Alert Route Admin"
+                }[Users.id]
+            val organizationId =
+                Organizations.insert {
+                    it[name] = "Alert Route Organization"
+                    it[Organizations.slug] = slug
+                }[Organizations.id]
+            Memberships.insert {
+                it[user_id] = userId
+                it[Memberships.organization_id] = organizationId
+                it[role] = "owner"
+            }
+            SeededAlertRouteOrganization(organizationId, userId)
+        }
+
+    fun seedUser(organizationId: Int, slug: String, role: String = "member"): Int =
+        transaction {
+            val userId =
+                Users.insert {
+                    it[email] = "$slug@example.test"
+                    it[password_hash] = "x"
+                    it[name] = "Alert Route $slug"
+                }[Users.id]
+            Memberships.insert {
+                it[user_id] = userId
+                it[Memberships.organization_id] = organizationId
+                it[Memberships.role] = role
+            }
+            userId
+        }
+
+    fun seedEscalationPolicy(organizationId: Int, name: String): SeededEscalationPolicy =
+        transaction {
+            val resource = Uuid.random()
+            val now = Clock.System.now()
+            val id =
+                EscalationPolicies.insert {
+                    it[resourceId] = resource
+                    it[EscalationPolicies.organizationId] = organizationId
+                    it[EscalationPolicies.name] = name
+                    it[repeatCount] = 1
+                    it[createdAt] = now
+                    it[updatedAt] = now
+                }[EscalationPolicies.id].value
+            SeededEscalationPolicy(id, resource)
+        }
+
+    fun seedTeam(
+        organizationId: Int,
+        name: String,
+        escalationPolicyId: Int? = null,
+    ): SeededTeam =
+        transaction {
+            val resource = Uuid.random()
+            val id =
+                OrganizationTeams.insert {
+                    it[resourceId] = resource
+                    it[OrganizationTeams.organizationId] = organizationId
+                    it[OrganizationTeams.name] = name
+                    it[slug] = name.lowercase().replace(' ', '-')
+                    it[OrganizationTeams.escalationPolicyId] = escalationPolicyId
+                }[OrganizationTeams.id].value
+            SeededTeam(id, resource, name)
+        }
+
+    fun seedOwnershipClaim(
+        organizationId: Int,
+        catalogResourceId: String,
+        teamId: Int,
+    ) {
+        transaction {
+            ResourceOwnership.insert {
+                it[organization_id] = organizationId
+                it[resource_id] = catalogResourceId
+                it[team_id] = teamId
+                it[updated_by] = "test@example.test"
+                it[updated_at] = Clock.System.now()
+            }
+        }
+    }
+
+    fun seedAlertEpisode(
+        organizationId: Int,
+        source: String,
+        deduplicationKey: String,
+        priority: String = "P1",
+    ): Uuid =
+        transaction {
+            val resource = Uuid.random()
+            val now = Clock.System.now()
+            AlertEpisodes.insert {
+                it[resourceId] = resource
+                it[AlertEpisodes.organizationId] = organizationId
+                it[sourceName] = source
+                it[AlertEpisodes.deduplicationKey] = deduplicationKey
+                it[title] = "Checkout latency"
+                it[description] = "Latency above threshold"
+                it[AlertEpisodes.priority] = priority
+                it[episodeSeq] = 1
+                it[episodeKey] = "$deduplicationKey#1"
+                it[status] = "OPEN"
+                it[openedAt] = now
+                it[lastSeenAt] = now
+                it[createdAt] = now
+                it[updatedAt] = now
+            }
+            resource
+        }
+
+    private const val H2_URL =
+        "jdbc:h2:mem:moneat_enterprise_alert_routes;MODE=PostgreSQL;" +
+            "DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1"
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluatorTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluatorTest.kt
@@ -30,6 +30,7 @@ import com.moneat.enterprise.alertroutes.models.AlertRouteTargetDefinition
 import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -391,13 +392,17 @@ class AlertRouteEvaluatorTest {
                 source = AlertSource.DASHBOARD_ALERT,
                 deduplicationKey = "moneat-dashboard-alert-42",
                 organizationId = organizationId,
-                metadata = mapOf("service" to JsonArray(listOf(JsonPrimitive("checkout")))),
+                metadata =
+                    mapOf(
+                        "environment" to JsonArray(listOf(JsonPrimitive("production"))),
+                        "service" to JsonNull,
+                    ),
                 moneatUrl = "https://moneat.example/alerts/42",
             )
 
         val routeContext = AlertRouteContextFactory.fromLifecycleEvent(event)
 
         assertTrue(routeContext.metadata.isEmpty())
-        assertEquals(listOf("service"), routeContext.droppedMetadataKeys)
+        assertEquals(listOf("environment", "service"), routeContext.droppedMetadataKeys)
     }
 }

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluatorTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/evaluation/AlertRouteEvaluatorTest.kt
@@ -1,0 +1,403 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.evaluation
+
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.enterprise.alertroutes.context.AlertRouteContext
+import com.moneat.enterprise.alertroutes.context.AlertRouteContextFactory
+import com.moneat.enterprise.alertroutes.context.AlertRouteEpisodeIdentity
+import com.moneat.enterprise.alertroutes.context.AlertRouteOwnership
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionGroupDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingWindowKind
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteOwnershipSource
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteRecoveryDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetDefinition
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonArray
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.Uuid
+
+class AlertRouteEvaluatorTest {
+    private val organizationId = 7
+    private val now = Clock.System.now()
+
+    private val baseRoute =
+        AlertRouteDefinition(
+            id = 1,
+            resourceId = Uuid.random(),
+            organizationId = organizationId,
+            key = "base",
+            name = "Base",
+            description = null,
+            enabled = true,
+            position = 0,
+            revision = 1,
+            conditionGroups = emptyList(),
+            paging = AlertRoutePagingDefinition(AlertRoutePagingMode.NONE, emptyList()),
+            grouping =
+                AlertRouteGroupingDefinition(
+                    behavior = AlertRouteGroupingBehavior.SUGGESTED,
+                    keys = emptyList(),
+                    windowKind = AlertRouteGroupingWindowKind.ROLLING,
+                    windowSeconds = 900,
+                ),
+            incident =
+                AlertRouteIncidentDefinition(
+                    create = false,
+                    mode = AlertRouteIncidentMode.TRIAGE,
+                    titleTemplate = null,
+                    summaryTemplate = null,
+                    severity = null,
+                    incidentType = null,
+                ),
+            recovery =
+                AlertRouteRecoveryDefinition(
+                    cancelEscalations = false,
+                    declineUnacceptedTriage = false,
+                    graceSeconds = 0,
+                ),
+            createdAt = now,
+            updatedAt = now,
+        )
+
+    private fun context(
+        source: String = AlertSource.DASHBOARD_ALERT.name,
+        priority: String = "P1",
+        metadata: Map<String, String> = mapOf("service" to "checkout"),
+        ownership: AlertRouteOwnership = AlertRouteOwnership(serviceName = "checkout"),
+    ): AlertRouteContext =
+        AlertRouteContext(
+            organizationId = organizationId,
+            source = source,
+            status = AlertStatus.FIRING.name,
+            priority = priority,
+            title = "Checkout latency high",
+            description = "p95 latency above 800ms",
+            deduplicationKey = "moneat-dashboard-alert-42",
+            url = "https://moneat.example/alerts/42",
+            episode = AlertRouteEpisodeIdentity(key = "moneat-dashboard-alert-42#3", sequence = 3, status = "OPEN"),
+            metadata = metadata,
+            ownership = ownership,
+        )
+
+    private fun conditionGroup(vararg conditions: AlertRouteConditionDefinition) =
+        AlertRouteConditionGroupDefinition(conditions.toList())
+
+    @Test
+    fun `first matching enabled route wins and later routes report why they were skipped`() {
+        val early =
+            baseRoute.copy(
+                id = 1,
+                resourceId = Uuid.random(),
+                key = "hosts",
+                position = 0,
+                conditionGroups =
+                    listOf(
+                        conditionGroup(
+                            AlertRouteConditionDefinition(
+                                field = AlertRouteContextField.SOURCE,
+                                operator = AlertRouteConditionOperator.EQUALS,
+                                values = listOf(AlertSource.HOST_ALERT.name),
+                            ),
+                        ),
+                    ),
+            )
+        val middle =
+            baseRoute.copy(
+                id = 2,
+                resourceId = Uuid.random(),
+                key = "dashboards",
+                position = 1,
+                conditionGroups =
+                    listOf(
+                        conditionGroup(
+                            AlertRouteConditionDefinition(
+                                field = AlertRouteContextField.SOURCE,
+                                operator = AlertRouteConditionOperator.EQUALS,
+                                values = listOf(AlertSource.DASHBOARD_ALERT.name),
+                            ),
+                        ),
+                    ),
+            )
+        val catchAll = baseRoute.copy(id = 3, resourceId = Uuid.random(), key = "catch-all", position = 2)
+
+        val result = AlertRouteEvaluator().evaluate(listOf(catchAll, middle, early), context())
+
+        assertEquals(middle.resourceId, result.decision?.routeId)
+        assertEquals(
+            listOf(
+                AlertRouteEvaluationReason.NO_GROUP_MATCHED,
+                AlertRouteEvaluationReason.SELECTED,
+                AlertRouteEvaluationReason.EARLIER_ROUTE_SELECTED,
+            ),
+            result.evaluations.map { it.reason },
+        )
+    }
+
+    @Test
+    fun `condition groups are ORed while conditions inside one group are ANDed`() {
+        val route =
+            baseRoute.copy(
+                conditionGroups =
+                    listOf(
+                        conditionGroup(
+                            AlertRouteConditionDefinition(
+                                field = AlertRouteContextField.SOURCE,
+                                operator = AlertRouteConditionOperator.EQUALS,
+                                values = listOf(AlertSource.HOST_ALERT.name),
+                            ),
+                            AlertRouteConditionDefinition(
+                                field = AlertRouteContextField.PRIORITY,
+                                operator = AlertRouteConditionOperator.AT_LEAST_AS_SEVERE_AS,
+                                values = listOf("P2"),
+                            ),
+                        ),
+                        conditionGroup(
+                            AlertRouteConditionDefinition(
+                                field = AlertRouteContextField.METADATA,
+                                operator = AlertRouteConditionOperator.EQUALS,
+                                values = listOf("checkout"),
+                                metadataKey = "service",
+                            ),
+                        ),
+                    ),
+            )
+
+        val result = AlertRouteEvaluator().evaluate(listOf(route), context())
+        val evaluation = result.evaluations.single()
+
+        assertTrue(evaluation.matched)
+        assertFalse(evaluation.groups[0].matched)
+        assertTrue(evaluation.groups[1].matched)
+        assertFalse(evaluation.groups[0].conditions[0].matched)
+        assertTrue(evaluation.groups[0].conditions[1].matched)
+    }
+
+    @Test
+    fun `disabled routes are explained but never selected`() {
+        val disabled =
+            baseRoute.copy(resourceId = Uuid.random(), key = "disabled", enabled = false, position = 0)
+
+        val result = AlertRouteEvaluator().evaluate(listOf(disabled), context())
+
+        assertNull(result.decision)
+        assertEquals(AlertRouteEvaluationReason.ROUTE_DISABLED, result.evaluations.single().reason)
+    }
+
+    @Test
+    fun `a matching disabled route does not prevent a later enabled route from winning`() {
+        val disabled =
+            baseRoute.copy(resourceId = Uuid.random(), key = "disabled", enabled = false, position = 0)
+        val enabled =
+            baseRoute.copy(resourceId = Uuid.random(), key = "enabled", enabled = true, position = 1)
+
+        val result = AlertRouteEvaluator().evaluate(listOf(disabled, enabled), context())
+
+        assertEquals(enabled.resourceId, result.decision?.routeId)
+        assertEquals(
+            listOf(AlertRouteEvaluationReason.ROUTE_DISABLED, AlertRouteEvaluationReason.SELECTED),
+            result.evaluations.map { it.reason },
+        )
+    }
+
+    @Test
+    fun `suggested grouping is the default and automatic grouping needs an explicit opt in`() {
+        val suggested = baseRoute.copy(resourceId = Uuid.random(), key = "suggested", position = 0)
+        val automatic =
+            baseRoute.copy(
+                resourceId = Uuid.random(),
+                key = "automatic",
+                position = 0,
+                grouping = baseRoute.grouping.copy(behavior = AlertRouteGroupingBehavior.AUTOMATIC),
+            )
+
+        val suggestedResult = AlertRouteEvaluator().evaluate(listOf(suggested), context())
+        val automaticResult = AlertRouteEvaluator().evaluate(listOf(automatic), context())
+
+        val suggestedGrouping = suggestedResult.decision!!.grouping
+        assertFalse(suggestedGrouping.automatic)
+        assertEquals(AlertRouteGroupingBehavior.SUGGESTED, suggestedGrouping.behavior)
+        assertTrue(automaticResult.decision!!.grouping.automatic)
+    }
+
+    @Test
+    fun `grouping keys build a stable group key and fixed windows differ from rolling windows`() {
+        val route =
+            baseRoute.copy(
+                key = "checkout",
+                grouping =
+                    baseRoute.grouping.copy(
+                        keys = listOf("ownership.service", "alert.source", "metadata.environment"),
+                        windowKind = AlertRouteGroupingWindowKind.FIXED,
+                        windowSeconds = 600,
+                    ),
+            )
+
+        val result =
+            AlertRouteEvaluator()
+                .evaluate(listOf(route), context(metadata = mapOf("service" to "checkout")))
+        val grouping = result.decision!!.grouping
+
+        assertEquals("checkout|checkout|DASHBOARD_ALERT|", grouping.groupKey)
+        assertEquals(listOf("metadata.environment"), grouping.unresolvedKeys)
+        assertEquals(now + 10.minutes, grouping.windowClosesAt(groupStartedAt = now, lastAlertAt = now + 5.minutes))
+
+        val rolling = grouping.copy(windowKind = AlertRouteGroupingWindowKind.ROLLING)
+        assertEquals(now + 15.minutes, rolling.windowClosesAt(groupStartedAt = now, lastAlertAt = now + 5.minutes))
+    }
+
+    @Test
+    fun `one route resolves multiple static and ownership derived escalation targets`() {
+        val staticPolicyResource = Uuid.random()
+        val teamResource = Uuid.random()
+        val teamPolicyResource = Uuid.random()
+        val ownershipPolicyResource = Uuid.random()
+        val route =
+            baseRoute.copy(
+                paging =
+                    AlertRoutePagingDefinition(
+                        mode = AlertRoutePagingMode.EVERY_EPISODE,
+                        targets =
+                            listOf(
+                                AlertRouteTargetDefinition(
+                                    kind = AlertRouteTargetKind.ESCALATION_POLICY,
+                                    escalationPolicyId = 11,
+                                    escalationPolicyResourceId = staticPolicyResource,
+                                ),
+                                AlertRouteTargetDefinition(
+                                    kind = AlertRouteTargetKind.TEAM,
+                                    teamId = 5,
+                                    teamResourceId = teamResource,
+                                ),
+                                AlertRouteTargetDefinition(
+                                    kind = AlertRouteTargetKind.OWNERSHIP_DERIVED,
+                                    ownershipSource = AlertRouteOwnershipSource.CATALOG,
+                                ),
+                                AlertRouteTargetDefinition(
+                                    kind = AlertRouteTargetKind.OWNERSHIP_DERIVED,
+                                    ownershipSource = AlertRouteOwnershipSource.TEAM,
+                                ),
+                            ),
+                    ),
+            )
+        val evaluator =
+            AlertRouteEvaluator { _, teamId ->
+                AlertRouteEscalationPolicyRef(teamId + 100, teamPolicyResource)
+            }
+
+        val result =
+            evaluator.evaluate(
+                listOf(route),
+                context(
+                    ownership =
+                        AlertRouteOwnership(
+                            serviceName = "checkout",
+                            catalogResourceId = "service:7:checkout",
+                            escalationPolicyId = 42,
+                            escalationPolicyResourceId = ownershipPolicyResource,
+                        ),
+                ),
+            )
+        val paging = result.decision!!.paging
+
+        assertEquals(listOf(11, 105, 42), paging.escalationPolicies.map { it.id })
+        assertEquals(
+            listOf(staticPolicyResource, teamPolicyResource, ownershipPolicyResource),
+            paging.escalationPolicies.mapNotNull { it.resourceId },
+        )
+        assertEquals(listOf("OWNERSHIP_DERIVED:TEAM"), paging.unresolvedTargets)
+    }
+
+    @Test
+    fun `incident templates render from the normalized context and report unresolved references`() {
+        val route =
+            baseRoute.copy(
+                incident =
+                    baseRoute.incident.copy(
+                        create = true,
+                        mode = AlertRouteIncidentMode.ACTIVE,
+                        titleTemplate = "{{ ownership.service }}: {{ alert.title }}",
+                        summaryTemplate = "Episode {{ episode.key }} owner {{ ownership.team }}",
+                        severity = "SEV-2",
+                    ),
+            )
+
+        val incident = AlertRouteEvaluator().evaluate(listOf(route), context()).decision!!.incident
+
+        assertEquals("checkout: Checkout latency high", incident.title)
+        assertEquals("Episode moneat-dashboard-alert-42#3 owner", incident.summary)
+        assertEquals(listOf("ownership.team"), incident.unresolvedReferences)
+        assertTrue(incident.create)
+        assertEquals(AlertRouteIncidentMode.ACTIVE, incident.mode)
+    }
+
+    @Test
+    fun `unapproved metadata never reaches conditions or templates`() {
+        val event =
+            AlertLifecycleEvent(
+                title = "Checkout latency high",
+                description = "p95 latency above 800ms",
+                priority = AlertPriority.P1,
+                status = AlertStatus.FIRING,
+                source = AlertSource.DASHBOARD_ALERT,
+                deduplicationKey = "moneat-dashboard-alert-42",
+                organizationId = organizationId,
+                metadata =
+                    mapOf(
+                        "service" to JsonPrimitive("checkout"),
+                        "internal_secret" to JsonPrimitive("do-not-route"),
+                    ),
+                moneatUrl = "https://moneat.example/alerts/42",
+            )
+
+        val routeContext = AlertRouteContextFactory.fromLifecycleEvent(event)
+
+        assertEquals(mapOf("service" to "checkout"), routeContext.metadata)
+        assertEquals(listOf("internal_secret"), routeContext.droppedMetadataKeys)
+        assertEquals("checkout", routeContext.ownership.serviceName)
+        assertNull(routeContext.reference("metadata.internal_secret"))
+    }
+
+    @Test
+    fun `approved metadata with a non scalar value is reported as dropped`() {
+        val event =
+            AlertLifecycleEvent(
+                title = "Checkout latency high",
+                description = "p95 latency above 800ms",
+                priority = AlertPriority.P1,
+                status = AlertStatus.FIRING,
+                source = AlertSource.DASHBOARD_ALERT,
+                deduplicationKey = "moneat-dashboard-alert-42",
+                organizationId = organizationId,
+                metadata = mapOf("service" to JsonArray(listOf(JsonPrimitive("checkout")))),
+                moneatUrl = "https://moneat.example/alerts/42",
+            )
+
+        val routeContext = AlertRouteContextFactory.fromLifecycleEvent(event)
+
+        assertTrue(routeContext.metadata.isEmpty())
+        assertEquals(listOf("service"), routeContext.droppedMetadataKeys)
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteRoutesTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/routes/AlertRouteRoutesTest.kt
@@ -1,0 +1,323 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.routes
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.moneat.enterprise.alertroutes.AlertRouteTestDatabase
+import com.moneat.enterprise.alertroutes.SeededAlertRouteOrganization
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
+import com.moneat.enterprise.alertroutes.services.AlertRouteCommandService
+import com.moneat.enterprise.alertroutes.services.AlertRouteEvaluationService
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.jwt.JWTPrincipal
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+private const val JWT_SECRET = "alert-route-route-test-secret"
+private const val ISSUER = "moneat"
+private const val AUDIENCE = "moneat-dashboard"
+private const val IDEMPOTENCY_HEADER = "Idempotency-Key"
+
+private val CREATE_BODY =
+    """
+    {
+      "key": "dashboard-alerts",
+      "name": "Dashboard alerts",
+      "conditionGroups": [
+        {"conditions": [{"field": "source", "operator": "EQUALS", "values": ["DASHBOARD_ALERT"]}]}
+      ],
+      "grouping": {"behavior": "AUTOMATIC", "keys": ["alert.deduplication_key"], "windowSeconds": 600},
+      "incident": {"create": true, "mode": "ACTIVE", "titleTemplate": "{{ alert.title }}", "severity": "SEV-2"},
+      "recovery": {"cancelEscalations": true, "declineUnacceptedTriage": true, "graceSeconds": 120}
+    }
+    """.trimIndent()
+
+class AlertRouteRoutesTest {
+    private lateinit var organization: SeededAlertRouteOrganization
+
+    @BeforeEach
+    fun setUp() {
+        AlertRouteTestDatabase.reset()
+        organization = AlertRouteTestDatabase.seedOrganization("alert-route-routes")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        AlertRouteTestDatabase.clearReference()
+    }
+
+    @Test
+    fun `administrators create routes idempotently and read them back`() = testApplication {
+        application { installAlertRoutes() }
+
+        val created = createRoute("create-1")
+        assertEquals(HttpStatusCode.Created, created.status)
+        val body = created.jsonObject()
+        assertEquals("dashboard-alerts", body.string("key"))
+        assertEquals(1, body["revision"]!!.jsonPrimitive.int)
+        assertEquals("AUTOMATIC", body["grouping"]!!.jsonObject.string("behavior"))
+        Uuid.parse(body.string("id"))
+
+        val replay = createRoute("create-1")
+        assertEquals(HttpStatusCode.OK, replay.status)
+        assertEquals(body.string("id"), replay.jsonObject().string("id"))
+
+        val listed = client.get("/v1/on-call/alert-routes") { authorize() }
+        assertEquals(HttpStatusCode.OK, listed.status)
+        assertEquals(1, listed.jsonArray().size)
+    }
+
+    @Test
+    fun `route ids must be uuids and unknown routes are not found`() = testApplication {
+        application { installAlertRoutes() }
+
+        val numeric = client.get("/v1/on-call/alert-routes/17") { authorize() }
+        assertEquals(HttpStatusCode.BadRequest, numeric.status)
+
+        val unknown = client.get("/v1/on-call/alert-routes/${Uuid.random()}") { authorize() }
+        assertEquals(HttpStatusCode.NotFound, unknown.status)
+    }
+
+    @Test
+    fun `updates with a stale expected revision are rejected with conflict`() = testApplication {
+        application { installAlertRoutes() }
+        val routeId = createRoute("create-1").jsonObject().string("id")
+
+        val first = updateRoute(routeId, expectedRevision = 1, idempotencyKey = "update-1")
+        assertEquals(HttpStatusCode.OK, first.status)
+        assertEquals(2, first.jsonObject()["revision"]!!.jsonPrimitive.int)
+
+        val stale = updateRoute(routeId, expectedRevision = 1, idempotencyKey = "update-2")
+        assertEquals(HttpStatusCode.Conflict, stale.status)
+
+        val revisions = client.get("/v1/on-call/alert-routes/$routeId/revisions") { authorize() }
+        assertEquals(HttpStatusCode.OK, revisions.status)
+        val revisionBody = revisions.jsonArray()
+        assertEquals(listOf("UPDATED", "CREATED"), revisionBody.map { it.jsonObject.string("changeType") })
+        assertEquals(
+            routeId,
+            revisionBody.first().jsonObject["snapshot"]!!.jsonObject["route"]!!.jsonObject.string("id"),
+        )
+        assertTrue("actorUserId" !in revisionBody.first().jsonObject["snapshot"]!!.jsonObject)
+    }
+
+    @Test
+    fun `update and delete require an expected revision`() = testApplication {
+        application { installAlertRoutes() }
+        val routeId = createRoute("create-1").jsonObject().string("id")
+
+        val update =
+            client.put("/v1/on-call/alert-routes/$routeId") {
+                authorize()
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                header(IDEMPOTENCY_HEADER, "update-without-revision")
+                setBody(CREATE_BODY)
+            }
+        assertEquals(HttpStatusCode.BadRequest, update.status)
+
+        val delete =
+            client.delete("/v1/on-call/alert-routes/$routeId") {
+                authorize()
+                header(IDEMPOTENCY_HEADER, "delete-without-revision")
+            }
+        assertEquals(HttpStatusCode.BadRequest, delete.status)
+    }
+
+    @Test
+    fun `over length incident types are rejected as bad requests`() = testApplication {
+        application { installAlertRoutes() }
+        val response =
+            client.post("/v1/on-call/alert-routes") {
+                authorize()
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                header(IDEMPOTENCY_HEADER, "long-incident-type")
+                setBody(
+                    """
+                    {
+                      "key": "long-incident-type",
+                      "name": "Long incident type",
+                      "incident": {"create": true, "incidentType": "${"x".repeat(121)}"}
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `preview explains match and non-match for a supplied sample`() = testApplication {
+        application { installAlertRoutes() }
+        createRoute("create-1")
+
+        val matched =
+            client.post("/v1/on-call/alert-routes/preview") {
+                authorize()
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                setBody("""{"sample": {"source": "DASHBOARD_ALERT", "title": "Checkout latency"}}""")
+            }
+        assertEquals(HttpStatusCode.OK, matched.status)
+        val matchedBody = matched.jsonObject()
+        assertEquals("SELECTED", matchedBody["evaluations"]!!.jsonArray.single().jsonObject.string("reason"))
+        assertEquals("Checkout latency", matchedBody["decision"]!!.jsonObject["incident"]!!.jsonObject.string("title"))
+
+        val unmatched =
+            client.post("/v1/on-call/alert-routes/preview") {
+                authorize()
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                setBody("""{"sample": {"source": "HOST_ALERT"}}""")
+            }
+        assertEquals(HttpStatusCode.OK, unmatched.status)
+        val unmatchedBody = unmatched.jsonObject()
+        assertTrue(unmatchedBody["decision"] == null || unmatchedBody["decision"].toString() == "null")
+        assertEquals(
+            "NO_GROUP_MATCHED",
+            unmatchedBody["evaluations"]!!.jsonArray.single().jsonObject.string("reason"),
+        )
+
+        val invalid =
+            client.post("/v1/on-call/alert-routes/preview") {
+                authorize()
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                setBody("""{}""")
+            }
+        assertEquals(HttpStatusCode.BadRequest, invalid.status)
+    }
+
+    @Test
+    fun `non administrators cannot create routes but may read them`() = testApplication {
+        application { installAlertRoutes() }
+        createRoute("create-1")
+        val memberUserId = AlertRouteTestDatabase.seedUser(organization.organizationId, "member")
+
+        val forbidden =
+            client.post("/v1/on-call/alert-routes") {
+                authorize(memberUserId)
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                setBody(CREATE_BODY)
+            }
+        assertEquals(HttpStatusCode.Forbidden, forbidden.status)
+
+        val readable = client.get("/v1/on-call/alert-routes") { authorize(memberUserId) }
+        assertEquals(HttpStatusCode.OK, readable.status)
+    }
+
+    @Test
+    fun `rollout gated organizations are refused`() = testApplication {
+        application { installAlertRoutes(AlertRoutePolicy.denyForTests()) }
+
+        val listed = client.get("/v1/on-call/alert-routes") { authorize() }
+        assertEquals(HttpStatusCode.Forbidden, listed.status)
+
+        val created = createRoute("create-1")
+        assertEquals(HttpStatusCode.Forbidden, created.status)
+    }
+
+    private suspend fun ApplicationTestBuilder.createRoute(idempotencyKey: String): HttpResponse =
+        client.post("/v1/on-call/alert-routes") {
+            authorize()
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            header(IDEMPOTENCY_HEADER, idempotencyKey)
+            setBody(CREATE_BODY)
+        }
+
+    private suspend fun ApplicationTestBuilder.updateRoute(
+        routeId: String,
+        expectedRevision: Int,
+        idempotencyKey: String,
+    ): HttpResponse =
+        client.put("/v1/on-call/alert-routes/$routeId") {
+            authorize()
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+            header(IDEMPOTENCY_HEADER, idempotencyKey)
+            setBody(
+                """
+                {
+                  "key": "dashboard-alerts",
+                  "name": "Dashboard alerts $idempotencyKey",
+                  "expectedRevision": $expectedRevision,
+                  "conditionGroups": [
+                    {"conditions": [{"field": "source", "operator": "EQUALS", "values": ["DASHBOARD_ALERT"]}]}
+                  ]
+                }
+                """.trimIndent(),
+            )
+        }
+
+    private fun Application.installAlertRoutes(policy: AlertRoutePolicy = AlertRoutePolicy.allowForTests()) {
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        install(Authentication) {
+            jwt("auth-jwt") {
+                verifier(
+                    JWT
+                        .require(Algorithm.HMAC256(JWT_SECRET))
+                        .withIssuer(ISSUER)
+                        .withAudience(AUDIENCE)
+                        .build(),
+                )
+                validate { JWTPrincipal(it.payload) }
+            }
+        }
+        routing {
+            alertRouteRoutes(
+                commandService = AlertRouteCommandService(policy = policy),
+                evaluationService = AlertRouteEvaluationService(policy = policy),
+            )
+        }
+    }
+
+    private fun HttpRequestBuilder.authorize(userId: Int = organization.adminUserId) {
+        bearerAuth(
+            JWT
+                .create()
+                .withIssuer(ISSUER)
+                .withAudience(AUDIENCE)
+                .withClaim("userId", userId)
+                .withClaim("orgId", organization.organizationId)
+                .sign(Algorithm.HMAC256(JWT_SECRET)),
+        )
+    }
+
+    private fun JsonObject.string(name: String): String = checkNotNull(this[name]).jsonPrimitive.content
+
+    private suspend fun HttpResponse.jsonObject(): JsonObject =
+        Json.parseToJsonElement(bodyAsText()).jsonObject
+
+    private suspend fun HttpResponse.jsonArray(): JsonArray =
+        Json.parseToJsonElement(bodyAsText()).jsonArray
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandServiceTest.kt
@@ -566,6 +566,29 @@ class AlertRouteCommandServiceTest {
         assertFailsWith<IllegalArgumentException> {
             service.execute(
                 CreateAlertRouteCommand(
+                    commandKey = "bad-priority-list",
+                    actor = admin(),
+                    specification =
+                        specification().copy(
+                            conditionGroups =
+                                listOf(
+                                    AlertRouteConditionGroupInput(
+                                        listOf(
+                                            AlertRouteConditionInput(
+                                                field = AlertRouteContextField.PRIORITY,
+                                                operator = AlertRouteConditionOperator.AT_LEAST_AS_SEVERE_AS,
+                                                values = listOf("P1", "not-a-priority"),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                        ),
+                ),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                CreateAlertRouteCommand(
                     commandKey = "bad-incident",
                     actor = admin(),
                     specification =

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandServiceTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRouteCommandServiceTest.kt
@@ -1,0 +1,610 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.alertroutes.AlertRouteTestDatabase
+import com.moneat.enterprise.alertroutes.SeededAlertRouteOrganization
+import com.moneat.enterprise.alertroutes.commands.AlertRouteActor
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionGroupInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteGroupingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteIncidentInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePagingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
+import com.moneat.enterprise.alertroutes.commands.AlertRouteQuotaAdmission
+import com.moneat.enterprise.alertroutes.commands.AlertRouteRecoveryInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteOrderEntry
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.AlertRouteTargetInput
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.DeleteAlertRouteCommand
+import com.moneat.enterprise.alertroutes.commands.ReorderAlertRoutesCommand
+import com.moneat.enterprise.alertroutes.commands.UpdateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.models.AlertRouteChangeType
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteGroupingBehavior
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import com.moneat.enterprise.alertroutes.models.EnterpriseAlertRoutes
+import com.moneat.enterprise.NativeIncidentQuotaDecision
+import com.moneat.enterprise.NativeIncidentQuotaKey
+import com.moneat.enterprise.NativeIncidentQuotaStatus
+import com.moneat.enterprise.incidents.commands.IncidentCommandConflictException
+import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
+import com.moneat.enterprise.incidents.commands.IncidentCommandQuotaExceededException
+import com.moneat.enterprise.incidents.commands.IncidentEntitlement
+import com.moneat.shared.models.EscalationPolicies
+import com.moneat.shared.models.OrganizationTeams
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+
+class AlertRouteCommandServiceTest {
+    private lateinit var organization: SeededAlertRouteOrganization
+    private lateinit var service: AlertRouteCommandService
+
+    @BeforeEach
+    fun setUp() {
+        AlertRouteTestDatabase.reset()
+        organization = AlertRouteTestDatabase.seedOrganization()
+        service = AlertRouteCommandService(policy = AlertRoutePolicy.allowForTests())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        AlertRouteTestDatabase.clearReference()
+    }
+
+    private fun admin(): AlertRouteActor =
+        AlertRouteActor(organization.organizationId, organization.adminUserId, "TEST")
+
+    private fun specification(
+        key: String = "checkout-paging",
+        name: String = "Checkout paging",
+        enabled: Boolean = true,
+    ): AlertRouteSpecification =
+        AlertRouteSpecification(
+            key = key,
+            name = name,
+            enabled = enabled,
+            conditionGroups =
+                listOf(
+                    AlertRouteConditionGroupInput(
+                        listOf(
+                            AlertRouteConditionInput(
+                                field = AlertRouteContextField.METADATA,
+                                operator = AlertRouteConditionOperator.EQUALS,
+                                values = listOf("checkout"),
+                                metadataKey = "service",
+                            ),
+                        ),
+                    ),
+                ),
+            grouping =
+                AlertRouteGroupingInput(
+                    behavior = AlertRouteGroupingBehavior.AUTOMATIC,
+                    keys = listOf("ownership.service"),
+                ),
+            incident =
+                AlertRouteIncidentInput(
+                    create = true,
+                    mode = AlertRouteIncidentMode.ACTIVE,
+                    titleTemplate = "{{ alert.title }}",
+                    severity = "SEV-2",
+                ),
+        )
+
+    private fun create(
+        key: String = "checkout-paging",
+        commandKey: String = "create-$key",
+    ) = service.execute(
+        CreateAlertRouteCommand(
+            commandKey = commandKey,
+            actor = admin(),
+            specification = specification(key = key, name = key),
+        ),
+    )
+
+    @Test
+    fun `create persists the full specification and records the first audited revision`() {
+        val policy = AlertRouteTestDatabase.seedEscalationPolicy(organization.organizationId, "Payments")
+        val result =
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "create-checkout",
+                    actor = admin(),
+                    specification =
+                        specification().copy(
+                            paging =
+                                AlertRoutePagingInput(
+                                    mode = AlertRoutePagingMode.EVERY_EPISODE,
+                                    targets =
+                                        listOf(
+                                            AlertRouteTargetInput(
+                                                kind = AlertRouteTargetKind.ESCALATION_POLICY,
+                                                escalationPolicyId = policy.resourceId,
+                                            ),
+                                        ),
+                                ),
+                            recovery =
+                                AlertRouteRecoveryInput(
+                                    cancelEscalations = true,
+                                    declineUnacceptedTriage = false,
+                                    graceSeconds = 120,
+                                ),
+                        ),
+                ),
+            )
+
+        val route = result.route!!
+        assertFalse(result.replayed)
+        assertEquals(1, route.revision)
+        assertEquals(0, route.position)
+        assertEquals(AlertRouteGroupingBehavior.AUTOMATIC, route.grouping.behavior)
+        assertEquals(AlertRoutePagingMode.EVERY_EPISODE, route.paging.mode)
+        assertTrue(route.recovery.cancelEscalations)
+        assertFalse(route.recovery.declineUnacceptedTriage)
+        assertEquals(120, route.recovery.graceSeconds)
+        assertEquals(policy.id, route.paging.targets.single().escalationPolicyId)
+        assertEquals(policy.resourceId, route.paging.targets.single().escalationPolicyResourceId)
+        assertEquals("service", route.conditionGroups.single().conditions.single().metadataKey)
+
+        val revisions = service.revisions(organization.organizationId, route.resourceId)
+        assertEquals(listOf(AlertRouteChangeType.CREATED), revisions.map { it.changeType })
+        assertEquals("create-checkout", revisions.single().commandKey)
+    }
+
+    @Test
+    fun `repeating a command key replays the same route and a different payload conflicts`() {
+        val first = create(commandKey = "idempotent-create")
+        val replay = create(commandKey = "idempotent-create")
+
+        assertTrue(replay.replayed)
+        assertEquals(first.route!!.resourceId, replay.route!!.resourceId)
+        assertEquals(1, service.list(organization.organizationId).size)
+
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "idempotent-create",
+                    actor = admin(),
+                    specification = specification(key = "other-key", name = "Other"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `command keys are organization global across different route mutations`() {
+        val first = create(key = "route-a", commandKey = "create-a").route!!
+        val second = create(key = "route-b", commandKey = "create-b").route!!
+
+        service.execute(
+            UpdateAlertRouteCommand(
+                commandKey = "global-update",
+                actor = admin(),
+                routeId = first.resourceId,
+                expectedRevision = first.revision,
+                specification = specification(key = first.key, name = "Updated A"),
+            ),
+        )
+
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                UpdateAlertRouteCommand(
+                    commandKey = "global-update",
+                    actor = admin(),
+                    routeId = second.resourceId,
+                    expectedRevision = second.revision,
+                    specification = specification(key = second.key, name = "Updated B"),
+                ),
+            )
+        }
+        assertEquals("route-b", service.get(organization.organizationId, second.resourceId).name)
+    }
+
+    @Test
+    fun `duplicate route keys are rejected as conflicts`() {
+        create(key = "checkout-paging", commandKey = "first")
+
+        assertFailsWith<IncidentCommandConflictException> {
+            create(key = "checkout-paging", commandKey = "second")
+        }
+    }
+
+    @Test
+    fun `update bumps the revision and rejects stale expected revisions`() {
+        val route = create().route!!
+
+        val updated =
+            service.execute(
+                UpdateAlertRouteCommand(
+                    commandKey = "update-1",
+                    actor = admin(),
+                    routeId = route.resourceId,
+                    expectedRevision = route.revision,
+                    specification = specification(name = "Checkout paging v2").copy(enabled = false),
+                ),
+            ).route!!
+
+        assertEquals(2, updated.revision)
+        assertFalse(updated.enabled)
+
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                UpdateAlertRouteCommand(
+                    commandKey = "update-2",
+                    actor = admin(),
+                    routeId = route.resourceId,
+                    expectedRevision = route.revision,
+                    specification = specification(name = "Checkout paging v3"),
+                ),
+            )
+        }
+
+        assertEquals(
+            listOf(AlertRouteChangeType.UPDATED, AlertRouteChangeType.CREATED),
+            service.revisions(organization.organizationId, route.resourceId).map { it.changeType },
+        )
+    }
+
+    @Test
+    fun `reorder rewrites positions once and replays when the order already matches`() {
+        val first = create(key = "route-a", commandKey = "create-a").route!!
+        val second = create(key = "route-b", commandKey = "create-b").route!!
+
+        val reordered =
+            service.execute(
+                ReorderAlertRoutesCommand(
+                    commandKey = "reorder-1",
+                    actor = admin(),
+                    orderedRoutes =
+                        listOf(
+                            AlertRouteOrderEntry(second.resourceId, second.revision),
+                            AlertRouteOrderEntry(first.resourceId, first.revision),
+                        ),
+                ),
+            )
+
+        assertFalse(reordered.replayed)
+        assertEquals(listOf(second.resourceId, first.resourceId), reordered.routes.map { it.resourceId })
+        assertEquals(listOf(0, 1), reordered.routes.map { it.position })
+        assertEquals(listOf(2, 2), reordered.routes.map { it.revision })
+
+        val replay =
+            service.execute(
+                ReorderAlertRoutesCommand(
+                    commandKey = "reorder-1",
+                    actor = admin(),
+                    orderedRoutes =
+                        listOf(
+                            AlertRouteOrderEntry(second.resourceId, second.revision),
+                            AlertRouteOrderEntry(first.resourceId, first.revision),
+                        ),
+                ),
+            )
+        assertTrue(replay.replayed)
+        assertEquals(listOf(2, 2), service.list(organization.organizationId).map { it.revision })
+
+        val appended = create(key = "route-c", commandKey = "create-c").route!!
+        assertEquals(2, appended.position)
+    }
+
+    @Test
+    fun `delete and reorder reject stale revisions without partial mutations`() {
+        val first = create(key = "route-a", commandKey = "create-a").route!!
+        val second = create(key = "route-b", commandKey = "create-b").route!!
+        val updated =
+            service.execute(
+                UpdateAlertRouteCommand(
+                    commandKey = "update-a",
+                    actor = admin(),
+                    routeId = first.resourceId,
+                    expectedRevision = first.revision,
+                    specification = specification(key = first.key, name = "Updated A"),
+                ),
+            ).route!!
+
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                DeleteAlertRouteCommand(
+                    commandKey = "stale-delete",
+                    actor = admin(),
+                    routeId = first.resourceId,
+                    expectedRevision = first.revision,
+                ),
+            )
+        }
+        assertFailsWith<IncidentCommandConflictException> {
+            service.execute(
+                ReorderAlertRoutesCommand(
+                    commandKey = "stale-reorder",
+                    actor = admin(),
+                    orderedRoutes =
+                        listOf(
+                            AlertRouteOrderEntry(second.resourceId, second.revision),
+                            AlertRouteOrderEntry(first.resourceId, first.revision),
+                        ),
+                ),
+            )
+        }
+        assertEquals(
+            listOf(first.resourceId, second.resourceId),
+            service.list(organization.organizationId).map { it.resourceId },
+        )
+        assertEquals(updated.revision, service.get(organization.organizationId, first.resourceId).revision)
+    }
+
+    @Test
+    fun `delete removes the route while the audit history survives`() {
+        val route = create().route!!
+
+        service.execute(
+            DeleteAlertRouteCommand(
+                commandKey = "delete-1",
+                actor = admin(),
+                routeId = route.resourceId,
+                expectedRevision = route.revision,
+            ),
+        )
+
+        assertTrue(service.list(organization.organizationId).isEmpty())
+        assertEquals(
+            listOf(AlertRouteChangeType.DELETED, AlertRouteChangeType.CREATED),
+            service.revisions(organization.organizationId, route.resourceId).map { it.changeType },
+        )
+        val deletedSnapshot = service.revisions(organization.organizationId, route.resourceId).first().snapshot
+        assertEquals(
+            route.resourceId.toString(),
+            deletedSnapshot.getValue("route").jsonObject.getValue("id").jsonPrimitive.content,
+        )
+        assertFailsWith<IncidentCommandNotFoundException> {
+            service.get(organization.organizationId, route.resourceId)
+        }
+    }
+
+    @Test
+    fun `enabled route quota denial rolls back the attempted mutation`() {
+        val quotaPolicy =
+            AlertRoutePolicy(
+                entitlement = IncidentEntitlement { true },
+                quotaAdmission = AlertRouteQuotaAdmission { _, count, _ ->
+                    NativeIncidentQuotaDecision(
+                        allowed = count <= 1,
+                        status = NativeIncidentQuotaStatus(NativeIncidentQuotaKey.ENABLED_ALERT_ROUTES, 1, count),
+                    )
+                },
+            )
+        service = AlertRouteCommandService(policy = quotaPolicy)
+        create(key = "route-a", commandKey = "create-a")
+
+        assertFailsWith<IncidentCommandQuotaExceededException> {
+            create(key = "route-b", commandKey = "create-b")
+        }
+        assertEquals(listOf("route-a"), service.list(organization.organizationId).map { it.key })
+        assertEquals(1, transaction { EnterpriseAlertRoutes.selectAll().count() })
+    }
+
+    @Test
+    fun `referenced teams and escalation policies cannot be deleted silently`() {
+        val policy = AlertRouteTestDatabase.seedEscalationPolicy(organization.organizationId, "Payments")
+        val team = AlertRouteTestDatabase.seedTeam(organization.organizationId, "Payments Team")
+        val route =
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "create-referenced",
+                    actor = admin(),
+                    specification =
+                        specification(key = "referenced", name = "Referenced").copy(
+                            paging =
+                                AlertRoutePagingInput(
+                                    mode = AlertRoutePagingMode.EVERY_EPISODE,
+                                    targets =
+                                        listOf(
+                                            AlertRouteTargetInput(
+                                                kind = AlertRouteTargetKind.ESCALATION_POLICY,
+                                                escalationPolicyId = policy.resourceId,
+                                            ),
+                                            AlertRouteTargetInput(
+                                                kind = AlertRouteTargetKind.TEAM,
+                                                teamId = team.resourceId,
+                                            ),
+                                        ),
+                                ),
+                        ),
+                ),
+            ).route!!
+
+        assertFailsWith<ExposedSQLException> {
+            transaction { OrganizationTeams.deleteWhere { OrganizationTeams.id eq team.id } }
+        }
+        assertFailsWith<ExposedSQLException> {
+            transaction { EscalationPolicies.deleteWhere { EscalationPolicies.id eq policy.id } }
+        }
+        assertEquals(route.revision, service.get(organization.organizationId, route.resourceId).revision)
+        assertEquals(2, service.get(organization.organizationId, route.resourceId).paging.targets.size)
+    }
+
+    @Test
+    fun `concurrent creates serialize into unique appended positions`() {
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val results =
+                executor.invokeAll(
+                    listOf(
+                        Callable { create(key = "route-a", commandKey = "concurrent-a") },
+                        Callable { create(key = "route-b", commandKey = "concurrent-b") },
+                    ),
+                ).map { it.get() }
+
+            assertEquals(2, results.size)
+            assertEquals(listOf(0, 1), service.list(organization.organizationId).map { it.position })
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `concurrent retries with one command key create exactly one route`() {
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val results =
+                executor.invokeAll(
+                    listOf(
+                        Callable { create(key = "route-a", commandKey = "same-command") },
+                        Callable { create(key = "route-a", commandKey = "same-command") },
+                    ),
+                ).map { it.get() }
+
+            assertEquals(listOf(false, true), results.map { it.replayed }.sorted())
+            assertEquals(1, service.list(organization.organizationId).size)
+            assertEquals(1, service.revisions(organization.organizationId, results.first().route!!.resourceId).size)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `unknown routes are not found and other organizations cannot read them`() {
+        val route = create().route!!
+        val otherOrganization = AlertRouteTestDatabase.seedOrganization("other-org")
+
+        assertFailsWith<IncidentCommandNotFoundException> {
+            service.get(organization.organizationId, Uuid.random())
+        }
+        assertFailsWith<IncidentCommandNotFoundException> {
+            service.get(otherOrganization.organizationId, route.resourceId)
+        }
+    }
+
+    @Test
+    fun `only organization administrators may mutate alert routes`() {
+        val memberUserId = AlertRouteTestDatabase.seedUser(organization.organizationId, "member")
+        val outsiderOrganization = AlertRouteTestDatabase.seedOrganization("outsider-org")
+
+        assertFailsWith<IncidentCommandDeniedException> {
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "member-create",
+                    actor = AlertRouteActor(organization.organizationId, memberUserId, "TEST"),
+                    specification = specification(),
+                ),
+            )
+        }
+        assertFailsWith<IncidentCommandDeniedException> {
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "outsider-create",
+                    actor = AlertRouteActor(organization.organizationId, outsiderOrganization.adminUserId, "TEST"),
+                    specification = specification(),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `rollout gating denies reads and writes for organizations without native incident response`() {
+        val gatedService = AlertRouteCommandService(policy = AlertRoutePolicy.denyForTests())
+
+        assertFailsWith<IncidentCommandDeniedException> { gatedService.list(organization.organizationId) }
+        assertFailsWith<IncidentCommandDeniedException> {
+            gatedService.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "gated-create",
+                    actor = admin(),
+                    specification = specification(),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `specifications reject unapproved metadata and require severity only for active incidents`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "bad-metadata",
+                    actor = admin(),
+                    specification =
+                        specification().copy(
+                            conditionGroups =
+                                listOf(
+                                    AlertRouteConditionGroupInput(
+                                        listOf(
+                                            AlertRouteConditionInput(
+                                                field = AlertRouteContextField.METADATA,
+                                                operator = AlertRouteConditionOperator.EQUALS,
+                                                values = listOf("nope"),
+                                                metadataKey = "internal_secret",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                        ),
+                ),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "bad-incident",
+                    actor = admin(),
+                    specification =
+                        specification().copy(
+                            incident =
+                                AlertRouteIncidentInput(
+                                    create = true,
+                                    mode = AlertRouteIncidentMode.ACTIVE,
+                                    severity = null,
+                                ),
+                        ),
+                ),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "long-incident-type",
+                    actor = admin(),
+                    specification =
+                        specification().copy(
+                            incident = specification().incident.copy(incidentType = "x".repeat(121)),
+                        ),
+                ),
+            )
+        }
+
+        val triage =
+            service.execute(
+                CreateAlertRouteCommand(
+                    commandKey = "unclassified-triage",
+                    actor = admin(),
+                    specification =
+                        specification(key = "triage", name = "Triage").copy(
+                            incident = AlertRouteIncidentInput(create = true),
+                        ),
+                ),
+            ).route!!
+        assertEquals(AlertRouteIncidentMode.TRIAGE, triage.incident.mode)
+        assertEquals(null, triage.incident.severity)
+    }
+}

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRoutePreviewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRoutePreviewTest.kt
@@ -121,7 +121,7 @@ class AlertRoutePreviewTest {
                     priority = "P1",
                     title = "Checkout latency high",
                     deduplicationKey = "moneat-dashboard-alert-42",
-                    metadata = mapOf("catalog_resource_id" to catalogResourceId),
+                    metadata = mapOf(" catalog_resource_id " to catalogResourceId),
                 ),
             )
 

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRoutePreviewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRoutePreviewTest.kt
@@ -132,6 +132,40 @@ class AlertRoutePreviewTest {
     }
 
     @Test
+    fun `preview treats blank ownership metadata the same as live evaluation`() {
+        commandService.execute(
+            CreateAlertRouteCommand(
+                commandKey = "create-service-ownership-route",
+                actor = AlertRouteActor(organization.organizationId, organization.adminUserId, "TEST"),
+                specification =
+                    AlertRouteSpecification(
+                        key = "service-ownership",
+                        name = "Service ownership",
+                        paging =
+                            AlertRoutePagingInput(
+                                mode = AlertRoutePagingMode.EVERY_EPISODE,
+                                targets =
+                                    listOf(
+                                        AlertRouteTargetInput(
+                                            kind = AlertRouteTargetKind.OWNERSHIP_DERIVED,
+                                            ownershipSource = AlertRouteOwnershipSource.SERVICE,
+                                        ),
+                                    ),
+                            ),
+                    ),
+            ),
+        )
+
+        val result =
+            evaluationService.preview(
+                organization.organizationId,
+                AlertRouteSampleInput(source = "DASHBOARD_ALERT", metadata = mapOf("service" to "")),
+            )
+
+        assertEquals(listOf("OWNERSHIP_DERIVED:SERVICE"), result.decision!!.paging.unresolvedTargets)
+    }
+
+    @Test
     fun `preview explains non-matching routes without selecting one`() {
         seedOwnedCatalogResource()
         createCatalogRoute()

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRoutePreviewTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/AlertRoutePreviewTest.kt
@@ -1,0 +1,211 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.enterprise.alertroutes.AlertRouteTestDatabase
+import com.moneat.enterprise.alertroutes.SeededAlertRouteOrganization
+import com.moneat.enterprise.alertroutes.commands.AlertRouteActor
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionGroupInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteConditionInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteGroupingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRouteIncidentInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePagingInput
+import com.moneat.enterprise.alertroutes.commands.AlertRoutePolicy
+import com.moneat.enterprise.alertroutes.commands.AlertRouteSpecification
+import com.moneat.enterprise.alertroutes.commands.AlertRouteTargetInput
+import com.moneat.enterprise.alertroutes.commands.CreateAlertRouteCommand
+import com.moneat.enterprise.alertroutes.context.AlertRouteSampleInput
+import com.moneat.enterprise.alertroutes.evaluation.AlertRouteEvaluationReason
+import com.moneat.enterprise.alertroutes.models.AlertRouteConditionOperator
+import com.moneat.enterprise.alertroutes.models.AlertRouteContextField
+import com.moneat.enterprise.alertroutes.models.AlertRouteIncidentMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteOwnershipSource
+import com.moneat.enterprise.alertroutes.models.AlertRoutePagingMode
+import com.moneat.enterprise.alertroutes.models.AlertRouteTargetKind
+import com.moneat.enterprise.incidents.commands.IncidentCommandDeniedException
+import com.moneat.enterprise.incidents.commands.IncidentCommandNotFoundException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class AlertRoutePreviewTest {
+    private val catalogResourceId = "service:7:checkout"
+
+    private lateinit var organization: SeededAlertRouteOrganization
+    private lateinit var commandService: AlertRouteCommandService
+    private lateinit var evaluationService: AlertRouteEvaluationService
+
+    @BeforeEach
+    fun setUp() {
+        AlertRouteTestDatabase.reset()
+        organization = AlertRouteTestDatabase.seedOrganization("preview-org")
+        commandService = AlertRouteCommandService(policy = AlertRoutePolicy.allowForTests())
+        evaluationService = AlertRouteEvaluationService(policy = AlertRoutePolicy.allowForTests())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        AlertRouteTestDatabase.clearReference()
+    }
+
+    private fun seedOwnedCatalogResource(): Int {
+        val policy = AlertRouteTestDatabase.seedEscalationPolicy(organization.organizationId, "Checkout")
+        val team = AlertRouteTestDatabase.seedTeam(organization.organizationId, "Checkout Team", policy.id)
+        AlertRouteTestDatabase.seedOwnershipClaim(organization.organizationId, catalogResourceId, team.id)
+        return policy.id
+    }
+
+    private fun createCatalogRoute() {
+        commandService.execute(
+            CreateAlertRouteCommand(
+                commandKey = "create-catalog-route",
+                actor = AlertRouteActor(organization.organizationId, organization.adminUserId, "TEST"),
+                specification =
+                    AlertRouteSpecification(
+                        key = "checkout-ownership",
+                        name = "Checkout ownership",
+                        conditionGroups =
+                            listOf(
+                                AlertRouteConditionGroupInput(
+                                    listOf(
+                                        AlertRouteConditionInput(
+                                            field = AlertRouteContextField.METADATA,
+                                            operator = AlertRouteConditionOperator.EQUALS,
+                                            values = listOf(catalogResourceId),
+                                            metadataKey = "catalog_resource_id",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        paging =
+                            AlertRoutePagingInput(
+                                mode = AlertRoutePagingMode.EVERY_EPISODE,
+                                targets =
+                                    listOf(
+                                        AlertRouteTargetInput(
+                                            kind = AlertRouteTargetKind.OWNERSHIP_DERIVED,
+                                            ownershipSource = AlertRouteOwnershipSource.CATALOG,
+                                        ),
+                                    ),
+                            ),
+                        grouping = AlertRouteGroupingInput(keys = listOf("episode.key")),
+                        incident =
+                            AlertRouteIncidentInput(
+                                create = true,
+                                mode = AlertRouteIncidentMode.ACTIVE,
+                                titleTemplate = "{{ ownership.team }} - {{ alert.title }}",
+                                severity = "SEV-2",
+                            ),
+                    ),
+            ),
+        )
+    }
+
+    @Test
+    fun `preview of a supplied sample resolves ownership derived escalation targets`() {
+        val policyId = seedOwnedCatalogResource()
+        createCatalogRoute()
+
+        val result =
+            evaluationService.preview(
+                organization.organizationId,
+                AlertRouteSampleInput(
+                    source = "DASHBOARD_ALERT",
+                    priority = "P1",
+                    title = "Checkout latency high",
+                    deduplicationKey = "moneat-dashboard-alert-42",
+                    metadata = mapOf("catalog_resource_id" to catalogResourceId),
+                ),
+            )
+
+        val decision = result.decision!!
+        assertEquals(listOf(policyId), decision.paging.escalationPolicies.map { it.id })
+        assertEquals("Checkout Team - Checkout latency high", decision.incident.title)
+        assertTrue(result.evaluations.single().selected)
+    }
+
+    @Test
+    fun `preview explains non-matching routes without selecting one`() {
+        seedOwnedCatalogResource()
+        createCatalogRoute()
+
+        val result =
+            evaluationService.preview(
+                organization.organizationId,
+                AlertRouteSampleInput(
+                    source = "HOST_ALERT",
+                    metadata = mapOf("catalog_resource_id" to "service:9:billing"),
+                ),
+            )
+
+        assertNull(result.decision)
+        val evaluation = result.evaluations.single()
+        assertEquals(AlertRouteEvaluationReason.NO_GROUP_MATCHED, evaluation.reason)
+        val condition = evaluation.groups.single().conditions.single()
+        assertEquals("service:9:billing", condition.actualValue)
+        assertEquals(false, condition.matched)
+    }
+
+    @Test
+    fun `preview of a saved alert episode carries episode identity into grouping`() {
+        seedOwnedCatalogResource()
+        createCatalogRoute()
+        val episodeId =
+            AlertRouteTestDatabase.seedAlertEpisode(
+                organizationId = organization.organizationId,
+                source = "DASHBOARD_ALERT",
+                deduplicationKey = "moneat-dashboard-alert-42",
+            )
+
+        val result =
+            evaluationService.previewSavedEpisode(
+                organizationId = organization.organizationId,
+                episodeId = episodeId,
+                metadata = mapOf("catalog_resource_id" to catalogResourceId),
+            )
+
+        val grouping = result.decision!!.grouping
+        assertEquals("checkout-ownership|moneat-dashboard-alert-42#1", grouping.groupKey)
+        assertTrue(grouping.unresolvedKeys.isEmpty())
+    }
+
+    @Test
+    fun `preview reports unapproved metadata keys and rejects unknown episodes`() {
+        seedOwnedCatalogResource()
+        createCatalogRoute()
+
+        val result =
+            evaluationService.preview(
+                organization.organizationId,
+                AlertRouteSampleInput(
+                    source = "DASHBOARD_ALERT",
+                    metadata =
+                        mapOf(
+                            "catalog_resource_id" to catalogResourceId,
+                            "internal_secret" to "hidden",
+                        ),
+                ),
+            )
+
+        assertEquals(listOf("internal_secret"), result.droppedMetadataKeys)
+        assertFailsWith<IncidentCommandNotFoundException> {
+            evaluationService.previewSavedEpisode(organization.organizationId, Uuid.random())
+        }
+    }
+
+    @Test
+    fun `preview is rollout gated`() {
+        val gated = AlertRouteEvaluationService(policy = AlertRoutePolicy.denyForTests())
+
+        assertFailsWith<IncidentCommandDeniedException> {
+            gated.preview(organization.organizationId, AlertRouteSampleInput(source = "HOST_ALERT"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add organization-scoped, versioned enterprise Alert Routes with deterministic first-match evaluation and UUID CRUD/reorder/preview APIs
- enforce rollout, paid entitlement, enabled-route quota, global idempotency, optimistic revisions, target integrity, and durable audit snapshots
- model paging cadence, suggested/automatic grouping, TRIAGE-default incident creation, and independent recovery controls in V160
- preserve OSS incident-provider forwarding and cover the compatibility boundary

## Verification
- `./gradlew :ee:test --no-daemon`
- `./gradlew :features:incident:test --no-daemon`
- `./gradlew :ee:test --tests 'com.moneat.enterprise.alertroutes.*' :ee:detekt --no-daemon`\n- `./gradlew test --tests 'com.moneat.contracts.PublicSerializableResourceIdsTest' --no-daemon`\n- `python3 scripts/check-migration-versions.py --base-ref origin/develop`\n- `git diff --check`\n- Claude Opus max-effort review: `NO BLOCKING FINDINGS`; valid incident-type length finding fixed and regression-tested\n\n## Environment note\n- A direct private PostgreSQL worktree setup retry was blocked by `ssh: connect to host 10.0.0.10 port 22: Operation timed out`; V160 is covered by the migration allocator and mirrored H2 constraint tests pending restoration of that private host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enterprise alert routing with configurable conditions, priorities, paging targets, grouping, incident creation, recovery behavior, and templates.
  * Added authenticated APIs to create, update, delete, reorder, review, and preview alert routes.
  * Added previews using sample alerts or saved episodes, with match explanations and unresolved-reference reporting.
  * Added ownership-based routing to teams and escalation policies.
* **Security & Reliability**
  * Added quotas, rollout controls, idempotency, revision checks, and audit history.
  * Preserved existing provider-routing behavior independently from enterprise alert routes.
  * Improved provider removal safety when providers are replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->