### PR TITLE
feat: orchestrate alert lifecycle fanout

### DIFF
--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/DashboardModule.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/DashboardModule.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.dashboards
 
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.dashboards.repositories.DashboardFolderRepository
 import com.moneat.dashboards.repositories.DashboardFolderRepositoryImpl
 import com.moneat.dashboards.repositories.DashboardRepository
@@ -65,12 +66,14 @@ class DashboardModule : EnterpriseModule {
                 single { DashboardTemplateCatalogService() }
                 single {
                     DashboardAlertService(
-                        incidentService = get(),
-                        workflowService = get(),
                         queryEngine = get(),
                         retentionPolicyService = get(),
                         dataSourceService = get(),
                         dataSourceExecutor = get(),
+                        alertOrchestrator = getOrNull<AlertLifecycleOrchestrator>() ?: AlertLifecycleOrchestrator(
+                            workflowFanoutProvider = { get() },
+                            incidentFanoutProvider = { get() },
+                        ),
                     )
                 }
                 single {

--- a/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
+++ b/backend/features/dashboards/src/main/kotlin/com/moneat/dashboards/services/DashboardAlertService.kt
@@ -32,12 +32,12 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
-import com.moneat.incident.services.IncidentService
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.shared.services.TaskLock
 import com.moneat.shared.services.toUuidOrNull
 import com.moneat.utils.suspendRunCatching
-import com.moneat.workflows.services.WorkflowService
 import io.ktor.server.config.ApplicationConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -90,12 +90,11 @@ private data class AlertThresholdHit(
 )
 
 class DashboardAlertService(
-    private val incidentService: IncidentService = IncidentService(),
-    private val workflowService: WorkflowService = WorkflowService(),
     private val queryEngine: DashboardQueryEngine = DashboardQueryEngine(),
     private val retentionPolicyService: RetentionPolicyService = RetentionPolicyService(),
     private val dataSourceService: CustomDataSourceService = CustomDataSourceService(),
     private val dataSourceExecutor: CustomDataSourceExecutor = CustomDataSourceExecutor(),
+    private val alertOrchestrator: AlertLifecycleOrchestrator = AlertLifecycleOrchestrator(),
 ) {
     private val config = ApplicationConfig("application.conf")
     private val json = Json { ignoreUnknownKeys = true }
@@ -492,26 +491,10 @@ class DashboardAlertService(
                 ),
                 moneatUrl = moneatUrl
             )
-        suspendRunCatching {
-            workflowService.publishAlertTriggered(event)
-        }.onFailure { e ->
-            logger.error(e) { "Failed to publish recovered dashboard alert workflow ${alert.alertId}" }
-        }
-        if (configuredAlertPriority != null) {
-            suspendRunCatching {
-                incidentService.autoResolveAlert(
-                    organizationId = alert.orgId.toInt(),
-                    source = AlertSource.DASHBOARD_ALERT,
-                    deduplicationKey = "moneat-dashboard-alert-${alert.alertId}",
-                    title = title,
-                    description = description,
-                    moneatUrl = moneatUrl,
-                    publishWorkflow = false
-                )
-            }.onFailure { e ->
-                logger.error(e) { "Failed to resolve incident for recovered dashboard alert ${alert.alertId}" }
-            }
-        }
+        alertOrchestrator.process(
+            event,
+            if (configuredAlertPriority == null) AlertFanoutPlan.WORKFLOW_ONLY else AlertFanoutPlan.FULL,
+        )
         logger.info { "Dashboard alert ${alert.alertId} recovered" }
     }
 
@@ -817,18 +800,10 @@ class DashboardAlertService(
                 moneatUrl = "$baseUrl/dashboards/${alert.dashboardResourceId}"
             )
 
-        val shouldNotifyIncidentProvider = suspendRunCatching {
-            workflowService.publishAlertTriggered(event)
-        }.onFailure { e ->
-            logger.error(e) { "Failed to publish dashboard alert workflow" }
-        }.getOrElse { true }
-        if (configuredAlertPriority != null && shouldNotifyIncidentProvider) {
-            suspendRunCatching {
-                incidentService.fireAlert(event.copy(priority = configuredAlertPriority), publishWorkflow = false)
-            }.onFailure { e ->
-                logger.error(e) { "Failed to fire dashboard alert incident" }
-            }
-        }
+        alertOrchestrator.process(
+            event,
+            if (configuredAlertPriority == null) AlertFanoutPlan.WORKFLOW_ONLY else AlertFanoutPlan.FULL,
+        )
     }
 
     private fun validateCondition(condition: String) {

--- a/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
+++ b/backend/features/dashboards/src/test/kotlin/com/moneat/dashboards/DashboardAlertServiceTest.kt
@@ -34,11 +34,12 @@ import com.moneat.dashboards.services.DataSourceCredentials
 import com.moneat.dashboards.services.DashboardAlertService
 import com.moneat.dashboards.services.DashboardQueryEngine
 import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
 import com.moneat.alerts.models.AlertPriority
-import com.moneat.incident.services.IncidentService
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
+import com.moneat.alerts.services.AlertFanoutPlan
 import com.moneat.shared.services.RetentionPolicyService
 import com.moneat.testsupport.TestDatabaseHelper
-import com.moneat.workflows.services.WorkflowService
 import io.lettuce.core.api.sync.RedisCommands
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -72,8 +73,7 @@ import kotlin.uuid.Uuid
 
 class DashboardAlertServiceTest {
 
-    private val incidentService: IncidentService = mockk(relaxed = true)
-    private val workflowService: WorkflowService = mockk(relaxed = true)
+    private val alertOrchestrator: AlertLifecycleOrchestrator = mockk(relaxed = true)
     private val queryEngine: DashboardQueryEngine = mockk(relaxed = true)
     private val retentionPolicyService: RetentionPolicyService = mockk(relaxed = true)
     private val dataSourceService: CustomDataSourceService = mockk(relaxed = true)
@@ -81,12 +81,11 @@ class DashboardAlertServiceTest {
     private var redisConfigMocked = false
 
     private val service = DashboardAlertService(
-        incidentService = incidentService,
-        workflowService = workflowService,
         queryEngine = queryEngine,
         retentionPolicyService = retentionPolicyService,
         dataSourceService = dataSourceService,
         dataSourceExecutor = dataSourceExecutor,
+        alertOrchestrator = alertOrchestrator,
     )
 
     companion object {
@@ -127,7 +126,6 @@ class DashboardAlertServiceTest {
         every { queryEngine.isTemplateDataSourceMarker(any()) } answers {
             firstArg<String>().startsWith("__")
         }
-        coEvery { workflowService.publishAlertTriggered(any()) } returns true
         transaction {
             exec(
                 """
@@ -901,14 +899,13 @@ class DashboardAlertServiceTest {
                     ),
                 )
             val numericAlertId = alertNumericId(created.id)
-            val dashboardPublicId = dashboardResourceId(dashboardId)
             every { redis.get("dashboard_alert_state:$numericAlertId") } returns "TRIGGERED"
             every { redis.del(any<String>()) } returns REDIS_DELETE_COUNT
 
             callPrivateSuspend("evaluateAlerts")
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(
+                alertOrchestrator.process(
                     match {
                         it.status.name == "RESOLVED" &&
                             it.metadata["alert.channels.email"]?.jsonPrimitive?.content == "false" &&
@@ -916,18 +913,8 @@ class DashboardAlertServiceTest {
                             it.metadata["alert.channels.discord"]?.jsonPrimitive?.content == "false" &&
                             it.metadata["alert.display_title"]?.jsonPrimitive?.content == "High Error Rate" &&
                             it.metadata["alert.current_value"]?.jsonPrimitive?.content == "50.00"
-                    }
-                )
-            }
-            coVerify(exactly = 1) {
-                incidentService.autoResolveAlert(
-                    organizationId = ORG_ID.toInt(),
-                    source = AlertSource.DASHBOARD_ALERT,
-                    deduplicationKey = "moneat-dashboard-alert-$numericAlertId",
-                    title = "Dashboard Alert Resolved: High Error Rate",
-                    description = "Test Widget on Test Dashboard recovered. Current value: 50.00",
-                    moneatUrl = "https://moneat.io/dashboards/$dashboardPublicId",
-                    publishWorkflow = false,
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
         }
@@ -972,14 +959,15 @@ class DashboardAlertServiceTest {
             assertEquals("WARNING", fired.lastTriggeredLevel)
             assertEquals(90.0, fired.lastValue)
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(
+                alertOrchestrator.process(
                     match {
                         it.priority == AlertPriority.P3 &&
                             it.title == "Dashboard Warning: High Error Rate" &&
                             it.source == AlertSource.DASHBOARD_ALERT &&
                             it.metadata["alert.display_title"]?.jsonPrimitive?.content == "High Error Rate" &&
                             it.metadata["alert.dashboard.title"]?.jsonPrimitive?.content == "Test Dashboard"
-                    }
+                    },
+                    AlertFanoutPlan.WORKFLOW_ONLY,
                 )
             }
         }
@@ -1025,27 +1013,21 @@ class DashboardAlertServiceTest {
             assertEquals("ERROR", fired.lastTriggeredLevel)
             assertEquals(125.0, fired.lastValue)
             coVerify(exactly = 1) {
-                incidentService.fireAlert(
+                alertOrchestrator.process(
                     match {
                         it.priority == AlertPriority.P1 &&
-                            it.title == "Dashboard Error: High Error Rate"
-                    },
-                    publishWorkflow = false,
-                )
-            }
-            coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(
-                    match {
-                        it.metadata["alert.channels.email"]?.jsonPrimitive?.content == "false" &&
+                            it.title == "Dashboard Error: High Error Rate" &&
+                            it.metadata["alert.channels.email"]?.jsonPrimitive?.content == "false" &&
                             it.metadata["alert.channels.slack"]?.jsonPrimitive?.content == "false" &&
                             it.metadata["alert.channels.discord"]?.jsonPrimitive?.content == "false"
-                    }
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
         }
 
     @Test
-    fun `evaluateAlerts does not fan out suppressed workflow episodes to incident providers`() =
+    fun `evaluateAlerts uses workflow only fanout without an incident priority`() =
         runBlocking {
             mockkObject(RedisConfig)
             redisConfigMocked = true
@@ -1056,8 +1038,6 @@ class DashboardAlertServiceTest {
             coEvery {
                 queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(125.0)))
-            coEvery { workflowService.publishAlertTriggered(any()) } returns false
-
             val dashboardId = seedDashboard()
             val widgetId = seedWidget(dashboardId, queryConfigs = "[{\"dataSource\":\"events\"}]")
             service.createAlert(
@@ -1066,19 +1046,19 @@ class DashboardAlertServiceTest {
                 CREATED_BY,
                 buildCreateRequest(
                     widgetId,
-                    AlertRequestOverrides(threshold = 100.0, alertPriority = "P1"),
+                    AlertRequestOverrides(threshold = 100.0),
                 ),
             )
 
             callPrivateSuspend("evaluateAlerts")
 
-            coVerify(exactly = 0) {
-                incidentService.fireAlert(any(), publishWorkflow = false)
+            coVerify(exactly = 1) {
+                alertOrchestrator.process(any(), AlertFanoutPlan.WORKFLOW_ONLY)
             }
         }
 
     @Test
-    fun `evaluateAlerts fails open to incident providers when workflow publication fails`() =
+    fun `evaluateAlerts sends the dashboard episode through full fanout`() =
         runBlocking {
             mockkObject(RedisConfig)
             redisConfigMocked = true
@@ -1089,8 +1069,6 @@ class DashboardAlertServiceTest {
             coEvery {
                 queryEngine.executeQuery(any(), any(), any(), any(), any())
             } returns listOf(mapOf("total" to JsonPrimitive(125.0)))
-            coEvery { workflowService.publishAlertTriggered(any()) } throws RuntimeException("workflow unavailable")
-
             val dashboardId = seedDashboard()
             val widgetId = seedWidget(dashboardId, queryConfigs = "[{\"dataSource\":\"events\"}]")
             service.createAlert(
@@ -1106,7 +1084,14 @@ class DashboardAlertServiceTest {
             callPrivateSuspend("evaluateAlerts")
 
             coVerify(exactly = 1) {
-                incidentService.fireAlert(any(), publishWorkflow = false)
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.FIRING &&
+                            it.source == AlertSource.DASHBOARD_ALERT &&
+                            it.organizationId == ORG_ID.toInt()
+                    },
+                    AlertFanoutPlan.FULL,
+                )
             }
         }
 
@@ -1149,7 +1134,7 @@ class DashboardAlertServiceTest {
             val pending = service.listAlerts(dashboardId, ORG_ID).single { it.id == created.id }
             assertNull(pending.lastTriggeredLevel)
             assertEquals(90.0, pending.lastValue)
-            coVerify(exactly = 0) { incidentService.fireAlert(any()) }
+            coVerify(exactly = 0) { alertOrchestrator.process(any(), any()) }
         }
 
     @Test
@@ -1188,7 +1173,7 @@ class DashboardAlertServiceTest {
             callPrivateSuspend("evaluateAlerts")
             callPrivateSuspend("evaluateAlerts")
 
-            coVerify(exactly = 1) { workflowService.publishAlertTriggered(any()) }
+            coVerify(exactly = 1) { alertOrchestrator.process(any(), any()) }
         }
 
     @Test
@@ -1226,7 +1211,7 @@ class DashboardAlertServiceTest {
             val inactive = service.listAlerts(dashboardId, ORG_ID).single { it.id == created.id }
             assertNull(inactive.lastTriggeredLevel)
             assertEquals(70.0, inactive.lastValue)
-            coVerify(exactly = 0) { incidentService.fireAlert(any()) }
+            coVerify(exactly = 0) { alertOrchestrator.process(any(), any()) }
         }
 
     @Test
@@ -1281,7 +1266,7 @@ class DashboardAlertServiceTest {
 
             val unchanged = service.listAlerts(dashboardId, ORG_ID).single { it.id == created.id }
             assertNull(unchanged.lastValue)
-            coVerify(exactly = 0) { incidentService.fireAlert(any()) }
+            coVerify(exactly = 0) { alertOrchestrator.process(any(), any()) }
         }
 
     @Test

--- a/backend/features/incident/src/main/kotlin/com/moneat/incident/IncidentModule.kt
+++ b/backend/features/incident/src/main/kotlin/com/moneat/incident/IncidentModule.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.incident
 
+import com.moneat.alerts.services.AlertIncidentFanout
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.incident.routes.incidentProviderRoutes
 import com.moneat.incident.services.IncidentService
@@ -36,6 +37,7 @@ class IncidentModule : EnterpriseModule {
         listOf(
             module {
                 single { IncidentService(get(), get<ResourceOwnershipRepository>(), get()) }
+                single<AlertIncidentFanout> { get<IncidentService>() }
             }
         )
 

--- a/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
+++ b/backend/features/monitoring/src/main/kotlin/com/moneat/monitoring/MonitoringModule.kt
@@ -16,6 +16,9 @@
 
 package com.moneat.monitoring
 
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
+import com.moneat.alerts.services.AlertSilenceService
+import com.moneat.incident.services.IncidentService
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.monitor.repositories.HostAlertRepository
 import com.moneat.monitor.repositories.HostAlertRepositoryImpl
@@ -38,6 +41,7 @@ import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.monitor.services.MonitorService
 import com.moneat.monitor.services.ResourceCatalogService
 import com.moneat.monitor.services.ResourceCatalogTeamResolver
+import com.moneat.workflows.services.WorkflowService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
 import kotlinx.coroutines.CoroutineScope
@@ -76,7 +80,20 @@ class MonitoringModule : EnterpriseModule {
                 single<HostAlertRepository> { HostAlertRepositoryImpl() }
 
                 single { MonitorService(get(), get(), get(), get()) }
-                single { MonitorAlertService(get(), get(), get()) }
+                single {
+                    val incidentService = get<IncidentService>()
+                    val workflowService = get<WorkflowService>()
+                    val silenceService = get<AlertSilenceService>()
+                    MonitorAlertService(
+                        incidentService,
+                        workflowService,
+                        silenceService,
+                        getOrNull<AlertLifecycleOrchestrator>() ?: AlertLifecycleOrchestrator(
+                            workflowFanoutProvider = { workflowService },
+                            incidentFanoutProvider = { incidentService },
+                        ),
+                    )
+                }
                 single<ResourceOwnershipRepository> { ResourceOwnershipRepositoryImpl() }
                 single {
                     ResourceCatalogService(

--- a/backend/features/org/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
+++ b/backend/features/org/src/main/kotlin/com/moneat/org/routes/AdminRoutes.kt
@@ -27,7 +27,8 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
-import com.moneat.incident.services.IncidentService
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.notifications.services.DiscordService
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.SlackService
@@ -208,7 +209,7 @@ fun Route.adminRoutes() {
     val emailService = GlobalContext.get().get<EmailService>()
     val slackService = GlobalContext.get().get<SlackService>()
     val discordService = GlobalContext.get().get<DiscordService>()
-    val incidentService = GlobalContext.get().get<IncidentService>()
+    val alertOrchestrator = GlobalContext.get().get<AlertLifecycleOrchestrator>()
 
     authenticate("auth-jwt") {
         route("/v1/admin") {
@@ -410,7 +411,7 @@ fun Route.adminRoutes() {
                             metadata = mapOf("triggered_by" to JsonPrimitive(userResourceId(userId)))
                         )
 
-                    incidentService.fireAlert(event)
+                    alertOrchestrator.process(event, AlertFanoutPlan.FULL)
                     call.respond(HttpStatusCode.OK, AdminSuccessResponse(success = true))
                 }.getOrElse { e ->
                     call.respond(

--- a/backend/features/org/src/test/kotlin/com/moneat/routes/AdminRoutesTest.kt
+++ b/backend/features/org/src/test/kotlin/com/moneat/routes/AdminRoutesTest.kt
@@ -18,6 +18,9 @@ package com.moneat.routes
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.org.routes.adminRoutes
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.Organizations
@@ -27,9 +30,16 @@ import com.moneat.testsupport.startTestKoin
 import com.moneat.testsupport.stopTestKoin
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -42,6 +52,7 @@ import io.ktor.server.testing.testApplication
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.koin.core.context.GlobalContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -175,6 +186,46 @@ class AdminRoutesTest {
 
             assertEquals(HttpStatusCode.Forbidden, response.status)
         }
+
+    @Test
+    fun `admin incident trigger delegates one full lifecycle event`() = testApplication {
+        val orchestrator = mockk<AlertLifecycleOrchestrator>()
+        coEvery { orchestrator.process(any(), any()) } returns mockk(relaxed = true)
+        GlobalContext.get().declare(orchestrator, allowOverride = true)
+        application {
+            install(ContentNegotiation) { json() }
+            installAuth()
+            routing { adminRoutes() }
+        }
+        val userId = seedUser(isAdmin = true)
+        transaction {
+            val organizationId = Organizations.insert {
+                it[name] = "Admin Alert Organization"
+                it[slug] = "admin-alert-organization"
+            } get Organizations.id
+            Memberships.insert {
+                it[user_id] = userId
+                it[organization_id] = organizationId
+                it[role] = "admin"
+            }
+        }
+
+        val response = client.post("/v1/admin/incidents/trigger") {
+            header(HttpHeaders.Authorization, "Bearer ${token(userId)}")
+            contentType(ContentType.Application.Json)
+            setBody(
+                """{"source":"DASHBOARD_ALERT","severity":"P1","title":"Latency","description":"High"}""",
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        coVerify(exactly = 1) {
+            orchestrator.process(
+                match { it.source == AlertSource.DASHBOARD_ALERT && it.organizationId > 0 },
+                AlertFanoutPlan.FULL,
+            )
+        }
+    }
 
     @AfterTest
     fun teardownKoin() {

--- a/backend/features/synthetics/src/main/kotlin/com/moneat/synthetics/SyntheticsModule.kt
+++ b/backend/features/synthetics/src/main/kotlin/com/moneat/synthetics/SyntheticsModule.kt
@@ -16,10 +16,14 @@
 
 package com.moneat.synthetics
 
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
+import com.moneat.billing.services.BillingQuotaService
 import com.moneat.enterprise.EnterpriseModule
+import com.moneat.synthetics.routes.SyntheticLocationService
 import com.moneat.synthetics.routes.SyntheticsScheduler
 import com.moneat.synthetics.routes.SyntheticsService
 import com.moneat.synthetics.routes.syntheticsRoutes
+import com.moneat.workflows.services.WorkflowService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
 import org.koin.core.module.Module
@@ -37,7 +41,18 @@ class SyntheticsModule : EnterpriseModule {
     override fun koinModules(): List<Module> =
         listOf(
             module {
-                single { SyntheticsService(get(), get()) }
+                single {
+                    val billingQuotaService = get<BillingQuotaService>()
+                    val workflowService = get<WorkflowService>()
+                    SyntheticsService(
+                        billingQuotaService,
+                        workflowService,
+                        SyntheticLocationService(),
+                        getOrNull<AlertLifecycleOrchestrator>() ?: AlertLifecycleOrchestrator(
+                            workflowFanoutProvider = { workflowService },
+                        ),
+                    )
+                }
             }
         )
 

--- a/backend/features/synthetics/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsService.kt
+++ b/backend/features/synthetics/src/main/kotlin/com/moneat/synthetics/routes/SyntheticsService.kt
@@ -20,6 +20,8 @@ import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.EnvConfig
@@ -62,6 +64,9 @@ class SyntheticsService(
     private val billingQuotaService: BillingQuotaService = BillingQuotaService(),
     private val workflowService: WorkflowService = WorkflowService(),
     private val locationService: SyntheticLocationService = SyntheticLocationService(),
+    private val alertOrchestrator: AlertLifecycleOrchestrator = AlertLifecycleOrchestrator(
+        workflowFanoutProvider = { workflowService },
+    ),
 ) {
     companion object {
         private val logger = KotlinLogging.logger {}
@@ -498,7 +503,7 @@ class SyntheticsService(
             "https://moneat.io"
         )
 
-        workflowService.publishAlertTriggered(
+        alertOrchestrator.process(
             AlertLifecycleEvent(
                 title = subject,
                 description = message,
@@ -508,7 +513,8 @@ class SyntheticsService(
                 deduplicationKey = "moneat-synthetic-${test.id}",
                 organizationId = test.organizationId,
                 moneatUrl = "$frontendUrl/synthetics/${test.id}"
-            )
+            ),
+            AlertFanoutPlan.WORKFLOW_ONLY,
         )
     }
 
@@ -517,7 +523,7 @@ class SyntheticsService(
             "FRONTEND_URL",
             "https://moneat.io"
         )
-        workflowService.publishAlertTriggered(
+        alertOrchestrator.process(
             AlertLifecycleEvent(
                 title = "Synthetic test recovered: ${test.name}",
                 description = "Test '${test.name}' (${test.testType}) passed after previous failures.",
@@ -527,7 +533,8 @@ class SyntheticsService(
                 deduplicationKey = "moneat-synthetic-${test.id}",
                 organizationId = test.organizationId,
                 moneatUrl = "$frontendUrl/synthetics/${test.id}"
-            )
+            ),
+            AlertFanoutPlan.WORKFLOW_ONLY,
         )
     }
 

--- a/backend/features/synthetics/src/test/kotlin/com/moneat/services/SyntheticsServiceTest.kt
+++ b/backend/features/synthetics/src/test/kotlin/com/moneat/services/SyntheticsServiceTest.kt
@@ -19,6 +19,7 @@ package com.moneat.services
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.config.ClickHouseClient
 import com.moneat.shared.models.Memberships
@@ -774,9 +775,11 @@ class SyntheticsServiceTest {
     fun `executeTestAndRecord publishes firing alert for failed check`() =
         runBlocking {
             val workflowService = mockk<WorkflowService>(relaxed = true)
+            val alertOrchestrator = mockk<AlertLifecycleOrchestrator>(relaxed = true)
             val service = SyntheticsService(
                 billingQuotaService = mockk<BillingQuotaService>(relaxed = true),
-                workflowService = workflowService
+                workflowService = workflowService,
+                alertOrchestrator = alertOrchestrator,
             )
             val eventSlot = slot<AlertLifecycleEvent>()
             val testData = syntheticTestData()
@@ -789,7 +792,7 @@ class SyntheticsServiceTest {
             service.executeTestAndRecord(testData, executorReturning(failure))
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(capture(eventSlot))
+                alertOrchestrator.process(capture(eventSlot), any())
             }
             val event = eventSlot.captured
             assertEquals(AlertStatus.FIRING, event.status)
@@ -803,9 +806,11 @@ class SyntheticsServiceTest {
     fun `executeTestAndRecord publishes recovery alert after failed synthetic passes`() =
         runBlocking {
             val workflowService = mockk<WorkflowService>(relaxed = true)
+            val alertOrchestrator = mockk<AlertLifecycleOrchestrator>(relaxed = true)
             val service = SyntheticsService(
                 billingQuotaService = mockk<BillingQuotaService>(relaxed = true),
-                workflowService = workflowService
+                workflowService = workflowService,
+                alertOrchestrator = alertOrchestrator,
             )
             val eventSlot = slot<AlertLifecycleEvent>()
             val testData = syntheticTestData(lastStatus = "failed")
@@ -814,7 +819,7 @@ class SyntheticsServiceTest {
             service.executeTestAndRecord(testData, executorReturning(success))
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(capture(eventSlot))
+                alertOrchestrator.process(capture(eventSlot), any())
             }
             val event = eventSlot.captured
             assertEquals(AlertStatus.RESOLVED, event.status)
@@ -830,9 +835,11 @@ class SyntheticsServiceTest {
             seedManagedLocation("aws-us-east-1", "US East")
             seedManagedLocation("aws-us-west-2", "US West")
             val workflowService = mockk<WorkflowService>(relaxed = true)
+            val alertOrchestrator = mockk<AlertLifecycleOrchestrator>(relaxed = true)
             val service = SyntheticsService(
                 billingQuotaService = mockk<BillingQuotaService>(relaxed = true),
-                workflowService = workflowService
+                workflowService = workflowService,
+                alertOrchestrator = alertOrchestrator,
             )
             val eventSlot = slot<AlertLifecycleEvent>()
             val testData = syntheticTestData(
@@ -855,7 +862,7 @@ class SyntheticsServiceTest {
             }
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(capture(eventSlot))
+                alertOrchestrator.process(capture(eventSlot), any())
             }
             assertEquals(AlertStatus.FIRING, eventSlot.captured.status)
             assertEquals(AlertSource.SYNTHETIC_TEST, eventSlot.captured.source)

--- a/backend/features/uptime/src/main/kotlin/com/moneat/uptime/UptimeModule.kt
+++ b/backend/features/uptime/src/main/kotlin/com/moneat/uptime/UptimeModule.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.uptime
 
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.incident.services.IncidentService
@@ -61,8 +62,11 @@ class UptimeModule : EnterpriseModule {
                 checkExecutor = koin.get<UptimeCheckExecutor>(),
                 incidentService = koin.get<IncidentService>(),
                 billingQuotaService = koin.get<BillingQuotaService>(),
-                workflowService = koin.get<WorkflowService>(),
                 frontendBaseUrl = application.frontendBaseUrl(),
+                alertOrchestrator = koin.getOrNull<AlertLifecycleOrchestrator>() ?: AlertLifecycleOrchestrator(
+                    workflowFanoutProvider = { koin.get<WorkflowService>() },
+                    incidentFanoutProvider = { koin.get<IncidentService>() },
+                ),
             )
             uptimeScheduler.set(scheduler)
             scheduler.start()

--- a/backend/features/uptime/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
+++ b/backend/features/uptime/src/test/kotlin/com/moneat/services/UptimeSchedulerTest.kt
@@ -19,6 +19,8 @@ package com.moneat.services
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
+import com.moneat.alerts.services.AlertFanoutPlan
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.incident.services.IncidentService
 import com.moneat.shared.services.TaskLock
@@ -27,7 +29,6 @@ import com.moneat.uptime.models.UptimeMonitorData
 import com.moneat.uptime.services.UptimeCheckExecutor
 import com.moneat.uptime.services.UptimeScheduler
 import com.moneat.uptime.services.UptimeService
-import com.moneat.workflows.services.WorkflowService
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -55,15 +56,15 @@ class UptimeSchedulerTest {
     private val checkExecutor = mockk<UptimeCheckExecutor>(relaxed = true)
     private val incidentService = mockk<IncidentService>(relaxed = true)
     private val billingQuotaService = mockk<BillingQuotaService>(relaxed = true)
-    private val workflowService = mockk<WorkflowService>(relaxed = true)
+    private val alertOrchestrator = mockk<AlertLifecycleOrchestrator>(relaxed = true)
 
     private val scheduler = UptimeScheduler(
         uptimeService = uptimeService,
         checkExecutor = checkExecutor,
         incidentService = incidentService,
         billingQuotaService = billingQuotaService,
-        workflowService = workflowService,
         frontendBaseUrl = TEST_FRONTEND_BASE_URL,
+        alertOrchestrator = alertOrchestrator,
     )
 
     @AfterTest
@@ -276,7 +277,7 @@ class UptimeSchedulerTest {
             callPrivateSuspend("performCheck", monitor.id)
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(capture(eventSlot))
+                alertOrchestrator.process(capture(eventSlot), AlertFanoutPlan.WORKFLOW_ONLY)
             }
             val event = eventSlot.captured
             assertEquals(AlertStatus.FIRING, event.status)
@@ -301,13 +302,14 @@ class UptimeSchedulerTest {
             )
 
             coVerify(exactly = 1) {
-                incidentService.autoResolveAlert(
-                    organizationId = monitor.organizationId,
-                    source = AlertSource.UPTIME_MONITOR,
-                    deduplicationKey = "moneat-uptime-${monitor.id}",
-                    title = "Uptime Monitor Recovered: Test Monitor",
-                    description = "Monitor 'Test Monitor' (http) is back up.",
-                    moneatUrl = "https://moneat.io/uptime/${monitor.id}",
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.RESOLVED &&
+                            it.source == AlertSource.UPTIME_MONITOR &&
+                            it.deduplicationKey == "moneat-uptime-${monitor.id}" &&
+                            it.title == "Uptime Monitor Recovered: Test Monitor"
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
         }

--- a/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowsModule.kt
+++ b/backend/features/workflows/src/main/kotlin/com/moneat/workflows/WorkflowsModule.kt
@@ -16,6 +16,7 @@
 
 package com.moneat.workflows
 
+import com.moneat.alerts.services.AlertWorkflowFanout
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.monitor.services.MonitorAlertService
 import com.moneat.workflows.engine.temporal.ExecuteActionActivityImpl
@@ -72,6 +73,7 @@ class WorkflowsModule : EnterpriseModule {
                 single { TemporalClientProvider() }
                 single<WorkflowExecutionEngine> { TemporalWorkflowExecutionEngine(get()) }
                 single { WorkflowService(get(), get(), get(), get(), get(), get(), get(), get()) }
+                single<AlertWorkflowFanout> { get<WorkflowService>() }
                 single { WorkflowGovernanceService(get()) }
             }
         )

--- a/backend/src/main/kotlin/com/moneat/alerts/services/AlertLifecycleOrchestrator.kt
+++ b/backend/src/main/kotlin/com/moneat/alerts/services/AlertLifecycleOrchestrator.kt
@@ -1,0 +1,243 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.alerts.services
+
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.utils.suspendRunCatching
+import mu.KotlinLogging
+import org.koin.core.context.GlobalContext
+
+private val logger = KotlinLogging.logger {}
+
+/** Delivery arms selected by a producer without changing episode ownership. */
+data class AlertFanoutPlan(
+    val workflow: Boolean = true,
+    val nativeOnCall: Boolean = false,
+    val incidentProviders: Boolean = false,
+    val route: Boolean = true,
+) {
+    companion object {
+        val WORKFLOW_ONLY = AlertFanoutPlan()
+        val FULL = AlertFanoutPlan(nativeOnCall = true, incidentProviders = true)
+    }
+}
+
+/** One immutable episode-first context shared by every fan-out arm. */
+data class AlertFanoutContext(
+    val event: AlertLifecycleEvent,
+    val episodeDecision: AlertEpisodeDecision?,
+    val episode: AlertEpisodeContext?,
+    val deliverySilenced: Boolean,
+) {
+    val deliveryKey: String = buildString {
+        append(episode?.episodeKey ?: "${event.source.name}:${event.deduplicationKey}")
+        append(':')
+        append(event.status.name)
+        append(':')
+        append(episodeDecision?.notificationSequence ?: 0)
+    }
+}
+
+enum class AlertFanoutArm {
+    ROUTE,
+    WORKFLOW,
+    NATIVE_ON_CALL,
+    INCIDENT_PROVIDERS,
+}
+
+enum class AlertFanoutState {
+    SUCCEEDED,
+    FAILED,
+    SKIPPED,
+    UNAVAILABLE,
+}
+
+data class AlertFanoutOutcome(
+    val arm: AlertFanoutArm,
+    val state: AlertFanoutState,
+    val error: String? = null,
+)
+
+data class AlertOrchestrationResult(
+    val context: AlertFanoutContext,
+    val outcomes: List<AlertFanoutOutcome>,
+)
+
+fun interface AlertWorkflowFanout {
+    suspend fun publish(context: AlertFanoutContext)
+}
+
+interface AlertIncidentFanout {
+    suspend fun fireNative(context: AlertFanoutContext)
+
+    suspend fun fireProviders(context: AlertFanoutContext)
+
+    suspend fun resolveNative(context: AlertFanoutContext)
+
+    suspend fun resolveProviders(context: AlertFanoutContext)
+}
+
+fun interface AlertRouteFanout {
+    suspend fun process(context: AlertFanoutContext)
+}
+
+/** Optional enterprise route arm; core-only deployments safely retain the no-op bridge. */
+object AlertRouteFanoutRegistry {
+    @Volatile
+    private var registered: AlertRouteFanout? = null
+
+    fun register(fanout: AlertRouteFanout) {
+        registered = fanout
+    }
+
+    fun unregister(fanout: AlertRouteFanout) {
+        synchronized(this) {
+            if (registered === fanout) registered = null
+        }
+    }
+
+    fun current(): AlertRouteFanout? = registered
+}
+
+/** Records or resolves one episode once, then isolates every selected downstream arm. */
+class AlertLifecycleOrchestrator(
+    private val episodeService: AlertEpisodeService = AlertEpisodeService(),
+    private val workflowFanoutProvider: () -> AlertWorkflowFanout? = ::workflowFanoutFromKoin,
+    private val incidentFanoutProvider: () -> AlertIncidentFanout? = ::incidentFanoutFromKoin,
+    private val routeFanoutProvider: () -> AlertRouteFanout? = AlertRouteFanoutRegistry::current,
+) {
+    suspend fun process(
+        event: AlertLifecycleEvent,
+        plan: AlertFanoutPlan = AlertFanoutPlan.WORKFLOW_ONLY,
+    ): AlertOrchestrationResult = fanOut(recordEpisode(event), plan)
+
+    /** Retries selected arms without recording the episode or reserving another notification. */
+    suspend fun retry(
+        context: AlertFanoutContext,
+        plan: AlertFanoutPlan,
+    ): AlertOrchestrationResult = fanOut(context, plan)
+
+    private suspend fun fanOut(
+        context: AlertFanoutContext,
+        plan: AlertFanoutPlan,
+    ): AlertOrchestrationResult {
+        val outcomes = mutableListOf<AlertFanoutOutcome>()
+        outcomes += runRouteArm(context, plan)
+
+        val workflowDue = !context.deliverySilenced && context.episodeDecision?.shouldPublish == true
+        val incidentDue = context.episodeDecision?.shouldPublish != false &&
+            (!context.deliverySilenced || context.event.status == AlertStatus.RESOLVED)
+        outcomes += runWorkflowArm(context, plan, workflowDue)
+        outcomes += runIncidentArm(context, plan.nativeOnCall, incidentDue, AlertFanoutArm.NATIVE_ON_CALL)
+        outcomes += runIncidentArm(
+            context,
+            plan.incidentProviders,
+            incidentDue,
+            AlertFanoutArm.INCIDENT_PROVIDERS,
+        )
+        return AlertOrchestrationResult(context, outcomes)
+    }
+
+    private fun recordEpisode(event: AlertLifecycleEvent): AlertFanoutContext {
+        val silenced = isDeliverySilenced(event.organizationId)
+        return if (event.status == AlertStatus.RESOLVED) {
+            val decision = episodeService.recordResolved(event)
+            AlertFanoutContext(event, decision, decision?.episode, silenced)
+        } else if (silenced) {
+            val episode = episodeService.recordFiringWithoutNotification(event)
+            AlertFanoutContext(event, null, episode, deliverySilenced = true)
+        } else {
+            val decision = episodeService.recordFiring(event)
+            AlertFanoutContext(event, decision, decision?.episode, deliverySilenced = false)
+        }
+    }
+
+    private fun isDeliverySilenced(organizationId: Int): Boolean =
+        runCatching { episodeService.isOrganizationSilenced(organizationId) }
+            .getOrElse { error ->
+                logger.error(error) {
+                    "Failed to check alert silence for organization $organizationId; delivering alert"
+                }
+                false
+            }
+
+    private suspend fun runRouteArm(context: AlertFanoutContext, plan: AlertFanoutPlan): AlertFanoutOutcome {
+        if (!plan.route) return AlertFanoutOutcome(AlertFanoutArm.ROUTE, AlertFanoutState.SKIPPED)
+        val fanout = routeFanoutProvider() ?: return AlertFanoutOutcome(
+            AlertFanoutArm.ROUTE,
+            AlertFanoutState.UNAVAILABLE,
+        )
+        return runArm(AlertFanoutArm.ROUTE) { fanout.process(context) }
+    }
+
+    private suspend fun runWorkflowArm(
+        context: AlertFanoutContext,
+        plan: AlertFanoutPlan,
+        deliveryDue: Boolean,
+    ): AlertFanoutOutcome {
+        if (!plan.workflow || !deliveryDue) {
+            return AlertFanoutOutcome(AlertFanoutArm.WORKFLOW, AlertFanoutState.SKIPPED)
+        }
+        val fanout = workflowFanoutProvider() ?: return AlertFanoutOutcome(
+            AlertFanoutArm.WORKFLOW,
+            AlertFanoutState.UNAVAILABLE,
+        )
+        return runArm(AlertFanoutArm.WORKFLOW) { fanout.publish(context) }
+    }
+
+    private suspend fun runIncidentArm(
+        context: AlertFanoutContext,
+        selected: Boolean,
+        deliveryDue: Boolean,
+        arm: AlertFanoutArm,
+    ): AlertFanoutOutcome {
+        if (!selected || !deliveryDue) return AlertFanoutOutcome(arm, AlertFanoutState.SKIPPED)
+        val fanout = incidentFanoutProvider() ?: return AlertFanoutOutcome(arm, AlertFanoutState.UNAVAILABLE)
+        return runArm(arm) {
+            when (arm) {
+                AlertFanoutArm.NATIVE_ON_CALL -> if (context.event.status == AlertStatus.RESOLVED) {
+                    fanout.resolveNative(context)
+                } else {
+                    fanout.fireNative(context)
+                }
+                AlertFanoutArm.INCIDENT_PROVIDERS -> if (context.event.status == AlertStatus.RESOLVED) {
+                    fanout.resolveProviders(context)
+                } else {
+                    fanout.fireProviders(context)
+                }
+                else -> error("Incident fan-out received unsupported arm $arm")
+            }
+        }
+    }
+
+    private suspend fun runArm(arm: AlertFanoutArm, block: suspend () -> Unit): AlertFanoutOutcome =
+        suspendRunCatching { block() }
+            .fold(
+                onSuccess = { AlertFanoutOutcome(arm, AlertFanoutState.SUCCEEDED) },
+                onFailure = { error ->
+                    logger.error(error) { "Alert fan-out arm $arm failed" }
+                    AlertFanoutOutcome(arm, AlertFanoutState.FAILED, error.message)
+                },
+            )
+}
+
+private fun workflowFanoutFromKoin(): AlertWorkflowFanout? =
+    GlobalContext.getOrNull()?.getOrNull()
+
+private fun incidentFanoutFromKoin(): AlertIncidentFanout? =
+    GlobalContext.getOrNull()?.getOrNull()

--- a/backend/src/main/kotlin/com/moneat/di/AppModules.kt
+++ b/backend/src/main/kotlin/com/moneat/di/AppModules.kt
@@ -17,6 +17,7 @@
 package com.moneat.di
 
 import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.events.repositories.EventRepository
 import com.moneat.events.repositories.EventRepositoryImpl
@@ -58,6 +59,7 @@ val sharedModule = module {
     single { AlertNotificationPreferencesService() }
     single { AlertSilenceService() }
     single { AlertEpisodeService(get()) }
+    single { AlertLifecycleOrchestrator(get()) }
 
     single { RetentionPolicyService(get()) }
     single { RetentionBackgroundService(get()) }
@@ -81,7 +83,7 @@ val eventsModule = module {
     }
 
     single { ReleaseService() }
-    single { NotificationService(get(), get()) }
+    single { NotificationService(get(), get(), get()) }
     single { EventService(get(), get(), get()) }
     single { DashboardService(get(), get(), get(), get()) }
 }

--- a/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
+++ b/backend/src/main/kotlin/com/moneat/incident/services/IncidentService.kt
@@ -20,6 +20,8 @@ import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.alerts.services.AlertIncidentFanout
 import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.config.EnvConfig
 import com.moneat.enterprise.FeatureRegistry
@@ -59,7 +61,7 @@ class IncidentService(
     private val workflowService: WorkflowService = WorkflowService(),
     private val ownershipRepository: ResourceOwnershipRepository = NoopResourceOwnershipRepository,
     private val alertSilenceService: AlertSilenceService = AlertSilenceService(),
-) {
+) : AlertIncidentFanout {
     private val logger = LoggerFactory.getLogger(IncidentService::class.java)
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -80,67 +82,41 @@ class IncidentService(
      * Fire an alert to all enabled incident providers for the organization.
      * Priority is resolved in order: per-monitor override > routing rule default > skip
      */
+    override suspend fun fireNative(context: AlertFanoutContext) {
+        if (!EnvConfig.get("ONCALL_ENABLED", "false").toBoolean()) return
+        triggerNativeEscalation(context.event)
+    }
+
+    override suspend fun fireProviders(context: AlertFanoutContext) {
+        fireProviderAlerts(context.event)
+    }
+
+    override suspend fun resolveNative(context: AlertFanoutContext) {
+        if (!EnvConfig.get("ONCALL_ENABLED", "false").toBoolean()) return
+        val event = context.event
+        resolveNativeEscalation(event.organizationId, event.source, event.deduplicationKey)
+    }
+
+    override suspend fun resolveProviders(context: AlertFanoutContext) {
+        val event = context.event
+        resolveProviderAlerts(event.organizationId, event.source, event.deduplicationKey)
+    }
+
     suspend fun fireAlert(
         event: AlertLifecycleEvent,
         publishWorkflow: Boolean = true
     ) {
         if (!shouldDeliverAlert(event, publishWorkflow)) return
-
-        // Check if native on-call is enabled
-        val onCallEnabled = EnvConfig.get("ONCALL_ENABLED", "false").toBoolean()
-
-        if (onCallEnabled) {
-            suspendRunCatching {
-                triggerNativeEscalation(event)
-            }.getOrElse { e ->
-                logger.error("Error triggering native escalation", e)
-            }
-        }
-
+        val context = AlertFanoutContext(event, null, null, deliverySilenced = false)
         suspendRunCatching {
-            val configs = getEnabledProviderConfigs(event.organizationId)
-            if (configs.isEmpty()) {
-                logger.debug("No enabled incident providers for org ${event.organizationId}")
-                return
-            }
-
-            configs.forEach { config ->
-                suspendRunCatching {
-                    // Check if we should route this alert
-                    val shouldRoute = shouldRouteAlert(config.id, event.source)
-                    if (!shouldRoute) {
-                        logger.debug("Skipping alert for provider ${config.name}: no routing rule for ${event.source}")
-                        return@forEach
-                    }
-
-                    // Get the provider implementation
-                    val provider = IncidentProviderRegistry.getProvider(config.providerType)
-                    if (provider == null) {
-                        logger.error("Provider type ${config.providerType} not registered")
-                        logEvent(config, event, success = false, errorMessage = "Provider not registered")
-                        return@forEach
-                    }
-
-                    // Send the alert
-                    val result = provider.sendAlert(event, config)
-
-                    result.fold(
-                        onSuccess = { incidentId ->
-                            logger.info("Alert sent to ${config.name}: $incidentId")
-                            logEvent(config, event, success = true, providerIncidentId = incidentId)
-                        },
-                        onFailure = { error ->
-                            logger.error("Failed to send alert to ${config.name}: ${error.message}", error)
-                            logEvent(config, event, success = false, errorMessage = error.message ?: "Unknown error")
-                        }
-                    )
-                }.getOrElse { e ->
-                    logger.error("Error processing alert for provider ${config.name}", e)
-                    logEvent(config, event, success = false, errorMessage = e.message ?: "Unknown error")
-                }
-            }
+            fireNative(context)
         }.getOrElse { e ->
-            logger.error("Error firing alert", e)
+            logger.error("Error triggering native escalation", e)
+        }
+        suspendRunCatching {
+            fireProviders(context)
+        }.getOrElse { e ->
+            logger.error("Error firing provider alert", e)
         }
     }
 
@@ -165,6 +141,41 @@ class IncidentService(
         }
     }
 
+    private suspend fun fireProviderAlerts(event: AlertLifecycleEvent) {
+        val configs = getEnabledProviderConfigs(event.organizationId)
+        if (configs.isEmpty()) {
+            logger.debug("No enabled incident providers for org ${event.organizationId}")
+            return
+        }
+        configs.forEach { config ->
+            suspendRunCatching {
+                if (!shouldRouteAlert(config.id, event.source)) {
+                    logger.debug("Skipping alert for provider ${config.name}: no routing rule for ${event.source}")
+                    return@forEach
+                }
+                val provider = IncidentProviderRegistry.getProvider(config.providerType)
+                if (provider == null) {
+                    logger.error("Provider type ${config.providerType} not registered")
+                    logEvent(config, event, success = false, errorMessage = "Provider not registered")
+                    return@forEach
+                }
+                provider.sendAlert(event, config).fold(
+                    onSuccess = { incidentId ->
+                        logger.info("Alert sent to ${config.name}: $incidentId")
+                        logEvent(config, event, success = true, providerIncidentId = incidentId)
+                    },
+                    onFailure = { error ->
+                        logger.error("Failed to send alert to ${config.name}: ${error.message}", error)
+                        logEvent(config, event, success = false, errorMessage = error.message ?: "Unknown error")
+                    },
+                )
+            }.getOrElse { error ->
+                logger.error("Error processing alert for provider ${config.name}", error)
+                logEvent(config, event, success = false, errorMessage = error.message ?: "Unknown error")
+            }
+        }
+    }
+
     /**
      * Resolve an alert with all enabled incident providers.
      */
@@ -177,14 +188,19 @@ class IncidentService(
         moneatUrl: String = "",
         publishWorkflow: Boolean = true
     ) {
-        val onCallEnabled = EnvConfig.get("ONCALL_ENABLED", "false").toBoolean()
-        if (onCallEnabled) {
-            suspendRunCatching {
-                resolveNativeEscalation(organizationId, source, deduplicationKey)
-            }.getOrElse { e ->
-                logger.error("Error resolving native escalation", e)
-            }
-        }
+        val event = AlertLifecycleEvent(
+            title = title,
+            description = description,
+            priority = AlertPriority.P3,
+            status = AlertStatus.RESOLVED,
+            source = source,
+            deduplicationKey = deduplicationKey,
+            organizationId = organizationId,
+            moneatUrl = moneatUrl,
+        )
+        val context = AlertFanoutContext(event, null, null, deliverySilenced = false)
+        suspendRunCatching { resolveNative(context) }
+            .onFailure { error -> logger.error("Error resolving native escalation", error) }
 
         if (publishWorkflow) {
             suspendRunCatching {
@@ -203,67 +219,62 @@ class IncidentService(
             }
         }
 
-        suspendRunCatching {
-            val configs = getEnabledProviderConfigs(organizationId)
-            if (configs.isEmpty()) {
-                return
-            }
+        suspendRunCatching { resolveProviders(context) }
+            .onFailure { error -> logger.error("Error resolving provider alert", error) }
+    }
 
-            configs.forEach { config ->
-                suspendRunCatching {
-                    // Check if this provider has a routing rule for this source
-                    val shouldRoute = shouldRouteAlert(config.id, source)
-                    if (!shouldRoute) {
-                        logger.debug("Skipping resolve for provider ${config.name}: no routing rule for $source")
-                        return@forEach
-                    }
-
-                    val provider = IncidentProviderRegistry.getProvider(config.providerType)
-                    if (provider == null) {
-                        logger.error("Provider type ${config.providerType} not registered")
-                        return@forEach
-                    }
-
-                    val result = provider.resolveAlert(deduplicationKey, config)
-
-                    result.fold(
-                        onSuccess = { incidentId ->
-                            logger.info("Alert resolved with ${config.name}: $incidentId")
-                            logResolveEvent(
-                                config,
-                                organizationId,
-                                source,
-                                deduplicationKey,
-                                success = true,
-                                providerIncidentId = incidentId
-                            )
-                        },
-                        onFailure = { error ->
-                            logger.error("Failed to resolve alert with ${config.name}: ${error.message}", error)
-                            logResolveEvent(
-                                config,
-                                organizationId,
-                                source,
-                                deduplicationKey,
-                                success = false,
-                                errorMessage = error.message
-                            )
-                        }
-                    )
-                }.getOrElse { e ->
-                    logger.error("Error resolving alert for provider ${config.name}", e)
-                    logResolveEvent(
-                        config,
-                        organizationId,
-                        source,
-                        deduplicationKey,
-                        success = false,
-                        errorMessage = e.message
-                    )
+    private suspend fun resolveProviderAlerts(
+        organizationId: Int,
+        source: AlertSource,
+        deduplicationKey: String,
+    ) {
+        val configs = getEnabledProviderConfigs(organizationId)
+        configs.forEach { config ->
+            suspendRunCatching {
+                if (!shouldRouteAlert(config.id, source)) {
+                    logger.debug("Skipping resolve for provider ${config.name}: no routing rule for $source")
+                    return@forEach
                 }
+                val provider = IncidentProviderRegistry.getProvider(config.providerType)
+                if (provider == null) {
+                    logger.error("Provider type ${config.providerType} not registered")
+                    return@forEach
+                }
+                provider.resolveAlert(deduplicationKey, config).fold(
+                    onSuccess = { incidentId ->
+                        logger.info("Alert resolved with ${config.name}: $incidentId")
+                        logResolveEvent(
+                            config,
+                            organizationId,
+                            source,
+                            deduplicationKey,
+                            success = true,
+                            providerIncidentId = incidentId,
+                        )
+                    },
+                    onFailure = { error ->
+                        logger.error("Failed to resolve alert with ${config.name}: ${error.message}", error)
+                        logResolveEvent(
+                            config,
+                            organizationId,
+                            source,
+                            deduplicationKey,
+                            success = false,
+                            errorMessage = error.message,
+                        )
+                    },
+                )
+            }.getOrElse { error ->
+                logger.error("Error resolving alert for provider ${config.name}", error)
+                logResolveEvent(
+                    config,
+                    organizationId,
+                    source,
+                    deduplicationKey,
+                    success = false,
+                    errorMessage = error.message,
+                )
             }
-        }.getOrElse { e ->
-            logger.error("Error resolving alert", e)
         }
     }
 
@@ -424,56 +435,52 @@ class IncidentService(
             logger.debug("On-call enterprise module not loaded — skipping native escalation")
             return
         }
-        suspendRunCatching {
-            val escalationPolicyId = getEscalationPolicyForAlert(event)
+        val escalationPolicyId = getEscalationPolicyForAlert(event)
 
-            if (escalationPolicyId == null) {
-                logger.debug("No escalation policy configured for org ${event.organizationId}, source ${event.source}")
-                return
-            }
+        if (escalationPolicyId == null) {
+            logger.debug("No escalation policy configured for org ${event.organizationId}, source ${event.source}")
+            return
+        }
 
-            val priority = bridge.resolvePriority(event.organizationId, event.priority.wire)
-            if (priority == null) {
-                logger.warn("Could not resolve alert priority ${event.priority.wire}")
-                return
-            }
+        val priority = bridge.resolvePriority(event.organizationId, event.priority.wire)
+        if (priority == null) {
+            logger.warn("Could not resolve alert priority ${event.priority.wire}")
+            return
+        }
 
-            // Check if we should escalate based on business hours
-            val shouldEscalate = bridge.shouldEscalate(event.organizationId, priority.priority)
+        // Check if we should escalate based on business hours
+        val shouldEscalate = bridge.shouldEscalate(event.organizationId, priority.priority)
 
-            if (!shouldEscalate) {
-                logger.debug("Alert deferred: outside business hours for priority ${priority.priority}")
-                return
-            }
+        if (!shouldEscalate) {
+            logger.debug("Alert deferred: outside business hours for priority ${priority.priority}")
+            return
+        }
 
-            // Trigger escalation
-            val serializedMetadata =
-                if (event.metadata.isNotEmpty()) {
-                    kotlinx.serialization.json.Json.encodeToString(
-                        kotlinx.serialization.serializer(),
-                        event.metadata,
-                    )
-                } else {
-                    null
-                }
-
-            val incidentId =
-                bridge.triggerEscalation(
-                    organizationId = event.organizationId,
-                    escalationPolicyId = escalationPolicyId,
-                    title = event.title,
-                    description = event.description,
-                    priority = priority.priority,
-                    alertSource = event.source.name,
-                    deduplicationKey = event.deduplicationKey,
-                    metadata = serializedMetadata,
+        // Trigger escalation
+        val serializedMetadata =
+            if (event.metadata.isNotEmpty()) {
+                kotlinx.serialization.json.Json.encodeToString(
+                    kotlinx.serialization.serializer(),
+                    event.metadata,
                 )
-
-            if (incidentId != null) {
-                logger.info("Native escalation triggered for incident $incidentId")
+            } else {
+                null
             }
-        }.getOrElse { e ->
-            logger.error("Error triggering native escalation", e)
+
+        val incidentId =
+            bridge.triggerEscalation(
+                organizationId = event.organizationId,
+                escalationPolicyId = escalationPolicyId,
+                title = event.title,
+                description = event.description,
+                priority = priority.priority,
+                alertSource = event.source.name,
+                deduplicationKey = event.deduplicationKey,
+                metadata = serializedMetadata,
+            )
+
+        if (incidentId != null) {
+            logger.info("Native escalation triggered for incident $incidentId")
         }
     }
 

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -22,6 +22,7 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutArm
 import com.moneat.alerts.services.AlertFanoutPlan
 import com.moneat.alerts.services.AlertFanoutState
 import com.moneat.alerts.services.AlertLifecycleOrchestrator
@@ -1132,7 +1133,11 @@ class MonitorAlertService(
                 ),
                 AlertFanoutPlan.FULL,
             )
-            result.outcomes.none { it.state == AlertFanoutState.FAILED }
+            result.outcomes
+                .filter {
+                    it.arm == AlertFanoutArm.NATIVE_ON_CALL ||
+                        it.arm == AlertFanoutArm.INCIDENT_PROVIDERS
+                }.none { it.state == AlertFanoutState.FAILED }
         }.getOrElse { e ->
             logger.error(e) { "Failed to resolve incident alert for host up" }
             false

--- a/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
+++ b/backend/src/main/kotlin/com/moneat/monitor/services/MonitorAlertService.kt
@@ -22,6 +22,9 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertFanoutState
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.alerts.services.AlertSilenceService
 import com.moneat.incident.services.IncidentService
 import com.moneat.monitor.models.AlertData
@@ -40,7 +43,6 @@ import com.moneat.shared.services.toUuidOrNull
 import com.moneat.shared.services.userResourceId
 import com.moneat.shared.services.userResourceIds
 import com.moneat.utils.suspendRunCatching
-import com.moneat.workflows.services.AlertResolvedWorkflowEvent
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
@@ -250,6 +252,10 @@ class MonitorAlertService(
     private val incidentService: IncidentService = IncidentService(),
     private val workflowService: WorkflowService = WorkflowService(),
     private val alertSilenceService: AlertSilenceService = AlertSilenceService(),
+    private val alertOrchestrator: AlertLifecycleOrchestrator = AlertLifecycleOrchestrator(
+        workflowFanoutProvider = { workflowService },
+        incidentFanoutProvider = { incidentService },
+    ),
 ) {
     private val config = ApplicationConfig("application.conf")
     private val clickhouseDb: String get() = ClickHouseClient.getDatabase()
@@ -530,77 +536,20 @@ class MonitorAlertService(
         val description = "The alert for $metricLabel is no longer active."
         val deduplicationKey = hostAlertDedupKey(alert)
 
-        publishRecoveredHostAlertWorkflow(
-            alert = alert,
-            organizationId = organizationId,
-            deduplicationKey = deduplicationKey,
-            title = title,
-            description = description,
-            dashboardUrl = dashboardUrl,
-            priority = alertPriorityOverride ?: AlertPriority.P1
-        )
-        autoResolveRecoveredHostIncident(
-            alert = alert,
-            organizationId = organizationId,
-            deduplicationKey = deduplicationKey,
-            title = title,
-            description = description,
-            dashboardUrl = dashboardUrl,
-            alertPriorityOverride = alertPriorityOverride
-        )
-        logger.info { "Alert ${alert.id} recovered for host ${alert.hostId}" }
-    }
-
-    private suspend fun publishRecoveredHostAlertWorkflow(
-        alert: AlertData,
-        organizationId: Int,
-        deduplicationKey: String,
-        title: String,
-        description: String,
-        dashboardUrl: String,
-        priority: AlertPriority
-    ) {
-        suspendRunCatching {
-            workflowService.publishAlertResolved(
-                AlertResolvedWorkflowEvent(
-                    organizationId = organizationId,
-                    source = AlertSource.HOST_ALERT.name,
-                    deduplicationKey = deduplicationKey,
-                    title = title,
-                    description = description,
-                    moneatUrl = dashboardUrl,
-                    priority = priority,
-                )
-            )
-        }.getOrElse { e ->
-            logger.error(e) { "Failed to publish recovered host alert workflow ${alert.id}" }
-        }
-    }
-
-    private suspend fun autoResolveRecoveredHostIncident(
-        alert: AlertData,
-        organizationId: Int,
-        deduplicationKey: String,
-        title: String,
-        description: String,
-        dashboardUrl: String,
-        alertPriorityOverride: AlertPriority?
-    ) {
-        if (alertPriorityOverride == null) return
-
-        suspendRunCatching {
-            incidentService.autoResolveAlert(
-                organizationId = organizationId,
-                source = AlertSource.HOST_ALERT,
-                deduplicationKey = deduplicationKey,
+        alertOrchestrator.process(
+            AlertLifecycleEvent(
                 title = title,
                 description = description,
+                priority = alertPriorityOverride ?: AlertPriority.P1,
+                status = AlertStatus.RESOLVED,
+                source = AlertSource.HOST_ALERT,
+                deduplicationKey = deduplicationKey,
+                organizationId = organizationId,
                 moneatUrl = dashboardUrl,
-                publishWorkflow = false
-            )
-        }.getOrElse { e ->
-            logger.error(e) { "Failed to resolve incident for recovered alert ${alert.id}" }
-        }
+            ),
+            if (alertPriorityOverride == null) AlertFanoutPlan.WORKFLOW_ONLY else AlertFanoutPlan.FULL,
+        )
+        logger.info { "Alert ${alert.id} recovered for host ${alert.hostId}" }
     }
 
     private suspend fun triggerAlert(
@@ -1033,19 +982,10 @@ class MonitorAlertService(
                 moneatUrl = dashboardUrl
             )
 
-        val shouldNotifyIncidentProvider = suspendRunCatching {
-            workflowService.publishAlertTriggered(alertLifecycleEvent)
-        }.getOrElse { e ->
-            logger.error(e) { "Failed to publish host alert workflow" }
-            true
-        }
-        if (alertPriority != null && shouldNotifyIncidentProvider) {
-            suspendRunCatching {
-                incidentService.fireAlert(alertLifecycleEvent, publishWorkflow = false)
-            }.getOrElse { e ->
-                logger.error(e) { "Failed to fire host alert" }
-            }
-        }
+        alertOrchestrator.process(
+            alertLifecycleEvent,
+            if (alertPriority == null) AlertFanoutPlan.WORKFLOW_ONLY else AlertFanoutPlan.FULL,
+        )
     }
 
     private fun hostAlertPriorityOverride(alert: AlertData): AlertPriority? =
@@ -1166,7 +1106,7 @@ class MonitorAlertService(
                     metadata = metadata,
                     moneatUrl = dashboardUrl
                 )
-            incidentService.fireAlert(alertLifecycleEvent)
+            alertOrchestrator.process(alertLifecycleEvent, AlertFanoutPlan.FULL)
         }.getOrElse { e ->
             logger.error(e) { "Failed to fire incident provider alert for host down" }
         }
@@ -1179,15 +1119,20 @@ class MonitorAlertService(
     ): Boolean =
         suspendRunCatching {
             val hostUrl = hostDashboardUrl(hostId, organizationId)
-            incidentService.autoResolveAlert(
-                organizationId = organizationId,
-                source = AlertSource.HOST_DOWN,
-                deduplicationKey = hostDownDedupKey(hostId),
-                title = "Host Recovered: $hostName",
-                description = "$hostName is reporting metrics again.",
-                moneatUrl = hostUrl
+            val result = alertOrchestrator.process(
+                AlertLifecycleEvent(
+                    title = "Host Recovered: $hostName",
+                    description = "$hostName is reporting metrics again.",
+                    priority = AlertPriority.P0,
+                    status = AlertStatus.RESOLVED,
+                    source = AlertSource.HOST_DOWN,
+                    deduplicationKey = hostDownDedupKey(hostId),
+                    organizationId = organizationId,
+                    moneatUrl = hostUrl,
+                ),
+                AlertFanoutPlan.FULL,
             )
-            true
+            result.outcomes.none { it.state == AlertFanoutState.FAILED }
         }.getOrElse { e ->
             logger.error(e) { "Failed to resolve incident alert for host up" }
             false

--- a/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
+++ b/backend/src/main/kotlin/com/moneat/notifications/services/NotificationService.kt
@@ -22,6 +22,8 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.shared.models.Memberships
 import com.moneat.shared.models.NotificationPreferences
@@ -72,6 +74,9 @@ private const val WEEKLY_SUMMARY_JOB_NAME = "weekly_summary"
 class NotificationService(
     private val emailService: EmailService,
     private val workflowService: WorkflowService = WorkflowService(),
+    private val alertOrchestrator: AlertLifecycleOrchestrator = AlertLifecycleOrchestrator(
+        workflowFanoutProvider = { workflowService },
+    ),
 ) {
     enum class WeeklySummaryResult { SENT, SKIPPED, FAILED }
     private val config = ApplicationConfig("application.conf")
@@ -208,7 +213,7 @@ class NotificationService(
                     stackFrames = emailStackFrames
                 )
 
-            workflowService.publishAlertTriggered(
+            alertOrchestrator.process(
                 AlertLifecycleEvent(
                     title = "New Issue: ${emailData.issueTitle}",
                     description = "${emailData.projectName} reported ${emailData.issueLevel.uppercase()}: " +
@@ -219,7 +224,8 @@ class NotificationService(
                     deduplicationKey = "moneat-error-$issueId",
                     organizationId = orgId,
                     moneatUrl = issueUrl
-                )
+                ),
+                AlertFanoutPlan.WORKFLOW_ONLY,
             )
         }.getOrElse { e ->
             logger.error(e) { "Error in onNewIssue handler" }

--- a/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
+++ b/backend/src/main/kotlin/com/moneat/uptime/services/UptimeScheduler.kt
@@ -20,6 +20,8 @@ import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.billing.services.BillingQuotaService
 import com.moneat.incident.services.IncidentService
 import com.moneat.shared.services.TaskLock
@@ -28,7 +30,6 @@ import com.moneat.uptime.models.UptimeMonitorData
 import com.moneat.uptime.repositories.UptimeMonitorRepositoryImpl
 import com.moneat.utils.TimeConstants.MILLIS_PER_SECOND_LONG
 import com.moneat.utils.suspendRunCatching
-import com.moneat.workflows.services.WorkflowService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -59,8 +60,10 @@ class UptimeScheduler(
     private val checkExecutor: UptimeCheckExecutor = UptimeCheckExecutor(),
     private val incidentService: IncidentService = IncidentService(),
     private val billingQuotaService: BillingQuotaService = BillingQuotaService(),
-    private val workflowService: WorkflowService = WorkflowService(),
     private val frontendBaseUrl: String,
+    private val alertOrchestrator: AlertLifecycleOrchestrator = AlertLifecycleOrchestrator(
+        incidentFanoutProvider = { incidentService },
+    ),
 ) {
     companion object {
         private const val CHECK_STATUS_DOWN = 0
@@ -321,16 +324,20 @@ class UptimeScheduler(
         suspendRunCatching {
             if (newStatus == "down") {
                 val alertLifecycleEvent = uptimeDownEvent(monitor, result, baseUrl)
-                incidentService.fireAlert(alertLifecycleEvent)
+                alertOrchestrator.process(alertLifecycleEvent, AlertFanoutPlan.FULL)
             } else if (newStatus == "up") {
-                // Resolve the incident
-                incidentService.autoResolveAlert(
-                    organizationId = monitor.organizationId,
-                    source = AlertSource.UPTIME_MONITOR,
-                    deduplicationKey = "moneat-uptime-${monitor.id}",
-                    title = "Uptime Monitor Recovered: ${monitor.name}",
-                    description = "Monitor '${monitor.name}' (${monitor.type}) is back up.",
-                    moneatUrl = "$baseUrl/uptime/${monitor.id}"
+                alertOrchestrator.process(
+                    AlertLifecycleEvent(
+                        title = "Uptime Monitor Recovered: ${monitor.name}",
+                        description = "Monitor '${monitor.name}' (${monitor.type}) is back up.",
+                        priority = monitor.alertPriority?.let { AlertPriority.fromString(it) } ?: AlertPriority.P1,
+                        status = AlertStatus.RESOLVED,
+                        source = AlertSource.UPTIME_MONITOR,
+                        deduplicationKey = "moneat-uptime-${monitor.id}",
+                        organizationId = monitor.organizationId,
+                        moneatUrl = "$baseUrl/uptime/${monitor.id}",
+                    ),
+                    AlertFanoutPlan.FULL,
                 )
             }
         }.onFailure { e ->
@@ -342,7 +349,10 @@ class UptimeScheduler(
         monitor: UptimeMonitorData,
         result: CheckResult
     ) {
-        workflowService.publishAlertTriggered(uptimeDownEvent(monitor, result, frontendBaseUrl))
+        alertOrchestrator.process(
+            uptimeDownEvent(monitor, result, frontendBaseUrl),
+            AlertFanoutPlan.WORKFLOW_ONLY,
+        )
     }
 
     private fun uptimeDownEvent(

--- a/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
+++ b/backend/src/main/kotlin/com/moneat/workflows/services/WorkflowService.kt
@@ -24,6 +24,8 @@ import com.moneat.alerts.models.AlertStatus
 import com.moneat.alerts.services.AlertEpisodeContext
 import com.moneat.alerts.services.AlertEpisodeDecision
 import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.alerts.services.AlertWorkflowFanout
 import com.moneat.config.EnvConfig
 import com.moneat.monitoring.OperationalMetrics
 import com.moneat.security.signals.SignalOutcome
@@ -169,7 +171,7 @@ class WorkflowService(
     private val runPersistence: PersistRunActivityImpl = PersistRunActivityImpl(),
     private val executionEngine: WorkflowExecutionEngine = TemporalWorkflowExecutionEngine(TemporalClientProvider()),
     private val alertEpisodeService: AlertEpisodeService = AlertEpisodeService()
-) {
+) : AlertWorkflowFanout {
     private val json = workflowJson
     private val graphValidator = WorkflowGraphValidator()
     private val directRunExecutor =
@@ -858,6 +860,12 @@ class WorkflowService(
             logger.error(e) { "Failed to publish alert workflow triggers" }
         }
         return true
+    }
+
+    /** Publish from the shared episode-first orchestration seam without recording the episode again. */
+    override suspend fun publish(context: AlertFanoutContext) {
+        val decision = context.episodeDecision ?: return
+        publishAlertWorkflowTriggers(context.event, decision)
     }
 
     private fun isAlertDeliverySilenced(organizationId: Int): Boolean =

--- a/backend/src/test/kotlin/com/moneat/alerts/AlertLifecycleOrchestratorTest.kt
+++ b/backend/src/test/kotlin/com/moneat/alerts/AlertLifecycleOrchestratorTest.kt
@@ -1,0 +1,278 @@
+// Moneat - observability platform
+// Copyright (C) 2026 Moneat
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package com.moneat.alerts
+
+import com.moneat.alerts.models.AlertEpisodes
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertEpisodeService
+import com.moneat.alerts.services.AlertFanoutArm
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertFanoutState
+import com.moneat.alerts.services.AlertIncidentFanout
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
+import com.moneat.alerts.services.AlertRouteFanout
+import com.moneat.alerts.services.AlertSilenceService
+import com.moneat.alerts.services.AlertWorkflowFanout
+import com.moneat.shared.models.Organizations
+import com.moneat.shared.models.Users
+import com.moneat.testsupport.TestDatabaseHelper
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class AlertLifecycleOrchestratorTest {
+    companion object {
+        private var database: Database? = null
+    }
+
+    private lateinit var silenceService: AlertSilenceService
+    private lateinit var episodeService: AlertEpisodeService
+    private var organizationId: Int = 0
+
+    @BeforeTest
+    fun setUp() {
+        if (database == null) {
+            database = Database.connect(
+                url = "jdbc:h2:mem:moneat_alert_orchestration;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver",
+            )
+        }
+        TransactionManager.defaultDatabase = database
+        TestDatabaseHelper.dropAndPatchJsonb(AlertEpisodes, Users, Organizations)
+        transaction { SchemaUtils.create(Users, Organizations, AlertEpisodes) }
+        organizationId = transaction {
+            Organizations.insert {
+                it[name] = "Alert Orchestration"
+                it[slug] = "alert-orchestration"
+            }[Organizations.id]
+        }
+        silenceService = mockk()
+        every { silenceService.isOrganizationSilenced(any(), any()) } returns false
+        episodeService = AlertEpisodeService(silenceService)
+    }
+
+    @Test
+    fun `one episode context is shared by every selected fanout arm`() = runBlocking {
+        val captured = mutableListOf<AlertFanoutContext>()
+        val workflow = AlertWorkflowFanout { captured += it }
+        val incidents = capturingIncidentFanout(captured)
+        val route = AlertRouteFanout { captured += it }
+        val orchestrator = orchestrator(workflow, incidents, route)
+
+        val result = orchestrator.process(event(), AlertFanoutPlan.FULL)
+
+        assertEquals(4, captured.size)
+        captured.forEach { assertSame(result.context, it) }
+        assertEquals(1, transaction { AlertEpisodes.selectAll().count() })
+        assertEquals(1, result.context.episode?.notificationCount)
+        assertTrue(result.outcomes.all { it.state == AlertFanoutState.SUCCEEDED })
+    }
+
+    @Test
+    fun `one arm failure is observable and does not suppress other arms`() = runBlocking {
+        val captured = mutableListOf<AlertFanoutContext>()
+        val workflow = AlertWorkflowFanout { error("workflow unavailable") }
+        val orchestrator = orchestrator(
+            workflow,
+            capturingIncidentFanout(captured),
+            AlertRouteFanout { captured += it },
+        )
+
+        val result = orchestrator.process(event(), AlertFanoutPlan.FULL)
+
+        assertEquals(AlertFanoutState.FAILED, result.outcome(AlertFanoutArm.WORKFLOW).state)
+        assertEquals(3, captured.size)
+        assertEquals(AlertFanoutState.SUCCEEDED, result.outcome(AlertFanoutArm.NATIVE_ON_CALL).state)
+        assertEquals(AlertFanoutState.SUCCEEDED, result.outcome(AlertFanoutArm.INCIDENT_PROVIDERS).state)
+    }
+
+    @Test
+    fun `retry reuses the episode notification and delivery identity`() = runBlocking {
+        var attempts = 0
+        val workflow = AlertWorkflowFanout {
+            attempts += 1
+            if (attempts == 1) error("workflow unavailable")
+        }
+        val orchestrator = orchestrator(workflow, capturingIncidentFanout(mutableListOf()), AlertRouteFanout {})
+
+        val first = orchestrator.process(event(), AlertFanoutPlan.WORKFLOW_ONLY)
+        val retried = orchestrator.retry(first.context, AlertFanoutPlan.WORKFLOW_ONLY.copy(route = false))
+
+        assertEquals(AlertFanoutState.FAILED, first.outcome(AlertFanoutArm.WORKFLOW).state)
+        assertEquals(AlertFanoutState.SUCCEEDED, retried.outcome(AlertFanoutArm.WORKFLOW).state)
+        assertEquals(first.context.episode?.id, retried.context.episode?.id)
+        assertEquals(first.context.deliveryKey, retried.context.deliveryKey)
+        assertEquals(1, transaction { AlertEpisodes.selectAll().single()[AlertEpisodes.notificationCount] })
+    }
+
+    @Test
+    fun `repeat firing updates route context but suppresses reminder delivery`() = runBlocking {
+        val workflowContexts = mutableListOf<AlertFanoutContext>()
+        val incidentContexts = mutableListOf<AlertFanoutContext>()
+        val routeContexts = mutableListOf<AlertFanoutContext>()
+        val orchestrator = orchestrator(
+            AlertWorkflowFanout { workflowContexts += it },
+            capturingIncidentFanout(incidentContexts),
+            AlertRouteFanout { routeContexts += it },
+        )
+
+        orchestrator.process(event(), AlertFanoutPlan.FULL)
+        val repeated = orchestrator.process(event(), AlertFanoutPlan.FULL)
+
+        assertEquals(2, routeContexts.size)
+        assertEquals(routeContexts.first().episode?.id, routeContexts.last().episode?.id)
+        assertEquals(1, workflowContexts.size)
+        assertEquals(2, incidentContexts.size)
+        assertEquals(AlertFanoutState.SKIPPED, repeated.outcome(AlertFanoutArm.WORKFLOW).state)
+        assertEquals(AlertFanoutState.SKIPPED, repeated.outcome(AlertFanoutArm.NATIVE_ON_CALL).state)
+    }
+
+    @Test
+    fun `organization silence records and routes the episode but blocks delivery arms`() = runBlocking {
+        every { silenceService.isOrganizationSilenced(organizationId, any()) } returns true
+        val delivered = mutableListOf<AlertFanoutContext>()
+        val routed = mutableListOf<AlertFanoutContext>()
+        val orchestrator = orchestrator(
+            AlertWorkflowFanout { delivered += it },
+            capturingIncidentFanout(delivered),
+            AlertRouteFanout { routed += it },
+        )
+
+        val result = orchestrator.process(event(), AlertFanoutPlan.FULL)
+
+        assertEquals(1, routed.size)
+        assertTrue(result.context.deliverySilenced)
+        assertEquals(0, result.context.episode?.notificationCount)
+        assertTrue(delivered.isEmpty())
+        assertEquals(AlertFanoutState.SKIPPED, result.outcome(AlertFanoutArm.WORKFLOW).state)
+    }
+
+    @Test
+    fun `resolved lifecycle shares the closed episode with every arm`() = runBlocking {
+        val captured = mutableListOf<AlertFanoutContext>()
+        val orchestrator = orchestrator(
+            AlertWorkflowFanout { captured += it },
+            capturingIncidentFanout(captured),
+            AlertRouteFanout { captured += it },
+        )
+        orchestrator.process(event(), AlertFanoutPlan.FULL)
+        captured.clear()
+
+        val result = orchestrator.process(event().copy(status = AlertStatus.RESOLVED), AlertFanoutPlan.FULL)
+
+        assertEquals("RESOLVED", result.context.episode?.status)
+        assertEquals(4, captured.size)
+        captured.forEach { assertSame(result.context, it) }
+    }
+
+    @Test
+    fun `silenced resolution closes delivery targets without publishing workflows`() = runBlocking {
+        val workflowContexts = mutableListOf<AlertFanoutContext>()
+        val incidentContexts = mutableListOf<AlertFanoutContext>()
+        val orchestrator = orchestrator(
+            AlertWorkflowFanout { workflowContexts += it },
+            capturingIncidentFanout(incidentContexts),
+            AlertRouteFanout {},
+        )
+        orchestrator.process(event(), AlertFanoutPlan.FULL)
+        workflowContexts.clear()
+        incidentContexts.clear()
+        every { silenceService.isOrganizationSilenced(organizationId, any()) } returns true
+
+        val result = orchestrator.process(event().copy(status = AlertStatus.RESOLVED), AlertFanoutPlan.FULL)
+
+        assertTrue(workflowContexts.isEmpty())
+        assertEquals(2, incidentContexts.size)
+        assertEquals(AlertFanoutState.SKIPPED, result.outcome(AlertFanoutArm.WORKFLOW).state)
+        assertEquals(AlertFanoutState.SUCCEEDED, result.outcome(AlertFanoutArm.NATIVE_ON_CALL).state)
+        assertEquals(AlertFanoutState.SUCCEEDED, result.outcome(AlertFanoutArm.INCIDENT_PROVIDERS).state)
+    }
+
+    @Test
+    fun `core only operation reports unavailable optional arms without failing`() = runBlocking {
+        val orchestrator = AlertLifecycleOrchestrator(
+            episodeService = episodeService,
+            workflowFanoutProvider = { null },
+            incidentFanoutProvider = { null },
+            routeFanoutProvider = { null },
+        )
+
+        val result = orchestrator.process(event(), AlertFanoutPlan.FULL)
+
+        assertTrue(result.outcomes.all { it.state == AlertFanoutState.UNAVAILABLE })
+        assertEquals(1, transaction { AlertEpisodes.selectAll().count() })
+    }
+
+    private fun orchestrator(
+        workflow: AlertWorkflowFanout,
+        incidents: AlertIncidentFanout,
+        route: AlertRouteFanout,
+    ) = AlertLifecycleOrchestrator(
+        episodeService = episodeService,
+        workflowFanoutProvider = { workflow },
+        incidentFanoutProvider = { incidents },
+        routeFanoutProvider = { route },
+    )
+
+    private fun capturingIncidentFanout(captured: MutableList<AlertFanoutContext>) =
+        object : AlertIncidentFanout {
+            override suspend fun fireNative(context: AlertFanoutContext) {
+                captured += context
+            }
+
+            override suspend fun fireProviders(context: AlertFanoutContext) {
+                captured += context
+            }
+
+            override suspend fun resolveNative(context: AlertFanoutContext) {
+                captured += context
+            }
+
+            override suspend fun resolveProviders(context: AlertFanoutContext) {
+                captured += context
+            }
+        }
+
+    private fun event() = AlertLifecycleEvent(
+        title = "Checkout latency",
+        description = "Latency exceeded the threshold",
+        priority = AlertPriority.P1,
+        status = AlertStatus.FIRING,
+        source = AlertSource.DASHBOARD_ALERT,
+        deduplicationKey = "dashboard-alert-1",
+        organizationId = organizationId,
+        moneatUrl = "https://moneat.test/dashboards/checkout",
+    )
+
+    private fun com.moneat.alerts.services.AlertOrchestrationResult.outcome(arm: AlertFanoutArm) =
+        outcomes.single { it.arm == arm }
+}

--- a/backend/src/test/kotlin/com/moneat/enterprise/IncidentServiceOnCallBridgeTest.kt
+++ b/backend/src/test/kotlin/com/moneat/enterprise/IncidentServiceOnCallBridgeTest.kt
@@ -16,9 +16,14 @@
 
 package com.moneat.enterprise
 
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutContext
 import com.moneat.config.EnvConfig
 import com.moneat.incident.services.IncidentService
+import com.moneat.monitor.repositories.ResourceOwnershipRepository
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.server.application.Application
 import io.ktor.server.routing.Route
@@ -27,10 +32,12 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 private const val ORGANIZATION_ID = 42
 private const val UPTIME_DEDUPLICATION_KEY = "uptime-monitor:payments-api"
@@ -97,6 +104,40 @@ class IncidentServiceOnCallBridgeTest {
             bridge.resolvedEscalations,
         )
     }
+
+    @Test
+    fun `native fanout propagates escalation failure for orchestration visibility`() = runBlocking {
+        val ownershipRepository = mockk<ResourceOwnershipRepository>()
+        every {
+            ownershipRepository.escalationPolicyIdForResource(ORGANIZATION_ID, "service:payments")
+        } returns 7
+        service = IncidentService(
+            workflowService = mockk<WorkflowService>(relaxed = true),
+            ownershipRepository = ownershipRepository,
+        )
+        bridge.failTrigger = true
+        val context = AlertFanoutContext(
+            event = AlertLifecycleEvent(
+                title = "Payments unavailable",
+                description = "The payments service is unavailable",
+                priority = AlertPriority.P1,
+                status = AlertStatus.FIRING,
+                source = AlertSource.UPTIME_MONITOR,
+                deduplicationKey = UPTIME_DEDUPLICATION_KEY,
+                organizationId = ORGANIZATION_ID,
+                metadata = mapOf("catalog_resource_id" to JsonPrimitive("service:payments")),
+                moneatUrl = "https://moneat.example/alerts/payments",
+            ),
+            episodeDecision = null,
+            episode = null,
+            deliverySilenced = false,
+        )
+
+        assertFailsWith<IllegalStateException> {
+            service.fireNative(context)
+        }
+        Unit
+    }
 }
 
 private data class ResolvedEscalation(
@@ -109,6 +150,7 @@ private class RecordingOnCallBridgeModule :
     EnterpriseModule,
     OnCallBridge {
     val resolvedEscalations = mutableListOf<ResolvedEscalation>()
+    var failTrigger = false
 
     override val name: String = "Recording On-Call"
 
@@ -121,12 +163,12 @@ private class RecordingOnCallBridgeModule :
     override fun resolvePriority(
         organizationId: Int,
         priority: String,
-    ): PriorityInfo? = null
+    ): PriorityInfo? = PriorityInfo(priority, null)
 
     override fun shouldEscalate(
         organizationId: Int,
         priority: String,
-    ): Boolean = false
+    ): Boolean = true
 
     override fun resolveEscalationPolicyId(
         organizationId: Int,
@@ -152,7 +194,10 @@ private class RecordingOnCallBridgeModule :
         alertSource: String,
         deduplicationKey: String?,
         metadata: String?,
-    ): String? = null
+    ): String? {
+        if (failTrigger) error("Native escalation failed")
+        return null
+    }
 
     override suspend fun resolveEscalation(
         organizationId: Int,

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -18,8 +18,13 @@ package com.moneat.services
 
 import com.moneat.config.ClickHouseClient
 import com.moneat.config.RedisConfig
-import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutArm
+import com.moneat.alerts.services.AlertFanoutOutcome
+import com.moneat.alerts.services.AlertFanoutPlan
+import com.moneat.alerts.services.AlertFanoutState
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.incident.services.IncidentService
 import com.moneat.monitor.models.AlertData
 import com.moneat.monitor.models.CreateSilencePeriodRequest
@@ -37,7 +42,6 @@ import com.moneat.shared.models.OrganizationAlertTemplates
 import com.moneat.shared.models.Organizations
 import com.moneat.shared.models.Users
 import com.moneat.testsupport.TestDatabaseHelper
-import com.moneat.workflows.services.AlertResolvedWorkflowEvent
 import com.moneat.workflows.services.WorkflowService
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
@@ -76,30 +80,6 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
-private fun expectedResolvedWorkflowEvent(
-    organizationId: Int,
-    hostId: Int,
-    deduplicationKey: String,
-    hostName: String = "host-alert-workflow",
-): AlertResolvedWorkflowEvent {
-    val hostResourceId = transaction {
-        Hosts
-            .selectAll()
-            .where { Hosts.id eq hostId }
-            .single()[Hosts.resource_id]
-            .toString()
-    }
-    return AlertResolvedWorkflowEvent(
-        organizationId = organizationId,
-        source = AlertSource.HOST_ALERT.name,
-        deduplicationKey = deduplicationKey,
-        title = "$hostName - CPU Usage recovered",
-        description = "The alert for CPU Usage is no longer active.",
-        moneatUrl = "https://moneat.io/monitoring/hosts/$hostResourceId",
-        priority = AlertPriority.P1,
-    )
-}
-
 class MonitorAlertServiceCoverageTest {
 
     companion object {
@@ -108,6 +88,7 @@ class MonitorAlertServiceCoverageTest {
 
     private lateinit var incidentService: IncidentService
     private lateinit var workflowService: WorkflowService
+    private lateinit var alertOrchestrator: AlertLifecycleOrchestrator
     private lateinit var service: MonitorAlertService
 
     private data class HostAlertFixture(
@@ -142,11 +123,13 @@ class MonitorAlertServiceCoverageTest {
 
         incidentService = mockk(relaxed = true)
         workflowService = mockk(relaxed = true)
+        alertOrchestrator = mockk(relaxed = true)
         coEvery { workflowService.publishAlertTriggered(any()) } returns true
         service =
             MonitorAlertService(
                 incidentService = incidentService,
                 workflowService = workflowService,
+                alertOrchestrator = alertOrchestrator,
             )
 
         mockkObject(ClickHouseClient, RedisConfig)
@@ -580,7 +563,7 @@ class MonitorAlertServiceCoverageTest {
             callPrivateSuspend("sendAlertNotification", alert, "host-a", 1, 91.0)
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(any())
+                alertOrchestrator.process(any(), AlertFanoutPlan.WORKFLOW_ONLY)
             }
         }
 
@@ -611,14 +594,15 @@ class MonitorAlertServiceCoverageTest {
             )
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(
+                alertOrchestrator.process(
                     match {
                         it.title ==
                             "host-a - Disk Usage (/dev/sda at /mnt/volume_nyc3_01) > 75.0" &&
                             it.description.contains("Filesystem: /dev/sda at /mnt/volume_nyc3_01") &&
                             it.metadata["resource_label"]?.toString() ==
                             "\"/dev/sda at /mnt/volume_nyc3_01\""
-                    }
+                    },
+                    AlertFanoutPlan.WORKFLOW_ONLY,
                 )
             }
         }
@@ -648,19 +632,13 @@ class MonitorAlertServiceCoverageTest {
                 }
             assertNull(clearedLastTriggeredAt)
             coVerify(exactly = 1) {
-                workflowService.publishAlertResolved(
-                    expectedResolvedWorkflowEvent(fixture.orgId, fixture.hostId, deduplicationKey),
-                )
-            }
-            coVerify(exactly = 1) {
-                incidentService.autoResolveAlert(
-                    fixture.orgId,
-                    AlertSource.HOST_ALERT,
-                    deduplicationKey,
-                    any(),
-                    any(),
-                    any(),
-                    false,
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.RESOLVED &&
+                            it.source == AlertSource.HOST_ALERT &&
+                            it.deduplicationKey == deduplicationKey
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
         }
@@ -682,8 +660,11 @@ class MonitorAlertServiceCoverageTest {
             callPrivateSuspend("handleRecoveredAlert", triggeredAlert, "host-alert-workflow", fixture.orgId, alertKey)
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertResolved(
-                    expectedResolvedWorkflowEvent(fixture.orgId, fixture.hostId, deduplicationKey),
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.RESOLVED && it.deduplicationKey == deduplicationKey
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
             val clearedLastTriggeredAt =
@@ -756,8 +737,11 @@ class MonitorAlertServiceCoverageTest {
             callPrivateSuspend("handleRecoveredAlert", alert, "global-alert-workflow", orgId, alertKey)
 
             coVerify(exactly = 1) {
-                workflowService.publishAlertResolved(
-                    expectedResolvedWorkflowEvent(orgId, hostId, deduplicationKey, "global-alert-workflow"),
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.RESOLVED && it.deduplicationKey == deduplicationKey
+                    },
+                    AlertFanoutPlan.WORKFLOW_ONLY,
                 )
             }
             val clearedTemplateState =
@@ -804,21 +788,43 @@ class MonitorAlertServiceCoverageTest {
                 }
             assertNotNull(lastTriggeredAt)
             coVerify(exactly = 1) {
-                workflowService.publishAlertTriggered(
+                alertOrchestrator.process(
                     match {
                         it.source == AlertSource.HOST_ALERT &&
                             it.deduplicationKey == deduplicationKey &&
                             it.organizationId == fixture.orgId
-                    }
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
+        }
+
+    @Test
+    fun `triggerAlert uses workflow only fanout without an incident priority`() =
+        runBlocking {
+            val fixture = createHostAlertFixture(alertPriority = null)
+            val alertKey = "alert_state:${fixture.hostId}:id_${fixture.alert.id}"
+            every { RedisConfig.isConnected() } returns true
+            val redis = mockk<RedisCommands<String, String>>()
+            every { RedisConfig.sync() } returns redis
+            every { redis.set(alertKey, "TRIGGERED") } returns "OK"
+            callPrivateSuspend(
+                "triggerAlert",
+                fixture.alert,
+                "host-alert-workflow",
+                fixture.orgId,
+                91.0,
+                alertKey,
+                Clock.System.now(),
+            )
+
             coVerify(exactly = 1) {
-                incidentService.fireAlert(any(), false)
+                alertOrchestrator.process(any(), AlertFanoutPlan.WORKFLOW_ONLY)
             }
         }
 
     @Test
-    fun `triggerAlert suppresses provider fanout when the episode gate declines`() =
+    fun `triggerAlert sends the host episode through full fanout`() =
         runBlocking {
             val fixture = createHostAlertFixture()
             val alertKey = "alert_state:${fixture.hostId}:id_${fixture.alert.id}"
@@ -826,8 +832,6 @@ class MonitorAlertServiceCoverageTest {
             val redis = mockk<RedisCommands<String, String>>()
             every { RedisConfig.sync() } returns redis
             every { redis.set(alertKey, "TRIGGERED") } returns "OK"
-            coEvery { workflowService.publishAlertTriggered(any()) } returns false
-
             callPrivateSuspend(
                 "triggerAlert",
                 fixture.alert,
@@ -838,31 +842,16 @@ class MonitorAlertServiceCoverageTest {
                 Clock.System.now(),
             )
 
-            coVerify(exactly = 0) { incidentService.fireAlert(any(), false) }
-        }
-
-    @Test
-    fun `triggerAlert fails open to provider fanout when workflow publication fails`() =
-        runBlocking {
-            val fixture = createHostAlertFixture()
-            val alertKey = "alert_state:${fixture.hostId}:id_${fixture.alert.id}"
-            every { RedisConfig.isConnected() } returns true
-            val redis = mockk<RedisCommands<String, String>>()
-            every { RedisConfig.sync() } returns redis
-            every { redis.set(alertKey, "TRIGGERED") } returns "OK"
-            coEvery { workflowService.publishAlertTriggered(any()) } throws RuntimeException("redis down")
-
-            callPrivateSuspend(
-                "triggerAlert",
-                fixture.alert,
-                "host-alert-workflow",
-                fixture.orgId,
-                91.0,
-                alertKey,
-                Clock.System.now(),
-            )
-
-            coVerify(exactly = 1) { incidentService.fireAlert(any(), false) }
+            coVerify(exactly = 1) {
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.FIRING &&
+                            it.source == AlertSource.HOST_ALERT &&
+                            it.organizationId == fixture.orgId
+                    },
+                    AlertFanoutPlan.FULL,
+                )
+            }
         }
 
     // ──── Key helpers ────
@@ -956,29 +945,20 @@ class MonitorAlertServiceCoverageTest {
                 }
             assertEquals("up", status)
             coVerify(exactly = 1) {
-                incidentService.autoResolveAlert(
-                    orgId,
-                    AlertSource.HOST_DOWN,
-                    "moneat-host-down-$hostId",
-                    any(),
-                    any(),
-                    any(),
-                    true,
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.RESOLVED &&
+                            it.source == AlertSource.HOST_DOWN &&
+                            it.deduplicationKey == "moneat-host-down-$hostId"
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
 
             callPrivateSuspend("checkHostStatuses")
 
             coVerify(exactly = 1) {
-                incidentService.autoResolveAlert(
-                    orgId,
-                    AlertSource.HOST_DOWN,
-                    "moneat-host-down-$hostId",
-                    any(),
-                    any(),
-                    any(),
-                    true,
-                )
+                alertOrchestrator.process(any(), AlertFanoutPlan.FULL)
             }
         }
 
@@ -1029,14 +1009,13 @@ class MonitorAlertServiceCoverageTest {
                 }
             assertEquals("up", status)
             coVerify(exactly = 1) {
-                incidentService.autoResolveAlert(
-                    orgId,
-                    AlertSource.HOST_DOWN,
-                    "moneat-host-down-$hostId",
-                    any(),
-                    any(),
-                    any(),
-                    true,
+                alertOrchestrator.process(
+                    match {
+                        it.status == AlertStatus.RESOLVED &&
+                            it.source == AlertSource.HOST_DOWN &&
+                            it.deduplicationKey == "moneat-host-down-$hostId"
+                    },
+                    AlertFanoutPlan.FULL,
                 )
             }
         }
@@ -1063,17 +1042,17 @@ class MonitorAlertServiceCoverageTest {
                     } get Hosts.id
                 }
             val deduplicationKey = "moneat-host-down-$hostId"
+            val failedResult = mockk<com.moneat.alerts.services.AlertOrchestrationResult>()
+            every { failedResult.outcomes } returns listOf(
+                AlertFanoutOutcome(AlertFanoutArm.INCIDENT_PROVIDERS, AlertFanoutState.FAILED, "resolve failed"),
+            )
+            val succeededResult = mockk<com.moneat.alerts.services.AlertOrchestrationResult>(relaxed = true)
             coEvery {
-                incidentService.autoResolveAlert(
-                    orgId,
-                    AlertSource.HOST_DOWN,
-                    deduplicationKey,
-                    any(),
-                    any(),
-                    any(),
-                    true,
+                alertOrchestrator.process(
+                    match { it.status == AlertStatus.RESOLVED && it.deduplicationKey == deduplicationKey },
+                    AlertFanoutPlan.FULL,
                 )
-            } throws RuntimeException("resolve failed")
+            } returnsMany listOf(failedResult, succeededResult)
 
             callPrivateSuspend("checkHostStatuses")
 
@@ -1083,18 +1062,6 @@ class MonitorAlertServiceCoverageTest {
                 }
             assertEquals("down", failedStatus)
 
-            coEvery {
-                incidentService.autoResolveAlert(
-                    orgId,
-                    AlertSource.HOST_DOWN,
-                    deduplicationKey,
-                    any(),
-                    any(),
-                    any(),
-                    true,
-                )
-            } returns Unit
-
             callPrivateSuspend("checkHostStatuses")
 
             val recoveredStatus =
@@ -1103,14 +1070,9 @@ class MonitorAlertServiceCoverageTest {
                 }
             assertEquals("up", recoveredStatus)
             coVerify(exactly = 2) {
-                incidentService.autoResolveAlert(
-                    orgId,
-                    AlertSource.HOST_DOWN,
-                    deduplicationKey,
-                    any(),
-                    any(),
-                    any(),
-                    true,
+                alertOrchestrator.process(
+                    match { it.status == AlertStatus.RESOLVED && it.deduplicationKey == deduplicationKey },
+                    AlertFanoutPlan.FULL,
                 )
             }
         }

--- a/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/MonitorAlertServiceCoverageTest.kt
@@ -1046,13 +1046,17 @@ class MonitorAlertServiceCoverageTest {
             every { failedResult.outcomes } returns listOf(
                 AlertFanoutOutcome(AlertFanoutArm.INCIDENT_PROVIDERS, AlertFanoutState.FAILED, "resolve failed"),
             )
-            val succeededResult = mockk<com.moneat.alerts.services.AlertOrchestrationResult>(relaxed = true)
+            val nonIncidentFailureResult = mockk<com.moneat.alerts.services.AlertOrchestrationResult>()
+            every { nonIncidentFailureResult.outcomes } returns listOf(
+                AlertFanoutOutcome(AlertFanoutArm.WORKFLOW, AlertFanoutState.FAILED, "workflow unavailable"),
+                AlertFanoutOutcome(AlertFanoutArm.ROUTE, AlertFanoutState.FAILED, "route unavailable"),
+            )
             coEvery {
                 alertOrchestrator.process(
                     match { it.status == AlertStatus.RESOLVED && it.deduplicationKey == deduplicationKey },
                     AlertFanoutPlan.FULL,
                 )
-            } returnsMany listOf(failedResult, succeededResult)
+            } returnsMany listOf(failedResult, nonIncidentFailureResult)
 
             callPrivateSuspend("checkHostStatuses")
 

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceRoutingTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceRoutingTest.kt
@@ -25,6 +25,7 @@ import com.moneat.alerts.models.AlertSource
 import com.moneat.alerts.models.AlertLifecycleEvent
 import com.moneat.alerts.models.AlertPriority
 import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.shared.models.Organizations
@@ -53,6 +54,7 @@ class NotificationServiceRoutingTest {
 
     private val emailService = mockk<EmailService>(relaxed = true)
     private val workflowService = mockk<WorkflowService>(relaxed = true)
+    private val alertOrchestrator = mockk<AlertLifecycleOrchestrator>(relaxed = true)
 
     @BeforeTest
     fun setupDatabase() {
@@ -142,13 +144,13 @@ class NotificationServiceRoutingTest {
             val orgId = seedOrg("Workflow Route Org")
             val projectId = seedProject(orgId, "WorkflowProject")
             val eventSlot = slot<AlertLifecycleEvent>()
-            val service = NotificationService(emailService, workflowService)
+            val service = NotificationService(emailService, workflowService, alertOrchestrator)
 
             try {
                 service.onNewIssue(projectId, "2001", buildEvent())
 
                 coVerify(exactly = 1) {
-                    workflowService.publishAlertTriggered(capture(eventSlot))
+                    alertOrchestrator.process(capture(eventSlot), any())
                 }
             } finally {
                 service.shutdown()
@@ -171,13 +173,13 @@ class NotificationServiceRoutingTest {
             val orgId = seedOrg("Exception Org")
             val projectId = seedProject(orgId, "ExceptionProject")
             val eventSlot = slot<AlertLifecycleEvent>()
-            val service = NotificationService(emailService, workflowService)
+            val service = NotificationService(emailService, workflowService, alertOrchestrator)
 
             try {
                 service.onNewIssue(projectId, "4001", buildEventWithException())
 
                 coVerify(exactly = 1) {
-                    workflowService.publishAlertTriggered(capture(eventSlot))
+                    alertOrchestrator.process(capture(eventSlot), any())
                 }
             } finally {
                 service.shutdown()
@@ -193,13 +195,13 @@ class NotificationServiceRoutingTest {
     @Test
     fun `onNewIssue returns early when project does not exist`() =
         runBlocking {
-            val service = NotificationService(emailService, workflowService)
+            val service = NotificationService(emailService, workflowService, alertOrchestrator)
 
             try {
                 service.onNewIssue(99999L, "5001", buildEvent())
 
                 coVerify(exactly = 0) {
-                    workflowService.publishAlertTriggered(any())
+                    alertOrchestrator.process(any(), any())
                 }
             } finally {
                 service.shutdown()
@@ -212,15 +214,15 @@ class NotificationServiceRoutingTest {
             val orgId = seedOrg("Failure Org")
             val projectId = seedProject(orgId, "FailureProject")
             coEvery {
-                workflowService.publishAlertTriggered(any())
+                alertOrchestrator.process(any(), any())
             } throws RuntimeException("workflow queue unavailable")
-            val service = NotificationService(emailService, workflowService)
+            val service = NotificationService(emailService, workflowService, alertOrchestrator)
 
             try {
                 service.onNewIssue(projectId, "6001", buildEvent())
 
                 coVerify(exactly = 1) {
-                    workflowService.publishAlertTriggered(any())
+                    alertOrchestrator.process(any(), any())
                 }
             } finally {
                 service.shutdown()

--- a/backend/src/test/kotlin/com/moneat/services/NotificationServiceTest.kt
+++ b/backend/src/test/kotlin/com/moneat/services/NotificationServiceTest.kt
@@ -18,6 +18,7 @@ package com.moneat.services
 
 import com.moneat.events.models.SentryEvent
 import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.services.AlertLifecycleOrchestrator
 import com.moneat.notifications.services.EmailService
 import com.moneat.notifications.services.NotificationService
 import com.moneat.shared.models.EmailsSent
@@ -112,7 +113,8 @@ class NotificationServiceTest {
             }
 
             val workflowService = mockk<WorkflowService>(relaxed = true)
-            val notificationService = NotificationService(EmailService(), workflowService)
+            val alertOrchestrator = mockk<AlertLifecycleOrchestrator>(relaxed = true)
+            val notificationService = NotificationService(EmailService(), workflowService, alertOrchestrator)
             try {
                 val event =
                     SentryEvent(
@@ -128,7 +130,7 @@ class NotificationServiceTest {
                 notificationService.onNewIssue(projectId, "1002", event.copy(eventId = "evt-2"))
 
                 coVerify(exactly = 2) {
-                    workflowService.publishAlertTriggered(capture(publishedEvents))
+                    alertOrchestrator.process(capture(publishedEvents), any())
                 }
                 assertEquals("moneat-error-1001", publishedEvents[0].deduplicationKey)
                 assertEquals("moneat-error-1002", publishedEvents[1].deduplicationKey)

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanout.kt
@@ -1,0 +1,22 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.services.AlertFanoutContext
+import com.moneat.alerts.services.AlertRouteFanout
+import com.moneat.enterprise.FeatureRegistry
+import com.moneat.enterprise.alertroutes.context.AlertRouteEpisodeIdentity
+
+/** Enterprise route-evaluation arm. Action execution is added by the downstream execution task. */
+class EnterpriseAlertRouteFanout(
+    private val evaluationService: AlertRouteEvaluationService = AlertRouteEvaluationService(),
+    private val enabled: (Int) -> Boolean = FeatureRegistry::isNativeIncidentResponseEnabled,
+) : AlertRouteFanout {
+    override suspend fun process(context: AlertFanoutContext) {
+        if (!enabled(context.event.organizationId)) return
+        val episode = context.episode?.let(AlertRouteEpisodeIdentity::from) ?: AlertRouteEpisodeIdentity.UNKNOWN
+        evaluationService.evaluate(context.event, episode)
+    }
+}

--- a/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
+++ b/ee/backend/src/main/kotlin/com/moneat/enterprise/oncall/OnCallModule.kt
@@ -5,6 +5,7 @@
 package com.moneat.enterprise.oncall
 
 import com.moneat.config.RedisClient
+import com.moneat.alerts.services.AlertRouteFanoutRegistry
 import com.moneat.enterprise.EnterpriseModule
 import com.moneat.enterprise.IncidentInfo
 import com.moneat.enterprise.OnCallBridge
@@ -13,6 +14,7 @@ import com.moneat.enterprise.OnCallUserInfo
 import com.moneat.enterprise.PriorityInfo
 import com.moneat.enterprise.alertroutes.routes.alertRouteRoutes
 import com.moneat.enterprise.alertroutes.routes.alertGroupRoutes
+import com.moneat.enterprise.alertroutes.services.EnterpriseAlertRouteFanout
 import com.moneat.enterprise.incidents.commands.DeclareIncidentCommand
 import com.moneat.enterprise.incidents.commands.IncidentCommandActor
 import com.moneat.enterprise.incidents.events.IncidentOutboxService
@@ -114,6 +116,7 @@ class OnCallModule :
             )
         }
     private val incidentOutboxWorker by incidentOutboxWorkerDelegate
+    private val alertRouteFanout = EnterpriseAlertRouteFanout()
 
     override val name: String = "On-Call"
     override val licenseFeature: String = "oncall"
@@ -143,6 +146,7 @@ class OnCallModule :
 
     override fun startBackgroundJobs(application: Application) {
         logger.info { "Starting on-call enterprise background jobs" }
+        AlertRouteFanoutRegistry.register(alertRouteFanout)
         escalationEngine.start()
         slackUserGroupSyncService.start()
         onCallHandoffService.start()
@@ -152,6 +156,7 @@ class OnCallModule :
 
     override fun stopBackgroundJobs() {
         logger.info { "Stopping on-call enterprise background jobs" }
+        AlertRouteFanoutRegistry.unregister(alertRouteFanout)
         if (escalationEngineDelegate.isInitialized()) escalationEngine.stop()
         if (slackUserGroupSyncServiceDelegate.isInitialized()) slackUserGroupSyncService.stop()
         if (onCallHandoffServiceDelegate.isInitialized()) onCallHandoffService.stop()

--- a/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanoutTest.kt
+++ b/ee/backend/src/test/kotlin/com/moneat/enterprise/alertroutes/services/EnterpriseAlertRouteFanoutTest.kt
@@ -1,0 +1,46 @@
+// Moneat Enterprise - proprietary module
+// Copyright (c) 2026 Moneat. All rights reserved.
+// See ee/LICENSE for license terms.
+
+package com.moneat.enterprise.alertroutes.services
+
+import com.moneat.alerts.models.AlertLifecycleEvent
+import com.moneat.alerts.models.AlertPriority
+import com.moneat.alerts.models.AlertSource
+import com.moneat.alerts.models.AlertStatus
+import com.moneat.alerts.services.AlertFanoutContext
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+class EnterpriseAlertRouteFanoutTest {
+    @Test
+    fun `live fanout skips route evaluation when organization is not entitled`() = runBlocking {
+        val evaluationService = mockk<AlertRouteEvaluationService>()
+        val fanout = EnterpriseAlertRouteFanout(
+            evaluationService = evaluationService,
+            enabled = { false },
+        )
+
+        fanout.process(
+            AlertFanoutContext(
+                event = AlertLifecycleEvent(
+                    title = "Error rate elevated",
+                    description = "Error rate exceeded its threshold",
+                    priority = AlertPriority.P2,
+                    status = AlertStatus.FIRING,
+                    source = AlertSource.DASHBOARD_ALERT,
+                    deduplicationKey = "dashboard-alert:error-rate",
+                    organizationId = 42,
+                    moneatUrl = "https://moneat.example/alerts/error-rate",
+                ),
+                episodeDecision = null,
+                episode = null,
+                deliverySilenced = false,
+            ),
+        )
+
+        confirmVerified(evaluationService)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an episode-first alert lifecycle orchestrator with isolated route, workflow, native on-call, and incident-provider arms
- migrate dashboard, monitor, uptime, synthetic, error, and admin alert producers while preserving silence, reminders, and recovery safeguards
- expose stable retry identity and optional enterprise route evaluation without breaking core-only deployments
- propagate native paging failures and skip enterprise route evaluation for non-entitled organizations

## Verification
- full backend unit suite (`./gradlew :test ...`): passed, 190 tasks
- `./gradlew detekt --no-daemon`: passed
- focused native paging regression: passed
- focused enterprise route entitlement regression: passed
- `git diff --check`: passed
- Claude CLI review completed; both material findings addressed

Backlog: TASK-1.54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized alert processing across dashboards, monitoring, uptime, synthetics, notifications, and administrative triggers.
  * Alerts now coordinate workflow, incident, on-call, and route notifications with shared lifecycle tracking.
  * Added retry handling, duplicate suppression, silencing support, and isolated notification failures.
  * Enterprise alert-route evaluation is integrated when enabled.

* **Bug Fixes**
  * Improved alert recovery handling and prevented duplicate episode creation during retries.

* **Tests**
  * Expanded coverage for routing, silencing, retries, failures, and lifecycle persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->